### PR TITLE
Plugins: Add scoping functionality to the Plugins API

### DIFF
--- a/packages/plugins/CHANGELOG.md
+++ b/packages/plugins/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add optional `settings.scope` field in the `registerPlugin` function ([#27438](https://github.com/WordPress/gutenberg/pull/27438)).
+-   Add optional `scope` param in the `getPlugins` function([#27438](https://github.com/WordPress/gutenberg/pull/27438)).
+-   Add optional `scope` prop in the `PluginArea` component ([#27438](https://github.com/WordPress/gutenberg/pull/27438)).
+
 ## 2.0.10 (2019-01-03)
 
 ## 2.0.9 (2018-11-15)
@@ -20,4 +26,4 @@
 
 ### Breaking Change
 
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -50,7 +50,7 @@ var PluginArea = wp.plugins.PluginArea;
 function Layout() {
 	return el(
 		'div',
-		{},
+		{ area: 'my-app-area' },
 		'Content of the page',
 		PluginArea
 	);
@@ -64,7 +64,7 @@ import { PluginArea } from '@wordpress/plugins';
 const Layout = () => (
 	<div>
 		Content of the page
-		<PluginArea />
+		<PluginArea area="my-app-area" />
 	</div>
 );
 ```
@@ -112,6 +112,7 @@ function Component() {
 registerPlugin( 'plugin-name', {
 	icon: moreIcon,
 	render: Component,
+	area: "my-app-area",
 } );
 ```
 
@@ -140,6 +141,7 @@ const Component = () => (
 registerPlugin( 'plugin-name', {
 	icon: more,
 	render: Component,
+	area: "my-app-area",
 } );
 ```
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -30,15 +30,15 @@ _Returns_
 
 <a name="getPlugins" href="#getPlugins">#</a> **getPlugins**
 
-Returns all registered plugins.
+Returns all registered plugins without a scope or for a given scope.
 
 _Parameters_
 
--   _scope_ `[string]`: The scope to be used when rendering inside a plugin area.
+-   _scope_ `[string]`: The scope to be used when rendering inside a plugin area. No scope by default.
 
 _Returns_
 
--   `WPPlugin[]`: The list of all plugins or for a give scope.
+-   `WPPlugin[]`: The list of plugins without a scope or for a given scope.
 
 <a name="PluginArea" href="#PluginArea">#</a> **PluginArea**
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -32,9 +32,13 @@ _Returns_
 
 Returns all registered plugins.
 
+_Parameters_
+
+-   _scope_ `[string]`: The scope to be used when rendering inside a plugin area.
+
 _Returns_
 
--   `WPPlugin[]`: Plugin settings.
+-   `WPPlugin[]`: The list of all plugins or for a give scope.
 
 <a name="PluginArea" href="#PluginArea">#</a> **PluginArea**
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -50,7 +50,7 @@ var PluginArea = wp.plugins.PluginArea;
 function Layout() {
 	return el(
 		'div',
-		{ area: 'my-app-area' },
+		{ scope: 'my-page' },
 		'Content of the page',
 		PluginArea
 	);
@@ -64,7 +64,7 @@ import { PluginArea } from '@wordpress/plugins';
 const Layout = () => (
 	<div>
 		Content of the page
-		<PluginArea area="my-app-area" />
+		<PluginArea scope="my-page" />
 	</div>
 );
 ```
@@ -112,7 +112,7 @@ function Component() {
 registerPlugin( 'plugin-name', {
 	icon: moreIcon,
 	render: Component,
-	area: "my-app-area",
+	scope: 'my-page',
 } );
 ```
 
@@ -141,7 +141,7 @@ const Component = () => (
 registerPlugin( 'plugin-name', {
 	icon: more,
 	render: Component,
-	area: "my-app-area",
+	scope: 'my-page',
 } );
 ```
 

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -24,8 +24,8 @@ import { isFunction } from 'lodash';
  *                                               choose to render your own SVG.
  * @property {Function}                  render  A component containing the UI elements
  *                                               to be rendered.
- * @property {string}                    [scope] The scope to be used when rendering inside
- * 												 a plugin area.
+ * @property {string}                    [scope] The optional scope to be used when rendering inside
+ *                                               a plugin area. No scope by default.
  */
 
 /**
@@ -216,12 +216,12 @@ export function getPlugin( name ) {
 }
 
 /**
- * Returns all registered plugins.
+ * Returns all registered plugins without a scope or for a given scope.
  *
  * @param {string} [scope] The scope to be used when rendering inside
- * 						   a plugin area.
+ *                         a plugin area. No scope by default.
  *
- * @return {WPPlugin[]} The list of all plugins or for a give scope.
+ * @return {WPPlugin[]} The list of plugins without a scope or for a given scope.
  */
 export function getPlugins( scope ) {
 	return Object.values( plugins ).filter(

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -16,15 +16,16 @@ import { isFunction } from 'lodash';
  *
  * @typedef {Object} WPPlugin
  *
- * @property {string}                    name   A string identifying the plugin. Must be
- *                                              unique across all registered plugins.
- * @property {string|WPElement|Function} icon   An icon to be shown in the UI. It can
- *                                              be a slug of the Dashicon, or an element
- *                                              (or function returning an element) if you
- *                                              choose to render your own SVG.
- * @property {Function}                  render A component containing the UI elements
- *                                              to be rendered.
- * @property {string}                    area   The pluginArea name to be rendered inside of.
+ * @property {string}                    name    A string identifying the plugin. Must be
+ *                                               unique across all registered plugins.
+ * @property {string|WPElement|Function} [icon]  An icon to be shown in the UI. It can
+ *                                               be a slug of the Dashicon, or an element
+ *                                               (or function returning an element) if you
+ *                                               choose to render your own SVG.
+ * @property {Function}                  render  A component containing the UI elements
+ *                                               to be rendered.
+ * @property {string}                    [scope] The scope to be used when rendering inside
+ * 												 a plugin area.
  */
 
 /**
@@ -75,7 +76,7 @@ const plugins = {};
  * registerPlugin( 'plugin-name', {
  * 	icon: moreIcon,
  * 	render: Component,
- * 	area: "my-app-area",
+ * 	scope: 'my-page',
  * } );
  * ```
  *
@@ -105,7 +106,7 @@ const plugins = {};
  * registerPlugin( 'plugin-name', {
  * 	icon: more,
  * 	render: Component,
- * 	area: "my-app-area",
+ * 	scope: 'my-page',
  * } );
  * ```
  *

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -118,12 +118,12 @@ export function registerPlugin( name, settings ) {
 		return null;
 	}
 	if ( typeof name !== 'string' ) {
-		console.error( 'Plugin names must be strings.' );
+		console.error( 'Plugin name must be string.' );
 		return null;
 	}
 	if ( ! /^[a-z][a-z0-9-]*$/.test( name ) ) {
 		console.error(
-			'Plugin names must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
+			'Plugin name must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
 		);
 		return null;
 	}
@@ -133,11 +133,27 @@ export function registerPlugin( name, settings ) {
 
 	settings = applyFilters( 'plugins.registerPlugin', settings, name );
 
-	if ( ! isFunction( settings.render ) ) {
+	const { render, scope } = settings;
+
+	if ( ! isFunction( render ) ) {
 		console.error(
 			'The "render" property must be specified and must be a valid function.'
 		);
 		return null;
+	}
+
+	if ( scope ) {
+		if ( typeof scope !== 'string' ) {
+			console.error( 'Plugin scope must be string.' );
+			return null;
+		}
+
+		if ( ! /^[a-z][a-z0-9-]*$/.test( scope ) ) {
+			console.error(
+				'Plugin scope must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-page".'
+			);
+			return null;
+		}
 	}
 
 	plugins[ name ] = {
@@ -202,8 +218,13 @@ export function getPlugin( name ) {
 /**
  * Returns all registered plugins.
  *
- * @return {WPPlugin[]} Plugin settings.
+ * @param {string} [scope] The scope to be used when rendering inside
+ * 						   a plugin area.
+ *
+ * @return {WPPlugin[]} The list of all plugins or for a give scope.
  */
-export function getPlugins() {
-	return Object.values( plugins );
+export function getPlugins( scope ) {
+	return Object.values( plugins ).filter(
+		( plugin ) => plugin.scope === scope
+	);
 }

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -18,13 +18,13 @@ import { isFunction } from 'lodash';
  *
  * @property {string}                    name   A string identifying the plugin. Must be
  *                                              unique across all registered plugins.
- *                                              unique across all registered plugins.
  * @property {string|WPElement|Function} icon   An icon to be shown in the UI. It can
  *                                              be a slug of the Dashicon, or an element
  *                                              (or function returning an element) if you
  *                                              choose to render your own SVG.
  * @property {Function}                  render A component containing the UI elements
  *                                              to be rendered.
+ * @property {string}                    area   The pluginArea name to be rendered inside of.
  */
 
 /**
@@ -75,6 +75,7 @@ const plugins = {};
  * registerPlugin( 'plugin-name', {
  * 	icon: moreIcon,
  * 	render: Component,
+ * 	area: "my-app-area",
  * } );
  * ```
  *
@@ -104,6 +105,7 @@ const plugins = {};
  * registerPlugin( 'plugin-name', {
  * 	icon: more,
  * 	render: Component,
+ * 	area: "my-app-area",
  * } );
  * ```
  *

--- a/packages/plugins/src/api/test/index.js
+++ b/packages/plugins/src/api/test/index.js
@@ -37,7 +37,7 @@ describe( 'registerPlugin', () => {
 			render: () => {},
 		} );
 		expect( console ).toHaveErroredWith(
-			'Plugin names must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
+			'Plugin name must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
 		);
 	} );
 
@@ -48,13 +48,31 @@ describe( 'registerPlugin', () => {
 				render: () => {},
 			}
 		);
-		expect( console ).toHaveErroredWith( 'Plugin names must be strings.' );
+		expect( console ).toHaveErroredWith( 'Plugin name must be string.' );
 	} );
 
 	it( 'fails to register a plugin without a render function', () => {
 		registerPlugin( 'another-plugin', {} );
 		expect( console ).toHaveErroredWith(
 			'The "render" property must be specified and must be a valid function.'
+		);
+	} );
+
+	it( 'fails to register a plugin with a non-string scope', () => {
+		registerPlugin( 'my-plugin', {
+			render: () => {},
+			scope: {},
+		} );
+		expect( console ).toHaveErroredWith( 'Plugin scope must be string.' );
+	} );
+
+	it( 'fails to register a plugin with special character in the scope', () => {
+		registerPlugin( 'my-plugin', {
+			render: () => {},
+			scope: 'special/characters!',
+		} );
+		expect( console ).toHaveErroredWith(
+			'Plugin scope must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-page".'
 		);
 	} );
 
@@ -68,5 +86,39 @@ describe( 'registerPlugin', () => {
 		expect( console ).toHaveErroredWith(
 			'Plugin "plugin" is already registered.'
 		);
+	} );
+} );
+
+describe( 'getPlugins', () => {
+	const scope = 'my-page';
+
+	beforeAll( () => {
+		const Component = () => 'plugin content';
+		const icon = 'smiley';
+
+		registerPlugin( 'unscoped', {
+			render: Component,
+			icon,
+		} );
+		registerPlugin( 'scoped', {
+			render: Component,
+			icon,
+			scope,
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterPlugin( 'unscoped' );
+		unregisterPlugin( 'scoped' );
+	} );
+
+	it( 'returns all unscoped plugins', () => {
+		expect( getPlugins() ).toHaveLength( 1 );
+	} );
+
+	it( 'returns all plugins of a given scope', () => {
+		const scopedPlugins = getPlugins( scope );
+		expect( scopedPlugins ).toHaveLength( 1 );
+		expect( scopedPlugins[ 0 ].name ).toBe( 'scoped' );
 	} );
 } );

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -27,7 +27,7 @@ import { getPlugins } from '../../api';
  * function Layout() {
  * 	return el(
  * 		'div',
- * 		{},
+ * 		{ area: 'my-app-area' },
  * 		'Content of the page',
  * 		PluginArea
  * 	);
@@ -42,7 +42,7 @@ import { getPlugins } from '../../api';
  * const Layout = () => (
  * 	<div>
  * 		Content of the page
- * 		<PluginArea />
+ * 		<PluginArea area="my-app-area" />
  * 	</div>
  * );
  * ```
@@ -59,15 +59,17 @@ class PluginArea extends Component {
 
 	getCurrentPluginsState() {
 		return {
-			plugins: map( getPlugins(), ( { icon, name, render } ) => {
-				return {
-					Plugin: render,
-					context: {
-						name,
-						icon,
-					},
-				};
-			} ),
+			plugins: map( getPlugins(), ( { icon, name, render, area } ) => {
+				if ( this.props.area === area ) {
+					return {
+						Plugin: render,
+						context: {
+							name,
+							icon,
+						},
+					};
+				}
+			} ).filter( Boolean ),
 		};
 	}
 

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -27,7 +27,7 @@ import { getPlugins } from '../../api';
  * function Layout() {
  * 	return el(
  * 		'div',
- * 		{ area: 'my-app-area' },
+ * 		{ scope: 'my-page' },
  * 		'Content of the page',
  * 		PluginArea
  * 	);
@@ -42,7 +42,7 @@ import { getPlugins } from '../../api';
  * const Layout = () => (
  * 	<div>
  * 		Content of the page
- * 		<PluginArea area="my-app-area" />
+ * 		<PluginArea scope="my-page" />
  * 	</div>
  * );
  * ```
@@ -59,8 +59,8 @@ class PluginArea extends Component {
 
 	getCurrentPluginsState() {
 		return {
-			plugins: map( getPlugins(), ( { icon, name, render, area } ) => {
-				if ( this.props.area === area ) {
+			plugins: map( getPlugins(), ( { icon, name, render, scope } ) => {
+				if ( this.props.scope === scope ) {
 					return {
 						Plugin: render,
 						context: {

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -59,8 +59,9 @@ class PluginArea extends Component {
 
 	getCurrentPluginsState() {
 		return {
-			plugins: map( getPlugins(), ( { icon, name, render, scope } ) => {
-				if ( this.props.scope === scope ) {
+			plugins: map(
+				getPlugins( this.props.scope ),
+				( { icon, name, render } ) => {
 					return {
 						Plugin: render,
 						context: {
@@ -69,7 +70,7 @@ class PluginArea extends Component {
 						},
 					};
 				}
-			} ).filter( Boolean ),
+			),
 		};
 	}
 


### PR DESCRIPTION
## Description

Currently, when you register a plugin with Plugins API from the `@wordpress/plugins` package, that component is rendered on all pages that use the `PluginArea` component. In addition to that, if you render `PluginArea` multiple times, then the same plugin will get rendered multiple times on the same page. The solution for that issue is the concept of scopes. This way, you can have more fine-grained control of where your plugin is going to be displayed.

There is now a new `scope` field added to the settings object passed as a second param to the `registerPlugin` function. There is also a `scope` prop introduced to the `PluginArea` component. A named `PluginArea` would only render plugins registered for the matching scope passed to the `registerPlugin` call. If the scope is not provided, then all plugins without a scope will render as before. It makes this approach fully backward compatible.

```js
import { PluginArea, registerPlugin } from '@wordpress/plugins';
import MyPlugin from './my-plugin';

registerPlugin( 'plugin', {
    render() {
        return <MyPlugin >Renders in the default area</MyPlugin>;
    },
} );

registerPlugin( 'plugin-scoped', {
    render() {
        return <MyPlugin>Renders in the scoped area</MyPlugin>;
    },
    scope: 'named',
} );

const App = () => {
    return (
        <>
            <PluginArea />
            <PluginArea scope="named" />
        </>
    );
};
```

This PR combines work from #21908 proposed by @psealock.

## Testing

The existing functionality should work as before.

`npm run test-e2e` should still pass.

New unit tests were added that cover new functionality:

`npm run test-unit` should pass.

## Type

This PR adds new functionality to public APi in `@wordpress/plugins` package.