### PR TITLE
Another experiment for block variations - No reviews please :)

### DIFF
--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -59,6 +59,10 @@ _Returns_
 
 -   `Array`: Block Types.
 
+<a name="getBlockVariationMatchProps" href="#getBlockVariationMatchProps">#</a> **getBlockVariationMatchProps**
+
+Undocumented declaration.
+
 <a name="getBlockVariations" href="#getBlockVariations">#</a> **getBlockVariations**
 
 Returns block variations by block name.

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	getBlockType,
+	getBlockVariationMatchProps,
 	getUnregisteredTypeHandlerName,
 	hasBlockSupport,
 	store as blocksStore,
@@ -27,6 +28,7 @@ import DefaultStylePicker from '../default-style-picker';
 import BlockVariationTransforms from '../block-variation-transforms';
 const BlockInspector = ( {
 	blockType,
+	selectedBlockType,
 	count,
 	hasBlockStyles,
 	selectedBlockClientId,
@@ -67,7 +69,8 @@ const BlockInspector = ( {
 
 	return (
 		<div className="block-editor-block-inspector">
-			<BlockCard blockType={ blockType } />
+			{ /* <BlockCard blockType={ blockType } /> */ }
+			<BlockCard blockType={ selectedBlockType } />
 			<BlockVariationTransforms blockClientId={ selectedBlockClientId } />
 			{ hasBlockStyles && (
 				<div>
@@ -120,14 +123,18 @@ export default withSelect( ( select ) => {
 	const {
 		getSelectedBlockClientId,
 		getSelectedBlockCount,
+		getSelectedBlock,
 		getBlockName,
-	} = select( 'core/block-editor' );
+	} = select( 'core/block-editor' ); // TODO change string store value
 	const { getBlockStyles } = select( blocksStore );
 	const selectedBlockClientId = getSelectedBlockClientId();
 	const selectedBlockName =
 		selectedBlockClientId && getBlockName( selectedBlockClientId );
 	const blockType =
 		selectedBlockClientId && getBlockType( selectedBlockName );
+	const selectedBlock = getSelectedBlock();
+	const selectedBlockType =
+		selectedBlock && getBlockVariationMatchProps( selectedBlock );
 	const blockStyles =
 		selectedBlockClientId && getBlockStyles( selectedBlockName );
 	return {
@@ -136,5 +143,6 @@ export default withSelect( ( select ) => {
 		selectedBlockName,
 		selectedBlockClientId,
 		blockType,
+		selectedBlockType,
 	};
 } )( BlockInspector );

--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -8,7 +8,8 @@ import classnames from 'classnames';
  */
 import {
 	__experimentalGetBlockLabel as getBlockLabel,
-	getBlockType,
+	// getBlockType,
+	getBlockVariationMatchProps,
 } from '@wordpress/blocks';
 import { Button, VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
@@ -38,9 +39,11 @@ function BlockNavigationBlockSelectButton(
 	},
 	ref
 ) {
-	const { name, attributes } = block;
+	const { attributes } = block;
+	// const { name, attributes } = block;
 
-	const blockType = getBlockType( name );
+	// const blockType = getBlockType( name );
+	const blockType = getBlockVariationMatchProps( block );
 	const blockDisplayName = getBlockLabel( blockType, attributes );
 	const instanceId = useInstanceId( BlockNavigationBlockSelectButton );
 	const descriptionId = `block-navigation-block-select-button__${ instanceId }`;

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -6,7 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { getBlockType } from '@wordpress/blocks';
+// import { getBlockType } from '@wordpress/blocks';
+import { getBlockVariationMatchProps } from '@wordpress/blocks';
 import { Fill, Slot, VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
@@ -54,8 +55,9 @@ function BlockNavigationBlockSlot( props, ref ) {
 					onFocus,
 				} = props;
 
-				const { name } = block;
-				const blockType = getBlockType( name );
+				// const { name } = block;
+				// const blockType = getBlockType( name );
+				const blockType = getBlockVariationMatchProps( block );
 				const descriptionId = `block-navigation-block-slot__${ instanceId }`;
 				const blockPositionDescription = getBlockPositionDescription(
 					position,

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import {
 	getBlockType,
+	getBlockVariationMatchProps,
 	getPossibleBlockTransformations,
 	switchToBlockType,
 	cloneBlock,
@@ -120,8 +121,9 @@ export class BlockSwitcher extends Component {
 
 		let icon;
 		if ( isSelectionOfSameType ) {
-			const sourceBlockName = hoveredBlock.name;
-			const blockType = getBlockType( sourceBlockName );
+			// const sourceBlockName = hoveredBlock.name;
+			// const blockType = getBlockType( sourceBlockName );
+			const blockType = getBlockVariationMatchProps( hoveredBlock );
 			icon = blockType.icon;
 		} else {
 			icon = stack;
@@ -246,6 +248,7 @@ export default compose(
 		const blocks = getBlocksByClientId( clientIds );
 		const firstBlock = blocks && blocks.length === 1 ? blocks[ 0 ] : null;
 		const styles = firstBlock && getBlockStyles( firstBlock.name );
+
 		return {
 			blocks,
 			inserterItems: getInserterItems( rootClientId ),

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -59,3 +59,5 @@ function InserterPreviewPanel( { item } ) {
 }
 
 export default InserterPreviewPanel;
+
+// TODO check this usage of BlockCard as well

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -28,4 +28,8 @@ export const settings = {
 	transforms,
 	variations,
 	deprecated,
+	variationMatcher: ( blockAttributes ) => ( variation ) => {
+		const { providerNameSlug } = blockAttributes || {};
+		return variation.name === providerNameSlug;
+	},
 };

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -23,4 +23,8 @@ export const settings = {
 		'Display an icon linking to a social media profile or website.'
 	),
 	variations,
+	variationMatcher: ( blockAttributes ) => ( variation ) => {
+		const { service } = blockAttributes || {};
+		return variation.name === service;
+	},
 };

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -363,6 +363,10 @@ _Returns_
 
 -   `Array`: Block settings.
 
+<a name="getBlockVariationMatchProps" href="#getBlockVariationMatchProps">#</a> **getBlockVariationMatchProps**
+
+Undocumented declaration.
+
 <a name="getBlockVariations" href="#getBlockVariations">#</a> **getBlockVariations**
 
 Returns an array with the variations of a given block type.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -43,6 +43,7 @@ export {
 	getGroupingBlockName,
 	getBlockType,
 	getBlockTypes,
+	getBlockVariationMatchProps,
 	getBlockSupport,
 	hasBlockSupport,
 	getBlockVariations,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -414,6 +414,10 @@ export function getBlockTypes() {
 	return select( blocksStore ).getBlockTypes();
 }
 
+export function getBlockVariationMatchProps( block ) {
+	return select( blocksStore ).getBlockVariationMatchProps( block );
+}
+
 /**
  * Returns the block support value for a feature, if defined.
  *

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -95,6 +95,21 @@ export function getBlockVariations( state, blockName, scope ) {
 	} );
 }
 
+export function getBlockVariationMatchProps( state, block ) {
+	const { name, attributes } = block;
+	const variations = state.blockVariations[ name ];
+	const blockType = getBlockType( state, name );
+	if ( ! variations || ! blockType?.variationMatcher ) return blockType;
+	const variationMatcherClosure = blockType.variationMatcher( attributes );
+	const match = variations.find( variationMatcherClosure );
+	if ( ! match ) return blockType;
+	return {
+		title: match.title || blockType.title,
+		icon: match.icon || blockType.icon,
+		description: match.description || blockType.description,
+	};
+}
+
 /**
  * Returns the default block variation for the given block type.
  * When there are multiple variations annotated as the default one,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Quick prototype for expanding the Blocks API to try to find a matched block variation to show the appropriate display properties. You can test it with `social icons` and `embeds`.

I made some quick changes to `Block Card`, `Transforms icon`(in toolbar), and `Navigation list view` (top bar).

![pocVariationsDisplayMatcher](https://user-images.githubusercontent.com/16275880/100781013-27b30a00-3413-11eb-94d8-2b1d360470d6.gif)

