### PR TITLE
[Try] Async stan

### DIFF
--- a/packages/stan/src/atom.js
+++ b/packages/stan/src/atom.js
@@ -25,19 +25,19 @@ export const createAtom = ( initialValue, config = {} ) => () => {
 		type: 'root',
 		set( newValue ) {
 			value = newValue;
-			listeners.forEach( ( l ) => l() );
+			return Promise.all( Array.from( listeners ).map( ( l ) => l() ) );
 		},
 		get() {
-			return value;
+			return Promise.resolve( value );
 		},
 		async resolve() {
-			return value;
+			return Promise.resolve( value );
 		},
 		subscribe( listener ) {
 			listeners.add( listener );
-			return () => {
+			return Promise.resolve( () => {
 				listeners.delete( listener );
-			};
+			} );
 		},
 		isResolved: true,
 	};

--- a/packages/stan/src/registry.js
+++ b/packages/stan/src/registry.js
@@ -132,7 +132,7 @@ export const createAtomRegistry = ( onAdd = noop, onDelete = noop ) => {
 		// This shouldn't be necessary since we rely on week map
 		// But the legacy selectors/actions API requires us to know when
 		// some atoms are removed entirely to unsubscribe.
-		delete( atom ) {
+		async delete( atom ) {
 			if ( isAtomFamilyItem( atom ) ) {
 				const {
 					config,
@@ -140,8 +140,8 @@ export const createAtomRegistry = ( onAdd = noop, onDelete = noop ) => {
 				} = /** @type {WPAtomFamilyItem<any>} */ ( atom );
 				return familyRegistry.deleteAtomFromFamily( config, key );
 			}
-			const atomState = atoms.get( atom );
-			atoms.delete( atom );
+			const atomState = await atoms.get( atom );
+			await atoms.delete( atom );
 			onDelete( atomState );
 		},
 	};

--- a/packages/stan/src/test/atom.js
+++ b/packages/stan/src/test/atom.js
@@ -4,25 +4,25 @@
 import { createAtomRegistry, createAtom } from '../';
 
 describe( 'atoms', () => {
-	it( 'should allow getting and setting atom values', () => {
+	it( 'should allow getting and setting atom values', async () => {
 		const count = createAtom( 1 );
 		const registry = createAtomRegistry();
-		expect( registry.get( count ) ).toEqual( 1 );
-		registry.set( count, 2 );
-		expect( registry.get( count ) ).toEqual( 2 );
+		expect( await registry.get( count ) ).toEqual( 1 );
+		await registry.set( count, 2 );
+		expect( await registry.get( count ) ).toEqual( 2 );
 	} );
 
-	it( 'should allow subscribing to atom changes', () => {
+	it( 'should allow subscribing to atom changes', async () => {
 		const count = createAtom( 1 );
 		const registry = createAtomRegistry();
 		const listener = jest.fn();
-		registry.subscribe( count, listener );
-		expect( registry.get( count ) ).toEqual( 1 );
-		registry.set( count, 2 );
+		await registry.subscribe( count, listener );
+		expect( await registry.get( count ) ).toEqual( 1 );
+		await registry.set( count, 2 );
 		expect( listener ).toHaveBeenCalledTimes( 1 );
-		expect( registry.get( count ) ).toEqual( 2 );
-		registry.set( count, 3 );
+		expect( await registry.get( count ) ).toEqual( 2 );
+		await registry.set( count, 3 );
 		expect( listener ).toHaveBeenCalledTimes( 2 );
-		expect( registry.get( count ) ).toEqual( 3 );
+		expect( await registry.get( count ) ).toEqual( 3 );
 	} );
 } );

--- a/packages/stan/src/test/derived.js
+++ b/packages/stan/src/test/derived.js
@@ -18,15 +18,18 @@ describe( 'creating derived atoms', () => {
 		const count2 = createAtom( 1 );
 		const count3 = createAtom( 1 );
 		const sum = createDerivedAtom(
-			( { get } ) => get( count1 ) + get( count2 ) + get( count3 )
+			async ( { get } ) =>
+				( await get( count1 ) ) +
+				( await get( count2 ) ) +
+				( await get( count3 ) )
 		);
 		const registry = createAtomRegistry();
 
 		// Atoms don't compute any value unless there's a subscriber.
-		const unsubscribe = registry.subscribe( sum, () => {} );
-		expect( registry.get( sum ) ).toEqual( 3 );
-		registry.set( count1, 2 );
-		expect( registry.get( sum ) ).toEqual( 4 );
+		const unsubscribe = await registry.subscribe( sum, () => {} );
+		expect( await registry.get( sum ) ).toEqual( 3 );
+		await registry.set( count1, 2 );
+		expect( await registry.get( sum ) ).toEqual( 4 );
 		unsubscribe();
 	} );
 
@@ -34,13 +37,12 @@ describe( 'creating derived atoms', () => {
 		const count1 = createAtom( 1 );
 		const sum = createDerivedAtom( async ( { get } ) => {
 			const value = await Promise.resolve( 10 );
-			return get( count1 ) + value;
+			return ( await get( count1 ) ) + value;
 		} );
 		const registry = createAtomRegistry();
 		// Atoms don't compute any value unless there's a subscriber.
-		const unsubscribe = registry.subscribe( sum, () => {} );
-		await flushImmediatesAndTicks();
-		expect( registry.get( sum ) ).toEqual( 11 );
+		const unsubscribe = await registry.subscribe( sum, () => {} );
+		expect( await registry.get( sum ) ).toEqual( 11 );
 		unsubscribe();
 	} );
 
@@ -54,14 +56,19 @@ describe( 'creating derived atoms', () => {
 			return 10;
 		} );
 		const sum = createDerivedAtom( async ( { get } ) => {
-			return get( count1 ) + get( count2 );
+			const [ c1, c2 ] = await Promise.all( [
+				get( count1 ),
+				get( count2 ),
+			] );
+			return c1 + c2;
 		} );
 		const registry = createAtomRegistry();
 		// Atoms don't compute any value unless there's a subscriber.
-		const unsubscribe = registry.subscribe( sum, () => {} );
+		const unsubscribePromise = registry.subscribe( sum, () => {} );
 		await jest.advanceTimersByTime( 1000 );
 		await flushImmediatesAndTicks();
-		expect( registry.get( sum ) ).toEqual( 20 );
+		const unsubscribe = await unsubscribePromise;
+		expect( await registry.get( sum ) ).toEqual( 20 );
 		unsubscribe();
 	} );
 
@@ -72,98 +79,153 @@ describe( 'creating derived atoms', () => {
 			return ( await get( count2 ) ) * 2;
 		} );
 		const sum = createDerivedAtom( async ( { get } ) => {
-			return get( count1 ) + get( asyncCount );
+			return ( await get( count1 ) ) + ( await get( asyncCount ) );
 		} );
 		const registry = createAtomRegistry();
 		// Atoms don't compute any value unless there's a subscriber.
-		const unsubscribe = registry.subscribe( sum, () => {} );
-		await flushImmediatesAndTicks( 2 );
-		expect( registry.get( sum ) ).toEqual( 21 );
+		const unsubscribe = await registry.subscribe( sum, () => {} );
+		expect( await registry.get( sum ) ).toEqual( 21 );
 		unsubscribe();
 	} );
 
-	it( 'should only compute derived atoms when they have subscribers or when you try to retrieve their value', () => {
+	it( 'should only compute derived atoms when they have subscribers or when you try to retrieve their value', async () => {
 		const mock = jest.fn();
 		mock.mockImplementation( () => 10 );
 		const count1 = createAtom( 1 );
 		const count2 = createAtom( 1 );
 		const sum = createDerivedAtom(
-			( { get } ) => get( count1 ) + get( count2 ) + mock()
+			async ( { get } ) =>
+				( await get( count1 ) ) + ( await get( count2 ) ) + mock()
 		);
 		const registry = createAtomRegistry();
 		// Creating an atom or adding it to the registry don't trigger its resolution
 		expect( mock ).not.toHaveBeenCalled();
-		expect( registry.get( sum ) ).toEqual( 12 );
+		expect( await registry.get( sum ) ).toEqual( 12 );
 		// Calling "get" triggers a resolution.
 		expect( mock ).toHaveBeenCalledTimes( 1 );
 
 		// This shouldn't trigger the resolution because the atom has no listener.
-		registry.set( count1, 2 );
+		await registry.set( count1, 2 );
 		expect( mock ).toHaveBeenCalledTimes( 1 );
 
 		// Subscribing triggers the resolution again.
-		const unsubscribe = registry.subscribe( sum, () => {} );
+		const unsubscribe = await registry.subscribe( sum, () => {} );
 		expect( mock ).toHaveBeenCalledTimes( 2 );
-		expect( registry.get( sum ) ).toEqual( 13 );
+		expect( await registry.get( sum ) ).toEqual( 13 );
 		unsubscribe();
 	} );
 
-	it( 'should notify subscribers on change', () => {
+	it( 'should notify subscribers on change', async () => {
 		const count1 = createAtom( 1 );
 		const count2 = createAtom( 1 );
 		const sum = createDerivedAtom(
-			( { get } ) => get( count1 ) + get( count2 )
+			async ( { get } ) =>
+				( await get( count1 ) ) + ( await get( count2 ) )
 		);
 		const registry = createAtomRegistry();
 		const listener = jest.fn();
-		const unsubscribe = registry.subscribe( sum, listener );
+		const unsubscribe = await registry.subscribe( sum, listener );
 
-		registry.set( count1, 2 );
+		await registry.set( count1, 2 );
 		expect( listener ).toHaveBeenCalledTimes( 1 );
 
-		registry.set( count2, 2 );
+		await registry.set( count2, 2 );
 		expect( listener ).toHaveBeenCalledTimes( 2 );
 
 		unsubscribe();
 	} );
 } );
 
+describe( 'error handling in derived atoms', () => {
+	it( 'should not suppress resolution errors in get (async)', () => {
+		const asyncCount = createDerivedAtom( () =>
+			Promise.reject( 'test123' )
+		);
+		const sum = createDerivedAtom( async ( { get } ) => {
+			return get( asyncCount );
+		} );
+		const registry = createAtomRegistry();
+		expect( registry.get( sum ) ).rejects.toThrow( 'test123' );
+	} );
+
+	it( 'should not suppress resolution errors in subscribe (async)', () => {
+		const asyncCount = createDerivedAtom( () =>
+			Promise.reject( 'test123' )
+		);
+		const sum = createDerivedAtom( async ( { get } ) => {
+			return get( asyncCount );
+		} );
+		const registry = createAtomRegistry();
+		expect( registry.subscribe( sum, () => {} ) ).rejects.toThrow(
+			'test123'
+		);
+	} );
+
+	it( 'should not suppress resolution errors in get', () => {
+		const count = createDerivedAtom( () => {
+			throw new Error( 'test123' );
+		} );
+		const sum = createDerivedAtom( async ( { get } ) => {
+			return await get( count );
+		} );
+		const registry = createAtomRegistry();
+		expect( registry.subscribe( sum, () => {} ) ).rejects.toThrow(
+			'test123'
+		);
+	} );
+
+	it( 'should not suppress resolution errors in subscribe', () => {
+		const count = createDerivedAtom( () => {
+			throw new Error( 'test123' );
+		} );
+		const sum = createDerivedAtom( async ( { get } ) => {
+			return await get( count );
+		} );
+		const registry = createAtomRegistry();
+		expect( registry.subscribe( sum, () => {} ) ).rejects.toThrow(
+			'test123'
+		);
+	} );
+} );
+
 describe( 'updating derived atoms', () => {
-	it( 'should allow derived atoms to update dependencies', () => {
+	it( 'should allow derived atoms to update dependencies', async () => {
 		const count1 = createAtom( 1 );
 		const count2 = createAtom( 1 );
 		const sum = createDerivedAtom(
-			( { get } ) => get( count1 ) + get( count2 ),
-			( { set }, value ) => {
-				set( count1, value / 2 );
-				set( count2, value / 2 );
+			async ( { get } ) =>
+				( await get( count1 ) ) + ( await get( count2 ) ),
+			async ( { set }, value ) => {
+				await set( count1, value / 2 );
+				await set( count2, value / 2 );
 			}
 		);
 		const registry = createAtomRegistry();
-		registry.set( sum, 4 );
-		expect( registry.get( count1 ) ).toEqual( 2 );
-		expect( registry.get( count2 ) ).toEqual( 2 );
+		await registry.set( sum, 4 );
+		expect( await registry.get( count1 ) ).toEqual( 2 );
+		expect( await registry.get( count2 ) ).toEqual( 2 );
 	} );
 
-	it( 'should allow nested derived atoms to update dependencies', () => {
+	it( 'should allow nested derived atoms to update dependencies', async () => {
 		const count1 = createAtom( 1 );
 		const count2 = createAtom( 1 );
 		const sum = createDerivedAtom(
-			( { get } ) => get( count1 ) + get( count2 ),
-			( { set }, value ) => {
-				set( count1, value / 2 );
-				set( count2, value / 2 );
+			async ( { get } ) =>
+				( await get( count1 ) ) + ( await get( count2 ) ),
+			async ( { set }, value ) => {
+				await set( count1, value / 2 );
+				await set( count2, value / 2 );
 			}
 		);
 		const multiply = createDerivedAtom(
-			( { get } ) => get( sum ) * 3,
-			( { set }, value ) => {
-				set( sum, value / 3 );
+			async ( { get } ) => ( await get( sum ) ) * 3,
+			async ( { set }, value ) => {
+				await set( sum, value / 3 );
 			}
 		);
 		const registry = createAtomRegistry();
-		registry.set( multiply, 18 );
-		expect( registry.get( count1 ) ).toEqual( 3 );
-		expect( registry.get( count2 ) ).toEqual( 3 );
+		await registry.set( multiply, 18 );
+		expect( await registry.get( count1 ) ).toEqual( 3 );
+		expect( await registry.get( count2 ) ).toEqual( 3 );
 	} );
 } );

--- a/packages/stan/src/test/family.js
+++ b/packages/stan/src/test/family.js
@@ -4,10 +4,10 @@
 import { createAtomRegistry, createAtom, createAtomFamily } from '../';
 
 describe( 'creating and subscribing to atom families', () => {
-	it( 'should allow adding and removing items to families', () => {
+	it( 'should allow adding and removing items to families', async () => {
 		const itemsByIdAtom = createAtom( {} );
-		const itemFamilyAtom = createAtomFamily( ( key ) => ( { get } ) =>
-			get( itemsByIdAtom )[ key ]
+		const itemFamilyAtom = createAtomFamily( ( key ) => async ( { get } ) =>
+			( await get( itemsByIdAtom ) )[ key ]
 		);
 
 		const registry = createAtomRegistry();
@@ -19,71 +19,84 @@ describe( 'creating and subscribing to atom families', () => {
 			registry.__unstableGetAtomState( itemFamilyAtom( 1 ) )
 		);
 		// Atoms don't compute any value unless there's a subscriber.
-		const unsubscribe = registry.subscribe( itemFamilyAtom( 1 ), () => {} );
-		expect( firstItemAtom.get() ).toBe( undefined );
+		const unsubscribe = await registry.subscribe(
+			itemFamilyAtom( 1 ),
+			() => {}
+		);
+		expect( await firstItemAtom.get() ).toBe( undefined );
 
 		// Add some items
-		registry.set( itemsByIdAtom, {
+		await registry.set( itemsByIdAtom, {
 			1: { name: 'first' },
 			2: { name: 'second' },
 		} );
 
 		// Should update the value automatically as we set the items.
-		expect( registry.get( itemFamilyAtom( 1 ) ) ).toEqual( {
+		expect( await registry.get( itemFamilyAtom( 1 ) ) ).toEqual( {
 			name: 'first',
 		} );
 
 		// Remove items
-		registry.set( itemsByIdAtom, {
+		await registry.set( itemsByIdAtom, {
 			2: { name: 'second' },
 		} );
 
 		// Should update the value automatically as we unset the items.
-		expect( registry.get( itemFamilyAtom( 1 ) ) ).toBe( undefined );
+		expect( await registry.get( itemFamilyAtom( 1 ) ) ).toBe( undefined );
 		unsubscribe();
 	} );
 
-	it( 'should allow creating families based on other families', () => {
+	it( 'should allow creating families based on other families', async () => {
 		const itemsByIdAtom = createAtom( {} );
-		const itemFamilyAtom = createAtomFamily( ( key ) => ( { get } ) => {
-			return get( itemsByIdAtom )[ key ];
-		} );
+		const itemFamilyAtom = createAtomFamily(
+			( key ) => async ( { get } ) => {
+				return ( await get( itemsByIdAtom ) )[ key ];
+			}
+		);
 		// Family atom that depends on another family atom.
-		const itemNameFamilyAtom = createAtomFamily( ( key ) => ( { get } ) => {
-			return get( itemFamilyAtom( key ) )?.name;
-		} );
+		const itemNameFamilyAtom = createAtomFamily(
+			( key ) => async ( { get } ) => {
+				return ( await get( itemFamilyAtom( key ) ) )?.name;
+			}
+		);
 
 		const registry = createAtomRegistry();
-		registry.set( itemsByIdAtom, {
+		await registry.set( itemsByIdAtom, {
 			1: { name: 'first' },
 			2: { name: 'second' },
 		} );
 
 		// Atoms don't compute any value unless there's a subscriber.
-		const unsubscribe = registry.subscribe(
+		const unsubscribe = await registry.subscribe(
 			itemNameFamilyAtom( 1 ),
 			() => {}
 		);
-		expect( registry.get( itemNameFamilyAtom( 1 ) ) ).toEqual( 'first' );
+		expect( await registry.get( itemNameFamilyAtom( 1 ) ) ).toEqual(
+			'first'
+		);
 		unsubscribe();
 	} );
 
-	it( 'should not recompute a family dependency if its untouched', () => {
+	it( 'should not recompute a family dependency if its untouched', async () => {
 		const itemsByIdAtom = createAtom( {} );
-		const itemFamilyAtom = createAtomFamily( ( key ) => ( { get } ) => {
-			return get( itemsByIdAtom )[ key ];
-		} );
+		const itemFamilyAtom = createAtomFamily(
+			( key ) => async ( { get } ) => {
+				return ( await get( itemsByIdAtom ) )[ key ];
+			}
+		);
 		// Family atom that depends on another family atom.
-		const itemNameFamilyAtom = createAtomFamily( ( key ) => ( { get } ) => {
-			return get( itemFamilyAtom( key ) )?.name;
-		} );
+		const itemNameFamilyAtom = createAtomFamily(
+			( key ) => async ( { get } ) => {
+				return ( await get( itemFamilyAtom( key ) ) )?.name;
+			}
+		);
 
 		const registry = createAtomRegistry();
 		const initialItems = {
 			1: { name: 'first' },
 			2: { name: 'second' },
 		};
-		registry.set( itemsByIdAtom, initialItems );
+		await registry.set( itemsByIdAtom, initialItems );
 
 		const name1Listener = jest.fn();
 		const name2Listener = jest.fn();
@@ -91,17 +104,17 @@ describe( 'creating and subscribing to atom families', () => {
 		const name1 = itemNameFamilyAtom( 1 );
 		const name2 = itemNameFamilyAtom( 2 );
 
-		const unsubscribe = registry.subscribe( name1, name1Listener );
-		const unsubscribe2 = registry.subscribe( name2, name2Listener );
+		const unsubscribe = await registry.subscribe( name1, name1Listener );
+		const unsubscribe2 = await registry.subscribe( name2, name2Listener );
 
 		// If I update item 1, item 2 dedendencies shouldn't recompute.
-		registry.set( itemsByIdAtom, {
+		await registry.set( itemsByIdAtom, {
 			...initialItems,
 			1: { name: 'updated first' },
 		} );
 
-		expect( registry.get( name1 ) ).toEqual( 'updated first' );
-		expect( registry.get( name2 ) ).toEqual( 'second' );
+		expect( await registry.get( name1 ) ).toEqual( 'updated first' );
+		expect( await registry.get( name2 ) ).toEqual( 'second' );
 		expect( name1Listener ).toHaveBeenCalledTimes( 1 );
 		expect( name2Listener ).not.toHaveBeenCalled();
 
@@ -111,47 +124,47 @@ describe( 'creating and subscribing to atom families', () => {
 } );
 
 describe( 'updating family atoms', () => {
-	it( 'should allow family atoms to update dependencies', () => {
+	it( 'should allow family atoms to update dependencies', async () => {
 		const itemsByIdAtom = createAtom( {} );
 		const itemFamilyAtom = createAtomFamily(
-			( key ) => ( { get } ) => get( itemsByIdAtom )[ key ],
-			( key ) => ( { get, set }, value ) => {
+			( key ) => async ( { get } ) =>
+				( await get( itemsByIdAtom ) )[ key ],
+			( key ) => async ( { get, set }, value ) =>
 				set( itemsByIdAtom, {
-					...get( itemsByIdAtom ),
+					...( await get( itemsByIdAtom ) ),
 					[ key ]: value,
-				} );
-			}
+				} )
 		);
 		const registry = createAtomRegistry();
-		registry.set( itemFamilyAtom( 1 ), { name: 'first' } );
-		expect( registry.get( itemsByIdAtom ) ).toEqual( {
+		await registry.set( itemFamilyAtom( 1 ), { name: 'first' } );
+		expect( await registry.get( itemsByIdAtom ) ).toEqual( {
 			1: { name: 'first' },
 		} );
 	} );
 
-	it( 'should allow updating nested family atoms', () => {
+	it( 'should allow updating nested family atoms', async () => {
 		const itemsByIdAtom = createAtom( {} );
 		const itemFamilyAtom = createAtomFamily(
-			( key ) => ( { get } ) => get( itemsByIdAtom )[ key ],
-			( key ) => ( { get, set }, value ) => {
+			( key ) => async ( { get } ) =>
+				( await get( itemsByIdAtom ) )[ key ],
+			( key ) => async ( { get, set }, value ) =>
 				set( itemsByIdAtom, {
-					...get( itemsByIdAtom ),
+					...( await get( itemsByIdAtom ) ),
 					[ key ]: value,
-				} );
-			}
+				} )
 		);
 		const itemNameFamilyAtom = createAtomFamily(
-			( key ) => ( { get } ) => get( itemFamilyAtom( key ) ).name,
-			( key ) => ( { get, set }, value ) => {
+			( key ) => async ( { get } ) =>
+				( await get( itemsByIdAtom ) )[ key ],
+			( key ) => async ( { get, set }, value ) =>
 				set( itemFamilyAtom( key ), {
-					...get( itemFamilyAtom( key ) ),
+					...( await get( itemsByIdAtom )[ key ] ),
 					name: value,
-				} );
-			}
+				} )
 		);
 		const registry = createAtomRegistry();
-		registry.set( itemNameFamilyAtom( 1 ), 'first' );
-		expect( registry.get( itemsByIdAtom ) ).toEqual( {
+		await registry.set( itemNameFamilyAtom( 1 ), 'first' );
+		expect( await registry.get( itemsByIdAtom ) ).toEqual( {
 			1: { name: 'first' },
 		} );
 	} );


### PR DESCRIPTION
## Description
**For now this PR won't even work - it serves as a discussion prompt.** I didn't bother to update types or consumers of this API as I'd like to talk it out first.

#26866 introduced a new state management system called `stan`. As discussed in https://github.com/WordPress/gutenberg/pull/26866#discussion_r527737511, there are some rough edges related to asynchronicity. For example, resolution rejection of dependent derived atoms are suppressed and never bubble up:

```js
subscribe( listener ) {
	if ( ! isListening ) {
		isListening = true;
		resolve(); // This returns a promise, rejections go unnoticed and the only symptom is unresolved "parent" atom
	}
	listeners.add( listener );
	return () => {
		listeners.delete( listener );
	};
},
```

I was pondering what's the right way of approaching this problem and concluded that as soon as there are promises in the mix, everything handling these promises should also be "promisified". This PR is an experiment in which everything in `stan` becomes `async`.

Usage would change from this:

```js
const sum = createDerivedAtom(
	( { get } ) => get( count1 ) + get( count2 ) + get( count3 )
);
```

to this:

```js
const sum = createDerivedAtom(
	async ( { get } ) =>
		( await get( count1 ) ) +
		( await get( count2 ) ) +
		( await get( count3 ) )
);
```

Ubiquitious `await` is an obvious downside. Also in this implementation it's even more important to cancel resolution when a "concurrent" update arrives - I think `rx.js` could make this part very easy but I abstained from introducing a new dependency for now.

Upsides are that all the errors are now catchable as they'll bubble up the promise chain. We also no longer need any heuristics to reason about exceptions (`if ( unresolved.length === 0 ) { throw e; }`). Also, should we decide to switch to any other way of handling the state internally, this API opens many doors that are not trivially opened with synchronous `get`.

cc @jsnajdr @youknowriad @gziolo 