### PR TITLE
Reduces margin on placeholder for media

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -8,7 +8,6 @@
 
 	// @todo: this deserves a refactor, by being moved to the toolbar.
 	.block-editor-media-placeholder {
-		margin-bottom: $grid-unit-15;
 		padding: $grid-unit-15;
 
 		// This element is empty here anyway.


### PR DESCRIPTION
This is a small PR to fix the margin on focus for the placeholder.

**Before:**

![before-placeholder](https://user-images.githubusercontent.com/253067/100139074-d7720000-2e86-11eb-934d-54d0338c06ea.png)

**After:**

![placeholder-after](https://user-images.githubusercontent.com/253067/100139085-dccf4a80-2e86-11eb-8c2c-d2c05e1ba31b.png)

## Feedback
I would specifically like to know if there are any issues with this fix as placeholders seem a little tangled when it comes to the media blocks.