### PR TITLE
Docs: Update `@wordpress/data` README with API changes

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -9,6 +9,11 @@
 -   Extended `select` and `dispatch` functions to accept a data store definition as their first param in addition to a string-based store name value [#26655](https://github.com/WordPress/gutenberg/pull/26655)).
 -   Extended `useDispatch` hook to accept a data store definition as their first param in addition to a string-based store name value [#26655](https://github.com/WordPress/gutenberg/pull/26655)).
 
+### Deprecations
+
+-   `registerGenericStore` has been deprecated. Use `register` instead.
+-   `registerStore` has been deprecated. Use `register` instead.
+
 ## 4.6.0 (2019-06-12)
 
 ### New Feature

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -16,11 +16,11 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## Registering a Store
 
-Use the `registerStore` function to add your own store to the centralized data registry. This function accepts two arguments: a name to identify the module, and an object with values describing how your state is represented, modified, and accessed. At a minimum, you must provide a reducer function describing the shape of your state and how it changes in response to actions dispatched to the store.
+Use the `register` function to add your own store to the centralized data registry. This function accepts one argument – a store definition object that can be created with `createReduxStore` factory function. `createReduxStore` accepts two arguments: a name to identify the module, and an object with values describing how your state is represented, modified, and accessed. At a minimum, you must provide a reducer function describing the shape of your state and how it changes in response to actions dispatched to the store.
 
 ```js
 import apiFetch from '@wordpress/api-fetch';
-import { registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 
 const DEFAULT_STATE = {
 	prices: {},
@@ -51,7 +51,7 @@ const actions = {
 	},
 };
 
-registerStore( 'my-shop', {
+const store = createReduxStore( 'my-shop', {
 	reducer( state = DEFAULT_STATE, action ) {
 		switch ( action.type ) {
 			case 'SET_PRICE':
@@ -98,9 +98,11 @@ registerStore( 'my-shop', {
 		},
 	},
 } );
+
+register( store );
 ```
 
-The return value of `registerStore` is a [Redux-like store object](https://redux.js.org/basics/store) with the following methods:
+The return value of `createReduxStore` is a [Redux-like store object](https://redux.js.org/basics/store) with the following methods:
 
 -   `store.getState()`: Returns the state value of the registered reducer
     -   _Redux parallel:_ [`getState`](https://redux.js.org/api/store#getstate)
@@ -308,7 +310,7 @@ reducing functions into a single reducing function you can pass to registerReduc
 _Usage_
 
 ```js
-import { combineReducers, registerStore } from '@wordpress/data';
+import { combineReducers, createReduxStore, register } from '@wordpress/data';
 
 const prices = ( state = {}, action ) => {
 	return action.type === 'SET_PRICE' ?
@@ -325,12 +327,13 @@ const discountPercent = ( state = 0, action ) => {
 		state;
 };
 
-registerStore( 'my-shop', {
+const store = createReduxStore( 'my-shop', {
 	reducer: combineReducers( {
 		prices,
 		discountPercent,
 	} ),
 } );
+register( store );
 ```
 
 _Parameters_
@@ -479,7 +482,7 @@ dispatch( 'my-shop' ).setPrice( 'hammer', 9.75 );
 
 _Parameters_
 
--   _name_ `string`: Store name.
+-   _storeNameOrDefinition_ `(string|WPDataStore)`: Unique namespace identifier for the store or the store definition.
 
 _Returns_
 
@@ -512,7 +515,7 @@ const store = createReduxStore( 'demo', {
         getValue: ( state ) => state,
     },
 } );
-registry.register( store );
+register( store );
 ```
 
 _Parameters_
@@ -520,6 +523,8 @@ _Parameters_
 -   _store_ `WPDataStore`: Store definition.
 
 <a name="registerGenericStore" href="#registerGenericStore">#</a> **registerGenericStore**
+
+> **Deprecated** Use `register` instead.
 
 Registers a generic store.
 
@@ -529,6 +534,8 @@ _Parameters_
 -   _config_ `Object`: Configuration (getSelectors, getActions, subscribe).
 
 <a name="registerStore" href="#registerStore">#</a> **registerStore**
+
+> **Deprecated** Use `register` instead.
 
 Registers a standard `@wordpress/data` store.
 
@@ -584,7 +591,7 @@ example.
 
 <a name="select" href="#select">#</a> **select**
 
-Given the name of a registered store, returns an object of the store's selectors.
+Given the name or definition of a registered store, returns an object of the store's selectors.
 The selector functions are been pre-bound to pass the current state automatically.
 As a consumer, you need only pass arguments of the selector, if applicable.
 
@@ -598,7 +605,7 @@ select( 'my-shop' ).getPrice( 'hammer' );
 
 _Parameters_
 
--   _name_ `string`: Store name.
+-   _storeNameOrDefinition_ `(string|WPDataStore)`: Unique namespace identifier for the store or the store definition.
 
 _Returns_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -275,19 +275,19 @@ _Usage_
 import { useSelect, AsyncModeProvider } from '@wordpress/data';
 
 function BlockCount() {
-	const count = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getBlockCount();
-	}, [] );
+  const count = useSelect( ( select ) => {
+    return select( 'core/block-editor' ).getBlockCount()
+  }, [] );
 
-	return count;
+  return count;
 }
 
 function App() {
-	return (
-		<AsyncModeProvider value={ true }>
-			<BlockCount />
-		</AsyncModeProvider>
-	);
+  return (
+    <AsyncModeProvider value={ true }>
+      <BlockCount />
+    </AsyncModeProvider>
+  );
 }
 ```
 
@@ -315,16 +315,18 @@ _Usage_
 import { combineReducers, createReduxStore, register } from '@wordpress/data';
 
 const prices = ( state = {}, action ) => {
-	return action.type === 'SET_PRICE'
-		? {
-				...state,
-				[ action.item ]: action.price,
-		  }
-		: state;
+	return action.type === 'SET_PRICE' ?
+		{
+			...state,
+			[ action.item ]: action.price,
+		} :
+		state;
 };
 
 const discountPercent = ( state = 0, action ) => {
-	return action.type === 'START_SALE' ? action.discountPercent : state;
+	return action.type === 'START_SALE' ?
+		action.discountPercent :
+		state;
 };
 
 const store = createReduxStore( 'my-shop', {
@@ -359,10 +361,10 @@ _Usage_
 import { createReduxStore } from '@wordpress/data';
 
 const store = createReduxStore( 'demo', {
-	reducer: ( state = 'OK' ) => state,
-	selectors: {
-		getValue: ( state ) => state,
-	},
+    reducer: ( state = 'OK' ) => state,
+    selectors: {
+        getValue: ( state ) => state,
+    },
 } );
 ```
 
@@ -395,13 +397,13 @@ Creates a control function that takes additional curried argument with the `regi
 While a regular control has signature
 
 ```js
-( action ) => iteratorOrPromise;
+( action ) => ( iteratorOrPromise )
 ```
 
 where the control works with the `action` that it's bound to, a registry control has signature:
 
 ```js
-( registry ) => ( action ) => iteratorOrPromise;
+( registry ) => ( action ) => ( iteratorOrPromise )
 ```
 
 A registry control is typically used to select data or dispatch an action to a registered
@@ -424,14 +426,14 @@ Creates a selector function that takes additional curried argument with the
 registry `select` function. While a regular selector has signature
 
 ```js
-( state, ...selectorArgs ) => result;
+( state, ...selectorArgs ) => ( result )
 ```
 
 that allows to select data from the store's `state`, a registry selector
 has signature:
 
 ```js
-( select ) => ( state, ...selectorArgs ) => result;
+( select ) => ( state, ...selectorArgs ) => ( result )
 ```
 
 that supports also selecting from other registered stores.
@@ -440,18 +442,14 @@ _Usage_
 
 ```js
 const getCurrentPostId = createRegistrySelector( ( select ) => ( state ) => {
-	return select( 'core/editor' ).getCurrentPostId();
+  return select( 'core/editor' ).getCurrentPostId();
 } );
 
 const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
-	// calling another registry selector just like any other function
-	const postType = getCurrentPostType( state );
-	const postId = getCurrentPostId( state );
-	return select( 'core' ).getEntityRecordEdits(
-		'postType',
-		postType,
-		postId
-	);
+  // calling another registry selector just like any other function
+  const postType = getCurrentPostType( state );
+  const postId = getCurrentPostId( state );
+ return select( 'core' ).getEntityRecordEdits( 'postType', postType, postId );
 } );
 ```
 
@@ -502,7 +500,7 @@ _Related_
 
 _Type_
 
--   `Object`
+-   `Object` 
 
 <a name="register" href="#register">#</a> **register**
 
@@ -514,10 +512,10 @@ _Usage_
 import { createReduxStore, register } from '@wordpress/data';
 
 const store = createReduxStore( 'demo', {
-	reducer: ( state = 'OK' ) => state,
-	selectors: {
-		getValue: ( state ) => state,
-	},
+    reducer: ( state = 'OK' ) => state,
+    selectors: {
+        getValue: ( state ) => state,
+    },
 } );
 register( store );
 ```
@@ -667,25 +665,21 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 
 function Button( { onClick, children } ) {
-	return (
-		<button type="button" onClick={ onClick }>
-			{ children }
-		</button>
-	);
+  return <button type="button" onClick={ onClick }>{ children }</button>
 }
 
 const SaleButton = ( { children } ) => {
-	const { stockNumber } = useSelect(
-		( select ) => select( 'my-shop' ).getStockNumber(),
-		[]
-	);
-	const { startSale } = useDispatch( 'my-shop' );
-	const onClick = useCallback( () => {
-		const discountPercent = stockNumber > 50 ? 10 : 20;
-		startSale( discountPercent );
-	}, [ stockNumber ] );
-	return <Button onClick={ onClick }>{ children }</Button>;
-};
+  const { stockNumber } = useSelect(
+    ( select ) => select( 'my-shop' ).getStockNumber(),
+    []
+  );
+  const { startSale } = useDispatch( 'my-shop' );
+  const onClick = useCallback( () => {
+    const discountPercent = stockNumber > 50 ? 10: 20;
+    startSale( discountPercent );
+  }, [ stockNumber ] );
+  return <Button onClick={ onClick }>{ children }</Button>
+}
 
 // Rendered somewhere in the application:
 //
@@ -712,27 +706,30 @@ It acts similarly to the `useContext` react hook.
 
 Note: Generally speaking, `useRegistry` is a low level hook that in most cases
 won't be needed for implementation. Most interactions with the `@wordpress/data`
-API can be performed via the `useSelect` hook, or the `withSelect` and
+API can be performed via the `useSelect` hook,  or the `withSelect` and
 `withDispatch` higher order components.
 
 _Usage_
 
 ```js
-import { RegistryProvider, createRegistry, useRegistry } from '@wordpress/data';
+import {
+  RegistryProvider,
+  createRegistry,
+  useRegistry,
+} from '@wordpress/data';
 
 const registry = createRegistry( {} );
 
 const SomeChildUsingRegistry = ( props ) => {
-	const registry = useRegistry( registry );
-	// ...logic implementing the registry in other react hooks.
+  const registry = useRegistry( registry );
+  // ...logic implementing the registry in other react hooks.
 };
 
+
 const ParentProvidingRegistry = ( props ) => {
-	return (
-		<RegistryProvider value={ registry }>
-			<SomeChildUsingRegistry { ...props } />
-		</RegistryProvider>
-	);
+  return <RegistryProvider value={ registry }>
+    <SomeChildUsingRegistry { ...props } />
+  </RegistryProvider>
 };
 ```
 
@@ -753,16 +750,13 @@ _Usage_
 import { useSelect } from '@wordpress/data';
 
 function HammerPriceDisplay( { currency } ) {
-	const price = useSelect(
-		( select ) => {
-			return select( 'my-shop' ).getPrice( 'hammer', currency );
-		},
-		[ currency ]
-	);
-	return new Intl.NumberFormat( 'en-US', {
-		style: 'currency',
-		currency,
-	} ).format( price );
+  const price = useSelect( ( select ) => {
+    return select( 'my-shop' ).getPrice( 'hammer', currency )
+  }, [ currency ] );
+  return new Intl.NumberFormat( 'en-US', {
+    style: 'currency',
+    currency,
+  } ).format( price );
 }
 
 // Rendered in the application:
@@ -794,24 +788,20 @@ _Usage_
 
 ```jsx
 function Button( { onClick, children } ) {
-	return (
-		<button type="button" onClick={ onClick }>
-			{ children }
-		</button>
-	);
+    return <button type="button" onClick={ onClick }>{ children }</button>;
 }
 
 import { withDispatch } from '@wordpress/data';
 
 const SaleButton = withDispatch( ( dispatch, ownProps ) => {
-	const { startSale } = dispatch( 'my-shop' );
-	const { discountPercent } = ownProps;
+    const { startSale } = dispatch( 'my-shop' );
+    const { discountPercent } = ownProps;
 
-	return {
-		onClick() {
-			startSale( discountPercent );
-		},
-	};
+    return {
+        onClick() {
+            startSale( discountPercent );
+        },
+    };
 } )( Button );
 
 // Rendered in the application:
@@ -834,25 +824,21 @@ only.
 
 ```jsx
 function Button( { onClick, children } ) {
-	return (
-		<button type="button" onClick={ onClick }>
-			{ children }
-		</button>
-	);
+    return <button type="button" onClick={ onClick }>{ children }</button>;
 }
 
 import { withDispatch } from '@wordpress/data';
 
 const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
-	// Stock number changes frequently.
-	const { getStockNumber } = select( 'my-shop' );
-	const { startSale } = dispatch( 'my-shop' );
-	return {
-		onClick() {
-			const discountPercent = getStockNumber() > 50 ? 10 : 20;
-			startSale( discountPercent );
-		},
-	};
+   // Stock number changes frequently.
+   const { getStockNumber } = select( 'my-shop' );
+   const { startSale } = dispatch( 'my-shop' );
+   return {
+       onClick() {
+           const discountPercent = getStockNumber() > 50 ? 10 : 20;
+           startSale( discountPercent );
+       },
+   };
 } )( Button );
 
 // Rendered in the application:
@@ -928,6 +914,7 @@ _Parameters_
 _Returns_
 
 -   `WPComponent`: Enhanced component with merged state data props.
+
 
 <!-- END TOKEN(Autogenerated API docs) -->
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -102,16 +102,18 @@ const store = createReduxStore( 'my-shop', {
 register( store );
 ```
 
-The return value of `createReduxStore` is a [Redux-like store object](https://redux.js.org/basics/store) with the following methods:
+The return value of `createReduxStore` is the `WPDataStore` object that contains two properties:
 
--   `store.getState()`: Returns the state value of the registered reducer
-    -   _Redux parallel:_ [`getState`](https://redux.js.org/api/store#getstate)
--   `store.subscribe( listener: Function )`: Registers a function called any time the value of state changes.
-    -   _Redux parallel:_ [`subscribe`](https://redux.js.org/api/store#subscribelistener)
--   `store.dispatch( action: Object )`: Given an action object, calls the registered reducer and updates the state value.
-    -   _Redux parallel:_ [`dispatch`](https://redux.js.org/api/store#dispatchaction)
+-   `name` (`string`) – the name of the store
+-   `instantiate` (`Function`) - it returns a [Redux-like store object](https://redux.js.org/basics/store) with the following methods:
+    -   `getState()`: Returns the state value of the registered reducer
+        -   _Redux parallel:_ [`getState`](https://redux.js.org/api/store#getstate)
+    -   `subscribe( listener: Function )`: Registers a function called any time the value of state changes.
+        -   _Redux parallel:_ [`subscribe`](https://redux.js.org/api/store#subscribelistener)
+    -   `dispatch( action: Object )`: Given an action object, calls the registered reducer and updates the state value.
+        -   _Redux parallel:_ [`dispatch`](https://redux.js.org/api/store#dispatchaction)
 
-### Options
+### Redux Store Options
 
 #### `reducer`
 
@@ -273,19 +275,19 @@ _Usage_
 import { useSelect, AsyncModeProvider } from '@wordpress/data';
 
 function BlockCount() {
-  const count = useSelect( ( select ) => {
-    return select( 'core/block-editor' ).getBlockCount()
-  }, [] );
+	const count = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getBlockCount();
+	}, [] );
 
-  return count;
+	return count;
 }
 
 function App() {
-  return (
-    <AsyncModeProvider value={ true }>
-      <BlockCount />
-    </AsyncModeProvider>
-  );
+	return (
+		<AsyncModeProvider value={ true }>
+			<BlockCount />
+		</AsyncModeProvider>
+	);
 }
 ```
 
@@ -313,18 +315,16 @@ _Usage_
 import { combineReducers, createReduxStore, register } from '@wordpress/data';
 
 const prices = ( state = {}, action ) => {
-	return action.type === 'SET_PRICE' ?
-		{
-			...state,
-			[ action.item ]: action.price,
-		} :
-		state;
+	return action.type === 'SET_PRICE'
+		? {
+				...state,
+				[ action.item ]: action.price,
+		  }
+		: state;
 };
 
 const discountPercent = ( state = 0, action ) => {
-	return action.type === 'START_SALE' ?
-		action.discountPercent :
-		state;
+	return action.type === 'START_SALE' ? action.discountPercent : state;
 };
 
 const store = createReduxStore( 'my-shop', {
@@ -359,10 +359,10 @@ _Usage_
 import { createReduxStore } from '@wordpress/data';
 
 const store = createReduxStore( 'demo', {
-    reducer: ( state = 'OK' ) => state,
-    selectors: {
-        getValue: ( state ) => state,
-    },
+	reducer: ( state = 'OK' ) => state,
+	selectors: {
+		getValue: ( state ) => state,
+	},
 } );
 ```
 
@@ -395,13 +395,13 @@ Creates a control function that takes additional curried argument with the `regi
 While a regular control has signature
 
 ```js
-( action ) => ( iteratorOrPromise )
+( action ) => iteratorOrPromise;
 ```
 
 where the control works with the `action` that it's bound to, a registry control has signature:
 
 ```js
-( registry ) => ( action ) => ( iteratorOrPromise )
+( registry ) => ( action ) => iteratorOrPromise;
 ```
 
 A registry control is typically used to select data or dispatch an action to a registered
@@ -424,14 +424,14 @@ Creates a selector function that takes additional curried argument with the
 registry `select` function. While a regular selector has signature
 
 ```js
-( state, ...selectorArgs ) => ( result )
+( state, ...selectorArgs ) => result;
 ```
 
 that allows to select data from the store's `state`, a registry selector
 has signature:
 
 ```js
-( select ) => ( state, ...selectorArgs ) => ( result )
+( select ) => ( state, ...selectorArgs ) => result;
 ```
 
 that supports also selecting from other registered stores.
@@ -440,14 +440,18 @@ _Usage_
 
 ```js
 const getCurrentPostId = createRegistrySelector( ( select ) => ( state ) => {
-  return select( 'core/editor' ).getCurrentPostId();
+	return select( 'core/editor' ).getCurrentPostId();
 } );
 
 const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
-  // calling another registry selector just like any other function
-  const postType = getCurrentPostType( state );
-  const postId = getCurrentPostId( state );
- return select( 'core' ).getEntityRecordEdits( 'postType', postType, postId );
+	// calling another registry selector just like any other function
+	const postType = getCurrentPostType( state );
+	const postId = getCurrentPostId( state );
+	return select( 'core' ).getEntityRecordEdits(
+		'postType',
+		postType,
+		postId
+	);
 } );
 ```
 
@@ -498,7 +502,7 @@ _Related_
 
 _Type_
 
--   `Object` 
+-   `Object`
 
 <a name="register" href="#register">#</a> **register**
 
@@ -510,10 +514,10 @@ _Usage_
 import { createReduxStore, register } from '@wordpress/data';
 
 const store = createReduxStore( 'demo', {
-    reducer: ( state = 'OK' ) => state,
-    selectors: {
-        getValue: ( state ) => state,
-    },
+	reducer: ( state = 'OK' ) => state,
+	selectors: {
+		getValue: ( state ) => state,
+	},
 } );
 register( store );
 ```
@@ -663,21 +667,25 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 
 function Button( { onClick, children } ) {
-  return <button type="button" onClick={ onClick }>{ children }</button>
+	return (
+		<button type="button" onClick={ onClick }>
+			{ children }
+		</button>
+	);
 }
 
 const SaleButton = ( { children } ) => {
-  const { stockNumber } = useSelect(
-    ( select ) => select( 'my-shop' ).getStockNumber(),
-    []
-  );
-  const { startSale } = useDispatch( 'my-shop' );
-  const onClick = useCallback( () => {
-    const discountPercent = stockNumber > 50 ? 10: 20;
-    startSale( discountPercent );
-  }, [ stockNumber ] );
-  return <Button onClick={ onClick }>{ children }</Button>
-}
+	const { stockNumber } = useSelect(
+		( select ) => select( 'my-shop' ).getStockNumber(),
+		[]
+	);
+	const { startSale } = useDispatch( 'my-shop' );
+	const onClick = useCallback( () => {
+		const discountPercent = stockNumber > 50 ? 10 : 20;
+		startSale( discountPercent );
+	}, [ stockNumber ] );
+	return <Button onClick={ onClick }>{ children }</Button>;
+};
 
 // Rendered somewhere in the application:
 //
@@ -704,30 +712,27 @@ It acts similarly to the `useContext` react hook.
 
 Note: Generally speaking, `useRegistry` is a low level hook that in most cases
 won't be needed for implementation. Most interactions with the `@wordpress/data`
-API can be performed via the `useSelect` hook,  or the `withSelect` and
+API can be performed via the `useSelect` hook, or the `withSelect` and
 `withDispatch` higher order components.
 
 _Usage_
 
 ```js
-import {
-  RegistryProvider,
-  createRegistry,
-  useRegistry,
-} from '@wordpress/data';
+import { RegistryProvider, createRegistry, useRegistry } from '@wordpress/data';
 
 const registry = createRegistry( {} );
 
 const SomeChildUsingRegistry = ( props ) => {
-  const registry = useRegistry( registry );
-  // ...logic implementing the registry in other react hooks.
+	const registry = useRegistry( registry );
+	// ...logic implementing the registry in other react hooks.
 };
 
-
 const ParentProvidingRegistry = ( props ) => {
-  return <RegistryProvider value={ registry }>
-    <SomeChildUsingRegistry { ...props } />
-  </RegistryProvider>
+	return (
+		<RegistryProvider value={ registry }>
+			<SomeChildUsingRegistry { ...props } />
+		</RegistryProvider>
+	);
 };
 ```
 
@@ -748,13 +753,16 @@ _Usage_
 import { useSelect } from '@wordpress/data';
 
 function HammerPriceDisplay( { currency } ) {
-  const price = useSelect( ( select ) => {
-    return select( 'my-shop' ).getPrice( 'hammer', currency )
-  }, [ currency ] );
-  return new Intl.NumberFormat( 'en-US', {
-    style: 'currency',
-    currency,
-  } ).format( price );
+	const price = useSelect(
+		( select ) => {
+			return select( 'my-shop' ).getPrice( 'hammer', currency );
+		},
+		[ currency ]
+	);
+	return new Intl.NumberFormat( 'en-US', {
+		style: 'currency',
+		currency,
+	} ).format( price );
 }
 
 // Rendered in the application:
@@ -786,20 +794,24 @@ _Usage_
 
 ```jsx
 function Button( { onClick, children } ) {
-    return <button type="button" onClick={ onClick }>{ children }</button>;
+	return (
+		<button type="button" onClick={ onClick }>
+			{ children }
+		</button>
+	);
 }
 
 import { withDispatch } from '@wordpress/data';
 
 const SaleButton = withDispatch( ( dispatch, ownProps ) => {
-    const { startSale } = dispatch( 'my-shop' );
-    const { discountPercent } = ownProps;
+	const { startSale } = dispatch( 'my-shop' );
+	const { discountPercent } = ownProps;
 
-    return {
-        onClick() {
-            startSale( discountPercent );
-        },
-    };
+	return {
+		onClick() {
+			startSale( discountPercent );
+		},
+	};
 } )( Button );
 
 // Rendered in the application:
@@ -822,21 +834,25 @@ only.
 
 ```jsx
 function Button( { onClick, children } ) {
-    return <button type="button" onClick={ onClick }>{ children }</button>;
+	return (
+		<button type="button" onClick={ onClick }>
+			{ children }
+		</button>
+	);
 }
 
 import { withDispatch } from '@wordpress/data';
 
 const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
-   // Stock number changes frequently.
-   const { getStockNumber } = select( 'my-shop' );
-   const { startSale } = dispatch( 'my-shop' );
-   return {
-       onClick() {
-           const discountPercent = getStockNumber() > 50 ? 10 : 20;
-           startSale( discountPercent );
-       },
-   };
+	// Stock number changes frequently.
+	const { getStockNumber } = select( 'my-shop' );
+	const { startSale } = dispatch( 'my-shop' );
+	return {
+		onClick() {
+			const discountPercent = getStockNumber() > 50 ? 10 : 20;
+			startSale( discountPercent );
+		},
+	};
 } )( Button );
 
 // Rendered in the application:
@@ -912,7 +928,6 @@ _Parameters_
 _Returns_
 
 -   `WPComponent`: Enhanced component with merged state data props.
-
 
 <!-- END TOKEN(Autogenerated API docs) -->
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -45,7 +45,7 @@ export { plugins };
  *
  * @example
  * ```js
- * import { combineReducers, registerStore } from '@wordpress/data';
+ * import { combineReducers, createReduxStore, register } from '@wordpress/data';
  *
  * const prices = ( state = {}, action ) => {
  * 	return action.type === 'SET_PRICE' ?
@@ -62,12 +62,13 @@ export { plugins };
  * 		state;
  * };
  *
- * registerStore( 'my-shop', {
+ * const store = createReduxStore( 'my-shop', {
  * 	reducer: combineReducers( {
  * 		prices,
  * 		discountPercent,
  * 	} ),
  * } );
+ * register( store );
  * ```
  *
  * @return {Function}       A reducer that invokes every reducer inside the reducers
@@ -76,11 +77,12 @@ export { plugins };
 export { combineReducers };
 
 /**
- * Given the name of a registered store, returns an object of the store's selectors.
+ * Given the name or definition of a registered store, returns an object of the store's selectors.
  * The selector functions are been pre-bound to pass the current state automatically.
  * As a consumer, you need only pass arguments of the selector, if applicable.
  *
- * @param {string} name Store name.
+ * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+ *                                                   or the store definition.
  *
  * @example
  * ```js
@@ -99,7 +101,8 @@ export const select = defaultRegistry.select;
  * and modified so that they return promises that resolve to their eventual values,
  * after any resolvers have ran.
  *
- * @param {string} name Store name.
+ * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+ *                                                   or the store definition.
  *
  * @example
  * ```js
@@ -120,7 +123,8 @@ export const __experimentalResolveSelect =
  * Note: Action creators returned by the dispatch will return a promise when
  * they are called.
  *
- * @param {string} name Store name.
+ * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+ *                                                   or the store definition.
  *
  * @example
  * ```js
@@ -157,6 +161,8 @@ export const subscribe = defaultRegistry.subscribe;
 /**
  * Registers a generic store.
  *
+ * @deprecated Use `register` instead.
+ *
  * @param {string} key    Store registry key.
  * @param {Object} config Configuration (getSelectors, getActions, subscribe).
  */
@@ -164,6 +170,8 @@ export const registerGenericStore = defaultRegistry.registerGenericStore;
 
 /**
  * Registers a standard `@wordpress/data` store.
+ *
+ * @deprecated Use `register` instead.
  *
  * @param {string} storeName Unique namespace identifier for the store.
  * @param {Object} options   Store description (reducer, actions, selectors, resolvers).
@@ -194,7 +202,7 @@ export const use = defaultRegistry.use;
  *         getValue: ( state ) => state,
  *     },
  * } );
- * registry.register( store );
+ * register( store );
  * ```
  *
  * @param {WPDataStore} store Store definition.

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -149,13 +149,13 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 * and modified so that they return promises that resolve to their eventual values,
 	 * after any resolvers have ran.
 	 *
-	 * @param {string|Object} storeName Unique namespace identifier for the store
-	 *                                  or the store definition.
+	 * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+	 *                                                   or the store definition.
 	 *
 	 * @return {Object} Each key of the object matches the name of a selector.
 	 */
-	function __experimentalResolveSelect( storeName ) {
-		return getResolveSelectors( select( storeName ) );
+	function __experimentalResolveSelect( storeNameOrDefinition ) {
+		return getResolveSelectors( select( storeNameOrDefinition ) );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Follow up for https://github.com/WordPress/gutenberg/pull/26655 and https://github.com/WordPress/gutenberg/pull/27061 that introduce API changes to `@wordpress/data` package.

This PR adds a section in the CHANGELOG file with deprecations for `registerStore` and `registerGenericStore` functions. Both functions are marked as deprecated in JSDoc comments. I don't think we are ready to add deprecation warnings in the code until we update usage in Gutenberg but that might take some time.

## Changes

The best way to see all important changes in this PR is with this view:

https://github.com/WordPress/gutenberg/pull/27180/files?diff=unified&w=1