### PR TITLE
Preserve 'Your homepage displays' settings when updating the 'general' settings

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -182,7 +182,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
  */
 function register_site_editor_homepage_settings() {
 	register_setting(
-		'general',
+		'reading',
 		'show_on_front',
 		array(
 			'show_in_rest' => true,
@@ -192,7 +192,7 @@ function register_site_editor_homepage_settings() {
 	);
 
 	register_setting(
-		'general',
+		'reading',
 		'page_on_front',
 		array(
 			'show_in_rest' => true,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/27167

If you update the `general` settings, your `Your homepage displays` options (show_on_front and page_on_front) in `reading` settings are lost.

## To reproduce
1. Visit Settings >Reading and set values for Your homepage displays. eg Static page: Home and Blog
2. Visit Settings > General
3. Save Changes (changes are not required since all values are submitted)
4. Revisit Settings > Reading.
5. The values you set in step 2. have gone. The radio button isn't set.
<!-- Please describe what you have changed or added -->
