### PR TITLE
Adjust borders on gallery to prevent overlap

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -15,14 +15,6 @@
 			margin-bottom: 0;
 		}
 	}
-
-	// &.block-editor-block-list__block::after,
-	// &.block-editor-block-list__block:not([contenteditable]):focus::after {
-	// 	top: -1px;
-	// 	right: -1px;
-	// 	bottom: -1px;
-	// 	left: -1px;
-	// }
 }
 
 figure.wp-block-gallery {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -16,13 +16,13 @@
 		}
 	}
 
-	&.block-editor-block-list__block::after,
-	&.block-editor-block-list__block:not([contenteditable]):focus::after {
-		top: -1px;
-		right: -1px;
-		bottom: -1px;
-		left: -1px;
-	}
+	// &.block-editor-block-list__block::after,
+	// &.block-editor-block-list__block:not([contenteditable]):focus::after {
+	// 	top: -1px;
+	// 	right: -1px;
+	// 	bottom: -1px;
+	// 	left: -1px;
+	// }
 }
 
 figure.wp-block-gallery {
@@ -46,12 +46,25 @@ figure.wp-block-gallery {
 	}
 
 	figure.is-selected {
-		box-shadow: 0 0 0 $border-width $white, 0 0 0 3px var(--wp-admin-theme-color);
+		
 		border-radius: $radius-block-ui;
-		outline: 2px solid transparent;
+		position: relative;
 
 		img {
 			border-radius: $radius-block-ui;
+		}
+
+		&::before {
+			border-radius: $radius-block-ui;
+			bottom: 0;
+			box-shadow: 0 0 0 $border-width $white inset, 0 0 0 3px var(--wp-admin-theme-color) inset;
+			content: "";
+			left: 0;
+			outline: 2px solid transparent;
+			position: absolute;
+			right: 0;
+			top: 0;
+			z-index: 1;
 		}
 	}
 

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -15,6 +15,14 @@
 			margin-bottom: 0;
 		}
 	}
+
+	&.block-editor-block-list__block::after,
+	&.block-editor-block-list__block:not([contenteditable]):focus::after {
+		top: -1px;
+		right: -1px;
+		bottom: -1px;
+		left: -1px;
+	}
 }
 
 figure.wp-block-gallery {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -46,7 +46,7 @@ figure.wp-block-gallery {
 	}
 
 	figure.is-selected {
-		
+
 		border-radius: $radius-block-ui;
 		position: relative;
 

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -39,14 +39,7 @@ figure.wp-block-gallery {
 
 	figure.is-selected {
 
-		border-radius: $radius-block-ui;
-
-		img {
-			border-radius: $radius-block-ui;
-		}
-
 		&::before {
-			border-radius: $radius-block-ui;
 			bottom: 0;
 			box-shadow: 0 0 0 $border-width $white inset, 0 0 0 3px var(--wp-admin-theme-color) inset;
 			content: "";

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -40,7 +40,6 @@ figure.wp-block-gallery {
 	figure.is-selected {
 
 		border-radius: $radius-block-ui;
-		//position: relative;
 
 		img {
 			border-radius: $radius-block-ui;

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -48,7 +48,7 @@ figure.wp-block-gallery {
 	figure.is-selected {
 
 		border-radius: $radius-block-ui;
-		position: relative;
+		//position: relative;
 
 		img {
 			border-radius: $radius-block-ui;

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -40,14 +40,15 @@ figure.wp-block-gallery {
 	figure.is-selected {
 
 		&::before {
-			bottom: 0;
 			box-shadow: 0 0 0 $border-width $white inset, 0 0 0 3px var(--wp-admin-theme-color) inset;
 			content: "";
-			left: 0;
+			// Shown in Windows 10 high contrast mode.
 			outline: 2px solid transparent;
 			position: absolute;
-			right: 0;
 			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
 			z-index: 1;
 		}
 	}


### PR DESCRIPTION
This iteration is hopefully a temporary workaround that having a better method for this block can solve in longer term. That said there is a current issue where the borders overlap on select. 

**Before:**

![image](https://user-images.githubusercontent.com/253067/100391817-a16e8080-302c-11eb-88a2-81421b7dc96f.png)

In order to not touch the other elements that use this, I added to the block specific CSS. Props to @jasmussen for helping me learn more about this CSS and the potential iterations in future. It's my understanding whatever I am adding here will be changed later, so a workaround like this could be suitable.

**After:**

![image](https://user-images.githubusercontent.com/253067/100391903-daa6f080-302c-11eb-9a73-e00006d2fff3.png)

## Feedback
I would love a code review as I admit, it got a little complex finding this specifically and I would love to know if there is a more elegant declaration. Similarly, whilst I took the method of treating borders to '-1px', perhaps alternatives could be done. I explored adding padding in the block, however that meant more visual impact.