### PR TITLE
Add GitHub support document

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,12 @@
+
+# Gutenberg Project Support
+
+Welcome to WordPress' Gutenberg project! We hope you join us in creating the future platform for publishing; all are welcome here.
+
+* Please see the [Contributing Guidelines](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md) for additional information on how to contribute.
+
+* As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://github.com/WordPress/gutenberg/blob/master/CODE_OF_CONDUCT.md).
+
+* Join us on Slack for real-time communication, it is where maintainers coordinate around the project. To get started using Slack, see: https://make.wordpress.org/chat/
+
+* For WordPress support see the [WordPress.org support forums](https://wordpress.org/support/) — it is highly active and well maintained.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,7 +1,7 @@
 
 # Gutenberg Project Support
 
-Welcome to WordPress' Gutenberg project! We hope you join us in creating the future platform for publishing; all are welcome here.
+Welcome to Gutenberg, a WordPress project. We hope you join us in creating the future platform for publishing; all are welcome here.
 
 * Please see the [Contributing Guidelines](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md) for additional information on how to contribute.
 
@@ -9,4 +9,4 @@ Welcome to WordPress' Gutenberg project! We hope you join us in creating the fut
 
 * Join us on Slack for real-time communication, it is where maintainers coordinate around the project. To get started using Slack, see: https://make.wordpress.org/chat/
 
-* For WordPress support see the [WordPress.org support forums](https://wordpress.org/support/) — it is highly active and well maintained.
+* For general WordPress support with the core editor, see the [WordPress.org support forums](https://wordpress.org/support/) — it is highly active and well maintained.


### PR DESCRIPTION

## Description

Adds a support page with links to relevant info.

Closers #26758


## Types of changes

New GitHub documentation page.
