### PR TITLE
Search Block: Remove the button only option from the UI

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -221,17 +221,6 @@ export default function SearchEdit( {
 								>
 									{ __( 'Button Inside' ) }
 								</MenuItem>
-								<MenuItem
-									icon={ buttonOnly }
-									onClick={ () => {
-										setAttributes( {
-											buttonPosition: 'button-only',
-										} );
-										onClose();
-									} }
-								>
-									{ __( 'Button Only' ) }
-								</MenuItem>
 							</MenuGroup>
 						) }
 					</DropdownMenu>


### PR DESCRIPTION
Fixes #27329 

## Description
<!-- Please describe what you have changed or added -->
Remove the "Button Only" option from the UI of the search block until this can be wired up to something that works on the front end of the site. This could either be a slide out search box, or even a full screen search overlay. Until then this will confuse users since the button doesn't do anything.

The code to support this has been left in since folks may have used it in the plugin version. Once this is wired up it could easily be added back to the UI as a menu option.

**Before**

<img width="652" alt="Screen Shot 2020-11-30 at 9 46 25 AM" src="https://user-images.githubusercontent.com/1464705/100645034-f93d0e00-32f0-11eb-80e2-2c7065ec99cd.png">

**After**

<img width="655" alt="Screen Shot 2020-11-30 at 9 45 02 AM" src="https://user-images.githubusercontent.com/1464705/100645039-fcd09500-32f0-11eb-8f20-db277ffeb0f8.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested locally, tests passing.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
