### PR TITLE
Code block: paste plain text

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -120,6 +120,7 @@ function RichTextWrapper(
 		__unstableOnSplitMiddle: onSplitMiddle,
 		identifier,
 		preserveWhiteSpace,
+		__unstablePastePlainText: pastePlainText,
 		__unstableEmbedURLOnPaste,
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
@@ -408,6 +409,11 @@ function RichTextWrapper(
 
 	const onPaste = useCallback(
 		( { value, onChange, html, plainText, files, activeFormats } ) => {
+			if ( pastePlainText ) {
+				onChange( insert( value, create( { text: plainText } ) ) );
+				return;
+			}
+
 			// Only process file if no HTML is present.
 			// Note: a pasted file may have the URL as plain text.
 			if ( files && files.length && ! html ) {
@@ -503,6 +509,7 @@ function RichTextWrapper(
 			__unstableEmbedURLOnPaste,
 			multiline,
 			preserveWhiteSpace,
+			pastePlainText,
 		]
 	);
 

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -16,6 +16,7 @@ export default function CodeEdit( { attributes, setAttributes, onRemove } ) {
 				placeholder={ __( 'Write code…' ) }
 				aria-label={ __( 'Code' ) }
 				preserveWhiteSpace
+				__unstablePastePlainText
 			/>
 		</pre>
 	);

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -536,6 +536,17 @@ _Parameters_
 
 -   _viewport_ `WPViewport`: Viewport name or dimensions object to assign.
 
+<a name="setClipboardData" href="#setClipboardData">#</a> **setClipboardData**
+
+Sets the clipboard data that can be pasted with
+`pressKeyWithModifier( 'primary', 'v' )`.
+
+_Parameters_
+
+-   _$1_ `Object`: Options.
+-   _$1.plainText_ `string`: Plain text to set.
+-   _$1.html_ `string`: HTML to set.
+
 <a name="setPostContent" href="#setPostContent">#</a> **setPostContent**
 
 Sets code editor content

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -52,7 +52,10 @@ export { openDocumentSettingsSidebar } from './open-document-settings-sidebar';
 export { openPublishPanel } from './open-publish-panel';
 export { trashAllPosts } from './posts';
 export { pressKeyTimes } from './press-key-times';
-export { pressKeyWithModifier } from './press-key-with-modifier';
+export {
+	pressKeyWithModifier,
+	setClipboardData,
+} from './press-key-with-modifier';
 export { publishPost } from './publish-post';
 export { publishPostWithPrePublishChecksDisabled } from './publish-post-with-pre-publish-checks-disabled';
 export { saveDraft } from './save-draft';

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -81,6 +81,26 @@ async function emulateSelectAll() {
 	} );
 }
 
+/**
+ * Sets the clipboard data that can be pasted with
+ * `pressKeyWithModifier( 'primary', 'v' )`.
+ *
+ * @param {Object} $1           Options.
+ * @param {string} $1.plainText Plain text to set.
+ * @param {string} $1.html      HTML to set.
+ */
+export async function setClipboardData( { plainText = '', html = '' } ) {
+	await page.evaluate(
+		( _plainText, _html ) => {
+			window._clipboardData = new DataTransfer();
+			window._clipboardData.setData( 'text/plain', _plainText );
+			window._clipboardData.setData( 'text/html', _html );
+		},
+		plainText,
+		html
+	);
+}
+
 async function emulateClipboard( type ) {
 	await page.evaluate( ( _type ) => {
 		if ( _type !== 'paste' ) {

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/code.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/code.test.js.snap
@@ -5,3 +5,10 @@ exports[`Code can be created by three backticks and enter 1`] = `
 <pre class=\\"wp-block-code\\"><code>&lt;?php</code></pre>
 <!-- /wp:code -->"
 `;
+
+exports[`Code should paste plain text 1`] = `
+"<!-- wp:code -->
+<pre class=\\"wp-block-code\\"><code>&lt;img />
+	&lt;br></code></pre>
+<!-- /wp:code -->"
+`;

--- a/packages/e2e-tests/specs/editor/blocks/code.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/code.test.js
@@ -6,6 +6,8 @@ import {
 	clickBlockAppender,
 	getEditedPostContent,
 	createNewPost,
+	setClipboardData,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Code', () => {
@@ -31,5 +33,16 @@ describe( 'Code', () => {
 
 		// Expect code block to be deleted.
 		expect( await getEditedPostContent() ).toBe( '' );
+	} );
+
+	it( 'should paste plain text', async () => {
+		await insertBlock( 'Code' );
+
+		// Test to see if HTML and white space is kept.
+		await setClipboardData( { plainText: '<img />\n\t<br>' } );
+
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #26689.

The problem: when plain text is pasted into the code block, the text is parsed as markdown. We need a way to return plain text early if desired.

The issue can only be reproduced if you copy the text as plain text like from a code editor. Copying code from an HTML page works because it's already encoded.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
