### PR TITLE
Animate: Deprecate component and stabilize getAnimateClassName

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import {
-	__unstableGetAnimateClassName as getAnimateClassName,
+	getAnimateClassName,
 	withNotices,
 	ToolbarGroup,
 	ToolbarButton,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### New Features
+
+- Add `getAnimateClassName` animation className helper [#27390](https://github.com/WordPress/gutenberg/pull/27390).
+
+### Deprecations
+
+- `Animate` component has been deprecated in favor of `getAnimateClassName` [#27390](https://github.com/WordPress/gutenberg/pull/27390)
+
 ## 12.0.0 (2020-12-17)
 
 ### Enhancements

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -4,6 +4,11 @@
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * @typedef {'top' | 'top left' | 'top right' | 'middle' | 'middle left' | 'middle right' | 'bottom' | 'bottom left' | 'bottom right'} AppearOrigin
  * @typedef {'left' | 'right'} SlideInOrigin
  * @typedef {{ type: 'appear'; origin?: AppearOrigin }} AppearOptions
@@ -50,8 +55,13 @@ export function getAnimateClassName( options ) {
 	}
 }
 
-// @ts-ignore Reason: Planned for deprecation
+// @ts-ignore Reason: Deprecated
 export default function Animate( { type, options = {}, children } ) {
+	deprecated( 'Animate component', {
+		version: '9.7',
+		alternative: 'getAnimateClassName',
+		hint: '`<AnimatedComponent className={ getAnimateClassName() } />`',
+	} );
 	return children( {
 		className: getAnimateClassName( { type, ...options } ),
 	} );

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -58,7 +58,7 @@ export function getAnimateClassName( options ) {
 // @ts-ignore Reason: Deprecated
 export default function Animate( { type, options = {}, children } ) {
 	deprecated( 'Animate component', {
-		version: '9.7',
+		version: '9.8',
 		alternative: 'getAnimateClassName',
 		hint: '`<AnimatedComponent className={ getAnimateClassName() } />`',
 	} );

--- a/packages/components/src/animate/stories/index.js
+++ b/packages/components/src/animate/stories/index.js
@@ -1,53 +1,62 @@
 /**
+ * External dependencies
+ */
+import { button, radios } from '@storybook/addon-knobs';
+import { useMemo, useState } from 'react';
+
+/**
  * Internal dependencies
  */
-import Animate from '../';
+import { getAnimateClassName } from '../';
 import Notice from '../../notice';
 
-export default { title: 'Components/Animate', component: Animate };
+export default { title: 'Components/getAnimateClassName' };
 
-export const _default = () => (
-	<Animate>
-		{ ( { className } ) => (
-			<Notice className={ className } status="success">
-				<p>{ `No default animation. Use one of type = "appear", "slide-in", or "loading".` }</p>
-			</Notice>
-		) }
-	</Animate>
-);
+export const _default = () => {
+	const typeToOrigin = useMemo(
+		() => ( {
+			appear: [
+				[
+					'top',
+					'top left',
+					'top right',
+					'middle',
+					'middle left',
+					'middle right',
+					'bottom',
+					'bottom left',
+					'bottom right',
+				],
+				'top left',
+			],
+			'slide-in': [ [ 'left', 'right' ], 'left' ],
+			loading: [ [], undefined ],
+		} ),
+		[]
+	);
+	const [ k, setK ] = useState( Number.MIN_SAFE_INTEGER );
+	button( 'Replay animation', () => setK( ( prevK ) => prevK + 1 ) );
+	const type = radios(
+		'Type',
+		[ 'appear', 'slide-in', 'loading' ],
+		'appear'
+	);
+	const origin = radios( 'Origin', ...typeToOrigin[ type ] );
 
-// Unexported helper for different origins.
-const Appear = ( { origin } ) => (
-	<Animate type="appear" options={ { origin } }>
-		{ ( { className } ) => (
-			<Notice className={ className } status="success">
-				<p>Appear animation. Origin: { origin }.</p>
-			</Notice>
-		) }
-	</Animate>
-);
-
-export const appearTopLeft = () => <Appear origin="top left" />;
-export const appearTopRight = () => <Appear origin="top right" />;
-export const appearBottomLeft = () => <Appear origin="bottom left" />;
-export const appearBottomRight = () => <Appear origin="bottom right" />;
-
-export const loading = () => (
-	<Animate type="loading">
-		{ ( { className } ) => (
-			<Notice className={ className } status="success">
-				<p>Loading animation.</p>
-			</Notice>
-		) }
-	</Animate>
-);
-
-export const slideIn = () => (
-	<Animate type="slide-in">
-		{ ( { className } ) => (
-			<Notice className={ className } status="success">
-				<p>Slide-in animation.</p>
-			</Notice>
-		) }
-	</Animate>
-);
+	return (
+		<Notice
+			className={ getAnimateClassName( { type, origin } ) }
+			status="success"
+			key={ k }
+		>
+			<p>
+				<code>{ type }</code> animation.
+			</p>
+			{ origin && (
+				<p>
+					Origin: <code>{ origin }</code>.
+				</p>
+			) }
+		</Notice>
+	);
+};

--- a/packages/components/src/animate/stories/index.js
+++ b/packages/components/src/animate/stories/index.js
@@ -34,20 +34,21 @@ export const _default = () => {
 		} ),
 		[]
 	);
-	const [ k, setK ] = useState( Number.MIN_SAFE_INTEGER );
-	button( 'Replay animation', () => setK( ( prevK ) => prevK + 1 ) );
+	const [ keySuffix, setKeySuffix ] = useState( Number.MIN_SAFE_INTEGER );
+	button( 'Replay animation', () => setKeySuffix( ( prevK ) => prevK + 1 ) );
 	const type = radios(
 		'Type',
 		[ 'appear', 'slide-in', 'loading' ],
 		'appear'
 	);
 	const origin = radios( 'Origin', ...typeToOrigin[ type ] );
+	const key = `${ type }${ origin }${ keySuffix }`;
 
 	return (
 		<Notice
 			className={ getAnimateClassName( { type, origin } ) }
 			status="success"
-			key={ k }
+			key={ key }
 		>
 			<p>
 				<code>{ type }</code> animation.

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -12,10 +12,7 @@ export {
 
 // Components
 export { default as __experimentalAlignmentMatrixControl } from './alignment-matrix-control';
-export {
-	default as Animate,
-	getAnimateClassName as __unstableGetAnimateClassName,
-} from './animate';
+export { default as Animate, getAnimateClassName } from './animate';
 export { default as AnglePickerControl } from './angle-picker-control';
 export { default as Autocomplete } from './autocomplete';
 export { default as BaseControl } from './base-control';

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	__unstableGetAnimateClassName as getAnimateClassName,
-	Button,
-} from '@wordpress/components';
+import { Button, getAnimateClassName } from '@wordpress/components';
 import { usePrevious, useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';


### PR DESCRIPTION
## Description

Follow-up to #27123. Stabilize the `getAnimateClassName` function and deprecate the Animate component.

- Deprecate `Animate` component as suggested (https://github.com/WordPress/gutenberg/pull/26965#issuecomment-727190649)
- Stabilize the `getAnimateClassName` function, suggested alternative to `Animate`.

(Slightly outdated screenshot of deprecation message)

<img width="793" alt="Screen Shot 2020-11-19 at 22 26 43" src="https://user-images.githubusercontent.com/841763/99726574-eb98b480-2ab6-11eb-92d8-8384078c53e9.png">


**Suggested Dev Note**

The `Animate` component from `@wordpress/components` has been deprecated and is scheduled for removal in Gutenberg 9.8. Please migrate to use the `getAnimateClassName` function from `@wordpress/components`.
 
```js
// Before
import { Animate } from '@wordpress/components';
const MyComponent = ( props ) => {
  return <Animate type="loading">{ ( className ) => <div className={ className }>Loading…</div> }</Animate>;
}

// After
import { getAnimateClassName } from '@wordpress/components';
<div className={ getAnimateClassName( { type: "loading" } }>Loading…</div> }</Animate>
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
New feature: `getAnimateClassName` function from `@wordpress/components`
Deprecation: `Animate` Component (scheduled for 9.7)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
