### PR TITLE
Add backward compatibility support for lightBlockWrapper in getSaveElement

### DIFF
--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -17,6 +17,7 @@ import {
 	getBlockType,
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
+	hasBlockSupport,
 } from './registration';
 import { normalizeBlockType } from './utils';
 import BlockContentProvider from '../block-content-provider';
@@ -116,10 +117,14 @@ export function getSaveElement(
 
 	let element = save( { attributes, innerBlocks } );
 
+	const hasLightBlockWrapper =
+		blockType.apiVersion > 1 ||
+		hasBlockSupport( blockType, 'lightBlockWrapper', false );
+
 	if (
 		isObject( element ) &&
 		hasFilter( 'blocks.getSaveContent.extraProps' ) &&
-		! blockType.apiVersion
+		! hasLightBlockWrapper
 	) {
 		/**
 		 * Filters the props applied to the block save result element.


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #26672

https://github.com/WordPress/gutenberg/pull/25642 added support for the `apiVersion: 2` block setting which replaces the `lightBlockWrapper` supports setting.

In some places in that PR, backwards compatibility for `lightBlockWrapper` was left in place:
- https://github.com/WordPress/gutenberg/blob/0ca97366d0e6c2020dde9015bace9d9c1c970a1d/packages/block-editor/src/components/block-edit/edit.js#L54-L57
- https://github.com/WordPress/gutenberg/blob/1f0d0f5d945e93232a20741221b125432a5993ac/packages/block-editor/src/components/block-list/block.js#L137-L139

But `getSaveElement` doesn't seem to have that, which causes the duplicate classnames described in #26672:
https://github.com/WordPress/gutenberg/blob/1f0d0f5d945e93232a20741221b125432a5993ac/packages/blocks/src/api/serializer.js#L119-L123

## How has this been tested?
1. Load the post editor and register the following block by copying the code and running it in your browser console:
```jsx
wp.blocks.registerBlockType( `example/example-new`, {
    title: wp.i18n.__( 'Example Block (New)', 'example' ),
    description: wp.i18n.__( 'Example Block', 'example' ),
    icon: 'smiley',
    category: 'common',
    example: {},
    supports: {
        html: false,
        lightBlockWrapper: true,
        align: true,
        anchor: true,
        color: {
            link: true
        },
    },
    attributes: {},
    transforms: {},
    variations: [],
    edit: () => {
        return wp.element.createElement( 'div', wp.blockEditor.useBlockProps(), 'Hello World' );
    },
    save: () => {
        return wp.element.createElement( 'div', wp.blockEditor.useBlockProps.save(), 'Hello World' );
    }
} );
```
2. Add the new block and set some custom colors
3. Preview the post and inspect the element created by the block
4. Confirm it has no duplicate classnames.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
