### PR TITLE
Eslint: Add no-unsafe-wp-apis to recommended config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
 				allowedTextDomain: 'default',
 			},
 		],
+		'@wordpress/no-unsafe-wp-apis': 'off',
 		'no-restricted-syntax': [
 			'error',
 			// NOTE: We can't include the forward slash in our regex or

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Enabled `import/no-extraneous-dependencies` rule in the `recommended` ruleset.
 -   Enabled `import/no-unresolved` rule in the `recommended` ruleset.
+-   Enabled `no-unsafe-wp-apis` rule in the `recommended` ruleset ([#27327](https://github.com/WordPress/gutenberg/pull/27327)).
 
 ## 7.4.0 (2020-12-17)
 

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -7,6 +7,7 @@ module.exports = {
 		'@wordpress/no-global-active-element': 'error',
 		'@wordpress/no-global-get-selection': 'error',
 		'@wordpress/no-global-event-listener': 'warn',
+		'@wordpress/no-unsafe-wp-apis': 'error',
 	},
 	overrides: [
 		{


### PR DESCRIPTION
## Description

Adds new rule prohibiting unsafe (experimental and unstable) APIs to recommended config. See #27301 which adds the rule.

## Types of changes
Breaking change - Adds a new rule to the recommended rules.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
