### PR TITLE
e2e: Fix multi entity editing test

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -137,11 +137,6 @@ const removeErrorMocks = () => {
 };
 
 describe( 'Multi-entity editor states', () => {
-	// Setup & Teardown.
-	const templateName = 'Front Page';
-	const templatePartName = 'Test Template Part Name Edit';
-	const nestedTPName = 'Test Nested Template Part Name Edit';
-
 	beforeAll( async () => {
 		await activateTheme( 'twentytwentyone-blocks' );
 		await trashAllPosts( 'wp_template' );
@@ -167,7 +162,7 @@ describe( 'Multi-entity editor states', () => {
 		expect( await isEntityDirty( 'front-page' ) ).toBe( false );
 
 		// Switch back and make sure it is still clean.
-		await clickTemplateItem( 'Templates', templateName );
+		await clickTemplateItem( 'Templates', 'Front Page' );
 		await page.waitForSelector( '.wp-block' );
 		expect( await isEntityDirty( 'header' ) ).toBe( false );
 		expect( await isEntityDirty( 'front-page' ) ).toBe( false );
@@ -176,6 +171,10 @@ describe( 'Multi-entity editor states', () => {
 	} );
 
 	describe( 'Multi-entity edit', () => {
+		const templatePartName = 'Test Template Part Name Edit';
+		const nestedTPName = 'Test Nested Template Part Name Edit';
+		const templateName = 'Custom Template';
+
 		beforeAll( async () => {
 			await trashAllPosts( 'wp_template' );
 			await trashAllPosts( 'wp_template_part' );
@@ -196,10 +195,18 @@ describe( 'Multi-entity editor states', () => {
 			);
 			await saveAllEntities();
 			await visitSiteEditor();
-			// Waits for the template part to load...
+
+			// Wait for site editor to load.
 			await page.waitForSelector(
 				'.wp-block-template-part .block-editor-block-list__layout'
 			);
+
+			// Our custom template shows up in the " templates > all" menu; let's use it.
+			clickTemplateItem( [ 'Templates', 'All' ], templateName );
+			await page.waitForXPath(
+				`//p[contains(@class, "edit-site-document-actions__title") and contains(text(), '${ templateName }')]`
+			);
+
 			removeErrorMocks();
 		} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In #27303, the behavior of template resolution was changed such that a custom manually-created user template no longer overrides a theme template which has the same slug. This breaks the test because the test assumes two things:
1. That the site editor will load the template used for the front page by default.
2. That a custom manually created template with the slug `front-page` will always be used instead of the theme template with the same slug.

These assumptions should not be taken by the test, so we need to make it more robust. The failure always seems unrelated since these PRs continue to be merged. :P This PR fixes the issue by using a user created custom template which doesn't correspond to the template hierarchy. This way, it's not possible for a theme file to conflict with it. This test is only concerned with making sure that entity save states work correctly, so this is a fine approach for this test.

We should also follow up to create tests which cover the template resolution hierarchy so that it is more obvious when we are breaking it in some way or another. Currently I don't think we cover template priorities at all with tests. We definitely shouldn't rely on some unrelated test to inform us when it is broken :P

## How has this been tested?
The multi entity editing test should pass. (I verified it does locally.)

## Screenshots <!-- if applicable -->

## Types of changes
Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
