### PR TITLE
[RNMobile] File block V - Making Download button use RichText

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View, AccessibilityInfo, Platform, Text } from 'react-native';
+import { View, AccessibilityInfo, Platform } from 'react-native';
 /**
  * WordPress dependencies
  */
@@ -37,7 +37,6 @@ import getColorAndStyleProps from './color-props';
 const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUE = 50;
 const INITIAL_MAX_WIDTH = 108;
-const MIN_WIDTH = 40;
 
 class ButtonEdit extends Component {
 	constructor( props ) {
@@ -53,13 +52,11 @@ class ButtonEdit extends Component {
 		this.onToggleButtonFocus = this.onToggleButtonFocus.bind( this );
 		this.setRef = this.setRef.bind( this );
 		this.onRemove = this.onRemove.bind( this );
-		this.getPlaceholderWidth = this.getPlaceholderWidth.bind( this );
 
 		this.state = {
 			maxWidth: INITIAL_MAX_WIDTH,
 			isLinkSheetVisible: false,
 			isButtonFocused: true,
-			placeholderTextWidth: 0,
 		};
 	}
 
@@ -260,31 +257,6 @@ class ButtonEdit extends Component {
 		this.richTextRef = richText;
 	}
 
-	// Render `Text` with `placeholderText` styled as a placeholder
-	// to calculate its width which then is set as a `minWidth`
-	getPlaceholderWidth( placeholderText ) {
-		const { maxWidth, placeholderTextWidth } = this.state;
-		return (
-			<Text
-				style={ styles.placeholder }
-				onTextLayout={ ( { nativeEvent } ) => {
-					const textWidth =
-						nativeEvent.lines[ 0 ] && nativeEvent.lines[ 0 ].width;
-					if ( textWidth && textWidth !== placeholderTextWidth ) {
-						this.setState( {
-							placeholderTextWidth: Math.min(
-								textWidth,
-								maxWidth
-							),
-						} );
-					}
-				} }
-			>
-				{ placeholderText }
-			</Text>
-		);
-	}
-
 	render() {
 		const {
 			attributes,
@@ -295,7 +267,7 @@ class ButtonEdit extends Component {
 			parentWidth,
 		} = this.props;
 		const { placeholder, text, borderRadius, url } = attributes;
-		const { maxWidth, isButtonFocused, placeholderTextWidth } = this.state;
+		const { maxWidth, isButtonFocused } = this.state;
 		const { paddingTop: spacing, borderWidth } = styles.defaultButton;
 
 		if ( parentWidth === 0 ) {
@@ -310,13 +282,6 @@ class ButtonEdit extends Component {
 				? borderRadiusValue + spacing + borderWidth
 				: 0;
 
-		// To achieve proper expanding and shrinking `RichText` on iOS, there is a need to set a `minWidth`
-		// value at least on 1 when `RichText` is focused or when is not focused, but `RichText` value is
-		// different than empty string.
-		const minWidth =
-			isButtonFocused || ( ! isButtonFocused && text && text !== '' )
-				? MIN_WIDTH
-				: placeholderTextWidth;
 		// To achieve proper expanding and shrinking `RichText` on Android, there is a need to set
 		// a `placeholder` as an empty string when `RichText` is focused,
 		// because `AztecView` is calculating a `minWidth` based on placeholder text.
@@ -330,7 +295,6 @@ class ButtonEdit extends Component {
 
 		return (
 			<View onLayout={ this.onLayout }>
-				{ this.getPlaceholderWidth( placeholderText ) }
 				<ColorBackground
 					borderRadiusValue={ borderRadiusValue }
 					backgroundColor={ backgroundColor }
@@ -363,7 +327,7 @@ class ButtonEdit extends Component {
 						}
 						identifier="text"
 						tagName="p"
-						minWidth={ minWidth }
+						minWidth={ 1 }
 						maxWidth={ maxWidth }
 						id={ clientId }
 						isSelected={ isButtonFocused }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -12,7 +12,6 @@ import {
 	MediaPlaceholder,
 	MediaUploadProgress,
 	RichText,
-	PlainText,
 	BlockControls,
 	MediaUpload,
 	InspectorControls,
@@ -43,6 +42,7 @@ import { withSelect } from '@wordpress/data';
 import styles from './style.scss';
 
 const URL_COPIED_NOTIFICATION_DURATION_MS = 1500;
+const DEFAULT_DOWNLOAD_BUTTON_TEXT = _x( 'Download', 'button label' );
 
 export class FileEdit extends Component {
 	constructor( props ) {
@@ -50,10 +50,12 @@ export class FileEdit extends Component {
 
 		this.state = {
 			isUploadInProgress: false,
+			maxWidth: 0,
 		};
 
 		this.timerRef = null;
 
+		this.onLayout = this.onLayout.bind( this );
 		this.onSelectFile = this.onSelectFile.bind( this );
 		this.onChangeFileName = this.onChangeFileName.bind( this );
 		this.onChangeDownloadButtonText = this.onChangeDownloadButtonText.bind(
@@ -83,7 +85,7 @@ export class FileEdit extends Component {
 
 		if ( downloadButtonText === undefined || downloadButtonText === '' ) {
 			setAttributes( {
-				downloadButtonText: _x( 'Download', 'button label' ),
+				downloadButtonText: DEFAULT_DOWNLOAD_BUTTON_TEXT,
 			} );
 		}
 	}
@@ -285,6 +287,14 @@ export class FileEdit extends Component {
 		}
 	}
 
+	onLayout( { nativeEvent } ) {
+		const { width } = nativeEvent.layout;
+		const { paddingLeft, paddingRight } = styles.defaultButton;
+		this.setState( {
+			maxWidth: width - ( paddingLeft + paddingRight ),
+		} );
+	}
+
 	getFileComponent( openMediaOptions, getMediaOptions ) {
 		const { attributes, media } = this.props;
 
@@ -323,7 +333,7 @@ export class FileEdit extends Component {
 					}
 
 					return (
-						<View>
+						<View onLayout={ this.onLayout }>
 							{ isUploadInProgress ||
 								this.getToolbarEditButton( openMediaOptions ) }
 							{ getMediaOptions() }
@@ -334,6 +344,7 @@ export class FileEdit extends Component {
 								isUploadFailed
 							) }
 							<RichText
+								withoutInteractiveFormatting
 								__unstableMobileNoFocusOnMount
 								onChange={ this.onChangeFileName }
 								placeholder={ __( 'File name' ) }
@@ -353,9 +364,23 @@ export class FileEdit extends Component {
 										this.getStyleForAlignment( align ),
 									] }
 								>
-									<PlainText
+									<RichText
+										withoutInteractiveFormatting
+										__unstableMobileNoFocusOnMount
+										rootTagsToEliminate={ [ 'p' ] }
+										tagName="p"
+										minWidth={ 1 }
+										maxWidth={ this.state.maxWidth }
+										deleteEnter={ true }
 										style={ styles.buttonText }
 										value={ downloadButtonText }
+										placeholder={
+											DEFAULT_DOWNLOAD_BUTTON_TEXT
+										}
+										placeholderTextColor={
+											styles.placeholderTextColor.color
+										}
+										underlineColorAndroid="transparent"
 										onChange={
 											this.onChangeDownloadButtonText
 										}

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -1,9 +1,12 @@
 .defaultButton {
 	border-radius: $border-width * 4;
 	padding: $block-spacing * 2;
-	border-width: $border-width;
 	margin-top: $grid-unit-20;
 	background-color: $button-fallback-bg;
+}
+
+.placeholderTextColor {
+	color: rgba($color: $white, $alpha: 0.43);
 }
 
 .buttonText {

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -183,7 +183,11 @@ class RCTAztecView: Aztec.TextView {
         if (maxWidth > 0 && minWidth > 0) {
             let maxSize = CGSize(width: maxWidth, height: CGFloat.greatestFiniteMagnitude)
             let newWidth = sizeThatFits(maxSize).width
-            if (newWidth != frame.size.width) {
+            if placeholderLabel.isHidden == false {
+                // When placeholder is visible, we set the view's with to match the placeholder label's width
+                placeholderLabel.sizeToFit()
+                frame.size.width = placeholderLabel.frame.width
+            } else if (newWidth != frame.size.width) {
                 frame.size.width = max(newWidth, minWidth)
             }
         }
@@ -202,6 +206,10 @@ class RCTAztecView: Aztec.TextView {
         let minimumHeight = placeholderLabel.frame.height
         let fittingSize = super.sizeThatFits(size)
         let height = max(fittingSize.height, minimumHeight)
+
+        if placeholderLabel.isHidden == false {
+            return CGSize(width: placeholderLabel.frame.width, height: height)
+        }
         return CGSize(width: fittingSize.width, height: height)
     }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR fixes an issue on iOS where using RichText on the Download Button makes it lose its width.

**NOTE:** We will also need a fix for Android, since it's also not behaving as intended.

These are the issues on Android:
![RT-Android](https://user-images.githubusercontent.com/9772967/99971569-a10c8600-2d9d-11eb-9362-0fbf7d88cecb.png)

This is how it works on iOS:
![RT-iOS](https://user-images.githubusercontent.com/9772967/99971833-052f4a00-2d9e-11eb-9596-86f928d2520a.gif)



## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Add a File block
- Check that the Download button layout is correct.
- Test change the button's text and removing all text to show the placeholder.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
