### PR TITLE
Fix the image block's zoom slider width

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -106,6 +106,7 @@ figure.wp-block-image:not(.wp-block) {
 .wp-block-image__zoom {
 	.components-popover__content {
 		overflow: visible;
+		min-width: 260px;
 	}
 
 	.components-range-control {


### PR DESCRIPTION
## Description
To fix #27126. Which seems to have been a result of #25218. The previous min-width was 260px so that's what's been applied here.

## How has this been tested?
1.  Add an image block and upload/choose an image from the media library
2. Click the Crop button
3. Click the Zoom button
4. Observe the dropdown is wide enough so that the slider/range input is usable

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
