### PR TITLE
Try: Fix appender margins again.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -1,7 +1,11 @@
 // These styles are only applied to the appender when it appears inside of a block.
 // Otherwise the default appender may be improperly positioned in some themes.
 .block-editor-block-list__block .block-list-appender {
-	margin: $grid-unit-10 0;
+	margin: 0;
+
+	.block-editor-default-block-appender {
+		margin: $grid-unit-10 0;
+	}
 
 	// Add additional margin to the appender when inside a group with a background color.
 	// If changing this, be sure to sync up with group/editor.scss line 13.


### PR DESCRIPTION
This is round 2 of #27274, which was reverted in #27309 because it broke the buttons block. This time I've tested more widely, including justifications. The purpose of the PR is the same:

> The default block appender has an 8px margin above and below it. This margin usually collapses with adjacent margins that are almost always bigger.

> However some themes zero out the top and bottom margins of the first and last blocks inside groups (such as Twenty Twenty One, see WordPress/twentytwentyone#859). When this is the case, the small 8px margin causes a jump

Before:

![before](https://user-images.githubusercontent.com/1204802/100728522-f19c6880-33c7-11eb-83b2-ccfefe060e5e.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/100728526-f3662c00-33c7-11eb-8ede-e3d067d9b7e3.gif)
