### PR TITLE
Adds back in icon and title for gallery block

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -5,14 +5,6 @@
 	li {
 		list-style-type: none;
 	}
-
-	// @todo: this deserves a refactor, by being moved to the toolbar.
-	.block-editor-media-placeholder {
-
-		.components-button {
-			margin-bottom: 0;
-		}
-	}
 }
 
 figure.wp-block-gallery {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -8,7 +8,6 @@
 
 	// @todo: this deserves a refactor, by being moved to the toolbar.
 	.block-editor-media-placeholder {
-		padding: $grid-unit-15;
 
 		// This element is empty here anyway.
 		.components-placeholder__label {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -9,11 +9,6 @@
 	// @todo: this deserves a refactor, by being moved to the toolbar.
 	.block-editor-media-placeholder {
 
-		// This element is empty here anyway.
-		.components-placeholder__label {
-			display: none;
-		}
-
 		.components-button {
 			margin-bottom: 0;
 		}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -5,6 +5,24 @@
 	li {
 		list-style-type: none;
 	}
+
+	.wp-block-gallery {
+		// Override the default list style type _only in the editor_
+		// to avoid :not() selector specificity issues.
+		// See https://github.com/WordPress/gutenberg/pull/10358
+		li {
+			list-style-type: none;
+		}
+		// @todo: this deserves a refactor, by being moved to the toolbar.
+		.block-editor-media-placeholder.is-appender {
+			.components-placeholder__label {
+				display: none;
+			}
+			.block-editor-media-placeholder__button {
+				margin-bottom: 0;
+			}
+		}
+	}
 }
 
 figure.wp-block-gallery {


### PR DESCRIPTION
The gallery block's title and icon are missing as of the latest build. Here is what currently shows - giving context with other blocks.

**Before:**

![image](https://user-images.githubusercontent.com/253067/100346100-3779bb00-2fdb-11eb-8228-3c2222a42be2.png)

It seems as if this was removed as part of G2 PR #19344. As the other blocks still have these, I would suggest bringing them back for the gallery block.

**After:**

![image](https://user-images.githubusercontent.com/253067/100346439-c4bd0f80-2fdb-11eb-844c-95a0550c9357.png)

## Additional fixes included
In addition to bringing back these, I also brought in a padding inheritance fix for the block on hover. There are no visual changes as a result to that. Props to @jasmussen for noting in #27252 this could be reduced in code. I'm adding this to group iterations.

I also discovered that I could remove the margin value from the button as part of this fix now it's inheriting. Here is after on select:

![image](https://user-images.githubusercontent.com/253067/100347071-bc190900-2fdc-11eb-942c-c496a1a2b6e5.png)

## Feedback
I'd love a code review to check everything is working and also input whether this is a suitable reverting.
