### PR TITLE
Add thunk actions to replace rungen and controls

### DIFF
--- a/packages/data/src/redux-store/thunk-middleware.js
+++ b/packages/data/src/redux-store/thunk-middleware.js
@@ -1,0 +1,9 @@
+export default function createThunkMiddleware( args ) {
+	return () => ( next ) => ( action ) => {
+		if ( typeof action === 'function' ) {
+			return action( args );
+		}
+
+		return next( action );
+	};
+}

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, without, mapValues, isObject } from 'lodash';
-import memize from 'memize';
+import { without, mapValues, isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -102,47 +101,6 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		return result;
 	}
 
-	const getResolveSelectors = memize(
-		( selectors ) => {
-			return mapValues(
-				omit( selectors, [
-					'getIsResolving',
-					'hasStartedResolution',
-					'hasFinishedResolution',
-					'isResolving',
-					'getCachedResolvers',
-				] ),
-				( selector, selectorName ) => {
-					return ( ...args ) => {
-						return new Promise( ( resolve ) => {
-							const hasFinished = () =>
-								selectors.hasFinishedResolution(
-									selectorName,
-									args
-								);
-							const getResult = () =>
-								selector.apply( null, args );
-
-							// trigger the selector (to trigger the resolver)
-							const result = getResult();
-							if ( hasFinished() ) {
-								return resolve( result );
-							}
-
-							const unsubscribe = subscribe( () => {
-								if ( hasFinished() ) {
-									unsubscribe();
-									resolve( getResult() );
-								}
-							} );
-						} );
-					};
-				}
-			);
-		},
-		{ maxSize: 1 }
-	);
-
 	/**
 	 * Given the name of a registered store, returns an object containing the store's
 	 * selectors pre-bound to state so that you only need to supply additional arguments,
@@ -155,7 +113,16 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 * @return {Object} Each key of the object matches the name of a selector.
 	 */
 	function __experimentalResolveSelect( storeNameOrDefinition ) {
-		return getResolveSelectors( select( storeNameOrDefinition ) );
+		const storeName = isObject( storeNameOrDefinition )
+			? storeNameOrDefinition.name
+			: storeNameOrDefinition;
+		__experimentalListeningStores.add( storeName );
+		const store = stores[ storeName ];
+		if ( store ) {
+			return store.__experimentalGetResolveSelectors();
+		}
+
+		return parent && parent.__experimentalResolveSelect( storeName );
 	}
 
 	/**


### PR DESCRIPTION
## Description
As the future of `@wordpress/stan` is uncertain (https://github.com/WordPress/gutenberg/issues/27109), I thought I'd experiment with removing `rungen` dependency. This PR refactors a bunch of generator-based actions leveraging controls into regular asynchronous functions without dependency on controls. This is not time-sensitive and could be made obsolete by stan, but I just wanted to set things in motion here.

A bunch of unit tests are going to fail simply because I did not adjust them. For now I'm more interested in e2e tests to see if such implementation breaks anything for the user.

### Refactored use-cases:

#### Using selectors in actions

**Before:** `yield select( 'core', 'getEntityRecord', 'root', 'post', id );`
**After:** `select( 'core' ).getEntityRecord( 'root', 'post', id );`

#### Dispatching store-bound actions

**Before:** `yield dispatch( 'core', 'receiveEntityRecord', 'root', 'post', data );`
**After:** `await dispatch( 'core' ).receiveEntityRecord( 'root', 'post', data );`

#### Dispatching inline actions

**Before:** `yield { type: 'ACTION_NAME' }`
**After:** `await yieldAction( { type: 'ACTION_NAME' } )`

I'm not overly enthusiastic about this API, but I don't have any better ideas, other than maybe exposing every tiny action as a public API.

#### Deferring to generatorfunction (for compat)

**Before:** `yield* generatorFunction()`
**After:** `await yieldAction( generatorFunction() )`
**A better way:** `await dispatch( 'core' ).generatorAction();`

#### Using controls

Just do the task inline, e.g.:

**Before:**
```js
import { apiFetch } from '@wordpress/data-controls';
yield apiFetch( request );
```

**After:**
```js
import { apiFetch } from '@wordpress/api-fetch';
await apiFetch( request );
```

### Notes
* Not all `core` actions and resolvers were refactored in this PR - this shows how generators and async are interoperable, which is important in between landing PRs.
* This PR should really do a better job of not using string as store keys (wink wink @gziolo :-))
* Refactoring all stores will make it possible to remove `reduxRoutime` middleware and all the code related to rungen, controls, generators, etc.
* At the moment, actions have access to `dispatch`, `select`, and `yieldAction` via `registryArgs` that's added via store creator. This should be okay for the first version, but ideally we wouldn't expose these functions globally.
* My largest concern about this approach is the fact that `const data = yield anotherAction();` could be entirely synchronous while `const data await = await dispatch( 'store' ).anotherAction();` will always be asynchronous. I am not sure if that's a problem though. First, we have locks API for when that matters. Second, yield-based dispatch could suddenly go asynchronous if anything in the call tree uses an async control. In other words, refactoring generator-based action A could have a ripple effect in seemingly unrelated action D that calls A via C and B. 

Related #26849 #27109
cc @jsnajdr @kevin940726 @noisysocks @draganescu @youknowriad @ellatrix 