### PR TITLE
Fix an issue with the serializer not ignoring attribute values of object attribute type when the value is equal to the default.

### DIFF
--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, isObject, castArray, startsWith } from 'lodash';
+import {
+	isEmpty,
+	reduce,
+	isObject,
+	castArray,
+	startsWith,
+	isEqual,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -219,7 +226,7 @@ export function getCommentAttributes( blockType, attributes ) {
 			// Ignore default value.
 			if (
 				'default' in attributeSchema &&
-				attributeSchema.default === value
+				isEqual( attributeSchema.default, value )
 			) {
 				return accumulator;
 			}

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -148,6 +148,28 @@ describe( 'block serializer', () => {
 
 			expect( attributes ).toEqual( { fruit: 'bananas' } );
 		} );
+
+		it( 'should skip attributes of type "object" whose values are equal to the default value of the attribute', () => {
+			const attributes = getCommentAttributes(
+				{
+					attributes: {
+						fruit: {
+							type: 'string',
+						},
+						ripeness: {
+							type: 'object',
+							default: {},
+						},
+					},
+				},
+				{
+					fruit: 'apples',
+					ripeness: {},
+				}
+			);
+
+			expect( attributes ).toEqual( { fruit: 'apples' } );
+		} );
 	} );
 
 	describe( 'serializeAttributes()', () => {

--- a/packages/e2e-tests/fixtures/blocks/core__gallery__deprecated-2.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__gallery__deprecated-2.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:gallery {"ids":[],"columns":2,"linkTo":"none","align":"wide"} -->
+<!-- wp:gallery {"columns":2,"linkTo":"none","align":"wide"} -->
 <figure class="wp-block-gallery alignwide columns-2 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title" data-id="1" class="wp-image-1"/></figure></li><li class="blocks-gallery-item"><figure><img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" alt="title" data-id="2" class="wp-image-2"/></figure></li></ul></figure>
 <!-- /wp:gallery -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
When an attribute is of type `object`, if its value is manipulated and ends up empty, it is always saved in the database no matter if the attribute has an empty object as a default value or not. Changing the way of comparing the actual value of the attribute with its default value, during attribute serialization can resolve the issue. Checking with `===` always returns false for `{} === {}` for known reason. Switching to `isEqual` seems to resolve the issue.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manual testing and unit tests.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This is a bug fix obviously.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
