### PR TITLE
Code Quality: Use store definition instead of string for notices packages

### DIFF
--- a/packages/block-directory/src/index.js
+++ b/packages/block-directory/src/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import '@wordpress/notices';
-
-/**
  * Internal dependencies
  */
 import './plugins';

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -5,6 +5,7 @@ import { store as blocksStore } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { controls } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -144,7 +145,7 @@ export function* uninstallBlockType( block ) {
 		yield removeInstalledBlockType( block );
 	} catch ( error ) {
 		yield controls.dispatch(
-			'core/notices',
+			noticesStore,
 			'createErrorNotice',
 			error.message || __( 'An error occurred.' )
 		);

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -281,7 +281,7 @@ describe( 'actions', () => {
 			expect( generator.throw( apiError ).value ).toMatchObject( {
 				type: '@@data/DISPATCH',
 				actionName: 'createErrorNotice',
-				storeKey: 'core/notices',
+				storeKey: noticesStore,
 			} );
 
 			expect( generator.next() ).toEqual( {

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -13,6 +13,7 @@ import {
 } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -28,7 +28,7 @@ export function useNotifyCopy() {
 		( select ) => select( blocksStore ),
 		[]
 	);
-	const { createSuccessNotice } = useDispatch( 'core/notices' );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	return useCallback( ( eventType, selectedBlockClientIds ) => {
 		let notice = '';

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -29,7 +29,7 @@ const usePatternsState = ( onInsert ) => {
 			patternCategories: __experimentalBlockPatternCategories,
 		};
 	}, [] );
-	const { createSuccessNotice } = useDispatch( 'core/notices' );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const onClickPattern = useCallback( ( pattern, blocks ) => {
 		onInsert(
 			map( blocks, ( block ) => cloneBlock( block ) ),

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -10,6 +10,7 @@ import { useCallback } from '@wordpress/element';
 import { cloneBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Retrieves the block patterns inserter state.

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -205,7 +205,7 @@ const MediaReplaceFlow = ( {
 
 export default compose( [
 	withDispatch( ( dispatch ) => {
-		const { createNotice, removeNotice } = dispatch( 'core/notices' );
+		const { createNotice, removeNotice } = dispatch( noticesStore );
 		return {
 			createNotice,
 			removeNotice,

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -22,6 +22,7 @@ import { withDispatch, useSelect } from '@wordpress/data';
 import { DOWN, TAB, ESCAPE } from '@wordpress/keycodes';
 import { compose } from '@wordpress/compose';
 import { upload, media as mediaIcon } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import '@wordpress/rich-text';
-import '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -76,7 +76,7 @@ export default function ReusableBlockEdit( {
 	} = useDispatch( reusableBlocksStore );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch(
-		'core/notices'
+		noticesStore
 	);
 	const save = useCallback( async function () {
 		try {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -19,6 +19,7 @@ import {
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import { store as noticesStore } from '@wordpress/notices';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 
 /**

--- a/packages/block-library/src/image/image-editing/use-save-image.js
+++ b/packages/block-library/src/image/image-editing/use-save-image.js
@@ -5,6 +5,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 export default function useSaveImage( {
 	crop,
@@ -17,7 +18,7 @@ export default function useSaveImage( {
 	onSaveImage,
 	onFinishEditing,
 } ) {
-	const { createErrorNotice } = useDispatch( 'core/notices' );
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const [ isInProgress, setIsInProgress ] = useState( false );
 
 	const cancel = useCallback( () => {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -119,7 +119,7 @@ export default function Image( {
 	} );
 	const { toggleSelection } = useDispatch( 'core/block-editor' );
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
-		'core/notices'
+		noticesStore
 	);
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ captionFocused, setCaptionFocused ] = useState( false );

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -33,6 +33,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { createBlock } from '@wordpress/blocks';
 import { crop, upload } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import '@wordpress/core-data';
-import '@wordpress/notices';
 import '@wordpress/block-editor';
 import {
 	registerBlockType,

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -9,6 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
 import { Icon } from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * External dependencies

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -36,7 +36,7 @@ function TemplatePartItem( {
 	// The fallback prevents an error in the parse function while saving.
 	const content = templatePart.content.raw || '';
 	const blocks = useMemo( () => parse( content ), [ content ] );
-	const { createSuccessNotice } = useDispatch( 'core/notices' );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const onClick = useCallback( () => {
 		setAttributes( { postId: id, slug, theme } );

--- a/packages/edit-navigation/src/components/header/add-menu-form.js
+++ b/packages/edit-navigation/src/components/header/add-menu-form.js
@@ -17,9 +17,7 @@ const menuNameMatches = ( menuName ) => ( menu ) =>
 export default function AddMenuForm( { menus, onCreate } ) {
 	const [ menuName, setMenuName ] = useState( '' );
 
-	const { createErrorNotice, createInfoNotice } = useDispatch(
-		'core/notices'
-	);
+	const { createErrorNotice, createInfoNotice } = useDispatch( noticesStore );
 
 	const [ isCreatingMenu, setIsCreatingMenu ] = useState( false );
 

--- a/packages/edit-navigation/src/components/header/add-menu-form.js
+++ b/packages/edit-navigation/src/components/header/add-menu-form.js
@@ -10,6 +10,7 @@ import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { TextControl, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 const menuNameMatches = ( menuName ) => ( menu ) =>
 	menu.name.toLowerCase() === menuName.toLowerCase();

--- a/packages/edit-navigation/src/components/layout/use-menu-notifications.js
+++ b/packages/edit-navigation/src/components/layout/use-menu-notifications.js
@@ -3,6 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 
 export default function useMenuNotifications( menuId ) {
 	const { lastSaveError, lastDeleteError } = useSelect(

--- a/packages/edit-navigation/src/components/layout/use-menu-notifications.js
+++ b/packages/edit-navigation/src/components/layout/use-menu-notifications.js
@@ -20,7 +20,7 @@ export default function useMenuNotifications( menuId ) {
 		[ menuId ]
 	);
 
-	const { createErrorNotice } = useDispatch( 'core/notices' );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const processError = ( error ) => {
 		const document = new window.DOMParser().parseFromString(

--- a/packages/edit-navigation/src/components/notices/index.js
+++ b/packages/edit-navigation/src/components/notices/index.js
@@ -8,6 +8,7 @@ import { filter } from 'lodash';
  */
 import { NoticeList, SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
 export default function EditNavigationNotices() {
 	const { removeNotice } = useDispatch( noticesStore );

--- a/packages/edit-navigation/src/components/notices/index.js
+++ b/packages/edit-navigation/src/components/notices/index.js
@@ -10,9 +10,9 @@ import { NoticeList, SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 export default function EditNavigationNotices() {
-	const { removeNotice } = useDispatch( 'core/notices' );
+	const { removeNotice } = useDispatch( noticesStore );
 	const notices = useSelect(
-		( select ) => select( 'core/notices' ).getNotices(),
+		( select ) => select( noticesStore ).getNotices(),
 		[]
 	);
 	const dismissibleNotices = filter( notices, {

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -6,7 +6,6 @@ import { map, set, flatten, omit, partialRight } from 'lodash';
 /**
  * WordPress dependencies
  */
-import '@wordpress/notices';
 import {
 	registerCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,

--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -96,7 +96,7 @@ export const saveNavigationPost = serializeProcessing( function* ( post ) {
 			throw new Error();
 		}
 		yield dispatch(
-			'core/notices',
+			noticesStore,
 			'createSuccessNotice',
 			__( 'Navigation saved.' ),
 			{
@@ -105,7 +105,7 @@ export const saveNavigationPost = serializeProcessing( function* ( post ) {
 		);
 	} catch ( e ) {
 		yield dispatch(
-			'core/notices',
+			noticesStore,
 			'createErrorNotice',
 			__( 'There was an error.' ),
 			{

--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -8,6 +8,7 @@ import { v4 as uuid } from 'uuid';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/edit-navigation/src/store/test/actions.js
+++ b/packages/edit-navigation/src/store/test/actions.js
@@ -346,7 +346,7 @@ describe( 'saveNavigationPost', () => {
 
 		expect( action.next( { success: true } ).value ).toEqual(
 			dispatch(
-				'core/notices',
+				noticesStore,
 				'createSuccessNotice',
 				__( 'Navigation saved.' ),
 				{
@@ -476,7 +476,7 @@ describe( 'saveNavigationPost', () => {
 
 		expect( action.next( { success: false } ).value ).toEqual(
 			dispatch(
-				'core/notices',
+				noticesStore,
 				'createErrorNotice',
 				__( 'There was an error.' ),
 				{

--- a/packages/edit-navigation/src/store/test/actions.js
+++ b/packages/edit-navigation/src/store/test/actions.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -103,7 +103,7 @@ export class AdminNotices extends Component {
 }
 
 export default withDispatch( ( dispatch ) => {
-	const { createNotice } = dispatch( 'core/notices' );
+	const { createNotice } = dispatch( noticesStore );
 
 	return { createNotice };
 } )( AdminNotices );

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -3,6 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 import { withDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Mapping of server-supported notice class names to an equivalent notices

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -4,7 +4,6 @@
 import '@wordpress/core-data';
 import '@wordpress/block-editor';
 import '@wordpress/editor';
-import '@wordpress/notices';
 import {
 	registerCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import '@wordpress/core-data';
-import '@wordpress/notices';
 import '@wordpress/format-library';
 import { render } from '@wordpress/element';
 

--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -36,7 +36,7 @@ export default compose(
 		),
 	} ) ),
 	withDispatch( ( dispatch ) => {
-		const { createNotice } = dispatch( 'core/notices' );
+		const { createNotice } = dispatch( noticesStore );
 
 		return {
 			createNotice,

--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -6,6 +6,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCopyOnClick, compose, ifCondition } from '@wordpress/compose';
 import { useRef, useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 
 function CopyContentMenuItem( { createNotice, editedPostContent } ) {
 	const ref = useRef();

--- a/packages/edit-site/src/components/notices/index.js
+++ b/packages/edit-site/src/components/notices/index.js
@@ -3,6 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { SnackbarList } from '@wordpress/components';
+import { store as noticesStore } from '@wordpress/notices';
 
 export default function Notices() {
 	const notices = useSelect(

--- a/packages/edit-site/src/components/notices/index.js
+++ b/packages/edit-site/src/components/notices/index.js
@@ -7,12 +7,12 @@ import { SnackbarList } from '@wordpress/components';
 export default function Notices() {
 	const notices = useSelect(
 		( select ) =>
-			select( 'core/notices' )
+			select( noticesStore )
 				.getNotices()
 				.filter( ( notice ) => notice.type === 'snackbar' ),
 		[]
 	);
-	const { removeNotice } = useDispatch( 'core/notices' );
+	const { removeNotice } = useDispatch( noticesStore );
 	return (
 		<SnackbarList
 			className="edit-site-notices"

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -4,7 +4,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
-import '@wordpress/notices';
 import {
 	registerCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,

--- a/packages/edit-widgets/src/components/notices/index.js
+++ b/packages/edit-widgets/src/components/notices/index.js
@@ -12,13 +12,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 function Notices() {
 	const { notices } = useSelect( ( select ) => {
 		return {
-			notices: select( 'core/notices' ).getNotices(),
+			notices: select( noticesStore ).getNotices(),
 		};
 	}, [] );
 	const snackbarNotices = filter( notices, {
 		type: 'snackbar',
 	} );
-	const { removeNotice } = useDispatch( 'core/notices' );
+	const { removeNotice } = useDispatch( noticesStore );
 
 	return (
 		<SnackbarList

--- a/packages/edit-widgets/src/components/notices/index.js
+++ b/packages/edit-widgets/src/components/notices/index.js
@@ -8,6 +8,7 @@ import { filter } from 'lodash';
  */
 import { SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
 function Notices() {
 	const { notices } = useSelect( ( select ) => {

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -5,7 +5,6 @@ import {
 	registerBlockType,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
-import '@wordpress/notices';
 import { render } from '@wordpress/element';
 import {
 	registerCoreBlocks,

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -8,6 +8,7 @@ import { invert } from 'lodash';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { dispatch as dataDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -57,7 +57,7 @@ export function* saveEditedWidgetAreas() {
 	try {
 		yield* saveWidgetAreas( editedWidgetAreas );
 		yield dispatch(
-			'core/notices',
+			noticesStore,
 			'createSuccessNotice',
 			__( 'Widgets saved.' ),
 			{
@@ -66,7 +66,7 @@ export function* saveEditedWidgetAreas() {
 		);
 	} catch ( e ) {
 		yield dispatch(
-			'core/notices',
+			noticesStore,
 			'createErrorNotice',
 			/* translators: %s: The error message. */
 			sprintf( __( 'There was an error. %s' ), e.message ),

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -52,9 +52,9 @@ export function EditorNotices( { notices, onRemove } ) {
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		notices: select( 'core/notices' ).getNotices(),
+		notices: select( noticesStore ).getNotices(),
 	} ) ),
 	withDispatch( ( dispatch ) => ( {
-		onRemove: dispatch( 'core/notices' ).removeNotice,
+		onRemove: dispatch( noticesStore ).removeNotice,
 	} ) ),
 ] )( EditorNotices );

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -9,6 +9,7 @@ import { filter } from 'lodash';
 import { NoticeList, SnackbarList } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -62,7 +62,7 @@ function useAutosaveNotice() {
 		[]
 	);
 
-	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+	const { createWarningNotice, removeNotice } = useDispatch( noticesStore );
 	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
 
 	useEffect( () => {

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -11,6 +11,7 @@ import { ifCondition, usePrevious } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -353,7 +353,7 @@ export default compose( [
 			undo,
 			__unstableSetupTemplate,
 		} = dispatch( 'core/editor' );
-		const { createWarningNotice } = dispatch( 'core/notices' );
+		const { createWarningNotice } = dispatch( noticesStore );
 		const { __unstableCreateUndoLevel, editEntityRecord } = dispatch(
 			'core'
 		);

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -20,6 +20,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -3,7 +3,6 @@
  */
 import '@wordpress/block-editor';
 import '@wordpress/core-data';
-import '@wordpress/notices';
 import '@wordpress/rich-text';
 
 /**

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -10,6 +10,7 @@ import deprecated from '@wordpress/deprecated';
 import { controls } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
 import { parse, synchronizeBlocksWithTemplate } from '@wordpress/blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -299,7 +299,7 @@ export function* savePost( options = {} ) {
 		} );
 		if ( args.length ) {
 			yield controls.dispatch(
-				'core/notices',
+				noticesStore,
 				'createErrorNotice',
 				...args
 			);
@@ -321,7 +321,7 @@ export function* savePost( options = {} ) {
 		} );
 		if ( args.length ) {
 			yield controls.dispatch(
-				'core/notices',
+				noticesStore,
 				'createSuccessNotice',
 				...args
 			);
@@ -375,7 +375,7 @@ export function* trashPost() {
 		postTypeSlug
 	);
 	yield controls.dispatch(
-		'core/notices',
+		noticesStore,
 		'removeNotice',
 		TRASH_POST_NOTICE_ID
 	);
@@ -389,7 +389,7 @@ export function* trashPost() {
 		yield controls.dispatch( STORE_NAME, 'savePost' );
 	} catch ( error ) {
 		yield controls.dispatch(
-			'core/notices',
+			noticesStore,
 			'createErrorNotice',
 			...getNotificationArgumentsForTrashFail( { error } )
 		);

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -3,6 +3,7 @@
  */
 import { apiFetch } from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -195,7 +195,7 @@ describe( 'Post generator actions', () => {
 						const { value } = fulfillment.next( postType );
 						expect( value ).toEqual(
 							controls.dispatch(
-								'core/notices',
+								noticesStore,
 								'createSuccessNotice',
 								'Updated Post',
 								{
@@ -310,7 +310,7 @@ describe( 'Post generator actions', () => {
 				const { value } = fulfillment.next( postType );
 				expect( value ).toEqual(
 					controls.dispatch(
-						'core/notices',
+						noticesStore,
 						'removeNotice',
 						TRASH_POST_NOTICE_ID
 					)
@@ -338,7 +338,7 @@ describe( 'Post generator actions', () => {
 				const { value } = fulfillment.throw( error );
 				expect( value ).toEqual(
 					controls.dispatch(
-						'core/notices',
+						noticesStore,
 						'createErrorNotice',
 						'Trashing failed',
 						{

--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -16,7 +16,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## Usage
 
-When imported, the notices module registers a data store on the `core/notices` namespace. In WordPress, this is accessed from `wp.data.dispatch( 'core/notices' )`.
+When imported, the notices module registers a data store on the `core/notices` namespace. In WordPress, this is accessed from `wp.data.dispatch( noticesStore )`.
 
 For more information about consuming from a data store, refer to [the `@wordpress/data` documentation on _Data Access and Manipulation_](/packages/data/README.md#data-access-and-manipulation).
 

--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -16,7 +16,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## Usage
 
-When imported, the notices module registers a data store on the `core/notices` namespace. In WordPress, this is accessed from `wp.data.dispatch( noticesStore )`.
+When imported, the notices module registers a data store on the `core/notices` namespace. In WordPress, this is accessed from `wp.data.dispatch( 'core/notices' )`.
 
 For more information about consuming from a data store, refer to [the `@wordpress/data` documentation on _Data Access and Manipulation_](/packages/data/README.md#data-access-and-manipulation).
 

--- a/packages/notices/src/store/index.js
+++ b/packages/notices/src/store/index.js
@@ -10,7 +10,7 @@ import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 
-const STORE_NAME = 'core/notices';
+const STORE_NAME = noticesStore;
 
 /**
  * Store definition for the notices namespace.

--- a/packages/notices/src/store/index.js
+++ b/packages/notices/src/store/index.js
@@ -10,8 +10,6 @@ import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 
-const STORE_NAME = noticesStore;
-
 /**
  * Store definition for the notices namespace.
  *
@@ -19,7 +17,7 @@ const STORE_NAME = noticesStore;
  *
  * @type {Object}
  */
-export const store = createReduxStore( STORE_NAME, {
+export const store = createReduxStore( 'core/notices', {
 	reducer,
 	actions,
 	selectors,

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -8,6 +8,7 @@ import { MenuItem } from '@wordpress/components';
 import { reusableBlock } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -72,7 +72,7 @@ export default function ReusableBlockConvertButton( {
 	} = useDispatch( store );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch(
-		'core/notices'
+		noticesStore
 	);
 	const onConvert = useCallback(
 		async function () {

--- a/packages/reusable-blocks/src/index.js
+++ b/packages/reusable-blocks/src/index.js
@@ -3,7 +3,6 @@
  */
 import '@wordpress/block-editor';
 import '@wordpress/core-data';
-import '@wordpress/notices';
 
 export { store } from './store';
 export * from './components';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Part of #27088.

The goal of this PR is to replace all occurrences of `core/notices` as a store name with the store definition exposed from `@wordpress/notices. It also removes no longer necessary bare imports for `@wordpress/notices` package.

## How has this been tested?
`npm run test-unit`
`npm run lint-js`
`npm run test-e2e`

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
