### PR TITLE
Block editor: move block focus listener to block props hook

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -189,8 +189,16 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			 * selected. This specifically handles the case where block does not
 			 * set focus on its own (via `setFocus`), typically if there is no
 			 * focusable input in the block.
+			 *
+			 * @param {FocusEvent} event Focus event.
 			 */
-			function onFocus() {
+			function onFocus( event ) {
+				// If an inner block is focussed, that block is resposible for
+				// setting the selected block.
+				if ( ! isInsideRootBlock( ref.current, event.target ) ) {
+					return;
+				}
+
 				selectBlock( clientId );
 			}
 
@@ -242,12 +250,24 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			}
 		}
 
+		/**
+		 * Prevents default dragging behavior within a block. To do: we must
+		 * handle this in the future and clean up the drag target.
+		 *
+		 * @param {DragEvent} event Drag event.
+		 */
+		function onDragStart( event ) {
+			event.preventDefault();
+		}
+
 		ref.current.addEventListener( 'keydown', onKeyDown );
 		ref.current.addEventListener( 'mouseleave', onMouseLeave );
+		ref.current.addEventListener( 'dragstart', onDragStart );
 
 		return () => {
 			ref.current.removeEventListener( 'mouseleave', onMouseLeave );
 			ref.current.removeEventListener( 'keydown', onKeyDown );
+			ref.current.removeEventListener( 'dragstart', onDragStart );
 		};
 	}, [ isSelected, onSelectionStart, insertDefaultBlock, removeBlock ] );
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -91,7 +91,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		},
 		[ isSelected ]
 	);
-	const { insertDefaultBlock, removeBlock } = useDispatch(
+	const { insertDefaultBlock, removeBlock, selectBlock } = useDispatch(
 		'core/block-editor'
 	);
 	const [ isHovered, setHovered ] = useState( false );
@@ -184,7 +184,21 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	useEffect( () => {
 		if ( ! isSelected ) {
-			return;
+			/**
+			 * Marks the block as selected when focused and not already
+			 * selected. This specifically handles the case where block does not
+			 * set focus on its own (via `setFocus`), typically if there is no
+			 * focusable input in the block.
+			 */
+			function onFocus() {
+				selectBlock( clientId );
+			}
+
+			ref.current.addEventListener( 'focus', onFocus, true );
+
+			return () => {
+				ref.current.removeEventListener( 'focus', onFocus, true );
+			};
 		}
 
 		/**

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -12,30 +12,12 @@ import { createContext, forwardRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import useMultiSelection from './use-multi-selection';
-import { getBlockClientId } from '../../utils/dom';
 import useInsertionPoint from './insertion-point';
 import BlockPopover from './block-popover';
-
-/** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
 export const Context = createContext();
 export const BlockNodes = createContext();
 export const SetBlockNodes = createContext();
-
-/**
- * Prevents default dragging behavior within a block.
- * To do: we must handle this in the future and clean up the drag target.
- * Previously dragging was prevented for multi-selected, but this is no longer
- * needed.
- *
- * @param {WPSyntheticEvent} event Synthetic drag event.
- */
-function onDragStart( event ) {
-	// Ensure we target block content, not block controls.
-	if ( getBlockClientId( event.target ) ) {
-		event.preventDefault();
-	}
-}
 
 function RootContainer( { children, className }, ref ) {
 	const onSelectionStart = useMultiSelection( ref );
@@ -49,7 +31,6 @@ function RootContainer( { children, className }, ref ) {
 			<div
 				ref={ ref }
 				className={ classnames( className, 'is-root-container' ) }
-				onDragStart={ onDragStart }
 			>
 				<SetBlockNodes.Provider value={ setBlockNodes }>
 					<Context.Provider value={ onSelectionStart }>

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { createContext, forwardRef, useState } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,17 +21,6 @@ import BlockPopover from './block-popover';
 export const Context = createContext();
 export const BlockNodes = createContext();
 export const SetBlockNodes = createContext();
-
-function selector( select ) {
-	const { getSelectedBlockClientId, hasMultiSelection } = select(
-		'core/block-editor'
-	);
-
-	return {
-		selectedBlockClientId: getSelectedBlockClientId(),
-		hasMultiSelection: hasMultiSelection(),
-	};
-}
 
 /**
  * Prevents default dragging behavior within a block.
@@ -50,32 +38,7 @@ function onDragStart( event ) {
 }
 
 function RootContainer( { children, className }, ref ) {
-	const { selectedBlockClientId, hasMultiSelection } = useSelect(
-		selector,
-		[]
-	);
-	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const onSelectionStart = useMultiSelection( ref );
-
-	/**
-	 * Marks the block as selected when focused and not already selected. This
-	 * specifically handles the case where block does not set focus on its own
-	 * (via `setFocus`), typically if there is no focusable input in the block.
-	 *
-	 * @param {WPSyntheticEvent} event
-	 */
-	function onFocus( event ) {
-		if ( hasMultiSelection ) {
-			return;
-		}
-
-		const clientId = getBlockClientId( event.target );
-
-		if ( clientId && clientId !== selectedBlockClientId ) {
-			selectBlock( clientId );
-		}
-	}
-
 	const [ blockNodes, setBlockNodes ] = useState( {} );
 	const insertionPoint = useInsertionPoint( ref );
 
@@ -86,7 +49,6 @@ function RootContainer( { children, className }, ref ) {
 			<div
 				ref={ ref }
 				className={ classnames( className, 'is-root-container' ) }
-				onFocus={ onFocus }
 				onDragStart={ onDragStart }
 			>
 				<SetBlockNodes.Provider value={ setBlockNodes }>

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -59,6 +59,7 @@ export default function ReusableBlockEdit( {
 		[ ref, clientId ]
 	);
 
+	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 	const { __experimentalSetEditingReusableBlock } = useDispatch(
 		reusableBlocksStore
@@ -118,6 +119,15 @@ export default function ReusableBlockEdit( {
 		);
 	}
 
+	/**
+	 * Clear the selected block when focus moves to the reusable block list.
+	 * These blocks are in different stores and only one block should be
+	 * selected at a time.
+	 */
+	function onFocus() {
+		clearSelectedBlock();
+	}
+
 	let element = (
 		<BlockEditorProvider
 			value={ blocks }
@@ -125,9 +135,11 @@ export default function ReusableBlockEdit( {
 			onChange={ onChange }
 			settings={ settings }
 		>
-			<WritingFlow>
-				<BlockList />
-			</WritingFlow>
+			<div className="block-editor-block-list__block" onFocus={ onFocus }>
+				<WritingFlow>
+					<BlockList />
+				</WritingFlow>
+			</div>
 		</BlockEditorProvider>
 	);
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This essential logic belongs in the block itself rather than on the root container. In the block we have access to the client ID without having to query the DOM.

Eventually, it would be good to get rid of the root container.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
