### PR TITLE
Writing flow: consider events only from DOM descendents

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -229,6 +229,7 @@ function BlockPopover( {
 				<BlockSelectionButton
 					clientId={ clientId }
 					rootClientId={ rootClientId }
+					blockElement={ node }
 				/>
 			) }
 			{ showEmptyBlockSideInserter && (

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -32,7 +32,6 @@ import { focus } from '@wordpress/dom';
  * Internal dependencies
  */
 import BlockTitle from '../block-title';
-import { getBlockDOMNode } from '../../utils/dom';
 
 /**
  * Returns true if the user is using windows.
@@ -87,7 +86,7 @@ function selector( select ) {
  *
  * @return {WPComponent} The component to be rendered.
  */
-function BlockSelectionButton( { clientId, rootClientId, ...props } ) {
+function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 	const selected = useSelect(
 		( select ) => {
 			const {
@@ -220,16 +219,12 @@ function BlockSelectionButton( { clientId, rootClientId, ...props } ) {
 				event.preventDefault();
 				selectBlock( focusedBlockUid );
 			} else if ( isTab && selectedBlockClientId ) {
-				const wrapper = getBlockDOMNode(
-					selectedBlockClientId,
-					document
-				);
 				let nextTabbable;
 
 				if ( navigateDown ) {
-					nextTabbable = focus.tabbable.findNext( wrapper );
+					nextTabbable = focus.tabbable.findNext( blockElement );
 				} else {
-					nextTabbable = focus.tabbable.findPrevious( wrapper );
+					nextTabbable = focus.tabbable.findPrevious( blockElement );
 				}
 
 				if ( nextTabbable ) {
@@ -257,7 +252,7 @@ function BlockSelectionButton( { clientId, rootClientId, ...props } ) {
 	);
 
 	return (
-		<div className={ classNames } { ...props }>
+		<div className={ classNames }>
 			<Button
 				ref={ ref }
 				onClick={ () => setNavigationMode( false ) }

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -9,17 +9,30 @@ import classnames from 'classnames';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
-import { BACKSPACE, DELETE } from '@wordpress/keycodes';
+import {
+	BACKSPACE,
+	DELETE,
+	UP,
+	DOWN,
+	LEFT,
+	RIGHT,
+	TAB,
+	ESCAPE,
+	ENTER,
+	SPACE,
+} from '@wordpress/keycodes';
 import {
 	getBlockType,
 	__experimentalGetAccessibleBlockLabel as getAccessibleBlockLabel,
 } from '@wordpress/blocks';
 import { speak } from '@wordpress/a11y';
+import { focus } from '@wordpress/dom';
 
 /**
  * Internal dependencies
  */
 import BlockTitle from '../block-title';
+import { getBlockDOMNode } from '../../utils/dom';
 
 /**
  * Returns true if the user is using windows.
@@ -28,6 +41,40 @@ import BlockTitle from '../block-title';
  */
 function isWindows() {
 	return window.navigator.platform.indexOf( 'Win' ) > -1;
+}
+
+function selector( select ) {
+	const {
+		getSelectedBlockClientId,
+		getMultiSelectedBlocksEndClientId,
+		getPreviousBlockClientId,
+		getNextBlockClientId,
+		hasBlockMovingClientId,
+		getBlockIndex,
+		getBlockRootClientId,
+		getClientIdsOfDescendants,
+		canInsertBlockType,
+		getBlockName,
+	} = select( 'core/block-editor' );
+
+	const selectedBlockClientId = getSelectedBlockClientId();
+	const selectionEndClientId = getMultiSelectedBlocksEndClientId();
+
+	return {
+		selectedBlockClientId,
+		selectionBeforeEndClientId: getPreviousBlockClientId(
+			selectionEndClientId || selectedBlockClientId
+		),
+		selectionAfterEndClientId: getNextBlockClientId(
+			selectionEndClientId || selectedBlockClientId
+		),
+		hasBlockMovingClientId,
+		getBlockIndex,
+		getBlockRootClientId,
+		getClientIdsOfDescendants,
+		canInsertBlockType,
+		getBlockName,
+	};
 }
 
 /**
@@ -82,12 +129,115 @@ function BlockSelectionButton( { clientId, rootClientId, ...props } ) {
 		}
 	}, [] );
 
+	const {
+		selectedBlockClientId,
+		selectionBeforeEndClientId,
+		selectionAfterEndClientId,
+		hasBlockMovingClientId,
+		getBlockIndex,
+		getBlockRootClientId,
+		getClientIdsOfDescendants,
+	} = useSelect( selector, [] );
+	const {
+		selectBlock,
+		clearSelectedBlock,
+		setBlockMovingClientId,
+		moveBlockToPosition,
+	} = useDispatch( 'core/block-editor' );
+
 	function onKeyDown( event ) {
 		const { keyCode } = event;
+		const isUp = keyCode === UP;
+		const isDown = keyCode === DOWN;
+		const isLeft = keyCode === LEFT;
+		const isRight = keyCode === RIGHT;
+		const isTab = keyCode === TAB;
+		const isEscape = keyCode === ESCAPE;
+		const isEnter = keyCode === ENTER;
+		const isSpace = keyCode === SPACE;
+		const isShift = event.shiftKey;
 
 		if ( keyCode === BACKSPACE || keyCode === DELETE ) {
 			removeBlock( clientId );
 			event.preventDefault();
+			return;
+		}
+
+		const navigateUp = ( isTab && isShift ) || isUp;
+		const navigateDown = ( isTab && ! isShift ) || isDown;
+		// Move out of current nesting level (no effect if at root level).
+		const navigateOut = isLeft;
+		// Move into next nesting level (no effect if the current block has no innerBlocks).
+		const navigateIn = isRight;
+
+		let focusedBlockUid;
+		if ( navigateUp ) {
+			focusedBlockUid = selectionBeforeEndClientId;
+		} else if ( navigateDown ) {
+			focusedBlockUid = selectionAfterEndClientId;
+		} else if ( navigateOut ) {
+			focusedBlockUid =
+				getBlockRootClientId( selectedBlockClientId ) ??
+				selectedBlockClientId;
+		} else if ( navigateIn ) {
+			focusedBlockUid =
+				getClientIdsOfDescendants( [ selectedBlockClientId ] )[ 0 ] ??
+				selectedBlockClientId;
+		}
+		const startingBlockClientId = hasBlockMovingClientId();
+
+		if ( isEscape && startingBlockClientId ) {
+			setBlockMovingClientId( null );
+		}
+		if ( ( isEnter || isSpace ) && startingBlockClientId ) {
+			const sourceRoot = getBlockRootClientId( startingBlockClientId );
+			const destRoot = getBlockRootClientId( selectedBlockClientId );
+			const sourceBlockIndex = getBlockIndex(
+				startingBlockClientId,
+				sourceRoot
+			);
+			let destinationBlockIndex = getBlockIndex(
+				selectedBlockClientId,
+				destRoot
+			);
+			if (
+				sourceBlockIndex < destinationBlockIndex &&
+				sourceRoot === destRoot
+			) {
+				destinationBlockIndex -= 1;
+			}
+			moveBlockToPosition(
+				startingBlockClientId,
+				sourceRoot,
+				destRoot,
+				destinationBlockIndex
+			);
+			selectBlock( startingBlockClientId );
+			setBlockMovingClientId( null );
+		}
+		if ( navigateDown || navigateUp || navigateOut || navigateIn ) {
+			if ( focusedBlockUid ) {
+				event.preventDefault();
+				selectBlock( focusedBlockUid );
+			} else if ( isTab && selectedBlockClientId ) {
+				const wrapper = getBlockDOMNode(
+					selectedBlockClientId,
+					document
+				);
+				let nextTabbable;
+
+				if ( navigateDown ) {
+					nextTabbable = focus.tabbable.findNext( wrapper );
+				} else {
+					nextTabbable = focus.tabbable.findPrevious( wrapper );
+				}
+
+				if ( nextTabbable ) {
+					event.preventDefault();
+					nextTabbable.focus();
+					clearSelectedBlock();
+				}
+			}
 		}
 	}
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -86,6 +86,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			} = select( 'core/block-editor' );
 
 			const movingClientId = hasBlockMovingClientId();
+			const _isBlockMovingMode = isSelected && !! movingClientId;
 
 			return {
 				shouldFocusFirstElement:
@@ -96,10 +97,9 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 					? getSelectedBlocksInitialCaretPosition()
 					: undefined,
 				isNavigationMode: _isNavigationMode,
-				isBlockMovingMode: isSelected && !! movingClientId,
+				isBlockMovingMode: _isBlockMovingMode,
 				canInsertMovingBlock:
-					isSelected &&
-					movingClientId &&
+					_isBlockMovingMode &&
 					canInsertBlockType(
 						getBlockName( movingClientId ),
 						getBlockRootClientId( clientId )

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -71,13 +71,21 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		initialPosition,
 		shouldFocusFirstElement,
 		isNavigationMode,
+		isBlockMovingMode,
+		canInsertMovingBlock,
 	} = useSelect(
 		( select ) => {
 			const {
 				getSelectedBlocksInitialCaretPosition,
 				isMultiSelecting: _isMultiSelecting,
 				isNavigationMode: _isNavigationMode,
+				hasBlockMovingClientId,
+				canInsertBlockType,
+				getBlockName,
+				getBlockRootClientId,
 			} = select( 'core/block-editor' );
+
+			const movingClientId = hasBlockMovingClientId();
 
 			return {
 				shouldFocusFirstElement:
@@ -88,9 +96,17 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 					? getSelectedBlocksInitialCaretPosition()
 					: undefined,
 				isNavigationMode: _isNavigationMode,
+				isBlockMovingMode: isSelected && !! movingClientId,
+				canInsertMovingBlock:
+					isSelected &&
+					movingClientId &&
+					canInsertBlockType(
+						getBlockName( movingClientId ),
+						getBlockRootClientId( clientId )
+					),
 			};
 		},
-		[ isSelected ]
+		[ isSelected, clientId ]
 	);
 	const { insertDefaultBlock, removeBlock, selectBlock } = useDispatch(
 		'core/block-editor'
@@ -331,7 +347,11 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			className,
 			props.className,
 			wrapperProps.className,
-			{ 'is-hovered': isHovered }
+			{
+				'is-hovered': isHovered,
+				'is-block-moving-mode': isBlockMovingMode,
+				'can-insert-moving-block': canInsertMovingBlock,
+			}
 		),
 		style: { ...wrapperProps.style, ...props.style },
 	};

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -86,12 +86,12 @@
 		box-shadow: 0 0 0 1px $gray-600;
 	}
 
-	.is-block-moving-mode & .block-editor-block-list__block.has-child-selected {
+	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected {
 		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 		outline: $border-width-focus solid transparent;
 	}
 
-	.is-block-moving-mode & .block-editor-block-list__block.is-selected {
+	& .is-block-moving-mode.block-editor-block-list__block.is-selected {
 
 		&::before {
 			content: "";
@@ -114,7 +114,7 @@
 		}
 	}
 
-	.is-block-moving-mode.can-insert-moving-block & .block-editor-block-list__block.is-selected {
+	& .is-block-moving-mode.can-insert-moving-block.block-editor-block-list__block.is-selected {
 		&::before {
 			border-color: var(--wp-admin-theme-color);
 		}

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { VisuallyHidden } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -19,8 +18,6 @@ import ReusableBlocksTab from './reusable-blocks-tab';
 import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
-
-const stopKeyPropagation = ( event ) => event.stopPropagation();
 
 function InserterMenu( {
 	rootClientId,
@@ -62,17 +59,6 @@ function InserterMenu( {
 	}, [] );
 
 	const showPatterns = ! destinationRootClientId && hasPatterns;
-
-	const onKeyDown = ( event ) => {
-		if (
-			[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].includes(
-				event.keyCode
-			)
-		) {
-			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-			event.stopPropagation();
-		}
-	};
 
 	const onInsert = ( blocks ) => {
 		onInsertBlocks( blocks );
@@ -133,15 +119,9 @@ function InserterMenu( {
 	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 	// is always visible, and one which already incurs this behavior of autoFocus via
 	// Popover's focusOnMount.
-	// Disable reason (no-static-element-interactions): Navigational key-presses within
-	// the menu are prevented from triggering WritingFlow and ObserveTyping interactions.
-	/* eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
+	/* eslint-disable jsx-a11y/no-autofocus */
 	return (
-		<div
-			className="block-editor-inserter__menu"
-			onKeyPress={ stopKeyPropagation }
-			onKeyDown={ onKeyDown }
-		>
+		<div className="block-editor-inserter__menu">
 			<div className="block-editor-inserter__main-area">
 				{ /* the following div is necessary to fix the sticky position of the search form */ }
 				<div className="block-editor-inserter__content">
@@ -193,7 +173,7 @@ function InserterMenu( {
 			) }
 		</div>
 	);
-	/* eslint-enable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
+	/* eslint-enable jsx-a11y/no-autofocus */
 }
 
 export default InserterMenu;

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -10,7 +10,6 @@ import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -24,16 +23,6 @@ import useBlockTypesState from './hooks/use-block-types-state';
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
 const SHOWN_BLOCK_PATTERNS = 2;
-
-const preventArrowKeysPropagation = ( event ) => {
-	if (
-		[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].includes( event.keyCode )
-	) {
-		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-		event.stopPropagation();
-	}
-};
-const stopKeyPropagation = ( event ) => event.stopPropagation();
 
 export default function QuickInserter( {
 	onSelect,
@@ -103,8 +92,6 @@ export default function QuickInserter( {
 				'has-search': showSearch,
 				'has-expand': setInserterIsOpened,
 			} ) }
-			onKeyPress={ stopKeyPropagation }
-			onKeyDown={ preventArrowKeysPropagation }
 		>
 			{ showSearch && (
 				<InserterSearchForm

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -22,11 +22,6 @@ import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { isURL } from '@wordpress/url';
 
-// Since URLInput is rendered in the context of other inputs, but should be
-// considered a separate modal node, prevent keyboard events from propagating
-// as being considered from the input.
-const stopEventPropagation = ( event ) => event.stopPropagation();
-
 /* eslint-disable jsx-a11y/no-autofocus */
 class URLInput extends Component {
 	constructor( props ) {
@@ -425,7 +420,6 @@ class URLInput extends Component {
 			type: 'text',
 			onChange: this.onChange,
 			onFocus: this.onFocus,
-			onInput: stopEventPropagation,
 			placeholder,
 			onKeyDown: this.onKeyDown,
 			role: 'combobox',

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -18,7 +18,6 @@ import {
 	SVG,
 	Path,
 } from '@wordpress/components';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { link as linkIcon, close } from '@wordpress/icons';
 
 /**
@@ -60,21 +59,6 @@ const ImageURLInputUI = ( {
 	const [ urlInput, setUrlInput ] = useState( null );
 
 	const autocompleteRef = useRef( null );
-
-	const stopPropagation = ( event ) => {
-		event.stopPropagation();
-	};
-
-	const stopPropagationRelevantKeys = ( event ) => {
-		if (
-			[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf(
-				event.keyCode
-			) > -1
-		) {
-			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-			event.stopPropagation();
-		}
-	};
 
 	const startEditLink = useCallback( () => {
 		if (
@@ -240,14 +224,10 @@ const ImageURLInputUI = ( {
 				label={ __( 'Link Rel' ) }
 				value={ removeNewTabRel( rel ) || '' }
 				onChange={ onSetLinkRel }
-				onKeyPress={ stopPropagation }
-				onKeyDown={ stopPropagationRelevantKeys }
 			/>
 			<TextControl
 				label={ __( 'Link CSS Class' ) }
 				value={ linkClass || '' }
-				onKeyPress={ stopPropagation }
-				onKeyDown={ stopPropagationRelevantKeys }
 				onChange={ onSetLinkClass }
 			/>
 		</>
@@ -299,8 +279,6 @@ const ImageURLInputUI = ( {
 							className="block-editor-format-toolbar__link-container-content"
 							value={ linkEditorValue }
 							onChangeInputValue={ setUrlInput }
-							onKeyDown={ stopPropagationRelevantKeys }
-							onKeyPress={ stopPropagation }
 							onSubmit={ onSubmitLinkChange() }
 							autocompleteRef={ autocompleteRef }
 						/>
@@ -309,7 +287,6 @@ const ImageURLInputUI = ( {
 						<>
 							<URLPopover.LinkViewer
 								className="block-editor-format-toolbar__link-container-content"
-								onKeyPress={ stopPropagation }
 								url={ url }
 								onEditLinkClick={ startEditLink }
 								urlLabel={ urlLabel }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1585,6 +1585,10 @@ export function hasBlockMovingClientId( state = null, action ) {
 		return action.hasBlockMovingClientId;
 	}
 
+	if ( action.type === 'SET_NAVIGATION_MODE' ) {
+		return null;
+	}
+
 	return state;
 }
 

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -10,7 +10,6 @@ import {
 	RichTextToolbarButton,
 	MediaUploadCheck,
 } from '@wordpress/block-editor';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { keyboardReturn } from '@wordpress/icons';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -34,21 +33,6 @@ export const image = {
 	edit: Edit,
 };
 
-function stopKeyPropagation( event ) {
-	event.stopPropagation();
-}
-
-function onKeyDown( event ) {
-	if (
-		[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) >
-		-1
-	) {
-		// Stop the key event from propagating up to
-		// ObserveTyping.startTypingInTextField.
-		event.stopPropagation();
-	}
-}
-
 function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 	const { style } = activeObjectAttributes;
 	const [ width, setWidth ] = useState( style.replace( /\D/g, '' ) );
@@ -64,14 +48,8 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 			focusOnMount={ false }
 			anchorRef={ anchorRef }
 		>
-			{
-				// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-				/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-			 }
 			<form
 				className="block-editor-format-toolbar__image-container-content"
-				onKeyPress={ stopKeyPropagation }
-				onKeyDown={ onKeyDown }
 				onSubmit={ ( event ) => {
 					const newReplacements = value.replacements.slice();
 
@@ -105,7 +83,6 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 					type="submit"
 				/>
 			</form>
-			{ /* eslint-enable jsx-a11y/no-noninteractive-element-interactions */ }
 		</Popover>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Replaces #19879.

Other than the benefits of avoiding `stopPropagation`, outlined in #19879, it's an opportunity to split writing flow. This PR removes navigation mode logic to the block selection button (displayed in navigation mode), listening for keydown events as close as possible to the source.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
