### PR TITLE
Try: Move block appender margin to child.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -1,7 +1,9 @@
 // These styles are only applied to the appender when it appears inside of a block.
 // Otherwise the default appender may be improperly positioned in some themes.
 .block-editor-block-list__block .block-list-appender {
-	margin: $grid-unit-10 0;
+	.block-editor-default-block-appender {
+		margin: $grid-unit-10 0;
+	}
 
 	// Add additional margin to the appender when inside a group with a background color.
 	// If changing this, be sure to sync up with group/editor.scss line 13.


### PR DESCRIPTION
The default block appender has an 8px margin above and below it. This margin usually collapses with adjacent margins that are almost always bigger.

However some themes zero out the top and bottom margins of the first and last blocks inside groups (such as Twenty Twenty One, see https://github.com/WordPress/twentytwentyone/pull/859). When this is the case, the small 8px margin causes a jump. See:

![before](https://user-images.githubusercontent.com/1204802/100236494-0a230380-2f2e-11eb-973f-b1421d18e96e.gif)

As noted the cause is the margin on the appender:

<img width="1227" alt="the cause" src="https://user-images.githubusercontent.com/1204802/100236507-10b17b00-2f2e-11eb-8e5b-2164632220fe.png">

This is unnecessary because that appender is empty when the preceeding block is just a paragraph — the appender should really only be visible if the preceeding block is a non-text block, such as an image. 

This PR moves the margin to the child appender, fixing the issue:

![after](https://user-images.githubusercontent.com/1204802/100236640-376fb180-2f2e-11eb-9b7f-a1333218c3e1.gif)

This works because when the appender follows a text block, it's technically empty, so there's nothing to attach that margin to:

<img width="1252" alt="the solution" src="https://user-images.githubusercontent.com/1204802/100236690-48b8be00-2f2e-11eb-98ec-a0e0556f1143.png">
