### PR TITLE
Fallback to regular subscribe if the store doesn't exist in useSelect

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -199,8 +199,7 @@ export default function useSelect( _mapSelect, deps ) {
 
 		return () => {
 			isMountedAndNotUnsubscribing.current = false;
-			// Gracefully swallow the error if the unsubscribe function doesn't exist.
-			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
+			unsubscribers.forEach( ( unsubscribe ) => unsubscribe() );
 			renderQueue.flush( queueContext );
 		};
 	}, [ registry, trapSelect, depsChangedFlag ] );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -199,7 +199,8 @@ export default function useSelect( _mapSelect, deps ) {
 
 		return () => {
 			isMountedAndNotUnsubscribing.current = false;
-			unsubscribers.forEach( ( unsubscribe ) => unsubscribe() );
+			// Gracefully swallow the error if the unsubscribe function doesn't exist.
+			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
 			renderQueue.flush( queueContext );
 		};
 	}, [ registry, trapSelect, depsChangedFlag ] );

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -234,8 +234,15 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 			return stores[ storeName ].subscribe( handler );
 		}
 
-		// Gracefully swallow the error if parent doesn't exist.
-		return parent?.__experimentalSubscribeStore( storeName, handler );
+		// Trying to access a store that hasn't been registered,
+		// this is a pattern rarely used but seen in some places.
+		// We fallback to regular `subscribe` here for backward-compatibility for now.
+		// See https://github.com/WordPress/gutenberg/pull/27466 for more info.
+		if ( ! parent ) {
+			return subscribe( handler );
+		}
+
+		return parent.__experimentalSubscribeStore( storeName, handler );
 	}
 
 	let registry = {

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -234,7 +234,8 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 			return stores[ storeName ].subscribe( handler );
 		}
 
-		return parent.__experimentalSubscribeStore( storeName, handler );
+		// Gracefully swallow the error if parent doesn't exist.
+		return parent?.__experimentalSubscribeStore( storeName, handler );
 	}
 
 	let registry = {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix an error when selecting a non-existing store in `useSelect` throw an error. A regression introduced in #26724. This pattern can be seen in some existing code before:

https://github.com/Automattic/wp-calypso/blob/9e0e3a8fdc49088aa005cf53c2ebf85a24f0ede4/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L29

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Added new test, run `npm run test-unit`.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
