### PR TITLE
Word count: Adjust to count numbers as words

### DIFF
--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -50,7 +50,7 @@ export const defaultSettings = {
 			'[',
 
 			// Basic Latin (extract)
-			'\u0021-\u002F\u005B-\u0060\u007B-\u007E',
+			'\u0021-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u007E',
 
 			// Latin-1 Supplement (extract)
 			'\u0080-\u00BF\u00D7\u00F7',

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -50,7 +50,7 @@ export const defaultSettings = {
 			'[',
 
 			// Basic Latin (extract)
-			'\u0021-\u0040\u005B-\u0060\u007B-\u007E',
+			'\u0021-\u002F\u005B-\u0060\u007B-\u007E',
 
 			// Latin-1 Supplement (extract)
 			'\u0080-\u00BF\u00D7\u00F7',

--- a/packages/wordcount/src/test/index.test.js
+++ b/packages/wordcount/src/test/index.test.js
@@ -43,9 +43,16 @@ describe( 'WordCounter', () => {
 		{
 			message: 'Punctuation.',
 			string: 'It’s two three \u2026 4?',
-			words: 3,
+			words: 4,
 			characters_excluding_spaces: 15,
 			characters_including_spaces: 19,
+		},
+		{
+			message: 'Numbers as word',
+			string: 'Should be 4 words',
+			words: 4,
+			characters_excluding_spaces: 14,
+			characters_including_spaces: 17,
 		},
 		{
 			message: 'Em dash.',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adjusted the character range to be removed so count logic can count numbers.
Fixes #26339

## How has this been tested?
Used the unit test suite come with the repo. I have adjusted 1 existing case and added a new one

## Types of changes
Adjusted the character range to be removed so count logic can count numbers. It doesn't break anything. All test related to the `wordcount` package passed

## Checklist:
- [x] My code is tested.
