### PR TITLE
[Reusable blocks] Edit single instance at a time, cancel on escape key

### DIFF
--- a/packages/block-library/src/block/edit-panel/index.js
+++ b/packages/block-library/src/block/edit-panel/index.js
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { useInstanceId, usePrevious } from '@wordpress/compose';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ESCAPE } from '@wordpress/keycodes';
 
 /** @typedef {import('@wordpress/element').WPComponent} WPComponent */
 
@@ -43,6 +44,7 @@ export default function ReusableBlockEditPanel( {
 	isEditDisabled,
 	isEditing,
 	isSaving,
+	onCancel,
 	onChangeTitle,
 	onEdit,
 	onSave,
@@ -75,6 +77,12 @@ export default function ReusableBlockEditPanel( {
 
 	function handleTitleChange( event ) {
 		onChangeTitle( event.target.value );
+	}
+	function handleTitleKeyDown( event ) {
+		if ( event.keyCode === ESCAPE ) {
+			event.stopPropagation();
+			onCancel();
+		}
 	}
 
 	return (
@@ -111,6 +119,7 @@ export default function ReusableBlockEditPanel( {
 						className="reusable-block-edit-panel__title"
 						value={ title }
 						onChange={ handleTitleChange }
+						onKeyDown={ handleTitleKeyDown }
 						id={ `reusable-block-edit-panel__title-${ instanceId }` }
 					/>
 					<Button


### PR DESCRIPTION
## Description
This PR reinstates the changes from https://github.com/WordPress/gutenberg/pull/21427 that were reverted after making reusable blocks a separate package:

* Editing reusable blocks only affects the edited instance until the changes are saved. This means that other instances of the same reusable blocks will remain unaffected during editing.
* Escape key cancels the editing.

## How has this been tested?
Go to post editor and confirm the two changes described above indeed work.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
