### PR TITLE
Edit Navigation: Replace store name string with exposed store definition

### DIFF
--- a/packages/edit-navigation/src/components/layout/use-navigation-block-editor.js
+++ b/packages/edit-navigation/src/components/layout/use-navigation-block-editor.js
@@ -9,9 +9,10 @@ import { useEntityBlockEditor } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { KIND, POST_TYPE } from '../../store/utils';
+import { store as editNavigationStore } from '../../store';
 
 export default function useNavigationBlockEditor( post ) {
-	const { createMissingMenuItems } = useDispatch( 'core/edit-navigation' );
+	const { createMissingMenuItems } = useDispatch( editNavigationStore );
 
 	const [ blocks, onInput, _onChange ] = useEntityBlockEditor(
 		KIND,

--- a/packages/edit-navigation/src/components/layout/use-navigation-editor.js
+++ b/packages/edit-navigation/src/components/layout/use-navigation-editor.js
@@ -4,6 +4,11 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { store as editNavigationStore } from '../../store';
+
 export default function useNavigationEditor() {
 	const menus = useSelect(
 		( select ) => select( 'core' ).getMenus( { per_page: -1 } ),
@@ -20,7 +25,7 @@ export default function useNavigationEditor() {
 
 	const navigationPost = useSelect(
 		( select ) =>
-			select( 'core/edit-navigation' ).getNavigationPostForMenu(
+			select( editNavigationStore ).getNavigationPostForMenu(
 				selectedMenuId
 			),
 		[ selectedMenuId ]

--- a/packages/edit-navigation/src/components/toolbar/save-button.js
+++ b/packages/edit-navigation/src/components/toolbar/save-button.js
@@ -5,8 +5,13 @@ import { useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { store as editNavigationStore } from '../../store';
+
 export default function SaveButton( { navigationPost } ) {
-	const { saveNavigationPost } = useDispatch( 'core/edit-navigation' );
+	const { saveNavigationPost } = useDispatch( editNavigationStore );
 
 	return (
 		<Button


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addresses #27088. Replaces the store names (hardcoded strings) with the exposed `store` definitions. 

## How has this been tested?
`npm run test`, no additional test was done.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![edit-navigation](https://user-images.githubusercontent.com/18705930/99909323-94692e80-2cc6-11eb-9ac9-e93a8b3cbeed.png)

## Types of changes
Code refactoring, non-breaking change.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
