### PR TITLE
[WIP]: handle duplicated blocks from entities with aliases and entity management

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1433,6 +1433,16 @@ _Returns_
 
 -   `Object`: Action object.
 
+<a name="synchronizeBlockSubTrees" href="#synchronizeBlockSubTrees">#</a> **synchronizeBlockSubTrees**
+
+Returns an action object that sets the block tree underneath the given target
+to be the same as the one under the source using block aliases.
+
+_Parameters_
+
+-   _sourceTree_ `string`: The client ID of the source for the sync.
+-   _targetTree_ `string`: The client ID of the target for the sync.
+
 <a name="synchronizeTemplate" href="#synchronizeTemplate">#</a> **synchronizeTemplate**
 
 Returns an action object synchronize the template with the list of blocks

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -65,7 +65,8 @@
 		"redux-multi": "^0.1.12",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
-		"traverse": "^0.6.6"
+		"traverse": "^0.6.6",
+		"uuid": "^8.3.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-editor/src/components/provider/use-entity-manager.js
+++ b/packages/block-editor/src/components/provider/use-entity-manager.js
@@ -3,8 +3,45 @@
  */
 import { useEffect, useRef, useState } from '@wordpress/element';
 
+/**
+ * A function to call to inform the entity manager that it is now in charge.
+ *
+ * @callback setAsPrimary
+ * @param {boolean} isPrimary If true, set the entity manager is the primary.
+ */
+
+/**
+ * A manager is something which needs to keep track of changes in the block editor
+ * which might need to be synced back to an entity, or vice-versa.
+ *
+ * @typedef WPEntityManager
+ * @property {string}       id           The id of the manager. Typically the block client
+ *                                       ID of an inner block controller.
+ * @property {setAsPrimary} setAsPrimary A function to call to set the manager
+ *                                       as the primary manager for the entity.
+ */
+
+/**
+ * This object maintains a list of the entity managers we have. Each entity ID
+ * is a key of the object which maps to an array of managers. The first entry in
+ * each array is considered the primary manager for the given entity. The primary
+ * manager is the only manager which is allowed to sync changes in and out of the
+ * block editor from the entity. This way, we do not have multiple managers trying
+ * to put identical blocks into the editor in different locations.
+ *
+ * @type {Object.<string, WPEntityManager[]>}
+ */
 const _ENTITY_MANAGERS = {};
 
+/**
+ * Adds an entity manager to the list under the given entity. A manager is only
+ * added to the list once. The first manager to be added is considered the primary
+ * manager.
+ *
+ * @param {string}          entityId The ID of the entity we want to watch.
+ * @param {WPEntityManager} manager  The manager to attache to the given entity.
+ * @return {boolean} True if the added entity manager is the primary manager.
+ */
 function addEntityManager( entityId, manager ) {
 	if ( ! entityId ) {
 		return true;
@@ -35,6 +72,16 @@ function addEntityManager( entityId, manager ) {
 	return isPrimary;
 }
 
+/**
+ * Removes a manager from the list. Does nothing if the manager does not exist.
+ * Once a manager is removed, the first manager in the list is informed that it
+ * is the manager via the `setAsPrimary` callback. Note that this callback is
+ * only called if the removed manager was the primary manager. It is not called
+ * if the old primary manager is still the same.
+ *
+ * @param {string} entityId  The ID of the entity the manager is attached to.
+ * @param {string} managerId The ID of the manager to remove.
+ */
 function removeEntityManager( entityId, managerId ) {
 	// Do nothing if no trackers have been set up.
 	if ( ! Array.isArray( _ENTITY_MANAGERS[ entityId ] ) ) {
@@ -46,48 +93,78 @@ function removeEntityManager( entityId, managerId ) {
 	if ( itemIndex > -1 ) {
 		// Remove the manager.
 		_ENTITY_MANAGERS[ entityId ].splice( itemIndex, 1 );
+
 		// Tell the new primary manager that it is now in charge.
-		const newManager = _ENTITY_MANAGERS[ entityId ][ 0 ];
-		if ( newManager ) {
-			newManager.setAsPrimary( true );
+		if ( itemIndex === 0 ) {
+			return _ENTITY_MANAGERS[ entityId ][ 0 ]?.setAsPrimary( true );
 		}
 	}
 }
 
-// Returns true if we are the current tracker for the given entity.
-// Basically only returns true if no entityId is given.
-export default function useIsPrimaryEntityManager( entityId, clientId ) {
-	// Set up a method for setting that we are now the tracker. Note that this
-	// should only trigger a re-render if the tracker status actually changes.
+/**
+ * A hook which keeps track of whether we are the primary manager for a given
+ * entity. When multiple components are trying to manage the same entity via this
+ * hook, the hook keeps everything organized. Only one component is allowed to
+ * manager an entity. This hook returns true when the component (identified by
+ * `managerId`) is the primary manager for the entity.
+ *
+ * In practice, if this returns true, it means that the component has permission
+ * to update and sync changes in/out of the block editor to the entity via the
+ * inner block controller mechanism.
+ *
+ * If no entity ID is passed, it's assumed that there is no need to keep track
+ * of multiple entitys per manager. For example, the root block-editor would not
+ * pass a clientId because there is no need for it to share management with
+ * multiple different components.
+ *
+ * However, a template part may need to share management of a single entity with
+ * multiple components when there are multiple template part blocks which each
+ * reference the same template part entity. In that case, it is important that
+ * only one component is in charge of handling syncs from the entity to the block
+ * editor.
+ *
+ * @param {string=} [entityId] A unique identifier for the entity to manage. If
+ *                             no entity ID is given, it is assumed that we are
+ *                             always the primary manager.
+ * @param {string} managerId   The ID to use for the entity manager.
+ */
+export default function useIsPrimaryEntityManager( entityId, managerId ) {
+	/**
+	 * This method sets that we are now the tracker. It is called when a different
+	 * primary manager has been removed to let this manager know that it is now
+	 * in charge.
+	 *
+	 * @type {setAsPrimary}
+	 */
 	const setAsPrimary = ( isPrimary ) => setIsTracker( isPrimary );
 
 	const [ isTracker, setIsTracker ] = useState( () =>
 		addEntityManager( entityId, {
-			id: clientId,
+			id: managerId,
 			setAsPrimary,
 		} )
 	);
 
 	const oldEntityId = useRef( entityId );
-	const oldClientId = useRef( clientId );
+	const oldManagerId = useRef( managerId );
 
 	useEffect( () => {
 		const didEntityChange = oldEntityId.current !== entityId;
-		const didClientIdChange = oldClientId.current !== clientId;
+		const didClientIdChange = oldManagerId.current !== managerId;
 		// If the info changed, we need to reset the tracker information.
 		if ( didEntityChange || didClientIdChange ) {
-			removeEntityManager( oldEntityId.current, oldClientId.current );
+			removeEntityManager( oldEntityId.current, oldManagerId.current );
 			const isNewPrimary = addEntityManager( entityId, {
-				id: clientId,
+				id: managerId,
 				setAsPrimary,
 			} );
 			setIsTracker( isNewPrimary );
 			oldEntityId.current = entityId;
-			oldClientId.current = clientId;
+			oldManagerId.current = managerId;
 		}
 		// Remove the manager on component unmount.
-		return () => removeEntityManager( entityId, clientId );
-	}, [ entityId, clientId ] );
+		return () => removeEntityManager( entityId, managerId );
+	}, [ entityId, managerId ] );
 
 	return isTracker;
 }

--- a/packages/block-editor/src/components/provider/use-entity-manager.js
+++ b/packages/block-editor/src/components/provider/use-entity-manager.js
@@ -61,23 +61,23 @@ export default function useIsPrimaryEntityManager( entityId, clientId ) {
 	// should only trigger a re-render if the tracker status actually changes.
 	const setAsPrimary = ( isPrimary ) => setIsTracker( isPrimary );
 
-	const isPrimary = addEntityManager( entityId, {
-		id: clientId,
-		setAsPrimary,
-	} );
-
-	const [ isTracker, setIsTracker ] = useState( isPrimary );
+	const [ isTracker, setIsTracker ] = useState( () =>
+		addEntityManager( entityId, {
+			id: clientId,
+			setAsPrimary,
+		} )
+	);
 
 	const oldEntityId = useRef( entityId );
 	const oldClientId = useRef( clientId );
 
 	useEffect( () => {
-		const didEntityChange = oldEntityId.current !== clientId;
+		const didEntityChange = oldEntityId.current !== entityId;
 		const didClientIdChange = oldClientId.current !== clientId;
 		// If the info changed, we need to reset the tracker information.
 		if ( didEntityChange || didClientIdChange ) {
 			removeEntityManager( oldEntityId.current, oldClientId.current );
-			const isNewPrimary = addEntityManager( {
+			const isNewPrimary = addEntityManager( entityId, {
 				id: clientId,
 				setAsPrimary,
 			} );

--- a/packages/block-editor/src/components/provider/use-entity-manager.js
+++ b/packages/block-editor/src/components/provider/use-entity-manager.js
@@ -1,0 +1,93 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+const _ENTITY_MANAGERS = {};
+
+function addEntityManager( entityId, manager ) {
+	if ( ! entityId ) {
+		return true;
+	}
+
+	let isPrimary = false;
+	if ( ! Array.isArray( _ENTITY_MANAGERS[ entityId ] ) ) {
+		_ENTITY_MANAGERS[ entityId ] = [];
+	}
+
+	/**
+	 * This basically handles two cases:
+	 * 1. There is no entity tracking setup for the entityId yet. As a result,
+	 *    this is the first one to be added, so it is primary.
+	 * 2. There has been entity tracking setup in the past, but there are no
+	 *    trackers currently assigned to the entity. As a result, this is the only
+	 *    manager which currently exists, so it is primary.
+	 */
+	if ( _ENTITY_MANAGERS[ entityId ].length === 0 ) {
+		isPrimary = true;
+	}
+
+	if (
+		! _ENTITY_MANAGERS[ entityId ].some( ( { id } ) => id === manager.id )
+	) {
+		_ENTITY_MANAGERS[ entityId ].push( manager );
+	}
+	return isPrimary;
+}
+
+function removeEntityManager( entityId, managerId ) {
+	// Do nothing if no trackers have been set up.
+	if ( ! Array.isArray( _ENTITY_MANAGERS[ entityId ] ) ) {
+		return;
+	}
+	const itemIndex = _ENTITY_MANAGERS[ entityId ].findIndex(
+		( { id } ) => id === managerId
+	);
+	if ( itemIndex > -1 ) {
+		// Remove the manager.
+		_ENTITY_MANAGERS[ entityId ].splice( itemIndex, 1 );
+		// Tell the new primary manager that it is now in charge.
+		const newManager = _ENTITY_MANAGERS[ entityId ][ 0 ];
+		if ( newManager ) {
+			newManager.setAsPrimary( true );
+		}
+	}
+}
+
+// Returns true if we are the current tracker for the given entity.
+// Basically only returns true if no entityId is given.
+export default function useIsPrimaryEntityManager( entityId, clientId ) {
+	// Set up a method for setting that we are now the tracker. Note that this
+	// should only trigger a re-render if the tracker status actually changes.
+	const setAsPrimary = ( isPrimary ) => setIsTracker( isPrimary );
+
+	const isPrimary = addEntityManager( entityId, {
+		id: clientId,
+		setAsPrimary,
+	} );
+
+	const [ isTracker, setIsTracker ] = useState( isPrimary );
+
+	const oldEntityId = useRef( entityId );
+	const oldClientId = useRef( clientId );
+
+	useEffect( () => {
+		const didEntityChange = oldEntityId.current !== clientId;
+		const didClientIdChange = oldClientId.current !== clientId;
+		// If the info changed, we need to reset the tracker information.
+		if ( didEntityChange || didClientIdChange ) {
+			removeEntityManager( oldEntityId.current, oldClientId.current );
+			const isNewPrimary = addEntityManager( {
+				id: clientId,
+				setAsPrimary,
+			} );
+			setIsTracker( isNewPrimary );
+			oldEntityId.current = entityId;
+			oldClientId.current = clientId;
+		}
+		// Remove the manager on component unmount.
+		return () => removeEntityManager( entityId, clientId );
+	}, [ entityId, clientId ] );
+
+	return isTracker;
+}

--- a/packages/block-editor/src/components/provider/use-entity-manager.js
+++ b/packages/block-editor/src/components/provider/use-entity-manager.js
@@ -128,7 +128,7 @@ function removeEntityManager( entityId, managerId ) {
  *                             always the primary manager.
  * @param {string} managerId   The ID to use for the entity manager.
  */
-export default function useIsPrimaryEntityManager( entityId, managerId ) {
+export default function useEntityManager( entityId, managerId ) {
 	/**
 	 * This method sets that we are now the tracker. It is called when a different
 	 * primary manager has been removed to let this manager know that it is now
@@ -136,9 +136,9 @@ export default function useIsPrimaryEntityManager( entityId, managerId ) {
 	 *
 	 * @type {setAsPrimary}
 	 */
-	const setAsPrimary = ( isPrimary ) => setIsTracker( isPrimary );
+	const setAsPrimary = ( isPrimary ) => setIsPrimary( isPrimary );
 
-	const [ isTracker, setIsTracker ] = useState( () =>
+	const [ isPrimaryManager, setIsPrimary ] = useState( () =>
 		addEntityManager( entityId, {
 			id: managerId,
 			setAsPrimary,
@@ -158,7 +158,7 @@ export default function useIsPrimaryEntityManager( entityId, managerId ) {
 				id: managerId,
 				setAsPrimary,
 			} );
-			setIsTracker( isNewPrimary );
+			setIsPrimary( isNewPrimary );
 			oldEntityId.current = entityId;
 			oldManagerId.current = managerId;
 		}
@@ -166,5 +166,8 @@ export default function useIsPrimaryEntityManager( entityId, managerId ) {
 		return () => removeEntityManager( entityId, managerId );
 	}, [ entityId, managerId ] );
 
-	return isTracker;
+	return {
+		isPrimaryManager,
+		primaryManagerId: _ENTITY_MANAGERS[ entityId ]?.[ 0 ]?.id,
+	};
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1348,3 +1348,18 @@ export function setHasControlledInnerBlocks(
 		clientId,
 	};
 }
+
+/**
+ * Returns an action object that sets the block tree underneath the given target
+ * to be the same as the one under the source using block aliases.
+ *
+ * @param {string} sourceTree The client ID of the source for the sync.
+ * @param {string} targetTree The client ID of the target for the sync.
+ */
+export function synchronizeBlockSubTrees( sourceTree, targetTree ) {
+	return {
+		type: 'SYNCHRONIZE_BLOCK_SUB_TREES',
+		sourceTree,
+		targetTree,
+	};
+}

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -25,6 +25,7 @@ export default function TemplatePartInnerBlocks( {
 			renderAppender: hasInnerBlocks
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,
+			entityId: `wp_template_part_${ id }`,
 		}
 	);
 	return <div { ...innerBlocksProps } />;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This resolves #22639 by implementing the approach I described here: https://github.com/WordPress/gutenberg/pull/24180#issuecomment-729389698.

TLDR:
1. If a second inner block controller is inserted using the same entity ID as another, only the first inner block controller syncs changes in/out of the editor.
2. Internally, block edits are synced between the first and second inner block controllers with a new concept called "block aliases."

This way, edits are up to date inside the block tree, and we only have incoming/outgoing changes happen once. No need to handle multiple syncs or any of that nonsense!

## Tasks:
- [x] Implement an entity "management" tracker. This lets us know which template part block is supposed to be in control of the sync process.
- [x] Implement a "clone/alias/synchronize" block tree function, which lets us alias the block tree of the one template part under the other template part.
- [ ] Add state to keep track of block aliases.
- [x] When a template part block is not in charge of syncing, make sure it does not sync.
- [x] When a template part block is in charge of syncing, make sure it does sync.
- [x] When a template part block is not in charge of syncing, make sure it calls the function to alias its block tree.
- [ ] When a block is **added** under any template part, make sure its changes are synced to all of the alias blocks.
- [ ] When a block is **edited** under any template part, make sure its changes are synced to all of the alias blocks.
- [ ] When a block is **deleted** under any template part, make sure its changes are synced to all of the alias blocks.
- [ ] When a block is **deleted** under any template part, make sure its changes are synced to all of the alias blocks.
- [ ] Make sure that when a template part blocks is removed, the duplicate block becomes the primary manager.
- [ ] Performance testing
- [ ] Add unit tests
- [ ] Add documentation


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
