### PR TITLE
Increase radio dimensions to match checkboxes

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -360,19 +360,14 @@
 	border-radius: $radius-round;
 
 	&:checked::before {
-		width: 7px;
-		height: 7px;
-		margin: 8px 0 0 8px;
+		width: 50%;
+		height: 50%;
+		transform: translate(50%, 50%);
+		margin: 0;
 		background-color: $white;
 
 		// This border serves as a background color in Windows High Contrast mode.
 		border: 3px solid $white;
-
-		@include break-medium() {
-			width: 6px;
-			height: 6px;
-			margin: 4px 0 0 4px;
-		}
 	}
 
 	&:focus {

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -358,6 +358,13 @@
 	margin-right: $grid-unit-15;
 	transition: none;
 	border-radius: $radius-round;
+	width: $radio-input-size-sm;
+	height: $radio-input-size-sm;
+
+	@include break-small() {
+		height: $radio-input-size;
+		width: $radio-input-size;
+	}
 
 	&:checked::before {
 		width: 50%;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -367,14 +367,18 @@
 	}
 
 	&:checked::before {
-		width: 50%;
-		height: 50%;
-		transform: translate(50%, 50%);
+		width: 8px;
+		height: 8px;
+		transform: translate(7px, 7px);
 		margin: 0;
 		background-color: $white;
 
 		// This border serves as a background color in Windows High Contrast mode.
-		border: 3px solid $white;
+		border: 4px solid $white;
+
+		@include break-small() {
+			transform: translate(5px, 5px);
+		}
 	}
 
 	&:focus {

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -19,6 +19,8 @@ $border-width: 1px;
 $border-width-focus: 1.5px;
 $border-width-tab: 4px;
 $helptext-font-size: 12px;
+$radio-input-size: 20px;
+$radio-input-size-sm: 24px; // Width & height for small viewports.
 
 /**
  * Grid System.

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -1,3 +1,6 @@
+$radio-input-size: 20px;
+$radio-input-size-sm: 24px; // Width & height for small viewports.
+
 .components-radio-control {
 	display: flex;
 	flex-direction: column;
@@ -19,4 +22,11 @@
 	@include radio-control;
 	margin-top: 0;
 	margin-right: 6px;
+	width: $checkbox-input-size-sm;
+	height: $checkbox-input-size-sm;
+
+	@include break-small() {
+		height: $checkbox-input-size;
+		width: $checkbox-input-size;
+	}
 }

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -1,6 +1,3 @@
-$radio-input-size: 20px;
-$radio-input-size-sm: 24px; // Width & height for small viewports.
-
 .components-radio-control {
 	display: flex;
 	flex-direction: column;
@@ -22,11 +19,4 @@ $radio-input-size-sm: 24px; // Width & height for small viewports.
 	@include radio-control;
 	margin-top: 0;
 	margin-right: 6px;
-	width: $checkbox-input-size-sm;
-	height: $checkbox-input-size-sm;
-
-	@include break-small() {
-		height: $checkbox-input-size;
-		width: $checkbox-input-size;
-	}
 }

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -13,6 +13,7 @@
 	.editor-post-visibility__dialog-radio[type="radio"] {
 		@include radio-control;
 		margin-top: 2px;
+		//margin-right: 8px;
 	}
 
 	.editor-post-visibility__dialog-label {
@@ -21,16 +22,20 @@
 
 	.editor-post-visibility__dialog-info {
 		margin-top: 0;
-		margin-left: 28px;
+		//margin-left: 28px;
+		margin-left: $grid-unit-40;
 	}
 
 	// Remove bottom margin on the last label only.
 	.editor-post-visibility__choice:last-child .editor-post-visibility__dialog-info {
 		margin-bottom: 0;
 	}
+}
 
+.editor-post-visibility__dialog-password {
 	.editor-post-visibility__dialog-password-input[type="text"] {
 		@include input-control;
-		margin-left: 28px;
+		margin-left: $grid-unit * 4.5;
+		margin-top: $grid-unit-10;
 	}
 }

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -13,7 +13,6 @@
 	.editor-post-visibility__dialog-radio[type="radio"] {
 		@include radio-control;
 		margin-top: 2px;
-		//margin-right: 8px;
 	}
 
 	.editor-post-visibility__dialog-label {
@@ -22,7 +21,6 @@
 
 	.editor-post-visibility__dialog-info {
 		margin-top: 0;
-		//margin-left: 28px;
 		margin-left: $grid-unit-40;
 	}
 


### PR DESCRIPTION
The dimensions of radio inputs is currently 16px while checkboxes are 20px. This PR updates radios to match checkboxes.

Before:

<img width="280" alt="Screenshot 2020-11-30 at 13 03 06" src="https://user-images.githubusercontent.com/846565/100617077-e424a700-3311-11eb-8f02-0d42060a3411.png">

After:

<img width="280" alt="Screenshot 2020-11-30 at 13 35 57" src="https://user-images.githubusercontent.com/846565/100617103-eedf3c00-3311-11eb-8869-538f4c0fc8da.png">
<img width="275" alt="Screenshot 2020-11-30 at 13 37 22" src="https://user-images.githubusercontent.com/846565/100617106-f0106900-3311-11eb-88cd-fb634b580daa.png">