### PR TITLE
Full Site Editing: Stop using auto-draft for auto-generated templates and template parts

### DIFF
--- a/docs/architecture/fse-templates.md
+++ b/docs/architecture/fse-templates.md
@@ -16,13 +16,13 @@ These capabilities mean that at any point in time, a mix of template files (from
 
 In order to simplify the algorithm used to edit and render the templates from two different places, we performed an operation called "template synchronization".
 
-The synchronization consists of duplicating the theme templates in the `wp_template` (and `wp_template_part`) custom templates with `publish` status and a `_wp_is_original` term. When a user edits these templates, the term is removed.
+The synchronization consists of duplicating the theme templates in the `wp_template` (and `wp_template_part`) custom templates with `publish` status and a `theme_file_original` term. When a user edits these templates, the term is removed.
 
 This means:
 
  - The rendering/fetching of templates only need to consider the custom post type templates. It is not necessary to fetch the template files from the theme folder directly. The synchronization will ensure these are duplicated in the CPT.
- - Untouched theme templates have the `_wp_is_original` term.
- - Edited theme templates don't have the `_wp_is_original` term.
+ - Untouched theme templates have the `theme_file_original` term.
+ - Edited theme templates have only the `theme_file_based` term instead.
 
 The synchronization is important for two different flows:
 

--- a/docs/architecture/fse-templates.md
+++ b/docs/architecture/fse-templates.md
@@ -16,13 +16,13 @@ These capabilities mean that at any point in time, a mix of template files (from
 
 In order to simplify the algorithm used to edit and render the templates from two different places, we performed an operation called "template synchronization".
 
-The synchronization consists of duplicating the theme templates in the `wp_template` (and `wp_template_part`) custom templates with an `auto-draft` status. When a user edits these templates, the status is updated to `publish`.
+The synchronization consists of duplicating the theme templates in the `wp_template` (and `wp_template_part`) custom templates with `publish` status and a `_wp_is_original` term. When a user edits these templates, the term is removed.
 
 This means:
 
  - The rendering/fetching of templates only need to consider the custom post type templates. It is not necessary to fetch the template files from the theme folder directly. The synchronization will ensure these are duplicated in the CPT.
- - Untouched theme templates have the `auto-draft` status.
- - Edited theme templates have the `publish` status.
+ - Untouched theme templates have the `_wp_is_original` term.
+ - Edited theme templates don't have the `_wp_is_original` term.
 
 The synchronization is important for two different flows:
 

--- a/lib/edit-site-export.php
+++ b/lib/edit-site-export.php
@@ -29,7 +29,7 @@ function gutenberg_edit_site_export() {
 	$template_query = new WP_Query(
 		array(
 			'post_type'      => 'wp_template',
-			'post_status'    => array( 'publish', 'auto-draft' ),
+			'post_status'    => array( 'publish' ),
 			'tax_query'      => array(
 				array(
 					'taxonomy' => 'wp_theme',
@@ -53,7 +53,7 @@ function gutenberg_edit_site_export() {
 	$template_part_query = new WP_Query(
 		array(
 			'post_type'      => 'wp_template_part',
-			'post_status'    => array( 'publish', 'auto-draft' ),
+			'post_status'    => array( 'publish' ),
 			'tax_query'      => array(
 				array(
 					'taxonomy' => 'wp_theme',

--- a/lib/full-site-editing/templates-utils.php
+++ b/lib/full-site-editing/templates-utils.php
@@ -6,40 +6,6 @@
  */
 
 /**
- * Parses the `wp_theme` terms of a template or template part into:
- * [
- *   'is_file_based', // Whether the template is based upon a theme-provided file.
- *   'is_original', // Whether the template is the original theme-provided file.
- *   'themes', // An array of themes that this template belongs to.
- * ]
- *
- * @param int $post_id The template or template part post ID.
- * @return array The parsed wp_theme terms.
- */
-function gutenberg_parse_wp_theme_terms( $post_id ) {
-	$parsed = array(
-	'is_file_based' => false,
-	'is_original'   => false,
-	'themes'        => array(),
-	);
-	$terms  = get_the_terms( $post_id, 'wp_theme' );
-	if ( empty( $terms ) || is_wp_error( $terms ) ) {
-		return $parsed;
-	}
-
-	foreach ( $terms as $term ) {
-		if ( '_wp_file_based' === $term->slug ) {
-			$parsed['is_file_based'] = true;
-		} else if ( '_wp_is_original' === $term->slug ) {
-			$parsed['is_original'] = true;
-		} else {
-			$parsed['themes'][] = $term->slug;
-		}
-	}
-	return $parsed;
-}
-
-/**
  * Filters the admin list columns to add those relevant to templates and template parts.
  *
  * @param array $columns Columns to display.
@@ -82,19 +48,24 @@ function gutenberg_render_templates_lists_custom_column( $column_name, $post_id 
 	}
 
 	if ( 'theme' === $column_name ) {
-		$terms  = gutenberg_parse_wp_theme_terms( $post_id );
 		$themes = array();
-		foreach( $terms['themes'] as $term_theme ) {
-			$theme = wp_get_theme( $term_theme );
+		$flags  = array();
+
+		$theme_terms = get_the_terms( $post_id, 'wp_theme' );
+		foreach( $theme_terms as $theme_term ) {
+			$theme = wp_get_theme( $theme_term->slug );
 			if ( $theme->exists() ) {
 				$themes[] = esc_html( $theme );
+			} else {
+				$themes[] = esc_html( $theme_term->slug );
 			}
 		}
 		echo implode( '<br />', $themes );
-		if ( $terms['is_original'] ) {
+
+		if ( has_term( 'theme_file_original', 'wp_flag', $post_id ) ) {
 			echo '<br />' . __( '(Template file — not customized)', 'gutenberg' );
-		} else if ( $terms['is_file_based'] ) {
-			echo '<br />' . __( '(Originated from a template file)', 'gutenberg' );
+		} else if ( has_term( 'theme_file_based', 'wp_flag', $post_id )) {
+			echo '<br />' . __( '(Template file — customized)', 'gutenberg' );
 		}
 		return;
 	}

--- a/lib/full-site-editing/templates-utils.php
+++ b/lib/full-site-editing/templates-utils.php
@@ -42,11 +42,6 @@ function gutenberg_render_templates_lists_custom_column( $column_name, $post_id 
 
 	if ( 'status' === $column_name ) {
 		$post_status = get_post_status( $post_id );
-		// The auto-draft status doesn't have localized labels.
-		if ( 'auto-draft' === $post_status ) {
-			echo esc_html_x( 'Auto-Draft', 'Post status', 'gutenberg' );
-			return;
-		}
 		$post_status_object = get_post_status_object( $post_status );
 		echo esc_html( $post_status_object->label );
 		return;
@@ -59,63 +54,23 @@ function gutenberg_render_templates_lists_custom_column( $column_name, $post_id 
 		}
 		$themes        = array();
 		$is_file_based = false;
+		$is_original   = false;
 		foreach ( $terms as $term ) {
 			if ( '_wp_file_based' === $term->slug ) {
 				$is_file_based = true;
+			} else if ( '_wp_is_original' === $term->slug ) {
+				$is_original = true;
 			} else {
 				$themes[] = esc_html( wp_get_theme( $term->slug ) );
 			}
 		}
 		echo implode( '<br />', $themes );
-		if ( $is_file_based ) {
-			echo '<br />' . __( '(Created from a template file)', 'gutenberg' );
+		if ( $is_original ) {
+			echo '<br />' . __( '(Template file — not customized)', 'gutenberg' );
+		} else if ( $is_file_based ) {
+			echo '<br />' . __( '(Originated from a template file)', 'gutenberg' );
 		}
+
 		return;
 	}
-}
-
-/**
- * Adds the auto-draft view to the templates and template parts admin lists.
- *
- * @param array $views The edit views to filter.
- */
-function gutenberg_filter_templates_edit_views( $views ) {
-	$post_type          = get_current_screen()->post_type;
-	$url                = add_query_arg(
-		array(
-			'post_type'   => $post_type,
-			'post_status' => 'auto-draft',
-		),
-		'edit.php'
-	);
-	$is_auto_draft_view = isset( $_REQUEST['post_status'] ) && 'auto-draft' === $_REQUEST['post_status'];
-	$class_html         = $is_auto_draft_view ? ' class="current"' : '';
-	$aria_current       = $is_auto_draft_view ? ' aria-current="page"' : '';
-	$post_count         = wp_count_posts( $post_type, 'readable' );
-	$label              = sprintf(
-		// The auto-draft status doesn't have localized labels.
-		translate_nooped_plural(
-			/* translators: %s: Number of auto-draft posts. */
-			_nx_noop(
-				'Auto-Draft <span class="count">(%s)</span>',
-				'Auto-Drafts <span class="count">(%s)</span>',
-				'Post status',
-				'gutenberg'
-			),
-			$post_count->{'auto-draft'}
-		),
-		number_format_i18n( $post_count->{'auto-draft'} )
-	);
-
-	$auto_draft_view = sprintf(
-		'<a href="%s"%s%s>%s</a>',
-		esc_url( $url ),
-		$class_html,
-		$aria_current,
-		$label
-	);
-
-	array_splice( $views, 1, 0, array( 'auto-draft' => $auto_draft_view ) );
-
-	return $views;
 }

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -128,7 +128,7 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 	$template_query = new WP_Query(
 		array(
 			'post_type'      => 'wp_template',
-			'post_status'    => array( 'publish', 'auto-draft' ),
+			'post_status'    => array( 'publish' ),
 			'post_name__in'  => $slugs,
 			'orderby'        => 'post_name__in',
 			'posts_per_page' => -1,

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -107,7 +107,6 @@ add_action( 'admin_menu', 'gutenberg_fix_template_part_admin_menu_entry' );
 // Customize the `wp_template` admin list.
 add_filter( 'manage_wp_template_part_posts_columns', 'gutenberg_templates_lists_custom_columns' );
 add_action( 'manage_wp_template_part_posts_custom_column', 'gutenberg_render_templates_lists_custom_column', 10, 2 );
-add_filter( 'views_edit-wp_template_part', 'gutenberg_filter_templates_edit_views' );
 
 /**
  * Filter for adding and a `theme` parameter to `wp_template_part` queries.

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -117,8 +117,8 @@ add_action( 'manage_wp_template_part_posts_custom_column', 'gutenberg_render_tem
 function filter_rest_wp_template_part_collection_params( $query_params ) {
 	$query_params += array(
 		'theme' => array(
-			'description' => __( 'The theme slug for the theme that created the template part.', 'gutenberg' ),
-			'type'        => 'string',
+			'description' => __( 'The theme slugs for the theme that created the template part.', 'gutenberg' ),
+			'type'        => 'array',
 		),
 	);
 	return $query_params;
@@ -139,6 +139,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 			'taxonomy' => 'wp_theme',
 			'field'    => 'slug',
 			'terms'    => $request['theme'],
+			'operator' => 'AND',
 		);
 
 		$args['tax_query'] = $tax_query;

--- a/lib/templates-sync.php
+++ b/lib/templates-sync.php
@@ -31,8 +31,7 @@ function _gutenberg_create_auto_draft_for_template( $post_type, $slug, $theme, $
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'slug',
-					'terms'    => array( $theme, '_wp_is_original' ),
-					'operator' => 'AND',
+					'terms'    => $theme,
 				),
 			),
 			'posts_per_page' => 1,
@@ -47,7 +46,10 @@ function _gutenberg_create_auto_draft_for_template( $post_type, $slug, $theme, $
 			'post_status'  => 'publish',
 			'post_type'    => $post_type,
 			'post_name'    => $slug,
-			'tax_input'    => array( 'wp_theme' => array( $theme, '_wp_file_based', '_wp_is_original' ) ),
+			'tax_input'    => array(
+				'wp_flag'  => array( 'theme_file_original', 'theme_file_based' ),
+				'wp_theme' => $theme,
+			),
 		);
 
 		if ( 'wp_template' === $post_type ) {
@@ -59,11 +61,17 @@ function _gutenberg_create_auto_draft_for_template( $post_type, $slug, $theme, $
 		}
 
 		wp_insert_post( $template_post );
-	} elseif ( has_term( '_wp_is_original', 'wp_theme', $post ) && $content !== $post->post_content ) {
+	} elseif ( has_term( 'theme_file_original', 'wp_flag', $post ) && $content !== $post->post_content ) {
 		// If the template already exists, but it was never changed by the user
 		// and the template file content changed then update the content of the post.
-		$post->post_content = $content;
-		wp_insert_post( $post );
+		$template_post = array(
+			'ID'           => $post->ID,
+			'post_content' => $content,
+			'tax_input'    => array(
+				'wp_flag' => array( 'theme_file_original', 'theme_file_based', 'theme_sync' ),
+			),
+		);
+		wp_update_post( $template_post );
 	}
 }
 

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -111,12 +111,17 @@ add_action( 'init', 'gutenberg_register_wp_theme_taxonomy' );
 /**
  * Automatically set the theme meta for templates.
  *
- * @param array $post_id Template ID.
+ * @param array   $post_id Template ID.
+ * @param WP_POST $post Template post object.
+ * @param boolean $update Whether this is an existing template being updated.
  */
-function gutenberg_set_template_and_template_part_post_theme( $post_id ) {
+function gutenberg_set_template_and_template_part_post_theme( $post_id, $post, $update ) {
 	$themes = wp_get_post_terms( $post_id, 'wp_theme' );
 	if ( ! $themes ) {
 		wp_set_post_terms( $post_id, array( wp_get_theme()->get_stylesheet() ), 'wp_theme', true );
+	}
+	if ( $update && has_term( '_wp_is_original', 'wp_theme', $post_id ) ) {
+		wp_remove_object_terms( $post_id, '_wp_is_original', 'wp_theme' );
 	}
 }
 add_action( 'save_post_wp_template', 'gutenberg_set_template_and_template_part_post_theme', 10, 3 );
@@ -195,7 +200,6 @@ add_action( 'admin_menu', 'gutenberg_fix_template_admin_menu_entry' );
 // Customize the `wp_template` admin list.
 add_filter( 'manage_wp_template_posts_columns', 'gutenberg_templates_lists_custom_columns' );
 add_action( 'manage_wp_template_posts_custom_column', 'gutenberg_render_templates_lists_custom_column', 10, 2 );
-add_filter( 'views_edit-wp_template', 'gutenberg_filter_templates_edit_views' );
 
 /**
  * Filter for adding a `resolved` parameter to `wp_template` queries.
@@ -238,7 +242,7 @@ function filter_rest_wp_template_query( $args, $request ) {
 			}
 		}
 		$args['post__in']    = $template_ids;
-		$args['post_status'] = array( 'publish', 'auto-draft' );
+		$args['post_status'] = array( 'publish' );
 	}
 
 	return $args;

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -259,27 +259,11 @@ function filter_rest_prepare_add_wp_theme_terms( $response ) {
 	if ( isset( $response->data ) && is_array( $response->data ) && isset( $response->data['id'] ) ) {
 		$response->data['wp_theme_slug'] = false;
 
-		// Get the wp_theme terms.
-		$wp_themes = wp_get_post_terms( $response->data['id'], 'wp_theme' );
-
-		// If a theme is assigned, add it to the REST response.
-		if ( $wp_themes && is_array( $wp_themes ) ) {
-			$wp_theme_slugs = array_column( $wp_themes, 'slug' );
-
-			$response->data['file_based']  = in_array( '_wp_file_based', $wp_theme_slugs, true );
-			$response->data['is_original'] = in_array( '_wp_is_original', $wp_theme_slugs, true );
-
-			$theme_slug = array_values(
-				array_filter(
-					$wp_theme_slugs,
-					function( $slug ) {
-						return ! in_array( $slug, array( '_wp_file_based', '_wp_is_original' ) );
-					}
-				)
-			);
-			if ( $theme_slug ) {
-				$response->data['wp_theme_slug'] = $theme_slug[0];
-			}
+		$terms = gutenberg_parse_wp_theme_terms( $response->data['id'] );
+		$response->data['file_based'] = $terms['is_file_based'];
+		$response->data['is_original'] = $terms['is_original'];
+		if ( ! empty( $terms['theme'] ) ) {
+			$response->data['wp_theme_slug'] = $terms['theme'][0];
 		}
 	}
 

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -255,7 +255,7 @@ add_filter( 'rest_wp_template_query', 'filter_rest_wp_template_query', 99, 2 );
  * @param WP_REST_Response $response The response object.
  * @return WP_REST_Response
  */
-function filter_rest_prepare_add_wp_theme_slug_and_file_based( $response ) {
+function filter_rest_prepare_add_wp_theme_terms( $response ) {
 	if ( isset( $response->data ) && is_array( $response->data ) && isset( $response->data['id'] ) ) {
 		$response->data['wp_theme_slug'] = false;
 
@@ -266,14 +266,14 @@ function filter_rest_prepare_add_wp_theme_slug_and_file_based( $response ) {
 		if ( $wp_themes && is_array( $wp_themes ) ) {
 			$wp_theme_slugs = array_column( $wp_themes, 'slug' );
 
-			$file_based                   = in_array( '_wp_file_based', $wp_theme_slugs, true );
-			$response->data['file_based'] = $file_based;
+			$response->data['file_based']  = in_array( '_wp_file_based', $wp_theme_slugs, true );
+			$response->data['is_original'] = in_array( '_wp_is_original', $wp_theme_slugs, true );
 
 			$theme_slug = array_values(
 				array_filter(
 					$wp_theme_slugs,
 					function( $slug ) {
-						return '_wp_file_based' !== $slug;
+						return ! in_array( $slug, array( '_wp_file_based', '_wp_is_original' ) );
 					}
 				)
 			);
@@ -285,5 +285,5 @@ function filter_rest_prepare_add_wp_theme_slug_and_file_based( $response ) {
 
 	return $response;
 }
-add_filter( 'rest_prepare_wp_template', 'filter_rest_prepare_add_wp_theme_slug_and_file_based' );
-add_filter( 'rest_prepare_wp_template_part', 'filter_rest_prepare_add_wp_theme_slug_and_file_based' );
+add_filter( 'rest_prepare_wp_template', 'filter_rest_prepare_add_wp_theme_terms' );
+add_filter( 'rest_prepare_wp_template_part', 'filter_rest_prepare_add_wp_theme_terms' );

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -205,7 +205,8 @@ export default function TemplatePartPreviews( {
 		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
 		return (
 			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
-				theme: [ currentTheme, '_wp_is_original' ],
+				theme: currentTheme,
+				flags: [ 'theme_file_original' ],
 				status: [ 'publish' ],
 				per_page: -1,
 			} ) || []

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -202,20 +202,14 @@ export default function TemplatePartPreviews( {
 } ) {
 	const composite = useCompositeState();
 	const templateParts = useSelect( ( select ) => {
-		const publishedTemplateParts =
+		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
+		return (
 			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
+				theme: [ currentTheme, '_wp_is_original' ],
 				status: [ 'publish' ],
 				per_page: -1,
-			} ) || [];
-
-		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
-		const themeTemplateParts =
-			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
-				theme: currentTheme,
-				status: [ 'auto-draft' ],
-				per_page: -1,
-			} ) || [];
-		return [ ...themeTemplateParts, ...publishedTemplateParts ];
+			} ) || []
+		);
 	}, [] );
 
 	if ( ! templateParts || ! templateParts.length ) {

--- a/packages/block-library/src/template-part/edit/use-template-part-post.js
+++ b/packages/block-library/src/template-part/edit/use-template-part-post.js
@@ -20,7 +20,7 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 			}
 
 			// This is not a custom template part,
-			// load the auto-draft created from the
+			// load the original post created from the
 			// relevant file.
 			if ( slug && theme ) {
 				const cleanedSlug = cleanForSlug( slug );
@@ -28,18 +28,12 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 					'postType',
 					'wp_template_part',
 					{
-						status: [ 'publish', 'auto-draft' ],
+						status: [ 'publish' ],
 						slug: cleanedSlug,
 						theme,
 					}
 				);
-
-				// A published post might already exist if this template part was customized elsewhere
-				// or if it's part of a customized template.
-				const foundPost =
-					posts?.find( ( post ) => post.status === 'publish' ) ||
-					posts?.find( ( post ) => post.status === 'auto-draft' );
-				return foundPost?.id;
+				return posts?.[ 0 ]?.id;
 			}
 		},
 		[ postId, slug, theme ]

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -20,7 +20,6 @@ describe( 'Site Editor Performance', () => {
 	beforeAll( async () => {
 		await activateTheme( 'twentytwentyone-blocks' );
 		await trashAllPosts( 'wp_template' );
-		await trashAllPosts( 'wp_template', 'auto-draft' );
 		await trashAllPosts( 'wp_template_part' );
 	} );
 	afterAll( async () => {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
@@ -9,7 +9,7 @@ export const TEMPLATES_GENERAL = [
 
 export const TEMPLATES_POSTS = [ 'home', 'single' ];
 
-export const TEMPLATES_STATUSES = [ 'publish', 'draft', 'auto-draft' ];
+export const TEMPLATES_STATUSES = [ 'publish', 'draft' ];
 
 export const TEMPLATES_NEW_OPTIONS = [
 	'front-page',

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
@@ -21,15 +21,13 @@ import { MENU_ROOT, MENU_TEMPLATE_PARTS } from '../constants';
 
 export default function TemplatePartsMenu() {
 	const templateParts = useSelect( ( select ) => {
-		const unfilteredTemplateParts =
-			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
-				status: [ 'publish', 'auto-draft' ],
-				per_page: -1,
-			} ) || [];
 		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
-		return unfilteredTemplateParts.filter(
-			( item ) =>
-				item.status === 'publish' || item.wp_theme_slug === currentTheme
+		return (
+			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
+				status: [ 'publish' ],
+				theme: currentTheme,
+				per_page: -1,
+			} ) || []
 		);
 	}, [] );
 

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -28,25 +28,6 @@ export default function EntityRecordItem( {
 		return parents[ parents.length - 1 ];
 	}, [] );
 
-	// Handle templates that might use default descriptive titles
-	const entityRecordTitle = useSelect(
-		( select ) => {
-			if ( 'postType' !== kind || 'wp_template' !== name ) {
-				return title;
-			}
-
-			const template = select( 'core' ).getEditedEntityRecord(
-				kind,
-				name,
-				key
-			);
-			return select( 'core/editor' ).__experimentalGetTemplateInfo(
-				template
-			).title;
-		},
-		[ name, kind, title, key ]
-	);
-
 	const isSelected = useSelect(
 		( select ) => {
 			const selectedBlockId = select(
@@ -69,9 +50,7 @@ export default function EntityRecordItem( {
 	return (
 		<PanelRow>
 			<CheckboxControl
-				label={
-					<strong>{ entityRecordTitle || __( 'Untitled' ) }</strong>
-				}
+				label={ <strong>{ title || __( 'Untitled' ) }</strong> }
 				checked={ checked }
 				onChange={ onChange }
 			/>


### PR DESCRIPTION
## Description

This PR proposes a change of direction regarding templates and template parts automatically generated from theme-provided files.
Instead of creating `auto-draft` posts, we create `publish` posts with a new internal `_wp_is_original` term (in the recently introduced `wp_theme` taxonomy).

The `_wp_is_original` term indicates those templates and template parts provided by the theme, that haven't been customized by the user yet.

Auto-generated templates and template parts will be created with a `_wp_is_original` term.
Once updated, they will lose that term, and won't be able to get it back.

✨ Props to @david-szabo97 for the idea! ✨ 

### Reasons

The `auto-draft` status is a rather unwieldy beast.
It's supposed to be used for posts that have been created and not manually saved yet; once they are saved, they gain a "stable" status, such as `draft` or `publish`. While the description seems to fit auto-generated templates, there are more quirks to consider.

`auto-draft` is not supposed to be handled by the user. It doesn't appear in normal queries (we always need to query specifically for that status) and it doesn't show up in wp-admin. WP [doesn't even provide localized labels to it when it's registered](https://github.com/WordPress/WordPress/blob/82d074fb0ae2383c9d857465ba1406cfaa8544ec/wp-includes/post.php#L399-L407).

In Gutenberg, `auto-draft` posts are not supposed to have titles. While `auto-draft` posts per se can have titles, Gutenberg [strips it from them](https://github.com/WordPress/gutenberg/blob/27425ea55085b747208fdb4266387fba3e0bff38/packages/core-data/src/actions.js#L86-L92).

`auto-draft` posts don't create revisions. This is logical, given the "auto-draft" state should only be a bridge between editor load and first save.
But even manually calling `wp_save_post_revision` isn't of any help, since it's a [no-op for `auto-draft` posts](https://github.com/WordPress/WordPress/blob/82d074fb0ae2383c9d857465ba1406cfaa8544ec/wp-includes/revision.php#L123-L125).

`auto-draft` posts can be pruned by functions such as [`wp_delete_auto_draft`](https://developer.wordpress.org/reference/functions/wp_delete_auto_drafts/), and also typically by database cleaning plugins. (Props to @carlomanf for noticing this!)

### Impact

- This PR shouldn't change the behaviour of Site Editor and front-end with one exception: the Template Part block's preview selector doesn't return "theme-agnostic" template parts anymore.
I'm considering this not an issue, considering we are removing that feature for the foreseeable future in #27152 anyway.

- I'm marking this PR as "breaking change", but in fact it should be relatively backward-compatible.
Templates and template parts that have been already customized won't be affected.
Old `auto-draft`s will be ignored (not deleted, though), and replaced with new auto-generated posts with status `publish` and `_is_wp_original` term.

## How has this been tested?

Smoke test everything! 🎉 

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
