### PR TITLE
Tag Cloud block: Adjust styles for the different block alignments

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -35,6 +35,7 @@
 @import "./social-links/style.scss";
 @import "./spacer/style.scss";
 @import "./subhead/style.scss";
+@import "./tag-cloud/style.scss";
 @import "./table/style.scss";
 @import "./text-columns/style.scss";
 @import "./video/style.scss";

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -4,7 +4,7 @@
 	}
 
 	&.alignfull {
-		padding-left: var(--global--spacing-unit, 20px);
-		padding-right: var(--global--spacing-unit, 20px);
+		padding-left: 1em;
+		padding-right: 1em;
 	}
 }

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -1,0 +1,10 @@
+.wp-block-tag-cloud {
+	&.aligncenter {
+		text-align: center;
+	}
+
+	&.alignfull {
+		padding-left: var(--global--spacing-unit, 20px);
+		padding-right: var(--global--spacing-unit, 20px);
+	}
+}


### PR DESCRIPTION
## Description
This adds CSS to the tag cloud block to add some styles when the block is aligned center or full.

We could add support for padding to this block in which case we'd want to make that the default probably.

## How has this been tested?
In TT1 Blocks

## Screenshots <!-- if applicable -->
Centered
<img width="837" alt="Screenshot 2020-11-27 at 18 33 13" src="https://user-images.githubusercontent.com/275961/100477010-05518180-30df-11eb-864c-6fa746ad97ef.png">

Full width
<img width="840" alt="Screenshot 2020-11-27 at 18 33 04" src="https://user-images.githubusercontent.com/275961/100477023-100c1680-30df-11eb-9c71-08ce28e8f859.png">


## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
