### PR TITLE
Add option to use Post Featured Image with consistent height 

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -6,6 +6,16 @@
 		"isLink": {
 			"type": "boolean",
 			"default": false
+		},
+		"useAsCover": {
+			"type": "boolean",
+			"default": false
+		},
+		"minHeight": {
+			"type": "number"
+		},
+		"minHeightUnit": {
+			"type": "string"
 		}
 	},
 	"usesContext": [

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -8,8 +8,7 @@
 			"default": false
 		},
 		"useAsCover": {
-			"type": "boolean",
-			"default": false
+			"type": "boolean"
 		},
 		"minHeight": {
 			"type": "number"

--- a/packages/block-library/src/post-featured-image/constants.js
+++ b/packages/block-library/src/post-featured-image/constants.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Platform } from '@wordpress/element';
+
+const isWeb = Platform.OS === 'web';
+export const CSS_UNITS = [
+	{
+		value: 'px',
+		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		default: '300',
+	},
+	{
+		value: 'em',
+		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
+		default: '20',
+	},
+	{
+		value: 'rem',
+		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
+		default: '20',
+	},
+	{
+		value: 'vw',
+		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
+		default: '20',
+	},
+	{
+		value: 'vh',
+		label: isWeb ? 'vh' : __( 'Viewport height (vh)' ),
+		default: '50',
+	},
+];
+export const ALLOWED_MEDIA_TYPES = [ 'image' ];
+export const COVER_MIN_HEIGHT = 50;

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -26,7 +26,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		if ( $featured_image_url ) {
 			$classnames[] = 'is-used-as-cover';
 			if ( isset( $attributes['minHeight'] ) ) {
-				$min_height_unit = $attributes['minHeightUnit'] ? $attributes['minHeightUnit'] : 'px';
+				$min_height_unit = isset( $attributes['minHeightUnit'] ) ? $attributes['minHeightUnit'] : 'px';
 				$styles[]        = "min-height:{$attributes['minHeight']}{$min_height_unit}";
 			}
 			$styles[] = "background-image:url('{$featured_image_url}')";

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -17,15 +17,35 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
-	$post_ID = $block->context['postId'];
+	$post_ID        = $block->context['postId'];
+	$featured_image = '';
+	$classnames     = array();
+	$styles         = array();
+	if ( isset( $attributes['useAsCover'] ) && $attributes['useAsCover'] ) {
+		$featured_image_url = get_the_post_thumbnail_url( $post_ID );
+		if ( $featured_image_url ) {
+			$classnames[] = 'is-used-as-cover';
+			if ( isset( $attributes['minHeight'] ) ) {
+				$min_height_unit = $attributes['minHeightUnit'] ? $attributes['minHeightUnit'] : 'px';
+				$styles[]        = "min-height:{$attributes['minHeight']}{$min_height_unit}";
+			}
+			$styles[] = "background-image:url('{$featured_image_url}')";
+		}
+		$featured_image = '';
+	} else {
+		$featured_image = get_the_post_thumbnail( $post_ID );
+	}
 
-	$featured_image = get_the_post_thumbnail( $post_ID );
-
-	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] && has_post_thumbnail( $post_ID ) ) {
 		$featured_image = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $post_ID ), $featured_image );
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class' => implode( ' ', $classnames ),
+			'style' => implode( ';', $styles ),
+		)
+	);
 
 	return '<p ' . $wrapper_attributes . '>' . $featured_image . '</p>';
 }

--- a/packages/block-library/src/post-featured-image/inspector-controls.js
+++ b/packages/block-library/src/post-featured-image/inspector-controls.js
@@ -1,0 +1,96 @@
+/**
+ * WordPress dependencies
+ */
+import { BaseControl, PanelBody, ToggleControl } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import {
+	InspectorControls,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/block-editor';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { CSS_UNITS, COVER_MIN_HEIGHT } from './constants';
+
+const CoverHeightInput = ( {
+	onChange,
+	onUnitChange,
+	unit = 'px',
+	value = '',
+} ) => {
+	const inputId = useInstanceId(
+		UnitControl,
+		'block-post-featured-image-height-input'
+	);
+	const handleOnChange = ( unprocessedValue ) => {
+		const inputValue = parseInt( unprocessedValue, 10 );
+		if ( Number.isNaN( inputValue ) ) return;
+		onChange( inputValue );
+	};
+	const min = unit === 'px' ? COVER_MIN_HEIGHT : 0;
+	return (
+		<BaseControl label={ __( 'Minimum height of cover' ) } id={ inputId }>
+			<UnitControl
+				id={ inputId }
+				min={ min }
+				onChange={ handleOnChange }
+				onUnitChange={ onUnitChange }
+				step="1"
+				style={ { maxWidth: 80 } }
+				unit={ unit }
+				units={ CSS_UNITS }
+				value={ value }
+				isResetValueOnUnitChange
+			/>
+		</BaseControl>
+	);
+};
+
+const FeaturedImageInspectorControls = ( {
+	attributes: { useAsCover, minHeight, minHeightUnit, isLink },
+	setAttributes,
+	postType,
+} ) => {
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Image settings' ) }>
+				<ToggleControl
+					label={ __( 'Use as cover' ) }
+					onChange={ () =>
+						setAttributes( { useAsCover: ! useAsCover } )
+					}
+					checked={ !! useAsCover }
+				/>
+				{ useAsCover && (
+					<CoverHeightInput
+						value={ minHeight }
+						unit={ minHeightUnit }
+						onChange={ ( newMinHeight ) =>
+							setAttributes( { minHeight: newMinHeight } )
+						}
+						onUnitChange={ ( newUnit ) =>
+							setAttributes( {
+								minHeightUnit: newUnit,
+							} )
+						}
+					/>
+				) }
+			</PanelBody>
+			<PanelBody title={ __( 'Link settings' ) }>
+				<ToggleControl
+					label={ sprintf(
+						// translators: %s: Name of the post type e.g: "post".
+						__( 'Link to %s' ),
+						postType
+					) }
+					onChange={ () => setAttributes( { isLink: ! isLink } ) }
+					checked={ !! isLink }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default FeaturedImageInspectorControls;

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -6,4 +6,17 @@
 		max-width: 100%;
 		height: auto;
 	}
+	&.is-used-as-cover {
+		position: relative;
+		min-height: 300px;
+		background-position: center center;
+		background-size: cover;
+		a {
+			position: absolute;
+			height: 100%;
+			width: 100%;
+			top: 0;
+			left: 0;
+		}
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds support for setting consistent height for the Post Featured Image block, using css `background-image` property. I think this is a very important thing for Post Featured Image to support, so as to enable basic/common designs mostly used through `Query` block.

I intentionally handled this specifically in this block by providing minimum functionality which provides value ( IMO :) ), as there are discussions for creating a generic `background` control to handle featured images, along with other options (https://github.com/WordPress/gutenberg/issues/24660).
<!-- Please describe what you have changed or added -->

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
![useAsCover](https://user-images.githubusercontent.com/16275880/101349142-8eae4400-3895-11eb-9c64-5bbae305fe1b.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
