### PR TITLE
Align single half width column to left

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -2,6 +2,8 @@
 // cascade into columns.
 .wp-block-columns .wp-block {
 	max-width: none;
+	margin-left: inherit;
+	margin-right: inherit;
 }
 
 // To do: remove horizontal margin override by the editor.

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -2,8 +2,8 @@
 // cascade into columns.
 .wp-block-columns .wp-block {
 	max-width: none;
-	margin-left: inherit;
-	margin-right: inherit;
+	margin-left: 0;
+	margin-right: 0;
 }
 
 // To do: remove horizontal margin override by the editor.


### PR DESCRIPTION
Fixes #26538

Adds more specific margin rules to `.wp-block-columns .wp-block `. Should not break anything else.
To test:

- In a new post
- Add a columns block with one column
- Set the width of the column to 50%
- The column should be aligned to the left