### PR TITLE
Popover: Fix issue with undefined getBoundingClientRect

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -83,10 +83,10 @@ function computeAnchorRect(
 			return getRectangleFromRange( anchorRef );
 		}
 
-		// Duck-type to check if `anchorRef` is an instance of Element
-		// `anchorRef instanceof window.Element` checks will break across document boundaries
-		// such as in an iframe
-		if ( typeof anchorRef?.getBoundingClientRect === 'function' ) {
+		if (
+			anchorRef?.ownerDocument &&
+			anchorRef instanceof anchorRef.ownerDocument.defaultView.Element
+		) {
 			const rect = anchorRef.getBoundingClientRect();
 
 			if ( shouldAnchorIncludePadding ) {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -71,15 +71,10 @@ function computeAnchorRect(
 			return;
 		}
 
-		if (
-			anchorRef?.startContainer &&
-			anchorRef instanceof
-				// A Range.startContainer may be a Node or a Document
-				(
-					anchorRef.startContainer.defaultView ??
-					anchorRef.startContainer.ownerDocument.defaultView
-				).Range
-		) {
+		// Duck-type to check if `anchorRef` is an instance of Range
+		// `anchorRef instanceof window.Range` checks will break across document boundaries
+		// such as in an iframe
+		if ( typeof anchorRef?.cloneRange === 'function' ) {
 			return getRectangleFromRange( anchorRef );
 		}
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -75,7 +75,10 @@ function computeAnchorRect(
 			return getRectangleFromRange( anchorRef );
 		}
 
-		if ( anchorRef instanceof window.Element ) {
+		if (
+			anchorRef?.ownerDocument &&
+			anchorRef instanceof anchorRef.ownerDocument.defaultView.Element
+		) {
 			const rect = anchorRef.getBoundingClientRect();
 
 			if ( shouldAnchorIncludePadding ) {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -71,7 +71,15 @@ function computeAnchorRect(
 			return;
 		}
 
-		if ( anchorRef instanceof window.Range ) {
+		if (
+			anchorRef?.startContainer &&
+			anchorRef instanceof
+				// A Range.startContainer may be a Node or a Document
+				(
+					anchorRef.startContainer.defaultView ??
+					anchorRef.startContainer.ownerDocument.defaultView
+				).Range
+		) {
 			return getRectangleFromRange( anchorRef );
 		}
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -83,10 +83,10 @@ function computeAnchorRect(
 			return getRectangleFromRange( anchorRef );
 		}
 
-		if (
-			anchorRef?.ownerDocument &&
-			anchorRef instanceof anchorRef.ownerDocument.defaultView.Element
-		) {
+		// Duck-type to check if `anchorRef` is an instance of Element
+		// `anchorRef instanceof window.Element` checks will break across document boundaries
+		// such as in an iframe
+		if ( typeof anchorRef?.getBoundingClientRect === 'function' ) {
 			const rect = anchorRef.getBoundingClientRect();
 
 			if ( shouldAnchorIncludePadding ) {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -75,10 +75,10 @@ function computeAnchorRect(
 			return getRectangleFromRange( anchorRef );
 		}
 
-		if (
-			anchorRef?.ownerDocument &&
-			anchorRef instanceof anchorRef.ownerDocument.defaultView.Element
-		) {
+		// Duck-type to check if `anchorRef` is an instance of Element
+		// `anchorRef instanceof window.Element` checks will break across document boundaries
+		// such as in an iframe
+		if ( typeof anchorRef?.getBoundingClientRect === 'function' ) {
 			const rect = anchorRef.getBoundingClientRect();
 
 			if ( shouldAnchorIncludePadding ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fix an issue where the `Popover` component throws a runtime `TypeError: Cannot read property 'getBoundingClientRect' of undefined.` on this line:

https://github.com/WordPress/gutenberg/blob/adacd0a898c4e6e8a7222655b2ef50273f3c46b6/packages/components/src/popover/index.js#L89

This may happen in WordPress if a Popover is rendered in an iframe. It's been observed by rendering a `BlockList` component containing a `RichText` component in an iframe 😵

This is the problematic section:

https://github.com/WordPress/gutenberg/blob/adacd0a898c4e6e8a7222655b2ef50273f3c46b6/packages/components/src/popover/index.js#L64-L86

In the issue I've observed, `anchorRef` _is_ an `Element` on line 78, but it's **not** an instance of `window.Element`. It's an instance of `anchorRef.ownerDocument.defaultView.Element` 😮 

Both of the conditional blocks are skipped and we end up calling `anchorRef.top.getBoundingClientRect()` on an Element. This triggers the error:

https://github.com/WordPress/gutenberg/blob/adacd0a898c4e6e8a7222655b2ef50273f3c46b6/packages/components/src/popover/index.js#L88-L90

You can verify this is problematic by running the following in a recent browser at `about:blank`:

```js
var iframe = document.createElement('iframe');
iframe.srcdoc = '<div></div>';
document.body.appendChild(iframe);

// Don't just paste this in a single command, we need to let the append complete…

var div = iframe.contentDocument.querySelector('div');

console.log( "Instance of window's Element? %o", div instanceof window.Element ); // False!!! 💥
console.log( "Instance of its iframe's Element? %o", div instanceof div?.ownerDocument.defaultView.Element ); // True 😎👍
```

The issue would apparently begin to manifest after #25332. The iframed issue described above worked with Gutenberg 9.3 but began to throw errors in 9.4.

## How has this been tested?

Appears to fix the issue where observed.

Popovers should continue to work in normal usage.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
