### PR TITLE
Add global styles PHP filters

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -404,7 +404,7 @@ class WP_Theme_JSON_Resolver {
 			$result->merge( $this->get_theme_origin( $theme_support_data ) );
 			$result->merge( self::get_user_origin() );
 			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
-			return apply_filters( 'get_global_styles_data', $result, $origin, $theme_support_data );
+			return apply_filters( 'global_styles_get_data', $result, $origin, $theme_support_data );
 		}
 
 		if ( ( 'theme' === $origin ) && $merged ) {
@@ -412,17 +412,17 @@ class WP_Theme_JSON_Resolver {
 			$result->merge( self::get_core_origin() );
 			$result->merge( $this->get_theme_origin( $theme_support_data ) );
 			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
-			return apply_filters( 'get_global_styles_data', $result, $origin, $theme_support_data );
+			return apply_filters( 'global_styles_get_data', $result, $origin, $theme_support_data );
 		}
 
 		if ( 'user' === $origin ) {
 			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
-			return apply_filters( 'get_global_styles_data', self::get_user_origin(), $origin, $theme_support_data );
+			return apply_filters( 'global_styles_get_data', self::get_user_origin(), $origin, $theme_support_data );
 		}
 
 		if ( 'theme' === $origin ) {
 			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
-			return apply_filters( 'get_global_styles_data', $this->get_theme_origin( $theme_support_data ), $origin, $theme_support_data );
+			return apply_filters( 'global_styles_get_data', $this->get_theme_origin( $theme_support_data ), $origin, $theme_support_data );
 		}
 
 		/**
@@ -435,7 +435,7 @@ class WP_Theme_JSON_Resolver {
 		 *
 		 * @return WP_Theme_JSON
 		 */
-		return apply_filters( 'get_global_styles_data', self::get_core_origin(), $origin, $theme_support_data );
+		return apply_filters( 'global_styles_get_data', self::get_core_origin(), $origin, $theme_support_data );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -398,31 +398,8 @@ class WP_Theme_JSON_Resolver {
 		$result->merge( self::get_core_data() );
 		$result->merge( self::get_theme_data( $theme_support_data ) );
 
-		if ( ( 'user' === $origin ) && $merged ) {
-			$result = new WP_Theme_JSON();
-			$result->merge( self::get_core_origin() );
-			$result->merge( $this->get_theme_origin( $theme_support_data ) );
-			$result->merge( self::get_user_origin() );
-			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
-			return apply_filters( 'global_styles_get_data', $result, $origin, $theme_support_data );
-		}
-
-		if ( ( 'theme' === $origin ) && $merged ) {
-			$result = new WP_Theme_JSON();
-			$result->merge( self::get_core_origin() );
-			$result->merge( $this->get_theme_origin( $theme_support_data ) );
-			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
-			return apply_filters( 'global_styles_get_data', $result, $origin, $theme_support_data );
-		}
-
 		if ( 'user' === $origin ) {
-			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
-			return apply_filters( 'global_styles_get_data', self::get_user_origin(), $origin, $theme_support_data );
-		}
-
-		if ( 'theme' === $origin ) {
-			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
-			return apply_filters( 'global_styles_get_data', $this->get_theme_origin( $theme_support_data ), $origin, $theme_support_data );
+			$result->merge( self::get_user_data() );
 		}
 
 		/**
@@ -435,7 +412,7 @@ class WP_Theme_JSON_Resolver {
 		 *
 		 * @return WP_Theme_JSON
 		 */
-		return apply_filters( 'global_styles_get_data', self::get_core_origin(), $origin, $theme_support_data );
+		return apply_filters( 'global_styles_get_data', $result, $theme_support_data, $origin );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -398,11 +398,30 @@ class WP_Theme_JSON_Resolver {
 		$result->merge( self::get_core_data() );
 		$result->merge( self::get_theme_data( $theme_support_data ) );
 
-		if ( 'user' === $origin ) {
-			$result->merge( self::get_user_data() );
+		if ( ( 'user' === $origin ) && $merged ) {
+			$result = new WP_Theme_JSON();
+			$result->merge( self::get_core_origin() );
+			$result->merge( $this->get_theme_origin( $theme_support_data ) );
+			$result->merge( self::get_user_origin() );
+			return apply_filters( 'get_global_styles_data', $result, $origin, $theme_support_data );
 		}
 
-		return $result;
+		if ( ( 'theme' === $origin ) && $merged ) {
+			$result = new WP_Theme_JSON();
+			$result->merge( self::get_core_origin() );
+			$result->merge( $this->get_theme_origin( $theme_support_data ) );
+			return apply_filters( 'get_global_styles_data', $result, $origin, $theme_support_data );
+		}
+
+		if ( 'user' === $origin ) {
+			return return apply_filters( 'get_global_styles_data', self::get_user_origin(), $origin, $theme_support_data );
+		}
+
+		if ( 'theme' === $origin ) {
+			return apply_filters( 'get_global_styles_data', $this->get_theme_origin( $theme_support_data ), $origin, $theme_support_data );
+		}
+
+		return apply_filters( 'get_global_styles_data', self::get_core_origin(), $origin, $theme_support_data );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -403,6 +403,7 @@ class WP_Theme_JSON_Resolver {
 			$result->merge( self::get_core_origin() );
 			$result->merge( $this->get_theme_origin( $theme_support_data ) );
 			$result->merge( self::get_user_origin() );
+			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
 			return apply_filters( 'get_global_styles_data', $result, $origin, $theme_support_data );
 		}
 
@@ -410,17 +411,30 @@ class WP_Theme_JSON_Resolver {
 			$result = new WP_Theme_JSON();
 			$result->merge( self::get_core_origin() );
 			$result->merge( $this->get_theme_origin( $theme_support_data ) );
+			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
 			return apply_filters( 'get_global_styles_data', $result, $origin, $theme_support_data );
 		}
 
 		if ( 'user' === $origin ) {
-			return return apply_filters( 'get_global_styles_data', self::get_user_origin(), $origin, $theme_support_data );
+			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
+			return apply_filters( 'get_global_styles_data', self::get_user_origin(), $origin, $theme_support_data );
 		}
 
 		if ( 'theme' === $origin ) {
+			/* This filter is documented in lib/class-wp-theme-json-resolver.php */
 			return apply_filters( 'get_global_styles_data', $this->get_theme_origin( $theme_support_data ), $origin, $theme_support_data );
 		}
 
+		/**
+		 * Return merged data.
+		 *
+		 * @param array   $theme_support_data Existing block editor settings.
+		 * @param string  $origin             The source of data the consumer wants.
+		 *                                    Valid values are 'core', 'theme', 'user'.
+		 *                                    Default is 'user'.
+		 *
+		 * @return WP_Theme_JSON
+		 */
 		return apply_filters( 'get_global_styles_data', self::get_core_origin(), $origin, $theme_support_data );
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -28,7 +28,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		// Check if we have the styles already cached.
 		$cached = get_transient( 'global_styles' );
 		if ( $cached ) {
-			return $cached;
+			return apply_filters( 'global_styles_get_stylesheet', $cached, $type, $tree );
 		}
 	}
 
@@ -49,7 +49,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		set_transient( 'global_styles', $stylesheet, MINUTE_IN_SECONDS );
 	}
 
-	return $stylesheet;
+	return apply_filters( 'global_styles_get_stylesheet', $stylesheet, $type, $tree );
 }
 
 /**

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -10,7 +10,7 @@
  * the corresponding stylesheet.
  *
  * @param WP_Theme_JSON $tree Input tree.
- * @param string        $type Type of stylesheet we want accepts 'all', 'block_styles', and 'css_variables'.
+ * @param string        $type Type of stylesheet we want. Accepts 'all', 'block_styles', and 'css_variables'.
  *
  * @return string Stylesheet.
  */
@@ -28,6 +28,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		// Check if we have the styles already cached.
 		$cached = get_transient( 'global_styles' );
 		if ( $cached ) {
+			/* This filter is documented in lib/global-styles.php */
 			return apply_filters( 'global_styles_get_stylesheet', $cached, $type, $tree );
 		}
 	}
@@ -49,6 +50,15 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		set_transient( 'global_styles', $stylesheet, MINUTE_IN_SECONDS );
 	}
 
+	/**
+	 * Filter generated styles.
+	 *
+	 * @param string        $stylesheet The generated styles.
+	 * @param string        $type       Type of stylesheet we want. Accepts 'all', 'block_styles', and 'css_variables'.
+	 * @param WP_Theme_JSON $tree       Input tree.
+	 *
+	 * @return string
+	 */
 	return apply_filters( 'global_styles_get_stylesheet', $stylesheet, $type, $tree );
 }
 


### PR DESCRIPTION
See #27504 

## Description

Adds 2 new filters:
* `global_styles_get_data`: Filter JSON for global-styles
* `global_styles_get_stylesheet`: Filter generated css from global-styles

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
