### PR TITLE
e2e tests: Run datepicker and scheduling tests in different timezones

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -40,6 +40,18 @@ _Returns_
 
 -   `Promise<boolean>`: Boolean which represents the state of prepublish checks.
 
+<a name="changeSiteTimezone" href="#changeSiteTimezone">#</a> **changeSiteTimezone**
+
+Visits general settings page and changes the timezone to the given value.
+
+_Parameters_
+
+-   _timezone_ `string`: Value of the timezone to set.
+
+_Returns_
+
+-   `string`: Value of the previous timezone.
+
 <a name="clearLocalStorage" href="#clearLocalStorage">#</a> **clearLocalStorage**
 
 Clears the local storage.

--- a/packages/e2e-test-utils/src/change-site-timezone.js
+++ b/packages/e2e-test-utils/src/change-site-timezone.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { visitAdminPage } from './visit-admin-page';
+import { switchUserToAdmin } from './switch-user-to-admin';
+import { switchUserToTest } from './switch-user-to-test';
+
+/**
+ * Visits general settings page and changes the timezone to the given value.
+ *
+ * @param {string} timezone Value of the timezone to set.
+ *
+ * @return {string} Value of the previous timezone.
+ */
+export async function changeSiteTimezone( timezone ) {
+	await switchUserToAdmin();
+	await visitAdminPage( 'options-general.php' );
+
+	const oldTimezone = await page.$eval(
+		'#timezone_string',
+		( element ) => element.options[ element.selectedIndex ].text
+	);
+	await page.select( '#timezone_string', timezone );
+	await page.click( '#submit' );
+
+	await switchUserToTest();
+
+	return oldTimezone;
+}

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -1,6 +1,7 @@
 export { activatePlugin } from './activate-plugin';
 export { activateTheme } from './activate-theme';
 export { arePrePublishChecksEnabled } from './are-pre-publish-checks-enabled';
+export { changeSiteTimezone } from './change-site-timezone';
 export { clearLocalStorage } from './clear-local-storage';
 export { clickBlockAppender } from './click-block-appender';
 export { clickBlockToolbarButton } from './click-block-toolbar-button';

--- a/packages/e2e-tests/specs/editor/various/datepicker.test.js
+++ b/packages/e2e-tests/specs/editor/various/datepicker.test.js
@@ -1,88 +1,137 @@
 /**
  * WordPress dependencies
  */
-import { createNewPost } from '@wordpress/e2e-test-utils';
+import { createNewPost, changeSiteTimezone } from '@wordpress/e2e-test-utils';
+
+async function getInputValue( selector ) {
+	return page.$eval( selector, ( element ) => element.value );
+}
+
+async function getSelectedOptionLabel( selector ) {
+	return page.$eval(
+		selector,
+		( element ) => element.options[ element.selectedIndex ].text
+	);
+}
+
+async function getDatePickerValues() {
+	const year = await getInputValue( '[aria-label="Year"]' );
+	const month = await getInputValue( '[aria-label="Month"]' );
+	const monthLabel = await getSelectedOptionLabel( '[aria-label="Month"]' );
+	const day = await getInputValue( '[aria-label="Day"]' );
+	const hours = await getInputValue( '[aria-label="Hours"]' );
+	const minutes = await getInputValue( '[aria-label="Minutes"]' );
+	const amOrPm = await page.$eval(
+		'.components-datetime__time-field-am-pm .is-primary',
+		( element ) => element.innerText.toLowerCase()
+	);
+
+	return { year, month, monthLabel, day, hours, minutes, amOrPm };
+}
+
+function trimLeadingZero( str ) {
+	return str[ 0 ] === '0' ? str.slice( 1 ) : str;
+}
+
+function formatDatePickerValues( {
+	year,
+	monthLabel,
+	day,
+	hours,
+	minutes,
+	amOrPm,
+} ) {
+	const dayTrimmed = trimLeadingZero( day );
+	const hoursTrimmed = trimLeadingZero( hours );
+	return `${ monthLabel } ${ dayTrimmed }, ${ year } ${ hoursTrimmed }:${ minutes } ${ amOrPm }`;
+}
+
+async function getPublishingDate() {
+	return page.$eval(
+		'.edit-post-post-schedule__toggle',
+		( dateLabel ) => dateLabel.textContent
+	);
+}
 
 describe( 'Datepicker', () => {
-	beforeEach( async () => {
-		await createNewPost();
-	} );
+	[ 'UTC-10', 'UTC', 'UTC+10' ].forEach( ( timezone ) => {
+		describe( timezone, () => {
+			let oldTimezone;
+			beforeEach( async () => {
+				oldTimezone = await changeSiteTimezone( timezone );
+				await createNewPost();
+			} );
+			afterEach( async () => {
+				await changeSiteTimezone( oldTimezone );
+			} );
 
-	it( 'should show the publishing date as "Immediately" if the date is not altered', async () => {
-		const publishingDate = await page.$eval(
-			'.edit-post-post-schedule__toggle',
-			( dateLabel ) => dateLabel.textContent
-		);
+			it( 'should show the publishing date as "Immediately" if the date is not altered', async () => {
+				const publishingDate = await getPublishingDate();
 
-		expect( publishingDate ).toEqual( 'Immediately' );
-	} );
+				expect( publishingDate ).toEqual( 'Immediately' );
+			} );
 
-	it( 'should show the publishing date if the date is in the past', async () => {
-		// Open the datepicker.
-		await page.click( '.edit-post-post-schedule__toggle' );
+			it( 'should show the publishing date if the date is in the past', async () => {
+				// Open the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
 
-		// Change the publishing date to a year in the past.
-		await page.click( '.components-datetime__time-field-year' );
-		await page.keyboard.press( 'ArrowDown' );
+				// Change the publishing date to a year in the past.
+				await page.click( '.components-datetime__time-field-year' );
+				await page.keyboard.press( 'ArrowDown' );
+				const datePickerValues = await getDatePickerValues();
 
-		// Close the datepicker.
-		await page.click( '.edit-post-post-schedule__toggle' );
+				// Close the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
 
-		const publishingDate = await page.$eval(
-			'.edit-post-post-schedule__toggle',
-			( dateLabel ) => dateLabel.textContent
-		);
+				const publishingDate = await getPublishingDate();
 
-		expect( publishingDate ).toMatch(
-			/[A-Za-z]{3} \d{1,2}, \d{4} \d{1,2}:\d{2} [ap]m/
-		);
-	} );
+				expect( publishingDate ).toBe(
+					formatDatePickerValues( datePickerValues )
+				);
+			} );
 
-	it( 'should show the publishing date if the date is in the future', async () => {
-		// Open the datepicker.
-		await page.click( '.edit-post-post-schedule__toggle' );
+			it( 'should show the publishing date if the date is in the future', async () => {
+				// Open the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
 
-		// Change the publishing date to a year in the future.
-		await page.click( '.components-datetime__time-field-year' );
-		await page.keyboard.press( 'ArrowUp' );
+				// Change the publishing date to a year in the future.
+				await page.click( '.components-datetime__time-field-year' );
+				await page.keyboard.press( 'ArrowUp' );
+				const datePickerValues = await getDatePickerValues();
 
-		// Close the datepicker.
-		await page.click( '.edit-post-post-schedule__toggle' );
+				// Close the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
 
-		const publishingDate = await page.$eval(
-			'.edit-post-post-schedule__toggle',
-			( dateLabel ) => dateLabel.textContent
-		);
+				const publishingDate = await getPublishingDate();
 
-		expect( publishingDate ).not.toEqual( 'Immediately' );
-		// The expected date format will be "Sep 26, 2018 11:52 pm".
-		expect( publishingDate ).toMatch(
-			/[A-Za-z]{3} \d{1,2}, \d{4} \d{1,2}:\d{2} [ap]m/
-		);
-	} );
+				expect( publishingDate ).not.toEqual( 'Immediately' );
+				// The expected date format will be "Sep 26, 2018 11:52 pm".
+				expect( publishingDate ).toBe(
+					formatDatePickerValues( datePickerValues )
+				);
+			} );
 
-	it( 'should show the publishing date as "Immediately" if the date is cleared', async () => {
-		// Open the datepicker.
-		await page.click( '.edit-post-post-schedule__toggle' );
+			it( `should show the publishing date as "Immediately" if the date is cleared`, async () => {
+				// Open the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
 
-		// Change the publishing date to a year in the future.
-		await page.click( '.components-datetime__time-field-year' );
-		await page.keyboard.press( 'ArrowUp' );
+				// Change the publishing date to a year in the future.
+				await page.click( '.components-datetime__time-field-year' );
+				await page.keyboard.press( 'ArrowUp' );
 
-		// Close the datepicker.
-		await page.click( '.edit-post-post-schedule__toggle' );
+				// Close the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
 
-		// Open the datepicker.
-		await page.click( '.edit-post-post-schedule__toggle' );
+				// Open the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
 
-		// Clear the date
-		await page.click( '.components-datetime__date-reset-button' );
+				// Clear the date
+				await page.click( '.components-datetime__date-reset-button' );
 
-		const publishingDate = await page.$eval(
-			'.edit-post-post-schedule__toggle',
-			( dateLabel ) => dateLabel.textContent
-		);
+				const publishingDate = await getPublishingDate();
 
-		expect( publishingDate ).toEqual( 'Immediately' );
+				expect( publishingDate ).toEqual( 'Immediately' );
+			} );
+		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/scheduling.test.js
+++ b/packages/e2e-tests/specs/editor/various/scheduling.test.js
@@ -1,11 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { createNewPost } from '@wordpress/e2e-test-utils';
+import { createNewPost, changeSiteTimezone } from '@wordpress/e2e-test-utils';
+
+async function getPublishButtonText() {
+	return page.$eval(
+		'.editor-post-publish-button__button',
+		( element ) => element.textContent
+	);
+}
 
 describe( 'Scheduling', () => {
-	beforeEach( createNewPost );
-
 	const isDateTimeComponentFocused = () => {
 		return page.evaluate( () => {
 			const dateTimeElement = document.querySelector(
@@ -18,7 +23,38 @@ describe( 'Scheduling', () => {
 		} );
 	};
 
+	[ 'UTC-10', 'UTC', 'UTC+10' ].forEach( ( timezone ) => {
+		describe( timezone, () => {
+			let oldTimezone;
+			beforeEach( async () => {
+				oldTimezone = await changeSiteTimezone( timezone );
+				await createNewPost();
+			} );
+			afterEach( async () => {
+				await changeSiteTimezone( oldTimezone );
+			} );
+
+			it( `should change publishing button text from "Publish" to "Schedule"`, async () => {
+				expect( await getPublishButtonText() ).toBe( 'Publish' );
+
+				// Open the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
+
+				// Change the publishing date to a year in the future.
+				await page.click( '.components-datetime__time-field-year' );
+				await page.keyboard.press( 'ArrowUp' );
+
+				// Close the datepicker.
+				await page.click( '.edit-post-post-schedule__toggle' );
+
+				expect( await getPublishButtonText() ).toBe( 'Schedule…' );
+			} );
+		} );
+	} );
+
 	it( 'Should keep date time UI focused when the previous and next month buttons are clicked', async () => {
+		await createNewPost();
+
 		await page.click( '.edit-post-post-schedule__toggle' );
 		await page.click(
 			'div[aria-label="Move backward to switch to the previous month."]'


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/27444

## Description
Add regression tests for:
- https://github.com/WordPress/gutenberg/issues/27251
- https://github.com/WordPress/gutenberg/issues/25256

## How has this been tested?
You can use any commit before #27550 

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
