### PR TITLE
Fix: Font size unit back-compatibility does not executes on post edit

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -57,12 +57,6 @@ function gutenberg_get_common_block_editor_settings() {
 
 	$font_sizes = current( (array) get_theme_support( 'editor-font-sizes' ) );
 	if ( false !== $font_sizes ) {
-		// Back-compatibility for presets without units.
-		foreach ( $font_sizes as &$font_size ) {
-			if ( is_numeric( $font_size['size'] ) ) {
-				$font_size['size'] = $font_size['size'] . 'px';
-			}
-		}
 		$settings['fontSizes'] = $font_sizes;
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -291,10 +291,17 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 	}
 
 	if ( isset( $settings['fontSizes'] ) ) {
+		$font_sizes = $settings['fontSizes'];
+		// Back-compatibility for presets without units.
+		foreach ( $font_sizes as &$font_size ) {
+			if ( is_numeric( $font_size['size'] ) ) {
+				$font_size['size'] = $font_size['size'] . 'px';
+			}
+		}
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
-		$theme_settings['global']['settings']['typography']['fontSizes'] = $settings['fontSizes'];
+		$theme_settings['global']['settings']['typography']['fontSizes'] = $font_sizes;
 	}
 
 	// Things that didn't land in core yet, so didn't have a setting assigned.


### PR DESCRIPTION
Fixes a regression that happened on https://github.com/WordPress/gutenberg/pull/26903.
Previously the back-compatibility that added units on font sizes executed on both edit post and edit site, but now it is only executing on edit-site.
That is problematic for example if in a paragraph we set a custom font size of 25 the same paragraph will have a value for font size attribute of "25px" on the edit site and 25 on edit post. This PR fixes the issue and makes sure the font size back-compatibility executes in both screens.


## How has this been tested?
I enabled the 2021 blocks theme.
On edit post, I added a paragraph I made the font size equal to 25. I verified using the code editor the attribute value was "25px" on the master, it is 25 (bug).
I verified using the browser dev tools that a paragraph with font size equal to 25 was attribute value of 25px same as in the master.