### PR TITLE
[RNMobile] File block link to toolbar - alternative

### DIFF
--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -230,11 +230,16 @@ export class FileEdit extends Component {
 			actionButtonStyle,
 			dimmedStyle
 		);
+
+		const bottomSheetPadding = withBottomSheet
+			? styles.linkSettingsPanel
+			: undefined;
+
 		const settings = (
 			<>
 				{ panelTitle && <PanelBody title={ panelTitle } /> }
 				{
-					<PanelBody>
+					<PanelBody style={ bottomSheetPadding }>
 						<SelectControl
 							icon={ link }
 							label={ __( 'Link to' ) }

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -34,3 +34,8 @@
 .actionButtonDark {
 	color: $blue-30;
 }
+
+.linkSettingsPanel {
+	padding-left: 0;
+	padding-right: 0;
+}

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -34,8 +34,3 @@
 .actionButtonDark {
 	color: $blue-30;
 }
-
-.linkSettingsPanel {
-	padding-left: 0;
-	padding-right: 0;
-}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR is an option to https://github.com/WordPress/gutenberg/pull/27127

The main difference is that we are reusing the Sidebar to show both Inspector controls and Links Settings.
This solves the style problems and simplifies (I think) the logic.

For the link settings, the `Show download button` option must be hidden, so we are implementing this detail here too.

<img width="414" alt="Screenshot 2020-11-24 at 13 43 44" src="https://user-images.githubusercontent.com/9772967/100095646-1c803d00-2e5b-11eb-8adb-36bb77d66e18.png">

@jd-alexander - please let me know what do you think about this approach.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Add a File Block. 
- Add a file. 
- Tap the Link toolbar button to see the menu. 
  - Check that `Show download button` option is Not present.
- Check that the Inspector controls still work as expected.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
