### PR TITLE
useMediaQuery: make it safe for SSR environments without window

### DIFF
--- a/packages/compose/src/hooks/use-media-query/index.js
+++ b/packages/compose/src/hooks/use-media-query/index.js
@@ -11,7 +11,12 @@ import { useState, useEffect } from '@wordpress/element';
  */
 export default function useMediaQuery( query ) {
 	const [ match, setMatch ] = useState(
-		query && window.matchMedia( query ).matches
+		() =>
+			!! (
+				query &&
+				typeof window !== 'undefined' &&
+				window.matchMedia( query ).matches
+			)
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
The `useMediaQuery` hook and the components that use it should be safe to use in a SSR environment, i.e., in a Node.js server without any `window` or DOM.

This PR fixes the hook by checking presence of `window` before accessing it.

It also makes the `useState` argument into a callback, so that `window.matchMedia( query ).matches` is not evaluated on every render.

Cc @alshakero 