### PR TITLE
Verse Block: Add support for font family

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -365,5 +365,6 @@ These are the current typography properties supported by blocks:
 | Post Title | Yes | Yes | - | - | Yes | - | - |
 | Site Tagline | Yes | Yes | - | - | Yes | - | - |
 | Site Title | Yes | Yes | - | - | Yes | - | - |
+| Verse | Yes | - | - | - | - | - | - |
 
 [1] The heading block represents 6 distinct HTML elements: H1-H6. It comes with selectors to target each individual element (ex: core/heading/h1 for H1, etc).

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -37,6 +37,7 @@
 @import "./subhead/style.scss";
 @import "./table/style.scss";
 @import "./text-columns/style.scss";
+@import "./verse/style.scss";
 @import "./video/style.scss";
 @import "./post-featured-image/style.scss";
 

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -15,6 +15,7 @@
 		}
 	},
 	"supports": {
-		"anchor": true
+		"anchor": true,
+		"__experimentalFontFamily": true
 	}
 }

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,7 +1,6 @@
 pre.wp-block-verse {
 	color: $gray-900;
 	white-space: nowrap;
-	font-family: inherit;
 	font-size: inherit;
 	padding: 1em;
 	overflow: auto;

--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,0 +1,3 @@
+pre.wp-block-verse {
+	font-family: inherit;
+}


### PR DESCRIPTION
## Description
Adds the ability to change the font family to the Verse block. The verse block uses a `pre` element, which defaults to a monospace font in some browsers. This also resets the frontend to match the backend.

## How has this been tested?
In TT1 Blocks

## Screenshots
<img width="1321" alt="Screenshot 2020-11-27 at 15 03 23" src="https://user-images.githubusercontent.com/275961/100462133-b47f6000-30c1-11eb-82ed-426fd423c8f9.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
