### PR TITLE
Fix: Font size picker bug that adds px units to empty string values.

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -121,6 +121,13 @@ export default function FontSizePicker( {
 							type="number"
 							min={ 1 }
 							onChange={ ( event ) => {
+								if (
+									! event.target.value &&
+									event.target.value !== 0
+								) {
+									onChange( undefined );
+									return;
+								}
 								if ( hasUnits ) {
 									onChange( event.target.value + 'px' );
 								} else {


### PR DESCRIPTION
There was a  bug on the font size picker component where if the user selected a custom value and then deleted the value using backspace instead of the reset button made the attribute have a value of "px".

## How has this been tested?
I added a paragraph block.
I made the paragraph block have a font size value of 52.
I deleted the value using backspace and I verified the font-size attribute was not set anymore. On master it is "px".