### PR TITLE
Full Site Editing: Add the theme source to the templates wp-admin list

### DIFF
--- a/lib/templates.php
+++ b/lib/templates.php
@@ -205,6 +205,7 @@ function gutenberg_filter_template_list_table_columns( array $columns ) {
 	$columns['slug']        = __( 'Slug', 'gutenberg' );
 	$columns['description'] = __( 'Description', 'gutenberg' );
 	$columns['status']      = __( 'Status', 'gutenberg' );
+	$columns['theme']       = __( 'Theme', 'gutenberg' );
 	if ( isset( $columns['date'] ) ) {
 		unset( $columns['date'] );
 	}
@@ -239,6 +240,24 @@ function gutenberg_render_template_list_table_column( $column_name, $post_id ) {
 		}
 		$post_status_object = get_post_status_object( $post_status );
 		echo esc_html( $post_status_object->label );
+		return;
+	}
+
+	if ( 'theme' === $column_name ) {
+		$terms         = get_the_terms( $post_id, 'wp_theme' );
+		$themes        = array();
+		$is_file_based = false;
+		foreach( $terms as $term ) {
+			if ( '_wp_file_based' === $term->slug ) {
+				$is_file_based = true;
+			} else {
+				$themes[] = esc_html( wp_get_theme( $term->slug ) );
+			}
+		}
+		echo implode( '<br />', $themes );
+		if ( $is_file_based ) {
+			echo '<br />' . __( '(Created from a template file)', 'gutenberg' );
+		}
 		return;
 	}
 }

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -112,16 +112,13 @@ add_action( 'init', 'gutenberg_register_wp_theme_taxonomy' );
  * Automatically set the theme meta for templates.
  *
  * @param array $post_id Template ID.
- * @param array $post    Template Post.
- * @param bool  $update  Is update.
  */
-function gutenberg_set_template_and_template_part_post_theme( $post_id, $post, $update ) {
+function gutenberg_set_template_and_template_part_post_theme( $post_id ) {
 	$themes = wp_get_post_terms( $post_id, 'wp_theme' );
 	if ( ! $themes ) {
 		wp_set_post_terms( $post_id, array( wp_get_theme()->get_stylesheet() ), 'wp_theme', true );
 	}
 }
-
 add_action( 'save_post_wp_template', 'gutenberg_set_template_and_template_part_post_theme', 10, 3 );
 add_action( 'save_post_wp_template_part', 'gutenberg_set_template_and_template_part_post_theme', 10, 3 );
 
@@ -247,7 +244,7 @@ function gutenberg_render_template_list_table_column( $column_name, $post_id ) {
 		$terms         = get_the_terms( $post_id, 'wp_theme' );
 		$themes        = array();
 		$is_file_based = false;
-		foreach( $terms as $term ) {
+		foreach ( $terms as $term ) {
 			if ( '_wp_file_based' === $term->slug ) {
 				$is_file_based = true;
 			} else {


### PR DESCRIPTION
## Description

We recently added a `wp_theme` taxonomy to templates that keeps track of the theme to which a template belongs to, and whether it was originally created from a file.

This PR simply adds a new column to the templates wp-admin list that shows the theme name (or its slug if the theme is not installed on the site anymore), and a message to clarify that it originated as a file.

### Note

I don't have a good idea regarding the "file based" label.
The current `(Created from a template file)` label is a placeholder intended to start a discussion.

## How has this been tested?

Try activating different FSE themes, let them generate template posts from the provided files.
Open `/wp-admin/edit.php?post_type=wp_template`.
Check the Theme column, and make sure it displays the correct informations.
Try creating a custom template from scratch, and make sure it's not labeled as "file based".

## Screenshots <!-- if applicable -->

<img width="1123" alt="Screenshot 2020-11-19 at 14 43 44" src="https://user-images.githubusercontent.com/2070010/99681262-d8192980-2a75-11eb-8b9d-aad7aa3af308.png">

<img width="1121" alt="Screenshot 2020-11-19 at 14 43 37" src="https://user-images.githubusercontent.com/2070010/99681267-d94a5680-2a75-11eb-9fdb-acd0036848f4.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
