### PR TITLE
Video Block: Let the video fill the container

### DIFF
--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -4,7 +4,7 @@
 	margin-right: 0;
 
 	video {
-		max-width: 100%;
+		width: 100%;
 	}
 
 	@supports (position: sticky) {


### PR DESCRIPTION
## Description
This is a fix for #26700. The video inside the video block needs to fill its container, so that it respects the alignment of the parent container.

## How has this been tested?
Tested in TwentyTwenty and TwentyTwentyOne.

## Screenshots <!-- if applicable -->
<img width="772" alt="Screenshot 2020-11-27 at 13 47 15" src="https://user-images.githubusercontent.com/275961/100455712-125a7a80-30b7-11eb-93c7-c5e2510db3e2.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
