### PR TITLE
Full Site Editing Framework: Fix template resolution priorities.

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -151,9 +151,7 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 	usort(
 		$templates,
 		function ( $template_a, $template_b ) use ( $slug_priorities ) {
-			$priority_a = $slug_priorities[ $template_a->post_name ] * 2 + ( 'publish' === $template_a->post_status ? 1 : 0 );
-			$priority_b = $slug_priorities[ $template_b->post_name ] * 2 + ( 'publish' === $template_b->post_status ? 1 : 0 );
-			return $priority_b - $priority_a;
+			return $slug_priorities[ $template_a->post_name ] - $slug_priorities[ $template_b->post_name ];
 		}
 	);
 


### PR DESCRIPTION
Fixes #27177

## Description
As per the discussion on #27177, this PR fixes the issue by simplifying the `usort` callback.

## How has this been tested?
Tested by creating a custom post-type and verifying that the `archive-$post_type` template loads before `archive`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

cc @bobbingwide 