### PR TITLE
Restore gray background.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -27,7 +27,7 @@
 
 .editor-styles-wrapper {
 	// Default background color so that grey .edit-post-editor-regions__content
-	// color doesn't show through.		
+	// color doesn't show through.
 	background-color: $white;
 
 	cursor: text;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -1,7 +1,5 @@
 .edit-post-visual-editor {
 	position: relative;
-	// Default background color so that grey .edit-post-editor-regions__content color doesn't show through.
-	background-color: $white;
 
 	// The button element easily inherits styles that are meant for the editor style.
 	// These rules enhance the specificity to reduce that inheritance.
@@ -28,6 +26,10 @@
 }
 
 .editor-styles-wrapper {
+	// Default background color so that grey .edit-post-editor-regions__content
+	// color doesn't show through.		
+	background-color: $white;
+
 	cursor: text;
 
 	> * {


### PR DESCRIPTION
The gray background that appears behind the editor styles canvas disappeared as part of #27035. This PR restores that, to help make responsive previews clear. Before:

![before](https://user-images.githubusercontent.com/1204802/99942294-b9fe4280-2d6f-11eb-92ee-695e86d11691.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/99942299-bcf93300-2d6f-11eb-9c0c-94bc07e062a9.gif)

Note, the double scrollbar is a separate/pre-existing issue. I did try an experiment that removes the explicit height and allowed overflow-y on the preview box, and it works well:

![experiment](https://user-images.githubusercontent.com/1204802/99942396-e619c380-2d6f-11eb-8902-789a397a67cd.gif)

however I also assume that there's a very good reason that explicit height is there in the first place, and will be even more necessary if/when the whole thing is boxed in an iframe. CC: @tellthemachines 