### PR TITLE
Dom Package: Fix `placeCaretAtHorizontalEdge`

### DIFF
--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 2.12.0 (2020-11-19)
+
+### Bug Fix
+
+- Update `placeCaretAtHorizontalEdge` to account for input element types that don't support selectionStart or selectionEnd attributes.
+
 ## 2.11.0 (2020-06-15)
 
 ### New Feature

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -277,6 +277,22 @@ export function computeCaretRect( win ) {
 }
 
 /**
+ * Only certain types of inputs support the selection start and selection end
+ * attributes. This method ensures that the provided selection attributes are
+ * available on the given HTML Input element.
+ * See https://html.spec.whatwg.org/multipage/input.html#do-not-apply
+ *
+ * @param {HTMLInputElement} container Focusable input element.
+ *
+ * @return {boolean} True if selection start and end are supported. False if not.
+ */
+function canSetInputSelectionRange( container ) {
+	const selectableTypes = [ 'text', 'search', 'password', 'tel', 'url' ];
+
+	return includes( selectableTypes, container.type );
+}
+
+/**
  * Places the caret at start or end of a given element.
  *
  * @param {Element} container Focusable element.
@@ -289,13 +305,20 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
 
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		container.focus();
-		if ( isReverse ) {
-			container.selectionStart = container.value.length;
-			container.selectionEnd = container.value.length;
-		} else {
-			container.selectionStart = 0;
-			container.selectionEnd = 0;
+
+		if (
+			container.tagName === 'TEXTAREA' ||
+			canSetInputSelectionRange( container )
+		) {
+			if ( isReverse ) {
+				container.selectionStart = container.value.length;
+				container.selectionEnd = container.value.length;
+			} else {
+				container.selectionStart = 0;
+				container.selectionEnd = 0;
+			}
 		}
+
 		return;
 	}
 

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -88,18 +88,33 @@ describe( 'DOM', () => {
 
 	describe( 'placeCaretAtHorizontalEdge', () => {
 		describe( 'when provided an input', () => {
-			it( 'should place caret at the start of the input', () => {
-				const input = document.createElement( 'input' );
-				input.value = 'value';
-				placeCaretAtHorizontalEdge( input, true );
-				expect( isHorizontalEdge( input, false ) ).toBe( true );
+			describe( 'and the input type supports setting a selection range', () => {
+				it( 'should place caret at the start of the input', () => {
+					const input = document.createElement( 'input' );
+					input.type = 'text';
+					input.value = 'value';
+					placeCaretAtHorizontalEdge( input, true );
+					expect( isHorizontalEdge( input, false ) ).toBe( true );
+				} );
+
+				it( 'should place caret at the end of the input', () => {
+					const input = document.createElement( 'input' );
+					input.type = 'text';
+					input.value = 'value';
+					placeCaretAtHorizontalEdge( input, false );
+					expect( isHorizontalEdge( input, true ) ).toBe( true );
+				} );
 			} );
 
-			it( 'should place caret at the end of the input', () => {
-				const input = document.createElement( 'input' );
-				input.value = 'value';
-				placeCaretAtHorizontalEdge( input, false );
-				expect( isHorizontalEdge( input, true ) ).toBe( true );
+			describe( 'and the input does not support setting a selection range', () => {
+				it( 'does not error', () => {
+					const input = document.createElement( 'input' );
+					input.type = 'time';
+					input.value = 'value';
+					expect( () =>
+						placeCaretAtHorizontalEdge( input, true )
+					).not.toThrow();
+				} );
 			} );
 		} );
 

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -87,18 +87,36 @@ describe( 'DOM', () => {
 	} );
 
 	describe( 'placeCaretAtHorizontalEdge', () => {
-		it( 'should place caret at the start of the input', () => {
-			const input = document.createElement( 'input' );
-			input.value = 'value';
-			placeCaretAtHorizontalEdge( input, true );
-			expect( isHorizontalEdge( input, false ) ).toBe( true );
+		describe( 'when provided an input', () => {
+			it( 'should place caret at the start of the input', () => {
+				const input = document.createElement( 'input' );
+				input.value = 'value';
+				placeCaretAtHorizontalEdge( input, true );
+				expect( isHorizontalEdge( input, false ) ).toBe( true );
+			} );
+
+			it( 'should place caret at the end of the input', () => {
+				const input = document.createElement( 'input' );
+				input.value = 'value';
+				placeCaretAtHorizontalEdge( input, false );
+				expect( isHorizontalEdge( input, true ) ).toBe( true );
+			} );
 		} );
 
-		it( 'should place caret at the end of the input', () => {
-			const input = document.createElement( 'input' );
-			input.value = 'value';
-			placeCaretAtHorizontalEdge( input, false );
-			expect( isHorizontalEdge( input, true ) ).toBe( true );
+		describe( 'when provided a text area', () => {
+			it( 'should place caret at the start of the input', () => {
+				const textarea = document.createElement( 'textarea' );
+				textarea.value = 'value';
+				placeCaretAtHorizontalEdge( textarea, true );
+				expect( isHorizontalEdge( textarea, false ) ).toBe( true );
+			} );
+
+			it( 'should place caret at the end of the input', () => {
+				const textarea = document.createElement( 'textarea' );
+				textarea.value = 'value';
+				placeCaretAtHorizontalEdge( textarea, false );
+				expect( isHorizontalEdge( textarea, true ) ).toBe( true );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
When using the list view to select a jetpack Business Block, the execution thread was invoking `placeCaretAtHorizontalEdge` from the `dom` library. `placeCaretAtHorizontalEdge` was, however, attempting to reassign `selectionStart` and `selectionEnd` on HTML Input Elements, and unfortunately, not all input types support those attributes. See [relevant documentation](https://html.spec.whatwg.org/multipage/input.html#do-not-apply).

https://github.com/WordPress/gutenberg/blob/d27e094d2bac7a5d1bdfd55598007563324e10e3/packages/dom/src/dom.js#L290-L297

Because the business block was using "time" input elements, the block broke.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Set up local instance of WordPress with Gutenberg
- Install Jetpack plugin
- Navigate to page or post editor
- Insert a paragraph block and add text content
- Insert a business hours block
- Focus on the paragraph block
- From the list view, focus on the business hours block
- Confirm that the block no longer errors on focus

## Screenshots <!-- if applicable -->
### Before
![BusinessHoursBlockIssue](https://user-images.githubusercontent.com/16104522/99191736-611a2300-274d-11eb-9b6b-1cabf3055a0c.gif)
### After
![2020-11-19 19 45 18](https://user-images.githubusercontent.com/5414230/99755610-0ca1db00-2aa0-11eb-9cbc-b4799951fe76.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fixes https://github.com/Automattic/wp-calypso/issues/47439

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
