### PR TITLE
Inserter: Show preview in search results

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -157,6 +157,7 @@ function InserterMenu( {
 						<InserterSearchResults
 							filterValue={ filterValue }
 							onSelect={ onSelect }
+							onHover={ onHover }
 							rootClientId={ rootClientId }
 							clientId={ clientId }
 							isAppender={ isAppender }

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -28,6 +28,7 @@ import { searchBlockItems, searchItems } from './search-items';
 function InserterSearchResults( {
 	filterValue,
 	onSelect,
+	onHover,
 	rootClientId,
 	clientId,
 	isAppender,
@@ -38,11 +39,7 @@ function InserterSearchResults( {
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
-	const [
-		destinationRootClientId,
-		onInsertBlocks,
-		onToggleInsertionPoint,
-	] = useInsertionPoint( {
+	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
 		onSelect,
 		rootClientId,
 		clientId,
@@ -117,7 +114,7 @@ function InserterSearchResults( {
 					<BlockTypesList
 						items={ filteredBlockTypes }
 						onSelect={ onSelectBlockType }
-						onHover={ onToggleInsertionPoint }
+						onHover={ onHover }
 						label={ __( 'Blocks' ) }
 					/>
 				</InserterPanel>
@@ -150,7 +147,7 @@ function InserterSearchResults( {
 				<__experimentalInserterMenuExtension.Slot
 					fillProps={ {
 						onSelect: onSelectBlockType,
-						onHover: onToggleInsertionPoint,
+						onHover,
 						filterValue,
 						hasItems,
 					} }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
With the unification of Inserter's search results here: https://github.com/WordPress/gutenberg/pull/26595, the preview is not shown `onHover` after entered some search term.

This PR fixes that.
<!-- Please describe what you have changed or added -->

### Before
![before](https://user-images.githubusercontent.com/16275880/99959842-681be380-2d94-11eb-9aa4-aca9584c4722.gif)

### After
![after](https://user-images.githubusercontent.com/16275880/99959854-6c480100-2d94-11eb-8a47-83b040437a0c.gif)


