### PR TITLE
List Block: Add font family to the list block

### DIFF
--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -41,6 +41,7 @@
 		"color": {
 			"gradients": true
 		},
+		"__experimentalFontFamily": true,
 		"__unstablePasteTextInline": true
 	},
 	"editorStyle": "wp-block-list-editor",


### PR DESCRIPTION
## Description
Add support for font families to the List Block

## How has this been tested?
Tested in TT1 Blocks

## Screenshots <!-- if applicable -->
<img width="1230" alt="Screenshot 2020-12-04 at 14 04 00" src="https://user-images.githubusercontent.com/275961/101172813-92de2580-3639-11eb-9cc3-e27a3ada7591.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
