### PR TITLE
Remove horizontal scroll from image block popover

### DIFF
--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -179,6 +179,7 @@ $arrow-size: 8px;
 	.components-popover & {
 		position: absolute;
 		height: auto;
+		overflow-x: hidden;
 		overflow-y: auto;
 	}
 


### PR DESCRIPTION
## Description
Fixes #27186.
Remove horizontal scroll from image block popover.

## How has this been tested?
On latest WordPress trunk version, add an image block in a post and add an image.
On a click on the Replace button, there should not be anymore an horizontal overflow in the popover.

Gutenberg plugin is not activated.
The issue initially appeared on Chrome browser.


## Types of changes
Non breaking CSS fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
