### PR TITLE
Update the block variation widths in the block placeholder

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/style.scss
+++ b/packages/block-editor/src/components/block-variation-picker/style.scss
@@ -31,7 +31,7 @@
 		list-style: none;
 		margin: $grid-unit-10 ( $grid-unit-10 + $grid-unit-15 ) 0 0;
 		flex-shrink: 1;
-		max-width: 100px;
+		width: 75px;
 		text-align: center;
 
 		button {
@@ -48,6 +48,7 @@
 		font-family: $default-font;
 		font-size: 12px;
 		display: block;
+		line-height: 1.4;
 	}
 }
 

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -41,7 +41,7 @@ const variations = [
 	},
 	{
 		name: 'title-date',
-		title: __( 'Title and Date' ),
+		title: __( 'Title & Date' ),
 		icon: titleDate,
 		innerBlocks: [
 			[
@@ -54,7 +54,7 @@ const variations = [
 	},
 	{
 		name: 'title-excerpt',
-		title: __( 'Title and Excerpt' ),
+		title: __( 'Title & Excerpt' ),
 		icon: titleExcerpt,
 		innerBlocks: [
 			[
@@ -67,7 +67,7 @@ const variations = [
 	},
 	{
 		name: 'title-date-excerpt',
-		title: __( 'Title, Date and Excerpt' ),
+		title: __( 'Title, Date, & Excerpt' ),
 		icon: titleDateExcerpt,
 		innerBlocks: [
 			[
@@ -84,7 +84,7 @@ const variations = [
 	},
 	{
 		name: 'image-date-title',
-		title: __( 'Image, Date and Title ' ),
+		title: __( 'Image, Date, & Title' ),
 		icon: imageDateTitle,
 		innerBlocks: [
 			[


### PR DESCRIPTION
Fixes #27254. 
Update the widths of the variations in the block placeholder so that spacing is consistent and alignment when the block is narrow is visually appealing.

## How has this been tested?
Tested locally with Columns and Query blocks.

## Screenshots 

**BEFORE**
![old](https://user-images.githubusercontent.com/617986/100161449-50ad2b00-2e66-11eb-964d-b6ffadb15c06.gif)

**AFTER**
![placeholder-variations](https://user-images.githubusercontent.com/617986/100161459-54d94880-2e66-11eb-9097-c8a3906d4996.gif)



## Types of changes
Non-breaking CSS changes. 
Includes some fine tuning for Query block's variation titles.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
