### PR TITLE
Change the Labels of the Vertical Align options

### DIFF
--- a/packages/block-editor/src/components/block-vertical-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-toolbar/index.js
@@ -12,21 +12,15 @@ import { alignTop, alignCenter, alignBottom } from './icons';
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	top: {
 		icon: alignTop,
-		title: _x( 'Vertically Align Top', 'Block vertical alignment setting' ),
+		title: _x( 'Align top', 'Block vertical alignment setting' ),
 	},
 	center: {
 		icon: alignCenter,
-		title: _x(
-			'Vertically Align Middle',
-			'Block vertical alignment setting'
-		),
+		title: _x( 'Align middle', 'Block vertical alignment setting' ),
 	},
 	bottom: {
 		icon: alignBottom,
-		title: _x(
-			'Vertically Align Bottom',
-			'Block vertical alignment setting'
-		),
+		title: _x( 'Align bottom', 'Block vertical alignment setting' ),
 	},
 };
 

--- a/packages/block-editor/src/components/block-vertical-alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-vertical-alignment-toolbar/test/__snapshots__/index.js.snap
@@ -16,7 +16,7 @@ exports[`BlockVerticalAlignmentToolbar should match snapshot 1`] = `
         "isActive": true,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Vertically Align Top",
+        "title": "Align top",
       },
       Object {
         "icon": <SVG
@@ -30,7 +30,7 @@ exports[`BlockVerticalAlignmentToolbar should match snapshot 1`] = `
         "isActive": false,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Vertically Align Middle",
+        "title": "Align middle",
       },
       Object {
         "icon": <SVG
@@ -44,7 +44,7 @@ exports[`BlockVerticalAlignmentToolbar should match snapshot 1`] = `
         "isActive": false,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Vertically Align Bottom",
+        "title": "Align bottom",
       },
     ]
   }


### PR DESCRIPTION
Closes: #26729 

## Description
I changed the label of the Vertically Align Options.

## How has this been tested?
I have tested the changes on my Local Environment.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
