### PR TITLE
Buttons: Add a font size control

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -65,6 +65,7 @@
 			"__experimentalSkipSerialization": true,
 			"gradients": true
 		},
+		"fontSize": true,
 		"reusable": false,
 		"__experimentalSelector": ".wp-block-button__link"
 	},

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -31,6 +31,10 @@ $blocks-block__margin: 0.5em;
 		/*rtl:ignore*/
 		text-align: right;
 	}
+
+	.wp-block-buttons > .wp-block-button > & {
+		font-size: inherit;
+	}
 }
 
 // Increased specificity needed to override margins


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
In #20967 we have discussed adding a font size control to the button
block. This explores doing that, by adding `fontSize` to the block's
supported features.

Unfortunately, in testing with the TwentyTwenty theme, the size is
overridden by the theme's CSS. I've reset this in the block's CSS but
it would probably require theme updates to set the style on
`.wp-block-button` rather than `.wp-block-button__link` in order to make
sure this doesn't do something unexpected.

As it stands the default button size will have increased. I'm not sure if it 
has other consequences.

## How has this been tested?
Just manually for now with the TwentyTwenty theme

## Screenshots <!-- if applicable -->

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/96462/99792680-57af0300-2b1f-11eb-9e6b-07da07e70be3.png">


## Types of changes

This is essentially a new feature. Introducing this capability to an existing block.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
