### PR TITLE
Revert "Try: Move block appender margin to child."

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -1,9 +1,7 @@
 // These styles are only applied to the appender when it appears inside of a block.
 // Otherwise the default appender may be improperly positioned in some themes.
 .block-editor-block-list__block .block-list-appender {
-	.block-editor-default-block-appender {
-		margin: $grid-unit-10 0;
-	}
+	margin: $grid-unit-10 0;
 
 	// Add additional margin to the appender when inside a group with a background color.
 	// If changing this, be sure to sync up with group/editor.scss line 13.


### PR DESCRIPTION
Reverts WordPress/gutenberg#27274

The above PR caused a regression at least in `Buttons` block
![buttons](https://user-images.githubusercontent.com/16275880/100381442-aaa62000-3021-11eb-812d-95bb2a0908b6.gif)
