### PR TITLE
Add moment timezone conf for plugins backward compatibility

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -209,6 +209,7 @@ function gutenberg_register_vendor_scripts( $scripts ) {
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 
 	$react_suffix = ( SCRIPT_DEBUG ? '.development' : '.production' ) . $suffix;
+
 	gutenberg_register_vendor_script(
 		$scripts,
 		'react',
@@ -233,6 +234,27 @@ function gutenberg_register_vendor_scripts( $scripts ) {
 		array(),
 		'4.17.19',
 		true
+	);
+
+	gutenberg_register_vendor_script(
+		$scripts,
+		'moment',
+		'https://unpkg.com/moment@2.29.1/moment.js',
+		array(),
+	);
+
+	gutenberg_register_vendor_script(
+		$scripts,
+		'moment-timezone/moment-timezone',
+		'https://unpkg.com/moment-timezone@0.5.32/moment-timezone.js',
+		array( 'moment' ),
+	);
+
+	gutenberg_register_vendor_script(
+		$scripts,
+		'moment-timezone/moment-timezone-utils',
+		'https://unpkg.com/moment-timezone@0.5.32/moment-timezone-utils.js',
+		array( 'moment' ),
 	);
 }
 add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -24,9 +24,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",
 		"date-fns": "^2.16.1",
-		"date-fns-tz": "^1.0.12",
-		"moment": "^2.22.1",
-		"moment-timezone": "^0.5.31"
+		"date-fns-tz": "^1.0.12"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -19,6 +19,9 @@ import originalLocale from 'date-fns/locale/en-US/index';
 import buildLocalizeFn from 'date-fns/locale/_lib/buildLocalizeFn';
 import buildFormatLongFn from 'date-fns/locale/_lib/buildFormatLongFn';
 
+require( 'moment-timezone/moment-timezone' );
+require( 'moment-timezone/moment-timezone-utils' );
+
 // This regular expression tests positive for UTC offsets as described in ISO 8601.
 // See: https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
 const VALID_UTC_OFFSET = /^[+-][0-1][0-9](:?[0-9][0-9])?$/;

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -18,6 +18,8 @@ const BUNDLED_PACKAGES = [
 function defaultRequestToExternal( request ) {
 	switch ( request ) {
 		case 'moment':
+		case 'moment-timezone/moment-timezone':
+		case 'moment-timezone/moment-timezone-utils':
 			return request;
 
 		case '@babel/runtime/regenerator':


### PR DESCRIPTION
## Description

Raised on this issue:
https://github.com/WordPress/gutenberg/issues/27159

Required to support the usage of `moment` directly from the browser—which
happens on some third party plugins—while we make date-fns functinality
available on the browser through `wp.date` as a part of https://github.com/WordPress/gutenberg/issues/26862

## Types of changes
Adding back a function that adds timezone support to a global `moment` instance.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
