### PR TITLE
Try: fix gray gap.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -27,8 +27,7 @@
 	}
 }
 
-.editor-styles-wrapper,
-.editor-styles-wrapper > .block-editor-writing-flow__click-redirect {
+.editor-styles-wrapper {
 	height: 100%;
 }
 


### PR DESCRIPTION
Fixes #27157.

Props @tellthemachines for suggested fix in https://github.com/WordPress/gutenberg/issues/27157#issuecomment-731897426.

Before there was a gray gap when you scrolled down to the bottom of the page. This PR fixes that:

<img width="1472" alt="Screenshot 2020-11-23 at 08 46 11" src="https://user-images.githubusercontent.com/1204802/99938762-d5b21a80-2d68-11eb-9d4a-655030ec58f7.png">
