### PR TITLE
Expand the multi-entity saving panel by default

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -97,17 +97,6 @@ const openEntitySavePanel = async () => {
 	}
 	// If we made it this far, the panel is opened.
 
-	// Expand to view savable entities if necessary.
-	const reviewChangesButton = await page.$(
-		'.entities-saved-states__review-changes-button'
-	);
-	const [ needsToOpen ] = await reviewChangesButton.$x(
-		'//*[contains(text(),"Review changes.")]'
-	);
-	if ( needsToOpen ) {
-		await reviewChangesButton.click();
-	}
-
 	return true;
 };
 

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -31,17 +31,6 @@ describe( 'Multi-entity save flow', () => {
 
 	// Reusable assertions across Post/Site editors.
 	const assertAllBoxesChecked = async () => {
-		// Expand to view savable entities if necessary.
-		const reviewChangesButton = await page.$(
-			'.entities-saved-states__review-changes-button'
-		);
-		const [ needsToOpen ] = await reviewChangesButton.$x(
-			'//*[contains(text(),"Review changes.")]'
-		);
-		if ( needsToOpen ) {
-			await reviewChangesButton.click();
-		}
-
 		const checkedBoxes = await page.$$( checkedBoxSelector );
 		const checkboxInputs = await page.$$( checkboxInputSelector );
 		expect( checkedBoxes.length - checkboxInputs.length ).toBe( 0 );

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -114,7 +114,7 @@ export default function EntitiesSavedStates( { isOpen, close } ) {
 		} );
 	};
 
-	const [ isReviewing, setIsReviewing ] = useState( false );
+	const [ isReviewing, setIsReviewing ] = useState( true );
 	const toggleIsReviewing = () => setIsReviewing( ( value ) => ! value );
 
 	// Explicitly define this with no argument passed.  Using `close` on

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -30,15 +30,21 @@ const PLACEHOLDER_PHRASES = {
 	// 0 is a back up, but should never be observed.
 	0: __( 'There are no changes.' ),
 	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	1: __( 'Changes have been made to your %s.' ),
+	1: __( 'The following changes have been made to your %s.' ),
 	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	2: __( 'Changes have been made to your %1$s and %2$s.' ),
+	2: __( 'The following changes have been made to your %1$s and %2$s.' ),
 	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	3: __( 'Changes have been made to your %1$s, %2$s, and %3$s.' ),
+	3: __(
+		'The following changes have been made to your %1$s, %2$s, and %3$s.'
+	),
 	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	4: __( 'Changes have been made to your %1$s, %2$s, %3$s, and %4$s.' ),
+	4: __(
+		'The following changes have been made to your %1$s, %2$s, %3$s, and %4$s.'
+	),
 	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	5: __( 'Changes have been made to your %1$s, %2$s, %3$s, %4$s, and %5$s.' ),
+	5: __(
+		'The following changes have been made to your %1$s, %2$s, %3$s, %4$s, and %5$s.'
+	),
 };
 
 export default function EntitiesSavedStates( { isOpen, close } ) {
@@ -69,7 +75,7 @@ export default function EntitiesSavedStates( { isOpen, close } ) {
 	const placeholderPhrase =
 		PLACEHOLDER_PHRASES[ entityNamesForPrompt.length ] ||
 		// Fallback for edge case that should not be observed (more than 5 entity types edited).
-		__( 'Changes have been made to multiple entity types.' );
+		__( 'The following changes have been made to multiple entities.' );
 	// eslint-disable-next-line @wordpress/valid-sprintf
 	const promptPhrase = sprintf( placeholderPhrase, ...entityNamesForPrompt );
 
@@ -114,9 +120,6 @@ export default function EntitiesSavedStates( { isOpen, close } ) {
 		} );
 	};
 
-	const [ isReviewing, setIsReviewing ] = useState( true );
-	const toggleIsReviewing = () => setIsReviewing( ( value ) => ! value );
-
 	// Explicitly define this with no argument passed.  Using `close` on
 	// its own will use the event object in place of the expected saved entities.
 	const dismissPanel = useCallback( () => close(), [ close ] );
@@ -146,31 +149,19 @@ export default function EntitiesSavedStates( { isOpen, close } ) {
 			<div className="entities-saved-states__text-prompt">
 				<strong>{ __( 'Are you ready to save?' ) }</strong>
 				<p>{ promptPhrase }</p>
-				<p>
-					<Button
-						onClick={ toggleIsReviewing }
-						isLink
-						className="entities-saved-states__review-changes-button"
-					>
-						{ isReviewing
-							? __( 'Hide changes.' )
-							: __( 'Review changes.' ) }
-					</Button>
-				</p>
 			</div>
 
-			{ isReviewing &&
-				partitionedSavables.map( ( list ) => {
-					return (
-						<EntityTypeList
-							key={ list[ 0 ].name }
-							list={ list }
-							closePanel={ dismissPanel }
-							unselectedEntities={ unselectedEntities }
-							setUnselectedEntities={ setUnselectedEntities }
-						/>
-					);
-				} ) }
+			{ partitionedSavables.map( ( list ) => {
+				return (
+					<EntityTypeList
+						key={ list[ 0 ].name }
+						list={ list }
+						closePanel={ dismissPanel }
+						unselectedEntities={ unselectedEntities }
+						setUnselectedEntities={ setUnselectedEntities }
+					/>
+				);
+			} ) }
 		</div>
 	) : null;
 }

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -57,7 +57,6 @@
 	}
 
 	.entities-saved-states__text-prompt {
-		border-bottom: $border-width solid $gray-300;
 		padding: $grid-unit-20;
 		padding-bottom: $grid-unit-05;
 	}


### PR DESCRIPTION
Follow up to #26355 

Based on some discussion with @jameskoster and @jasmussen it was decided that this multi-entity saving panel should be expanded by default.

**Testing instructions**

 - Enable an FSE theme
 - Add a site title block to a post
 - Edit the site title
 - Try to publish your post
