### PR TITLE
Navigation Component: Handle the no search results state

### DIFF
--- a/packages/components/src/navigation/menu/index.js
+++ b/packages/components/src/navigation/menu/index.js
@@ -17,6 +17,7 @@ import { useNavigationContext } from '../context';
 import { useNavigationTreeMenu } from './use-navigation-tree-menu';
 import NavigationBackButton from '../back-button';
 import NavigationMenuTitle from './menu-title';
+import NavigationSearchNoResultsFound from './search-no-results-found';
 import { NavigableMenu } from '../../navigable-container';
 import { MenuUI } from '../styles/navigation-styles';
 
@@ -81,7 +82,12 @@ export default function NavigationMenu( props ) {
 				/>
 
 				<NavigableMenu>
-					<ul aria-labelledby={ menuTitleId }>{ children }</ul>
+					<ul aria-labelledby={ menuTitleId }>
+						{ children }
+						{ search && (
+							<NavigationSearchNoResultsFound search={ search } />
+						) }
+					</ul>
 				</NavigableMenu>
 			</MenuUI>
 		</NavigationMenuContext.Provider>

--- a/packages/components/src/navigation/menu/search-no-results-found.js
+++ b/packages/components/src/navigation/menu/search-no-results-found.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useNavigationContext } from '../context';
+import { ItemBaseUI, ItemUI } from '../styles/navigation-styles';
+
+export default function NavigationSearchNoResultsFound( { search } ) {
+	const {
+		navigationTree: { items },
+	} = useNavigationContext();
+
+	const resultsCount = filter( items, '_isVisible' ).length;
+
+	if ( ! search || !! resultsCount ) {
+		return null;
+	}
+
+	return (
+		<ItemBaseUI>
+			<ItemUI>{ __( 'No results found.' ) } </ItemUI>
+		</ItemBaseUI>
+	);
+}


### PR DESCRIPTION
## Description

A missing feature for the built-in search of the Navigation component is handling the "no results" state.

The component is smart enough to count the results by itself, and announce them to screen readers.
But when we implemented it in a real case scenario (#26665), we had to create a "no results" message from scratch.
We tried rendering it as a simple, text-only, `NavigationItem`, which worked fine visually, but unfortunately was counted as a search result, and announced as "1 result found" to screen readers.

This PR adds a "No results found." message, visually identical to any other `NavigationItem`, but not counted towards the results.
It's only rendered if the search is active and "in progress" (there are characters in the search field), and there are no results.

## How has this been tested?

- `npm run storybook:dev` and search for the Navigation > Search story.
- Try searching in both the controlled and uncontrolled search examples, and make sure that:
  - The no results message only shows up when there are no other results.
  - The voice over announces 0 results.
  - The no results message doesn't remain visible when changing menu.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
