### PR TITLE
Site Editor: fix app header on small-medium screens

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -57,7 +57,6 @@ $mobile-header-toolbar-height: 44px;
 $mobile-floating-toolbar-height: 44px;
 $mobile-floating-toolbar-margin: 8px;
 $mobile-color-swatch: 48px;
-$header-toolbar-min-width: 335px;
 
 /**
  * Shadows.

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -50,7 +50,7 @@ body.is-navigation-sidebar-open {
 // Centred document title on small screens with sidebar open
 @media ( max-width: #{ ($break-large - 1) } ) {
 	body.is-navigation-sidebar-open .edit-site-header {
-		.edit-site-header_start .components-button:not(.is-primary),
+		.edit-site-header-toolbar__inserter-toggle ~ .components-button,
 		.edit-site-header_end .components-button:not(.is-primary) {
 			display: none;
 		}

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -8,10 +8,13 @@
 	justify-content: space-between;
 
 	@include break-medium() {
-		padding-left: 60px;
-		transition: padding-left 20ms linear;
-		transition-delay: 80ms;
-		@include reduce-motion("transition");
+		body.is-fullscreen-mode & {
+			padding-left: 60px;
+			transition: padding-left 20ms linear;
+			transition-delay: 80ms;
+			@include reduce-motion("transition");
+		}
+
 	}
 
 	.edit-site-header_start,

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -5,6 +5,7 @@
 	height: $header-height;
 	box-sizing: border-box;
 	width: 100%;
+	justify-content: space-between;
 
 	@include break-medium() {
 		padding-left: 60px;
@@ -15,29 +16,13 @@
 
 	.edit-site-header_start,
 	.edit-site-header_end {
-		flex: 1 0;
 		display: flex;
-	}
-
-	@include break-medium() {
-		.edit-site-header_start {
-			// Flex basis prevents the header_start toolbar
-			// from collapsing when shrinking the viewport.
-			flex-basis: calc(#{$header-toolbar-min-width} - #{$header-height});
-		}
-
-		.edit-site-header_end {
-			// Flex basis prevents the header_end toolbar
-			// from collapsing when shrinking the viewport
-			flex-basis: $header-toolbar-min-width;
-		}
 	}
 
 	.edit-site-header_center {
 		display: flex;
 		align-items: center;
 		height: 100%;
-		flex-shrink: 1;
 		// Flex items will, by default, refuse to shrink below a minimum
 		// intrinsic width. In order to shrink this flexbox item, and
 		// subsequently truncate child text, we set an explicit min-width.
@@ -56,20 +41,14 @@ body.is-navigation-sidebar-open {
 		padding-left: 0;
 		transition: padding-left 20ms linear;
 		transition-delay: 0ms;
-
-		.edit-site-header_start {
-			flex-basis: $header-toolbar-min-width;
-		}
 	}
 }
 
 // Centred document title on small screens with sidebar open
-@media ( max-width: #{ ($break-medium - 1) } ) {
+@media ( max-width: #{ ($break-large - 1) } ) {
 	body.is-navigation-sidebar-open .edit-site-header {
-		.edit-site-header_start {
-			flex-basis: 0;
-		}
-		.block-editor-post-preview__button-toggle {
+		.edit-site-header_start .components-button:not(.is-primary),
+		.edit-site-header_end .components-button:not(.is-primary) {
 			display: none;
 		}
 		.edit-site-save-button__button {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -1,15 +1,19 @@
 .edit-site-navigation-toggle {
+	align-items: center;
+	background: $gray-900;
+	border-radius: 0;
 	display: none;
+	position: absolute;
+	z-index: z-index(".edit-site-navigation-toggle");
+	height: $header-height + $border-width; // Cover header border
+	width: $header-height;
 
 	@include break-medium() {
-		align-items: center;
-		background: $gray-900;
-		border-radius: 0;
 		display: flex;
-		position: absolute;
-		z-index: z-index(".edit-site-navigation-toggle");
-		height: $header-height + $border-width; // Cover header border
-		width: $header-height;
+	}
+
+	body.is-navigation-sidebar-open & {
+		display: flex;
 	}
 }
 


### PR DESCRIPTION
## Description
This fixes various issues with app header alignment on small-medium screens, particularly with the navigation sidebar open.

It removes a lot of `flex` properties and just allows flexbox to do its thing. This keeps the document dropdown from being perfectly centred, but it improves reliability as we're not trying to compensate for edge cases.

Non-`is-primary` icons are simply hidden on < large screens while the navigation sidebar is open to ensure there's enough room.

Fixes #27245 #26754

## How has this been tested?
1. Open Site Editor
2. Open Navigation Sidebar
3. Try various widths, ensure that the app toolbar stays functional and unbroken
4. Note that the (W) icon now appears in the navigation sidebar on < medium screens to close it (it can be opened on those screens through "browse all templates" in the document dropdown)


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
