### PR TITLE
[RNMobile] File block V - Making Download button use RichText (Take 2)

### DIFF
--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View, Clipboard, TouchableWithoutFeedback } from 'react-native';
+import { View, Clipboard, TouchableWithoutFeedback, Text } from 'react-native';
 import React from 'react';
 
 /**
@@ -17,6 +17,7 @@ import {
 	MediaPlaceholder,
 	MediaUploadProgress,
 	RichText,
+	PlainText,
 	BlockControls,
 	MediaUpload,
 	InspectorControls,
@@ -352,7 +353,6 @@ export class FileEdit extends Component {
 		}
 	}
 
-
 	onLayout( { nativeEvent } ) {
 		const { width } = nativeEvent.layout;
 		const { paddingLeft, paddingRight } = styles.defaultButton;
@@ -399,14 +399,6 @@ export class FileEdit extends Component {
 			showDownloadButton,
 			align,
 		} = attributes;
-
-		const dimmedStyle =
-			this.state.isUploadInProgress && styles.disabledButton;
-		const finalButtonStyle = Object.assign(
-			{},
-			styles.defaultButton,
-			dimmedStyle
-		);
 
 		const minWidth =
 			isButtonFocused ||
@@ -530,7 +522,8 @@ export class FileEdit extends Component {
 												styles.buttonText.color
 											}
 											placeholderTextColor={
-												styles.placeholderTextColor.color
+												styles.placeholderTextColor
+													.color
 											}
 											underlineColorAndroid="transparent"
 											onChange={

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -17,7 +17,6 @@ import {
 	MediaPlaceholder,
 	MediaUploadProgress,
 	RichText,
-	PlainText,
 	BlockControls,
 	MediaUpload,
 	InspectorControls,
@@ -52,6 +51,7 @@ import { getProtocol } from '@wordpress/url';
 import styles from './style.scss';
 
 const URL_COPIED_NOTIFICATION_DURATION_MS = 1500;
+const MIN_WIDTH = 40;
 
 export class FileEdit extends Component {
 	constructor( props ) {
@@ -60,10 +60,13 @@ export class FileEdit extends Component {
 		this.state = {
 			isUploadInProgress: false,
 			isSidebarLinkSettings: false,
+			placeholderTextWidth: 0,
+			maxWidth: 0,
 		};
 
 		this.timerRef = null;
 
+		this.onLayout = this.onLayout.bind( this );
 		this.onSelectFile = this.onSelectFile.bind( this );
 		this.onChangeFileName = this.onChangeFileName.bind( this );
 		this.onChangeDownloadButtonText = this.onChangeDownloadButtonText.bind(
@@ -349,8 +352,45 @@ export class FileEdit extends Component {
 		}
 	}
 
+
+	onLayout( { nativeEvent } ) {
+		const { width } = nativeEvent.layout;
+		const { paddingLeft, paddingRight } = styles.defaultButton;
+		this.setState( {
+			maxWidth: width - ( paddingLeft + paddingRight ),
+		} );
+	}
+
+	// Render `Text` with `placeholderText` styled as a placeholder
+	// to calculate its width which then is set as a `minWidth`
+	// This should be fixed on RNAztec level. In the mean time,
+	// We use the same strategy implemented in Button block
+	getPlaceholderWidth( placeholderText ) {
+		const { maxWidth, placeholderTextWidth } = this.state;
+		return (
+			<Text
+				style={ styles.placeholder }
+				onTextLayout={ ( { nativeEvent } ) => {
+					const textWidth =
+						nativeEvent.lines[ 0 ] && nativeEvent.lines[ 0 ].width;
+					if ( textWidth && textWidth !== placeholderTextWidth ) {
+						this.setState( {
+							placeholderTextWidth: Math.min(
+								textWidth,
+								maxWidth
+							),
+						} );
+					}
+				} }
+			>
+				{ placeholderText }
+			</Text>
+		);
+	}
+
 	getFileComponent( openMediaOptions, getMediaOptions ) {
 		const { attributes, media, isSelected } = this.props;
+		const { isButtonFocused, placeholderTextWidth } = this.state;
 
 		const {
 			fileName,
@@ -359,6 +399,30 @@ export class FileEdit extends Component {
 			showDownloadButton,
 			align,
 		} = attributes;
+
+		const dimmedStyle =
+			this.state.isUploadInProgress && styles.disabledButton;
+		const finalButtonStyle = Object.assign(
+			{},
+			styles.defaultButton,
+			dimmedStyle
+		);
+
+		const minWidth =
+			isButtonFocused ||
+			( ! isButtonFocused &&
+				downloadButtonText &&
+				downloadButtonText !== '' )
+				? MIN_WIDTH
+				: placeholderTextWidth;
+
+		const placeholderText =
+			isButtonFocused ||
+			( ! isButtonFocused &&
+				downloadButtonText &&
+				downloadButtonText !== '' )
+				? ''
+				: __( 'Add text…' );
 
 		return (
 			<MediaUploadProgress
@@ -393,7 +457,8 @@ export class FileEdit extends Component {
 							onLongPress={ openMediaOptions }
 							disabled={ ! isSelected }
 						>
-							<View>
+							<View onLayout={ this.onLayout }>
+								{ this.getPlaceholderWidth( placeholderText ) }
 								{ isUploadInProgress ||
 									this.getToolbarEditButton(
 										openMediaOptions
@@ -439,10 +504,35 @@ export class FileEdit extends Component {
 											this.getStyleForAlignment( align ),
 										] }
 									>
-										<PlainText
-											editable={ ! isUploadFailed }
+										<RichText
+											withoutInteractiveFormatting
+											__unstableMobileNoFocusOnMount
+											rootTagsToEliminate={ [ 'p' ] }
+											tagName="p"
+											textAlign="center"
+											minWidth={ minWidth }
+											maxWidth={ this.state.maxWidth }
+											deleteEnter={ true }
 											style={ styles.buttonText }
 											value={ downloadButtonText }
+											placeholder={ placeholderText }
+											unstableOnFocus={ () =>
+												this.setState( {
+													isButtonFocused: true,
+												} )
+											}
+											onBlur={ () =>
+												this.setState( {
+													isButtonFocused: false,
+												} )
+											}
+											selectionColor={
+												styles.buttonText.color
+											}
+											placeholderTextColor={
+												styles.placeholderTextColor.color
+											}
+											underlineColorAndroid="transparent"
 											onChange={
 												this.onChangeDownloadButtonText
 											}

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -10,8 +10,8 @@
 	color: $white;
 	padding: 0;
 	font-size: 16px;
-	padding-left: $grid-unit-10;
-	padding-right: $grid-unit-10;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
 }
 
 .disabledButton {

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -1,7 +1,6 @@
 .defaultButton {
 	border-radius: $border-width * 4;
 	padding: $block-spacing * 2;
-	border-width: $border-width;
 	margin-top: $grid-unit-20;
 	background-color: $button-fallback-bg;
 }
@@ -9,8 +8,10 @@
 .buttonText {
 	background-color: transparent;
 	color: $white;
-	font-size: 16;
 	padding: 0;
+	font-size: 16px;
+	padding-left: $grid-unit-10;
+	padding-right: $grid-unit-10;
 }
 
 .disabledButton {
@@ -49,4 +50,15 @@
 .uploadFailed {
 	padding: 0;
 	color: $alert-red;
+}
+
+.placeholderTextColor {
+	color: rgba($color: $white, $alpha: 0.43);
+}
+
+.placeholder {
+	font-family: $default-regular-font;
+	min-height: 22px;
+	font-size: 16px;
+	display: none;
 }

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -8,6 +8,7 @@ exports[`File block renders file error state without crashing 1`] = `
     accessible={true}
     focusable={true}
     onClick={[Function]}
+    onLayout={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -15,6 +16,16 @@ exports[`File block renders file error state without crashing 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
   >
+    <Text
+      onTextLayout={[Function]}
+      style={
+        Object {
+          "color": "gray",
+        }
+      }
+    >
+      
+    </Text>
     Modal
     <View>
       <View>
@@ -101,21 +112,63 @@ exports[`File block renders file error state without crashing 1`] = `
         ]
       }
     >
-      <TextInput
-        allowFontScaling={true}
-        editable={false}
-        fontFamily="serif"
-        onChange={[Function]}
-        rejectResponderTermination={true}
-        scrollEnabled={false}
-        style={
-          Object {
-            "fontFamily": "serif",
+      <View>
+        <RCTAztecView
+          accessible={true}
+          activeFormats={Array []}
+          blockType={
+            Object {
+              "tag": "p",
+            }
           }
-        }
-        underlineColorAndroid="transparent"
-        value="Download"
-      />
+          color="white"
+          deleteEnter={true}
+          disableEditingMenu={false}
+          focusable={true}
+          fontFamily="serif"
+          isMultiline={false}
+          maxImagesWidth={200}
+          minWidth={40}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
+          onStartShouldSetResponder={[Function]}
+          placeholder=""
+          placeholderTextColor="white"
+          selectionColor="white"
+          style={
+            Object {
+              "backgroundColor": undefined,
+              "color": "white",
+              "maxWidth": 0,
+              "minHeight": 0,
+            }
+          }
+          text={
+            Object {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "text": "<p >Download</p>",
+            }
+          }
+          textAlign="center"
+          triggerKeyCodes={Array []}
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -129,6 +182,7 @@ exports[`File block renders file without crashing 1`] = `
     accessible={true}
     focusable={true}
     onClick={[Function]}
+    onLayout={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -136,6 +190,16 @@ exports[`File block renders file without crashing 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
   >
+    <Text
+      onTextLayout={[Function]}
+      style={
+        Object {
+          "color": "gray",
+        }
+      }
+    >
+      
+    </Text>
     Modal
     <View>
       <View>
@@ -205,18 +269,6 @@ exports[`File block renders file without crashing 1`] = `
         ]
       }
     >
-<<<<<<< HEAD
-      <TextInput
-        allowFontScaling={true}
-        editable={true}
-        fontFamily="serif"
-        onChange={[Function]}
-        rejectResponderTermination={true}
-        scrollEnabled={false}
-        style={
-          Object {
-            "fontFamily": "serif",
-=======
       <View>
         <RCTAztecView
           accessible={true}
@@ -225,7 +277,6 @@ exports[`File block renders file without crashing 1`] = `
             Object {
               "tag": "p",
             }
->>>>>>> Update unit tests
           }
           color="white"
           deleteEnter={true}

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -205,6 +205,7 @@ exports[`File block renders file without crashing 1`] = `
         ]
       }
     >
+<<<<<<< HEAD
       <TextInput
         allowFontScaling={true}
         editable={true}
@@ -215,11 +216,65 @@ exports[`File block renders file without crashing 1`] = `
         style={
           Object {
             "fontFamily": "serif",
+=======
+      <View>
+        <RCTAztecView
+          accessible={true}
+          activeFormats={Array []}
+          blockType={
+            Object {
+              "tag": "p",
+            }
+>>>>>>> Update unit tests
           }
-        }
-        underlineColorAndroid="transparent"
-        value="Download"
-      />
+          color="white"
+          deleteEnter={true}
+          disableEditingMenu={false}
+          focusable={true}
+          fontFamily="serif"
+          isMultiline={false}
+          maxImagesWidth={200}
+          minWidth={40}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
+          onStartShouldSetResponder={[Function]}
+          placeholder=""
+          placeholderTextColor="white"
+          selectionColor="white"
+          style={
+            Object {
+              "backgroundColor": undefined,
+              "color": "white",
+              "maxWidth": 0,
+              "minHeight": 0,
+            }
+          }
+          text={
+            Object {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "text": "<p >Download</p>",
+            }
+          }
+          textAlign="center"
+          triggerKeyCodes={Array []}
+        />
+      </View>
     </View>
   </View>
 </View>

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -96,4 +96,10 @@ module.exports = {
 	scrollableContent: {
 		paddingBottom: 20,
 	},
+	buttonText: {
+		color: 'white',
+	},
+	placeholderTextColor: {
+		color: 'white',
+	},
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR is an alternative to https://github.com/WordPress/gutenberg/pull/27201.
Patching the RichText size issue using the same strategy used by the Button block.

This approach works for both platforms 🎉 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Add a File block
- Check that the Download button layout is correct.
- Test change the button's text and removing all text to show the placeholder.
  - **Note:** The button must be deselected for the Placeholder to show.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
