### PR TITLE
Fixes duplicate class in gallery block

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -6,21 +6,13 @@
 		list-style-type: none;
 	}
 
-	.wp-block-gallery {
-		// Override the default list style type _only in the editor_
-		// to avoid :not() selector specificity issues.
-		// See https://github.com/WordPress/gutenberg/pull/10358
-		li {
-			list-style-type: none;
+	// @todo: this deserves a refactor, by being moved to the toolbar.
+	.block-editor-media-placeholder.is-appender {
+		.components-placeholder__label {
+			display: none;
 		}
-		// @todo: this deserves a refactor, by being moved to the toolbar.
-		.block-editor-media-placeholder.is-appender {
-			.components-placeholder__label {
-				display: none;
-			}
-			.block-editor-media-placeholder__button {
-				margin-bottom: 0;
-			}
+		.block-editor-media-placeholder__button {
+			margin-bottom: 0;
 		}
 	}
 }


### PR DESCRIPTION
This is just a code cleanup. Since #27293 there has been a duplicate class. This fixes that by removing. Nothing visual changes.