### PR TITLE
Update: Restrict edition of theme colors by users.

### DIFF
--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -53,7 +53,8 @@ function ColorOption( {
 	);
 
 	const isShowingControls =
-		isHover || isFocused || isEditingName || isShowingAdvancedPanel;
+		( isHover || isFocused || isEditingName || isShowingAdvancedPanel ) &&
+		! immutableColorSlugs.includes( slug );
 
 	return (
 		<div
@@ -119,9 +120,7 @@ function ColorOption( {
 							onChange={ ( newColorName ) =>
 								onChange( {
 									color,
-									slug: immutableColorSlugs.includes( slug )
-										? slug
-										: kebabCase( newColorName ),
+									slug: kebabCase( newColorName ),
 									name: newColorName,
 								} )
 							}


### PR DESCRIPTION
Supersedes https://github.com/WordPress/gutenberg/pull/27082.
This PR follows a suggestion by @nosolosw  in https://github.com/WordPress/gutenberg/pull/27082#issuecomment-732304679.

With it:
- Users can add/update/remove their own new colors.
- Users can modify the color value, but not remove or change the name and slug of theme/core colors.


## How has this been tested?
I made sure the behavior described above worked as expected.
