### PR TITLE
Adjusts settings modal height to 90%

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -36,7 +36,7 @@
 		left: 50%;
 		min-width: $modal-min-width;
 		max-width: calc(100% - #{ $grid-unit-20 } - #{ $grid-unit-20 });
-		max-height: calc(100% - #{ $header-height } - #{ $header-height });
+		max-height: 90%;
 		transform: translate(-50%, -50%);
 
 		// Animate the modal frame/contents appearing on the page.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Modal size has been improper - modal displayed too little content.
In issue https://github.com/WordPress/gutenberg/issues/22854 it was proposed to change the height to 90%


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested visually (minor css fix)
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
https://d.pr/free/i/lpTXeU

## Types of changes
CSS fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
