### PR TITLE
Site Editor: Fix item color and padding in navigation panel

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -95,8 +95,8 @@
 		height: auto;
 		min-height: $button-size;
 		text-align: left;
-		padding-top: $grid-unit-10;
-		padding-bottom: $grid-unit-10;
+		padding-left: $grid-unit-20;
+		padding-right: $grid-unit-20;
 		margin-bottom: $grid-unit-15;
 		color: inherit;
 	}

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -98,6 +98,7 @@
 		padding-top: $grid-unit-10;
 		padding-bottom: $grid-unit-10;
 		margin-bottom: $grid-unit-15;
+		color: inherit;
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
https://github.com/WordPress/gutenberg/pull/27003 introduced a few styling changes which broke the color in the navigation panel. Also introduced some inconsistencies in padding.

## Screenshots
Before (`master`) Notice missing template below Front Page
![image](https://user-images.githubusercontent.com/2256104/99657911-0d664d00-2a5f-11eb-8fc5-16255d4bbfc4.png)


After (this branch)
![image](https://user-images.githubusercontent.com/2256104/99661536-43f29680-2a64-11eb-9472-ec281f8a1c24.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ x I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
