### PR TITLE
Refactor click redirect (and avoid div)

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -119,6 +119,7 @@ export {
 } from './typewriter';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
+export { useCanvasClickRedirect as __unstableUseCanvasClickRedirect } from './use-canvas-click-redirect';
 
 /*
  * State Related Components

--- a/packages/block-editor/src/components/use-canvas-click-redirect/index.js
+++ b/packages/block-editor/src/components/use-canvas-click-redirect/index.js
@@ -24,8 +24,8 @@ const isTabbableTextField = overEvery( [
 
 export function useCanvasClickRedirect( ref ) {
 	useEffect( () => {
-		function onClick( event ) {
-			// Only handle clicks directly on the canvas itself, not on content.
+		function onMouseDown( event ) {
+			// Only handle clicks on the canvas, not the content.
 			if ( event.target !== ref.current ) {
 				return;
 			}
@@ -38,12 +38,13 @@ export function useCanvasClickRedirect( ref ) {
 			}
 
 			placeCaretAtHorizontalEdge( target, true );
+			event.preventDefault();
 		}
 
-		ref.current.addEventListener( 'click', onClick );
+		ref.current.addEventListener( 'mousedown', onMouseDown );
 
 		return () => {
-			ref.current.removeEventListener( 'click', onClick );
+			ref.current.addEventListener( 'mousedown', onMouseDown );
 		};
 	}, [] );
 }

--- a/packages/block-editor/src/components/use-canvas-click-redirect/index.js
+++ b/packages/block-editor/src/components/use-canvas-click-redirect/index.js
@@ -23,23 +23,23 @@ const isTabbableTextField = overEvery( [
 ] );
 
 export function useCanvasClickRedirect( ref ) {
-	function onClick( event ) {
-		// Only handle clicks directly on the canvas itself, not on content.
-		if ( event.target !== ref.current ) {
-			return;
-		}
-
-		const focusableNodes = focus.focusable.find( ref.current );
-		const target = findLast( focusableNodes, isTabbableTextField );
-
-		if ( ! target ) {
-			return;
-		}
-
-		placeCaretAtHorizontalEdge( target, true );
-	}
-
 	useEffect( () => {
+		function onClick( event ) {
+			// Only handle clicks directly on the canvas itself, not on content.
+			if ( event.target !== ref.current ) {
+				return;
+			}
+
+			const focusableNodes = focus.focusable.find( ref.current );
+			const target = findLast( focusableNodes, isTabbableTextField );
+
+			if ( ! target ) {
+				return;
+			}
+
+			placeCaretAtHorizontalEdge( target, true );
+		}
+
 		ref.current.addEventListener( 'click', onClick );
 
 		return () => {

--- a/packages/block-editor/src/components/use-canvas-click-redirect/index.js
+++ b/packages/block-editor/src/components/use-canvas-click-redirect/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { overEvery, findLast } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
+
+/**
+ * Given an element, returns true if the element is a tabbable text field, or
+ * false otherwise.
+ *
+ * @param {Element} element Element to test.
+ *
+ * @return {boolean} Whether element is a tabbable text field.
+ */
+const isTabbableTextField = overEvery( [
+	isTextField,
+	focus.tabbable.isTabbableIndex,
+] );
+
+export function useCanvasClickRedirect( ref ) {
+	function onClick( event ) {
+		// Only handle clicks directly on the canvas itself, not on content.
+		if ( event.target !== ref.current ) {
+			return;
+		}
+
+		const focusableNodes = focus.focusable.find( ref.current );
+		const target = findLast( focusableNodes, isTabbableTextField );
+
+		if ( ! target ) {
+			return;
+		}
+
+		placeCaretAtHorizontalEdge( target, true );
+	}
+
+	useEffect( () => {
+		ref.current.addEventListener( 'click', onClick );
+
+		return () => {
+			ref.current.removeEventListener( 'click', onClick );
+		};
+	}, [] );
+}

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { overEvery, find, findLast, reverse, first, last } from 'lodash';
+import { find, reverse, first, last } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -48,19 +48,6 @@ import FocusCapture from './focus-capture';
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
 }
-
-/**
- * Given an element, returns true if the element is a tabbable text field, or
- * false otherwise.
- *
- * @param {Element} element Element to test.
- *
- * @return {boolean} Whether element is a tabbable text field.
- */
-const isTabbableTextField = overEvery( [
-	isTextField,
-	focus.tabbable.isTabbableIndex,
-] );
 
 /**
  * Returns true if the element should consider edge navigation upon a keyboard
@@ -684,14 +671,6 @@ export default function WritingFlow( { children } ) {
 		}
 	}
 
-	function focusLastTextField() {
-		const focusableNodes = focus.focusable.find( container.current );
-		const target = findLast( focusableNodes, isTabbableTextField );
-		if ( target ) {
-			placeCaretAtHorizontalEdge( target, true );
-		}
-	}
-
 	useEffect( () => {
 		if ( hasMultiSelection && ! isMultiSelecting ) {
 			multiSelectionContainer.current.focus();
@@ -745,12 +724,6 @@ export default function WritingFlow( { children } ) {
 				hasMultiSelection={ hasMultiSelection }
 				multiSelectionContainer={ multiSelectionContainer }
 				isReverse
-			/>
-			<div
-				aria-hidden
-				tabIndex={ -1 }
-				onClick={ focusLastTextField }
-				className="block-editor-writing-flow__click-redirect"
 			/>
 		</>
 	);

--- a/packages/block-editor/src/components/writing-flow/style.scss
+++ b/packages/block-editor/src/components/writing-flow/style.scss
@@ -1,8 +1,3 @@
-.block-editor-writing-flow {
-	display: flex;
-	flex-direction: column;
-}
-
 .block-editor-writing-flow__click-redirect {
 	cursor: text;
 }

--- a/packages/block-editor/src/components/writing-flow/style.scss
+++ b/packages/block-editor/src/components/writing-flow/style.scss
@@ -1,3 +1,0 @@
-.block-editor-writing-flow__click-redirect {
-	cursor: text;
-}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -52,7 +52,6 @@
 @import "./components/url-input/style.scss";
 @import "./components/url-popover/style.scss";
 @import "./components/warning/style.scss";
-@import "./components/writing-flow/style.scss";
 @import "./hooks/anchor.scss";
 
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -1,8 +1,4 @@
 .edit-post-visual-editor .block-library-block__reusable-block-container {
-	.block-editor-writing-flow__click-redirect {
-		min-height: auto;
-	}
-
 	// Unset the padding that root containers get when they're actually root containers.
 	.is-root-container {
 		padding-left: 0;

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -15,6 +15,7 @@ import {
 	__unstableUseScrollMultiSelectionIntoView as useScrollMultiSelectionIntoView,
 	__experimentalBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
+	__unstableUseCanvasClickRedirect as useCanvasClickRedirect,
 } from '@wordpress/block-editor';
 import { Popover } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
@@ -30,13 +31,17 @@ export default function VisualEditor() {
 	const deviceType = useSelect( ( select ) => {
 		return select( 'core/edit-post' ).__experimentalGetPreviewDeviceType();
 	}, [] );
-	const inlineStyles = useResizeCanvas( deviceType );
+	const inlineStyles = useResizeCanvas( deviceType ) || {
+		height: '100%',
+		paddingBottom: '40vh',
+	};
 
 	useScrollMultiSelectionIntoView( ref );
 	useBlockSelectionClearer( ref );
 	useTypewriter( ref );
 	useClipboardHandler( ref );
 	useTypingObserver( ref );
+	useCanvasClickRedirect( ref );
 
 	return (
 		<div className="edit-post-visual-editor">

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -35,10 +35,13 @@ export default function VisualEditor() {
 		( select ) => select( 'core/edit-post' ).hasMetaBoxes(),
 		[]
 	);
-	const inlineStyles = useResizeCanvas( deviceType ) || {
+	const desktopCanvasStyles = {
 		height: '100%',
+		// Add a constant padding for the typewritter effect. When typing at the
+		// bottom, there needs to be room to scroll up.
 		paddingBottom: hasMetaBoxes ? null : '40vh',
 	};
+	const resizedCanvasStyles = useResizeCanvas( deviceType );
 
 	useScrollMultiSelectionIntoView( ref );
 	useBlockSelectionClearer( ref );
@@ -55,7 +58,7 @@ export default function VisualEditor() {
 				ref={ ref }
 				className="editor-styles-wrapper"
 				tabIndex="-1"
-				style={ inlineStyles }
+				style={ resizedCanvasStyles || desktopCanvasStyles }
 			>
 				<WritingFlow>
 					<div className="edit-post-visual-editor__post-title-wrapper">

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -31,9 +31,13 @@ export default function VisualEditor() {
 	const deviceType = useSelect( ( select ) => {
 		return select( 'core/edit-post' ).__experimentalGetPreviewDeviceType();
 	}, [] );
+	const hasMetaBoxes = useSelect(
+		( select ) => select( 'core/edit-post' ).hasMetaBoxes(),
+		[]
+	);
 	const inlineStyles = useResizeCanvas( deviceType ) || {
 		height: '100%',
-		paddingBottom: '40vh',
+		paddingBottom: hasMetaBoxes ? null : '40vh',
 	};
 
 	useScrollMultiSelectionIntoView( ref );

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -27,17 +27,6 @@
 	}
 }
 
-.editor-styles-wrapper,
-.editor-styles-wrapper > .block-editor-writing-flow__click-redirect {
-	height: 100%;
-}
-
-.edit-post-visual-editor .block-editor-writing-flow__click-redirect {
-	// Allow the page to be scrolled with the last block in the middle.
-	min-height: 40vh;
-	width: 100%;
-}
-
 // Hide the extra space when there are metaboxes.
 .has-metaboxes .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
 	height: 0;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -27,9 +27,12 @@
 	}
 }
 
-// Hide the extra space when there are metaboxes.
-.has-metaboxes .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
-	height: 0;
+.editor-styles-wrapper {
+	cursor: text;
+
+	> * {
+		cursor: auto;
+	}
 }
 
 // Ideally this wrapper div is not needed but if we want to match the positioning of blocks


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

What is the click redirect?

It's a trailing div element behind the content.

1) To redirect clicks after the content to focus the last text field.
2) To pad the editor canvas with `40vh` so the typewriter effect can scroll the page if the caret is at the end of the page.

The `40vh` padding can be done with... just padding. :)
The click redirect also doesn't really need a div. We can capture clicks directly on the canvas element.

It not only removed a useless div, we'll find later on that this div will be in the way when iframing the content. The div would have to be in the iframe _with_ the content, which should be avoided as anything that isn't content should. Trailing divs could interfere with CSS rules.

Fixes #27157.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
