### PR TITLE
Fix Image block crop glitch

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -55,7 +55,7 @@ figure.wp-block-image:not(.wp-block) {
 .wp-block[data-align="left"],
 .wp-block[data-align="center"],
 .wp-block[data-align="right"] {
-	> .wp-block-image {
+	> .wp-block-image.is-resized {
 		display: table;
 
 		> figcaption {

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -52,6 +52,16 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
+// Overrides styling from style.scss to avoid centering
+// when there has been no alignment set.
+.wp-block-image.is-resized {
+	display: block;
+
+	> figcaption {
+		display: block;
+	}
+}
+
 .wp-block[data-align="left"],
 .wp-block[data-align="center"],
 .wp-block[data-align="right"] {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -18,7 +18,8 @@
 
 	.alignleft,
 	.alignright,
-	.aligncenter {
+	.aligncenter,
+	&.is-resized {
 		display: table;
 
 		> figcaption {


### PR DESCRIPTION
Intended to fix #27145 without regressing #23986. Noticing that the cropping glitch does not affect aligned Image blocks that have been resized, I updated the selector for applying the table display so it wouldn't match non-resized image blocks (leaving their display as block).

There are two commits here. The first alone is enough for the fix. The second commit could be dropped from this PR but was made in the interest of being sure there are no style changes on the frontend from #26376. It undoes a removal in 990ba5ad while replicating its intended effect in the editor with an override in editor.scss instead. 

## How has this been tested?
1. add an image block
2. set its alignment to left, center, or right
3. press crop in the toolbar
4. notice the image remains the same size
5. cancel the image editing mode
6. unset the alignment
7. resize the image with the drag handles 
8. note the image stays in the default alignment (does not center)

## Types of changes
Bug fix 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
