### PR TITLE
Block Directory: Replace store name string with exposed store definition

### DIFF
--- a/packages/block-directory/src/components/auto-block-uninstaller/index.js
+++ b/packages/block-directory/src/components/auto-block-uninstaller/index.js
@@ -5,8 +5,13 @@ import { unregisterBlockType } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockDirectoryStore } from '../../store';
+
 export default function AutoBlockUninstaller() {
-	const { uninstallBlockType } = useDispatch( 'core/block-directory' );
+	const { uninstallBlockType } = useDispatch( blockDirectoryStore );
 
 	const shouldRemoveBlockTypes = useSelect( ( select ) => {
 		const { isAutosavingPost, isSavingPost } = select( 'core/editor' );
@@ -14,7 +19,7 @@ export default function AutoBlockUninstaller() {
 	}, [] );
 
 	const unusedBlockTypes = useSelect(
-		( select ) => select( 'core/block-directory' ).getUnusedBlockTypes(),
+		( select ) => select( blockDirectoryStore ).getUnusedBlockTypes(),
 		[]
 	);
 

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -10,12 +10,13 @@ import DownloadableBlockAuthorInfo from '../downloadable-block-author-info';
 import DownloadableBlockHeader from '../downloadable-block-header';
 import DownloadableBlockInfo from '../downloadable-block-info';
 import DownloadableBlockNotice from '../downloadable-block-notice';
+import { store as blockDirectoryStore } from '../../store';
 
 export default function DownloadableBlockListItem( { item, onClick } ) {
 	const { isLoading, isInstallable } = useSelect(
 		( select ) => {
 			const { isInstalling, getErrorNoticeForBlock } = select(
-				'core/block-directory'
+				blockDirectoryStore
 			);
 			const notice = getErrorNoticeForBlock( item.id );
 			const hasFatal = notice && notice.isFatal;

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -5,10 +5,15 @@ import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockDirectoryStore } from '../../store';
+
 export const DownloadableBlockNotice = ( { block, onClick } ) => {
 	const errorNotice = useSelect(
 		( select ) =>
-			select( 'core/block-directory' ).getErrorNoticeForBlock( block.id ),
+			select( blockDirectoryStore ).getErrorNoticeForBlock( block.id ),
 		[ block ]
 	);
 

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -12,9 +12,10 @@ import { useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import DownloadableBlockListItem from '../downloadable-block-list-item';
+import { store as blockDirectoryStore } from '../../store';
 
 function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
-	const { installBlockType } = useDispatch( 'core/block-directory' );
+	const { installBlockType } = useDispatch( blockDirectoryStore );
 	const { setIsInserterOpened } = useDispatch( 'core/edit-post' );
 
 	if ( ! items.length ) {

--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -12,6 +12,7 @@ import { speak } from '@wordpress/a11y';
  * Internal dependencies
  */
 import DownloadableBlocksList from '../downloadable-blocks-list';
+import { store as blockDirectoryStore } from '../../store';
 
 function DownloadableBlocksPanel( {
 	downloadableItems,
@@ -80,7 +81,7 @@ export default compose( [
 		const {
 			getDownloadableBlocks,
 			isRequestingDownloadableBlocks,
-		} = select( 'core/block-directory' );
+		} = select( blockDirectoryStore );
 
 		const hasPermission = select( 'core' ).canUser(
 			'read',

--- a/packages/block-directory/src/plugins/get-install-missing/index.js
+++ b/packages/block-directory/src/plugins/get-install-missing/index.js
@@ -12,6 +12,7 @@ import { Warning } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import InstallButton from './install-button';
+import { store as blockDirectoryStore } from '../../store';
 
 const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 	const { originalName, originalUndelimitedContent } = props.attributes;
@@ -19,7 +20,7 @@ const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const { block, hasPermission } = useSelect(
 		( select ) => {
-			const { getDownloadableBlocks } = select( 'core/block-directory' );
+			const { getDownloadableBlocks } = select( blockDirectoryStore );
 			const blocks = getDownloadableBlocks(
 				'block:' + originalName
 			).filter( ( { name } ) => originalName === name );

--- a/packages/block-directory/src/plugins/get-install-missing/install-button.js
+++ b/packages/block-directory/src/plugins/get-install-missing/install-button.js
@@ -6,11 +6,16 @@ import { Button } from '@wordpress/components';
 import { createBlock, getBlockType, parse } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockDirectoryStore } from '../../store';
+
 export default function InstallButton( { attributes, block, clientId } ) {
 	const isInstallingBlock = useSelect( ( select ) =>
-		select( 'core/block-directory' ).isInstalling( block.id )
+		select( blockDirectoryStore ).isInstalling( block.id )
 	);
-	const { installBlockType } = useDispatch( 'core/block-directory' );
+	const { installBlockType } = useDispatch( blockDirectoryStore );
 	const { replaceBlock } = useDispatch( 'core/block-editor' );
 
 	return (

--- a/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
+++ b/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
@@ -10,10 +10,11 @@ import { blockDefault } from '@wordpress/icons';
  * Internal dependencies
  */
 import CompactList from '../../components/compact-list';
+import { store as blockDirectoryStore } from '../../store';
 
 export default function InstalledBlocksPrePublishPanel() {
 	const newBlockTypes = useSelect(
-		( select ) => select( 'core/block-directory' ).getNewBlockTypes(),
+		( select ) => select( blockDirectoryStore ).getNewBlockTypes(),
 		[]
 	);
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addresses #27088. Replaces the store names (hardcoded strings) with the exposed `store` definitions.

## How has this been tested?
`npm run test`, no additional test was done.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/18705930/99892888-d65b8b80-2c58-11eb-901e-930432ffdc78.png)

## Types of changes
Code refactoring, non-breaking change.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
