### PR TITLE
Core Data: Normalize `_fields` value for use in `stableKey`

### DIFF
--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -48,7 +48,7 @@ export function getQueryParts( query ) {
 
 	for ( let i = 0; i < keys.length; i++ ) {
 		const key = keys[ i ];
-		const value = query[ key ];
+		let value = query[ key ];
 
 		switch ( key ) {
 			case 'page':
@@ -73,6 +73,8 @@ export function getQueryParts( query ) {
 				// Example: Asking for titles in posts without title support.
 				if ( key === '_fields' ) {
 					parts.fields = getNormalizedCommaSeparable( value );
+					// Make sure to normalize value for `stableKey`
+					value = parts.fields.join();
 				}
 
 				// While it could be any deterministic string, for simplicity's

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -79,4 +79,16 @@ describe( 'getQueryParts', () => {
 			include: null,
 		} );
 	} );
+
+	it( 'encodes stable string key with fields parameters', () => {
+		const parts = getQueryParts( { _fields: [ 'id', 'title' ] } );
+
+		expect( parts ).toEqual( {
+			page: 1,
+			perPage: 10,
+			stableKey: '_fields=id%2Ctitle',
+			fields: [ 'id', 'title' ],
+			include: null,
+		} );
+	} );
 } );

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -94,7 +94,7 @@ describe( 'getQueriedItems', () => {
 				2: true,
 			},
 			queries: {
-				'_fields%5B0%5D=content': [ 1, 2 ],
+				'_fields=content': [ 1, 2 ],
 			},
 		};
 
@@ -133,7 +133,7 @@ describe( 'getQueriedItems', () => {
 				2: true,
 			},
 			queries: {
-				'_fields%5B0%5D=content&_fields%5B1%5D=meta.template': [ 1, 2 ],
+				'_fields=content,meta.template': [ 1, 2 ],
 			},
 		};
 

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -133,7 +133,7 @@ describe( 'getQueriedItems', () => {
 				2: true,
 			},
 			queries: {
-				'_fields=content,meta.template': [ 1, 2 ],
+				'_fields=content%2Cmeta.template': [ 1, 2 ],
 			},
 		};
 

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -248,6 +248,39 @@ describe( 'getEntityRecords', () => {
 		] );
 	} );
 
+	it( 'should return filtered items', () => {
+		const state = deepFreeze( {
+			entities: {
+				data: {
+					postType: {
+						post: {
+							queriedData: {
+								items: {
+									1: {
+										id: 1,
+										content: 'chicken',
+										author: 'bob',
+									},
+								},
+								itemIsComplete: {
+									1: true,
+								},
+								queries: {
+									'_fields=id%2Ccontent': [ 1 ],
+								},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect(
+			getEntityRecords( state, 'postType', 'post', {
+				_fields: [ 'id', 'content' ],
+			} )
+		).toEqual( [ { id: 1, content: 'chicken' } ] );
+	} );
+
 	it( 'should return the same instance with the same arguments', () => {
 		let state = deepFreeze( {
 			entities: {


### PR DESCRIPTION
Requests using `getEntityRecords` with `_fields` specified are not returning any results. This seems to have been introduced with https://github.com/WordPress/gutenberg/commit/aa701ad82ede38371c0c8f00e044b7343ae03cf6 (when _fields is added to stableKey), because the format used for [encoding `fields` here](https://github.com/WordPress/gutenberg/blob/87171eb27d8bd346388944b5a448a846d64d352f/packages/core-data/src/queried-data/get-query-parts.js#L87) doesn't match the format [used in the resolver.](https://github.com/WordPress/gutenberg/blob/87171eb27d8bd346388944b5a448a846d64d352f/packages/core-data/src/resolvers.js#L100-L103)

In my example below, if you look at the state, the key used is `_fields=id%2Cslug%2Ctitle`, while `stableKey` is `_fields%5B0%5D=id&_fields%5B1%5D=slug&_fields%5B2%5D=title`. This mismatch means the results are never found in the state.

I'm not sure if this is the best solution - there still could be a mismatch if the entity key is left out; the selector will add that into `fields`, while it won't be added in `getQueryParts`.

**To Test**

Fetch records with getEntityRecords, like this:

```js
select("core").getEntityRecords("postType", "post", {
	_fields: ["id", "slug", "title"],
})
```

1. Use this [test case block:](https://gist.github.com/ryelle/52604f1a01de755586a8c73dd78b01b3) a simple `useSelect` query, logging result the console
2. Add the block by pasting the code into console
3. Add the block "Fields Test" to your page
4. That will trigger the request, so watch console for the results
5. On master, it will always return `null`, even after the API request completes
6. On this branch, you should see the results (a list of published posts, only ID, slug, and title)

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
