### PR TITLE
Refactored Gallery: Add loading state to gallery image size options

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -16,12 +16,14 @@ import {
  */
 import { compose } from '@wordpress/compose';
 import {
+	BaseControl,
 	Button,
 	PanelBody,
 	SelectControl,
 	ToggleControl,
 	withNotices,
 	RangeControl,
+	Spinner,
 } from '@wordpress/components';
 import {
 	MediaPlaceholder,
@@ -363,7 +365,7 @@ function GalleryEdit( props ) {
 		return <View { ...blockProps }>{ mediaPlaceholder }</View>;
 	}
 
-	const shouldShowSizeOptions = hasImages && ! isEmpty( imageSizeOptions );
+	const shouldShowSizeOptions = ! isEmpty( imageSizeOptions );
 	const hasLinkTo = linkTo && linkTo !== 'none';
 
 	return (
@@ -400,13 +402,23 @@ function GalleryEdit( props ) {
 							onChange={ toggleOpenInNewTab }
 						/>
 					) }
-					{ shouldShowSizeOptions && (
+					{ shouldShowSizeOptions ? (
 						<SelectControl
 							label={ __( 'Image size' ) }
 							value={ sizeSlug }
 							options={ imageSizeOptions }
 							onChange={ updateImagesSize }
 						/>
+					) : (
+						<BaseControl className={ 'gallery-image-sizes' }>
+							<BaseControl.VisualLabel>
+								{ __( 'Image size' ) }
+							</BaseControl.VisualLabel>
+							<div className={ 'gallery-image-sizes__loading' }>
+								<Spinner />
+								{ __( 'Loading options…' ) }
+							</div>
+						</BaseControl>
 					) }
 					{ dirtyImageOptions && (
 						<div className={ 'gallery-settings-buttons' }>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -414,14 +414,14 @@ function GalleryEdit( props ) {
 							<BaseControl.VisualLabel>
 								{ __( 'Image size' ) }
 							</BaseControl.VisualLabel>
-							<div className={ 'gallery-image-sizes__loading' }>
+							<View className={ 'gallery-image-sizes__loading' }>
 								<Spinner />
 								{ __( 'Loading options…' ) }
-							</div>
+							</View>
 						</BaseControl>
 					) }
 					{ dirtyImageOptions && (
-						<div className={ 'gallery-settings-buttons' }>
+						<View className={ 'gallery-settings-buttons' }>
 							<Button isPrimary onClick={ applyImageOptions }>
 								{ __( 'Apply to all images' ) }
 							</Button>
@@ -432,7 +432,7 @@ function GalleryEdit( props ) {
 							>
 								{ __( 'Cancel' ) }
 							</Button>
-						</div>
+						</View>
 					) }
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -40,14 +40,15 @@ figure.wp-block-gallery {
 
 .blocks-gallery-item {
 	// Hide the focus outline that otherwise briefly appears when selecting a block.
-	figure:not( .is-selected ):focus,
+	figure:not(.is-selected):focus,
 	img:focus {
 		outline: none;
 	}
 
 	figure.is-selected {
-		box-shadow: 0 0 0 $border-width $white,
-			0 0 0 3px var( --wp-admin-theme-color );
+		box-shadow:
+			0 0 0 $border-width $white,
+			0 0 0 3px var(--wp-admin-theme-color);
 		border-radius: $radius-block-ui;
 		outline: 2px solid transparent;
 
@@ -79,9 +80,9 @@ figure.wp-block-gallery {
 	position: absolute;
 	top: -2px;
 	margin: $grid-unit-10;
-	z-index: z-index( '.block-library-gallery-item__inline-menu' );
+	z-index: z-index(".block-library-gallery-item__inline-menu");
 	transition: box-shadow 0.2s ease-out;
-	@include reduce-motion( 'transition' );
+	@include reduce-motion( "transition" );
 	border-radius: $radius-block-ui;
 	background: $white;
 	border: $border-width solid $gray-900;
@@ -99,7 +100,7 @@ figure.wp-block-gallery {
 	}
 
 	.components-button.has-icon {
-		&:not( :focus ) {
+		&:not(:focus) {
 			border: none;
 			box-shadow: none;
 		}
@@ -135,5 +136,23 @@ figure.wp-block-gallery {
 .gallery-settings-buttons {
 	.components-button:first-child {
 		margin-right: 8px;
+	}
+}
+
+.gallery-image-sizes {
+	.components-base-control__label {
+		display: block;
+		margin-bottom: 4px;
+	}
+
+	.gallery-image-sizes__loading {
+		display: flex;
+		align-items: center;
+		color: $gray-700;
+		font-size: $helptext-font-size;
+	}
+
+	.components-spinner {
+		margin: 0 8px 0 4px;
 	}
 }


### PR DESCRIPTION
## Description
* Rather than not display image size options at all, this PR adds a simple loading state including a spinner until the gallery retrieves the size options from its images.
* Linting fixes in `editor.scss`

## How has this been tested?
Manually.

#### Testing Instructions
1. Add a gallery to a post
2. Drags some images into the gallery, either between existing images or via the media placeholder
3. You should temporarily see a loading state for the "Image size" option in the inspector controls sidebar 

## Screenshots <!-- if applicable -->

![GallerySizeOptionsLoadingState](https://user-images.githubusercontent.com/60436221/99640675-f3dff800-2a94-11eb-99ed-b487694548d8.gif)

## Types of changes
Enhancement

## Next Steps
* There is still an issue where if an undo is performed for an image upload, the current retrieval of image options won't actually update the size options, resulting in the "Image size" control being stuck in a loading state.
* This loading state could still be added and the above issue address in the main gallery refactoring branch.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
