### PR TITLE
ComboboxControl/FormTokenField: Fix iOS zooming for input

### DIFF
--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -6,10 +6,17 @@ input.components-combobox-control__input[type="text"] {
 	width: 100%;
 	border: none;
 	box-shadow: none;
+	font-size: 16px;
 	padding: 2px;
 	margin: 0;
 	line-height: inherit;
 	min-height: auto;
+
+	// Resolves Zooming on iOS devices
+	// https://github.com/WordPress/gutenberg/issues/27405
+	@include break-small() {
+		font-size: 13px;
+	}
 
 	&:focus {
 		outline: none;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -22,6 +22,7 @@
 	input[type="text"].components-form-token-field__input {
 		display: inline-block;
 		flex: 1;
+		font-size: 16px;
 		width: 100%;
 		max-width: 100%;
 		margin-left: 4px;
@@ -32,6 +33,12 @@
 		border: 0;
 		color: $gray-900;
 		box-shadow: none;
+
+		// Resolves Zooming on iOS devices
+		// https://github.com/WordPress/gutenberg/issues/27405
+		@include break-small() {
+			font-size: 13px;
+		}
 
 		&:focus,
 		.components-form-token-field.is-active & {


### PR DESCRIPTION
## Description
This update fixes the typing interaction for the `ComboboxControl` and `FormTokenField` components for iOS. Previously, the (mobile) browser would zoom into the fields. This is because iOS, by default, requires `input` elements to have a `font-size` of at least `16px`. Otherwise, it zooms in.

The solution was to ensure that the `input` elements have a `16px` font-size by default (for mobile), and is then adjusted for larger viewport sizes (tablet and beyond).

<img src="https://user-images.githubusercontent.com/2322354/101042281-048b7600-354b-11eb-84e0-4380d2991c4b.PNG" width="300" alt="Screenshot from an iPhone 8" />

(In the screenshot, above, you can see that the browser does NOT zoom in.)

It's worth noting that these fixes were styles applied to individual `input` elements used in both components. Ideally, there would be a [base `TextInput` component](https://github.com/ItsJonQ/g2/tree/master/packages/components/src/TextInput) of some kind with iOS zoom handling (and more) built it. These components would then use that `TextInput` instead of a raw HTML `input`.

Resolves https://github.com/WordPress/gutenberg/issues/27405


## How has this been tested?
* Tested locally in story, on an iPhone 8


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
