### PR TITLE
Add padding control to the Global Styles sidebar

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -493,10 +493,24 @@ class WP_Theme_JSON {
 				if ( 'gradient' === $property ) {
 					$name = 'background';
 				}
-				$result = safecss_filter_attr( "$name: $value" );
 
-				if ( '' === $result ) {
-					unset( $input[ $key ][ $property ] );
+				if ( is_array( $value ) ) {
+					foreach( $value as $subproperty => $subvalue ) {
+						$result_subproperty = safecss_filter_attr( "$name: $subvalue" );
+						if ( '' !== $result_subproperty ) {
+							$result[ $subproperty ] = $result_subproperty;
+						}
+					}
+
+					if ( empty( $result ) ) {
+						unset( $input[ $key ][ $property ] );
+					}
+				} else {
+					$result = safecss_filter_attr( "$name: $value" );
+
+					if ( '' === $result ) {
+						unset( $input[ $key ][ $property ] );
+					}
 				}
 			}
 		}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -495,7 +495,8 @@ class WP_Theme_JSON {
 				}
 
 				if ( is_array( $value ) ) {
-					foreach( $value as $subproperty => $subvalue ) {
+					$result = array();
+					foreach ( $value as $subproperty => $subvalue ) {
 						$result_subproperty = safecss_filter_attr( "$name: $subvalue" );
 						if ( '' !== $result_subproperty ) {
 							$result[ $subproperty ] = $result_subproperty;

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -273,13 +273,9 @@ class WP_Theme_JSON {
 			'support' => array( 'lineHeight' ),
 		),
 		'padding'                  => array(
-			'value'   => array(
-				'top'    => array( 'spacing', 'padding', 'top' ),
-				'right'  => array( 'spacing', 'padding', 'right' ),
-				'bottom' => array( 'spacing', 'padding', 'bottom' ),
-				'left'   => array( 'spacing', 'padding', 'left' ),
-			),
-			'support' => array( 'spacing', 'padding' ),
+			'value'      => array( 'spacing', 'padding' ),
+			'support'    => array( 'spacing', 'padding' ),
+			'properties' => array( 'top', 'right', 'bottom', 'left' )
 		),
 		'textDecoration'           => array(
 			'value'   => array( 'typography', 'textDecoration' ),
@@ -618,8 +614,8 @@ class WP_Theme_JSON {
 		return $value;
 	}
 
-	private static function is_shorthand_property( $metadata, $name ) {
-		if ( 'padding' === $name ) {
+	private static function has_properties( $metadata ) {
+		if ( array_key_exists( 'properties', $metadata ) ) {
 			return true;
 		}
 
@@ -656,11 +652,11 @@ class WP_Theme_JSON {
 
 			// Some properties can be shorthand properties, meaning that
 			// they contain multiple values instead of a single one.
-			if ( self::is_shorthand_property( $metadata, $name ) ) {
-				foreach ( $metadata['value'] as $property_name => $property_value ) {
+			if ( self::has_properties( $metadata ) ) {
+				foreach ( $metadata['properties'] as $property ) {
 					$properties[] = array(
-						'name'  => $name . ucfirst( $property_name ),
-						'value' => $property_value
+						'name'  => $name . ucfirst( $property ),
+						'value' => array_merge( $metadata['value'], array( $property ) )
 					);
 				}
 			} else {

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -275,7 +275,7 @@ class WP_Theme_JSON {
 		'padding'                  => array(
 			'value'      => array( 'spacing', 'padding' ),
 			'support'    => array( 'spacing', 'padding' ),
-			'properties' => array( 'top', 'right', 'bottom', 'left' )
+			'properties' => array( 'top', 'right', 'bottom', 'left' ),
 		),
 		'textDecoration'           => array(
 			'value'   => array( 'typography', 'textDecoration' ),
@@ -614,6 +614,13 @@ class WP_Theme_JSON {
 		return $value;
 	}
 
+	/**
+	 * Whether the medatata contains a key named properties.
+	 *
+	 * @param array $metadata Description of the style property.
+	 *
+	 * @return boolean True if properties exists, false otherwise.
+	 */
 	private static function has_properties( $metadata ) {
 		if ( array_key_exists( 'properties', $metadata ) ) {
 			return true;
@@ -656,7 +663,7 @@ class WP_Theme_JSON {
 				foreach ( $metadata['properties'] as $property ) {
 					$properties[] = array(
 						'name'  => $name . ucfirst( $property ),
-						'value' => array_merge( $metadata['value'], array( $property ) )
+						'value' => array_merge( $metadata['value'], array( $property ) ),
 					);
 				}
 			} else {
@@ -667,7 +674,7 @@ class WP_Theme_JSON {
 			}
 		}
 
-		foreach( $properties as $prop ) {
+		foreach ( $properties as $prop ) {
 			$value = self::get_property_value( $context['styles'], $prop['value'] );
 			if ( ! empty( $value ) ) {
 				$kebabcased_name = strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $prop['name'] ) );

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { has, get, startsWith, mapValues } from 'lodash';
+import { capitalize, has, get, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -54,18 +54,21 @@ function compileStyleValue( uncompiledValue ) {
  */
 export function getInlineStyles( styles = {} ) {
 	const output = {};
-	const styleProperties = mapValues( STYLE_PROPERTY, ( prop ) => prop.value );
-	Object.entries( styleProperties ).forEach(
-		( [ styleKey, ...otherObjectKeys ] ) => {
-			const [ objectKeys ] = otherObjectKeys;
-
-			if ( has( styles, objectKeys ) ) {
-				output[ styleKey ] = compileStyleValue(
-					get( styles, objectKeys )
-				);
+	Object.keys( STYLE_PROPERTY ).forEach( ( propKey ) => {
+		const path = STYLE_PROPERTY[ propKey ].value;
+		const subPaths = STYLE_PROPERTY[ propKey ].properties;
+		if ( has( styles, path ) ) {
+			if ( !! subPaths ) {
+				subPaths.forEach( ( suffix ) => {
+					output[
+						propKey + capitalize( suffix )
+					] = compileStyleValue( get( styles, [ ...path, suffix ] ) );
+				} );
+			} else {
+				output[ propKey ] = compileStyleValue( get( styles, path ) );
 			}
 		}
-	);
+	} );
 
 	return output;
 }

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -54,13 +54,9 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		support: [ 'lineHeight' ],
 	},
 	padding: {
-		value: {
-			top: [ 'spacing', 'padding', 'top' ],
-			right: [ 'spacing', 'padding', 'right' ],
-			bottom: [ 'spacing', 'padding', 'bottom' ],
-			left: [ 'spacing', 'padding', 'left' ],
-		},
+		value: [ 'spacing', 'padding' ],
 		support: [ 'spacing', 'padding' ],
+		subProperties: [ 'top', 'right', 'bottom', 'left' ],
 	},
 	textDecoration: {
 		value: [ 'typography', 'textDecoration' ],

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -56,7 +56,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	padding: {
 		value: [ 'spacing', 'padding' ],
 		support: [ 'spacing', 'padding' ],
-		subProperties: [ 'top', 'right', 'bottom', 'left' ],
+		properties: [ 'top', 'right', 'bottom', 'left' ],
 	},
 	textDecoration: {
 		value: [ 'typography', 'textDecoration' ],

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -53,20 +53,13 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		value: [ 'typography', 'lineHeight' ],
 		support: [ 'lineHeight' ],
 	},
-	paddingBottom: {
-		value: [ 'spacing', 'padding', 'bottom' ],
-		support: [ 'spacing', 'padding' ],
-	},
-	paddingLeft: {
-		value: [ 'spacing', 'padding', 'left' ],
-		support: [ 'spacing', 'padding' ],
-	},
-	paddingRight: {
-		value: [ 'spacing', 'padding', 'right' ],
-		support: [ 'spacing', 'padding' ],
-	},
-	paddingTop: {
-		value: [ 'spacing', 'padding', 'top' ],
+	padding: {
+		value: {
+			top: [ 'spacing', 'padding', 'top' ],
+			right: [ 'spacing', 'padding', 'right' ],
+			bottom: [ 'spacing', 'padding', 'bottom' ],
+			left: [ 'spacing', 'padding', 'left' ],
+		},
 		support: [ 'spacing', 'padding' ],
 	},
 	textDecoration: {

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -208,7 +208,6 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 					css: getGlobalStyles(
 						contexts,
 						mergedStyles,
-						STYLE_PROPERTY,
 						'cssVariables'
 					),
 					isGlobalStyles: true,
@@ -218,7 +217,6 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 					css: getGlobalStyles(
 						contexts,
 						mergedStyles,
-						STYLE_PROPERTY,
 						'blockStyles'
 					),
 					isGlobalStyles: true,

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -38,8 +38,8 @@ const GlobalStylesContext = createContext( {
 	/* eslint-disable no-unused-vars */
 	getSetting: ( context, path ) => {},
 	setSetting: ( context, path, newValue ) => {},
-	getStyleProperty: ( context, propertyName, origin ) => {},
-	setStyleProperty: ( context, propertyName, newValue ) => {},
+	getStyle: ( context, propertyName, origin ) => {},
+	setStyle: ( context, propertyName, newValue ) => {},
 	contexts: {},
 	/* eslint-enable no-unused-vars */
 } );
@@ -164,7 +164,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				set( contextSettings, path, newValue );
 				setContent( JSON.stringify( newContent ) );
 			},
-			getStyleProperty: ( context, propertyName, origin = 'merged' ) => {
+			getStyle: ( context, propertyName, origin = 'merged' ) => {
 				const styles = 'user' === origin ? userStyles : mergedStyles;
 
 				const value = get(
@@ -173,7 +173,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				);
 				return getValueFromVariable( mergedStyles, context, value );
 			},
-			setStyleProperty: ( context, propertyName, newValue ) => {
+			setStyle: ( context, propertyName, newValue ) => {
 				const newContent = { ...userStyles };
 				let contextStyles = newContent?.[ context ]?.styles;
 				if ( ! contextStyles ) {

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -107,13 +107,13 @@ function flattenTree( input = {}, prefix, token ) {
 function getBlockStylesDeclarations( blockSupports, blockStyles = {} ) {
 	return reduce(
 		STYLE_PROPERTY,
-		( declarations, { value, subProperties }, key ) => {
+		( declarations, { value, properties }, key ) => {
 			if ( ! blockSupports.includes( key ) ) {
 				return declarations;
 			}
 
-			if ( !! subProperties ) {
-				subProperties.forEach( ( prop ) => {
+			if ( !! properties ) {
+				properties.forEach( ( prop ) => {
 					const cssProperty = key.startsWith( '--' )
 						? key
 						: kebabCase( `${ key }${ capitalize( prop ) }` );

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -21,8 +21,8 @@ export function useHasColorPanel( { supports } ) {
 
 export default function ColorPanel( {
 	context: { supports, name },
-	getStyleProperty,
-	setStyleProperty,
+	getStyle,
+	setStyle,
 	getSetting,
 	setSetting,
 } ) {
@@ -37,12 +37,11 @@ export default function ColorPanel( {
 	const settings = [];
 
 	if ( supports.includes( 'color' ) ) {
-		const color = getStyleProperty( name, 'color' );
-		const userColor = getStyleProperty( name, 'color', 'user' );
+		const color = getStyle( name, 'color' );
+		const userColor = getStyle( name, 'color', 'user' );
 		settings.push( {
 			colorValue: color,
-			onColorChange: ( value ) =>
-				setStyleProperty( name, 'color', value ),
+			onColorChange: ( value ) => setStyle( name, 'color', value ),
 			label: __( 'Text color' ),
 			clearable: color === userColor,
 		} );
@@ -50,16 +49,12 @@ export default function ColorPanel( {
 
 	let backgroundSettings = {};
 	if ( supports.includes( 'backgroundColor' ) ) {
-		const backgroundColor = getStyleProperty( name, 'backgroundColor' );
-		const userBackgroundColor = getStyleProperty(
-			name,
-			'backgroundColor',
-			'user'
-		);
+		const backgroundColor = getStyle( name, 'backgroundColor' );
+		const userBackgroundColor = getStyle( name, 'backgroundColor', 'user' );
 		backgroundSettings = {
 			colorValue: backgroundColor,
 			onColorChange: ( value ) =>
-				setStyleProperty( name, 'backgroundColor', value ),
+				setStyle( name, 'backgroundColor', value ),
 		};
 		if ( backgroundColor ) {
 			backgroundSettings.clearable =
@@ -69,12 +64,12 @@ export default function ColorPanel( {
 
 	let gradientSettings = {};
 	if ( supports.includes( 'background' ) ) {
-		const gradient = getStyleProperty( name, 'background' );
-		const userGradient = getStyleProperty( name, 'background', 'user' );
+		const gradient = getStyle( name, 'background' );
+		const userGradient = getStyle( name, 'background', 'user' );
 		gradientSettings = {
 			gradientValue: gradient,
 			onGradientChange: ( value ) =>
-				setStyleProperty( name, 'background', value ),
+				setStyle( name, 'background', value ),
 		};
 		if ( gradient ) {
 			gradientSettings.clearable = gradient === userGradient;
@@ -93,12 +88,11 @@ export default function ColorPanel( {
 	}
 
 	if ( supports.includes( LINK_COLOR ) ) {
-		const color = getStyleProperty( name, LINK_COLOR );
-		const userColor = getStyleProperty( name, LINK_COLOR, 'user' );
+		const color = getStyle( name, LINK_COLOR );
+		const userColor = getStyle( name, LINK_COLOR, 'user' );
 		settings.push( {
 			colorValue: color,
-			onColorChange: ( value ) =>
-				setStyleProperty( name, LINK_COLOR, value ),
+			onColorChange: ( value ) => setStyle( name, LINK_COLOR, value ),
 			label: __( 'Link color' ),
 			clearable: color === userColor,
 		} );

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -25,6 +25,7 @@ import {
 	useHasTypographyPanel,
 } from './typography-panel';
 import { default as ColorPanel, useHasColorPanel } from './color-panel';
+import { default as SpacingPanel, useHasSpacingPanel } from './spacing-panel';
 
 function GlobalStylesPanel( {
 	wrapperPanelTitle,
@@ -36,8 +37,9 @@ function GlobalStylesPanel( {
 } ) {
 	const hasColorPanel = useHasColorPanel( context );
 	const hasTypographyPanel = useHasTypographyPanel( context );
+	const hasSpacingPanel = useHasSpacingPanel( context );
 
-	if ( ! hasColorPanel && ! hasTypographyPanel ) {
+	if ( ! hasColorPanel && ! hasTypographyPanel && ! hasSpacingPanel ) {
 		return null;
 	}
 
@@ -57,6 +59,13 @@ function GlobalStylesPanel( {
 					setStyleProperty={ setStyleProperty }
 					getSetting={ getSetting }
 					setSetting={ setSetting }
+				/>
+			) }
+			{ hasSpacingPanel && (
+				<SpacingPanel
+					context={ context }
+					getStyleProperty={ getStyleProperty }
+					setStyleProperty={ setStyleProperty }
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -30,8 +30,8 @@ import { default as SpacingPanel, useHasSpacingPanel } from './spacing-panel';
 function GlobalStylesPanel( {
 	wrapperPanelTitle,
 	context,
-	getStyleProperty,
-	setStyleProperty,
+	getStyle,
+	setStyle,
 	getSetting,
 	setSetting,
 } ) {
@@ -48,15 +48,15 @@ function GlobalStylesPanel( {
 			{ hasTypographyPanel && (
 				<TypographyPanel
 					context={ context }
-					getStyleProperty={ getStyleProperty }
-					setStyleProperty={ setStyleProperty }
+					getStyle={ getStyle }
+					setStyle={ setStyle }
 				/>
 			) }
 			{ hasColorPanel && (
 				<ColorPanel
 					context={ context }
-					getStyleProperty={ getStyleProperty }
-					setStyleProperty={ setStyleProperty }
+					getStyle={ getStyle }
+					setStyle={ setStyle }
 					getSetting={ getSetting }
 					setSetting={ setSetting }
 				/>
@@ -64,8 +64,8 @@ function GlobalStylesPanel( {
 			{ hasSpacingPanel && (
 				<SpacingPanel
 					context={ context }
-					getStyleProperty={ getStyleProperty }
-					setStyleProperty={ setStyleProperty }
+					getStyle={ getStyle }
+					setStyle={ setStyle }
 				/>
 			) }
 		</>
@@ -108,8 +108,8 @@ function getPanelTitle( context ) {
 
 function GlobalStylesBlockPanels( {
 	contexts,
-	getStyleProperty,
-	setStyleProperty,
+	getStyle,
+	setStyle,
 	getSetting,
 	setSetting,
 } ) {
@@ -137,8 +137,8 @@ function GlobalStylesBlockPanels( {
 				key={ 'panel-' + name }
 				wrapperPanelTitle={ wrapperPanelTitle }
 				context={ { ...context, name } }
-				getStyleProperty={ getStyleProperty }
-				setStyleProperty={ setStyleProperty }
+				getStyle={ getStyle }
+				setStyle={ setStyle }
 				getSetting={ getSetting }
 				setSetting={ setSetting }
 			/>
@@ -154,8 +154,8 @@ export default function GlobalStylesSidebar( {
 } ) {
 	const {
 		contexts,
-		getStyleProperty,
-		setStyleProperty,
+		getStyle,
+		setStyle,
 		getSetting,
 		setSetting,
 	} = useGlobalStylesContext();
@@ -200,8 +200,8 @@ export default function GlobalStylesSidebar( {
 						return (
 							<GlobalStylesBlockPanels
 								contexts={ contexts }
-								getStyleProperty={ getStyleProperty }
-								setStyleProperty={ setStyleProperty }
+								getStyle={ getStyle }
+								setStyle={ setStyle }
 								getSetting={ getSetting }
 								setSetting={ setSetting }
 							/>
@@ -214,8 +214,8 @@ export default function GlobalStylesSidebar( {
 								...contexts[ GLOBAL_CONTEXT_NAME ],
 								name: GLOBAL_CONTEXT_NAME,
 							} }
-							getStyleProperty={ getStyleProperty }
-							setStyleProperty={ setStyleProperty }
+							getStyle={ getStyle }
+							setStyle={ setStyle }
 							getSetting={ getSetting }
 							setSetting={ setSetting }
 						/>

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -37,21 +37,21 @@ function useCustomUnits( { units, contextName } ) {
 
 export default function SpacingPanel( {
 	context: { name },
-	getStyleProperty,
-	setStyleProperty,
+	getStyle,
+	setStyle,
 } ) {
 	const units = useCustomUnits( { contextName: name } );
 	const paddingValues = {
-		top: getStyleProperty( name, 'paddingTop' ),
-		right: getStyleProperty( name, 'paddingRight' ),
-		bottom: getStyleProperty( name, 'paddingBottom' ),
-		left: getStyleProperty( name, 'paddingLeft' ),
+		top: getStyle( name, 'paddingTop' ),
+		right: getStyle( name, 'paddingRight' ),
+		bottom: getStyle( name, 'paddingBottom' ),
+		left: getStyle( name, 'paddingLeft' ),
 	};
 	const setPaddingValues = ( { top, right, bottom, left } ) => {
-		setStyleProperty( name, 'paddingTop', top );
-		setStyleProperty( name, 'paddingRight', right );
-		setStyleProperty( name, 'paddingBottom', bottom );
-		setStyleProperty( name, 'paddingLeft', left );
+		setStyle( name, 'paddingTop', top );
+		setStyle( name, 'paddingRight', right );
+		setStyle( name, 'paddingBottom', bottom );
+		setStyle( name, 'paddingLeft', left );
 	};
 	return (
 		<PanelBody title={ __( 'Spacing' ) }>

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -13,7 +13,10 @@ import {
 import { useEditorFeature } from '../editor/utils';
 
 export function useHasSpacingPanel( { supports } ) {
-	return supports.includes( 'paddingBottom' );
+	return (
+		useEditorFeature( 'spacing.customPadding' ) &&
+		supports.includes( 'paddingBottom' )
+	);
 }
 
 function filterUnitsWithSettings( settings = [], units = [] ) {

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -41,17 +41,14 @@ export default function SpacingPanel( {
 	setStyle,
 } ) {
 	const units = useCustomUnits( { contextName: name } );
-	const paddingValues = {
-		top: getStyle( name, 'paddingTop' ),
-		right: getStyle( name, 'paddingRight' ),
-		bottom: getStyle( name, 'paddingBottom' ),
-		left: getStyle( name, 'paddingLeft' ),
-	};
+	const paddingValues = getStyle( name, 'padding' );
 	const setPaddingValues = ( { top, right, bottom, left } ) => {
-		setStyle( name, 'paddingTop', top );
-		setStyle( name, 'paddingRight', right );
-		setStyle( name, 'paddingBottom', bottom );
-		setStyle( name, 'paddingLeft', left );
+		setStyle( name, 'padding', {
+			top: top || paddingValues.top,
+			right: right || paddingValues.right,
+			bottom: bottom || paddingValues.bottom,
+			left: left || paddingValues.left,
+		} );
 	};
 	return (
 		<PanelBody title={ __( 'Spacing' ) }>

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -44,10 +44,10 @@ export default function SpacingPanel( {
 	const paddingValues = getStyle( name, 'padding' );
 	const setPaddingValues = ( { top, right, bottom, left } ) => {
 		setStyle( name, 'padding', {
-			top: top || paddingValues.top,
-			right: right || paddingValues.right,
-			bottom: bottom || paddingValues.bottom,
-			left: left || paddingValues.left,
+			top: top || paddingValues?.top,
+			right: right || paddingValues?.right,
+			bottom: bottom || paddingValues?.bottom,
+			left: left || paddingValues?.left,
 		} );
 	};
 	return (

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalBoxControl as BoxControl,
+	PanelBody,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useEditorFeature } from '../editor/utils';
+
+export function useHasSpacingPanel( { supports } ) {
+	return supports.includes( 'paddingBottom' );
+}
+
+function filterUnitsWithSettings( settings = [], units = [] ) {
+	return units.filter( ( unit ) => {
+		return settings.includes( unit.value );
+	} );
+}
+
+function useCustomUnits( units ) {
+	const availableUnits = useEditorFeature( 'spacing.units' );
+	const usedUnits = filterUnitsWithSettings(
+		! availableUnits ? [] : availableUnits,
+		units
+	);
+
+	return usedUnits.length === 0 ? false : usedUnits;
+}
+
+export default function SpacingPanel( {
+	context: { name },
+	getStyleProperty,
+	setStyleProperty,
+} ) {
+	const units = useCustomUnits();
+	const paddingValues = {
+		top: getStyleProperty( name, 'paddingTop' ),
+		right: getStyleProperty( name, 'paddingRight' ),
+		bottom: getStyleProperty( name, 'paddingBottom' ),
+		left: getStyleProperty( name, 'paddingLeft' ),
+	};
+	const setPaddingValues = ( { top, right, bottom, left } ) => {
+		setStyleProperty( name, 'paddingTop', top );
+		setStyleProperty( name, 'paddingRight', right );
+		setStyleProperty( name, 'paddingBottom', bottom );
+		setStyleProperty( name, 'paddingLeft', left );
+	};
+	return (
+		<PanelBody title={ __( 'Spacing' ) }>
+			<BoxControl
+				values={ paddingValues }
+				onChange={ setPaddingValues }
+				label={ __( 'Padding' ) }
+				units={ units }
+			/>
+		</PanelBody>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -12,9 +12,9 @@ import {
  */
 import { useEditorFeature } from '../editor/utils';
 
-export function useHasSpacingPanel( { supports } ) {
+export function useHasSpacingPanel( { supports, name } ) {
 	return (
-		useEditorFeature( 'spacing.customPadding' ) &&
+		useEditorFeature( 'spacing.customPadding', name ) &&
 		supports.includes( 'paddingBottom' )
 	);
 }

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -15,7 +15,7 @@ import { useEditorFeature } from '../editor/utils';
 export function useHasSpacingPanel( { supports, name } ) {
 	return (
 		useEditorFeature( 'spacing.customPadding', name ) &&
-		supports.includes( 'paddingBottom' )
+		supports.includes( 'padding' )
 	);
 }
 

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -25,8 +25,8 @@ function filterUnitsWithSettings( settings = [], units = [] ) {
 	} );
 }
 
-function useCustomUnits( units ) {
-	const availableUnits = useEditorFeature( 'spacing.units' );
+function useCustomUnits( { units, contextName } ) {
+	const availableUnits = useEditorFeature( 'spacing.units', contextName );
 	const usedUnits = filterUnitsWithSettings(
 		! availableUnits ? [] : availableUnits,
 		units
@@ -40,7 +40,7 @@ export default function SpacingPanel( {
 	getStyleProperty,
 	setStyleProperty,
 } ) {
-	const units = useCustomUnits();
+	const units = useCustomUnits( { contextName: name } );
 	const paddingValues = {
 		top: getStyleProperty( name, 'paddingTop' ),
 		right: getStyleProperty( name, 'paddingRight' ),

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -41,8 +41,8 @@ function useHasAppearenceControl( { supports, name } ) {
 
 export default function TypographyPanel( {
 	context: { supports, name },
-	getStyleProperty,
-	setStyleProperty,
+	getStyle,
+	setStyle,
 } ) {
 	const fontSizes = useEditorFeature( 'typography.fontSizes', name );
 	const disableCustomFontSizes = ! useEditorFeature(
@@ -64,17 +64,17 @@ export default function TypographyPanel( {
 			{ supports.includes( 'fontFamily' ) && (
 				<FontFamilyControl
 					fontFamilies={ fontFamilies }
-					value={ getStyleProperty( name, 'fontFamily' ) }
+					value={ getStyle( name, 'fontFamily' ) }
 					onChange={ ( value ) =>
-						setStyleProperty( name, 'fontFamily', value )
+						setStyle( name, 'fontFamily', value )
 					}
 				/>
 			) }
 			{ supports.includes( 'fontSize' ) && (
 				<FontSizePicker
-					value={ getStyleProperty( name, 'fontSize' ) }
+					value={ getStyle( name, 'fontSize' ) }
 					onChange={ ( value ) =>
-						setStyleProperty( name, 'fontSize', value )
+						setStyle( name, 'fontSize', value )
 					}
 					fontSizes={ fontSizes }
 					disableCustomFontSizes={ disableCustomFontSizes }
@@ -82,21 +82,21 @@ export default function TypographyPanel( {
 			) }
 			{ hasLineHeightEnabled && (
 				<LineHeightControl
-					value={ getStyleProperty( name, 'lineHeight' ) }
+					value={ getStyle( name, 'lineHeight' ) }
 					onChange={ ( value ) =>
-						setStyleProperty( name, 'lineHeight', value )
+						setStyle( name, 'lineHeight', value )
 					}
 				/>
 			) }
 			{ hasAppearenceControl && (
 				<FontAppearanceControl
 					value={ {
-						fontStyle: getStyleProperty( name, 'fontStyle' ),
-						fontWeight: getStyleProperty( name, 'fontWeight' ),
+						fontStyle: getStyle( name, 'fontStyle' ),
+						fontWeight: getStyle( name, 'fontWeight' ),
 					} }
 					onChange={ ( { fontStyle, fontWeight } ) => {
-						setStyleProperty( name, 'fontStyle', fontStyle );
-						setStyleProperty( name, 'fontWeight', fontWeight );
+						setStyle( name, 'fontStyle', fontStyle );
+						setStyle( name, 'fontWeight', fontWeight );
 					} }
 					hasFontStyles={ hasFontStyles }
 					hasFontWeights={ hasFontWeights }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -191,20 +191,30 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					),
 					'misc'     => 'value',
 				),
-			)
+				'core/group' => array(
+					'styles' => array(
+						'spacing' => array(
+							'padding' => array(
+								'top'    => '12px',
+								'bottom' => '24px'
+							),
+						),
+					),
+				),
+			),
 		);
 
 		$this->assertEquals(
-			$theme_json->get_stylesheet(),
-			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}'
+				':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}',
+				$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			$theme_json->get_stylesheet( 'block_styles' ),
-			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}'
+			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}',
+			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(
-			$theme_json->get_stylesheet( 'css_variables' ),
-			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}'
+				':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}',
+				$theme_json->get_stylesheet( 'css_variables' )
 		);
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -157,7 +157,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		// See schema at WP_Theme_JSON::SCHEMA.
 		$theme_json = new WP_Theme_JSON(
 			array(
-				'global' => array(
+				'global'     => array(
 					'settings' => array(
 						'color'      => array(
 							'text'    => 'value',
@@ -196,25 +196,25 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						'spacing' => array(
 							'padding' => array(
 								'top'    => '12px',
-								'bottom' => '24px'
+								'bottom' => '24px',
 							),
 						),
 					),
 				),
-			),
+			)
 		);
 
 		$this->assertEquals(
-				':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}',
-				$theme_json->get_stylesheet()
+			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}',
+			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
 			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(
-				':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}',
-				$theme_json->get_stylesheet( 'css_variables' )
+			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}',
+			$theme_json->get_stylesheet( 'css_variables' )
 		);
 	}
 


### PR DESCRIPTION
Depends on https://github.com/WordPress/gutenberg/pull/27099

This PR adds the spacing panel to the Global Styles sidebar, so if any block declares support for it (at the moment of writing this, only group and cover) it'll be shown at the global level as well.

## How to test

Test that the padding controls work in the site editor:

- Install and activate TwentyTwentyOne blocks theme.
- Go to the site editor and edit the site template to include a group.
- Open the Global Styles sidebar and look up for group or cover block, check that the spacing panel is visible for them.
- Update the padding values for the kind of block you added (group if you added a group, cover if you added a cover) and verify that the padding changes.
- Publish the changes and verify the front-end.

Test that the padding controls still work it the post editor:

- Go to the post editor.
- Add a group or cover.
- Check that they have the spacing panel, and edit its padding and verify that the block is updated.
- Publish and verify that the front-end is also updated.
