### PR TITLE
Fix: Global Styles getPresetVariable uses a wrong variable; Remove GLOBAL_CONTEXT

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -24,7 +24,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import {
-	GLOBAL_CONTEXT,
+	GLOBAL_CONTEXT_NAME,
+	GLOBAL_CONTEXT_SELECTOR,
+	GLOBAL_CONTEXT_SUPPORTS,
 	getValueFromVariable,
 	getPresetVariable,
 } from './utils';
@@ -78,7 +80,10 @@ const extractSupportKeys = ( supports ) => {
 
 const getContexts = ( blockTypes ) => {
 	const result = {
-		...GLOBAL_CONTEXT,
+		[ GLOBAL_CONTEXT_NAME ]: {
+			selector: GLOBAL_CONTEXT_SELECTOR,
+			supports: GLOBAL_CONTEXT_SUPPORTS,
+		},
 	};
 
 	// Add contexts from block metadata.

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -10,24 +10,19 @@ import { useSelect } from '@wordpress/data';
 /* Supporting data */
 export const GLOBAL_CONTEXT_NAME = 'global';
 export const GLOBAL_CONTEXT_SELECTOR = ':root';
-export const GLOBAL_CONTEXT = {
-	[ GLOBAL_CONTEXT_NAME ]: {
-		selector: GLOBAL_CONTEXT_SELECTOR,
-		supports: [
-			'--wp--style--color--link',
-			'background',
-			'backgroundColor',
-			'color',
-			'fontFamily',
-			'fontSize',
-			'fontStyle',
-			'fontWeight',
-			'lineHeight',
-			'textDecoration',
-			'textTransform',
-		],
-	},
-};
+export const GLOBAL_CONTEXT_SUPPORTS = [
+	'--wp--style--color--link',
+	'background',
+	'backgroundColor',
+	'color',
+	'fontFamily',
+	'fontSize',
+	'fontStyle',
+	'fontWeight',
+	'lineHeight',
+	'textDecoration',
+	'textTransform',
+];
 
 export const PRESET_CATEGORIES = {
 	color: { path: [ 'color', 'palette' ], key: 'color' },
@@ -99,7 +94,7 @@ export function getPresetVariable( styles, blockName, propertyName, value ) {
 	const { key, path } = presetData;
 	const presets =
 		get( styles, [ blockName, 'settings', ...path ] ) ??
-		get( styles, [ GLOBAL_CONTEXT, 'settings', ...path ] );
+		get( styles, [ GLOBAL_CONTEXT_NAME, 'settings', ...path ] );
 	const presetObject = find( presets, ( preset ) => {
 		return preset[ key ] === value;
 	} );


### PR DESCRIPTION
getPresetVariable was using the variable GLOBAL_CONTEXT instead of GLOBAL_CONTEXT_NAME.
Causing a bug.
These PR fixes the issue and removes GLOBAL_CONTEXT to avoid future confusion/bugs. The variable was just being used in a single place anyway.

## How has this been tested?
I opened the global styles panel.
I went to the paragraph block panel.
I applied a preset background color to the paragraph.
I used the browser dev tools and verified the background color references a preset CSS variable. On master it does not.