### PR TITLE
Packages: Remove package import statements in favor of store object usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17707,7 +17707,6 @@
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/primitives": "file:packages/primitives",
-				"@wordpress/reusable-blocks": "file:packages/reusable-blocks",
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"@wordpress/warning": "file:packages/warning",

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { controls } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
@@ -85,7 +86,7 @@ export function* installBlockType( block ) {
 
 		yield loadAssets( assets );
 		const registeredBlocks = yield controls.select(
-			'core/blocks',
+			blocksStore.name,
 			'getBlockTypes'
 		);
 		if ( ! registeredBlocks.some( ( i ) => i.name === block.name ) ) {

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { store as blocksStore } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import { installBlockType, uninstallBlockType } from '../actions';
@@ -80,7 +85,7 @@ describe( 'actions', () => {
 			expect( generator.next().value ).toEqual( {
 				args: [],
 				selectorName: 'getBlockTypes',
-				storeKey: 'core/blocks',
+				storeKey: blocksStore.name,
 				type: '@@data/SELECT',
 			} );
 
@@ -142,7 +147,7 @@ describe( 'actions', () => {
 			expect( generator.next().value ).toEqual( {
 				args: [],
 				selectorName: 'getBlockTypes',
-				storeKey: 'core/blocks',
+				storeKey: blocksStore.name,
 				type: '@@data/SELECT',
 			} );
 

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -1,9 +1,7 @@
 /**
  * WordPress dependencies
  */
-import '@wordpress/blocks';
 import '@wordpress/rich-text';
-import '@wordpress/keyboard-shortcuts';
 import '@wordpress/notices';
 
 /**

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -4,7 +4,6 @@
 import '@wordpress/core-data';
 import '@wordpress/notices';
 import '@wordpress/block-editor';
-import '@wordpress/reusable-blocks';
 import {
 	registerBlockType,
 	setDefaultBlockName,

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -46,7 +46,6 @@
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/primitives": "file:../primitives",
-		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/warning": "file:../warning",

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -4,8 +4,6 @@
 import '@wordpress/core-data';
 import '@wordpress/block-editor';
 import '@wordpress/editor';
-import '@wordpress/keyboard-shortcuts';
-import '@wordpress/reusable-blocks';
 import '@wordpress/notices';
 import {
 	registerCoreBlocks,

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -4,7 +4,6 @@
 import '@wordpress/core-data';
 import '@wordpress/notices';
 import '@wordpress/format-library';
-import '@wordpress/reusable-blocks';
 import { render } from '@wordpress/element';
 
 /**

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -12,7 +12,6 @@ import {
 	__experimentalGetCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
-import '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -2,11 +2,8 @@
  * WordPress dependencies
  */
 import '@wordpress/block-editor';
-import '@wordpress/blocks';
 import '@wordpress/core-data';
-import '@wordpress/keyboard-shortcuts';
 import '@wordpress/notices';
-import '@wordpress/reusable-blocks';
 import '@wordpress/rich-text';
 
 /**

--- a/packages/editor/src/index.native.js
+++ b/packages/editor/src/index.native.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import '@wordpress/block-editor';
-import '@wordpress/blocks';
 import '@wordpress/core-data';
 import '@wordpress/rich-text';
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related to #27088.

It's a general cleanup PR that remove package import statements in favor of store object usage for refactored stores.

## Testing

Nothing particular specific on my mind here:
`npm run lint-js`
`npm run test-unit`
`npm run test-e2e`

You also might want to test manually whether Block Directory still works as expected. To do so, open a block inserter and type the name of the block that doesn't ship with Gutenberg core like: `boxer`. You should be able to install it and insert through the inserter.