### PR TITLE
Site Editing: Simplify template part toolbar

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -119,7 +119,7 @@ export default function TemplatePartEdit( {
 								<ToolbarButton
 									aria-expanded={ isOpen }
 									icon={ isOpen ? chevronUp : chevronDown }
-									label={ __( 'Choose another' ) }
+									label={ __( 'Switch template part' ) }
 									onClick={ onToggle }
 									// Disable when open to prevent odd FireFox bug causing reopening.
 									// As noted in https://github.com/WordPress/gutenberg/pull/24990#issuecomment-689094119 .

--- a/packages/block-library/src/template-part/edit/name-panel.js
+++ b/packages/block-library/src/template-part/edit/name-panel.js
@@ -20,7 +20,7 @@ export default function TemplatePartNamePanel( { postId } ) {
 
 	return (
 		<div className="wp-block-template-part__name-panel">
-			<Text variant="label">{ title || slug }</Text>
+			<Text variant="body">{ title || slug }</Text>
 		</div>
 	);
 }

--- a/packages/block-library/src/template-part/edit/name-panel.js
+++ b/packages/block-library/src/template-part/edit/name-panel.js
@@ -2,46 +2,25 @@
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { TextControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { cleanForSlug } from '@wordpress/url';
+import { __experimentalText as Text } from '@wordpress/components';
 
-export default function TemplatePartNamePanel( { postId, setAttributes } ) {
-	const [ title, setTitle ] = useEntityProp(
+export default function TemplatePartNamePanel( { postId } ) {
+	const [ title ] = useEntityProp(
 		'postType',
 		'wp_template_part',
 		'title',
 		postId
 	);
-	const [ slug, setSlug ] = useEntityProp(
+	const [ slug ] = useEntityProp(
 		'postType',
 		'wp_template_part',
 		'slug',
 		postId
 	);
-	const [ status, setStatus ] = useEntityProp(
-		'postType',
-		'wp_template_part',
-		'status',
-		postId
-	);
 
 	return (
 		<div className="wp-block-template-part__name-panel">
-			<TextControl
-				label={ __( 'Name' ) }
-				value={ title || slug }
-				onChange={ ( value ) => {
-					setTitle( value );
-					const newSlug = cleanForSlug( value );
-					setSlug( newSlug );
-					if ( status !== 'publish' ) {
-						setStatus( 'publish' );
-					}
-					setAttributes( { slug: newSlug, postId } );
-				} }
-				onFocus={ ( event ) => event.target.select() }
-			/>
+			<Text variant="label">{ title || slug }</Text>
 		</div>
 	);
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -67,7 +67,9 @@
 
 	.wp-block-template-part__name-panel {
 		outline: 1px solid transparent;
-		padding: $grid-unit-10 0 $grid-unit-10 $grid-unit-15;
+		padding: $grid-unit-10 0 $grid-unit-10 $grid-unit-20;
+		display: flex;
+		align-items: center;
 
 		.components-base-control__field {
 			align-items: center;

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -91,3 +91,13 @@
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 }
+
+.block-editor-block-toolbar__slot {
+	.components-toolbar-group {
+		order: 1;
+	}
+
+	.wp-block-template-part__block-control-group {
+		order: 0;
+	}
+}


### PR DESCRIPTION
Here's the current template part toolbar:

<img width="1481" alt="Screenshot 2020-12-01 at 12 03 49" src="https://user-images.githubusercontent.com/846565/100747514-113c8c80-33da-11eb-89e0-d4b9002a7564.png">

While template part renaming is an important feature, I am not convinced it needs to be so prominent in the UI. Renaming a template part is a relatively rare exercise after all. 

If instead we just display the template part name we can remove the "name" label, and simplify the toolbar while saving space:

<img width="1487" alt="Screenshot 2020-12-01 at 13 27 32" src="https://user-images.githubusercontent.com/846565/100747879-860fc680-33da-11eb-922e-90d2c135089a.png">

Renaming can still be accomplished via the Appearance > Template Parts screen, and we might consider adding it to the ellipsis menu in the template part toolbar as well in the future.

In this branch I have also moved the name 'above' the alignment tool using CSS, but I am certain there is a better way to do that :D 