### PR TITLE
[WIP] Introduce snapshot/restore commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ phpcs.xml
 yarn.lock
 /wordpress
 /artifacts
+/snapshot
 
 playground/dist
 .cache

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -16,6 +16,7 @@ const env = require( './env' );
 const boldWhite = chalk.bold.white;
 const wpPrimary = boldWhite.bgHex( '#00669b' );
 const wpGreen = boldWhite.bgHex( '#4ab866' );
+const wpBlue = boldWhite.bgHex( '#000066' );
 const wpRed = boldWhite.bgHex( '#d94f4f' );
 const wpYellow = boldWhite.bgHex( '#f0b849' );
 
@@ -109,6 +110,18 @@ module.exports = function cli() {
 		),
 		() => {},
 		withSpinner( env.stop )
+	);
+	yargs.command(
+		'snapshot',
+		wpBlue( 'Makes a snapshot of the environment DB and files.' ),
+		() => {},
+		withSpinner( env.snapshot )
+	);
+	yargs.command(
+		'restore',
+		wpBlue( 'Restores a snapshot of the environment DB and files.' ),
+		() => {},
+		withSpinner( env.restore )
 	);
 	yargs.command(
 		'clean [environment]',

--- a/packages/env/lib/commands/index.js
+++ b/packages/env/lib/commands/index.js
@@ -7,6 +7,8 @@ const clean = require( './clean' );
 const run = require( './run' );
 const destroy = require( './destroy' );
 const logs = require( './logs' );
+const snapshot = require( './snapshot' );
+const restore = require( './restore' );
 
 module.exports = {
 	start,
@@ -15,4 +17,6 @@ module.exports = {
 	run,
 	destroy,
 	logs,
+	snapshot,
+	restore,
 };

--- a/packages/env/lib/commands/restore.js
+++ b/packages/env/lib/commands/restore.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+
+const util = require( 'util' );
+const exec = util.promisify( require( 'child_process' ).exec );
+/**
+ * Internal dependencies
+ */
+const initConfig = require( '../init-config' );
+
+/**
+ * @typedef {import('../wordpress').WPEnvironment} WPEnvironment
+ * @typedef {import('../wordpress').WPEnvironmentSelection} WPEnvironmentSelection
+ */
+
+/**
+ * Takes a snapshot of the development server's database.
+ *
+ * @param {Object}                 options
+ * @param {Object}                 options.spinner     A CLI spinner which indicates progress.
+ * @param {boolean}                options.debug       True if debug mode is enabled.
+ */
+module.exports = async function snapshot( { spinner, debug } ) {
+	const config = await initConfig( { spinner, debug } );
+
+	const snapshotPath = `${ config.configDirectoryPath }/snapshot`;
+	const directoryHash = path.basename( config.workDirectoryPath );
+	const filesVolume = `${ directoryHash }_wordpress`;
+	const dbVolume = `${ directoryHash }_mysql`;
+
+	spinner.text = `Restoring to ${ directoryHash }.`;
+
+	await exec(
+		`cat ${ snapshotPath }/db_backup.tar.bz2 | docker run -i -v ${ dbVolume }:/volume --rm loomchild/volume-backup restore -`
+	);
+	await exec(
+		`cat ${ snapshotPath }/app_backup.tar.bz2 | docker run -i -v ${ filesVolume }:/volume --rm loomchild/volume-backup restore -`
+	);
+
+	spinner.text = `Restored to ${ directoryHash }.`;
+};

--- a/packages/env/lib/commands/snapshot.js
+++ b/packages/env/lib/commands/snapshot.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+
+const fs = require( 'fs' );
+const util = require( 'util' );
+const exec = util.promisify( require( 'child_process' ).exec );
+/**
+ * Internal dependencies
+ */
+const initConfig = require( '../init-config' );
+
+/**
+ * @typedef {import('../wordpress').WPEnvironment} WPEnvironment
+ * @typedef {import('../wordpress').WPEnvironmentSelection} WPEnvironmentSelection
+ */
+
+/**
+ * Takes a snapshot of the development server's database.
+ *
+ * @param {Object}                 options
+ * @param {Object}                 options.spinner     A CLI spinner which indicates progress.
+ * @param {boolean}                options.debug       True if debug mode is enabled.
+ */
+module.exports = async function snapshot( { spinner, debug } ) {
+	const config = await initConfig( { spinner, debug } );
+
+	const snapshotPath = `${ config.configDirectoryPath }/snapshot`;
+	const directoryHash = path.basename( config.workDirectoryPath );
+	const filesVolume = `${ directoryHash }_wordpress`;
+	const dbVolume = `${ directoryHash }_mysql`;
+
+	spinner.text = `Snapshotting ${ directoryHash }.`;
+
+	if ( ! fs.existsSync( snapshotPath ) ) {
+		fs.mkdirSync( snapshotPath );
+	}
+
+	try {
+		await exec(
+			`docker run -v ${ dbVolume }:/volume --rm loomchild/volume-backup backup - > ${ snapshotPath }/db_backup.tar.bz2`
+		);
+		await exec(
+			`docker run -v ${ filesVolume }:/volume --rm loomchild/volume-backup backup - > ${ snapshotPath }/app_backup.tar.bz2`
+		);
+	} catch ( err ) {
+		//TODO: The most likely culpret is an EMPTY filesVolume.
+		//However I'm not sure how to ensure the snapshot is needed prior to execution.
+		//So for now... just failing silently... :(
+	}
+
+	spinner.text = `Snapshotted ${ directoryHash }.`;
+};


### PR DESCRIPTION

## Description
This change introduces the 'snapshot' and 'restore' commands to the wp-env tool.

`wp-env snapshot` will copy the database and file docker volumes into archives in the local /snapshot directory

`wp-env restore` will copy the contents of the archive files in /snapshot to the docker volumes

It leverages 'loomchild/volume-backup' (a very simple docker container for the purpose of snapshotting volumes)

I'm sure this can be greatly improved, this is a proof-of-concept to demonstrate the idea.


## How has this been tested?
* Start with a clean wp environment:
  `npx wp-env start`
  `npx wp-env clean`
* Make some changes to the website content.  I changed the 'Hello World' post to 'Howdy World'
* Take a snapshot of the environment
  `npx wp-env snapshot`
* Note that two new files have been created in a new folder called /snapshot
* Clean the wp environment
  `npx wp-env clean`
* Observe that the website has returned to the default state.
* Stop the wp environment and restore the website from your snapshot
  `npx wp-env stop`
  `npx wp-env restore`
* Start the wp environment back up
  `npx wp-env start`
* Observe that the website content has returned to the state of when the snapshot was made

## Types of changes
* This effects the wp-env utility only and only adds the two new commands.  Existing commands operate without change and Gutenberg is uneffected in any other way.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
