### PR TITLE
Upgrade wp-prettier to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17875,7 +17875,7 @@
 				"eslint-plugin-react": "^7.20.0",
 				"eslint-plugin-react-hooks": "^4.0.4",
 				"globals": "^12.0.0",
-				"prettier": "npm:wp-prettier@2.0.5",
+				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"requireindex": "^1.2.0"
 			}
 		},
@@ -18280,7 +18280,7 @@
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^5.0.0",
 				"postcss-loader": "^3.0.0",
-				"prettier": "npm:wp-prettier@2.0.5",
+				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"puppeteer": "npm:puppeteer-core@3.0.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
@@ -51354,9 +51354,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.0.5",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-			"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+			"version": "npm:wp-prettier@2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"patch-package": "6.2.2",
 		"postcss": "7.0.32",
 		"postcss-loader": "3.0.0",
-		"prettier": "npm:wp-prettier@2.0.5",
+		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"progress": "2.0.3",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"react": "16.13.1",

--- a/packages/block-library/src/query/test/utils.js
+++ b/packages/block-library/src/query/test/utils.js
@@ -13,8 +13,8 @@ describe( 'Query block utils', () => {
 			expect( getTermsInfo( terms ) ).toEqual(
 				expect.objectContaining( {
 					mapById: expect.objectContaining( {
-						'4': expect.objectContaining( { name: 'nba' } ),
-						'11': expect.objectContaining( {
+						4: expect.objectContaining( { name: 'nba' } ),
+						11: expect.objectContaining( {
 							name: 'featured',
 						} ),
 					} ),

--- a/packages/core-data/src/locks/test/selectors.js
+++ b/packages/core-data/src/locks/test/selectors.js
@@ -124,7 +124,7 @@ describe( '__unstableIsLockAvailable', () => {
 									post: {
 										locks: [],
 										children: {
-											'16': {
+											16: {
 												locks: [
 													{
 														store: 'core',
@@ -145,7 +145,7 @@ describe( '__unstableIsLockAvailable', () => {
 									wp_template_part: {
 										locks: [],
 										children: {
-											'17': {
+											17: {
 												locks: [],
 												children: {},
 											},

--- a/packages/data/src/types.d.ts
+++ b/packages/data/src/types.d.ts
@@ -2,31 +2,31 @@ export type WPDataFunctionOrGeneratorArray = Array< Function | Generator >;
 export type WPDataFunctionArray = Array< Function >;
 
 export interface WPDataAttachedStore {
-    getSelectors: () => WPDataFunctionArray,
-    getActions: () => WPDataFunctionArray,
-    subscribe: (listener: () => void) => (() => void)
-};
+	getSelectors: () => WPDataFunctionArray;
+	getActions: () => WPDataFunctionArray;
+	subscribe: ( listener: () => void ) => () => void;
+}
 
 export interface WPDataStore {
-    /**
-     * Store Name
-     */
-    name: string,
+	/**
+	 * Store Name
+	 */
+	name: string;
 
-    /**
-     * Store configuration object.
-     */
-    instantiate: (registry: WPDataRegistry) => WPDataAttachedStore,
-};
+	/**
+	 * Store configuration object.
+	 */
+	instantiate: ( registry: WPDataRegistry ) => WPDataAttachedStore;
+}
 
 export interface WPDataReduxStoreConfig {
-    reducer: ( state: any, action: any ) => any,
-    actions?: WPDataFunctionOrGeneratorArray,
-    resolvers?: WPDataFunctionOrGeneratorArray,
-    selectors?: WPDataFunctionArray,
-    controls?: WPDataFunctionArray,
+	reducer: ( state: any, action: any ) => any;
+	actions?: WPDataFunctionOrGeneratorArray;
+	resolvers?: WPDataFunctionOrGeneratorArray;
+	selectors?: WPDataFunctionArray;
+	controls?: WPDataFunctionArray;
 }
 
 export interface WPDataRegistry {
-    register: ( store: WPDataStore ) => void,
+	register: ( store: WPDataStore ) => void;
 }

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Add `no-unsafe-wp-apis` rule to discourage usage of unsafe APIs ([#27301](https://github.com/WordPress/gutenberg/pull/27301)).
 
+### Enhancements
+
+-   The bundled `wp-prettier` dependency has been upgraded from `2.0.5` to `2.2.1`.
+
 ### Documentation
 
 -   Include a note about the minimum version required for `node` (10.0.0) and `npm` (6.9.0).

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -42,7 +42,7 @@
 		"eslint-plugin-react": "^7.20.0",
 		"eslint-plugin-react-hooks": "^4.0.4",
 		"globals": "^12.0.0",
-		"prettier": "npm:wp-prettier@2.0.5",
+		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Autoformat TypeScript files (`*.ts` and `*.tsx`) in `format-js` script (#27138)[https://github.com/WordPress/gutenberg/pull/27138].
+-   The bundled `wp-prettier` dependency has been upgraded from `2.0.5` to `2.2.1`.
 
 ### Internal
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -59,7 +59,7 @@
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^5.0.0",
 		"postcss-loader": "^3.0.0",
-		"prettier": "npm:wp-prettier@2.0.5",
+		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -90,29 +90,23 @@ export function next( tag, text, index = 0 ) {
  * @return {string} Text with shortcodes replaced.
  */
 export function replace( tag, text, callback ) {
-	return text.replace( regexp( tag ), function (
-		match,
-		left,
-		$3,
-		attrs,
-		slash,
-		content,
-		closing,
-		right
-	) {
-		// If both extra brackets exist, the shortcode has been properly
-		// escaped.
-		if ( left === '[' && right === ']' ) {
-			return match;
+	return text.replace(
+		regexp( tag ),
+		function ( match, left, $3, attrs, slash, content, closing, right ) {
+			// If both extra brackets exist, the shortcode has been properly
+			// escaped.
+			if ( left === '[' && right === ']' ) {
+				return match;
+			}
+
+			// Create the match object and pass it through the callback.
+			const result = callback( fromMatch( arguments ) );
+
+			// Make sure to return any of the extra brackets if they weren't used to
+			// escape the shortcode.
+			return result ? left + result + right : match;
 		}
-
-		// Create the match object and pass it through the callback.
-		const result = callback( fromMatch( arguments ) );
-
-		// Make sure to return any of the extra brackets if they weren't used to
-		// escape the shortcode.
-		return result ? left + result + right : match;
-	} );
+	);
 }
 
 /**

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -626,7 +626,7 @@ describe( 'getQueryArgs', () => {
 
 		expect( getQueryArgs( url ) ).toEqual( {
 			foo: {
-				'0': '0',
+				0: '0',
 				one: '1',
 			},
 		} );


### PR DESCRIPTION
Upgrades `wp-prettier` to version 2.2.1 of the fork, making it up to date with the latest upstream.

I already upgraded Calypso successfully earlier today: https://github.com/Automattic/wp-calypso/pull/47950

