### PR TITLE
Refactor date functions to reflect expected test results

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -356,10 +356,6 @@ export function format( dateFormat, dateValue = new Date() ) {
 	}
 	// Join with [] between to separate characters, and replace
 	// unneeded separators with static text.
-<<<<<<< HEAD
-	newFormat = newFormat.join( '[]' );
-	return momentDate.format( newFormat );
-=======
 
 	newFormat = newFormat.join( '' );
 
@@ -487,11 +483,21 @@ function getActualTimezone( timezone = '' ) {
  * @return {string} Formatted date.
  */
 export function format( dateFormat, dateValue = new Date() ) {
-	const formatString = translateFormat( dateFormat, dateValue );
 	const parsedDate =
 		dateValue instanceof Date ? dateValue : parseISO( dateValue );
-	return formatTZ( parsedDate, formatString );
->>>>>>> 067501032f... wip
+
+	const hasOffset =
+		formatTZ( parsedDate, 'x' ) ===
+		formatTZ( parsedDate, 'x', { timeZone: getActualTimezone() } );
+
+	const offsetDate = hasOffset
+		? utcToZonedTime( parsedDate, getActualTimezone() )
+		: parsedDate;
+
+	const formatString = translateFormat( dateFormat, offsetDate );
+	return formatTZ( offsetDate, formatString, {
+		timeZone: getActualTimezone(),
+	} );
 }
 
 /**

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -356,8 +356,142 @@ export function format( dateFormat, dateValue = new Date() ) {
 	}
 	// Join with [] between to separate characters, and replace
 	// unneeded separators with static text.
+<<<<<<< HEAD
 	newFormat = newFormat.join( '[]' );
 	return momentDate.format( newFormat );
+=======
+
+	newFormat = newFormat.join( '' );
+
+	return newFormat;
+}
+
+/**
+ * Build date-fns locale settings from WordPress localization settings.
+ */
+function getLocalizationSettings() {
+	const monthValues = {
+		abbreviated: settings.l10n.monthsShort,
+		wide: settings.l10n.months,
+	};
+
+	const dayValues = {
+		abbreviated: settings.l10n.weekdaysShort,
+		wide: settings.l10n.weekdays,
+	};
+
+	return {
+		...originalLocale.localize,
+		month: buildLocalizeFn( {
+			values: monthValues,
+			defaultWidth: 'wide',
+		} ),
+		day: buildLocalizeFn( {
+			values: dayValues,
+			defaultWidth: 'wide',
+		} ),
+		formatLong: {
+			date: buildFormatLongFn( {
+				formats: {
+					full: settings.formats.date,
+					defaultWidth: 'full',
+				},
+			} ),
+			time: buildFormatLongFn( {
+				formats: {
+					full: settings.formats.time,
+					defaultWidth: 'full',
+				},
+			} ),
+			dateTime: buildFormatLongFn( {
+				formats: {
+					full: settings.formats.datetime,
+					short: settings.formats.datetimeAbbreviated,
+					defaultWidth: 'full',
+				},
+			} ),
+		},
+	};
+}
+
+/**
+ * Returns whether a certain UTC offset is valid or not.
+ *
+ * @param {number|string} offset a UTC offset.
+ *
+ * @return {boolean} whether a certain UTC offset is valid or not.
+ */
+function isValidUTCOffset( offset ) {
+	return VALID_UTC_OFFSET.test( offset );
+}
+
+/**
+ * Transform the given integer into a valid UTC Offset in hours.
+ *
+ * @param {number} offset A UTC offset as an integer
+ */
+function integerToUTCOffset( offset ) {
+	const offsetInHours = offset > 23 ? offset / 60 : offset;
+	const sign = offset < 0 ? '-' : '+';
+	const absoluteOffset =
+		offsetInHours < 0 ? offsetInHours * -1 : offsetInHours;
+
+	return offsetInHours < 10
+		? `${ sign }0${ absoluteOffset }`
+		: `${ sign }${ absoluteOffset }`;
+}
+
+/**
+ * Determines whether or not the given value can be parsed as a UTC offset,
+ * by checking if it is parseable as an integer and if it isn't a
+ * valid UTC offset already.
+ *
+ * @param {string} offset An offset as an integer or a string.
+ */
+function shouldParseAsUTCOffset( offset ) {
+	const isNumber = ! Number.isNaN( Number.parseInt( offset, 10 ) );
+	return isNumber && ! isValidUTCOffset( offset );
+}
+
+/**
+ * Get a properly formatted timezone from a timezone string or offset.
+ * Return system timezone or offset if no timezone was given.
+ *
+ * @param {string} timezone
+ */
+function getActualTimezone( timezone = '' ) {
+	if ( ! timezone ) {
+		const { string, offset } = settings.timezone;
+
+		if ( string ) {
+			return string;
+		}
+
+		if ( shouldParseAsUTCOffset( offset ) ) {
+			return integerToUTCOffset( offset );
+		}
+	}
+
+	return shouldParseAsUTCOffset( timezone )
+		? integerToUTCOffset( timezone )
+		: timezone;
+}
+
+/**
+ * Formats a date. Does not alter the date's timezone.
+ *
+ * @param {string}                  dateFormat PHP-style formatting string.
+ *                                             See php.net/date.
+ * @param {Date|string|null} dateValue  Date object or ISO string.
+ *
+ * @return {string} Formatted date.
+ */
+export function format( dateFormat, dateValue = new Date() ) {
+	const formatString = translateFormat( dateFormat, dateValue );
+	const parsedDate =
+		dateValue instanceof Date ? dateValue : parseISO( dateValue );
+	return formatTZ( parsedDate, formatString );
+>>>>>>> 067501032f... wip
 }
 
 /**

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalGetSettings,
 	date as dateNoI18n,
+	format,
 	dateI18n,
 	getDate,
 	gmdate,
@@ -239,6 +240,46 @@ describe( 'Function gmdate', () => {
 	} );
 } );
 
+describe( 'Function format', () => {
+	it( 'should not change a date at all the if it is already on the site timezone', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const input = '2020-10-16T14:36:58-04:00';
+		const formattedDate = format( 'c', input );
+		// Currently output is "2020-10-16T23:36:58-04:00" which is wrong.
+		expect( formattedDate ).toBe( input );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should not change a date if it specifies its timezone', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const input = '2020-10-16T22:36:58-04:00';
+		const formattedDate = format( 'c', input );
+		// Currently output is "2020-10-16T23:36:58-04:00" which is wrong.
+		expect( formattedDate ).toBe( input );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+} );
+
 describe( 'Function dateI18n', () => {
 	it( 'should format date using locale settings', () => {
 		const settings = __experimentalGetSettings();
@@ -415,6 +456,73 @@ describe( 'Function dateI18n', () => {
 			false
 		);
 		expect( formattedDate ).toBe( '2019-06-18 07:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format dates with site timezone output', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: '' },
+		} );
+
+		const winterFormattedDateWithC = dateI18n(
+			'c',
+			'2019-01-18T11:00:00.000Z'
+		);
+		expect( winterFormattedDateWithC ).toBe( '2019-01-18T07:00:00-04:00' );
+
+		const summerFormattedDateWithC = dateI18n(
+			'c',
+			'2019-06-18T11:00:00.000Z'
+		);
+		expect( summerFormattedDateWithC ).toBe( '2019-01-18T07:00:00-04:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format dates with specific timezone output', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const formattedDate = dateI18n(
+			'c',
+			'2019-06-18T11:00:00.000Z',
+			'Asia/Macau'
+		);
+		expect( formattedDate ).toBe( '2019-06-18T19:00:00+08:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format dates with specific utc offset output', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const formattedDate = dateI18n(
+			'c',
+			'2019-06-18T11:00:00.000Z',
+			'+08:00'
+		);
+		expect( formattedDate ).toBe( '2019-06-18T19:00:00+08:00' );
 
 		// Restore default settings
 		setSettings( settings );


### PR DESCRIPTION
## Changes

- Add global timezone to jest environment.
- Refactor date functions to only alter timezones when actually required.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
