### PR TITLE
CI: Update bundle size workflow to use the latest version

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         fetch-depth: 1
 
-    - uses: preactjs/compressed-size-action@v1
+    - uses: preactjs/compressed-size-action@v2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         pattern: "{build/**/*.js,build/**/*.css}"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Related https://github.com/WordPress/gutenberg/pull/27433.

I'm trying to find out why we see the following warning in the bundle size workflow:

> Warning: Unexpected input(s) 'pattern', valid inputs are ['repo-token', 'build-script', 'compression', 'show-total', 'collapse-unchanged', 'omit-unchanged']

`pattern` is supported but it might be v2 feature only:

https://github.com/preactjs/compressed-size-action#customizing-the-list-of-files

## How has this been tested?
Check the related GitHub action.
