### PR TITLE
Code block: Add support for font sizes

### DIFF
--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -10,6 +10,7 @@
 		}
 	},
 	"supports": {
-		"anchor": true
+		"anchor": true,
+		"fontSize": true
 	}
 }

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -1,5 +1,9 @@
 // Provide a minimum of overflow handling.
-.wp-block-code code {
-	white-space: pre-wrap;
-	overflow-wrap: break-word;
+.wp-block-code {
+	font-size: var(--wp--preset--font-size--extra-small, 0.9em);
+
+	code {
+		white-space: pre-wrap;
+		overflow-wrap: break-word;
+	}
 }

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -1,6 +1,5 @@
 .wp-block-code {
 	font-family: $editor-html-font;
-	font-size: 0.9em;
 	color: $gray-900;
 	padding: 0.8em 1em;
 	border: 1px solid $gray-300;


### PR DESCRIPTION
## Description
This adds support for font sizes to the code block. It also changes the CSS for this block to use the global styles variable with the old size as a fallback.

## How has this been tested?
Tested with a block based and non block based themes (twentytwentyone)

## Screenshots <!-- if applicable -->
<img width="957" alt="Screenshot 2020-11-26 at 11 54 54" src="https://user-images.githubusercontent.com/275961/100348030-34cc9500-2fde-11eb-8fdc-c2d030f1a3b8.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
