### PR TITLE
Stabilize adding blocks end to end test

### DIFF
--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -14,6 +14,29 @@ import {
 
 /** @typedef {import('puppeteer').ElementHandle} ElementHandle */
 
+/**
+ * Waits for all patterns in the inserter to have a height, which should
+ * indicate they've been parsed and are visible.
+ *
+ * This allows a test to wait for the layout in the inserter menu to stabilize
+ * before attempting to interact with the menu contents.
+ */
+async function waitForInserterPatternLoad() {
+	await page.waitForFunction( () => {
+		const previewElements = document.querySelectorAll(
+			'.block-editor-block-preview__container'
+		);
+
+		if ( ! previewElements.length ) {
+			return true;
+		}
+
+		return Array.from( previewElements ).every(
+			( previewElement ) => previewElement.offsetHeight > 0
+		);
+	} );
+}
+
 describe( 'adding blocks', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -214,7 +237,15 @@ describe( 'adding blocks', () => {
 
 		// Insert a paragraph block.
 		await page.waitForSelector( '.block-editor-inserter__search-input' );
-		await page.keyboard.type( 'Paragraph' );
+
+		// Search for the paragraph block if it's not in the list of blocks shown.
+		if ( ! page.$( '.editor-block-list-item-paragraph' ) ) {
+			await page.keyboard.type( 'Paragraph' );
+			await page.waitForSelector( '.editor-block-list-item-paragraph' );
+			await waitForInserterPatternLoad();
+		}
+
+		// Add the block.
 		await page.click( '.editor-block-list-item-paragraph' );
 		await page.keyboard.type( '2' );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The `adding blocks` test has been failing recently at the test `it inserts blocks at root level when using the root appender while selection is in an inner block`.

The image snapshot for this failure shows that the test makes it almost all the way to the end but fails to add a paragraph block from the quick inserter menu:
![adding-blocks-inserts-blocks-at-root-level-when-using-the-root-appender-while-selection-is-in-an-inner-block-2020-12-04t00-59-49](https://user-images.githubusercontent.com/677833/101115069-ab404700-361d-11eb-8f86-de24c4b8e2fd.jpg)

When manually testing it's noticable that the patterns in the menu have a slight delay in loading their content causing a shift in the layout in the inserter. I think what's happening is that the layout shift is causing the test to fail to click on the block. When the popover is above the button this is particularly difficult, because everything above the patterns shift up and down.

This PR should fix by doing the following:
- Most of the time the paragraph block doesn't actually need to be searched for. If it's immediately shown in the menu the test now adds the block without searching, bypassing the layout issue.
- If the block does need to be searched for I've added a `waitForInserterPatternLoad` helper function that waits for all the patterns to have a height greater than zero. I couldn't think of a better option here, I think the best idea would be to look at improving the way patterns load

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
