### PR TITLE
Revert "Use default cursor in CustomSelectControl items"

### DIFF
--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -58,7 +58,6 @@
 
 .components-custom-select-control__item {
 	align-items: center;
-	cursor: default;
 	display: flex;
 	list-style-type: none;
 	padding: $grid-unit-10;


### PR DESCRIPTION
Reverts WordPress/gutenberg#20217

The same changes were added already 😅