### PR TITLE
Reusable Blocks: Change from store name provided as a string to store definition

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -19,6 +19,7 @@ import {
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import {store as reusableBlocksStore} from '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies
@@ -51,7 +52,7 @@ export default function ReusableBlockEdit( {
 			isSaving: select( 'core' ).isSavingEntityRecord( ...recordArgs ),
 			canUserUpdate: select( 'core' ).canUser( 'update', 'blocks', ref ),
 			isEditing: select(
-				'core/reusable-blocks'
+				reusableBlocksStore
 			).__experimentalIsEditingReusableBlock( clientId ),
 			settings: select( 'core/block-editor' ).getSettings(),
 		} ),
@@ -60,7 +61,7 @@ export default function ReusableBlockEdit( {
 
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 	const { __experimentalSetEditingReusableBlock } = useDispatch(
-		'core/reusable-blocks'
+		reusableBlocksStore
 	);
 	const setIsEditing = useCallback(
 		( value ) => {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -19,7 +19,7 @@ import {
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import {store as reusableBlocksStore} from '@wordpress/reusable-blocks';
+import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies
@@ -72,7 +72,7 @@ export default function ReusableBlockEdit( {
 
 	const {
 		__experimentalConvertBlockToStatic: convertBlockToStatic,
-	} = useDispatch( 'core/reusable-blocks' );
+	} = useDispatch( reusableBlocksStore );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch(
 		'core/notices'

--- a/packages/reusable-blocks/README.md
+++ b/packages/reusable-blocks/README.md
@@ -72,8 +72,10 @@ return (
 This package also provides convenient utilities for managing reusable blocks through redux actions:
 
 ```js
+import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
+
 function MyConvertToStaticButton( { clientId } ) {
-    const { __experimentalConvertBlockToStatic } = useDispatch( 'core/reusable-blocks' );
+    const { __experimentalConvertBlockToStatic } = useDispatch( reusableBlocksStore );
     return (
         <button onClick={() => __experimentalConvertBlockToStatic( clientId )} >
             Convert to static
@@ -82,7 +84,7 @@ function MyConvertToStaticButton( { clientId } ) {
 }
 
 function MyConvertToReusableButton( { clientId } ) {
-    const { __experimentalConvertBlocksToReusable } = useDispatch( 'core/reusable-blocks' );
+    const { __experimentalConvertBlocksToReusable } = useDispatch( reusableBlocksStore );
     return (
         <button onClick={() => __experimentalConvertBlocksToReusable( [ clientId ] )} >
             Convert to reusable
@@ -91,7 +93,7 @@ function MyConvertToReusableButton( { clientId } ) {
 }
 
 function MyDeleteReusableBlockButton( { id } ) {
-    const { __experimentalDeleteReusableBlock } = useDispatch( 'core/reusable-blocks' );
+    const { __experimentalDeleteReusableBlock } = useDispatch( reusableBlocksStore );
     return (
         <button onClick={() => __experimentalDeleteReusableBlock( id )} >
             Delete reusable block

--- a/packages/reusable-blocks/src/store/controls.js
+++ b/packages/reusable-blocks/src/store/controls.js
@@ -9,7 +9,11 @@ import {
 } from '@wordpress/blocks';
 import { createRegistryControl } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as reusableBlocksStore } from './index.js';
 
 /**
  * Convert a reusable block to a static block effect handler

--- a/packages/reusable-blocks/src/store/controls.js
+++ b/packages/reusable-blocks/src/store/controls.js
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/blocks';
 import { createRegistryControl } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 
 /**
  * Convert a reusable block to a static block effect handler
@@ -94,7 +95,7 @@ const controls = {
 					.dispatch( 'core/block-editor' )
 					.replaceBlocks( clientIds, newBlock );
 				registry
-					.dispatch( 'core/reusable-blocks' )
+					.dispatch( reusableBlocksStore )
 					.__experimentalSetEditingReusableBlock(
 						newBlock.clientId,
 						true


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Regarding https://github.com/WordPress/gutenberg/issues/27088 
Change from store name provided as a string to store definition applied

## How has this been tested?
Not tested yet

## Types of changes 
Code refactor (non-breaking change)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
