### PR TITLE
Fix Media & Text “crop image to fill” to work with linked media

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -242,7 +242,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					}
 				/>
 			) }
-			{ imageFill && mediaUrl && (
+			{ imageFill && mediaUrl && mediaType === 'image' && (
 				<FocalPointPicker
 					label={ __( 'Focal point picker' ) }
 					url={ mediaUrl }

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -72,13 +72,18 @@
 	vertical-align: middle;
 }
 
-.wp-block-media-text.is-image-fill figure.wp-block-media-text__media {
+.wp-block-media-text.is-image-fill .wp-block-media-text__media {
 	height: 100%;
 	min-height: 250px;
 	background-size: cover;
 }
 
-.wp-block-media-text.is-image-fill figure.wp-block-media-text__media > img {
+.wp-block-media-text.is-image-fill .wp-block-media-text__media > a {
+	display: block;
+	height: 100%;
+}
+
+.wp-block-media-text.is-image-fill .wp-block-media-text__media img {
 	// The image is visually hidden but accessible to assistive technologies.
 	position: absolute;
 	width: 1px;


### PR DESCRIPTION
## Issues
Using a Media & Text block with both linked media and the ”Crop image to fill entire column” results in a styling failure. The `img` element is not hidden as intended (to allow the “crop” to be of the background image).
Editor: | Frontend:
-------|-------
<img src="https://user-images.githubusercontent.com/9000376/100007878-9217da80-2d81-11eb-82fe-5af2ee9b6363.png"/> | <img src="https://user-images.githubusercontent.com/9000376/100008017-bd9ac500-2d81-11eb-84fc-b7a4773c9105.png"/>

Variations of the breakage can be seen in the following issues:  #21399; https://core.trac.wordpress.org/ticket/49890

Additionally, I noticed that if the media is switched to a video while the ”Crop image to fill entire column” option is on then the Focal Point Picker is left in the UI which is possibly confusing as it has no effect on video media.
<details>
<summary>A screen recording to demonstrate leftover focal point picker</summary>
<img src="https://user-images.githubusercontent.com/9000376/100013059-16ba2700-2d89-11eb-8a25-030d332b5560.gif"/>
</details>
 
## Changes
### To address the issues
- Change the selector for the `img` element to be descendent instead of child combinator.
- Add a ruleset for the `a` to make the link cover the media area since the image is hidden.
- Omit the ”Focal Point Picker” when the media is not an image
### Tangential changes
- Remove the use of `figure` in the selectors for the media element

## How has this been tested?

1. Insert a Media & Text block
2. Add an image
3. Add a link 
4. Verify ”Crop image to fill entire column” setting works as intended (frontend)
5. Remove the link
6. Repeat step No.4
7. Change the media to a video
8. Verify that the Focal Point Picker is omitted from the UI

## Types of changes
Bug fix: #21399

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
