### PR TITLE
Site Editor: Revert templates to their original theme-provided files

### DIFF
--- a/lib/templates.php
+++ b/lib/templates.php
@@ -374,6 +374,20 @@ function filter_rest_prepare_add_wp_theme_slug_and_file_based( $response ) {
 			$file_based                   = in_array( '_wp_file_based', $wp_theme_slugs, true );
 			$response->data['file_based'] = $file_based;
 
+			$response->data['original_file_exists'] = false;
+			$template_files = array_unique(
+				array_merge(
+					_gutenberg_get_template_paths( get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'block-templates' ),
+					_gutenberg_get_template_paths( get_template_directory() . DIRECTORY_SEPARATOR . 'block-templates' )
+				)
+			);
+			foreach( $template_files as $template_file ) {
+				if ( basename( $template_file, '.html' ) === $response->data['slug'] ) {
+					$response->data['original_file_exists'] = true;
+					break;
+				}
+			}
+
 			$theme_slug = array_values(
 				array_filter(
 					$wp_theme_slugs,

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -375,13 +375,13 @@ function filter_rest_prepare_add_wp_theme_slug_and_file_based( $response ) {
 			$response->data['file_based'] = $file_based;
 
 			$response->data['original_file_exists'] = false;
-			$template_files = array_unique(
+			$template_files                         = array_unique(
 				array_merge(
 					_gutenberg_get_template_paths( get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'block-templates' ),
 					_gutenberg_get_template_paths( get_template_directory() . DIRECTORY_SEPARATOR . 'block-templates' )
 				)
 			);
-			foreach( $template_files as $template_file ) {
+			foreach ( $template_files as $template_file ) {
 				if ( basename( $template_file, '.html' ) === $response->data['slug'] ) {
 					$response->data['original_file_exists'] = true;
 					break;

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -36,6 +36,11 @@ export default function TemplateDetails( { template, onClose } ) {
 		currentTheme === template?.wp_theme_slug;
 	/* eslint-enable camelcase */
 
+	const revert = () => {
+		revertTemplate( template );
+		onClose();
+	};
+
 	const showTemplateInSidebar = () => {
 		onClose();
 		openNavigationPanelToMenu( MENU_TEMPLATES );
@@ -72,10 +77,7 @@ export default function TemplateDetails( { template, onClose } ) {
 			{ isRevertable && (
 				<div className="edit-site-template-details">
 					<Text variant="body">
-						<Button
-							isLink
-							onClick={ () => revertTemplate( template ) }
-						>
+						<Button isLink onClick={ revert }>
 							{ __( 'Revert' ) }
 						</Button>
 						<br />

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -8,6 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { isTemplateRevertable } from '../../utils';
 import { MENU_TEMPLATES } from '../navigation-sidebar/navigation-panel/constants';
 
 export default function TemplateDetails( { template, onClose } ) {
@@ -28,13 +29,6 @@ export default function TemplateDetails( { template, onClose } ) {
 	if ( ! template ) {
 		return null;
 	}
-
-	/* eslint-disable camelcase */
-	const isRevertable =
-		'auto-draft' !== template.status &&
-		template?.file_based &&
-		currentTheme === template?.wp_theme_slug;
-	/* eslint-enable camelcase */
 
 	const revert = () => {
 		revertTemplate( template );
@@ -74,7 +68,7 @@ export default function TemplateDetails( { template, onClose } ) {
 				) }
 			</div>
 
-			{ isRevertable && (
+			{ isTemplateRevertable( template, currentTheme ) && (
 				<div className="edit-site-template-details">
 					<Text variant="body">
 						<Button isLink onClick={ revert }>

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -70,11 +70,10 @@ export default function TemplateDetails( { template, onClose } ) {
 
 			{ isTemplateRevertable( template, currentTheme ) && (
 				<div className="edit-site-template-details">
-					<Text variant="body">
-						<Button isLink onClick={ revert }>
-							{ __( 'Revert' ) }
-						</Button>
-						<br />
+					<Button isLink onClick={ revert }>
+						{ __( 'Revert' ) }
+					</Button>
+					<Text variant="caption">
 						{ __(
 							'Reset this template to the theme supplied default'
 						) }

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -11,16 +11,30 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { MENU_TEMPLATES } from '../navigation-sidebar/navigation-panel/constants';
 
 export default function TemplateDetails( { template, onClose } ) {
-	const { title, description } = useSelect(
-		( select ) =>
-			select( 'core/editor' ).__experimentalGetTemplateInfo( template ),
-		[]
+	const { title, description, currentTheme } = useSelect( ( select ) => {
+		const templateInfo = select(
+			'core/editor'
+		).__experimentalGetTemplateInfo( template );
+		return {
+			title: templateInfo?.title,
+			description: templateInfo?.description,
+			currentTheme: select( 'core' ).getCurrentTheme()?.stylesheet,
+		};
+	}, [] );
+	const { openNavigationPanelToMenu, revertTemplate } = useDispatch(
+		'core/edit-site'
 	);
-	const { openNavigationPanelToMenu } = useDispatch( 'core/edit-site' );
 
 	if ( ! template ) {
 		return null;
 	}
+
+	/* eslint-disable camelcase */
+	const isRevertable =
+		'auto-draft' !== template.status &&
+		template?.file_based &&
+		currentTheme === template?.wp_theme_slug;
+	/* eslint-enable camelcase */
 
 	const showTemplateInSidebar = () => {
 		onClose();
@@ -54,6 +68,23 @@ export default function TemplateDetails( { template, onClose } ) {
 					</Text>
 				) }
 			</div>
+
+			{ isRevertable && (
+				<div className="edit-site-template-details">
+					<Text variant="body">
+						<Button
+							isLink
+							onClick={ () => revertTemplate( template ) }
+						>
+							{ __( 'Revert' ) }
+						</Button>
+						<br />
+						{ __(
+							'Reset this template to the theme supplied default'
+						) }
+					</Text>
+				</div>
+			) }
 
 			<Button
 				className="edit-site-template-details__show-all-button"

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -1,5 +1,10 @@
 .edit-site-template-details {
-	margin: $grid-unit-10 $grid-unit-20;
+	border-bottom: $border-width solid $gray-400;
+	padding: $grid-unit-10 $grid-unit-20;
+
+	&:last-of-type {
+		border-bottom: none;
+	}
 
 	p {
 		padding: $grid-unit-10 0;

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -281,7 +281,9 @@ export function* revertTemplate( template ) {
 			yield controls.dispatch(
 				'core/notices',
 				'createErrorNotice',
-				__( 'This template is not revertable' ),
+				__(
+					'The editor has encountered an unexpected error. Please reload.'
+				),
 				{ type: 'snackbar' }
 			);
 			return;
@@ -298,7 +300,7 @@ export function* revertTemplate( template ) {
 		const errorMessage =
 			error.message && error.code !== 'unknown_error'
 				? error.message
-				: __( 'Template revert failed' );
+				: __( 'Template revert failed. Please reload.' );
 		yield controls.dispatch(
 			'core/notices',
 			'createErrorNotice',

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -260,7 +260,8 @@ export function* revertTemplate( template ) {
 		yield controls.dispatch(
 			'core/notices',
 			'createErrorNotice',
-			__( 'This template is not revertable' )
+			__( 'This template is not revertable' ),
+			{ type: 'snackbar' }
 		);
 		return;
 	}
@@ -288,7 +289,8 @@ export function* revertTemplate( template ) {
 			yield controls.dispatch(
 				'core/notices',
 				'createErrorNotice',
-				__( 'This template is not revertable' )
+				__( 'This template is not revertable' ),
+				{ type: 'snackbar' }
 			);
 			return;
 		}
@@ -297,7 +299,8 @@ export function* revertTemplate( template ) {
 		yield controls.dispatch(
 			'core/notices',
 			'createSuccessNotice',
-			__( 'Template reverted' )
+			__( 'Template reverted' ),
+			{ type: 'snackbar' }
 		);
 	} catch ( error ) {
 		const errorMessage =
@@ -307,7 +310,8 @@ export function* revertTemplate( template ) {
 		yield controls.dispatch(
 			'core/notices',
 			'createErrorNotice',
-			errorMessage
+			errorMessage,
+			{ type: 'snackbar' }
 		);
 	}
 }

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -240,12 +240,6 @@ export function updateSettings( settings ) {
  * @param {Object} template The template to revert.
  */
 export function* revertTemplate( template ) {
-	const postType = yield controls.resolveSelect(
-		'core',
-		'getPostType',
-		'wp_template'
-	);
-
 	const currentTheme = yield controls.resolveSelect(
 		'core',
 		'getCurrentTheme'
@@ -262,10 +256,13 @@ export function* revertTemplate( template ) {
 	}
 
 	try {
-		yield apiFetch( {
-			path: `/wp/v2/${ postType.rest_base }/${ template.id }`,
-			method: 'DELETE',
-		} );
+		yield controls.dispatch(
+			'core',
+			'deleteEntityRecord',
+			'postType',
+			'wp_template',
+			template.id
+		);
 
 		const fileTemplates = yield controls.resolveSelect(
 			'core',

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -251,7 +251,7 @@ export function* revertTemplate( template ) {
 		'getCurrentTheme'
 	);
 
-	if ( ! isTemplateRevertable( template, currentTheme ) ) {
+	if ( ! isTemplateRevertable( template, currentTheme?.stylesheet ) ) {
 		yield controls.dispatch(
 			'core/notices',
 			'createErrorNotice',

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { findTemplate } from './controls';
+import { isTemplateRevertable } from '../utils';
 
 /**
  * Returns an action object used to toggle a feature flag.
@@ -250,13 +251,7 @@ export function* revertTemplate( template ) {
 		'getCurrentTheme'
 	);
 
-	if (
-		/* eslint-disable camelcase */
-		'auto-draft' !== template.status &&
-		template?.file_based &&
-		currentTheme === template?.wp_theme_slug
-		/* eslint-enable camelcase */
-	) {
+	if ( ! isTemplateRevertable( template, currentTheme ) ) {
 		yield controls.dispatch(
 			'core/notices',
 			'createErrorNotice',

--- a/packages/edit-site/src/utils/index.js
+++ b/packages/edit-site/src/utils/index.js
@@ -1,1 +1,2 @@
 export { default as findTemplate } from './find-template';
+export { default as isTemplateRevertable } from './is-template-revertable';

--- a/packages/edit-site/src/utils/is-template-revertable.js
+++ b/packages/edit-site/src/utils/is-template-revertable.js
@@ -13,6 +13,7 @@ export default function isTemplateRevertable( template, currentTheme ) {
 		'auto-draft' !== template.status &&
 		/* eslint-disable camelcase */
 		template?.file_based &&
+		template?.original_file_exists &&
 		currentTheme === template?.wp_theme_slug
 		/* eslint-enable camelcase */
 	);

--- a/packages/edit-site/src/utils/is-template-revertable.js
+++ b/packages/edit-site/src/utils/is-template-revertable.js
@@ -1,0 +1,19 @@
+/**
+ * Check if a template is revertable to its original theme-provided template file.
+ *
+ * @param {Object} template The template entity to check.
+ * @param {string} currentTheme The current theme slug (stylesheet).
+ * @return {boolean} Whether the template is revertable.
+ */
+export default function isTemplateRevertable( template, currentTheme ) {
+	if ( ! template || ! currentTheme ) {
+		return false;
+	}
+	return (
+		'auto-draft' !== template.status &&
+		/* eslint-disable camelcase */
+		template?.file_based &&
+		currentTheme === template?.wp_theme_slug
+		/* eslint-enable camelcase */
+	);
+}


### PR DESCRIPTION
## Description

Fixes #23421

- Create a new `core/edit-site` action that reverts a template to its original theme-provided file.
- Add a new "Revert" button in the Site Editor's document action for revertable templates.

### WIP Notes

- The templates REST API currently doesn't support the `theme` parameter used in this PR. I've introduced it in #27152.

### Technical Notes

"Reverting a template" means:
- Delete the current template.
- Let the templates sync run behind the scenes.
- The sync eventually will notice that a template is missing, and will create a new `auto-draft`.
- Get all `auto-draft` templates for the current theme, with the same slug of the deleted template.
- Pick the first (typically the only one), and set it in the Site Editor context.

"Revertable template" indicates a template that:
- Is not `auto-draft`.
- Belongs to the current theme (its `wp_theme` taxonomy includes the current theme's slug).
- Is `_wp_file_based` (its `wp_theme` taxonomy includes `_wp_file_based`).

### Edge Case Issue (see 19951bd)

This approach relies on the templates sync that runs automatically whenever the site detects differences between the theme-provided file templates and the template posts.
As far as I understand, this should reliably work in all scenarios I could think of, except in one.

What if the theme _used to provide_ a file template and it doesn't anymore?

For example, let's say a theme at version 1.0 provided an `index` template.
The sync creates an `index` auto-draft and tags it as `_wp_file_based`.
The user customizes that `index` template.
Then, the theme updates to version 2.0, dropping support for the `index` template by removing the `index` template file.

The `index` template post is still tagged as `_wp_file_based`, but it doesn't have an original file to revert to.

My first idea was to revert to the first revision of the template post, but as it turns out, `auto-draft` don't have revisions.
In other word, the first revision of a custom template would be the first time the user customized it.

Another idea could be to update the templates endpoint for `_wp_file_based` templates to check if the theme still has their original file to revert to.
I'm going to explore this, and see how complicated it would be.

## How has this been tested?

To simplify this test, set up your site like this:
- Use the 2021 Blocks theme.
- Directly edit the Front Page autodraft (`/wp-admin/edit.php?post_type=wp_template&post_status=auto-draft`).
Change its title in something like "CUSTOM FRONT PAGE", and make sure it's published.

Then:
- Open the Site Editor.
- Make sure it's showing the "CUSTOM FRONT PAGE".
- Open the document actions (in the editor header), and click on "Revert".
- Wait a little bit.
- Make sure the editor is now showing the "Front Page" template (not custom).
- Navigate to the templates CPT list (`/wp-admin/edit.php?post_type=wp_template`).
- Check that the custom template is in Trash.
- Check that there is a new Front Page template in Auto-Drafts (and make sure it's the only one!).

Harder test:
- Pick an auto-draft template and customize it.
- Make sure there is a "Revert" button in the document actions. (Don't revert!)
- Head into the source files of the theme, and navigate to `/wp-content/themes/THEME_NAME/block-templates`.
- Rename or delete the template file corresponding to the template you have customized.
- Reload the Site Editor.
- Make sure the "Revert" button in the document actions doesn't show up anymore.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
