### PR TITLE
Try fixing combobox a11y issues 

### DIFF
--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -135,7 +135,7 @@ function ComboboxControl( {
 	const onFocus = () => {
 		setIsExpanded( true );
 		onFilterValueChange( '' );
-		setInputValue( '' );
+		// setInputValue( '' );
 	};
 
 	const onFocusOutside = () => {
@@ -170,7 +170,7 @@ function ComboboxControl( {
 				  )
 				: __( 'No results.' );
 
-			speak( message, 'assertive' );
+			speak( message, 'polite' );
 		}
 	}, [ matchingSuggestions, isExpanded ] );
 

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -135,7 +135,7 @@ function ComboboxControl( {
 	const onFocus = () => {
 		setIsExpanded( true );
 		onFilterValueChange( '' );
-		// setInputValue( '' );
+		setInputValue( '' );
 	};
 
 	const onFocusOutside = () => {

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -203,6 +203,11 @@ function ComboboxControl( {
 								instanceId={ instanceId }
 								ref={ inputContainer }
 								value={ isExpanded ? inputValue : currentLabel }
+								aria-label={
+									currentLabel
+										? `${ currentLabel }, ${ label }`
+										: null
+								}
 								onFocus={ onFocus }
 								isExpanded={ isExpanded }
 								selectedSuggestionIndex={ matchingSuggestions.indexOf(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #27385.

The issue with VoiceOver not announcing the input label is straightforward: changing the `aria-live` setting to `polite` fixes it. (Thanks for the suggestion, @talldan 😄 )

The selection not being announced is trickier as different screen readers announce input selection in different order. What I tried here was adding an `aria-label` with the selection value as well as the original label value (because the aria-label will override the label) and that reads out in VoiceOver in the same order as a native `select` would, but in NVDA it doesn't quite match. 

Would be good to have some a11y input into this.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested with VoiceOver/Safari on macOS and NVDA/Firefox on Windows 10.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
