### PR TITLE
Chore: Update package lock to fix CI failures (again)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52102,9 +52102,9 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.0.tgz",
-					"integrity": "sha512-jjO6JD2rKfiZQnBoRzhRTbXjHLGLfH+UtGkWLc/UXAh/rzZMyjbgn0NcfFpqT8nd1kTtFnDiJcrIFkq4UKeJVg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"


### PR DESCRIPTION
Bump package lock file to fix CI failures.