### PR TITLE
Fixes the width on the circle color picker popover

### DIFF
--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -4,6 +4,7 @@ $color-palette-circle-spacing: 12px;
 .components-circular-option-picker {
 	display: inline-block;
 	width: 100%;
+	min-width: 244px;
 
 	.components-circular-option-picker__custom-clear-wrapper {
 		display: flex;

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -4,7 +4,7 @@ $color-palette-circle-spacing: 12px;
 .components-circular-option-picker {
 	display: inline-block;
 	width: 100%;
-	min-width: 244px;
+	min-width: 188px;
 
 	.components-circular-option-picker__custom-clear-wrapper {
 		display: flex;


### PR DESCRIPTION
Fixes #27522.
Sets a min-width on the circle color picker.

## How has this been tested?
Locally.

## Screenshots 

**BEFORE**

![before](https://user-images.githubusercontent.com/617986/101214489-f6b02080-3630-11eb-95b8-7ee9813cdd8a.png)

**AFTER**

![after](https://user-images.githubusercontent.com/617986/101214501-fadc3e00-3630-11eb-8ea6-2135303659ce.png)


## Types of changes
Non-breaking CSS changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
