### PR TITLE
Support gradients with omitted stop positions in CustomGradientPicker

### DIFF
--- a/packages/components/src/custom-gradient-picker/utils.js
+++ b/packages/components/src/custom-gradient-picker/utils.js
@@ -256,6 +256,21 @@ const DIRECTIONAL_ORIENTATION_ANGLE_MAP = {
 	'left top': 315,
 };
 
+function hasUnsupportedLength( item ) {
+	return item.length === undefined || item.length.type !== '%';
+}
+
+function assignColorStopLengths( gradientAST ) {
+	const { colorStops } = gradientAST;
+	const step = 100 / ( colorStops.length - 1 );
+	colorStops.forEach( ( stop, index ) => {
+		stop.length = {
+			value: step * index,
+			type: '%',
+		};
+	} );
+}
+
 export function getGradientParsed( value ) {
 	let hasGradient = !! value;
 	// gradientAST will contain the gradient AST as parsed by gradient-parser npm module.
@@ -280,6 +295,12 @@ export function getGradientParsed( value ) {
 			gradientAST.orientation.value
 		].toString();
 	}
+
+	if ( gradientAST.colorStops.some( hasUnsupportedLength ) ) {
+		assignColorStopLengths( gradientAST );
+		gradientValue = serializeGradient( gradientAST );
+	}
+
 	return {
 		hasGradient,
 		gradientAST,


### PR DESCRIPTION
## Description
Adds logic to test the color stops of the parsed gradient for any positions that are undefined or set with a unit other than percent. If some are found then each color stop in the gradient is reassigned a new equidistant position as percent.

Will fix #27382 and fix #23501 (duplicates).

## Commentary
These changes were aimed at doing the simplest thing to prevent errors and support common use cases. The 'fixup' applied when stop positions are omitted is simpler than [the spec](https://drafts.csswg.org/css-images-4/#color-stop-fixup) (which wouldn't make sense to implement with the current UI). Additionally, a use case not  handled by this is when stops are defined outside of 0-100:
`linear-gradient( 135deg, crimson -10%, gold 50%, lime 110% )`
Such cases produce no errors but the outside stops can be out of reach in the UI.

The reassignment of non-percentage units is coverage for an edge case not mentioned in either of the issues but is something that causes similar issues. It may be worthwhile to add some note about this in the documentation for the gradient presets, e.g. gradient presets support omitting positions or defining them in percentage only.

## How has this been tested?
In WP 5.5.3
1. Added these gradient presets to the theme:
```
"gradients": [
          {
            "slug": "azure-tan",
            "gradient": "linear-gradient( 135deg, #f0ffff, #d2b48c )"
          },
          {
            "slug": "turquoise-orange",
            "gradient": "linear-gradient( 135deg, #40e0d0 50px, #ffa500 100px )"
          },
          {
            "slug": "rastafarish",
            "gradient": "linear-gradient( 135deg, crimson 49.5%, gold, lime 50.5% )"
          },
          {
            "slug": "roygbiv",
            "gradient": "linear-gradient( 135deg, red 0%, orange 10%, yellow 20%, green 30%, blue 40%, indigo 50%, violet 60% )"
          },
          {
            "slug": "roygbiv-radial",
            "gradient": "radial-gradient( red, orange 10%, yellow 20%, green 30%, blue 40%, indigo 50%, violet 60% )"
          }
        ],
```
2. Assigned each gradient to a Cover block.
3. Verified that modifying the type of gradient (Linear/Radial) worked.
4. Verified that modifying the angle of the graident worked.
5. Verified that adding new stops to the gradient worked.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
