### PR TITLE
Post Featured Image: Remove 'clear' control

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -7,8 +7,6 @@ import {
 	Icon,
 	ToggleControl,
 	PanelBody,
-	ToolbarGroup,
-	ToolbarButton,
 	withNotices,
 } from '@wordpress/components';
 import {
@@ -104,22 +102,14 @@ function PostFeaturedImageDisplay( {
 			</InspectorControls>
 			<BlockControls>
 				{ !! media && (
-					<ToolbarGroup>
-						<ToolbarButton
-							name="unset"
-							onClick={ () => setFeaturedImage( 0 ) }
-						>
-							{ __( 'Clear' ) }
-						</ToolbarButton>
-						<MediaReplaceFlow
-							mediaId={ featuredImage }
-							mediaURL={ media.source_url }
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							accept="image/*"
-							onSelect={ onSelectImage }
-							onError={ onUploadError }
-						/>
-					</ToolbarGroup>
+					<MediaReplaceFlow
+						mediaId={ featuredImage }
+						mediaURL={ media.source_url }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						accept="image/*"
+						onSelect={ onSelectImage }
+						onError={ onUploadError }
+					/>
 				) }
 			</BlockControls>
 			<div { ...useBlockProps() }>{ image }</div>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
After some feedback about the recent added changes in Post Featured Image here: https://github.com/WordPress/gutenberg/pull/27224, it seems that there are no common use cases for the `clear` control to exist.

This PR removes it.