### PR TITLE
ESLint Plugin: Enable import rules used in Gutenberg

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,6 @@ module.exports = {
 		'plugin:@wordpress/eslint-plugin/recommended',
 		'plugin:eslint-comments/recommended',
 	],
-	plugins: [ 'import' ],
 	globals: {
 		wp: 'off',
 	},
@@ -124,14 +123,10 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ 'packages/**/*.js' ],
-			excludedFiles: [
-				'**/*.@(android|ios|native).js',
-				...developmentFiles,
-			],
+			files: [ '**/*.@(android|ios|native).js', ...developmentFiles ],
 			rules: {
-				'import/no-extraneous-dependencies': 'error',
-				'import/no-unresolved': 'error',
+				'import/no-extraneous-dependencies': 'off',
+				'import/no-unresolved': 'off',
 			},
 		},
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -169,15 +169,9 @@ module.exports = {
 			},
 		},
 		{
-			files: [ '@(bin|docs)/**/*.js', '*.js' ],
+			files: [ 'bin/**/*.js' ],
 			rules: {
 				'no-console': 'off',
-				'import/no-extraneous-dependencies': [
-					'error',
-					{
-						devDependencies: true,
-					},
-				],
 			},
 		},
 	],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -169,9 +169,15 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'bin/**/*.js' ],
+			files: [ '@(bin|docs)/**/*.js', '*.js' ],
 			rules: {
 				'no-console': 'off',
+				'import/no-extraneous-dependencies': [
+					'error',
+					{
+						devDependencies: true,
+					},
+				],
 			},
 		},
 	],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11891,6 +11891,24 @@
 			"requires": {
 				"json2php": "^0.0.4",
 				"webpack-sources": "^1.3.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"webpack-sources": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
+					}
+				}
 			}
 		},
 		"@wordpress/deprecated": {
@@ -12315,6 +12333,24 @@
 			"requires": {
 				"lodash": "^4.17.19",
 				"webpack-sources": "^1.1.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"webpack-sources": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
+					}
+				}
 			}
 		},
 		"@wordpress/list-reusable-blocks": {
@@ -12584,9 +12620,10 @@
 				"thread-loader": "^2.1.3",
 				"url-loader": "^3.0.0",
 				"webpack": "^4.42.0",
-				"webpack-bundle-analyzer": "^3.6.1",
+				"webpack-bundle-analyzer": "^4.2.0",
 				"webpack-cli": "^3.3.11",
-				"webpack-livereload-plugin": "^2.3.0"
+				"webpack-livereload-plugin": "^2.3.0",
+				"webpack-sources": "^2.2.0"
 			}
 		},
 		"@wordpress/server-side-render": {
@@ -22533,26 +22570,6 @@
 				}
 			}
 		},
-		"bfj": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
-			"integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
-			"dev": true,
-			"requires": {
-				"bluebird": "^3.5.5",
-				"check-types": "^8.0.3",
-				"hoopy": "^0.1.4",
-				"tryer": "^1.0.1"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-					"dev": true
-				}
-			}
-		},
 		"big-integer": {
 			"version": "1.6.48",
 			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
@@ -23504,12 +23521,6 @@
 					"dev": true
 				}
 			}
-		},
-		"check-types": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
-			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
-			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.3",
@@ -26482,12 +26493,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"ejs": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-			"integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-			"dev": true
 		},
 		"electron-to-chromium": {
 			"version": "1.3.629",
@@ -29687,9 +29692,9 @@
 			}
 		},
 		"filesize": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
+			"integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
 			"dev": true
 		},
 		"fill-range": {
@@ -31408,12 +31413,6 @@
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
-		},
-		"hoopy": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
-			"dev": true
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -40589,6 +40588,22 @@
 					"requires": {
 						"is-plain-obj": "^1.0.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"webpack-sources": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
+					}
 				}
 			}
 		},
@@ -42521,9 +42536,9 @@
 			"dev": true
 		},
 		"opener": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
 			"dev": true
 		},
 		"optimist": {
@@ -52700,12 +52715,6 @@
 			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
 			"dev": true
 		},
-		"tryer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
-			"dev": true
-		},
 		"ts-dedent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.0.0.tgz",
@@ -54016,48 +54025,110 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.1.tgz",
-			"integrity": "sha512-Nfd8HDwfSx1xBwC+P8QMGvHAOITxNBSvu/J/mCJvOwv+G4VWkU7zir9SSenTtyCi0LnVtmsc7G5SZo1uV+bxRw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.2.0.tgz",
+			"integrity": "sha512-gmjpdL/AJeGAftSzA+bjIPiChUffjBelcH2+3woCUiRpQfuwrTJuWRyZuqegiwBAroMJp7gIwcJaGeol039zbQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.1",
-				"acorn-walk": "^7.1.1",
-				"bfj": "^6.1.1",
-				"chalk": "^2.4.1",
-				"commander": "^2.18.0",
-				"ejs": "^2.6.1",
-				"express": "^4.16.3",
-				"filesize": "^3.6.1",
-				"gzip-size": "^5.0.0",
-				"lodash": "^4.17.15",
-				"mkdirp": "^0.5.1",
-				"opener": "^1.5.1",
-				"ws": "^6.0.0"
+				"acorn": "^8.0.4",
+				"acorn-walk": "^8.0.0",
+				"chalk": "^4.1.0",
+				"commander": "^6.2.0",
+				"express": "^4.17.1",
+				"filesize": "^6.1.0",
+				"gzip-size": "^6.0.0",
+				"lodash": "^4.17.20",
+				"opener": "^1.5.2",
+				"ws": "^7.3.1"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-					"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+					"version": "8.0.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
+					"integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==",
 					"dev": true
 				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+				"acorn-walk": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.0.tgz",
+					"integrity": "sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"color-convert": "^2.0.1"
 					}
 				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
+				},
+				"commander": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+					"integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+					"dev": true
+				},
+				"duplexer": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+					"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+					"dev": true
+				},
+				"gzip-size": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+					"integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+					"dev": true,
+					"requires": {
+						"duplexer": "^0.1.2"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
@@ -54496,15 +54567,21 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
+			"integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
+				"source-list-map": "^2.0.1",
+				"source-map": "^0.6.1"
 			},
 			"dependencies": {
+				"source-list-map": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+					"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -54889,13 +54966,10 @@
 			}
 		},
 		"ws": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-			"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-			"dev": true,
-			"requires": {
-				"async-limiter": "~1.0.0"
-			}
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+			"integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+			"dev": true
 		},
 		"x-is-string": {
 			"version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44947,12 +44947,6 @@
 						"readable-stream": "^3.1.1"
 					}
 				},
-				"ws": {
-					"version": "7.4.2",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-					"integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
-					"dev": true
-				},
 				"yauzl": {
 					"version": "2.10.0",
 					"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
 		"uuid": "8.3.0",
 		"wd": "1.12.1",
 		"webpack": "4.42.0",
+		"webpack-bundle-analyzer": "4.2.0",
 		"worker-farm": "1.7.0"
 	},
 	"scripts": {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Enabled `import/no-extraneous-dependencies` rule in the `recommended` ruleset.
+-   Enabled `import/no-unresolved` rule in the `recommended` ruleset.
+
 ## 7.4.0 (2020-12-17)
 
 ### New Feature

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -7,6 +7,7 @@ module.exports = {
 		require.resolve( './esnext.js' ),
 		require.resolve( './i18n.js' ),
 	],
+	plugins: [ 'import' ],
 	env: {
 		node: true,
 	},
@@ -15,16 +16,44 @@ module.exports = {
 		document: true,
 		wp: 'readonly',
 	},
+	rules: {
+		'import/no-extraneous-dependencies': [
+			'error',
+			{
+				devDependencies: false,
+				peerDependencies: true,
+			},
+		],
+		'import/no-unresolved': 'error',
+	},
 	overrides: [
 		{
 			// Unit test files and their helpers only.
 			files: [ '**/@(test|__tests__)/**/*.js', '**/?(*.)test.js' ],
 			extends: [ require.resolve( './test-unit.js' ) ],
+			rules: {
+				'import/no-extraneous-dependencies': [
+					'error',
+					{
+						devDependencies: true,
+						peerDependencies: true,
+					},
+				],
+			},
 		},
 		{
 			// End-to-end test files and their helpers only.
 			files: [ '**/specs/**/*.js', '**/?(*.)spec.js' ],
 			extends: [ require.resolve( './test-e2e.js' ) ],
+			rules: {
+				'import/no-extraneous-dependencies': [
+					'error',
+					{
+						devDependencies: true,
+						peerDependencies: true,
+					},
+				],
+			},
 		},
 	],
 };

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -20,7 +20,6 @@ module.exports = {
 		'import/no-extraneous-dependencies': [
 			'error',
 			{
-				devDependencies: false,
 				peerDependencies: true,
 			},
 		],
@@ -31,29 +30,11 @@ module.exports = {
 			// Unit test files and their helpers only.
 			files: [ '**/@(test|__tests__)/**/*.js', '**/?(*.)test.js' ],
 			extends: [ require.resolve( './test-unit.js' ) ],
-			rules: {
-				'import/no-extraneous-dependencies': [
-					'error',
-					{
-						devDependencies: true,
-						peerDependencies: true,
-					},
-				],
-			},
 		},
 		{
 			// End-to-end test files and their helpers only.
 			files: [ '**/specs/**/*.js', '**/?(*.)spec.js' ],
 			extends: [ require.resolve( './test-e2e.js' ) ],
-			rules: {
-				'import/no-extraneous-dependencies': [
-					'error',
-					{
-						devDependencies: true,
-						peerDependencies: true,
-					},
-				],
-			},
 		},
 	],
 };

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,11 +5,16 @@
 ### Breaking Changes
 
 -   The peer `jest` dependency has been updated from requiring `>=25` to requiring `>=26` (see [Breaking Changes](https://jestjs.io/blog/2020/05/05/jest-26), [#27956](https://github.com/WordPress/gutenberg/pull/27956)).
+-   The bundled `@wordpress/eslint-plugin` dependency has been updated to the next major version `^8.0.0`. There are new ESLint rules enabled in the recommended config used by `lint-js` command.
 -   The bundled `stylelint-config-wordpress` dependency has been replaced with `@wordpress/stylelint-config` (#27810)[https://github.com/WordPress/gutenberg/pull/27810].
 
 ### Enhancements
 
 -   `wordpress` subfolder is no longer ignored when detecting files for testing, linting or formatting.
+
+### Internal
+
+-   The bundled `webpack-bundle-analyzer` dependency has been updated from requiring `^3.6.1` to requiring `^4.2.0`.
 
 ## 12.6.0 (2020-12-17)
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -72,9 +72,10 @@
 		"thread-loader": "^2.1.3",
 		"url-loader": "^3.0.0",
 		"webpack": "^4.42.0",
-		"webpack-bundle-analyzer": "^3.6.1",
+		"webpack-bundle-analyzer": "^4.2.0",
 		"webpack-cli": "^3.3.11",
-		"webpack-livereload-plugin": "^2.3.0"
+		"webpack-livereload-plugin": "^2.3.0",
+		"webpack-sources": "^2.2.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Follow-up for #20905.

Fixes #15876.

This PR enables 2 ESLint rules from `esling-import-plugin` that ensure that dependencies used in the project are installed in the `node_modules` folder and listed as the project's dependencies.

## How has this been tested?
```bash
npm run lint-js
```

## Types of changes
It might be a breaking change for the `@wordpress/eslint-plugin`. Users will see errors reported when using the recommended ruleset.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
