### PR TITLE
Image: Fix double paste from clipboard

### DIFF
--- a/packages/block-editor/src/utils/get-paste-event-data.js
+++ b/packages/block-editor/src/utils/get-paste-event-data.js
@@ -25,9 +25,9 @@ export function getPasteEventData( { clipboardData } ) {
 		}
 	}
 
-	const files = [
-		...getFilesFromDataTransfer( clipboardData ),
-	].filter( ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
+	const files = getFilesFromDataTransfer(
+		clipboardData
+	).filter( ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
 
 	// Only process files if no HTML is present.
 	// A pasted file may have the URL as plain text.

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -22,7 +22,7 @@ const { Provider } = Context;
 
 function getDragEventType( { dataTransfer } ) {
 	if ( dataTransfer ) {
-		if ( getFilesFromDataTransfer( dataTransfer ).size > 0 ) {
+		if ( getFilesFromDataTransfer( dataTransfer ).length > 0 ) {
 			return 'file';
 		}
 
@@ -204,7 +204,7 @@ export default function DropZoneProvider( { children } ) {
 			switch ( dragEventType ) {
 				case 'file':
 					hoveredDropZone.onFilesDrop(
-						[ ...getFilesFromDataTransfer( event.dataTransfer ) ],
+						getFilesFromDataTransfer( event.dataTransfer ),
 						position
 					);
 					break;

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -84,7 +84,7 @@ _Parameters_
 
 _Returns_
 
--   `Set`: A set containing all files.
+-   `Array<Object>`: An array containing all files.
 
 <a name="getOffsetParent" href="#getOffsetParent">#</a> **getOffsetParent**
 

--- a/packages/dom/src/data-transfer.js
+++ b/packages/dom/src/data-transfer.js
@@ -3,16 +3,24 @@
  *
  * @param {DataTransfer} dataTransfer DataTransfer object to inspect.
  *
- * @return {Set} A set containing all files.
+ * @return {Object[]} An array containing all files.
  */
 export function getFilesFromDataTransfer( dataTransfer ) {
-	const files = new Set( dataTransfer.files );
+	const files = [ ...dataTransfer.files ];
 
 	Array.from( dataTransfer.items ).forEach( ( item ) => {
 		const file = item.getAsFile();
 
-		if ( file ) {
-			files.add( file );
+		if (
+			file &&
+			! files.find(
+				( { name, type, size } ) =>
+					name === file.name &&
+					type === file.type &&
+					size === file.size
+			)
+		) {
+			files.push( file );
 		}
 	} );
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -374,7 +374,7 @@ function RichText(
 		}
 
 		if ( onPaste ) {
-			const files = [ ...getFilesFromDataTransfer( clipboardData ) ];
+			const files = getFilesFromDataTransfer( clipboardData );
 
 			onPaste( {
 				value: removeEditorOnlyFormats( record.current ),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/27190

Now in master, if we try to paste a copied image from clipboard in the editor it will result in creating two Image blocks.

In this PR: https://github.com/WordPress/gutenberg/pull/ there were some changes to the way we detect the files to handle when pasting.

This PR fixes that problem.
<!-- Please describe what you have changed or added -->


## Screenshots <!-- if applicable -->
## Before
![after](https://user-images.githubusercontent.com/16275880/99968525-e8951100-2da1-11eb-950f-249752f91c63.gif)

## After
![realAfter](https://user-images.githubusercontent.com/16275880/99968538-ecc12e80-2da1-11eb-886e-6b916c2927e2.gif)
