### PR TITLE
Avoid cancelling other e2e test jobs when one fails.

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         part: [1, 2, 3, 4]
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
#27487 introduced the use of a matrix for running e2e tests over github actions.

I noticed one thing that's not working the same as before:
<img width="329" alt="Screenshot 2020-12-07 at 3 07 20 pm" src="https://user-images.githubusercontent.com/677833/101325832-5a438380-38a7-11eb-8d68-783572c6d89b.png">

If any matrix job fails the other matrix jobs are cancelled. The `fail-fast` setting causes this as it defaults to `true`, so here I'm setting it to `false` to restore the behavior we had before.