### PR TITLE
Site Editor: Only request templates and template parts for the current theme

### DIFF
--- a/lib/templates.php
+++ b/lib/templates.php
@@ -324,7 +324,7 @@ function filter_rest_wp_template_collection_params( $query_params ) {
 apply_filters( 'rest_wp_template_collection_params', 'filter_rest_wp_template_collection_params', 99, 1 );
 
 /**
- * Filter for supporting the `resolved` parameter in `wp_template` queries.
+ * Filter for supporting the `resolved` and `theme` parameter in `wp_template` queries.
  *
  * @param array           $args    The query arguments.
  * @param WP_REST_Request $request The request object.
@@ -348,6 +348,17 @@ function filter_rest_wp_template_query( $args, $request ) {
 		}
 		$args['post__in']    = $template_ids;
 		$args['post_status'] = array( 'publish', 'auto-draft' );
+	}
+
+	if ( $request['theme'] ) {
+		$tax_query   = isset( $args['tax_query'] ) ? $args['tax_query'] : array();
+		$tax_query[] = array(
+			'taxonomy' => 'wp_theme',
+			'field'    => 'slug',
+			'terms'    => $request['theme'],
+		);
+
+		$args['tax_query'] = $tax_query;
 	}
 
 	return $args;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
@@ -21,15 +21,13 @@ import { MENU_ROOT, MENU_TEMPLATE_PARTS } from '../constants';
 
 export default function TemplatePartsMenu() {
 	const templateParts = useSelect( ( select ) => {
-		const unfilteredTemplateParts =
+		const theme = select( 'core' ).getCurrentTheme()?.stylesheet;
+		return (
 			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
 				status: [ 'publish', 'auto-draft' ],
 				per_page: -1,
-			} ) || [];
-		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
-		return unfilteredTemplateParts.filter(
-			( item ) =>
-				item.status === 'publish' || item.wp_theme_slug === currentTheme
+				theme,
+			} ) || []
 		);
 	}, [] );
 

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
@@ -32,14 +32,14 @@ import NewTemplateDropdown from '../new-template-dropdown';
 import TemplateNavigationItem from '../template-navigation-item';
 
 export default function TemplatesMenu() {
-	const templates = useSelect(
-		( select ) =>
-			select( 'core' ).getEntityRecords( 'postType', 'wp_template', {
-				status: TEMPLATES_STATUSES,
-				per_page: -1,
-			} ),
-		[]
-	);
+	const templates = useSelect( ( select ) => {
+		const theme = select( 'core' ).getCurrentTheme()?.stylesheet;
+		return select( 'core' ).getEntityRecords( 'postType', 'wp_template', {
+			status: TEMPLATES_STATUSES,
+			per_page: -1,
+			theme,
+		} );
+	}, [] );
 
 	const generalTemplates = templates?.filter( ( { slug } ) =>
 		TEMPLATES_GENERAL.includes( slug )

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
@@ -24,17 +24,18 @@ import { TEMPLATES_STATUSES } from './constants';
 
 export default function NewTemplateDropdown() {
 	const { defaultTemplateTypes, templates } = useSelect( ( select ) => {
+		const theme = select( 'core' ).getCurrentTheme()?.stylesheet;
 		const {
 			__experimentalGetDefaultTemplateTypes: getDefaultTemplateTypes,
 		} = select( 'core/editor' );
-		const templateEntities = select( 'core' ).getEntityRecords(
+		const _templates = select( 'core' ).getEntityRecords(
 			'postType',
 			'wp_template',
-			{ status: TEMPLATES_STATUSES, per_page: -1 }
+			{ status: TEMPLATES_STATUSES, per_page: -1, theme }
 		);
 		return {
 			defaultTemplateTypes: getDefaultTemplateTypes(),
-			templates: templateEntities,
+			templates: _templates,
 		};
 	}, [] );
 	const { addTemplate } = useDispatch( 'core/edit-site' );


### PR DESCRIPTION
## Description

Fixes #27149

- Add a `theme` request parameter to `wp_template` REST request (identical to the existing one for `wp_template_part`) that allow to filter by theme slug (the built-in taxonomy filter only accepts term IDs).
- Update all templates and template parts `getEntityRecords` in the Site Editor's navigation panel to only request template and template parts belonging to the current theme.

The main reason for this is to avoid confusion when using multiple FSE themes, exposing multiple, seemingly duplicate, templates and parts.

## How has this been tested?

- Have two FSE themes ready (e.g. "Twenty Twenty-One Blocks", and "Seedlet (Blocks)").
- Activate the first, then the second.
- Open `/wp-admin/edit.php?post_type=wp_template` and take note of all the templates with the same slug belonging to both themes (`index` is the best bet).
- Open the Site Editor, then the navigation sidebar.
- Navigate to the Templates menu.
- Explore it and make sure there are no duplicates (or if you are able to tell, make sure the templates are only those for the current theme).
- Check the Template Parts menu as well.
The wp-admin menu for parts doesn't show auto-drafts and theme yet so you can't check there, but it should be enough to make sure there are no duplicates in the navigation sidebar.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
