### PR TITLE
Full Site Editing: Avoid throwing warnings if there are no terms for a template or template part

### DIFF
--- a/lib/full-site-editing/templates-utils.php
+++ b/lib/full-site-editing/templates-utils.php
@@ -54,7 +54,7 @@ function gutenberg_render_templates_lists_custom_column( $column_name, $post_id 
 
 	if ( 'theme' === $column_name ) {
 		$terms = get_the_terms( $post_id, 'wp_theme' );
-		if ( empty( $terms ) ) {
+		if ( empty( $terms ) || is_wp_error( $terms ) ) {
 			return;
 		}
 		$themes        = array();

--- a/lib/full-site-editing/templates-utils.php
+++ b/lib/full-site-editing/templates-utils.php
@@ -54,7 +54,7 @@ function gutenberg_render_templates_lists_custom_column( $column_name, $post_id 
 
 	if ( 'theme' === $column_name ) {
 		$terms = get_the_terms( $post_id, 'wp_theme' );
-		if ( ! is_array( $terms ) ) {
+		if ( empty( $terms ) ) {
 			return;
 		}
 		$themes        = array();
@@ -80,7 +80,7 @@ function gutenberg_render_templates_lists_custom_column( $column_name, $post_id 
  * @param array $views The edit views to filter.
  */
 function gutenberg_filter_templates_edit_views( $views ) {
-	$post_type = get_current_screen()->post_type;
+	$post_type          = get_current_screen()->post_type;
 	$url                = add_query_arg(
 		array(
 			'post_type'   => $post_type,

--- a/lib/full-site-editing/templates-utils.php
+++ b/lib/full-site-editing/templates-utils.php
@@ -53,7 +53,10 @@ function gutenberg_render_templates_lists_custom_column( $column_name, $post_id 
 	}
 
 	if ( 'theme' === $column_name ) {
-		$terms         = get_the_terms( $post_id, 'wp_theme' );
+		$terms = get_the_terms( $post_id, 'wp_theme' );
+		if ( ! is_array( $terms ) ) {
+			return;
+		}
 		$themes        = array();
 		$is_file_based = false;
 		foreach ( $terms as $term ) {


### PR DESCRIPTION
## Description

Fixes #27172

A recent change added the `wp_theme` taxonomy to the wp-admin lists of templates and template parts.
I didn't consider that `get_the_terms` returns false instead of an empty array if it doesn't find anything.

After the many changes on the `wp_template` and `wp_template_part` custom post types, we currently assign the current theme slug to `wp_theme` on templates and parts creation.
Therefore, new templates would never trigger this warning.

While older templates (without `wp_theme` taxonomy) are barely supported now, it's still appropriate to make sure the data is valid before looping through it.

## How has this been tested?

- Open both `/wp-admin/edit.php?post_type=wp_template` and `/wp-admin/edit.php?post_type=wp_template_part`.
- Make sure everything works as expected, and the items have the theme name in the Theme column.
- If you have older templates/parts, without `wp_theme` tag, make sure there are no warning in the PHP log.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
