### PR TITLE
Scripts: Autoformat TypeScript files with format-js

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Autoformat TypeScript files (`*.ts` and `*.tsx`) in `format-js` script (#)[].
+
 ## 12.5.0 (2020-10-30)
 
 ### Enhancements

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Autoformat TypeScript files (`*.ts` and `*.tsx`) in `format-js` script (#)[].
+-   Autoformat TypeScript files (`*.ts` and `*.tsx`) in `format-js` script (#27138)[https://github.com/WordPress/gutenberg/pull/27138].
 
 ## 12.5.0 (2020-10-30)
 

--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -103,7 +103,9 @@ if ( fileArgs.length === 0 ) {
 }
 
 // Converts `foo/bar` directory to `foo/bar/**/*.js`
-const globArgs = dirGlob( fileArgs, { extensions: [ 'js', 'jsx' ] } );
+const globArgs = dirGlob( fileArgs, {
+	extensions: [ 'js', 'jsx', 'ts', 'tsx' ],
+} );
 
 const result = spawn(
 	resolveBin( 'prettier' ),


### PR DESCRIPTION
## Description

`format-js` script formats `.js` and `.jsx` extensions, but can (and should!) format `.ts` and `.tsx` extensions as well.

## How has this been tested?

From the project root, run `npm run format-js`.

## Types of changes

New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
