### PR TITLE
Fix combobox suggestion list closure when clicking scrollbar

### DIFF
--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -7,7 +7,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useState, useMemo, useRef, useEffect } from '@wordpress/element';
+import {
+	Component,
+	useState,
+	useMemo,
+	useRef,
+	useEffect,
+} from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { ENTER, UP, DOWN, ESCAPE } from '@wordpress/keycodes';
 import { speak } from '@wordpress/a11y';
@@ -21,6 +27,19 @@ import SuggestionsList from '../form-token-field/suggestions-list';
 import BaseControl from '../base-control';
 import Button from '../button';
 import { Flex, FlexBlock, FlexItem } from '../flex';
+import withFocusOutside from '../higher-order/with-focus-outside';
+
+const DetectOutside = withFocusOutside(
+	class extends Component {
+		handleFocusOutside( event ) {
+			this.props.onFocusOutside( event );
+		}
+
+		render() {
+			return this.props.children;
+		}
+	}
+);
 
 function ComboboxControl( {
 	value,
@@ -119,7 +138,7 @@ function ComboboxControl( {
 		setInputValue( '' );
 	};
 
-	const onBlur = () => {
+	const onFocusOutside = () => {
 		setIsExpanded( false );
 	};
 
@@ -160,63 +179,69 @@ function ComboboxControl( {
 	// TODO: Refactor click detection to use blur to stop propagation.
 	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
-		<BaseControl
-			className={ classnames( className, 'components-combobox-control' ) }
-			tabIndex="-1"
-			label={ label }
-			id={ `components-form-token-input-${ instanceId }` }
-			hideLabelFromVision={ hideLabelFromVision }
-			help={ help }
-		>
-			<div
-				className="components-combobox-control__suggestions-container"
+		<DetectOutside onFocusOutside={ onFocusOutside }>
+			<BaseControl
+				className={ classnames(
+					className,
+					'components-combobox-control'
+				) }
 				tabIndex="-1"
-				onKeyDown={ onKeyDown }
+				label={ label }
+				id={ `components-form-token-input-${ instanceId }` }
+				hideLabelFromVision={ hideLabelFromVision }
+				help={ help }
 			>
-				<Flex>
-					<FlexBlock>
-						<TokenInput
-							className="components-combobox-control__input"
+				<div
+					className="components-combobox-control__suggestions-container"
+					tabIndex="-1"
+					onKeyDown={ onKeyDown }
+				>
+					<Flex>
+						<FlexBlock>
+							<TokenInput
+								className="components-combobox-control__input"
+								instanceId={ instanceId }
+								ref={ inputContainer }
+								value={ isExpanded ? inputValue : currentLabel }
+								onFocus={ onFocus }
+								isExpanded={ isExpanded }
+								selectedSuggestionIndex={ matchingSuggestions.indexOf(
+									selectedSuggestion
+								) }
+								onChange={ onInputChange }
+							/>
+						</FlexBlock>
+						{ allowReset && (
+							<FlexItem>
+								<Button
+									className="components-combobox-control__reset"
+									icon={ closeSmall }
+									disabled={ ! value }
+									onClick={ handleOnReset }
+									label={ __( 'Reset' ) }
+								/>
+							</FlexItem>
+						) }
+					</Flex>
+					{ isExpanded && (
+						<SuggestionsList
 							instanceId={ instanceId }
-							ref={ inputContainer }
-							value={ isExpanded ? inputValue : currentLabel }
-							onBlur={ onBlur }
-							onFocus={ onFocus }
-							isExpanded={ isExpanded }
-							selectedSuggestionIndex={ matchingSuggestions.indexOf(
+							match={ { label: inputValue } }
+							displayTransform={ ( suggestion ) =>
+								suggestion.label
+							}
+							suggestions={ matchingSuggestions }
+							selectedIndex={ matchingSuggestions.indexOf(
 								selectedSuggestion
 							) }
-							onChange={ onInputChange }
+							onHover={ setSelectedSuggestion }
+							onSelect={ onSuggestionSelected }
+							scrollIntoView
 						/>
-					</FlexBlock>
-					{ allowReset && (
-						<FlexItem>
-							<Button
-								className="components-combobox-control__reset"
-								icon={ closeSmall }
-								disabled={ ! value }
-								onClick={ handleOnReset }
-								label={ __( 'Reset' ) }
-							/>
-						</FlexItem>
 					) }
-				</Flex>
-				{ isExpanded && (
-					<SuggestionsList
-						instanceId={ instanceId }
-						match={ { label: inputValue } }
-						displayTransform={ ( suggestion ) => suggestion.label }
-						suggestions={ matchingSuggestions }
-						selectedIndex={ matchingSuggestions.indexOf(
-							selectedSuggestion
-						) }
-						onHover={ setSelectedSuggestion }
-						onSelect={ onSuggestionSelected }
-						scrollIntoView
-					/>
-				) }
-			</div>
-		</BaseControl>
+				</div>
+			</BaseControl>
+		</DetectOutside>
 	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
First attempt at fixing #27283.

The bug is caused by ComboxBoxControl hiding the suggestions list whenever its input is blurred, e.g. when clicking on something in the suggestions list, a sibling HTML element.

This PR uses `withFocusOutside` to check for blur of the entire control rather than just the input.

The downside of `withFocusOutside` is that it adds an extra wrapping div around the component, which is kind of nasty. But in testing didn't seem to cause any styling issues.

I've separately looked at refactoring `withFocusOutside` to a hook (https://github.com/WordPress/gutenberg/pull/27369) so that we can lose the wrapping div, which I've had some success with, but this would then require lots of changes to BaseControl to accept various event handler props from the hook. Quite a big change for a backport to a WordPress 5.6 release candidate.

## How has this been tested?
1. Go to the page editor
2. Activate the parent page selector
3. Click on scrollbar to scroll down or up : the selector closes itself

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
