### PR TITLE
Buttons: Add variations for vertical layout

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -19,7 +19,7 @@
 	}
 
 	// Add outline to button on focus to indicate focus-state
-	&:focus:not(.wp-block-buttons &) {
+	&:focus {
 		box-shadow: 0 0 0 1px $white, 0 0 0 3px var(--wp-admin-theme-color);
 
 		// Windows' High Contrast mode will show this outline, but not the box-shadow.

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -19,7 +19,7 @@
 	}
 
 	// Add outline to button on focus to indicate focus-state
-	&:focus {
+	&:focus:not(.wp-block-buttons &) {
 		box-shadow: 0 0 0 1px $white, 0 0 0 3px var(--wp-admin-theme-color);
 
 		// Windows' High Contrast mode will show this outline, but not the box-shadow.

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -5,6 +5,10 @@
 	"attributes": {
 		"contentJustification": {
 			"type": "string"
+		},
+		"orientation": {
+			"type": "string",
+			"default": "horizontal"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -23,18 +23,19 @@ const ALLOWED_BLOCKS = [ buttonBlockName ];
 const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
 
 function ButtonsEdit( {
-	attributes: { contentJustification },
+	attributes: { contentJustification, orientation },
 	setAttributes,
 } ) {
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `is-content-justification-${ contentJustification }` ]: contentJustification,
+			'is-vertical': orientation === 'vertical',
 		} ),
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		template: BUTTONS_TEMPLATE,
-		orientation: 'horizontal',
+		orientation,
 		__experimentalLayout: {
 			type: 'default',
 			alignments: [],

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -1,6 +1,7 @@
 .wp-block-buttons > .wp-block {
 	// Override editor auto block margins.
 	margin-left: 0;
+	margin-top: $button-margin;
 }
 
 .wp-block > .wp-block-buttons {
@@ -20,4 +21,8 @@
 .wp-block-buttons > .block-list-appender {
 	display: inline-flex;
 	align-items: center;
+
+	.is-vertical & {
+		align-items: flex-start;
+	}
 }

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -18,6 +18,11 @@
 			justify-content: flex-start;
 		}
 	}
+	> .wp-block-button {
+		&:focus {
+			box-shadow: none;
+		}
+	}
 }
 
 .wp-block[data-align="center"] > .wp-block-buttons {

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -1,12 +1,23 @@
-.wp-block-buttons > .wp-block {
-	// Override editor auto block margins.
-	margin-left: 0;
-	margin-top: $button-margin;
-}
-
 .wp-block > .wp-block-buttons {
 	display: flex;
 	flex-wrap: wrap;
+}
+
+.wp-block-buttons {
+	> .wp-block {
+		// Override editor auto block margins.
+		margin-left: 0;
+		margin-top: $button-margin;
+	}
+	> .block-list-appender {
+		display: inline-flex;
+		align-items: center;
+	}
+	&.is-vertical {
+		> .block-list-appender .block-list-appender__toggle {
+			justify-content: flex-start;
+		}
+	}
 }
 
 .wp-block[data-align="center"] > .wp-block-buttons {
@@ -16,13 +27,4 @@
 
 .wp-block[data-align="right"] > .wp-block-buttons {
 	justify-content: flex-end;
-}
-
-.wp-block-buttons > .block-list-appender {
-	display: inline-flex;
-	align-items: center;
-
-	.is-vertical & {
-		align-items: flex-start;
-	}
 }

--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -12,6 +12,7 @@ import transforms from './transforms';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -40,4 +41,5 @@ export const settings = {
 	transforms,
 	edit,
 	save,
+	variations,
 };

--- a/packages/block-library/src/buttons/save.js
+++ b/packages/block-library/src/buttons/save.js
@@ -8,12 +8,15 @@ import classnames from 'classnames';
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-export default function save( { attributes: { contentJustification } } ) {
+export default function save( {
+	attributes: { contentJustification, orientation },
+} ) {
 	return (
 		<div
 			{ ...useBlockProps.save( {
 				className: classnames( {
 					[ `is-content-justification-${ contentJustification }` ]: contentJustification,
+					'is-vertical': orientation === 'vertical',
 				} ),
 			} ) }
 		>

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -3,6 +3,10 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 
+	&.is-vertical {
+		flex-direction: column;
+	}
+
 	// Increased specificity to override blocks default margin.
 	> .wp-block-button {
 		display: inline-block;
@@ -14,14 +18,29 @@
 			/*rtl:ignore*/
 			margin-right: 0;
 		}
+
+		.is-vertical & {
+			margin-right: 0;
+
+			&:last-child {
+				/*rtl:ignore*/
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	&.is-content-justification-left {
 		justify-content: flex-start;
+		&.is-vertical {
+			align-items: flex-start;
+		}
 	}
 
 	&.is-content-justification-center {
 		justify-content: center;
+		&.is-vertical {
+			align-items: center;
+		}
 	}
 
 	&.is-content-justification-right {
@@ -37,6 +56,10 @@
 				/*rtl:ignore*/
 				margin-left: 0;
 			}
+		}
+
+		&.is-vertical {
+			align-items: flex-end;
 		}
 	}
 

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -5,6 +5,13 @@
 
 	&.is-vertical {
 		flex-direction: column;
+		> .wp-block-button {
+			/*rtl:ignore*/
+			margin-right: 0;
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	// Increased specificity to override blocks default margin.
@@ -17,15 +24,6 @@
 		&:last-child {
 			/*rtl:ignore*/
 			margin-right: 0;
-		}
-
-		.is-vertical & {
-			margin-right: 0;
-
-			&:last-child {
-				/*rtl:ignore*/
-				margin-bottom: 0;
-			}
 		}
 	}
 

--- a/packages/block-library/src/buttons/variations.js
+++ b/packages/block-library/src/buttons/variations.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const variations = [
+	{
+		name: 'buttons-horizontal',
+		isDefault: true,
+		title: __( 'Horizontal' ),
+		description: __( 'Buttons shown in a row.' ),
+		attributes: { orientation: 'horizontal' },
+		scope: [ 'transform' ],
+	},
+	{
+		name: 'buttons-vertical',
+		title: __( 'Vertical' ),
+		description: __( 'Buttons shown in a column.' ),
+		attributes: { orientation: 'vertical' },
+		scope: [ 'transform' ],
+	},
+];
+
+export default variations;

--- a/packages/e2e-tests/fixtures/blocks/core__buttons.json
+++ b/packages/e2e-tests/fixtures/blocks/core__buttons.json
@@ -5,6 +5,7 @@
         "isValid": true,
         "attributes": {
             "contentJustification": "center",
+            "orientation": "horizontal",
             "align": "wide"
         },
         "innerBlocks": [

--- a/packages/e2e-tests/fixtures/blocks/core_buttons__simple__deprecated.json
+++ b/packages/e2e-tests/fixtures/blocks/core_buttons__simple__deprecated.json
@@ -3,7 +3,9 @@
         "clientId": "_clientId_0",
         "name": "core/buttons",
         "isValid": true,
-        "attributes": {},
+        "attributes": {
+            "orientation": "horizontal"
+        },
         "innerBlocks": [
             {
                 "clientId": "_clientId_0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/20081

This PR adds block variations to `Buttons` block for enabling the switch to `vertical` and `horizontal` orientation, in the same fashion `Navigation` block handles this.

<!-- Please describe what you have changed or added -->

## How has this been tested?
Manually and by ensuring that previous versions of Buttons blocks would remain unaffected by this change.

## Screenshots <!-- if applicable -->
![verticalButtons](https://user-images.githubusercontent.com/16275880/100383909-7d5c7080-3027-11eb-8716-b1bd3a0e0172.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
