### PR TITLE
Try adding support for child themes in FSE/GS

### DIFF
--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -11,7 +11,7 @@
  * @return boolean Whether the current theme is an FSE theme or not.
  */
 function gutenberg_is_fse_theme() {
-	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' );
+	return is_readable( locate_template( 'block-templates/index.html' ) );
 }
 
 /**
@@ -21,6 +21,7 @@ function gutenberg_full_site_editing_notice() {
 	if ( ! gutenberg_is_fse_theme() ) {
 		return;
 	}
+
 	?>
 	<div class="notice notice-warning">
 		<p><?php _e( 'You\'re using an experimental Full Site Editing theme. Full Site Editing is an experimental feature and potential API changes are to be expected!', 'gutenberg' ); ?></p>

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -133,11 +133,31 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 			'orderby'        => 'post_name__in',
 			'posts_per_page' => -1,
 			'no_found_rows'  => true,
+			// Templates that either:
+			//
+			// - the active theme has declared (stylesheet)
+			// - its parent theme (template) has declared but there's not an equivalent in the active theme
+			//
 			'tax_query'      => array(
+				'relation' => 'OR',
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'slug',
 					'terms'    => wp_get_theme()->get_stylesheet(),
+				),
+				array(
+					'relation' => 'AND',
+					array(
+						'taxonomy' => 'wp_theme',
+						'field'    => 'slug',
+						'terms'    => wp_get_theme()->get_template(),
+					),
+					array(
+						'taxonomy' => 'wp_theme',
+						'field'    => 'slug',
+						'terms'    => wp_get_theme()->get_stylesheet(),
+						'operator' => 'NOT IN'
+					),
 				),
 			),
 		)


### PR DESCRIPTION
**WORK IN PROGRESS**

Fixes https://github.com/WordPress/gutenberg/issues/25612

This PR enables the site editor and global styles to work with child themes of block-based themes.

Places that were updated:

- [x] Check whether it is an FSE theme.
- [ ] Front end:
  - [x] Load template.
  - [ ] Load template parts.
- [ ] Edit site:
  - [ ] Load template.
  - [ ] Load template parts.
