### PR TITLE
Simplify CSS for the code block

### DIFF
--- a/packages/block-library/src/code/editor.scss
+++ b/packages/block-library/src/code/editor.scss
@@ -1,4 +1,0 @@
-.wp-block-code > code {
-	// PlainText cannot be an inline element yet.
-	display: block;
-}

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -3,6 +3,7 @@
 	font-size: var(--wp--preset--font-size--extra-small, 0.9em);
 
 	code {
+		display: block;
 		white-space: pre-wrap;
 		overflow-wrap: break-word;
 	}

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -9,7 +9,6 @@
 @import "./button/editor.scss";
 @import "./buttons/editor.scss";
 @import "./categories/editor.scss";
-@import "./code/editor.scss";
 @import "./columns/editor.scss";
 @import "./cover/editor.scss";
 @import "./embed/editor.scss";


### PR DESCRIPTION
## Description
This moves the `display: block;` rule to the front end, so that the frontend and backend match.

The [HTML spec](https://html.spec.whatwg.org/#the-pre-element) indicates that when a code element is used inside a pre element it represents a block of code, so I think this CSS fits with that approach.

## How has this been tested?
Tested in TwentyTwentyOne where this line came from

## Screenshots <!-- if applicable -->
<img width="1347" alt="Screenshot 2020-11-26 at 22 39 56" src="https://user-images.githubusercontent.com/275961/100395306-50fd2000-3038-11eb-907d-48207f25ecd6.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
