### PR TITLE
Load the block patterns in the site editor

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -112,6 +112,7 @@ function gutenberg_edit_site_init( $hook ) {
 		)
 	);
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
+	$settings = gutenberg_extend_settings_block_patterns( $settings );
 
 	// Preload block editor paths.
 	// most of these are copied from edit-forms-blocks.php.

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -59,7 +59,9 @@ export async function toggleGlobalBlockInserter() {
 async function waitForInserterCloseAndContentFocus() {
 	await page.waitForFunction( () =>
 		document.body
-			.querySelector( '.block-editor-block-list__layout' )
+			.querySelector(
+				'.interface-interface-skeleton__content .block-editor-block-list__layout'
+			)
 			.contains( document.activeElement )
 	);
 }


### PR DESCRIPTION
Nothing more than what the title says.
We still need to fix "patterns inside containers" separately.