### PR TITLE
HTML block: fix parsing

### DIFF
--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -10,7 +10,7 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"source": "html"
+			"source": "raw"
 		}
 	},
 	"supports": {

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -104,16 +104,18 @@ export function isOfTypes( value, types ) {
  *
  * @param {string}      attributeKey      Attribute key.
  * @param {Object}      attributeSchema   Attribute's schema.
- * @param {string|Node} innerHTML         Block's raw content.
+ * @param {Node}        innerDOM          Parsed DOM of block's inner HTML.
  * @param {Object}      commentAttributes Block's comment attributes.
+ * @param {string}      innerHTML         Raw HTML from block node's innerHTML property.
  *
  * @return {*} Attribute value.
  */
 export function getBlockAttribute(
 	attributeKey,
 	attributeSchema,
-	innerHTML,
-	commentAttributes
+	innerDOM,
+	commentAttributes,
+	innerHTML
 ) {
 	let value;
 
@@ -137,7 +139,7 @@ export function getBlockAttribute(
 		case 'node':
 		case 'query':
 		case 'tag':
-			value = parseWithAttributeSchema( innerHTML, attributeSchema );
+			value = parseWithAttributeSchema( innerDOM, attributeSchema );
 			break;
 	}
 
@@ -274,7 +276,7 @@ export function getBlockAttributes(
 	const blockType = normalizeBlockType( blockTypeOrName );
 
 	const blockAttributes = mapValues( blockType.attributes, ( schema, key ) =>
-		getBlockAttribute( key, schema, doc, attributes )
+		getBlockAttribute( key, schema, doc, attributes, innerHTML )
 	);
 
 	return applyFilters(

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -125,6 +125,10 @@ export function getBlockAttribute(
 				? commentAttributes[ attributeKey ]
 				: undefined;
 			break;
+		// raw source means that it's the original raw block content.
+		case 'raw':
+			value = innerHTML;
+			break;
 		case 'attribute':
 		case 'property':
 		case 'html':

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -160,6 +160,7 @@
 								"attribute",
 								"text",
 								"html",
+								"raw",
 								"query",
 								"meta"
 							]

--- a/test/e2e/specs/editor/blocks/html.spec.js
+++ b/test/e2e/specs/editor/blocks/html.spec.js
@@ -30,4 +30,20 @@ test.describe( 'HTML block', () => {
 <!-- /wp:html -->`
 		);
 	} );
+
+	test( 'should not encode <', async ( { editor, page } ) => {
+		// Create a Custom HTML block with the slash shortcut.
+		await page.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '/html' );
+		await expect(
+			page.locator( 'role=option[name="Custom HTML"i][selected]' )
+		).toBeVisible();
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1 < 2' );
+		await editor.publishPost();
+		await page.reload();
+		await expect(
+			page.locator( '[data-type="core/html"] textarea' )
+		).toBeVisible();
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #24282, or at least partly.
The issue has been around since the beginning of Gutenberg.

The problem is that, when parsing the blocks, `element.innerHTML` encodes these characters.

What we're looking for is the raw block content, so there's no need to parse the HTML at all, it can be skipped.

## How has this been tested?

Type `0 < 1` in an HTML block. Save and reload. There should be no error.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
