### PR TITLE
Full Site Editing: Make sure templates and parts queries filter by tax_query

### DIFF
--- a/lib/templates-sync.php
+++ b/lib/templates-sync.php
@@ -26,7 +26,7 @@ function _gutenberg_create_auto_draft_for_template( $post_type, $slug, $theme, $
 		array(
 			'post_type'      => $post_type,
 			'post_status'    => array( 'publish', 'auto-draft' ),
-			'name'           => $slug,
+			'post_name__in'  => array( $slug ),
 			'tax_query'      => array(
 				array(
 					'taxonomy' => 'wp_theme',

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -24,7 +24,7 @@ function render_block_core_template_part( $attributes ) {
 			array(
 				'post_type'      => 'wp_template_part',
 				'post_status'    => 'publish',
-				'name'           => $attributes['slug'],
+				'post_name__in'  => array( $attributes['slug'] ),
 				'tax_query'      => array(
 					array(
 						'taxonomy' => 'wp_theme',


### PR DESCRIPTION
## Description

In a recent PR I've updated a template/parts `WP_Query` to search by slug instead of title:
```diff
- 'title' => $slug
+ 'name' => $slug
```

Little did I know that searching by `name` (AKA slug) makes the query "singular", which ignores any `tax_query`.

This is a big deal with templates and template parts, where they can have duplicated slugs (e.g. for templates originating from different themes), and indeed it was messing up the auto-draft creation on theme change.

## How has this been tested?

- Have two FSE themes handy.
- Wipe all the things (templates, template parts, last them sync options).
- Activate the first FSE theme.
- Open the Site Editor and make sure templates and template parts load as expected.
- Activate the second FSE theme.
- Open the Site Editor and again make sure templates and template parts load as expected, and they all belong to the second theme.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
