### PR TITLE
Try: Update readme screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 
-![Screenshot of the Gutenberg Editor, editing a post in WordPress](https://user-images.githubusercontent.com/1204802/73433964-2540d900-4346-11ea-94f3-5df2e9d876bc.png)
+![Screenshot of the Gutenberg Editor, editing a post in WordPress](https://user-images.githubusercontent.com/1204802/100067796-fc3e8700-2e36-11eb-993b-6b80b4310b87.png)
 
 Welcome to the development hub for the WordPress Gutenberg project!
 


### PR DESCRIPTION
This PR simply updates the URL of the screenshot used in the readme to a new one, which shows a more recent version of the editor.

Before:

<img width="1069" alt="before" src="https://user-images.githubusercontent.com/1204802/100068011-40318c00-2e37-11eb-84db-b2efa144a280.png">

After is hard to show as I can't render the readme until the PR is merged, but I updated the screenshot to this:

![screenshot](https://user-images.githubusercontent.com/1204802/100068084-54758900-2e37-11eb-99e2-b3552f4d7b65.png)
