### PR TITLE
Update the rich text control titles to sentence case structure

### DIFF
--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -7,7 +7,7 @@ import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { code as codeIcon } from '@wordpress/icons';
 
 const name = 'core/code';
-const title = __( 'Inline Code' );
+const title = __( 'Inline code' );
 
 export const code = {
 	name,

--- a/packages/format-library/src/keyboard/index.js
+++ b/packages/format-library/src/keyboard/index.js
@@ -7,7 +7,7 @@ import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { button } from '@wordpress/icons';
 
 const name = 'core/keyboard';
-const title = __( 'Keyboard Input' );
+const title = __( 'Keyboard input' );
 
 export const keyboard = {
 	name,

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -21,7 +21,7 @@ import { removeFormat } from '@wordpress/rich-text';
 import { default as InlineColorUI, getActiveColor } from './inline';
 
 const name = 'core/text-color';
-const title = __( 'Text Color' );
+const title = __( 'Text color' );
 
 const EMPTY_ARRAY = [];
 


### PR DESCRIPTION
## Description
Some of the rich text controls were using title case. I updated them to sentence case.

## How has this been tested?
Locally.

## Screenshots <!-- if applicable -->

**BEFORE**

![before](https://user-images.githubusercontent.com/617986/100908803-c6298480-3480-11eb-809a-cc0d2e003b34.png)

**AFTER**

![after](https://user-images.githubusercontent.com/617986/100908812-ca55a200-3480-11eb-9c35-708c2c6cb035.png)


## Types of changes
Non-breaking.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
