### PR TITLE
Adds instance URL to wp-env start

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -175,7 +175,10 @@ module.exports = async function start( { spinner, debug, update } ) {
 		} );
 	}
 
-	spinner.text = 'WordPress started.';
+	const siteUrl = config.env.development.config.WP_SITEURL;
+	spinner.text = 'WordPress started'.concat(
+		siteUrl ? ` at ${ siteUrl }.` : '.'
+	);
 };
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Append site URL to "wordpress started" message.

## How has this been tested?
Pull branch, run `npx wp-env start` in gutenberg. You'll see the URL for the wordpress instance.

## Screenshots <!-- if applicable -->
<img width="1446" alt="Screen Shot 2020-11-25 at 1 46 31 PM" src="https://user-images.githubusercontent.com/6265975/100284809-a7793a00-2f24-11eb-9358-00d92e21e3c9.png">

## Types of changes
new feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
