### PR TITLE
Verse Block: Adds support for custom padding

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -342,6 +342,7 @@ These are the current color properties supported by blocks:
 | --- | --- |
 | Cover | Yes |
 | Group | Yes |
+| Verse | Yes |
 
 #### Typography Properties
 

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -10,12 +10,24 @@
 			"default": "",
 			"__unstablePreserveWhiteSpace": true
 		},
+		"style": {
+			"default": {
+				"spacing": {
+					"padding": {
+						"default": 20
+					}
+				}
+			}
+		},
 		"textAlign": {
 			"type": "string"
 		}
 	},
 	"supports": {
 		"anchor": true,
-		"__experimentalFontFamily": true
+		"__experimentalFontFamily": true,
+		"spacing": {
+			"padding": true
+		}
 	}
 }

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -14,7 +14,10 @@
 			"default": {
 				"spacing": {
 					"padding": {
-						"default": 20
+						"top": 20,
+						"right": 20,
+						"bottom": 20,
+						"left": 20
 					}
 				}
 			}

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -2,6 +2,5 @@ pre.wp-block-verse {
 	color: $gray-900;
 	white-space: nowrap;
 	font-size: inherit;
-	padding: 1em;
 	overflow: auto;
 }

--- a/packages/e2e-tests/fixtures/blocks/core__verse.html
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.html
@@ -1,3 +1,3 @@
-<!-- wp:core/verse -->
-<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
-<!-- /wp:core/verse -->
+<!-- wp:verse -->
+<pre class="wp-block-verse" style="padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -4,7 +4,14 @@
         "name": "core/verse",
         "isValid": true,
         "attributes": {
-            "content": "A <em>verse</em>…<br>And more!"
+            "content": "A <em>verse</em>…<br>And more!",
+            "style": {
+                "spacing": {
+                    "padding": {
+                        "default": 20
+                    }
+                }
+            }
         },
         "innerBlocks": [],
         "originalContent": "<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -8,10 +8,10 @@
             "style": {
                 "spacing": {
                     "padding": {
-						"top": 20,
-						"right": 20,
-						"bottom": 20,
-						"left": 20
+                        "top": 20,
+                        "right": 20,
+                        "bottom": 20,
+                        "left": 20
                     }
                 }
             }

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -17,6 +17,6 @@
             }
         },
         "innerBlocks": [],
-        "originalContent": "<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"
+        "originalContent": "<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -8,7 +8,10 @@
             "style": {
                 "spacing": {
                     "padding": {
-                        "default": 20
+						"top": 20,
+						"right": 20,
+						"bottom": 20,
+						"left": 20
                     }
                 }
             }

--- a/packages/e2e-tests/fixtures/blocks/core__verse.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.parsed.json
@@ -3,9 +3,9 @@
         "blockName": "core/verse",
         "attrs": {},
         "innerBlocks": [],
-        "innerHTML": "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n",
+        "innerHTML": "\n<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>\n",
         "innerContent": [
-            "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n"
+            "\n<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>\n"
         ]
     },
     {

--- a/packages/e2e-tests/fixtures/blocks/core__verse.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:verse -->
-<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<pre class="wp-block-verse" style="padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px">A <em>verse</em>…<br>And more!</pre>
 <!-- /wp:verse -->


### PR DESCRIPTION
## Description
Adds support for custom padding to the Verse block. Also adds a default of 20px to match the padding that the editor adds. We might decide that to remove this padding.

## How has this been tested?
Tested in TT1 Blocks in Chrome.

## Screenshots <!-- if applicable -->
<img width="838" alt="Screenshot 2020-11-27 at 16 44 15" src="https://user-images.githubusercontent.com/275961/100470248-ccf67700-30cf-11eb-8bbf-6f71b1c15689.png">

## Types of changes
New feature 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
