### PR TITLE
Block editor: use proper insertion point for drop

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -46,7 +46,7 @@ export default function BlockList( { className } ) {
 				) }
 			>
 				<SetBlockNodes.Provider value={ setBlockNodes }>
-					<BlockListItems wrapperRef={ ref } />
+					<BlockListItems />
 				</SetBlockNodes.Provider>
 			</div>
 		</BlockNodes.Provider>

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -61,7 +61,6 @@ function Items( {
 	function selector( select ) {
 		const {
 			getBlockOrder,
-			getBlockListSettings,
 			getSettings,
 			getSelectedBlockClientId,
 			getMultiSelectedBlockClientIds,
@@ -80,7 +79,6 @@ function Items( {
 			blockClientIds: getBlockOrder( rootClientId ),
 			selectedBlockClientId: getSelectedBlockClientId(),
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
-			orientation: getBlockListSettings( rootClientId )?.orientation,
 			hasMultiSelection: hasMultiSelection(),
 			enableAnimation:
 				! isTyping() &&
@@ -93,18 +91,15 @@ function Items( {
 		blockClientIds,
 		selectedBlockClientId,
 		multiSelectedBlockClientIds,
-		orientation,
 		hasMultiSelection,
 		enableAnimation,
 		activeEntityBlockId,
 	} = useSelect( selector, [ rootClientId ] );
 
-	const dropTargetIndex = useBlockDropZone( {
+	useBlockDropZone( {
 		element: wrapperRef,
 		rootClientId,
 	} );
-
-	const isAppenderDropTarget = dropTargetIndex === blockClientIds.length;
 
 	return (
 		<>
@@ -112,8 +107,6 @@ function Items( {
 				const isBlockInSelection = hasMultiSelection
 					? multiSelectedBlockClientIds.includes( clientId )
 					: selectedBlockClientId === clientId;
-
-				const isDropTarget = dropTargetIndex === index;
 
 				return (
 					<AsyncModeProvider
@@ -128,10 +121,6 @@ function Items( {
 							index={ index }
 							enableAnimation={ enableAnimation }
 							className={ classnames( {
-								'is-drop-target': isDropTarget,
-								'is-dropping-horizontally':
-									isDropTarget &&
-									orientation === 'horizontal',
 								'has-active-entity': activeEntityBlockId,
 							} ) }
 							activeEntityBlockId={ activeEntityBlockId }
@@ -144,11 +133,6 @@ function Items( {
 				tagName={ __experimentalAppenderTagName }
 				rootClientId={ rootClientId }
 				renderAppender={ renderAppender }
-				className={ classnames( {
-					'is-drop-target': isAppenderDropTarget,
-					'is-dropping-horizontally':
-						isAppenderDropTarget && orientation === 'horizontal',
-				} ) }
 			/>
 		</>
 	);

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -32,6 +32,8 @@ export default function BlockList( { className } ) {
 	const [ blockNodes, setBlockNodes ] = useState( {} );
 	const insertionPoint = useInsertionPoint( ref );
 
+	useBlockDropZone( { element: ref } );
+
 	return (
 		<BlockNodes.Provider value={ blockNodes }>
 			{ insertionPoint }
@@ -56,7 +58,6 @@ function Items( {
 	rootClientId,
 	renderAppender,
 	__experimentalAppenderTagName,
-	wrapperRef,
 } ) {
 	function selector( select ) {
 		const {
@@ -95,11 +96,6 @@ function Items( {
 		enableAnimation,
 		activeEntityBlockId,
 	} = useSelect( selector, [ rootClientId ] );
-
-	useBlockDropZone( {
-		element: wrapperRef,
-		rootClientId,
-	} );
 
 	return (
 		<>

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -118,11 +118,23 @@ function InsertionPointPopover( {
 		},
 		[ clientId, rootClientId ]
 	);
+	const orientation = useSelect(
+		( select ) =>
+			select( 'core/block-editor' ).getBlockListSettings( rootClientId )
+				?.orientation,
+		[ rootClientId ]
+	);
 
-	const position = clientId ? 'top' : 'bottom';
+	const position =
+		clientId || orientation === 'horizontal' ? 'top' : 'bottom';
 	const className = classnames( 'block-editor-block-list__insertion-point', {
+		'is-horizontal': orientation === 'horizontal',
 		'is-insert-after': ! clientId,
 	} );
+	const style =
+		orientation === 'horizontal'
+			? { width: element?.offsetWidth, height: element?.offsetHeight }
+			: { width: element?.offsetWidth };
 
 	return (
 		<Popover
@@ -131,14 +143,14 @@ function InsertionPointPopover( {
 			anchorRef={ element }
 			position={ `${ position } right left` }
 			focusOnMount={ false }
-			className="block-editor-block-list__insertion-point-popover"
+			className={ classnames(
+				'block-editor-block-list__insertion-point-popover',
+				{ 'is-horizontal': orientation === 'horizontal' }
+			) }
 			__unstableSlotName="block-toolbar"
 			__unstableForcePosition={ true }
 		>
-			<div
-				className={ className }
-				style={ { width: element?.offsetWidth } }
-			>
+			<div className={ className } style={ style }>
 				{ showInsertionPoint && (
 					<div className="block-editor-block-list__insertion-point-indicator" />
 				) }
@@ -264,7 +276,9 @@ export default function InsertionPoint( ref ) {
 				clientId={
 					isInserterVisible ? selectedClientId : inserterClientId
 				}
-				rootClientId={ selectedRootClientId }
+				rootClientId={
+					isInserterVisible ? selectedRootClientId : undefined
+				}
 				isInserterShown={ isInserterShown }
 				isInserterForced={ isInserterForced }
 				setIsInserterForced={ setIsInserterForced }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -8,33 +8,6 @@
  * Notices & Block Selected/Hover Styles.
  */
 
-.block-editor-block-list__layout .block-editor-block-list__block,
-.block-editor-block-list__layout .block-list-appender {
-	position: relative;
-
-	// Between-blocks dropzone line indicator.
-	&.is-drop-target::before {
-		content: "";
-		position: absolute;
-		z-index: 0;
-		pointer-events: none;
-		transition: border-color 0.1s linear, border-style 0.1s linear, box-shadow 0.1s linear;
-		top: -$default-block-margin / 2;
-		right: 0;
-		left: 0;
-		border-top: 4px solid var(--wp-admin-theme-color);
-	}
-
-	&.is-drop-target.is-dropping-horizontally::before {
-		top: 0;
-		bottom: 0;
-		// Drop target border-width plus a couple of pixels so that the border looks between blocks.
-		left: -6px;
-		border-top: none;
-		border-left: 4px solid var(--wp-admin-theme-color);
-	}
-}
-
 /**
  * Cross-Block Selection
  */

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -358,6 +358,10 @@
 	&.is-insert-after {
 		margin-top: $block-padding;
 	}
+
+	&.is-horizontal {
+		margin-top: 0;
+	}
 }
 
 .block-editor-block-list__insertion-point-indicator {
@@ -367,6 +371,20 @@
 	left: 0;
 	right: 0;
 	background: var(--wp-admin-theme-color);
+
+	.is-horizontal & {
+		left: 0;
+		width: $border-width-focus;
+		height: auto;
+		top: 0;
+		bottom: 0;
+		right: auto;
+	}
+
+	.is-horizontal.is-insert-after & {
+		left: auto;
+		right: 0;
+	}
 }
 
 // This is the clickable plus.
@@ -618,6 +636,10 @@
 		box-shadow: none;
 		overflow-y: visible;
 		margin-left: 0;
+	}
+
+	&.is-horizontal .components-popover__content {
+		bottom: auto;
 	}
 }
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -19,15 +19,12 @@ import DefaultBlockAppender from './default-block-appender';
 import useNestedSettingsUpdate from './use-nested-settings-update';
 import useInnerBlockTemplateSync from './use-inner-block-template-sync';
 import getBlockContext from './get-block-context';
-
-/**
- * Internal dependencies
- */
 import { BlockListItems } from '../block-list';
 import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { defaultLayout, LayoutProvider } from './layout';
+import useBlockDropZone from '../use-block-drop-zone';
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -43,7 +40,6 @@ function UncontrolledInnerBlocks( props ) {
 		allowedBlocks,
 		template,
 		templateLock,
-		wrapperRef,
 		templateInsertUpdatesSelection,
 		__experimentalCaptureToolbars: captureToolbars,
 		__experimentalAppenderTagName,
@@ -93,7 +89,6 @@ function UncontrolledInnerBlocks( props ) {
 					__experimentalAppenderTagName={
 						__experimentalAppenderTagName
 					}
-					wrapperRef={ wrapperRef }
 					placeholder={ placeholder }
 				/>
 			</BlockContextProvider>
@@ -168,6 +163,8 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			? ControlledInnerBlocks
 			: UncontrolledInnerBlocks;
 
+	useBlockDropZone( { element: ref, rootClientId: clientId } );
+
 	return {
 		...props,
 		ref,
@@ -178,13 +175,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				'has-overlay': hasOverlay,
 			}
 		),
-		children: (
-			<InnerBlocks
-				{ ...options }
-				clientId={ clientId }
-				wrapperRef={ ref }
-			/>
-		),
+		children: <InnerBlocks { ...options } clientId={ clientId } />,
 	};
 }
 

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -116,7 +116,7 @@ export default function useBlockDropZone( {
 
 	const dropEventHandlers = useOnBlockDrop();
 
-	const { position } = useDropZone( {
+	const { position, isDraggingOverDocument } = useDropZone( {
 		element,
 		isDisabled: isLockedAll,
 		withPosition: true,
@@ -134,16 +134,14 @@ export default function useBlockDropZone( {
 			);
 
 			setTargetBlockIndex( targetIndex === undefined ? 0 : targetIndex );
-		} else {
-			setTargetBlockIndex( null );
 		}
 	}, [ position ] );
 
 	useEffect( () => {
-		if ( targetBlockIndex !== null ) {
-			showInsertionPoint( targetRootClientId, targetBlockIndex );
-		} else {
+		if ( ! isDraggingOverDocument ) {
 			hideInsertionPoint();
+		} else if ( targetBlockIndex !== null ) {
+			showInsertionPoint( targetRootClientId, targetBlockIndex );
 		}
-	}, [ targetBlockIndex ] );
+	}, [ targetBlockIndex, isDraggingOverDocument ] );
 }

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __unstableUseDropZone as useDropZone } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 
 /**
@@ -85,8 +85,6 @@ export function getNearestBlockIndex( elements, position, orientation ) {
  * A React hook that can be used to make a block list handle drag and drop.
  *
  * @param {WPBlockDropZoneConfig} dropZoneConfig configuration data for the drop zone.
- *
- * @return {number|undefined} The block index that's closest to the drag position.
  */
 export default function useBlockDropZone( {
 	element,
@@ -112,10 +110,11 @@ export default function useBlockDropZone( {
 		[ targetRootClientId ]
 	);
 
-	const dropEventHandlers = useOnBlockDrop(
-		targetRootClientId,
-		targetBlockIndex
+	const { showInsertionPoint, hideInsertionPoint } = useDispatch(
+		'core/block-editor'
 	);
+
+	const dropEventHandlers = useOnBlockDrop();
 
 	const { position } = useDropZone( {
 		element,
@@ -135,10 +134,16 @@ export default function useBlockDropZone( {
 			);
 
 			setTargetBlockIndex( targetIndex === undefined ? 0 : targetIndex );
+		} else {
+			setTargetBlockIndex( null );
 		}
 	}, [ position ] );
 
-	if ( position ) {
-		return targetBlockIndex;
-	}
+	useEffect( () => {
+		if ( targetBlockIndex !== null ) {
+			showInsertionPoint( targetRootClientId, targetBlockIndex );
+		} else {
+			hideInsertionPoint();
+		}
+	}, [ targetBlockIndex ] );
 }

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -181,27 +181,30 @@ export function onHTMLDrop(
 /**
  * A React hook for handling block drop events.
  *
- * @param {string} targetRootClientId The root client id where the block(s) will be inserted.
- * @param {number} targetBlockIndex   The index where the block(s) will be inserted.
- *
  * @return {Object} An object that contains the event handlers `onDrop`, `onFilesDrop` and `onHTMLDrop`.
  */
-export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
+export default function useOnBlockDrop() {
 	const {
 		getBlockIndex,
 		getClientIdsOfDescendants,
 		hasUploadPermissions,
+		targetRootClientId,
+		targetBlockIndex,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockIndex: _getBlockIndex,
 			getClientIdsOfDescendants: _getClientIdsOfDescendants,
 			getSettings,
+			getBlockInsertionPoint,
 		} = select( 'core/block-editor' );
+		const insertionPoint = getBlockInsertionPoint();
 
 		return {
 			getBlockIndex: _getBlockIndex,
 			getClientIdsOfDescendants: _getClientIdsOfDescendants,
 			hasUploadPermissions: getSettings().mediaUpload,
+			targetRootClientId: insertionPoint.rootClientId,
+			targetBlockIndex: insertionPoint.index,
 		};
 	}, [] );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Currently an insertion point is added through a block class for drop on a block list. We should use the insertion point component for this instead, used by the inserter.

Additionally, the appender is currently used as an insertion point, which shouldn't be used as in some contexts there may be no appender.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
