### PR TITLE
Navigation Panel: Hide empty menus

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates-pages.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates-pages.js
@@ -20,15 +20,15 @@ import { MENU_TEMPLATES, MENU_TEMPLATES_PAGES } from '../constants';
 
 export default function TemplatesPagesMenu( { templates } ) {
 	const defaultTemplate = templates?.find( ( { slug } ) => slug === 'page' );
-	const specificTemplates = templates?.filter( ( { slug } ) =>
-		slug.startsWith( 'page-' )
-	);
+	const specificTemplates =
+		templates?.filter( ( { slug } ) => slug.startsWith( 'page-' ) ) ?? [];
 
 	return (
 		<NavigationMenu
 			menu={ MENU_TEMPLATES_PAGES }
 			title={ __( 'Pages' ) }
 			parentMenu={ MENU_TEMPLATES }
+			isEmpty={ ! defaultTemplate && specificTemplates.length === 0 }
 		>
 			<NavigationGroup title={ _x( 'Specific', 'specific templates' ) }>
 				{ map( specificTemplates, ( template ) => (

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates-posts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates-posts.js
@@ -23,18 +23,20 @@ import {
 } from '../constants';
 
 export default function TemplatesPostsMenu( { templates } ) {
-	const generalTemplates = templates?.filter( ( { slug } ) =>
-		TEMPLATES_POSTS.includes( slug )
-	);
-	const specificTemplates = templates?.filter( ( { slug } ) =>
-		slug.startsWith( 'post-' )
-	);
+	const generalTemplates =
+		templates?.filter( ( { slug } ) => TEMPLATES_POSTS.includes( slug ) ) ??
+		[];
+	const specificTemplates =
+		templates?.filter( ( { slug } ) => slug.startsWith( 'post-' ) ) ?? [];
 
 	return (
 		<NavigationMenu
 			menu={ MENU_TEMPLATES_POSTS }
 			title={ __( 'Posts' ) }
 			parentMenu={ MENU_TEMPLATES }
+			isEmpty={
+				generalTemplates.length === 0 && specificTemplates.length === 0
+			}
 		>
 			<NavigationGroup title={ _x( 'Specific', 'specific templates' ) }>
 				{ map( specificTemplates, ( template ) => (

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
@@ -65,10 +65,12 @@ export default function TemplatesMenu() {
 			<NavigationItem
 				navigateToMenu={ MENU_TEMPLATES_PAGES }
 				title={ __( 'Pages' ) }
+				hideIfTargetMenuEmpty
 			/>
 			<NavigationItem
 				navigateToMenu={ MENU_TEMPLATES_POSTS }
 				title={ __( 'Posts' ) }
+				hideIfTargetMenuEmpty
 			/>
 			<TemplatesPostsMenu templates={ templates } />
 			<TemplatesPagesMenu templates={ templates } />


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Hides empty menus in the navigation panel. Namely `Templates -> Pages` and `Templates -> Posts`.

## How has this been tested?
Since 2021-blocks theme includes templates for both Pages and Posts, we need to delete one of them. (Easiest way is using a file manager plugin and navigating to `wp-content/themes/twentytwentyone-blocks/block-templates` and delete `page.html` then delete your auto-draft in the Templates. This should hide `Pages`. You can do the same for `Posts` with the `single.html` file.

## Screenshots <!-- if applicable -->
Both pages and posts are hidden
![image](https://user-images.githubusercontent.com/2256104/99802761-8d141a80-2b38-11eb-8bfa-b8451f344498.png)
## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
