### PR TITLE
Add CSS Reset

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -108,3 +108,14 @@
 .aligncenter {
 	clear: both;
 }
+
+// This resets the WordPress default
+img {
+	height: auto;
+	max-width: 100%;
+}
+
+pre {
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+}

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -90,6 +90,11 @@ body.block-editor-page {
 	iframe {
 		width: 100%;
 	}
+
+	pre {
+		white-space: pre-wrap;
+		overflow-wrap: break-word;
+	}
 }
 
 @include default-block-widths();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds some CSS reset code to minimize boilerplate code needed to build a theme.

Fixes #27116 

## How has this been tested?
Tested in TT1 blocks

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
