### PR TITLE
add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ phpcs.xml
 yarn.lock
 /wordpress
 /artifacts
+.idea
 
 playground/dist
 .cache


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Adding .idea catalog to .gitignore. 
.idea is an intelliJ / WebStrorm / PHPStorm dir with IDE configs.


## How has this been tested?
doesn't apply


## Types of changes
environmental update
