### PR TITLE
Scripts: Add TypeScript support to linting command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11321,6 +11321,252 @@
 				"@types/node": "*"
 			}
 		},
+		"@typescript-eslint/eslint-plugin": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz",
+			"integrity": "sha512-DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "4.15.0",
+				"@typescript-eslint/scope-manager": "4.15.0",
+				"debug": "^4.1.1",
+				"functional-red-black-tree": "^1.0.1",
+				"lodash": "^4.17.15",
+				"regexpp": "^3.0.0",
+				"semver": "^7.3.2",
+				"tsutils": "^3.17.1"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+					"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+					"dev": true
+				},
+				"@typescript-eslint/experimental-utils": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
+					"integrity": "sha512-V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.3",
+						"@typescript-eslint/scope-manager": "4.15.0",
+						"@typescript-eslint/types": "4.15.0",
+						"@typescript-eslint/typescript-estree": "4.15.0",
+						"eslint-scope": "^5.0.0",
+						"eslint-utils": "^2.0.0"
+					}
+				},
+				"@typescript-eslint/scope-manager": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+					"integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.15.0",
+						"@typescript-eslint/visitor-keys": "4.15.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+					"integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
+					"integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.15.0",
+						"@typescript-eslint/visitor-keys": "4.15.0",
+						"debug": "^4.1.1",
+						"globby": "^11.0.1",
+						"is-glob": "^4.0.1",
+						"semver": "^7.3.2",
+						"tsutils": "^3.17.1"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+					"integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.15.0",
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+					"dev": true
+				},
+				"esrecurse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.2.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+							"dev": true
+						}
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+					"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
+					"integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"merge2": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"picomatch": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+					"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
+			}
+		},
 		"@typescript-eslint/experimental-utils": {
 			"version": "4.11.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.1.tgz",
@@ -12757,6 +13003,7 @@
 			"version": "file:packages/eslint-plugin",
 			"dev": true,
 			"requires": {
+				"@typescript-eslint/eslint-plugin": "^4.15.0",
 				"@typescript-eslint/parser": "^4.15.0",
 				"@wordpress/prettier-config": "file:packages/prettier-config",
 				"babel-eslint": "^10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11364,6 +11364,207 @@
 				}
 			}
 		},
+		"@typescript-eslint/parser": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.0.tgz",
+			"integrity": "sha512-L6Dtbq8Bc7g2aZwnIBETpmUa9XDKCMzKVwAArnGp5Mn7PRNFjf3mUzq8UeBjL3K8t311hvevnyqXAMSmxO8Gpg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/scope-manager": "4.15.0",
+				"@typescript-eslint/types": "4.15.0",
+				"@typescript-eslint/typescript-estree": "4.15.0",
+				"debug": "^4.1.1"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+					"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+					"dev": true
+				},
+				"@typescript-eslint/scope-manager": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+					"integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.15.0",
+						"@typescript-eslint/visitor-keys": "4.15.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+					"integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
+					"integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.15.0",
+						"@typescript-eslint/visitor-keys": "4.15.0",
+						"debug": "^4.1.1",
+						"globby": "^11.0.1",
+						"is-glob": "^4.0.1",
+						"semver": "^7.3.2",
+						"tsutils": "^3.17.1"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+					"integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.15.0",
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+					"dev": true
+				},
+				"fast-glob": {
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+					"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
+					"integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"merge2": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"picomatch": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+					"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
+			}
+		},
 		"@typescript-eslint/scope-manager": {
 			"version": "4.11.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.1.tgz",
@@ -12556,6 +12757,7 @@
 			"version": "file:packages/eslint-plugin",
 			"dev": true,
 			"requires": {
+				"@typescript-eslint/parser": "^4.15.0",
 				"@wordpress/prettier-config": "file:packages/prettier-config",
 				"babel-eslint": "^10.1.0",
 				"cosmiconfig": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -292,14 +292,14 @@
 		"*.scss": [
 			"wp-scripts lint-style"
 		],
-		"*.js": [
+		"*.{js,ts,tsx}": [
 			"wp-scripts format-js",
 			"wp-scripts lint-js"
 		],
 		"{docs/{toc.json,tool/*.js},packages/{*/README.md,components/src/*/**/README.md}}": [
 			"node ./docs/tool/index.js"
 		],
-		"packages/**/*.js": [
+		"packages/**/*.{js,ts,tsx}": [
 			"node ./bin/api-docs/update-api-docs.js",
 			"node ./bin/api-docs/are-api-docs-unstaged.js",
 			"node ./bin/packages/lint-staged-typecheck.js"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -67,6 +67,11 @@
 		"tinycolor2": "^1.4.2",
 		"uuid": "^8.3.0"
 	},
+	"peerDependencies": {
+		"@wp-g2/create-styles": "^0.0.154",
+		"react": "^16.13.1",
+		"reakit-utils": "^0.15.1"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,7 +69,6 @@
 	},
 	"peerDependencies": {
 		"@wp-g2/create-styles": "^0.0.154",
-		"react": "^16.13.1",
 		"reakit-utils": "^0.15.1"
 	},
 	"publishConfig": {

--- a/packages/components/src/ui/control-group/types.ts
+++ b/packages/components/src/ui/control-group/types.ts
@@ -2,12 +2,12 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 /**
  * Internal dependencies
  */
-import { FlexProps } from '../flex/types';
+import type { FlexProps } from '../flex/types';
 
 export type ControlGroupContext = {
 	isFirst?: boolean;

--- a/packages/components/src/ui/control-group/types.ts
+++ b/packages/components/src/ui/control-group/types.ts
@@ -1,5 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
 import { CSSProperties } from 'react';
 
+/**
+ * Internal dependencies
+ */
 import { FlexProps } from '../flex/types';
 
 export type ControlGroupContext = {

--- a/packages/components/src/ui/control-label/types.ts
+++ b/packages/components/src/ui/control-label/types.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { Props as TextProps } from '../text/types';
+import type { Props as TextProps } from '../text/types';
 
 export type Props = TextProps & {
 	isBlock?: boolean;

--- a/packages/components/src/ui/elevation/types.ts
+++ b/packages/components/src/ui/elevation/types.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 export type Props = {
 	/**

--- a/packages/components/src/ui/elevation/types.ts
+++ b/packages/components/src/ui/elevation/types.ts
@@ -1,3 +1,7 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
 import { CSSProperties } from 'react';
 
 export type Props = {

--- a/packages/components/src/ui/flex/types.ts
+++ b/packages/components/src/ui/flex/types.ts
@@ -2,12 +2,12 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 /**
  * Internal dependencies
  */
-import { ResponsiveCSSValue } from '../utils/types';
+import type { ResponsiveCSSValue } from '../utils/types';
 
 export type FlexDirection = ResponsiveCSSValue<
 	CSSProperties[ 'flexDirection' ]

--- a/packages/components/src/ui/flex/types.ts
+++ b/packages/components/src/ui/flex/types.ts
@@ -1,4 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
 import { CSSProperties } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import { ResponsiveCSSValue } from '../utils/types';
 
 export type FlexDirection = ResponsiveCSSValue<

--- a/packages/components/src/ui/form-group/types.ts
+++ b/packages/components/src/ui/form-group/types.ts
@@ -2,13 +2,13 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { CSSProperties, ReactNode, ReactText } from 'react';
+import type { CSSProperties, ReactNode, ReactText } from 'react';
 
 /**
  * Internal dependencies
  */
-import { Props as ControlLabelProps } from '../control-label/types';
-import { Props as GridProps } from '../grid/types';
+import type { Props as ControlLabelProps } from '../control-label/types';
+import type { Props as GridProps } from '../grid/types';
 
 export type FormGroupLabelProps = ControlLabelProps & {
 	labelHidden?: boolean;

--- a/packages/components/src/ui/form-group/types.ts
+++ b/packages/components/src/ui/form-group/types.ts
@@ -1,3 +1,7 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
 import { CSSProperties, ReactNode, ReactText } from 'react';
 
 /**

--- a/packages/components/src/ui/grid/types.ts
+++ b/packages/components/src/ui/grid/types.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 type ResponsiveCSSValue< T > = Array< T | undefined > | T;
 

--- a/packages/components/src/ui/grid/types.ts
+++ b/packages/components/src/ui/grid/types.ts
@@ -1,3 +1,7 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
 import { CSSProperties } from 'react';
 
 type ResponsiveCSSValue< T > = Array< T | undefined > | T;

--- a/packages/components/src/ui/h-stack/component.js
+++ b/packages/components/src/ui/h-stack/component.js
@@ -5,7 +5,7 @@ import { createComponent } from '../utils';
 import { useHStack } from './hook';
 
 /**
- *`HStack` (Horizontal Stack) arranges child elements in a horizontal line.
+ * `HStack` (Horizontal Stack) arranges child elements in a horizontal line.
  *
  * `HStack` can render anything inside.
  *
@@ -30,8 +30,10 @@ import { useHStack } from './hook';
  * }
  * ```
  */
-export default createComponent( {
+const HStack = createComponent( {
 	as: 'div',
 	useHook: useHStack,
 	name: 'HStack',
 } );
+
+export default HStack;

--- a/packages/components/src/ui/h-stack/types.ts
+++ b/packages/components/src/ui/h-stack/types.ts
@@ -2,12 +2,12 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 /**
  * Internal dependencies
  */
-import { FlexProps } from '../flex/types';
+import type { FlexProps } from '../flex/types';
 
 export type HStackAlignment =
 	| 'bottom'

--- a/packages/components/src/ui/h-stack/types.ts
+++ b/packages/components/src/ui/h-stack/types.ts
@@ -1,4 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
 import { CSSProperties } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import { FlexProps } from '../flex/types';
 
 export type HStackAlignment =

--- a/packages/components/src/ui/text/types.ts
+++ b/packages/components/src/ui/text/types.ts
@@ -1,4 +1,12 @@
+/**
+ * Internal dependencies
+ */
 import type { Props as TruncateProps } from '../truncate/types';
+
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 type TextAdjustLineHeightForInnerControls =

--- a/packages/components/src/ui/utils/types.ts
+++ b/packages/components/src/ui/utils/types.ts
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { As } from 'reakit-utils/types';
-import { ViewOwnProps } from '@wp-g2/create-styles';
+import type { As } from 'reakit-utils/types';
+import type { ViewOwnProps } from '@wp-g2/create-styles';
 
 export type Options< T extends As, P extends ViewOwnProps< {}, T > > = {
 	as: T;

--- a/packages/components/src/ui/utils/types.ts
+++ b/packages/components/src/ui/utils/types.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { As } from 'reakit-utils/types';
 import { ViewOwnProps } from '@wp-g2/create-styles';
 

--- a/packages/components/src/ui/v-stack/types.ts
+++ b/packages/components/src/ui/v-stack/types.ts
@@ -1,4 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
 import { CSSProperties } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import { HStackAlignment, Props as HStackProps } from '../h-stack/types';
 
 export type Props = HStackProps & {

--- a/packages/components/src/ui/v-stack/types.ts
+++ b/packages/components/src/ui/v-stack/types.ts
@@ -2,12 +2,12 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 /**
  * Internal dependencies
  */
-import { HStackAlignment, Props as HStackProps } from '../h-stack/types';
+import type { HStackAlignment, Props as HStackProps } from '../h-stack/types';
 
 export type Props = HStackProps & {
 	alignment?: HStackAlignment | CSSProperties[ 'alignItems' ];

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"importsNotUsedAsValues": "error",
 		"rootDir": "src",
 		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"importsNotUsedAsValues": "error",
 		"rootDir": "src",
 		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Prepare and lint rules for TypeScript. [#27143](https://github.com/WordPress/gutenberg/pull/27143)
+
 ### New Features
 
 -   Enabled `import/default` and `import/named` rules in the `recommended` ruleset. [#28513](https://github.com/WordPress/gutenberg/pull/28513)

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- Prepare and lint rules for TypeScript. [#27143](https://github.com/WordPress/gutenberg/pull/27143)
+- Add support and configuration for TypeScript files. [#27143](https://github.com/WordPress/gutenberg/pull/27143)
 
 ### New Features
 

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -13,6 +13,7 @@ const { config: localPrettierConfig } =
 const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
 
 module.exports = {
+	parser: '@typescript-eslint/parser',
 	extends: [
 		require.resolve( './recommended-with-formatting.js' ),
 		'plugin:prettier/recommended',

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -18,6 +18,7 @@ module.exports = {
 		require.resolve( './recommended-with-formatting.js' ),
 		'plugin:prettier/recommended',
 		'prettier/react',
+		'plugin:@typescript-eslint/eslint-recommended',
 	],
 	rules: {
 		'prettier/prettier': [ 'error', prettierConfig ],

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -23,4 +23,14 @@ module.exports = {
 	rules: {
 		'prettier/prettier': [ 'error', prettierConfig ],
 	},
+	overrides: [
+		{
+			// Unit test files and their helpers only.
+			files: [ '**/*.ts', '**/*.tsx' ],
+			rules: {
+				'jsdoc/require-param-type': 'off',
+				'jsdoc/require-returns-type': 'off',
+			},
+		},
+	],
 };

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -16,9 +16,9 @@ module.exports = {
 	settings: {
 		'import/resolver': {
 			node: {
-				"extensions": [".js", ".jsx", ".ts", ".tsx"]
-			}
-		}
+				extensions: [ '.js', '.jsx', '.ts', '.tsx' ],
+			},
+		},
 	},
 	parser: '@typescript-eslint/parser',
 	extends: [
@@ -32,11 +32,13 @@ module.exports = {
 	},
 	overrides: [
 		{
-			// Don't require redundant JSDoc types in TypeScript files.
 			files: [ '**/*.ts', '**/*.tsx' ],
 			rules: {
+				// Don't require redundant JSDoc types in TypeScript files.
 				'jsdoc/require-param-type': 'off',
 				'jsdoc/require-returns-type': 'off',
+				// handled by TS itself
+				'no-unused-vars': 'off',
 			},
 		},
 	],

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -13,6 +13,13 @@ const { config: localPrettierConfig } =
 const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
 
 module.exports = {
+	settings: {
+		'import/resolver': {
+			node: {
+				"extensions": [".js", ".jsx", ".ts", ".tsx"]
+			}
+		}
+	},
 	parser: '@typescript-eslint/parser',
 	extends: [
 		require.resolve( './recommended-with-formatting.js' ),

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -25,7 +25,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			// Unit test files and their helpers only.
+			// Don't require redundant JSDoc types in TypeScript files.
 			files: [ '**/*.ts', '**/*.tsx' ],
 			rules: {
 				'jsdoc/require-param-type': 'off',

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -21,7 +21,6 @@ module.exports = {
 		},
 		'import/core-modules': [ 'react' ],
 	},
-	parser: '@typescript-eslint/parser',
 	extends: [
 		require.resolve( './recommended-with-formatting.js' ),
 		'plugin:prettier/recommended',
@@ -34,6 +33,7 @@ module.exports = {
 	overrides: [
 		{
 			files: [ '**/*.ts', '**/*.tsx' ],
+			parser: '@typescript-eslint/parser',
 			rules: {
 				// Don't require redundant JSDoc types in TypeScript files.
 				'jsdoc/require-param-type': 'off',

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -27,6 +27,7 @@ module.exports = {
 		'prettier/react',
 		'plugin:@typescript-eslint/eslint-recommended',
 	],
+	ignorePatterns: [ '**/*.d.ts' ],
 	rules: {
 		'prettier/prettier': [ 'error', prettierConfig ],
 	},

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -19,8 +19,11 @@ module.exports = {
 				extensions: [ '.js', '.jsx', '.ts', '.tsx' ],
 			},
 		},
+		'import/parser': {
+			'@typescript-eslint/parser': [ '.ts', '.tsx' ],
+		},
+		'import/core-modules': [ 'react' ],
 	},
-	parser: '@typescript-eslint/parser',
 	extends: [
 		require.resolve( './recommended-with-formatting.js' ),
 		'plugin:prettier/recommended',

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -19,11 +19,9 @@ module.exports = {
 				extensions: [ '.js', '.jsx', '.ts', '.tsx' ],
 			},
 		},
-		'import/parser': {
-			'@typescript-eslint/parser': [ '.ts', '.tsx' ],
-		},
 		'import/core-modules': [ 'react' ],
 	},
+	parser: '@typescript-eslint/parser',
 	extends: [
 		require.resolve( './recommended-with-formatting.js' ),
 		'plugin:prettier/recommended',

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,6 +31,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
+		"@typescript-eslint/eslint-plugin": "^4.15.0",
 		"@typescript-eslint/parser": "^4.15.0",
 		"@wordpress/prettier-config": "file:../prettier-config",
 		"babel-eslint": "^10.1.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,6 +31,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
+		"@typescript-eslint/parser": "^4.15.0",
 		"@wordpress/prettier-config": "file:../prettier-config",
 		"babel-eslint": "^10.1.0",
 		"cosmiconfig": "^7.0.0",

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -38,6 +38,14 @@ ReactDom.render(
 You can also instantiate the provider without the `i18n` prop. In that case it will use the
 default `I18n` instance exported from `@wordpress/i18n`.
 
+_Parameters_
+
+-   _props_ ``: i18n provider props.
+
+_Returns_
+
+-   ``: Children wrapped in the I18nProvider.
+
 <a name="useI18n" href="#useI18n">#</a> **useI18n**
 
 React hook providing access to i18n functions. It exposes the `__`, `_x`, `_n`, `_nx`,

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -1,4 +1,11 @@
 /**
+ * External dependencies
+ */
+// Disable reason: Type-only import, this is fine. See https://github.com/typescript-eslint/typescript-eslint/issues/2661
+// eslint-disable-next-line no-restricted-imports
+import type { ComponentType, PropsWithChildren } from 'react';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -8,9 +15,7 @@ import {
 	useMemo,
 	useReducer,
 } from '@wordpress/element';
-import { defaultI18n } from '@wordpress/i18n';
-import type { I18n } from '@wordpress/i18n';
-import type { ComponentType, PropsWithChildren } from 'react';
+import { defaultI18n, I18n } from '@wordpress/i18n';
 import type { Subtract } from 'utility-types';
 
 interface I18nContextProps {

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -29,6 +29,8 @@ interface I18nContextProps {
 
 /**
  * Utility to make a new context value
+ *
+ * @param i18n
  */
 function makeContextValue( i18n: I18n ): I18nContextProps {
 	return {
@@ -64,8 +66,11 @@ type I18nProviderProps = PropsWithChildren< { i18n: I18n } >;
  *
  * You can also instantiate the provider without the `i18n` prop. In that case it will use the
  * default `I18n` instance exported from `@wordpress/i18n`.
+ *
+ * @param props i18n provider props.
+ * @return Children wrapped in the I18nProvider.
  */
-export function I18nProvider( props: I18nProviderProps ) {
+export function I18nProvider( props: I18nProviderProps ): JSX.Element {
 	const { children, i18n = defaultI18n } = props;
 	const [ update, forceUpdate ] = useReducer( () => [], [] );
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### New Features
 
 -   Default `check-engines` command to the `engines` config in `package.json` file of the current project ([#29066](https://github.com/WordPress/gutenberg/pull/29066)).
+### Breaking Changes
+
+- Lint TypeScript files as part of `lint-js`. [#27143](https://github.com/WordPress/gutenberg/pull/27143)
 
 ### Enhancements
 

--- a/packages/scripts/scripts/lint-js.js
+++ b/packages/scripts/scripts/lint-js.js
@@ -47,11 +47,16 @@ const defaultIgnoreArgs = ! hasIgnoredFiles
 	? [ '--ignore-path', fromConfigRoot( '.eslintignore' ) ]
 	: [];
 
+const defaultExtArgs = hasArgInCLI( '--ext' )
+	? []
+	: [ '--ext', 'js,jsx,ts,tsx' ];
+
 const result = spawn(
 	resolveBin( 'eslint' ),
 	[
 		...defaultConfigArgs,
 		...defaultIgnoreArgs,
+		...defaultExtArgs,
 		...args,
 		...defaultFilesArgs,
 	],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
 		"noUnusedParameters": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
+		"importsNotUsedAsValues": "error",
 
 		/* Module Resolution Options */
 		"moduleResolution": "node",

--- a/typings/gutenberg-env/index.d.ts
+++ b/typings/gutenberg-env/index.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef, no-unused-vars, no-var */
 interface Environment {
 	NODE_ENV: unknown;
 	COMPONENT_SYSTEM_PHASE: number | undefined;
@@ -6,3 +7,4 @@ interface Process {
 	env: Environment;
 }
 declare var process: Process;
+/* eslint-enable no-undef, no-unused-vars, no-var */

--- a/typings/gutenberg-env/index.d.ts
+++ b/typings/gutenberg-env/index.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars, no-var */
 interface Environment {
 	NODE_ENV: unknown;
 	COMPONENT_SYSTEM_PHASE: number | undefined;
@@ -7,4 +6,3 @@ interface Process {
 	env: Environment;
 }
 declare var process: Process;
-/* eslint-enable no-undef, no-unused-vars, no-var */


### PR DESCRIPTION
## Description

With some TypeScript in Gutenberg, .ts and .tsx (TypeScript) files should undergo the similar formatting and linting to `.js` files.

## How has this been tested?

Change a .ts file, stage, and commit it.
Work on `@wordpress/react-i18n` and see that lint issues are reported correctly.


## Types of changes

Breaking change: Add lint setup and rules for TypeScript files.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
