### PR TITLE
Drop zone: fix infinite loop in some contexts

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -7,7 +7,6 @@ import {
 	pasteHandler,
 } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -213,41 +212,24 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 	} = useDispatch( 'core/block-editor' );
 
 	return {
-		onDrop: useCallback(
-			onBlockDrop(
-				targetRootClientId,
-				targetBlockIndex,
-				getBlockIndex,
-				getClientIdsOfDescendants,
-				moveBlocksToPosition
-			),
-			[
-				targetRootClientId,
-				targetBlockIndex,
-				getBlockIndex,
-				getClientIdsOfDescendants,
-				moveBlocksToPosition,
-			]
+		onDrop: onBlockDrop(
+			targetRootClientId,
+			targetBlockIndex,
+			getBlockIndex,
+			getClientIdsOfDescendants,
+			moveBlocksToPosition
 		),
-		onFilesDrop: useCallback(
-			onFilesDrop(
-				targetRootClientId,
-				targetBlockIndex,
-				hasUploadPermissions,
-				updateBlockAttributes,
-				insertBlocks
-			),
-			[
-				targetRootClientId,
-				targetBlockIndex,
-				hasUploadPermissions,
-				updateBlockAttributes,
-				insertBlocks,
-			]
+		onFilesDrop: onFilesDrop(
+			targetRootClientId,
+			targetBlockIndex,
+			hasUploadPermissions,
+			updateBlockAttributes,
+			insertBlocks
 		),
-		onHTMLDrop: useCallback(
-			onHTMLDrop( targetRootClientId, targetBlockIndex, insertBlocks ),
-			[ targetRootClientId, targetBlockIndex, insertBlocks ]
+		onHTMLDrop: onHTMLDrop(
+			targetRootClientId,
+			targetBlockIndex,
+			insertBlocks
 		),
 	};
 }

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -52,7 +52,16 @@ export function useDropZone( {
 		isRelative,
 	] );
 
-	return state;
+	return {
+		...state,
+		position:
+			state.x && state.y
+				? {
+						x: state.x,
+						y: state.y,
+				  }
+				: null,
+	};
 }
 
 export default function DropZoneComponent( {

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -13,7 +13,7 @@ import { upload, Icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { Context } from './provider';
+import { Context, INITIAL_DROP_ZONE_STATE } from './provider';
 
 export function useDropZone( {
 	element,
@@ -25,11 +25,7 @@ export function useDropZone( {
 	__unstableIsRelative: isRelative = false,
 } ) {
 	const dropZones = useContext( Context );
-	const [ state, setState ] = useState( {
-		isDraggingOverDocument: false,
-		isDraggingOverElement: false,
-		type: null,
-	} );
+	const [ state, setState ] = useState( INITIAL_DROP_ZONE_STATE );
 
 	useEffect( () => {
 		if ( ! isDisabled ) {

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -52,15 +52,16 @@ export function useDropZone( {
 		isRelative,
 	] );
 
+	const { x, y, ...remainingState } = state;
+	let position = null;
+
+	if ( x !== null && y !== null ) {
+		position = { x, y };
+	}
+
 	return {
-		...state,
-		position:
-			state.x && state.y
-				? {
-						x: state.x,
-						y: state.y,
-				  }
-				: null,
+		...remainingState,
+		position,
 	};
 }
 

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -98,6 +98,13 @@ function getHoveredDropZone( dropZones, position, dragEventType ) {
 	} );
 }
 
+export const INITIAL_DROP_ZONE_STATE = {
+	isDraggingOverDocument: false,
+	isDraggingOverElement: false,
+	position: null,
+	type: null,
+};
+
 export default function DropZoneProvider( { children } ) {
 	const ref = useRef();
 	const dropZones = useRef( new Set( [] ) );
@@ -160,12 +167,7 @@ export default function DropZoneProvider( { children } ) {
 		throttledUpdateDragZones.cancel();
 
 		dropZones.current.forEach( ( dropZone ) =>
-			dropZone.setState( {
-				isDraggingOverDocument: false,
-				isDraggingOverElement: false,
-				position: null,
-				type: null,
-			} )
+			dropZone.setState( INITIAL_DROP_ZONE_STATE )
 		);
 	}, [] );
 

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -38,10 +38,10 @@ function getDragEventType( { dataTransfer } ) {
 }
 
 function isTypeSupportedByDropZone( type, dropZone ) {
-	return (
-		( type === 'file' && !! dropZone.onFilesDrop ) ||
-		( type === 'html' && !! dropZone.onHTMLDrop ) ||
-		( type === 'default' && !! dropZone.onDrop )
+	return Boolean(
+		( type === 'file' && dropZone.onFilesDrop ) ||
+			( type === 'html' && dropZone.onHTMLDrop ) ||
+			( type === 'default' && dropZone.onDrop )
 	);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

There's an issue caused by #26893 where, in some contexts, the block editor infinitely re-renders after a click on the page.

It was pointed out to me by @fullofcaffeine that `useOnBlockDrop` could be the cause. The only change made there is the wrapping of some callbacks in `useCallback`, which should be used to **avoid** re-renderings or re-calculations. Turns out that if I take this guard away, the block editor does re-render infinitely after a click, which seems to be the exact same issue.

The refactor should be working without the guard, just like it did before. I thought I was reducing the amount of re-rendering, but in fact I was masking the introduction of many more re-renderings.

Looking deeper, we can see that there is a `mouseup` event handler which reset the state of each drop zone with a new object. When I make sure the same object is set for an empty state, the infinite loop is gone.

I'm not entirely sure what is causing the infinite loop in some contexts. Maybe there's a custom drop zone with unguarded callbacks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
