### PR TITLE
Docs: Correct the link to the SelectControl readme file

### DIFF
--- a/packages/components/src/combobox-control/README.md
+++ b/packages/components/src/combobox-control/README.md
@@ -1,6 +1,6 @@
 # ComboboxControl
 
-`ComboboxControl` is an enhanced version of a [`SelectControl`](/packages/components/src/select-control/readme.md), with the addition of being able to search for options using a search input.
+`ComboboxControl` is an enhanced version of a [`SelectControl`](/packages/components/src/select-control/README.md), with the addition of being able to search for options using a search input.
 
 ## Table of contents
 
@@ -10,7 +10,7 @@
 
 ## Design guidelines
 
-These are the same as [the ones for `SelectControl`s](/packages/components/src/select-control/readme.md#design-guidelines), but this component is better suited for when there are too many items to scroll through or load at once so you need to filter them based on user input.
+These are the same as [the ones for `SelectControl`s](/packages/components/src/select-control/README.md#design-guidelines), but this component is better suited for when there are too many items to scroll through or load at once so you need to filter them based on user input.
 
 ## Development guidelines
 


### PR DESCRIPTION
## Description

The links on https://github.com/WordPress/gutenberg/blob/master/packages/components/src/combobox-control/README.md that point to the SelectControl component return a 404. They point to `readme.md` instead of `README.md`.
