### PR TITLE
CI: Run package/date unit tests in different timezones

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        timezone: ['EST', 'GMT', 'CET']
+        timezone: ['EST', 'GMT', 'CET', 'JST']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,8 +45,7 @@ jobs:
         npx lerna run build
 
     - name: Running the tests
-      run: |
-        npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
+      run: npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
   unit-js-date:
     name: JavaScript / Date functions

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,8 +55,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        timezone: ['EST', 'GMT', 'CET', 'JST']
-        locale: ['en_US', 'en_GB', 'fr_FR', 'ja_JP']
+        timezone: ['EST', 'GMT', 'CET']
+        locale: ['en_US', 'ja_JP']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -57,6 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         timezone: ['EST', 'GMT', 'CET', 'JST']
+        locale: ['en_US', 'en_GB', 'fr_FR', 'ja_JP']
 
     steps:
     - uses: actions/checkout@v2
@@ -90,6 +91,8 @@ jobs:
     - name: Running the tests
       env:
         TZ: ${{ matrix.timezone }}
+        LANG: ${{ matrix.locale }}
+
       run: |
         npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache" \
           --testPathPattern="packages/date/"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,7 +45,55 @@ jobs:
         npx lerna run build
 
     - name: Running the tests
-      run: npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
+      run: |
+        npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache" \
+          --testPathIgnorePatterns="packages/date/"
+
+  unit-js-date:
+    name: JavaScript (Date functions)
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        timezone: ['EST', 'GMT', 'CET']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache node modules
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - name: Npm install and build
+      # It's not necessary to run the full build, since Jest can interpret
+      # source files with `babel-jest`. Some packages have their own custom
+      # build tasks, however. These must be run.
+      run: |
+        npm ci
+        npx lerna run build
+
+    - name: Running the tests
+      env:
+        TZ: ${{ matrix.timezone }}
+      run: |
+        npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache" \
+          --testPathPattern="packages/date/"
 
   unit-php:
     name: PHP

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -46,8 +46,7 @@ jobs:
 
     - name: Running the tests
       run: |
-        npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache" \
-          --testPathIgnorePatterns="packages/date/"
+        npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
   unit-js-date:
     name: JavaScript (Date functions)

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,7 +49,7 @@ jobs:
         npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
   unit-js-date:
-    name: JavaScript (Date functions)
+    name: JavaScript / Date functions
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Fixes #27500. See https://github.com/WordPress/gutenberg/pull/27550#issuecomment-739944522 for more context.

## Description
Run unit tests for the `@wordpress/date` package in different timezones, and with different locales. This will be important to guard against regressions once we re-attempt migrating away from `moment.js` to another date/time package (such as `date-fns`).

## How has this been tested?
Verify that the Unit Tests GH action goes green.

## Types of changes
Increase test coverage.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
