### PR TITLE
List Block: Add custom spacing to the list block

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -342,6 +342,7 @@ These are the current color properties supported by blocks:
 | --- | --- |
 | Cover | Yes |
 | Group | Yes |
+| List | Yes |
 | Verse | Yes |
 
 #### Typography Properties

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -23,6 +23,18 @@
 		},
 		"reversed": {
 			"type": "boolean"
+		},
+		"style": {
+			"default": {
+				"spacing": {
+					"padding": {
+						"top": 0,
+						"right": 0,
+						"bottom": 0,
+						"left": 40
+					}
+				}
+			}
 		}
 	},
 	"supports": {
@@ -32,6 +44,9 @@
 		"color": {
 			"gradients": true
 		},
-		"__unstablePasteTextInline": true
+		"__unstablePasteTextInline": true,
+		"spacing": {
+			"padding": true
+		}
 	}
 }

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -57,10 +57,9 @@ export default function BoxControl( {
 	} );
 	const inputValues = values || DEFAULT_VALUES;
 	const hasInitialValue = isValuesDefined( valuesProp );
-
 	const [ isDirty, setIsDirty ] = useState( hasInitialValue );
 	const [ isLinked, setIsLinked ] = useState(
-		! hasInitialValue || ! isValuesMixed( inputValues )
+		! hasInitialValue || ( ! isValuesMixed( inputValues ) && Object.keys(inputValues).length === 4 )
 	);
 
 	const [ side, setSide ] = useState( isLinked ? 'all' : 'top' );

--- a/packages/e2e-tests/fixtures/blocks/core__list__ul.html
+++ b/packages/e2e-tests/fixtures/blocks/core__list__ul.html
@@ -1,3 +1,3 @@
 <!-- wp:core/list -->
-<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
+<ul style="padding-bottom:0;padding-left:40px;padding-right:0;padding-top:0"><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
 <!-- /wp:core/list -->

--- a/packages/e2e-tests/fixtures/blocks/core__list__ul.json
+++ b/packages/e2e-tests/fixtures/blocks/core__list__ul.json
@@ -5,9 +5,19 @@
         "isValid": true,
         "attributes": {
             "ordered": false,
-            "values": "<li>Text &amp; Headings</li><li>Images &amp; Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li>"
+            "values": "<li>Text &amp; Headings</li><li>Images &amp; Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li>",
+            "style": {
+                "spacing": {
+                    "padding": {
+                        "top": 0,
+                        "right": 0,
+                        "bottom": 0,
+                        "left": 40
+                    }
+                }
+            }
         },
         "innerBlocks": [],
-        "originalContent": "<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>"
+        "originalContent": "<ul style=\"padding-bottom:0;padding-left:40px;padding-right:0;padding-top:0\"><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__list__ul.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__list__ul.parsed.json
@@ -3,9 +3,9 @@
         "blockName": "core/list",
         "attrs": {},
         "innerBlocks": [],
-        "innerHTML": "\n<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>\n",
+        "innerHTML": "\n<ul style=\"padding-bottom:0;padding-left:40px;padding-right:0;padding-top:0\"><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>\n",
         "innerContent": [
-            "\n<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>\n"
+            "\n<ul style=\"padding-bottom:0;padding-left:40px;padding-right:0;padding-top:0\"><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>\n"
         ]
     },
     {

--- a/packages/e2e-tests/fixtures/blocks/core__list__ul.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__list__ul.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:list -->
-<ul><li>Text &amp; Headings</li><li>Images &amp; Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
+<ul style="padding-bottom:0;padding-left:40px;padding-right:0;padding-top:0"><li>Text &amp; Headings</li><li>Images &amp; Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
 <!-- /wp:list -->

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -90,7 +90,6 @@ p {
 ul,
 ol {
 	margin-bottom: $default-block-margin;
-	padding-left: 1.3em;
 	margin-left: 1.3em;
 
 	// Remove bottom margin from nested lists.


### PR DESCRIPTION
## Description
Adds custom spacing settings to the list block.

This also fixes a bug in the box control component. When a list block is saved, only the set padding value is saved (left: 40px). The others are removed - this means when we check for mixed values we need to also check that there are 4 values, otherwise the check can return false just because the value match even though there's less than 4.

## How has this been tested?
Tested in TT1 Blocks

## Screenshots <!-- if applicable -->
<img width="883" alt="Screenshot 2020-12-04 at 14 31 53" src="https://user-images.githubusercontent.com/275961/101175792-82c84500-363d-11eb-9a97-7aec30be72ed.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
