### PR TITLE
Blocks: Replace store name string with exposed store definition

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -7,7 +7,11 @@ import { castArray, first, last, every } from 'lodash';
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { hasBlockSupport, switchToBlockType } from '@wordpress/blocks';
+import {
+	hasBlockSupport,
+	switchToBlockType,
+	store as blocksStore,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -26,7 +30,7 @@ export default function BlockActions( {
 		getTemplateLock,
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
 	const { getDefaultBlockName, getGroupingBlockName } = useSelect(
-		( select ) => select( 'core/blocks' ),
+		( select ) => select( blocksStore ),
 		[]
 	);
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -6,6 +6,7 @@ import {
 	getBlockType,
 	getUnregisteredTypeHandlerName,
 	hasBlockSupport,
+	store as blocksStore,
 } from '@wordpress/blocks';
 import {
 	PanelBody,
@@ -121,7 +122,7 @@ export default withSelect( ( select ) => {
 		getSelectedBlockCount,
 		getBlockName,
 	} = select( 'core/block-editor' );
-	const { getBlockStyles } = select( 'core/blocks' );
+	const { getBlockStyles } = select( blocksStore );
 	const selectedBlockClientId = getSelectedBlockClientId();
 	const selectedBlockName =
 		selectedBlockClientId && getBlockName( selectedBlockClientId );

--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { hasBlockSupport } from '@wordpress/blocks';
+import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -16,7 +16,7 @@ function BlockContextualToolbar( { focusOnMount, ...props } ) {
 		const { getBlockName, getSelectedBlockClientIds } = select(
 			'core/block-editor'
 		);
-		const { getBlockType } = select( 'core/blocks' );
+		const { getBlockType } = select( blocksStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
 		return {

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, store as blocksStore } from '@wordpress/blocks';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -26,7 +26,7 @@ export default function BlockParentSelector() {
 				getBlockParents,
 				getSelectedBlockClientId,
 			} = select( 'core/block-editor' );
-			const { hasBlockSupport } = select( 'core/blocks' );
+			const { hasBlockSupport } = select( blocksStore );
 			const selectedBlockClientId = getSelectedBlockClientId();
 			const parents = getBlockParents( selectedBlockClientId );
 			const _firstParentClientId = parents[ parents.length - 1 ];

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -15,6 +15,7 @@ import {
 	getBlockType,
 	cloneBlock,
 	getBlockFromExample,
+	store as blocksStore,
 } from '@wordpress/blocks';
 
 /**
@@ -43,7 +44,7 @@ function BlockStyles( {
 } ) {
 	const selector = ( select ) => {
 		const { getBlock } = select( 'core/block-editor' );
-		const { getBlockStyles } = select( 'core/blocks' );
+		const { getBlockStyles } = select( blocksStore );
 		const block = getBlock( clientId );
 		const blockType = getBlockType( block.name );
 		return {

--- a/packages/block-editor/src/components/block-styles/index.native.js
+++ b/packages/block-editor/src/components/block-styles/index.native.js
@@ -7,6 +7,7 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
 
@@ -20,7 +21,7 @@ import containerStyles from './style.scss';
 function BlockStyles( { clientId, url } ) {
 	const selector = ( select ) => {
 		const { getBlock } = select( 'core/block-editor' );
-		const { getBlockStyles } = select( 'core/blocks' );
+		const { getBlockStyles } = select( blocksStore );
 		const block = getBlock( clientId );
 		return {
 			styles: getBlockStyles( block.name ),

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -21,6 +21,7 @@ import {
 	switchToBlockType,
 	cloneBlock,
 	getBlockFromExample,
+	store as blocksStore,
 } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -238,7 +239,7 @@ export default compose(
 			getBlockRootClientId,
 			getInserterItems,
 		} = select( 'core/block-editor' );
-		const { getBlockStyles } = select( 'core/blocks' );
+		const { getBlockStyles } = select( blocksStore );
 		const rootClientId = getBlockRootClientId(
 			castArray( clientIds )[ 0 ]
 		);

--- a/packages/block-editor/src/components/block-variation-picker/index.native.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.native.js
@@ -14,7 +14,10 @@ import {
  */
 import { withSelect, useDispatch } from '@wordpress/data';
 import { compose, usePreferredColorSchemeStyle } from '@wordpress/compose';
-import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
+import {
+	createBlocksFromInnerBlocksTemplate,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import {
 	PanelBody,
@@ -110,7 +113,7 @@ function BlockVariationPicker( { isVisible, onClose, clientId, variations } ) {
 
 export default compose(
 	withSelect( ( select, {} ) => {
-		const { getBlockVariations } = select( 'core/blocks' );
+		const { getBlockVariations } = select( blocksStore );
 
 		return {
 			date: getBlockVariations( 'core/columns', 'block' ),

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import {
 	DropdownMenu,
@@ -21,7 +22,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const { variations, blockAttributes } = useSelect(
 		( select ) => {
-			const { getBlockVariations } = select( 'core/blocks' );
+			const { getBlockVariations } = select( blocksStore );
 			const { getBlockName, getBlockAttributes } = select(
 				'core/block-editor'
 			);

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { useCallback, useEffect, useRef } from '@wordpress/element';
-import { serialize, pasteHandler } from '@wordpress/blocks';
+import {
+	serialize,
+	pasteHandler,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import {
 	documentHasSelection,
 	documentHasUncollapsedSelection,
@@ -21,7 +25,7 @@ export function useNotifyCopy() {
 		[]
 	);
 	const { getBlockType } = useSelect(
-		( select ) => select( 'core/blocks' ),
+		( select ) => select( blocksStore ),
 		[]
 	);
 	const { createSuccessNotice } = useDispatch( 'core/notices' );

--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { useMemo, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
@@ -20,7 +21,7 @@ export default function DefaultStylePicker( { blockName } ) {
 				preferredStyle: preferredStyleVariations?.value?.[ blockName ],
 				onUpdatePreferredStyleVariations:
 					preferredStyleVariations?.onChange ?? null,
-				styles: select( 'core/blocks' ).getBlockStyles( blockName ),
+				styles: select( blocksStore ).getBlockStyles( blockName ),
 			};
 		},
 		[ blockName ]

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -7,6 +7,7 @@ import { map, findIndex, flow, sortBy, groupBy, orderBy } from 'lodash';
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { store as blocksStore } from '@wordpress/blocks';
 import { useMemo, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
@@ -36,7 +37,7 @@ export function BlockTypesTab( {
 	const hasChildItems = useSelect(
 		( select ) => {
 			const { getBlockName } = select( 'core/block-editor' );
-			const { getChildBlockNames } = select( 'core/blocks' );
+			const { getChildBlockNames } = select( blocksStore );
 			const rootBlockName = getBlockName( rootClientId );
 
 			return !! getChildBlockNames( rootBlockName ).length;

--- a/packages/block-editor/src/components/inserter/child-blocks.js
+++ b/packages/block-editor/src/components/inserter/child-blocks.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -10,7 +11,7 @@ import BlockIcon from '../block-icon';
 
 export default function ChildBlocks( { rootClientId, children } ) {
 	const { rootBlockTitle, rootBlockIcon } = useSelect( ( select ) => {
-		const { getBlockType } = select( 'core/blocks' );
+		const { getBlockType } = select( blocksStore );
 		const { getBlockName } = select( 'core/block-editor' );
 		const rootBlockName = getBlockName( rootClientId );
 		const rootBlockType = getBlockType( rootBlockName );

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -4,6 +4,7 @@
 import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
+	store as blocksStore,
 } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 
@@ -18,7 +19,7 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 	const { categories, collections, items } = useSelect(
 		( select ) => {
 			const { getInserterItems } = select( 'core/block-editor' );
-			const { getCategories, getCollections } = select( 'core/blocks' );
+			const { getCategories, getCollections } = select( blocksStore );
 
 			return {
 				categories: getCategories(),

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -13,7 +13,7 @@ import { Dropdown, Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, ifCondition } from '@wordpress/compose';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -199,7 +199,7 @@ export default compose( [
 			hasInserterItems,
 			__experimentalGetAllowedBlocks,
 		} = select( 'core/block-editor' );
-		const { getBlockVariations } = select( 'core/blocks' );
+		const { getBlockVariations } = select( blocksStore );
 
 		rootClientId =
 			rootClientId || getBlockRootClientId( clientId ) || undefined;

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -14,7 +14,11 @@ import { pick } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { createBlock, rawHandler } from '@wordpress/blocks';
+import {
+	createBlock,
+	rawHandler,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 import {
@@ -181,7 +185,7 @@ export default compose(
 			getSettings,
 			canInsertBlockType,
 		} = select( 'core/block-editor' );
-		const { getChildBlockNames, getBlockType } = select( 'core/blocks' );
+		const { getChildBlockNames, getBlockType } = select( blocksStore );
 		const { getClipboard } = select( 'core/editor' );
 
 		let destinationRootClientId = rootClientId;

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -6,6 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { Toolbar, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -37,7 +38,7 @@ export default compose( [
 			'core/block-editor'
 		);
 
-		const { getGroupingBlockName } = select( 'core/blocks' );
+		const { getGroupingBlockName } = select( blocksStore );
 
 		const selectedId = getSelectedBlockClientId();
 		const selectedBlock = getBlock( selectedId );

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -6,6 +6,7 @@ import { get, isObject } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -78,7 +79,7 @@ export default function useEditorFeature( featurePath ) {
 				'core/block-editor'
 			);
 			const settings = getSettings();
-			const blockType = select( 'core/blocks' ).getBlockType( blockName );
+			const blockType = select( blocksStore ).getBlockType( blockName );
 
 			let context = blockName;
 			const selectors = get( blockType, [

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -22,6 +22,7 @@ import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
 import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
+	store as blocksStore,
 } from '@wordpress/blocks';
 
 /**
@@ -209,7 +210,7 @@ function Placeholder( { clientId, name, setAttributes } ) {
 				getBlockVariations,
 				getBlockType,
 				getDefaultBlockVariation,
-			} = select( 'core/blocks' );
+			} = select( blocksStore );
 
 			return {
 				blockType: getBlockType( name ),

--- a/packages/block-library/src/post-hierarchical-terms/edit.js
+++ b/packages/block-library/src/post-hierarchical-terms/edit.js
@@ -14,6 +14,7 @@ import {
 	useBlockProps,
 	__experimentalBlockVariationPicker as BlockVariationPicker,
 } from '@wordpress/block-editor';
+import { store as blocksStore } from '@wordpress/blocks';
 import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -39,7 +40,7 @@ export default function PostHierarchicalTermsEdit( {
 				getBlockVariations,
 				getBlockType,
 				getDefaultBlockVariation,
-			} = select( 'core/blocks' );
+			} = select( blocksStore );
 
 			return {
 				blockType: getBlockType( name ),

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -7,7 +7,10 @@ import {
 	__experimentalBlockVariationPicker,
 	__experimentalGetMatchingVariation as getMatchingVariation,
 } from '@wordpress/block-editor';
-import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
+import {
+	createBlocksFromInnerBlocksTemplate,
+	store as blocksStore,
+} from '@wordpress/blocks';
 
 const QueryPlaceholder = ( { clientId, name, attributes, setAttributes } ) => {
 	const {
@@ -21,7 +24,7 @@ const QueryPlaceholder = ( { clientId, name, attributes, setAttributes } ) => {
 				getBlockVariations,
 				getBlockType,
 				getDefaultBlockVariation,
-			} = select( 'core/blocks' );
+			} = select( blocksStore );
 
 			return {
 				blockType: getBlockType( name ),

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -3,6 +3,11 @@
  */
 import { dispatch, select } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as blocksStore } from '../store';
+
 /** @typedef {import('../store/reducer').WPBlockCategory} WPBlockCategory */
 
 /**
@@ -11,7 +16,7 @@ import { dispatch, select } from '@wordpress/data';
  * @return {WPBlockCategory[]} Block categories.
  */
 export function getCategories() {
-	return select( 'core/blocks' ).getCategories();
+	return select( blocksStore ).getCategories();
 }
 
 /**
@@ -20,7 +25,7 @@ export function getCategories() {
  * @param {WPBlockCategory[]} categories Block categories.
  */
 export function setCategories( categories ) {
-	dispatch( 'core/blocks' ).setCategories( categories );
+	dispatch( blocksStore ).setCategories( categories );
 }
 
 /**
@@ -31,5 +36,5 @@ export function setCategories( categories ) {
  *                                   that should be updated.
  */
 export function updateCategory( slug, category ) {
-	dispatch( 'core/blocks' ).updateCategory( slug, category );
+	dispatch( blocksStore ).updateCategory( slug, category );
 }

--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -7,12 +7,15 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { getBlockContentSchema, isPlain } from '../utils';
+import { store as mockStore } from '../../../store';
+import { STORE_NAME as mockStoreName } from '../../../store/constants';
 
 jest.mock( '@wordpress/data', () => {
 	return {
 		select: jest.fn( ( store ) => {
 			switch ( store ) {
-				case 'core/blocks': {
+				case [ mockStoreName ]:
+				case mockStore: {
 					return {
 						hasBlockSupport: ( blockName, supports ) => {
 							return (
@@ -24,6 +27,18 @@ jest.mock( '@wordpress/data', () => {
 				}
 			}
 		} ),
+		combineReducers: () => {
+			const mock = jest.fn();
+			return mock;
+		},
+		createReduxStore: () => {
+			const mock = jest.fn();
+			return mock;
+		},
+		register: () => {
+			const mock = jest.fn();
+			return mock;
+		},
 	};
 } );
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -26,6 +26,7 @@ import { blockDefault } from '@wordpress/icons';
  */
 import { isValidIcon, normalizeIconObject } from './utils';
 import { DEPRECATED_ENTRY_KEYS } from './constants';
+import { store as blocksStore } from '../store';
 
 /**
  * An icon type definition. One of a Dashicon slug, an element,
@@ -191,7 +192,7 @@ export function registerBlockType( name, settings ) {
 		);
 		return;
 	}
-	if ( select( 'core/blocks' ).getBlockType( name ) ) {
+	if ( select( blocksStore ).getBlockType( name ) ) {
 		console.error( 'Block "' + name + '" is already registered.' );
 		return;
 	}
@@ -242,7 +243,7 @@ export function registerBlockType( name, settings ) {
 
 	if (
 		'category' in settings &&
-		! some( select( 'core/blocks' ).getCategories(), {
+		! some( select( blocksStore ).getCategories(), {
 			slug: settings.category,
 		} )
 	) {
@@ -274,7 +275,7 @@ export function registerBlockType( name, settings ) {
 		return;
 	}
 
-	dispatch( 'core/blocks' ).addBlockTypes( settings );
+	dispatch( blocksStore ).addBlockTypes( settings );
 
 	return settings;
 }
@@ -288,7 +289,7 @@ export function registerBlockType( name, settings ) {
  * @param {Object} [settings.icon] The icon to display in the block inserter.
  */
 export function registerBlockCollection( namespace, { title, icon } ) {
-	dispatch( 'core/blocks' ).addBlockCollection( namespace, title, icon );
+	dispatch( blocksStore ).addBlockCollection( namespace, title, icon );
 }
 
 /**
@@ -298,7 +299,7 @@ export function registerBlockCollection( namespace, { title, icon } ) {
  *
  */
 export function unregisterBlockCollection( namespace ) {
-	dispatch( 'core/blocks' ).removeBlockCollection( namespace );
+	dispatch( blocksStore ).removeBlockCollection( namespace );
 }
 
 /**
@@ -310,12 +311,12 @@ export function unregisterBlockCollection( namespace ) {
  *                    unregistered; otherwise `undefined`.
  */
 export function unregisterBlockType( name ) {
-	const oldBlock = select( 'core/blocks' ).getBlockType( name );
+	const oldBlock = select( blocksStore ).getBlockType( name );
 	if ( ! oldBlock ) {
 		console.error( 'Block "' + name + '" is not registered.' );
 		return;
 	}
-	dispatch( 'core/blocks' ).removeBlockTypes( name );
+	dispatch( blocksStore ).removeBlockTypes( name );
 	return oldBlock;
 }
 
@@ -325,7 +326,7 @@ export function unregisterBlockType( name ) {
  * @param {string} blockName Block name.
  */
 export function setFreeformContentHandlerName( blockName ) {
-	dispatch( 'core/blocks' ).setFreeformFallbackBlockName( blockName );
+	dispatch( blocksStore ).setFreeformFallbackBlockName( blockName );
 }
 
 /**
@@ -335,7 +336,7 @@ export function setFreeformContentHandlerName( blockName ) {
  * @return {?string} Block name.
  */
 export function getFreeformContentHandlerName() {
-	return select( 'core/blocks' ).getFreeformFallbackBlockName();
+	return select( blocksStore ).getFreeformFallbackBlockName();
 }
 
 /**
@@ -344,7 +345,7 @@ export function getFreeformContentHandlerName() {
  * @return {?string} Block name.
  */
 export function getGroupingBlockName() {
-	return select( 'core/blocks' ).getGroupingBlockName();
+	return select( blocksStore ).getGroupingBlockName();
 }
 
 /**
@@ -353,7 +354,7 @@ export function getGroupingBlockName() {
  * @param {string} blockName Block name.
  */
 export function setUnregisteredTypeHandlerName( blockName ) {
-	dispatch( 'core/blocks' ).setUnregisteredFallbackBlockName( blockName );
+	dispatch( blocksStore ).setUnregisteredFallbackBlockName( blockName );
 }
 
 /**
@@ -363,7 +364,7 @@ export function setUnregisteredTypeHandlerName( blockName ) {
  * @return {?string} Block name.
  */
 export function getUnregisteredTypeHandlerName() {
-	return select( 'core/blocks' ).getUnregisteredFallbackBlockName();
+	return select( blocksStore ).getUnregisteredFallbackBlockName();
 }
 
 /**
@@ -372,7 +373,7 @@ export function getUnregisteredTypeHandlerName() {
  * @param {string} name Block name.
  */
 export function setDefaultBlockName( name ) {
-	dispatch( 'core/blocks' ).setDefaultBlockName( name );
+	dispatch( blocksStore ).setDefaultBlockName( name );
 }
 
 /**
@@ -381,7 +382,7 @@ export function setDefaultBlockName( name ) {
  * @param {string} name Block name.
  */
 export function setGroupingBlockName( name ) {
-	dispatch( 'core/blocks' ).setGroupingBlockName( name );
+	dispatch( blocksStore ).setGroupingBlockName( name );
 }
 
 /**
@@ -390,7 +391,7 @@ export function setGroupingBlockName( name ) {
  * @return {?string} Block name.
  */
 export function getDefaultBlockName() {
-	return select( 'core/blocks' ).getDefaultBlockName();
+	return select( blocksStore ).getDefaultBlockName();
 }
 
 /**
@@ -401,7 +402,7 @@ export function getDefaultBlockName() {
  * @return {?Object} Block type.
  */
 export function getBlockType( name ) {
-	return select( 'core/blocks' ).getBlockType( name );
+	return select( blocksStore ).getBlockType( name );
 }
 
 /**
@@ -410,7 +411,7 @@ export function getBlockType( name ) {
  * @return {Array} Block settings.
  */
 export function getBlockTypes() {
-	return select( 'core/blocks' ).getBlockTypes();
+	return select( blocksStore ).getBlockTypes();
 }
 
 /**
@@ -424,7 +425,7 @@ export function getBlockTypes() {
  * @return {?*} Block support value
  */
 export function getBlockSupport( nameOrType, feature, defaultSupports ) {
-	return select( 'core/blocks' ).getBlockSupport(
+	return select( blocksStore ).getBlockSupport(
 		nameOrType,
 		feature,
 		defaultSupports
@@ -442,7 +443,7 @@ export function getBlockSupport( nameOrType, feature, defaultSupports ) {
  * @return {boolean} Whether block supports feature.
  */
 export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
-	return select( 'core/blocks' ).hasBlockSupport(
+	return select( blocksStore ).hasBlockSupport(
 		nameOrType,
 		feature,
 		defaultSupports
@@ -470,7 +471,7 @@ export function isReusableBlock( blockOrType ) {
  * @return {Array} Array of child block names.
  */
 export const getChildBlockNames = ( blockName ) => {
-	return select( 'core/blocks' ).getChildBlockNames( blockName );
+	return select( blocksStore ).getChildBlockNames( blockName );
 };
 
 /**
@@ -481,7 +482,7 @@ export const getChildBlockNames = ( blockName ) => {
  * @return {boolean} True if a block contains child blocks and false otherwise.
  */
 export const hasChildBlocks = ( blockName ) => {
-	return select( 'core/blocks' ).hasChildBlocks( blockName );
+	return select( blocksStore ).hasChildBlocks( blockName );
 };
 
 /**
@@ -493,9 +494,7 @@ export const hasChildBlocks = ( blockName ) => {
  *                   and false otherwise.
  */
 export const hasChildBlocksWithInserterSupport = ( blockName ) => {
-	return select( 'core/blocks' ).hasChildBlocksWithInserterSupport(
-		blockName
-	);
+	return select( blocksStore ).hasChildBlocksWithInserterSupport( blockName );
 };
 
 /**
@@ -505,7 +504,7 @@ export const hasChildBlocksWithInserterSupport = ( blockName ) => {
  * @param {Object} styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
  */
 export const registerBlockStyle = ( blockName, styleVariation ) => {
-	dispatch( 'core/blocks' ).addBlockStyles( blockName, styleVariation );
+	dispatch( blocksStore ).addBlockStyles( blockName, styleVariation );
 };
 
 /**
@@ -515,10 +514,7 @@ export const registerBlockStyle = ( blockName, styleVariation ) => {
  * @param {string} styleVariationName Name of class applied to the block.
  */
 export const unregisterBlockStyle = ( blockName, styleVariationName ) => {
-	dispatch( 'core/blocks' ).removeBlockStyles(
-		blockName,
-		styleVariationName
-	);
+	dispatch( blocksStore ).removeBlockStyles( blockName, styleVariationName );
 };
 
 /**
@@ -530,7 +526,7 @@ export const unregisterBlockStyle = ( blockName, styleVariationName ) => {
  * @return {(WPBlockVariation[]|void)} Block variations.
  */
 export const getBlockVariations = ( blockName, scope ) => {
-	return select( 'core/blocks' ).getBlockVariations( blockName, scope );
+	return select( blocksStore ).getBlockVariations( blockName, scope );
 };
 
 /**
@@ -540,7 +536,7 @@ export const getBlockVariations = ( blockName, scope ) => {
  * @param {WPBlockVariation} variation Object describing a block variation.
  */
 export const registerBlockVariation = ( blockName, variation ) => {
-	dispatch( 'core/blocks' ).addBlockVariations( blockName, variation );
+	dispatch( blocksStore ).addBlockVariations( blockName, variation );
 };
 
 /**
@@ -550,5 +546,5 @@ export const registerBlockVariation = ( blockName, variation ) => {
  * @param {string} variationName Name of the variation defined for the block.
  */
 export const unregisterBlockVariation = ( blockName, variationName ) => {
-	dispatch( 'core/blocks' ).removeBlockVariations( blockName, variationName );
+	dispatch( blocksStore ).removeBlockVariations( blockName, variationName );
 };

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -37,6 +37,7 @@ import {
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '../registration';
 import { DEPRECATED_ENTRY_KEYS } from '../constants';
+import { store as blocksStore } from '../../store';
 
 describe( 'blocks', () => {
 	const defaultBlockSettings = {
@@ -732,7 +733,7 @@ describe( 'blocks', () => {
 		it( 'creates a new block collection', () => {
 			registerBlockCollection( 'core', { title: 'Core' } );
 
-			expect( select( 'core/blocks' ).getCollections() ).toEqual( {
+			expect( select( blocksStore ).getCollections() ).toEqual( {
 				core: { title: 'Core', icon: undefined },
 			} );
 		} );
@@ -744,7 +745,7 @@ describe( 'blocks', () => {
 			registerBlockCollection( 'core2', { title: 'Core2' } );
 			unregisterBlockCollection( 'core' );
 
-			expect( select( 'core/blocks' ).getCollections() ).toEqual( {
+			expect( select( blocksStore ).getCollections() ).toEqual( {
 				core2: { title: 'Core2', icon: undefined },
 			} );
 		} );

--- a/packages/blocks/src/store/constants.js
+++ b/packages/blocks/src/store/constants.js
@@ -1,0 +1,1 @@
+export const STORE_NAME = 'core/blocks';

--- a/packages/blocks/src/store/index.js
+++ b/packages/blocks/src/store/index.js
@@ -9,8 +9,7 @@ import { createReduxStore, register } from '@wordpress/data';
 import reducer from './reducer';
 import * as selectors from './selectors';
 import * as actions from './actions';
-
-const STORE_NAME = 'core/blocks';
+import { STORE_NAME } from './constants';
 
 /**
  * Store definition for the blocks namespace.

--- a/packages/edit-post/src/components/manage-blocks-modal/manager.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/manager.js
@@ -6,6 +6,7 @@ import { filter, includes, isArray } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { withSelect } from '@wordpress/data';
 import { compose, withState } from '@wordpress/compose';
 import { TextControl } from '@wordpress/components';
@@ -102,7 +103,7 @@ export default compose( [
 			getCategories,
 			hasBlockSupport,
 			isMatchingSearchTerm,
-		} = select( 'core/blocks' );
+		} = select( blocksStore );
 		const { getPreference } = select( 'core/edit-post' );
 		const hiddenBlockTypes = getPreference( 'hiddenBlockTypes' );
 		const numberOfHiddenBlocks =

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -7,6 +7,7 @@ import { size, map, without, omit } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import {
 	EditorProvider,
@@ -169,7 +170,7 @@ export default compose( [
 			__experimentalGetPreviewDeviceType,
 		} = select( 'core/edit-post' );
 		const { getEntityRecord } = select( 'core' );
-		const { getBlockTypes } = select( 'core/blocks' );
+		const { getBlockTypes } = select( blocksStore );
 
 		return {
 			hasFixedToolbar:

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -10,7 +10,12 @@ import { I18nManager } from 'react-native';
  */
 import { Component } from '@wordpress/element';
 import { EditorProvider } from '@wordpress/editor';
-import { parse, serialize, rawHandler } from '@wordpress/blocks';
+import {
+	parse,
+	serialize,
+	rawHandler,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { subscribeSetFocusOnTitle } from '@wordpress/react-native-bridge';
@@ -167,7 +172,7 @@ export default compose( [
 			getPreference,
 			__experimentalGetPreviewDeviceType,
 		} = select( 'core/edit-post' );
-		const { getBlockTypes } = select( 'core/blocks' );
+		const { getBlockTypes } = select( blocksStore );
 
 		return {
 			hasFixedToolbar:

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -13,7 +13,10 @@ import {
 	useEffect,
 	useMemo,
 } from '@wordpress/element';
-import { __EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY } from '@wordpress/blocks';
+import {
+	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -118,7 +121,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 	const [ content, setContent ] = useGlobalStylesEntityContent();
 	const { blockTypes, settings } = useSelect( ( select ) => {
 		return {
-			blockTypes: select( 'core/blocks' ).getBlockTypes(),
+			blockTypes: select( blocksStore ).getBlockTypes(),
 			settings: select( 'core/edit-site' ).getSettings(),
 		};
 	} );

--- a/packages/editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/editor/src/components/convert-to-group-buttons/index.js
@@ -3,7 +3,7 @@
  */
 import { MenuItem } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
-import { switchToBlockType } from '@wordpress/blocks';
+import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { BlockSettingsMenuControls } from '@wordpress/block-editor';
@@ -60,7 +60,7 @@ export default compose( [
 			getSelectedBlockClientIds,
 		} = select( 'core/block-editor' );
 
-		const { getGroupingBlockName } = select( 'core/blocks' );
+		const { getGroupingBlockName } = select( blocksStore );
 
 		const clientIds = getSelectedBlockClientIds();
 		const groupingBlockName = getGroupingBlockName();

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -6,6 +6,7 @@ import { pickBy, mapValues, isEmpty, mapKeys } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { select as globalSelect, useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
@@ -135,7 +136,7 @@ addFilter(
 //
 // In the future, we could support updating block settings, at which point this
 // implementation could use that mechanism instead.
-globalSelect( 'core/blocks' )
+globalSelect( blocksStore )
 	.getBlockTypes()
-	.map( ( { name } ) => globalSelect( 'core/blocks' ).getBlockType( name ) )
+	.map( ( { name } ) => globalSelect( blocksStore ).getBlockType( name ) )
 	.forEach( shimAttributeSource );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addresses #27088. Replaces the `core/blocks` store name references (hardcoded strings) with the exposed `store` definitions. Had to change some `core/blocks` unit tests too, since they're testing the exposed definition now.

## How has this been tested?
Just making sure `npm run test` wasn't failing.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![blocks_unit_tests](https://user-images.githubusercontent.com/18705930/100466357-8c870100-30af-11eb-936d-762ecbab1fa6.png)

## Types of changes
Code refactoring, non-breaking change.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
