### PR TITLE
Move the templates prePersist logic to core-data

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -503,18 +503,15 @@ export function* saveEntityRecord(
 			} else {
 				// Auto drafts should be converted to drafts on explicit saves and we should not respect their default title,
 				// but some plugins break with this behavior so we can't filter it on the server.
-				let data = record;
-				if (
-					kind === 'postType' &&
-					persistedRecord &&
-					persistedRecord.status === 'auto-draft'
-				) {
-					if ( ! data.status ) {
-						data = { ...data, status: 'draft' };
-					}
-					if ( ! data.title || data.title === 'Auto Draft' ) {
-						data = { ...data, title: '' };
-					}
+				let edits = record;
+				if ( entity.__unstablePrePersist ) {
+					edits = {
+						...edits,
+						...entity.__unstablePrePersist(
+							persistedRecord,
+							edits
+						),
+					};
 				}
 
 				// Get the full local version of the record before the update,
@@ -536,7 +533,7 @@ export function* saveEntityRecord(
 				yield receiveEntityRecords(
 					kind,
 					name,
-					{ ...persistedEntity, ...data },
+					{ ...persistedEntity, ...edits },
 					undefined,
 					// This must be false or it will trigger a GET request in parallel to the PUT/POST below
 					false
@@ -545,7 +542,7 @@ export function* saveEntityRecord(
 				updatedRecord = yield apiFetch( {
 					path,
 					method: recordId ? 'PUT' : 'POST',
-					data,
+					edits,
 				} );
 				yield receiveEntityRecords(
 					kind,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -501,8 +501,6 @@ export function* saveEntityRecord(
 					yield receiveAutosaves( persistedRecord.id, updatedRecord );
 				}
 			} else {
-				// Auto drafts should be converted to drafts on explicit saves and we should not respect their default title,
-				// but some plugins break with this behavior so we can't filter it on the server.
 				let edits = record;
 				if ( entity.__unstablePrePersist ) {
 					edits = {
@@ -542,7 +540,7 @@ export function* saveEntityRecord(
 				updatedRecord = yield apiFetch( {
 					path,
 					method: recordId ? 'PUT' : 'POST',
-					edits,
+					data: edits,
 				} );
 				yield receiveEntityRecords(
 					kind,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -143,7 +143,7 @@ export const getPostTypePrePersistHandler = ( postTypeName ) => (
 
 	// Fix template titles.
 	if (
-		postTypeName === 'wp_template' &&
+		[ 'wp_template', 'wp_template_part' ].includes( postTypeName ) &&
 		! edits.title &&
 		! persistedRecord.title
 	) {

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -115,6 +115,64 @@ export const kinds = [
 ];
 
 /**
+ * Returns a function to be used to retrieve the title of a given post type record.
+ *
+ * @param {string} postTypeName PostType name.
+ * @return {Function} getTitle.
+ */
+export const getPostTypeTitle = ( postTypeName ) => ( record ) => {
+	if ( [ 'wp_template_part', 'wp_template' ].includes( postTypeName ) ) {
+		return (
+			record?.title?.rendered || record?.title || startCase( record.slug )
+		);
+	}
+	return record?.title?.rendered || record?.title || record.id;
+};
+
+/**
+ * Returns a function to be used to retrieve extra edits to apply before persisting a post type.
+ *
+ * @param {string} postTypeName PostType name.
+ * @return {Function} prePersistHandler.
+ */
+export const getPostTypePrePersistHandler = ( postTypeName ) => (
+	persistedRecord,
+	edits
+) => {
+	const newEdits = {};
+
+	if ( persistedRecord?.status === 'auto-draft' ) {
+		// Saving an auto-draft should create a draft by default.
+		if ( ! edits.status ) {
+			newEdits.status = 'draft';
+		}
+
+		// Fix the auto-draft default title.
+		if (
+			( ! edits.title || edits.title === 'Auto Draft' ) &&
+			( ! persistedRecord?.title ||
+				persistedRecord?.title === 'Auto Draft' )
+		) {
+			newEdits.title = '';
+		}
+	}
+
+	// Fix template titles.
+	if ( postTypeName === 'wp_template' ) {
+		newEdits.title = persistedRecord
+			? getPostTypeTitle( postTypeName )( persistedRecord )
+			: edits.slug;
+	}
+
+	// Templates and template parts can only be published.
+	if ( [ 'wp_template', 'wp_template_part' ].includes( postTypeName ) ) {
+		newEdits.status = 'publish';
+	}
+
+	return newEdits;
+};
+
+/**
  * Returns the list of post type entities.
  *
  * @return {Promise} Entities promise
@@ -133,16 +191,8 @@ function* loadPostTypeEntities() {
 				selectionEnd: true,
 			},
 			mergedEdits: { meta: true },
-			getTitle( record ) {
-				if ( [ 'wp_template_part', 'wp_template' ].includes( name ) ) {
-					return (
-						record?.title?.rendered ||
-						record?.title ||
-						startCase( record.slug )
-					);
-				}
-				return record?.title?.rendered || record?.title || record.id;
-			},
+			getTitle: getPostTypeTitle( name ),
+			__unstablePrePersist: getPostTypePrePersistHandler( name ),
 		};
 	} );
 }

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -1,7 +1,13 @@
 /**
  * Internal dependencies
  */
-import { getMethodName, defaultEntities, getKindEntities } from '../entities';
+import {
+	getMethodName,
+	defaultEntities,
+	getKindEntities,
+	getPostTypeTitle,
+	getPostTypePrePersistHandler,
+} from '../entities';
 import { addEntities } from '../actions';
 
 describe( 'getMethodName', () => {
@@ -77,5 +83,139 @@ describe( 'getKindEntities', () => {
 		expect( action ).toEqual( addEntities( fetchedEntities ) );
 		const end = fulfillment.next();
 		expect( end ).toEqual( { done: true, value: fetchedEntities } );
+	} );
+} );
+
+describe( 'getPostTypeTitle', () => {
+	it( 'should prefer the rendered value for titles for regular post types', async () => {
+		const record = {
+			id: 10,
+			title: {
+				rendered: 'My Title',
+			},
+		};
+		expect( getPostTypeTitle( 'post' )( record ) ).toBe( 'My Title' );
+	} );
+
+	it( "should fallback to the title if it's a string", async () => {
+		const record = {
+			id: 10,
+			title: 'My Title',
+		};
+		expect( getPostTypeTitle( 'post' )( record ) ).toBe( 'My Title' );
+	} );
+
+	it( 'should fallback to the id if no title provided', async () => {
+		const record = {
+			id: 10,
+		};
+		expect( getPostTypeTitle( 'post' )( record ) ).toBe( '10' );
+	} );
+
+	it( 'should prefer the rendered value for titles for templates', async () => {
+		const record = {
+			slug: 'single',
+			title: {
+				rendered: 'My Template',
+			},
+		};
+		expect( getPostTypeTitle( 'wp_template' )( record ) ).toBe(
+			'My Template'
+		);
+	} );
+
+	it( "should fallback to the title if it's a string for templates", async () => {
+		const record = {
+			slug: 'single',
+			title: 'My Template',
+		};
+		expect( getPostTypeTitle( 'wp_template' )( record ) ).toBe(
+			'My Template'
+		);
+	} );
+
+	it( 'should fallback to the slug if no title provided', async () => {
+		const record = {
+			slug: 'single',
+		};
+		expect( getPostTypeTitle( 'wp_template' )( record ) ).toBe( 'Single' );
+	} );
+} );
+
+describe( 'getPostTypePrePersistHandler', () => {
+	it( 'set the status to draft and empty the title when saving auto-draft posts', () => {
+		let record = {
+			status: 'auto-draft',
+		};
+		const edits = {};
+		expect(
+			getPostTypePrePersistHandler( 'post' )( record, edits )
+		).toEqual( {
+			status: 'draft',
+			title: '',
+		} );
+
+		record = {
+			status: 'publish',
+		};
+		expect(
+			getPostTypePrePersistHandler( 'post' )( record, edits )
+		).toEqual( {} );
+
+		record = {
+			status: 'auto-draft',
+			title: 'Auto Draft',
+		};
+		expect(
+			getPostTypePrePersistHandler( 'post' )( record, edits )
+		).toEqual( {
+			status: 'draft',
+			title: '',
+		} );
+
+		record = {
+			status: 'publish',
+			title: 'My Title',
+		};
+		expect(
+			getPostTypePrePersistHandler( 'post' )( record, edits )
+		).toEqual( {} );
+	} );
+
+	it( 'should set the status of templates to publish and fix the title', () => {
+		let record = {
+			status: 'auto-draft',
+			slug: 'single',
+		};
+		const edits = {};
+		expect(
+			getPostTypePrePersistHandler( 'wp_template' )( record, edits )
+		).toEqual( {
+			status: 'publish',
+			title: 'Single',
+		} );
+
+		record = {
+			status: 'auto-draft',
+		};
+		expect(
+			getPostTypePrePersistHandler( 'wp_template_part' )( record, edits )
+		).toEqual( {
+			status: 'publish',
+			title: '',
+		} );
+
+		record = {
+			status: 'auto-draft',
+			slug: 'single',
+			title: {
+				rendered: 'My title',
+			},
+		};
+		expect(
+			getPostTypePrePersistHandler( 'wp_template' )( record, edits )
+		).toEqual( {
+			status: 'publish',
+		} );
 	} );
 } );

--- a/packages/edit-post/src/components/header/template-save-button/index.js
+++ b/packages/edit-post/src/components/header/template-save-button/index.js
@@ -1,12 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { EntitiesSavedStates, store as editorStore } from '@wordpress/editor';
+import { EntitiesSavedStates } from '@wordpress/editor';
 import { Button } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,18 +19,6 @@ function TemplateSaveButton() {
 		setIsEntitiesReviewPanelOpen,
 	] = useState( false );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
-	const { editEntityRecord } = useDispatch( coreStore );
-	const { getTemplateInfo, getEditedEntityRecord } = useSelect(
-		( select ) => {
-			return {
-				getTemplateInfo: select( editorStore )
-					.__experimentalGetTemplateInfo,
-				getEditedEntityRecord: select( coreStore )
-					.getEditedEntityRecord,
-			};
-		},
-		[]
-	);
 	return (
 		<>
 			<Button onClick={ () => setIsEditingTemplate( false ) } isTertiary>
@@ -48,44 +35,6 @@ function TemplateSaveButton() {
 				<EntitiesSavedStates
 					isOpen={ isEntitiesReviewPanelOpen }
 					close={ ( entities ) => {
-						// The logic here should be abstracted in the entities save handler/component
-						// and not duplicated accross multi-entity save behavior.
-						if ( entities?.length ) {
-							entities.forEach( ( entity ) => {
-								const edits = {};
-								if (
-									entity.kind === 'postType' &&
-									entity.name === 'wp_template'
-								) {
-									const record = getEditedEntityRecord(
-										entity.kind,
-										entity.name,
-										entity.key
-									);
-									edits.title =
-										getTemplateInfo( record ).title ??
-										entity.title ??
-										record.slug;
-								}
-
-								if (
-									entity.kind === 'postType' &&
-									[
-										'wp_template',
-										'wp_template_part',
-									].includes( entity.name )
-								) {
-									edits.status = 'publish';
-								}
-
-								editEntityRecord(
-									entity.kind,
-									entity.name,
-									entity.key,
-									edits
-								);
-							} );
-						}
 						setIsEntitiesReviewPanelOpen( false );
 						if ( entities?.length ) {
 							setIsEditingTemplate( false );

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -63,9 +63,8 @@ function Editor() {
 		templateType,
 		page,
 		template,
-		select,
 		isNavigationOpen,
-	} = useSelect( ( _select ) => {
+	} = useSelect( ( select ) => {
 		const {
 			isFeatureActive,
 			isInserterOpened,
@@ -76,7 +75,7 @@ function Editor() {
 			getTemplateType,
 			getPage,
 			isNavigationOpened,
-		} = _select( 'core/edit-site' );
+		} = select( 'core/edit-site' );
 		const _templateId = getTemplateId();
 		const _templatePartId = getTemplatePartId();
 		const _templateType = getTemplateType();
@@ -92,25 +91,23 @@ function Editor() {
 			isInserterOpen: isInserterOpened(),
 			isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
 			deviceType: __experimentalGetPreviewDeviceType(),
-			sidebarIsOpened: !! _select(
+			sidebarIsOpened: !! select(
 				'core/interface'
 			).getActiveComplementaryArea( 'core/edit-site' ),
 			settings: getSettings(),
 			templateType: _templateType,
 			page: getPage(),
 			template: _templateType
-				? _select( 'core' ).getEntityRecord(
+				? select( 'core' ).getEntityRecord(
 						'postType',
 						_templateType,
 						_entityId
 				  )
 				: null,
-			select: _select,
 			entityId: _entityId,
 			isNavigationOpen: isNavigationOpened(),
 		};
 	}, [] );
-	const { editEntityRecord } = useDispatch( 'core' );
 	const { updateEditorSettings } = useDispatch( 'core/editor' );
 	const { setPage, setIsInserterOpened } = useDispatch( 'core/edit-site' );
 
@@ -133,28 +130,9 @@ function Editor() {
 		() => setIsEntitiesSavedStatesOpen( true ),
 		[]
 	);
-	const closeEntitiesSavedStates = useCallback(
-		( entitiesToSave ) => {
-			if ( entitiesToSave ) {
-				const { getEditedEntityRecord } = select( 'core' );
-				const {
-					__experimentalGetTemplateInfo: getTemplateInfo,
-				} = select( 'core/editor' );
-				entitiesToSave.forEach( ( { kind, name, key, title } ) => {
-					const record = getEditedEntityRecord( kind, name, key );
-					if ( kind === 'postType' && name === 'wp_template' ) {
-						( { title } = getTemplateInfo( record ) );
-					}
-					editEntityRecord( kind, name, key, {
-						status: 'publish',
-						title: title || record.slug,
-					} );
-				} );
-			}
-			setIsEntitiesSavedStatesOpen( false );
-		},
-		[ select ]
-	);
+	const closeEntitiesSavedStates = useCallback( () => {
+		setIsEntitiesSavedStatesOpen( false );
+	}, [] );
 
 	// Set default query for misplaced Query Loop blocks, and
 	// provide the root `queryContext` for top-level Query Loop


### PR DESCRIPTION
Follow-up to #26355 

When saving templates whether it's from the site editor, the post editor or any editor, there's some logic that needs to run (fix titles and set the "publish" status).

Before this PR, this logic was applied in an ad-hoc way. This PR refactors it and implements a `prePersist` handler for entities and also consolidate this with some pre persist behavior we had for regular post types.