### PR TITLE
[RNMobile] File block IV - Error handling, retry, and cancel upload

### DIFF
--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -419,7 +419,7 @@ export class FileEdit extends Component {
 											align
 										) }
 									/>
-									{ isUploadFailed && (
+									{ ! isUploadFailed && (
 										<View style={ styles.errorContainer }>
 											<Icon
 												icon={ warning }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -419,7 +419,7 @@ export class FileEdit extends Component {
 											align
 										) }
 									/>
-									{ ! isUploadFailed && (
+									{ isUploadFailed && (
 										<View style={ styles.errorContainer }>
 											<Icon
 												icon={ warning }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -1,12 +1,17 @@
 /**
  * External dependencies
  */
-import { View, Text, Clipboard } from 'react-native';
+import { View, Clipboard, TouchableWithoutFeedback } from 'react-native';
 import React from 'react';
 
 /**
  * WordPress dependencies
  */
+import {
+	requestImageFailedRetryDialog,
+	requestImageUploadCancelDialog,
+	mediaUploadSync,
+} from '@wordpress/react-native-bridge';
 import {
 	BlockIcon,
 	MediaPlaceholder,
@@ -25,6 +30,7 @@ import {
 	ToggleControl,
 	BottomSheet,
 	SelectControl,
+	Icon,
 } from '@wordpress/components';
 import {
 	file as icon,
@@ -32,11 +38,13 @@ import {
 	button,
 	external,
 	link,
+	warning,
 } from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { getProtocol } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -65,6 +73,9 @@ export class FileEdit extends Component {
 		this.finishMediaUploadWithSuccess = this.finishMediaUploadWithSuccess.bind(
 			this
 		);
+		this.finishMediaUploadWithFailure = this.finishMediaUploadWithFailure.bind(
+			this
+		);
 		this.getFileComponent = this.getFileComponent.bind( this );
 		this.onChangeDownloadButtonVisibility = this.onChangeDownloadButtonVisibility.bind(
 			this
@@ -78,6 +89,8 @@ export class FileEdit extends Component {
 			this
 		);
 		this.onShowLinkSettings = this.onShowLinkSettings.bind( this );
+		this.onFilePressed = this.onFilePressed.bind( this );
+		this.mediaUploadStateReset = this.mediaUploadStateReset.bind( this );
 	}
 
 	componentDidMount() {
@@ -88,6 +101,14 @@ export class FileEdit extends Component {
 			setAttributes( {
 				downloadButtonText: _x( 'Download', 'button label' ),
 			} );
+		}
+
+		if (
+			attributes.id &&
+			attributes.url &&
+			getProtocol( attributes.url ) === 'file:'
+		) {
+			mediaUploadSync();
 		}
 	}
 
@@ -171,23 +192,22 @@ export class FileEdit extends Component {
 		this.setState( { isUploadInProgress: false } );
 	}
 
-	mediaUploadStateReset() {
-		const { setAttributes } = this.props;
-
-		setAttributes( { id: null, url: null } );
+	finishMediaUploadWithFailure( payload ) {
+		this.props.setAttributes( { id: payload.mediaId } );
 		this.setState( { isUploadInProgress: false } );
 	}
 
-	getErrorComponent( retryMessage ) {
-		return (
-			retryMessage && (
-				<View style={ styles.retryContainer }>
-					<Text style={ styles.uploadFailedText }>
-						{ retryMessage }
-					</Text>
-				</View>
-			)
-		);
+	mediaUploadStateReset() {
+		const { setAttributes } = this.props;
+
+		setAttributes( {
+			id: null,
+			href: null,
+			textLinkHref: null,
+			fileName: null,
+			downloadButtonText: null,
+		} );
+		this.setState( { isUploadInProgress: false } );
 	}
 
 	onShowLinkSettings() {
@@ -317,8 +337,21 @@ export class FileEdit extends Component {
 		}
 	}
 
+	onFilePressed() {
+		const { attributes } = this.props;
+
+		if ( this.state.isUploadInProgress ) {
+			requestImageUploadCancelDialog( attributes.id );
+		} else if (
+			attributes.id &&
+			getProtocol( attributes.url ) === 'file:'
+		) {
+			requestImageFailedRetryDialog( attributes.id );
+		}
+	}
+
 	getFileComponent( openMediaOptions, getMediaOptions ) {
-		const { attributes, media } = this.props;
+		const { attributes, media, isSelected } = this.props;
 
 		const {
 			fileName,
@@ -343,58 +376,77 @@ export class FileEdit extends Component {
 				onFinishMediaUploadWithSuccess={
 					this.finishMediaUploadWithSuccess
 				}
-				onFinishMediaUploadWithFailure={ () => {} }
+				onFinishMediaUploadWithFailure={
+					this.finishMediaUploadWithFailure
+				}
 				onMediaUploadStateReset={ this.mediaUploadStateReset }
-				renderContent={ ( {
-					isUploadInProgress,
-					isUploadFailed,
-					retryMessage,
-				} ) => {
-					if ( isUploadFailed ) {
-						return this.getErrorComponent( retryMessage );
-					}
-
+				renderContent={ ( { isUploadInProgress, isUploadFailed } ) => {
 					return (
-						<View>
-							{ isUploadInProgress ||
-								this.getToolbarEditButton( openMediaOptions ) }
-							{ getMediaOptions() }
-							{ this.getInspectorControls(
-								attributes,
-								media,
-								isUploadInProgress,
-								isUploadFailed
-							) }
-							<RichText
-								__unstableMobileNoFocusOnMount
-								onChange={ this.onChangeFileName }
-								placeholder={ __( 'File name' ) }
-								rootTagsToEliminate={ [ 'p' ] }
-								tagName="p"
-								underlineColorAndroid="transparent"
-								value={ fileName }
-								deleteEnter={ true }
-								textAlign={ this.getTextAlignmentForAlignment(
-									align
+						<TouchableWithoutFeedback
+							accessible={ ! isSelected }
+							onPress={ this.onFilePressed }
+							onLongPress={ openMediaOptions }
+							disabled={ ! isSelected }
+						>
+							<View>
+								{ isUploadInProgress ||
+									this.getToolbarEditButton(
+										openMediaOptions
+									) }
+								{ getMediaOptions() }
+								{ this.getInspectorControls(
+									attributes,
+									media,
+									isUploadInProgress,
+									isUploadFailed
 								) }
-							/>
-							{ showDownloadButton && (
-								<View
-									style={ [
-										finalButtonStyle,
-										this.getStyleForAlignment( align ),
-									] }
-								>
-									<PlainText
-										style={ styles.buttonText }
-										value={ downloadButtonText }
-										onChange={
-											this.onChangeDownloadButtonText
-										}
+								<View>
+									<RichText
+										__unstableMobileNoFocusOnMount
+										onChange={ this.onChangeFileName }
+										placeholder={ __( 'File name' ) }
+										rootTagsToEliminate={ [ 'p' ] }
+										tagName="p"
+										underlineColorAndroid="transparent"
+										value={ fileName }
+										deleteEnter={ true }
+										textAlign={ this.getTextAlignmentForAlignment(
+											align
+										) }
 									/>
+									{ isUploadFailed && (
+										<View
+											style={ { flexDirection: 'row' } }
+										>
+											<Icon
+												icon={ warning }
+												style={ styles.uploadFailed }
+											/>
+											<PlainText
+												value={ __( 'Error' ) }
+												style={ styles.uploadFailed }
+											/>
+										</View>
+									) }
 								</View>
-							) }
-						</View>
+								{ showDownloadButton && (
+									<View
+										style={ [
+											finalButtonStyle,
+											this.getStyleForAlignment( align ),
+										] }
+									>
+										<PlainText
+											style={ styles.buttonText }
+											value={ downloadButtonText }
+											onChange={
+												this.onChangeDownloadButtonText
+											}
+										/>
+									</View>
+								) }
+							</View>
+						</TouchableWithoutFeedback>
 					);
 				} }
 			/>

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -205,7 +205,6 @@ export class FileEdit extends Component {
 			href: null,
 			textLinkHref: null,
 			fileName: null,
-			downloadButtonText: null,
 		} );
 		this.setState( { isUploadInProgress: false } );
 	}
@@ -344,7 +343,7 @@ export class FileEdit extends Component {
 			requestImageUploadCancelDialog( attributes.id );
 		} else if (
 			attributes.id &&
-			getProtocol( attributes.url ) === 'file:'
+			getProtocol( attributes.href ) === 'file:'
 		) {
 			requestImageFailedRetryDialog( attributes.id );
 		}
@@ -361,14 +360,6 @@ export class FileEdit extends Component {
 			align,
 		} = attributes;
 
-		const dimmedStyle =
-			this.state.isUploadInProgress && styles.disabledButton;
-		const finalButtonStyle = Object.assign(
-			{},
-			styles.defaultButton,
-			dimmedStyle
-		);
-
 		return (
 			<MediaUploadProgress
 				mediaId={ id }
@@ -381,6 +372,20 @@ export class FileEdit extends Component {
 				}
 				onMediaUploadStateReset={ this.mediaUploadStateReset }
 				renderContent={ ( { isUploadInProgress, isUploadFailed } ) => {
+					const dimmedStyle =
+						( this.state.isUploadInProgress || isUploadFailed ) &&
+						styles.disabledButton;
+					const finalButtonStyle = [
+						styles.defaultButton,
+						dimmedStyle,
+					];
+
+					const errorIconStyle = Object.assign(
+						{},
+						styles.errorIcon,
+						styles.uploadFailed
+					);
+
 					return (
 						<TouchableWithoutFeedback
 							accessible={ ! isSelected }
@@ -415,12 +420,10 @@ export class FileEdit extends Component {
 										) }
 									/>
 									{ isUploadFailed && (
-										<View
-											style={ { flexDirection: 'row' } }
-										>
+										<View style={ styles.errorContainer }>
 											<Icon
 												icon={ warning }
-												style={ styles.uploadFailed }
+												style={ errorIconStyle }
 											/>
 											<PlainText
 												value={ __( 'Error' ) }
@@ -437,6 +440,7 @@ export class FileEdit extends Component {
 										] }
 									>
 										<PlainText
+											editable={ ! isUploadFailed }
 											style={ styles.buttonText }
 											value={ downloadButtonText }
 											onChange={

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -35,6 +35,14 @@
 	color: $blue-30;
 }
 
+.errorContainer {
+	flex-direction: row;
+}
+
+.errorIcon {
+	margin-left: -4px;
+}
+
 .uploadFailed {
 	color: $alert-red;
 }

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -34,3 +34,7 @@
 .actionButtonDark {
 	color: $blue-30;
 }
+
+.uploadFailed {
+	color: $alert-red;
+}

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -10,6 +10,7 @@
 	background-color: transparent;
 	color: $white;
 	font-size: 16;
+	padding: 0;
 }
 
 .disabledButton {
@@ -37,6 +38,8 @@
 
 .errorContainer {
 	flex-direction: row;
+	align-items: center;
+	padding-top: 4px;
 }
 
 .errorIcon {
@@ -44,5 +47,6 @@
 }
 
 .uploadFailed {
+	padding: 0;
 	color: $alert-red;
 }

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -4,65 +4,80 @@ exports[`File block renders file without crashing 1`] = `
 <View
   pointerEvents="box-none"
 >
-  <View>
+  <View
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+  >
     Modal
     <View>
-      <RCTAztecView
-        accessible={true}
-        activeFormats={Array []}
-        blockType={
-          Object {
-            "tag": "p",
+      <View>
+        <RCTAztecView
+          accessible={true}
+          activeFormats={Array []}
+          blockType={
+            Object {
+              "tag": "p",
+            }
           }
-        }
-        deleteEnter={true}
-        disableEditingMenu={false}
-        focusable={true}
-        fontFamily="serif"
-        isMultiline={false}
-        maxImagesWidth={200}
-        onBackspace={[Function]}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onContentSizeChange={[Function]}
-        onEnter={[Function]}
-        onFocus={[Function]}
-        onHTMLContentWithCursor={[Function]}
-        onKeyDown={[Function]}
-        onPaste={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onSelectionChange={[Function]}
-        onStartShouldSetResponder={[Function]}
-        placeholder="File name"
-        placeholderTextColor="gray"
-        style={
-          Object {
-            "backgroundColor": undefined,
-            "maxWidth": undefined,
-            "minHeight": 0,
+          deleteEnter={true}
+          disableEditingMenu={false}
+          focusable={true}
+          fontFamily="serif"
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
+          onStartShouldSetResponder={[Function]}
+          placeholder="File name"
+          placeholderTextColor="gray"
+          style={
+            Object {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
+            }
           }
-        }
-        text={
-          Object {
-            "eventCount": undefined,
-            "linkTextColor": undefined,
-            "selection": null,
-            "text": "<p >File name</p>",
+          text={
+            Object {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "text": "<p >File name</p>",
+            }
           }
-        }
-        textAlign="left"
-        triggerKeyCodes={Array []}
-      />
+          textAlign="left"
+          triggerKeyCodes={Array []}
+        />
+      </View>
     </View>
     <View
       style={
         Array [
-          Object {},
+          Array [
+            undefined,
+            false,
+          ],
           Object {
             "alignSelf": "flex-start",
           },
@@ -71,6 +86,7 @@ exports[`File block renders file without crashing 1`] = `
     >
       <TextInput
         allowFontScaling={true}
+        editable={true}
         fontFamily="serif"
         onChange={[Function]}
         rejectResponderTermination={true}

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -1,5 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`File block renders file error state without crashing 1`] = `
+<View
+  pointerEvents="box-none"
+>
+  <View
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+  >
+    Modal
+    <View>
+      <View>
+        <RCTAztecView
+          accessible={true}
+          activeFormats={Array []}
+          blockType={
+            Object {
+              "tag": "p",
+            }
+          }
+          deleteEnter={true}
+          disableEditingMenu={false}
+          focusable={true}
+          fontFamily="serif"
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
+          onStartShouldSetResponder={[Function]}
+          placeholder="File name"
+          placeholderTextColor="gray"
+          style={
+            Object {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
+            }
+          }
+          text={
+            Object {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "text": "<p >File name</p>",
+            }
+          }
+          textAlign="left"
+          triggerKeyCodes={Array []}
+        />
+      </View>
+      <View>
+        Svg
+        <TextInput
+          allowFontScaling={true}
+          fontFamily="serif"
+          onChange={[Function]}
+          rejectResponderTermination={true}
+          scrollEnabled={false}
+          style={
+            Object {
+              "fontFamily": "serif",
+            }
+          }
+          underlineColorAndroid="transparent"
+          value="Error"
+        />
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Array [
+            undefined,
+            undefined,
+          ],
+          Object {
+            "alignSelf": "flex-start",
+          },
+        ]
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        editable={false}
+        fontFamily="serif"
+        onChange={[Function]}
+        rejectResponderTermination={true}
+        scrollEnabled={false}
+        style={
+          Object {
+            "fontFamily": "serif",
+          }
+        }
+        underlineColorAndroid="transparent"
+        value="Download"
+      />
+    </View>
+  </View>
+</View>
+`;
+
 exports[`File block renders file without crashing 1`] = `
 <View
   pointerEvents="box-none"

--- a/packages/block-library/src/file/test/edit.native.js
+++ b/packages/block-library/src/file/test/edit.native.js
@@ -4,6 +4,11 @@
 import renderer from 'react-test-renderer';
 
 /**
+ * WordPress dependencies
+ */
+import { MediaUploadProgress } from '@wordpress/block-editor';
+
+/**
  * Internal dependencies
  */
 import { FileEdit } from '../edit.native.js';
@@ -35,6 +40,23 @@ describe( 'File block', () => {
 			textLinkHref: 'https://wordpress.org/latest.zip',
 			id: '1',
 		} );
+
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+
+	it( 'renders file error state without crashing', () => {
+		const component = getTestComponentWithContent( {
+			showDownloadButton: true,
+			downloadButtonText: 'Download',
+			href: 'https://wordpress.org/latest.zip',
+			fileName: 'File name',
+			textLinkHref: 'https://wordpress.org/latest.zip',
+			id: '1',
+		} );
+
+		const mediaUpload = component.root.findByType( MediaUploadProgress );
+		mediaUpload.instance.finishMediaUploadWithFailure( { mediaId: -1 } );
 
 		const rendered = component.toJSON();
 		expect( rendered ).toMatchSnapshot();

--- a/packages/react-native-editor/ios/GutenbergDemo/MediaUploadCoordinator.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/MediaUploadCoordinator.swift
@@ -20,6 +20,7 @@ class MediaUploadCoordinator: NSObject {
 
   func upload(url: URL) -> Int32? {
     //Make sure the media is not larger than a 32 bits to number to avoid problems when bridging to JS
+    successfullUpload = true
     let mediaID = Int32(truncatingIfNeeded:UUID().uuidString.hash)
     let progress = Progress(parent: nil, userInfo: [ProgressUserInfoKey.mediaID: mediaID, ProgressUserInfoKey.mediaURL: url])
     progress.totalUnitCount = 100


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2826
`WPiOS` (testing) PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15363
`WPAndroid` (testing) PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13449

## Description

This PR implements Error handling for the File Block.

![Error](https://user-images.githubusercontent.com/9772967/99811631-b5eedc80-2b45-11eb-8aaa-51395acfcc84.png)

We keep reusing elements from the other media blocks. In this case, the retry action sheet only has the `Retry` option.
I have chosen to add the Error label down the file name because of two reasons:
- The name can get large
- An issue with RichText where its width is lost on row layout (to be fixed).
( cc @iamthomasbishop )

<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### To test:

**Test cancel action**:
- Add a File block to an empty new post.
- Add a file to the block.
- While the file is uploading, tap on the block's background to see the cancel action sheet.
  - If you tap on the file name, it will start editing the file name fileld. This is intended (cc @iamthomasbishop )
- Tap the `Stop upload` action.
  - The File block should go back to the empty state.

**Test error and retry**:
- Add a File block to an empty new post.
- While it's uploading, long-press anywhere in the editor **to simulate an upload error**.
  - See the block switch to its error state.
- While in the error state, tap on the File block background to see the Retry action sheet.
- After reconnecting the device, press the Retry action.
  - Check that the file starts uploading again until it successfully finishes uploading.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
