### PR TITLE
[RNMobile] Implementing UI test and finalisation of File Block

### DIFF
--- a/packages/block-editor/src/components/media-upload-progress/index.native.js
+++ b/packages/block-editor/src/components/media-upload-progress/index.native.js
@@ -125,13 +125,16 @@ export class MediaUploadProgress extends React.Component {
 			'Failed to insert media.\nPlease tap for options.'
 		);
 
+		const progressBarStyle = [
+			styles.progressBar,
+			showSpinner || styles.progressBarHidden,
+		];
+
 		return (
 			<View style={ styles.mediaUploadProgress } pointerEvents="box-none">
-				{ showSpinner && (
-					<View style={ styles.progressBar }>
-						<Spinner progress={ progress } />
-					</View>
-				) }
+				<View style={ progressBarStyle }>
+					{ showSpinner && <Spinner progress={ progress } /> }
+				</View>
 				{ renderContent( {
 					isUploadInProgress,
 					isUploadFailed,

--- a/packages/block-editor/src/components/media-upload-progress/styles.native.scss
+++ b/packages/block-editor/src/components/media-upload-progress/styles.native.scss
@@ -6,4 +6,10 @@
 .progressBar {
 	background-color: $gray-lighten-30;
 	z-index: 1;
+	height: 6px;
+	margin-bottom: -6px;
+}
+
+.progressBarHidden {
+	background-color: transparent;
 }

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -17,8 +17,8 @@ import {
 	capturePhoto,
 	captureVideo,
 	image,
-	video,
 	wordpress,
+	mobile,
 } from '@wordpress/icons';
 
 export const MEDIA_TYPE_IMAGE = 'image';
@@ -125,18 +125,7 @@ export class MediaUpload extends React.Component {
 	}
 
 	getChooseFromDeviceIcon() {
-		const { allowedTypes = [] } = this.props;
-
-		const isOneType = allowedTypes.length === 1;
-		const isImage = isOneType && allowedTypes.includes( MEDIA_TYPE_IMAGE );
-		const isVideo = isOneType && allowedTypes.includes( MEDIA_TYPE_VIDEO );
-		const isAnyType = isOneType && allowedTypes.includes( MEDIA_TYPE_ANY );
-
-		if ( isImage || ! isOneType || isAnyType ) {
-			return image;
-		} else if ( isVideo ) {
-			return video;
-		}
+		return mobile;
 	}
 
 	onPickerPresent() {

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -462,7 +462,7 @@ export class FileEdit extends Component {
 									isUploadInProgress,
 									isUploadFailed
 								) }
-								<View>
+								<View style={ styles.container }>
 									<RichText
 										__unstableMobileNoFocusOnMount
 										onChange={ this.onChangeFileName }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -489,7 +489,7 @@ export class FileEdit extends Component {
 										</View>
 									) }
 								</View>
-								{ showDownloadButton && (
+								{ showDownloadButton && this.state.maxWidth > 0 && (
 									<View
 										style={ [
 											finalButtonStyle,

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -580,11 +580,11 @@ export class FileEdit extends Component {
 export default compose( [
 	withSelect( ( select, props ) => {
 		const { attributes } = props;
-		const { id } = attributes;
+		const { id, href } = attributes;
 		const { isEditorSidebarOpened } = select( 'core/edit-post' );
+		const isNotFileHref = id && getProtocol( href ) !== 'file:';
 		return {
-			media:
-				id === undefined ? undefined : select( 'core' ).getMedia( id ),
+			media: isNotFileHref ? select( 'core' ).getMedia( id ) : undefined,
 			isSidebarOpened: isEditorSidebarOpened(),
 		};
 	} ),

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -464,6 +464,7 @@ export class FileEdit extends Component {
 								) }
 								<View style={ styles.container }>
 									<RichText
+										withoutInteractiveFormatting
 										__unstableMobileNoFocusOnMount
 										onChange={ this.onChangeFileName }
 										placeholder={ __( 'File name' ) }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -483,6 +483,7 @@ export class FileEdit extends Component {
 												style={ errorIconStyle }
 											/>
 											<PlainText
+												editable={ false }
 												value={ __( 'Error' ) }
 												style={ styles.uploadFailed }
 											/>

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -489,49 +489,53 @@ export class FileEdit extends Component {
 										</View>
 									) }
 								</View>
-								{ showDownloadButton && this.state.maxWidth > 0 && (
-									<View
-										style={ [
-											finalButtonStyle,
-											this.getStyleForAlignment( align ),
-										] }
-									>
-										<RichText
-											withoutInteractiveFormatting
-											__unstableMobileNoFocusOnMount
-											rootTagsToEliminate={ [ 'p' ] }
-											tagName="p"
-											textAlign="center"
-											minWidth={ minWidth }
-											maxWidth={ this.state.maxWidth }
-											deleteEnter={ true }
-											style={ styles.buttonText }
-											value={ downloadButtonText }
-											placeholder={ placeholderText }
-											unstableOnFocus={ () =>
-												this.setState( {
-													isButtonFocused: true,
-												} )
-											}
-											onBlur={ () =>
-												this.setState( {
-													isButtonFocused: false,
-												} )
-											}
-											selectionColor={
-												styles.buttonText.color
-											}
-											placeholderTextColor={
-												styles.placeholderTextColor
-													.color
-											}
-											underlineColorAndroid="transparent"
-											onChange={
-												this.onChangeDownloadButtonText
-											}
-										/>
-									</View>
-								) }
+								{ showDownloadButton &&
+									this.state.maxWidth > 0 && (
+										<View
+											style={ [
+												finalButtonStyle,
+												this.getStyleForAlignment(
+													align
+												),
+											] }
+										>
+											<RichText
+												withoutInteractiveFormatting
+												__unstableMobileNoFocusOnMount
+												rootTagsToEliminate={ [ 'p' ] }
+												tagName="p"
+												textAlign="center"
+												minWidth={ minWidth }
+												maxWidth={ this.state.maxWidth }
+												deleteEnter={ true }
+												style={ styles.buttonText }
+												value={ downloadButtonText }
+												placeholder={ placeholderText }
+												unstableOnFocus={ () =>
+													this.setState( {
+														isButtonFocused: true,
+													} )
+												}
+												onBlur={ () =>
+													this.setState( {
+														isButtonFocused: false,
+													} )
+												}
+												selectionColor={
+													styles.buttonText.color
+												}
+												placeholderTextColor={
+													styles.placeholderTextColor
+														.color
+												}
+												underlineColorAndroid="transparent"
+												onChange={
+													this
+														.onChangeDownloadButtonText
+												}
+											/>
+										</View>
+									) }
 							</View>
 						</TouchableWithoutFeedback>
 					);

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -15,7 +15,7 @@
 }
 
 .disabledButton {
-	opacity: 0.25;
+	opacity: 0.45;
 }
 
 .uploadFailedText {

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -1,3 +1,7 @@
+.container {
+	margin-top: 2px;
+}
+
 .defaultButton {
 	border-radius: $border-width * 4;
 	padding: $block-spacing * 2;

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -5,6 +5,14 @@ exports[`File block renders file error state without crashing 1`] = `
   pointerEvents="box-none"
 >
   <View
+    style={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+  />
+  <View
     accessible={true}
     focusable={true}
     onClick={[Function]}
@@ -27,7 +35,13 @@ exports[`File block renders file error state without crashing 1`] = `
       
     </Text>
     Modal
-    <View>
+    <View
+      style={
+        Object {
+          "height": 44,
+        }
+      }
+    >
       <View>
         <RCTAztecView
           accessible={true}
@@ -85,6 +99,7 @@ exports[`File block renders file error state without crashing 1`] = `
         Svg
         <TextInput
           allowFontScaling={true}
+          editable={false}
           fontFamily="serif"
           onChange={[Function]}
           rejectResponderTermination={true}
@@ -182,6 +197,14 @@ exports[`File block renders file without crashing 1`] = `
   pointerEvents="box-none"
 >
   <View
+    style={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+  />
+  <View
     accessible={true}
     focusable={true}
     onClick={[Function]}
@@ -204,7 +227,13 @@ exports[`File block renders file without crashing 1`] = `
       
     </Text>
     Modal
-    <View>
+    <View
+      style={
+        Object {
+          "height": 44,
+        }
+      }
+    >
       <View>
         <RCTAztecView
           accessible={true}

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -103,7 +103,10 @@ exports[`File block renders file error state without crashing 1`] = `
       style={
         Array [
           Array [
-            undefined,
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            },
             undefined,
           ],
           Object {
@@ -153,7 +156,7 @@ exports[`File block renders file error state without crashing 1`] = `
             Object {
               "backgroundColor": undefined,
               "color": "white",
-              "maxWidth": 0,
+              "maxWidth": 80,
               "minHeight": 0,
             }
           }
@@ -260,7 +263,10 @@ exports[`File block renders file without crashing 1`] = `
       style={
         Array [
           Array [
-            undefined,
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            },
             false,
           ],
           Object {
@@ -310,7 +316,7 @@ exports[`File block renders file without crashing 1`] = `
             Object {
               "backgroundColor": undefined,
               "color": "white",
-              "maxWidth": 0,
+              "maxWidth": 80,
               "minHeight": 0,
             }
           }

--- a/packages/block-library/src/file/test/edit.native.js
+++ b/packages/block-library/src/file/test/edit.native.js
@@ -41,7 +41,9 @@ describe( 'File block', () => {
 			id: '1',
 		} );
 
-		component.getInstance().onLayout( { nativeEvent: { layout: { width: 100 } } } );
+		component
+			.getInstance()
+			.onLayout( { nativeEvent: { layout: { width: 100 } } } );
 
 		const rendered = component.toJSON();
 		expect( rendered ).toMatchSnapshot();
@@ -56,7 +58,9 @@ describe( 'File block', () => {
 			textLinkHref: 'https://wordpress.org/latest.zip',
 			id: '1',
 		} );
-		component.getInstance().onLayout( { nativeEvent: { layout: { width: 100 } } } );
+		component
+			.getInstance()
+			.onLayout( { nativeEvent: { layout: { width: 100 } } } );
 
 		const mediaUpload = component.root.findByType( MediaUploadProgress );
 		mediaUpload.instance.finishMediaUploadWithFailure( { mediaId: -1 } );

--- a/packages/block-library/src/file/test/edit.native.js
+++ b/packages/block-library/src/file/test/edit.native.js
@@ -41,6 +41,8 @@ describe( 'File block', () => {
 			id: '1',
 		} );
 
+		component.getInstance().onLayout( { nativeEvent: { layout: { width: 100 } } } );
+
 		const rendered = component.toJSON();
 		expect( rendered ).toMatchSnapshot();
 	} );
@@ -54,6 +56,7 @@ describe( 'File block', () => {
 			textLinkHref: 'https://wordpress.org/latest.zip',
 			id: '1',
 		} );
+		component.getInstance().onLayout( { nativeEvent: { layout: { width: 100 } } } );
 
 		const mediaUpload = component.root.findByType( MediaUploadProgress );
 		mediaUpload.instance.finishMediaUploadWithFailure( { mediaId: -1 } );

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -223,7 +223,7 @@ export const registerCoreBlocks = () => {
 		socialLink,
 		socialLinks,
 		pullquote,
-		devOnly( file ),
+		file,
 	].forEach( registerBlock );
 
 	registerBlockVariations( socialLink );

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -356,7 +356,7 @@ public class WPAndroidGlueCode {
                 if (mediaType == MediaType.IMAGE || mediaType == MediaType.MEDIA) {
                     ArrayList<MediaOption> otherMediaImageOptions = mOnMediaLibraryButtonListener.onGetOtherMediaImageOptions();
                     otherMediaOptionsReceivedCallback.onOtherMediaOptionsReceived(otherMediaImageOptions);
-                } else {
+                } else if (mediaType == MediaType.ANY) {
                     ArrayList<MediaOption> otherMediaFileOptions = mOnMediaLibraryButtonListener.onGetOtherMediaFileOptions();
                     otherMediaOptionsReceivedCallback.onOtherMediaOptionsReceived(otherMediaFileOptions);
                 }

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-file.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-file.test.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import EditorPage from './pages/editor-page';
+import { setupDriver, isLocalEnvironment, stopDriver } from './helpers/utils';
+import testData from './helpers/test-data';
+
+jest.setTimeout( 1000000 );
+
+describe( 'Gutenberg Editor File Block tests @canary', () => {
+	let driver;
+	let editorPage;
+	let allPassed = true;
+	const fileBlockName = 'File';
+
+	// Use reporter for setting status for saucelabs Job
+	if ( ! isLocalEnvironment() ) {
+		const reporter = {
+			specDone: async ( result ) => {
+				allPassed = allPassed && result.status !== 'failed';
+			},
+		};
+
+		jasmine.getEnv().addReporter( reporter );
+	}
+
+	beforeAll( async () => {
+		driver = await setupDriver();
+		editorPage = new EditorPage( driver );
+	} );
+
+	it( 'should be able to see visual editor', async () => {
+		await expect( editorPage.getBlockList() ).resolves.toBe( true );
+	} );
+
+	it( 'should be able to add an image block', async () => {
+		await editorPage.addNewBlock( fileBlockName );
+		await editorPage.verifyHtmlContent( testData.fileBlockPlaceholder );
+	} );
+
+	afterAll( async () => {
+		if ( ! isLocalEnvironment() ) {
+			driver.sauceJobStatus( allPassed );
+		}
+		await stopDriver( driver );
+	} );
+} );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-file.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-file.test.js
@@ -33,8 +33,13 @@ describe( 'Gutenberg Editor File Block tests @canary', () => {
 		await expect( editorPage.getBlockList() ).resolves.toBe( true );
 	} );
 
-	it( 'should be able to add an image block', async () => {
+	it( 'should be able to add a file block', async () => {
 		await editorPage.addNewBlock( fileBlockName );
+		const block = await editorPage.getFirstBlockVisible();
+
+		block.click();
+		await editorPage.chooseMediaLibrary();
+
 		await editorPage.verifyHtmlContent( testData.fileBlockPlaceholder );
 	} );
 

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-file.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-file.test.js
@@ -38,6 +38,7 @@ describe( 'Gutenberg Editor File Block tests @canary', () => {
 		const block = await editorPage.getFirstBlockVisible();
 
 		block.click();
+		await driver.sleep( 1000 );
 		await editorPage.chooseMediaLibrary();
 
 		await editorPage.verifyHtmlContent( testData.fileBlockPlaceholder );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-file.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-file.test.js
@@ -36,6 +36,11 @@ describe( 'Gutenberg Editor File Block tests @canary', () => {
 	it( 'should be able to add a file block', async () => {
 		await editorPage.addNewBlock( fileBlockName );
 		const block = await editorPage.getFirstBlockVisible();
+		await expect( block ).toBeTruthy();
+	} );
+
+	it( 'should add a file to the block ', async () => {
+		const block = await editorPage.getFirstBlockVisible();
 
 		block.click();
 		await driver.sleep( 1000 );

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -132,3 +132,5 @@ exports.coverHeightWithRemUnit = `<!-- wp:cover {"customOverlayColor":"#ffffff",
 <p class="has-text-align-center"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->`;
+
+exports.fileBlockPlaceholder = `<!-- wp:file /-->`;

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -133,4 +133,6 @@ exports.coverHeightWithRemUnit = `<!-- wp:cover {"customOverlayColor":"#ffffff",
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->`;
 
-exports.fileBlockPlaceholder = `<!-- wp:file /-->`;
+exports.fileBlockPlaceholder = `<!-- wp:file {"id":3,"href":"https://wordpress.org/latest.zip"} -->
+<div class="wp-block-file"><a href="https://wordpress.org/latest.zip">WordPress.zip</a><a href="https://wordpress.org/latest.zip" class="wp-block-file__button" download>Download</a></div>
+<!-- /wp:file -->`;

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -101,7 +101,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                     callback([MediaInfo(id: 2, url: "https://i.cloudup.com/YtZFJbuQCE.mov", type: "video", caption: "Cloudup")])
                 }
             case .other, .any:
-                 callback([MediaInfo(id: 1, url: "https://wordpress.org/latest.zip", type: "zip", caption: "WordPress latest version", title: "WordPress.zip")])
+                 callback([MediaInfo(id: 3, url: "https://wordpress.org/latest.zip", type: "zip", caption: "WordPress latest version", title: "WordPress.zip")])
             default:
                 break
             }

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -102,4 +102,8 @@ module.exports = {
 	placeholderTextColor: {
 		color: 'white',
 	},
+	defaultButton: {
+		paddingLeft: 10,
+		paddingRight: 10,
+	},
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2835
`WPiOS` PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15400
`WPAndroid` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13482

## Description
<!-- Please describe what you have changed or added -->

This PR adds canary UI tests for the File block.

**Note:**
- For the tests to pass, it was needed to enable the File block in prod build. So, this PR should be **the last one** to be merged.
- To test inserting a file block, we need the[ WPMediaLibrary PRs](https://github.com/WordPress/gutenberg/pull/26960) to be merged first.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- CI should be ✅  on https://github.com/wordpress-mobile/gutenberg-mobile/pull/2835
- Manual tests from WPiOS and WPAndroid PRs should be ✅ 

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
