### PR TITLE
Search Block: Add rounded block style

### DIFF
--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { search as icon } from '@wordpress/icons';
 
 /**
@@ -23,4 +23,12 @@ export const settings = {
 	example: {},
 	variations,
 	edit,
+	styles: [
+		{
+			name: 'default',
+			label: _x( 'Default', 'block style' ),
+			isDefault: true,
+		},
+		{ name: 'rounded', label: _x( 'Rounded', 'block style' ) },
+	],
 };

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -59,5 +59,20 @@
 			padding: 0.125em 0.5em;
 		}
 	}
+
+	&.is-style-rounded {
+		.wp-block-search__inside-wrapper,
+		.wp-block-search__input,
+		.wp-block-search__button {
+			border-radius: var(--wp--search--border-radius, 50px);
+		}
+
+		&.wp-block-search__button-inside {
+			.wp-block-search__input,
+			.wp-block-search__button {
+				border-radius: calc(var(--wp--search--border-radius, 50px) - #{$grid-unit-05});
+			}
+		}
+	}
 }
 


### PR DESCRIPTION
## Description
Adds a new rounded block style for the search block. This will add a border radius to the search block including adding adjusted border radii to the input and button when the button is placed "inside".

This is an alternate approach to adding border radius block support as suggested in https://github.com/WordPress/gutenberg/pull/25791#discussion_r522811059

Note: This uses a CSS variable for the border radius value. This allows;
- the value to be inherited and used with `calc()` for inner elements
- the user to define the border radius variable within different scopes if it makes sense for different search blocks to have different radius values
- the user to only have to set a single CSS variable rather than override multiple styles

## How has this been tested?
Manually.

1. Add a search block to a post
2. Select the rounded block style from the sidebar
3. Switch between different button positions via the block toolbar option and confirm rounded styles are applied
4. Check the frontend also gets correct styles

## Screenshots
![SearchRoundedStyle](https://user-images.githubusercontent.com/60436221/100061937-8a882c80-2e7a-11eb-895b-b8bf1577a476.gif)

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
