### PR TITLE
Packages: Improve the script that automates version bumps

### DIFF
--- a/bin/plugin/commands/common.js
+++ b/bin/plugin/commands/common.js
@@ -74,8 +74,71 @@ function findReleaseBranchName( packageJsonPath ) {
 	);
 }
 
+/**
+ * Calculates version bump for the packages based on the content
+ * from the provided CHANGELOG file split into individual lines.
+ *
+ * @param {string[]} lines                                 Changelog content split into lines.
+ * @param {('patch'|'minor'|'major')} [minimumVersionBump] Minimum version bump for the package.
+ *                                                         Defaults to `patch`.
+ *
+ * @return {string|null} Version bump when applicable, or null otherwise.
+ */
+function calculateVersionBumpFromChangelog(
+	lines,
+	minimumVersionBump = 'patch'
+) {
+	let changesDetected = false;
+	let versionBump = null;
+	for ( const line of lines ) {
+		const lineNormalized = line.toLowerCase().trimLeft();
+		// Detect unpublished changes first.
+		if ( lineNormalized.startsWith( '## unreleased' ) ) {
+			changesDetected = true;
+			continue;
+		}
+
+		// Skip all lines until unpublished changes found.
+		if ( ! changesDetected ) {
+			continue;
+		}
+
+		// A previous published version detected. Stop processing.
+		if ( lineNormalized.startsWith( '## ' ) ) {
+			break;
+		}
+
+		// A major version bump required. Stop processing.
+		if ( lineNormalized.startsWith( '### breaking change' ) ) {
+			versionBump = 'major';
+			break;
+		}
+
+		// A minor version bump required. Proceed to the next line.
+		if (
+			lineNormalized.startsWith( '### deprecation' ) ||
+			lineNormalized.startsWith( '### enhancement' ) ||
+			lineNormalized.startsWith( '### new feature' )
+		) {
+			versionBump = 'minor';
+			continue;
+		}
+
+		// A version bump required. Found new changelog section.
+		if (
+			versionBump !== 'minor' &&
+			( lineNormalized.startsWith( '### ' ) ||
+				lineNormalized.includes( '- ' ) )
+		) {
+			versionBump = minimumVersionBump;
+		}
+	}
+	return versionBump;
+}
+
 module.exports = {
+	calculateVersionBumpFromChangelog,
+	findReleaseBranchName,
 	runGitRepositoryCloneStep,
 	runCleanLocalFoldersStep,
-	findReleaseBranchName,
 };

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -13,9 +13,10 @@ const readline = require( 'readline' );
 const { log, formats } = require( '../lib/logger' );
 const { askForConfirmation, runStep, readJSONFile } = require( '../lib/utils' );
 const {
+	calculateVersionBumpFromChangelog,
+	findReleaseBranchName,
 	runGitRepositoryCloneStep,
 	runCleanLocalFoldersStep,
-	findReleaseBranchName,
 } = require( './common' );
 const git = require( '../lib/git' );
 
@@ -104,55 +105,14 @@ async function updatePackages(
 		changelogFiles.map( async ( changelogPath ) => {
 			const fileStream = fs.createReadStream( changelogPath );
 
-			const lines = readline.createInterface( {
+			const lines = await readline.createInterface( {
 				input: fileStream,
 			} );
 
-			let changesDetected = false;
-			let versionBump = null;
-			for await ( const line of lines ) {
-				const lineNormalized = line.toLowerCase();
-				// Detect unpublished changes first.
-				if ( lineNormalized.startsWith( '## unreleased' ) ) {
-					changesDetected = true;
-					continue;
-				}
-
-				// Skip all lines until unpublished changes found.
-				if ( ! changesDetected ) {
-					continue;
-				}
-
-				// A previous published version detected. Stop processing.
-				if ( lineNormalized.startsWith( '## ' ) ) {
-					break;
-				}
-
-				// A major version bump required. Stop processing.
-				if ( lineNormalized.startsWith( '### breaking change' ) ) {
-					versionBump = 'major';
-					break;
-				}
-
-				// A minor version bump required. Proceed to the next line.
-				if (
-					lineNormalized.startsWith( '### deprecation' ) ||
-					lineNormalized.startsWith( '### enhancement' ) ||
-					lineNormalized.startsWith( '### new feature' )
-				) {
-					versionBump = 'minor';
-					continue;
-				}
-
-				// A version bump required. Found new changelog section.
-				if (
-					versionBump !== 'minor' &&
-					( lineNormalized.startsWith( '### ' ) ||
-						lineNormalized.startsWith( '- initial release' ) )
-				) {
-					versionBump = minimumVersionBump;
-				}
-			}
+			const versionBump = calculateVersionBumpFromChangelog(
+				lines,
+				minimumVersionBump
+			);
 			const packageName = `@wordpress/${
 				changelogPath.split( '/' ).reverse()[ 1 ]
 			}`;

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -105,9 +105,13 @@ async function updatePackages(
 		changelogFiles.map( async ( changelogPath ) => {
 			const fileStream = fs.createReadStream( changelogPath );
 
-			const lines = await readline.createInterface( {
+			const rl = readline.createInterface( {
 				input: fileStream,
 			} );
+			const lines = [];
+			for await ( const line of rl ) {
+				lines.push( line );
+			}
 
 			const versionBump = calculateVersionBumpFromChangelog(
 				lines,

--- a/bin/plugin/commands/test/common.js
+++ b/bin/plugin/commands/test/common.js
@@ -1,0 +1,76 @@
+/**
+ * Internal dependencies
+ */
+import { calculateVersionBumpFromChangelog } from '../common';
+
+describe( 'calculateVersionBumpFromChangelog', () => {
+	it( 'should return null when no lines provided', () => {
+		expect( calculateVersionBumpFromChangelog( [] ) ).toBe( null );
+	} );
+
+	it( 'should return null when no unreleased header found', () => {
+		expect(
+			calculateVersionBumpFromChangelog( [
+				'First line',
+				'Second line',
+				'Third line',
+				'Fourth line',
+				'Fifth line',
+			] )
+		).toBe( null );
+	} );
+
+	it( 'should return null when Unreleased header found but no entries', () => {
+		expect(
+			calculateVersionBumpFromChangelog( [
+				'First line',
+				'## Unreleased',
+				'Third line',
+				'Fourth line',
+				'Fifth line',
+			] )
+		).toBe( null );
+	} );
+
+	it( 'should return patch version Unreleased header and new item detected', () => {
+		expect(
+			calculateVersionBumpFromChangelog( [
+				'First line',
+				'## Unreleased',
+				'Third line',
+				'  - new item added',
+				'Fifth line',
+			] )
+		).toBe( 'patch' );
+	} );
+
+	it( 'should return enforce higher version bump when new item detected with lower level', () => {
+		expect(
+			calculateVersionBumpFromChangelog(
+				[
+					'First line',
+					'## Unreleased',
+					'Third line',
+					'  - new item added',
+					'Fifth line',
+				],
+				'major'
+			)
+		).toBe( 'major' );
+	} );
+
+	it( 'should return major version bump when breaking changes detected', () => {
+		expect(
+			calculateVersionBumpFromChangelog(
+				[
+					'First line',
+					'## Unreleased',
+					'### Breaking Changes',
+					'  - new item added',
+					'Fifth line',
+				],
+				'major'
+			)
+		).toBe( 'major' );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Triggered by the issue discovered by @sirreal in https://github.com/WordPress/gutenberg/pull/25057#discussion_r532663207:

> I don't think this was correctly processed because it's under the Unreleased "version" but doesn't have a header like "Breaking Change" or "New Feature". This appears to have been released in 10.2.0 but has been stuck here…

## How has this been tested?

It's difficult to test in general, that's why I added some unit tests to make the process simpler in the future.

To test it locally, you can run `./bin/commander.js npm-stable`. You only need to abort when asked to push changes to the repository 😅 