### PR TITLE
URL: Enhance the way long URLs are handled in filterURLForDisplay

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -17,7 +17,8 @@ import { ViewerSlot } from './viewer-slot';
 
 export default function LinkPreview( { value, onEditClick } ) {
 	const displayURL =
-		( value && filterURLForDisplay( safeDecodeURI( value.url ) ) ) || '';
+		( value && filterURLForDisplay( safeDecodeURI( value.url ), 16 ) ) ||
+		'';
 
 	return (
 		<div

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -165,7 +165,6 @@ $block-editor-link-control-number-of-actions: 1;
 	.block-editor-link-control__search-item-title {
 		max-width: 230px;
 		overflow: hidden;
-		text-overflow: ellipsis;
 	}
 
 	.block-editor-link-control__search-item-title {

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-	Add optional argument `maxLength` for truncating URL in `filterURLForDisplay`
+
 ## 2.16.0 (2020-06-15)
 
 ### New Feature

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -96,11 +96,13 @@ _Usage_
 
 ```js
 const displayUrl = filterURLForDisplay( 'https://www.wordpress.org/gutenberg/' ); // wordpress.org/gutenberg
+const imageUrl = filterURLForDisplay( 'https://www.wordpress.org/wp-content/uploads/img.png', 20 ); // …ent/uploads/img.png
 ```
 
 _Parameters_
 
 -   _url_ `string`: Original URL.
+-   _maxLength_ `(number|null)`: URL length.
 
 _Returns_
 

--- a/packages/url/src/filter-url-for-display.js
+++ b/packages/url/src/filter-url-for-display.js
@@ -2,22 +2,53 @@
  * Returns a URL for display.
  *
  * @param {string} url Original URL.
+ * @param {number|null} maxLength URL length.
  *
  * @example
  * ```js
  * const displayUrl = filterURLForDisplay( 'https://www.wordpress.org/gutenberg/' ); // wordpress.org/gutenberg
+ * const imageUrl = filterURLForDisplay( 'https://www.wordpress.org/wp-content/uploads/img.png', 20 ); // …ent/uploads/img.png
  * ```
  *
  * @return {string} Displayed URL.
  */
-export function filterURLForDisplay( url ) {
+export function filterURLForDisplay( url, maxLength = null ) {
 	// Remove protocol and www prefixes.
-	const filteredURL = url.replace( /^(?:https?:)\/\/(?:www\.)?/, '' );
+	let filteredURL = url.replace( /^(?:https?:)\/\/(?:www\.)?/, '' );
 
 	// Ends with / and only has that single slash, strip it.
 	if ( filteredURL.match( /^[^\/]+\/$/ ) ) {
-		return filteredURL.replace( '/', '' );
+		filteredURL = filteredURL.replace( '/', '' );
 	}
 
-	return filteredURL;
+	const mediaRegexp = /([\w|:])*\.(?:jpg|jpeg|gif|png|svg)/;
+
+	if (
+		! maxLength ||
+		filteredURL.length <= maxLength ||
+		! filteredURL.match( mediaRegexp )
+	) {
+		return filteredURL;
+	}
+
+	// If the file is not greater than max length, return last portion of URL.
+	filteredURL = filteredURL.split( '?' )[ 0 ];
+	const urlPieces = filteredURL.split( '/' );
+	const file = urlPieces[ urlPieces.length - 1 ];
+	if ( file.length <= maxLength ) {
+		return '…' + filteredURL.slice( -maxLength );
+	}
+
+	// If the file is greater than max length, truncate the file.
+	const index = file.lastIndexOf( '.' );
+	const [ fileName, extension ] = [
+		file.slice( 0, index ),
+		file.slice( index + 1 ),
+	];
+	const truncatedFile = fileName.slice( -3 ) + '.' + extension;
+	return (
+		file.slice( 0, maxLength - truncatedFile.length - 1 ) +
+		'…' +
+		truncatedFile
+	);
 }

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -876,6 +876,54 @@ describe( 'filterURLForDisplay', () => {
 		const url = filterURLForDisplay( 'http://www.wordpress.org/something' );
 		expect( url ).toBe( 'wordpress.org/something' );
 	} );
+	it( 'should preserve the original url if no argument max length', () => {
+		const url = filterURLForDisplay(
+			'http://www.wordpress.org/wp-content/uploads/myimage.jpg'
+		);
+		expect( url ).toBe( 'wordpress.org/wp-content/uploads/myimage.jpg' );
+	} );
+	it( 'should preserve the original url if the url is short enough', () => {
+		const url = filterURLForDisplay(
+			'http://www.wordpress.org/ig.jpg',
+			20
+		);
+		expect( url ).toBe( 'wordpress.org/ig.jpg' );
+	} );
+	it( 'should return ellipsis, upper level pieces url, and filename when the url is long enough but filename is short enough', () => {
+		const url = filterURLForDisplay(
+			'http://www.wordpress.org/wp-content/uploads/myimage.jpg',
+			20
+		);
+		expect( url ).toBe( '…/uploads/myimage.jpg' );
+	} );
+	it( 'should return filename split by ellipsis plus three characters when filename is long enough', () => {
+		const url = filterURLForDisplay(
+			'http://www.wordpress.org/wp-content/uploads/superlongtitlewithextension.jpeg',
+			20
+		);
+		expect( url ).toBe( 'superlongti…ion.jpeg' );
+	} );
+	it( 'should remove query arguments', () => {
+		const url = filterURLForDisplay(
+			'http://www.wordpress.org/wp-content/uploads/myimage.jpeg?query_args=a',
+			20
+		);
+		expect( url ).toBe( '…uploads/myimage.jpeg' );
+	} );
+	it( 'should preserve the original url when it is not a file', () => {
+		const url = filterURLForDisplay(
+			'http://www.wordpress.org/wp-content/url/',
+			20
+		);
+		expect( url ).toBe( 'wordpress.org/wp-content/url/' );
+	} );
+	it( 'should return file split by ellipsis when the file name has multiple periods', () => {
+		const url = filterURLForDisplay(
+			'http://www.wordpress.org/wp-content/uploads/filename.2020.12.20.png',
+			20
+		);
+		expect( url ).toBe( 'filename.202….20.png' );
+	} );
 } );
 
 describe( 'cleanForSlug', () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #21100
Add an argument to truncate the URL by max length.

## How has this been tested?
Additional tests were added to the `url/src/test/index.tests.js` file.

## Screenshots
<img width="844" alt="truncated url" src="https://user-images.githubusercontent.com/56378160/101269320-da4cda80-373b-11eb-9328-9186a4d2a31d.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
