### PR TITLE
Site Editor: Update the new templates dropdown list

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
@@ -11,6 +11,16 @@ export const TEMPLATES_POSTS = [ 'home', 'single' ];
 
 export const TEMPLATES_STATUSES = [ 'publish', 'draft', 'auto-draft' ];
 
+export const TEMPLATES_NEW_OPTIONS = [
+	'front-page',
+	'single-post',
+	'page',
+	'archive',
+	'search',
+	'404',
+	'index',
+];
+
 export const MENU_ROOT = 'root';
 export const MENU_CONTENT_CATEGORIES = 'content-categories';
 export const MENU_CONTENT_PAGES = 'content-pages';

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
@@ -20,7 +20,7 @@ import { Icon, plus } from '@wordpress/icons';
  * Internal dependencies
  */
 import getClosestAvailableTemplate from '../../../utils/get-closest-available-template';
-import { TEMPLATES_STATUSES } from './constants';
+import { TEMPLATES_NEW_OPTIONS, TEMPLATES_STATUSES } from './constants';
 
 export default function NewTemplateDropdown() {
 	const { defaultTemplateTypes, templates } = useSelect( ( select ) => {
@@ -59,7 +59,9 @@ export default function NewTemplateDropdown() {
 
 	const missingTemplates = filter(
 		defaultTemplateTypes,
-		( template ) => ! includes( existingTemplateSlugs, template.slug )
+		( template ) =>
+			includes( TEMPLATES_NEW_OPTIONS, template.slug ) &&
+			! includes( existingTemplateSlugs, template.slug )
 	);
 
 	return (

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
@@ -64,6 +64,10 @@ export default function NewTemplateDropdown() {
 			! includes( existingTemplateSlugs, template.slug )
 	);
 
+	if ( ! missingTemplates.length ) {
+		return null;
+	}
+
 	return (
 		<DropdownMenu
 			className="edit-site-navigation-panel__new-template-dropdown"


### PR DESCRIPTION
##  Description

Fixes #27227

Update the new template dropdown list to only show a hand-picked list of templates — if they are missing from the current site/theme.
Also hide the new template button if there are no more missing templates to be added.
 
## How has this been tested?

- Activate a FSE theme and open the Site Editor.
- Open the sidebar, navigate into Templates, and click on the + icon.
- Make sure the dropdown shows the correct templates (they need to match the new list, and not exist already).
- Try adding all templates (make sure to trigger a change and publish them!).
- Make sure the + button is not visible anymore.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
