### PR TITLE
Chore: Search block: Remove: invalid prop throwing a React warning

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -343,7 +343,6 @@ export default function SearchEdit( {
 					width: `${ width }${ widthUnit }`,
 				} }
 				className="wp-block-search__inside-wrapper"
-				isResetValueOnUnitChange
 				minWidth={ MIN_WIDTH }
 				enable={ getResizableSides() }
 				onResizeStart={ ( event, direction, elt ) => {


### PR DESCRIPTION
This prop is not used by ResizableBox and is making React throw warnings when the search block is added:
```
react_devtools_backend.js:2430 Warning: React does not recognize the `isResetValueOnUnitChange` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isresetvalueonunitchange` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## How has this been tested?
I added the search block and verified there were no warnings on the browser console.
