### PR TITLE
Fix: Preset controls need the preset CSS variables in scope

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -115,12 +115,14 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
  * the corresponding stylesheet.
  *
  * @param WP_Theme_JSON $tree Input tree.
+ * @param string        $type Type of stylesheet we want accepts 'all', 'block_styles', and 'css_variables'.
  *
  * @return string Stylesheet.
  */
-function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
+function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'all' ) {
 	// Check if we can use cached.
 	$can_use_cached = (
+		( 'all' === $type ) &&
 		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
 		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
 		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
@@ -135,9 +137,9 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 		}
 	}
 
-	$stylesheet = $tree->get_stylesheet();
+	$stylesheet = $tree->get_stylesheet( $type );
 
-	if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
+	if ( ( 'all' === $type || 'block_styles' === $type ) && gutenberg_experimental_global_styles_has_theme_json_support() ) {
 		// To support all themes, we added in the block-library stylesheet
 		// a style rule such as .has-link-color a { color: var(--wp--style--color--link, #00e); }
 		// so that existing link colors themes used didn't break.
@@ -221,7 +223,13 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		// we need to add the styles via the settings. This is because
 		// we want them processed as if they were added via add_editor_styles,
 		// which adds the editor wrapper class.
-		$settings['styles'][] = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( $all ) );
+		$settings['styles'][] = array(
+			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( $all, 'css_variables' ),
+			'__experimentalNoWrapper' => true,
+		);
+		$settings['styles'][] = array(
+			'css' => gutenberg_experimental_global_styles_get_stylesheet( $all, 'block_styles' ),
+		);
 	}
 
 	return $settings;

--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -23,20 +23,23 @@ import wrap from './transforms/wrap';
  * @return {Array} converted rules.
  */
 const transformStyles = ( styles, wrapperClassName = '' ) => {
-	return map( styles, ( { css, baseURL } ) => {
-		const transforms = [];
-		if ( wrapperClassName ) {
-			transforms.push( wrap( wrapperClassName ) );
-		}
-		if ( baseURL ) {
-			transforms.push( urlRewrite( baseURL ) );
-		}
-		if ( transforms.length ) {
-			return traverse( css, compose( transforms ) );
-		}
+	return map(
+		styles,
+		( { css, baseURL, __experimentalNoWrapper = false } ) => {
+			const transforms = [];
+			if ( wrapperClassName && ! __experimentalNoWrapper ) {
+				transforms.push( wrap( wrapperClassName ) );
+			}
+			if ( baseURL ) {
+				transforms.push( urlRewrite( baseURL ) );
+			}
+			if ( transforms.length ) {
+				return traverse( css, compose( transforms ) );
+			}
 
-		return css;
-	} );
+			return css;
+		}
+	);
 };
 
 export default transformStyles;

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -20,12 +20,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { default as getGlobalStyles } from './global-styles-renderer';
 import {
 	GLOBAL_CONTEXT,
 	getValueFromVariable,
 	getPresetVariable,
 } from './utils';
+import getGlobalStyles from './global-styles-renderer';
 
 const EMPTY_CONTENT = '{}';
 
@@ -200,7 +200,18 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 					css: getGlobalStyles(
 						contexts,
 						mergedStyles,
-						STYLE_PROPERTY
+						STYLE_PROPERTY,
+						'cssVariables'
+					),
+					isGlobalStyles: true,
+					__experimentalNoWrapper: true,
+				},
+				{
+					css: getGlobalStyles(
+						contexts,
+						mergedStyles,
+						STYLE_PROPERTY,
+						'blockStyles'
 					),
 					isGlobalStyles: true,
 				},

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -26,141 +26,159 @@ function compileStyleValue( uncompiledValue ) {
 	return uncompiledValue;
 }
 
-export default ( blockData, tree, metadata ) => {
-	const styles = [];
-	// Can this be converted to a context, as the global context?
-	// See comment in the server.
-	styles.push( LINK_COLOR_DECLARATION );
+/**
+ * Transform given preset tree into a set of style declarations.
+ *
+ * @param {Object} blockPresets
+ *
+ * @return {Array} An array of style declarations.
+ */
+function getBlockPresetsDeclarations( blockPresets = {} ) {
+	return reduce(
+		PRESET_CATEGORIES,
+		( declarations, { path, key }, category ) => {
+			const preset = get( blockPresets, path, [] );
+			preset.forEach( ( value ) => {
+				declarations.push(
+					`--wp--preset--${ kebabCase( category ) }--${
+						value.slug
+					}: ${ value[ key ] }`
+				);
+			} );
+			return declarations;
+		},
+		[]
+	);
+}
 
-	/**
-	 * Transform given style tree into a set of style declarations.
-	 *
-	 * @param {Object} blockSupports What styles the block supports.
-	 * @param {Object} blockStyles Block styles.
-	 *
-	 * @return {Array} An array of style declarations.
-	 */
-	const getBlockStylesDeclarations = ( blockSupports, blockStyles = {} ) => {
-		const declarations = [];
-		Object.keys( metadata ).forEach( ( key ) => {
+/**
+ * Transform given preset tree into a set of preset class declarations.
+ *
+ * @param {string} blockSelector
+ * @param {Object} blockPresets
+ * @return {string} CSS declarations for the preset classes.
+ */
+function getBlockPresetClasses( blockSelector, blockPresets = {} ) {
+	return reduce(
+		PRESET_CLASSES,
+		( declarations, { path, key, property }, classSuffix ) => {
+			const presets = get( blockPresets, path, [] );
+			presets.forEach( ( preset ) => {
+				const slug = preset.slug;
+				const value = preset[ key ];
+				const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;
+				const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
+				declarations += `${ selectorToUse } {${ property }: ${ value };}`;
+			} );
+			return declarations;
+		},
+		''
+	);
+}
+
+function flattenTree( input = {}, prefix, token ) {
+	let result = [];
+	Object.keys( input ).forEach( ( key ) => {
+		const newKey = prefix + kebabCase( key.replace( '/', '-' ) );
+		const newLeaf = input[ key ];
+
+		if ( newLeaf instanceof Object ) {
+			const newPrefix = newKey + token;
+			result = [ ...result, ...flattenTree( newLeaf, newPrefix, token ) ];
+		} else {
+			result.push( `${ newKey }: ${ newLeaf }` );
+		}
+	} );
+	return result;
+}
+
+/**
+ * Transform given style tree into a set of style declarations.
+ *
+ * @param {Object} blockSupports What styles the block supports.
+ * @param {Object} blockStyles   Block styles.
+ * @param {Object} metadata      Block styles metadata information.
+ *
+ * @return {Array} An array of style declarations.
+ */
+function getBlockStylesDeclarations(
+	blockSupports,
+	blockStyles = {},
+	metadata
+) {
+	return reduce(
+		metadata,
+		( declarations, { value }, key ) => {
 			const cssProperty = key.startsWith( '--' ) ? key : kebabCase( key );
 			if (
 				blockSupports.includes( key ) &&
-				get( blockStyles, metadata[ key ].value, false )
+				get( blockStyles, value, false )
 			) {
 				declarations.push(
 					`${ cssProperty }: ${ compileStyleValue(
-						get( blockStyles, metadata[ key ].value )
+						get( blockStyles, value )
 					) }`
 				);
 			}
-		} );
+			return declarations;
+		},
+		[]
+	);
+}
 
-		return declarations;
-	};
-
-	/**
-	 * Transform given preset tree into a set of preset class declarations.
-	 *
-	 * @param {string} blockSelector
-	 * @param {Object} blockPresets
-	 * @return {string} CSS declarations for the preset classes.
-	 */
-	const getBlockPresetClasses = ( blockSelector, blockPresets = {} ) => {
-		return reduce(
-			PRESET_CLASSES,
-			( declarations, { path, key, property }, classSuffix ) => {
-				const presets = get( blockPresets, path, [] );
-				presets.forEach( ( preset ) => {
-					const slug = preset.slug;
-					const value = preset[ key ];
-					const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;
-					const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
-					declarations += `${ selectorToUse } {${ property }: ${ value };}`;
-				} );
-				return declarations;
-			},
-			''
-		);
-	};
-
-	/**
-	 * Transform given preset tree into a set of style declarations.
-	 *
-	 * @param {Object} blockPresets
-	 *
-	 * @return {Array} An array of style declarations.
-	 */
-	const getBlockPresetsDeclarations = ( blockPresets = {} ) => {
-		return reduce(
-			PRESET_CATEGORIES,
-			( declarations, { path, key }, category ) => {
-				const preset = get( blockPresets, path, [] );
-				preset.forEach( ( value ) => {
-					declarations.push(
-						`--wp--preset--${ kebabCase( category ) }--${
-							value.slug
-						}: ${ value[ key ] }`
-					);
-				} );
-				return declarations;
-			},
-			[]
-		);
-	};
-
-	const flattenTree = ( input, prefix, token ) => {
-		let result = [];
-		Object.keys( input ).forEach( ( key ) => {
-			const newKey = prefix + kebabCase( key.replace( '/', '-' ) );
-			const newLeaf = input[ key ];
-
-			if ( newLeaf instanceof Object ) {
-				const newPrefix = newKey + token;
-				result = [
-					...result,
-					...flattenTree( newLeaf, newPrefix, token ),
+export default ( blockData, tree, metadata, type = 'all' ) => {
+	return reduce(
+		blockData,
+		( styles, { selector }, context ) => {
+			if ( type === 'all' || type === 'cssVariables' ) {
+				const variableDeclarations = [
+					...getBlockPresetsDeclarations(
+						tree?.[ context ]?.settings
+					),
+					...flattenTree(
+						tree?.[ context ]?.settings?.custom,
+						'--wp--custom--',
+						'--'
+					),
 				];
-			} else {
-				result.push( `${ newKey }: ${ newLeaf }` );
+
+				if ( variableDeclarations.length > 0 ) {
+					styles.push(
+						`${ selector } { ${ variableDeclarations.join(
+							';'
+						) } }`
+					);
+				}
 			}
-		} );
-		return result;
-	};
+			if ( type === 'all' || type === 'blockStyles' ) {
+				const blockStyleDeclarations = getBlockStylesDeclarations(
+					blockData[ context ].supports,
+					tree?.[ context ]?.styles,
+					metadata
+				);
 
-	const getCustomDeclarations = ( blockCustom = {} ) => {
-		if ( Object.keys( blockCustom ).length === 0 ) {
-			return [];
-		}
+				if ( blockStyleDeclarations.length > 0 ) {
+					styles.push(
+						`${ selector } { ${ blockStyleDeclarations.join(
+							';'
+						) } }`
+					);
+				}
 
-		return flattenTree( blockCustom, '--wp--custom--', '--' );
-	};
-
-	Object.keys( blockData ).forEach( ( context ) => {
-		const blockSelector = blockData[ context ].selector;
-
-		const blockDeclarations = [
-			...getBlockStylesDeclarations(
-				blockData[ context ].supports,
-				tree?.[ context ]?.styles
-			),
-			...getBlockPresetsDeclarations( tree?.[ context ]?.settings ),
-			...getCustomDeclarations( tree?.[ context ]?.settings?.custom ),
-		];
-		if ( blockDeclarations.length > 0 ) {
-			styles.push(
-				`${ blockSelector } { ${ blockDeclarations.join( ';' ) } }`
-			);
-		}
-
-		const presetClasses = getBlockPresetClasses(
-			blockSelector,
-			tree?.[ context ]?.settings
-		);
-		if ( presetClasses ) {
-			styles.push( presetClasses );
-		}
-	} );
-
-	return styles.join( '' );
+				const presetClasses = getBlockPresetClasses(
+					selector,
+					tree?.[ context ]?.settings
+				);
+				if ( presetClasses ) {
+					styles.push( presetClasses );
+				}
+			}
+			return styles;
+		},
+		// Can this be converted to a context, as the global context?
+		// See comment in the server.
+		type === 'all' || type === 'blockStyles'
+			? [ LINK_COLOR_DECLARATION ]
+			: []
+	).join( '' );
 };

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -215,10 +215,18 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$result     = $theme_json->get_stylesheet();
-		$stylesheet = ':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}';
-
-		$this->assertEquals( $stylesheet, $result );
+		$this->assertEquals(
+			$theme_json->get_stylesheet(),
+			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}'
+		);
+		$this->assertEquals(
+			$theme_json->get_stylesheet( 'block_styles' ),
+			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}'
+		);
+		$this->assertEquals(
+			$theme_json->get_stylesheet( 'css_variables' ),
+			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}'
+		);
 	}
 
 	public function test_merge_incoming_data() {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/26511

This PR makes sure presets and CSS vars are available in the scope of editor UI. These styles are just defining CSS variables and specific classes they should not impact anything in the UI. But if a UI component needs a variable e.g: a gradient preset that depends on a color preset having the variable available makes the UI components look as expected.


## How has this been tested?
I enabled 2021 blocks.
I added the following declaration to theme.json:
```
{
  "color": {
    "gradients": [
      {
        "slug": "some-gradient",
        "gradient": "linear-gradient(to bottom, transparent 20%, var(--wp--preset--color--secondary) 20%, var(--wp--preset--color--secondary) 80%, transparent 80%)"
      }
    ],
    "palette": [
      {
        "slug": "primary",
        "color": "#000000"
      },
      {
        "slug": "secondary",
        "color": "#3C8067"
      }
    ]
  }
}
```
I verified the gradient control circle renders as expected.
