### PR TITLE
Navigation Block: Use draft status when user creates a post and don't render unpublished posts in menus

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -232,7 +232,7 @@ function NavigationLinkEdit( {
 
 		const page = await saveEntityRecord( 'postType', postType, {
 			title: pageTitle,
-			status: 'publish',
+			status: 'draft',
 		} );
 
 		return {
@@ -388,12 +388,12 @@ function NavigationLinkEdit( {
 									if ( type === 'post' ) {
 										/* translators: %s: search term. */
 										format = __(
-											'Create post: <mark>%s</mark>'
+											'Create draft post: <mark>%s</mark>'
 										);
 									} else {
 										/* translators: %s: search term. */
 										format = __(
-											'Create page: <mark>%s</mark>'
+											'Create draft page: <mark>%s</mark>'
 										);
 									}
 									return createInterpolateElement(

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -104,6 +104,14 @@ function block_core_navigation_link_render_submenu_icon() {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation_link( $attributes, $content, $block ) {
+	
+	// Don't render the block's subtree if it is a draft.
+	$post = get_post( $attributes['id'] );
+	if( 'publish' !== $post->post_status ) {
+		return '';
+	}
+	
+	
 	// Don't render the block's subtree if it has no label.
 	if ( empty( $attributes['label'] ) ) {
 		return '';

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -105,14 +105,13 @@ function block_core_navigation_link_render_submenu_icon() {
  */
 function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Don't render the block's subtree if it is a draft.
-	if( is_numeric( $attributes['id'] ) ) {
+	if ( is_numeric( $attributes['id'] ) ) {
 		$post = get_post( $attributes['id'] );
-		if( 'publish' !== $post->post_status ) {
+		if ( 'publish' !== $post->post_status ) {
 			return '';
 		}
 	}
-	
-	
+
 	// Don't render the block's subtree if it has no label.
 	if ( empty( $attributes['label'] ) ) {
 		return '';

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -104,11 +104,12 @@ function block_core_navigation_link_render_submenu_icon() {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation_link( $attributes, $content, $block ) {
-	
 	// Don't render the block's subtree if it is a draft.
-	$post = get_post( $attributes['id'] );
-	if( 'publish' !== $post->post_status ) {
-		return '';
+	if( is_numeric( $attributes['id'] ) ) {
+		$post = get_post( $attributes['id'] );
+		if( 'publish' !== $post->post_status ) {
+			return '';
+		}
 	}
 	
 	


### PR DESCRIPTION
Closes #20282.

This PR makes it so that when we're creating a page or post from the Navigation menu the status is 'draft'. Also on the server only links to content with status 'publish' are rendered.

This would benefit from an indicator that the link will not be visible on the front end. Alternatively we could go ahead and render everything.