### PR TITLE
[WIP] Attempt to fix issue that caused the the edited post date to always be in the future

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -636,8 +636,10 @@ export function isInTheFuture( dateValue ) {
  * @return {Date} Date
  */
 export function getDate( dateString ) {
-	const actualDate = dateString ? new Date( dateString ) : new Date();
-	return toDate( actualDate, { timeZone: getActualTimezone() } );
+	return zonedTimeToUtc(
+		dateString ? new Date( dateString ) : new Date(),
+		getActualTimezone()
+	);
 }
 
 export { zonedTimeToUtc };


### PR DESCRIPTION
## Description

Originally reported [here](https://github.com/WordPress/gutenberg/issues/27251), and [here](https://github.com/Automattic/wp-calypso/issues/47938).

Gutenberg 9.4 introduced a bug that caused the publish button on new posts to wrongly read "Schedule...". The bug was apparently introduced as part of the migration from moment to `date-fns`, in this [PR](https://github.com/WordPress/gutenberg/pull/25782). The culprit seems to be the new `getDate`'s implementation that ends up returning a date in the future due to a timezone miscalculation. Maybe something from the previous `getDate` implementation should be brought over? Any insights?

Disclaimer: This fix is not fully working yet. More on that below.

## How has this been tested?

1. Spin up a local wp-env
1. Start a new page or post
1. Publish button at the top-right-corner should read "Publish"
1. In the sidebar under "Status & Visibility", click on the left of "Publish" to select a date in the future. The button label should change to "Schedule..."*



## Screenshots

| Upon creating a new post ✅  | Choosing the next day ❌* | Choosing a date further in the future ✅ |
| ------------- | ------------- | ----- | 
| ![publish](https://user-images.githubusercontent.com/81248/100824155-40272280-341b-11eb-8250-6701b0129f40.png) | ![publishwrong](https://user-images.githubusercontent.com/81248/100824171-461d0380-341b-11eb-971e-f6e0a8b076c6.png) | ![scheduleworks](https://user-images.githubusercontent.com/81248/100824187-4d441180-341b-11eb-9b90-ecd077223912.png) |

_*The fix doesn't seem to be working for all scenarios. If you select the next day, it'll still show "Publish"._ If you select a date further in the future it will work.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
