### PR TITLE
GitHub Actions: Use a build matrix for the e2e tests GH action

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -6,6 +6,8 @@ on:
     - '**.md'
   push:
     branches: [master]
+    tags:
+      - 'v*'
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -11,13 +11,13 @@ on:
 
 jobs:
   admin:
-    name: Admin - ${{ matrix.part + 1 }}
+    name: Admin - ${{ matrix.part }}
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        part: [0, 1, 2, 3]
+        part: [1, 2, 3, 4]
 
 
     steps:
@@ -54,7 +54,7 @@ jobs:
     - name: Running the tests
       run: |
         $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == ${{ matrix.part }}' < ~/.jest-e2e-tests )
+        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == ${{ matrix.part }} - 1' < ~/.jest-e2e-tests )
 
     - name: Archive debug artifacts (screenshots, HTML snapshots)
       uses: actions/upload-artifact@v2

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -10,10 +10,15 @@ on:
     - '**.md'
 
 jobs:
-  admin-1:
-    name: Admin - 1
+  admin:
+    name: Admin - ${{ matrix.part + 1 }}
 
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        part: [0, 1, 2, 3]
+
 
     steps:
     - uses: actions/checkout@v2
@@ -49,7 +54,7 @@ jobs:
     - name: Running the tests
       run: |
         $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
+        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == ${{ matrix.part }}' < ~/.jest-e2e-tests )
 
     - name: Archive debug artifacts (screenshots, HTML snapshots)
       uses: actions/upload-artifact@v2
@@ -57,148 +62,3 @@ jobs:
       with:
         name: failures-artifacts
         path: artifacts
-
-  admin-2:
-    name: Admin - 2
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    - name: Use Node.js 14.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-
-    - name: Npm install and build
-      run: |
-        npm ci
-        FORCE_REDUCED_MOTION=true npm run build
-
-    - name: Install WordPress
-      run: |
-        chmod -R 767 ./ # TODO: Possibly integrate in wp-env
-        npm run wp-env start
-
-    - name: Running the tests
-      run: |
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
-
-    - name: Archive debug artifacts (screenshots, HTML snapshots)
-      uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: failures-artifacts
-        path: artifacts
-
-  admin-3:
-    name: Admin - 3
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    - name: Use Node.js 14.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-
-    - name: Npm install and build
-      run: |
-        npm ci
-        FORCE_REDUCED_MOTION=true npm run build
-
-    - name: Install WordPress
-      run: |
-        chmod -R 767 ./ # TODO: Possibly integrate in wp-env
-        npm run wp-env start
-
-    - name: Running the tests
-      run: |
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
-
-    - name: Archive debug artifacts (screenshots, HTML snapshots)
-      uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: failures-artifacts
-        path: artifacts
-
-  admin-4:
-    name: Admin - 4
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    - name: Use Node.js 14.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-
-    - name: Npm install and build
-      run: |
-        npm ci
-        FORCE_REDUCED_MOTION=true npm run build
-
-    - name: Install WordPress
-      run: |
-        chmod -R 767 ./ # TODO: Possibly integrate in wp-env
-        npm run wp-env start
-
-    - name: Running the tests
-      run: |
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 3' < ~/.jest-e2e-tests )
-
-    - name: Archive debug artifacts (screenshots, HTML snapshots)
-      uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: failures-artifacts
-        path: artifacts
-


### PR DESCRIPTION
## Description
The e2e tests GH action currently consists of 4 jobs, which all share the exact same code, except for one bit: Each of them only runs 1/4 of the available tests.

This PR de-duplicates the code by introducing a build matrix that's used by the remaining job.

(This might also cut down on build time.)

## How has this been tested?
Verify that the "Admin - 1" to "Admin - 4" GH actions are still present for this PR. Verify that each of them runs a different set of e2e tests.
