### PR TITLE
[RNMobile] File block link to toolbar

### DIFF
--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -230,11 +230,16 @@ export class FileEdit extends Component {
 			actionButtonStyle,
 			dimmedStyle
 		);
+
+		const bottomSheetPadding = withBottomSheet
+			? styles.linkSettingsPanel
+			: undefined;
+
 		const settings = (
 			<>
 				{ panelTitle && <PanelBody title={ panelTitle } /> }
 				{
-					<PanelBody>
+					<PanelBody style={ bottomSheetPadding }>
 						<SelectControl
 							icon={ link }
 							label={ __( 'Link to' ) }

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -34,3 +34,8 @@
 .actionButtonDark {
 	color: $blue-30;
 }
+
+.linkSettingsPanel {
+	padding-left: 0;
+	padding-right: 0;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
The Link button is added to the toolbar so that clicking it will open the bottom sheet with the options. 

## How has this been tested?
To test

1. Add a File Block. 
2. Add a file. 
3. Click the Link button to see the menu. 

## Screenshots <!-- if applicable -->
![linkto](https://user-images.githubusercontent.com/1509205/99775259-ff571180-2adc-11eb-8a92-daadc9baf66c.gif)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
