### PR TITLE
Query block: Fix dirtying post on load

### DIFF
--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -129,8 +129,12 @@ export default function QueryInspectorControls( {
 
 	const [ querySearch, setQuerySearch ] = useState( query.search );
 	const onChangeDebounced = useCallback(
-		debounce( () => setQuery( { search: querySearch } ), 250 ),
-		[ querySearch ]
+		debounce( () => {
+			if ( query.search !== querySearch ) {
+				setQuery( { search: querySearch } );
+			}
+		}, 250 ),
+		[ querySearch, query.search ]
 	);
 	useEffect( () => {
 		onChangeDebounced();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/26838

There was a bug that when loading a post with a `Query` block would trigger an initial update to its attributes without needing it. This PR fixes it.
