### PR TITLE
Fix crash when null date passed to TimePicker

### DIFF
--- a/packages/components/src/date-time/test/time.js
+++ b/packages/components/src/date-time/test/time.js
@@ -271,4 +271,28 @@ describe( 'TimePicker', () => {
 
 		expect( monthInputIndex > dayInputIndex ).toBe( true );
 	} );
+
+	it( 'Should set a time when passed a null currentTime', () => {
+		const onChangeSpy = jest.fn();
+
+		render(
+			<TimePicker
+				currentTime={ null }
+				onChange={ onChangeSpy }
+				is12Hour
+			/>
+		);
+
+		const monthInput = screen.getByLabelText( 'Month' ).value;
+		const dayInput = screen.getByLabelText( 'Day' ).value;
+		const yearInput = screen.getByLabelText( 'Year' ).value;
+		const hoursInput = screen.getByLabelText( 'Hours' ).value;
+		const minutesInput = screen.getByLabelText( 'Minutes' ).value;
+
+		expect( isNaN( monthInput ) ).toBe( false );
+		expect( isNaN( dayInput ) ).toBe( false );
+		expect( isNaN( yearInput ) ).toBe( false );
+		expect( isNaN( hoursInput ) ).toBe( false );
+		expect( isNaN( minutesInput ) ).toBe( false );
+	} );
 } );

--- a/packages/components/src/date-time/test/time.js
+++ b/packages/components/src/date-time/test/time.js
@@ -289,10 +289,10 @@ describe( 'TimePicker', () => {
 		const hoursInput = screen.getByLabelText( 'Hours' ).value;
 		const minutesInput = screen.getByLabelText( 'Minutes' ).value;
 
-		expect( isNaN( monthInput ) ).toBe( false );
-		expect( isNaN( dayInput ) ).toBe( false );
-		expect( isNaN( yearInput ) ).toBe( false );
-		expect( isNaN( hoursInput ) ).toBe( false );
-		expect( isNaN( minutesInput ) ).toBe( false );
+		expect( Number.isNaN( parseInt( monthInput, 10 ) ) ).toBe( false );
+		expect( Number.isNaN( parseInt( dayInput, 10 ) ) ).toBe( false );
+		expect( Number.isNaN( parseInt( yearInput, 10 ) ) ).toBe( false );
+		expect( Number.isNaN( parseInt( hoursInput, 10 ) ) ).toBe( false );
+		expect( Number.isNaN( parseInt( minutesInput, 10 ) ) ).toBe( false );
 	} );
 } );

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -88,7 +88,9 @@ export function TimePicker( { is12Hour, currentTime, onChange } ) {
 
 	// Reset the state when currentTime changed.
 	useEffect( () => {
-		setDate( moment( currentTime ).startOf( 'minutes' ) );
+		setDate(
+			currentTime ? moment( currentTime ).startOf( 'minutes' ) : moment()
+		);
 	}, [ currentTime ] );
 
 	const { day, month, year, minutes, hours, am } = useMemo(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #27246 
Adds a sad path test to check that a date and time is always output even if the component receives `null` as currentTime. This is needed as the reset function sets the date/time to null. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
