### PR TITLE
Testing: Make image size test more stable

### DIFF
--- a/packages/e2e-test-utils/src/open-document-settings-sidebar.js
+++ b/packages/e2e-test-utils/src/open-document-settings-sidebar.js
@@ -8,5 +8,6 @@ export async function openDocumentSettingsSidebar() {
 
 	if ( openButton ) {
 		await openButton.click();
+		await page.waitForSelector( '.edit-post-sidebar' );
 	}
 }

--- a/packages/e2e-tests/specs/editor/plugins/image-size.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/image-size.test.js
@@ -13,6 +13,7 @@ import {
 	activatePlugin,
 	createNewPost,
 	clickButton,
+	deactivatePlugin,
 	insertBlock,
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
@@ -23,9 +24,11 @@ describe( 'changing image size', () => {
 		await createNewPost();
 	} );
 
-	it( 'should insert and change my image size', async () => {
-		const expectedImageWidth = 499;
+	afterEach( async () => {
+		await deactivatePlugin( 'gutenberg-test-image-size' );
+	} );
 
+	it( 'should insert and change my image size', async () => {
 		// Create a paragraph.
 		await insertBlock( 'Image' );
 		await clickButton( 'Media Library' );
@@ -68,10 +71,14 @@ describe( 'changing image size', () => {
 
 		await page.waitForSelector( '.wp-block-image.size-custom-size-one' );
 
-		const imageWidth = await page.$eval(
+		// Disable reason: Wait for the input element to update with the new
+		// value, otherwise it can still contain the old one.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 100 );
+		const customImageWidth = await page.$eval(
 			'.block-editor-image-size-control__width input',
 			( el ) => parseInt( el.value, 10 )
 		);
-		expect( imageWidth ).toBe( expectedImageWidth );
+		expect( customImageWidth ).toBe( 499 );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/image-size.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/image-size.test.js
@@ -29,7 +29,6 @@ describe( 'changing image size', () => {
 	} );
 
 	it( 'should insert and change my image size', async () => {
-		// Create a paragraph.
 		await insertBlock( 'Image' );
 		await clickButton( 'Media Library' );
 
@@ -59,7 +58,6 @@ describe( 'changing image size', () => {
 
 		// Select the new size updated with the plugin.
 		await openDocumentSettingsSidebar();
-
 		const imageSizeLabel = await page.waitForXPath(
 			'//label[text()="Image size"]'
 		);
@@ -69,16 +67,13 @@ describe( 'changing image size', () => {
 		);
 		await imageSizeSelect.select( 'custom-size-one' );
 
+		// Verify that the custom size was applied to the image.
 		await page.waitForSelector( '.wp-block-image.size-custom-size-one' );
-
-		// Disable reason: Wait for the input element to update with the new
-		// value, otherwise it can still contain the old one.
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 100 );
-		const customImageWidth = await page.$eval(
-			'.block-editor-image-size-control__width input',
-			( el ) => parseInt( el.value, 10 )
+		await page.waitForFunction(
+			() =>
+				document.querySelector(
+					'.block-editor-image-size-control__width input'
+				).value === '499'
 		);
-		expect( customImageWidth ).toBe( 499 );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/image-size.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/image-size.test.js
@@ -57,14 +57,16 @@ describe( 'changing image size', () => {
 		// Select the new size updated with the plugin.
 		await openDocumentSettingsSidebar();
 
-		const [ imageSizeLabel ] = await page.$x(
+		const imageSizeLabel = await page.waitForXPath(
 			'//label[text()="Image size"]'
 		);
 		await imageSizeLabel.click();
 		const imageSizeSelect = await page.evaluateHandle(
 			() => document.activeElement
 		);
-		imageSizeSelect.select( 'custom-size-one' );
+		await imageSizeSelect.select( 'custom-size-one' );
+
+		await page.waitForSelector( '.wp-block-image.size-custom-size-one' );
 
 		const imageWidth = await page.$eval(
 			'.block-editor-image-size-control__width input',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Tries to address the issue discovered by @youknowriad in https://github.com/WordPress/gutenberg/pull/26355/checks?check_run_id=1485427192:

```
FAIL specs/editor/plugins/image-size.test.js (8.277s)
54
  ● changing image size › should insert and change my image size
55

56
    expect(received).toBe(expected) // Object.is equality
57

58
    Expected: 499
59
    Received: 1024
60

61
      71 | 			( el ) => parseInt( el.value, 10 )
62
      72 | 		);
63
    > 73 | 		expect( imageWidth ).toBe( expectedImageWidth );
64
         | 		                     ^
65
      74 | 	} );
66
      75 | } );
67
      76 | 
68

69
      at Object.<anonymous> (specs/editor/plugins/image-size.test.js:73:24)
70
          at runMicrotasks (<anonymous>)
```

## How has this been tested?
`npm run test-e2e`
