### PR TITLE
Replace adminbar customize link with site-editor in FSE themes

### DIFF
--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -76,7 +76,7 @@ function gutenberg_adminbar_items( $wp_admin_bar ) {
 	$wp_admin_bar->remove_node( 'widgets' );
 
 	// Add site-editor link.
-	if ( ! is_admin() ) {
+	if ( ! is_admin() && current_user_can( 'edit_theme_options' ) ) {
 		$wp_admin_bar->add_node(
 			array(
 				'id'    => 'site-editor',

--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -63,6 +63,12 @@ add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
  * @param WP_Admin_Bar $wp_admin_bar The admin-bar instance.
  */
 function gutenberg_remove_legacy_adminbar_items( $wp_admin_bar ) {
+
+	// Early exit if not an FSE theme.
+	if ( ! gutenberg_is_fse_theme() ) {
+		return;
+	}
+
 	$wp_admin_bar->remove_node( 'customize' );
 	$wp_admin_bar->remove_node( 'customize-background' );
 	$wp_admin_bar->remove_node( 'customize-header' );

--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -62,7 +62,7 @@ add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
  *
  * @param WP_Admin_Bar $wp_admin_bar The admin-bar instance.
  */
-function gutenberg_remove_legacy_adminbar_items( $wp_admin_bar ) {
+function gutenberg_adminbar_items( $wp_admin_bar ) {
 
 	// Early exit if not an FSE theme.
 	if ( ! gutenberg_is_fse_theme() ) {
@@ -74,7 +74,7 @@ function gutenberg_remove_legacy_adminbar_items( $wp_admin_bar ) {
 	$wp_admin_bar->remove_node( 'customize-header' );
 }
 
-add_action( 'admin_bar_menu', 'gutenberg_remove_legacy_adminbar_items', 999 );
+add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 999 );
 
 /**
  * Activates the 'menu_order' filter and then hooks into 'menu_order'

--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -69,12 +69,25 @@ function gutenberg_adminbar_items( $wp_admin_bar ) {
 		return;
 	}
 
+	// Remove customizer link.
 	$wp_admin_bar->remove_node( 'customize' );
 	$wp_admin_bar->remove_node( 'customize-background' );
 	$wp_admin_bar->remove_node( 'customize-header' );
+	$wp_admin_bar->remove_node( 'widgets' );
+
+	// Add site-editor link.
+	if ( ! is_admin() ) {
+		$wp_admin_bar->add_node(
+			array(
+				'id'    => 'site-editor',
+				'title' => __( 'Site Editor', 'gutenberg' ),
+				'href'  => admin_url( 'admin.php?page=gutenberg-edit-site' ),
+			)
+		);
+	}
 }
 
-add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 999 );
+add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
 
 /**
  * Activates the 'menu_order' filter and then hooks into 'menu_order'

--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -80,7 +80,7 @@ function gutenberg_adminbar_items( $wp_admin_bar ) {
 		$wp_admin_bar->add_node(
 			array(
 				'id'    => 'site-editor',
-				'title' => __( 'Site Editor', 'gutenberg' ),
+				'title' => __( 'Edit site', 'gutenberg' ),
 				'href'  => admin_url( 'admin.php?page=gutenberg-edit-site' ),
 			)
 		);

--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -58,6 +58,19 @@ function gutenberg_remove_legacy_pages() {
 add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
 
 /**
+ * Removes legacy adminbar items from FSE themes.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The admin-bar instance.
+ */
+function gutenberg_remove_legacy_adminbar_items( $wp_admin_bar ) {
+	$wp_admin_bar->remove_node( 'customize' );
+	$wp_admin_bar->remove_node( 'customize-background' );
+	$wp_admin_bar->remove_node( 'customize-header' );
+}
+
+add_action( 'admin_bar_menu', 'gutenberg_remove_legacy_adminbar_items', 999 );
+
+/**
  * Activates the 'menu_order' filter and then hooks into 'menu_order'
  */
 add_filter( 'custom_menu_order', '__return_true' );


### PR DESCRIPTION
## Description
Replaces the "Customize" link with "Edit site".

This is only for FSE themes on the frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
