### PR TITLE
Revert "Full Site Editing Framework: Fix template resolution priorities."

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -144,20 +144,13 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 	);
 	$templates      = $template_query->get_posts();
 
-	// Order these templates per slug priority.
-	// Build map of template slugs to their priority in the current hierarchy.
-	$slug_priorities = array_flip( $slugs );
-
-	usort(
-		$templates,
-		function ( $template_a, $template_b ) use ( $slug_priorities ) {
-			$priority_a = $slug_priorities[ $template_a->post_name ] * 2 + ( 'publish' === $template_a->post_status ? 1 : 0 );
-			$priority_b = $slug_priorities[ $template_b->post_name ] * 2 + ( 'publish' === $template_b->post_status ? 1 : 0 );
-			return $priority_a - $priority_b;
+	foreach ( $slugs as $slug ) {
+		foreach ( $templates as $template ) {
+			if ( $template->post_name === $slug ) {
+				return $template;
+			}
 		}
-	);
-
-	return count( $templates ) ? $templates[0] : null;
+	}
 }
 
 /**

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -153,7 +153,7 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 		function ( $template_a, $template_b ) use ( $slug_priorities ) {
 			$priority_a = $slug_priorities[ $template_a->post_name ] * 2 + ( 'publish' === $template_a->post_status ? 1 : 0 );
 			$priority_b = $slug_priorities[ $template_b->post_name ] * 2 + ( 'publish' === $template_b->post_status ? 1 : 0 );
-			return $priority_b - $priority_a;
+			return $priority_a - $priority_b;
 		}
 	);
 

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -151,8 +151,8 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 	usort(
 		$templates,
 		function ( $template_a, $template_b ) use ( $slug_priorities ) {
-			$priority_a = $slug_priorities[ $template_a->post_name ];
-			$priority_b = $slug_priorities[ $template_b->post_name ];
+			$priority_a = $slug_priorities[ $template_a->post_name ] * 2 + ( 'publish' === $template_a->post_status ? 1 : 0 );
+			$priority_b = $slug_priorities[ $template_b->post_name ] * 2 + ( 'publish' === $template_b->post_status ? 1 : 0 );
 			return $priority_b - $priority_a;
 		}
 	);

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -151,8 +151,8 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 	usort(
 		$templates,
 		function ( $template_a, $template_b ) use ( $slug_priorities ) {
-			$priority_a = $slug_priorities[ $template_a->post_name ] * 2 + ( 'publish' === $template_a->post_status ? 1 : 0 );
-			$priority_b = $slug_priorities[ $template_b->post_name ] * 2 + ( 'publish' === $template_b->post_status ? 1 : 0 );
+			$priority_a = $slug_priorities[ $template_a->post_name ];
+			$priority_b = $slug_priorities[ $template_b->post_name ];
 			return $priority_b - $priority_a;
 		}
 	);

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -151,7 +151,9 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 	usort(
 		$templates,
 		function ( $template_a, $template_b ) use ( $slug_priorities ) {
-			return $slug_priorities[ $template_a->post_name ] - $slug_priorities[ $template_b->post_name ];
+			$priority_a = $slug_priorities[ $template_a->post_name ] * 2 + ( 'publish' === $template_a->post_status ? 1 : 0 );
+			$priority_b = $slug_priorities[ $template_b->post_name ] * 2 + ( 'publish' === $template_b->post_status ? 1 : 0 );
+			return $priority_b - $priority_a;
 		}
 	);
 

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -144,13 +144,20 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 	);
 	$templates      = $template_query->get_posts();
 
-	foreach ( $slugs as $slug ) {
-		foreach ( $templates as $template ) {
-			if ( $template->post_name === $slug ) {
-				return $template;
-			}
+	// Order these templates per slug priority.
+	// Build map of template slugs to their priority in the current hierarchy.
+	$slug_priorities = array_flip( $slugs );
+
+	usort(
+		$templates,
+		function ( $template_a, $template_b ) use ( $slug_priorities ) {
+			$priority_a = $slug_priorities[ $template_a->post_name ] * 2 + ( 'publish' === $template_a->post_status ? 1 : 0 );
+			$priority_b = $slug_priorities[ $template_b->post_name ] * 2 + ( 'publish' === $template_b->post_status ? 1 : 0 );
+			return $priority_b - $priority_a;
 		}
-	}
+	);
+
+	return count( $templates ) ? $templates[0] : null;
 }
 
 /**


### PR DESCRIPTION
WordPress/gutenberg#27303 caused some tests to fail.
This PR reverts the changes. If merged then we should reopen https://github.com/WordPress/gutenberg/issues/27177 and find a better solution