### PR TITLE
Repositioned RangeControl tooltip and adjusted image zoom control dropdown height

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -112,7 +112,6 @@ figure.wp-block-image:not(.wp-block) {
 	.components-popover__content {
 		overflow: visible;
 		min-width: 260px;
-		min-height: 110px;
 	}
 
 	.components-range-control {

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -112,6 +112,7 @@ figure.wp-block-image:not(.wp-block) {
 	.components-popover__content {
 		overflow: visible;
 		min-width: 260px;
+		min-height: 110px;
 	}
 
 	.components-range-control {

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -265,6 +265,7 @@ function RangeControl(
 						<SimpleTooltip
 							className="components-range-control__tooltip"
 							inputRef={ inputRef }
+							tooltipPosition="bottom"
 							renderTooltipContent={ renderTooltipContent }
 							show={ isCurrentlyFocused || showTooltip }
 							style={ offsetStyle }

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -249,16 +249,16 @@ const tooltipShow = ( { show } ) => {
 };
 
 const tooltipPosition = ( { position } ) => {
-	const isTop = position === 'top';
+	const isBottom = position === 'bottom';
 
-	if ( isTop ) {
+	if ( isBottom ) {
 		return css`
-			top: -80%;
+			bottom: -80%;
 		`;
 	}
 
 	return css`
-		bottom: -80%;
+		top: -80%;
 	`;
 };
 

--- a/packages/components/src/range-control/tooltip.js
+++ b/packages/components/src/range-control/tooltip.js
@@ -50,17 +50,17 @@ export default function SimpleTooltip( {
 }
 
 function useTooltipPosition( { inputRef, position: positionProp } ) {
-	const [ position, setPosition ] = useState( 'top' );
+	const [ position, setPosition ] = useState( 'bottom' );
 
 	const calculatePosition = useCallback( () => {
 		if ( inputRef && inputRef.current ) {
 			let nextPosition = positionProp;
 
 			if ( positionProp === 'auto' ) {
-				const { top } = inputRef.current.getBoundingClientRect();
-				const isOffscreenTop = top - TOOLTIP_OFFSET_HEIGHT < 0;
+				const { bottom } = inputRef.current.getBoundingClientRect();
+				const isOffscreenBottom = bottom - TOOLTIP_OFFSET_HEIGHT < 0;
 
-				nextPosition = isOffscreenTop ? 'bottom' : 'top';
+				nextPosition = isOffscreenBottom ? 'top' : 'bottom';
 			}
 
 			setPosition( nextPosition );

--- a/packages/components/src/range-control/tooltip.js
+++ b/packages/components/src/range-control/tooltip.js
@@ -14,12 +14,10 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  */
 import { Tooltip } from './styles/range-control-styles';
 
-const TOOLTIP_OFFSET_HEIGHT = 32;
-
 export default function SimpleTooltip( {
 	className,
 	inputRef,
-	position: positionProp = 'auto',
+	tooltipPosition,
 	show = false,
 	style = {},
 	value = 0,
@@ -27,7 +25,7 @@ export default function SimpleTooltip( {
 	zIndex = 100,
 	...restProps
 } ) {
-	const position = useTooltipPosition( { inputRef, position: positionProp } );
+	const position = useTooltipPosition( { inputRef, tooltipPosition } );
 	const classes = classnames( 'components-simple-tooltip', className );
 	const styles = {
 		...style,
@@ -49,33 +47,24 @@ export default function SimpleTooltip( {
 	);
 }
 
-function useTooltipPosition( { inputRef, position: positionProp } ) {
-	const [ position, setPosition ] = useState( 'bottom' );
+function useTooltipPosition( { inputRef, tooltipPosition } ) {
+	const [ position, setPosition ] = useState();
 
-	const calculatePosition = useCallback( () => {
+	const setTooltipPosition = useCallback( () => {
 		if ( inputRef && inputRef.current ) {
-			let nextPosition = positionProp;
-
-			if ( positionProp === 'auto' ) {
-				const { bottom } = inputRef.current.getBoundingClientRect();
-				const isOffscreenBottom = bottom - TOOLTIP_OFFSET_HEIGHT < 0;
-
-				nextPosition = isOffscreenBottom ? 'top' : 'bottom';
-			}
-
-			setPosition( nextPosition );
+			setPosition( tooltipPosition );
 		}
-	}, [ positionProp ] );
+	}, [ tooltipPosition ] );
 
 	useEffect( () => {
-		calculatePosition();
-	}, [ calculatePosition ] );
+		setTooltipPosition();
+	}, [ setTooltipPosition ] );
 
 	useEffect( () => {
-		window.addEventListener( 'resize', calculatePosition );
+		window.addEventListener( 'resize', setTooltipPosition );
 
 		return () => {
-			window.removeEventListener( 'resize', calculatePosition );
+			window.removeEventListener( 'resize', setTooltipPosition );
 		};
 	} );
 


### PR DESCRIPTION
## Description
- Repositioned RangeControl tooltip to the bottom so that it doesn't obscure labels.
- Adjusted Image block zoom control dropdown height to accommodate RangeControl tooltip's new position.

## How has this been tested?
- I've tested the changes on Chrome and simulated different devices and it works as intended.
- I've run unit tests.

## Screenshots 
<img width="280" alt="Screenshot 2020-11-30 at 03 18 14" src="https://user-images.githubusercontent.com/23191929/100557996-68990a80-32bd-11eb-821b-7319c9016b1a.png">


## Types of changes
This is a Bug Fix that introduces changes that affect the positioning of the RangeControl's tooltip to prevent it from obscuring labels. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Fixes [#27261](https://github.com/WordPress/gutenberg/issues/27261)