### PR TITLE
Revert "Verse Block: Adds support for custom padding"

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -342,7 +342,6 @@ These are the current color properties supported by blocks:
 | --- | --- |
 | Cover | Yes |
 | Group | Yes |
-| Verse | Yes |
 
 #### Typography Properties
 

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -10,27 +10,12 @@
 			"default": "",
 			"__unstablePreserveWhiteSpace": true
 		},
-		"style": {
-			"default": {
-				"spacing": {
-					"padding": {
-						"top": 20,
-						"right": 20,
-						"bottom": 20,
-						"left": 20
-					}
-				}
-			}
-		},
 		"textAlign": {
 			"type": "string"
 		}
 	},
 	"supports": {
 		"anchor": true,
-		"__experimentalFontFamily": true,
-		"spacing": {
-			"padding": true
-		}
+		"__experimentalFontFamily": true
 	}
 }

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -2,5 +2,6 @@ pre.wp-block-verse {
 	color: $gray-900;
 	white-space: nowrap;
 	font-size: inherit;
+	padding: 1em;
 	overflow: auto;
 }

--- a/packages/e2e-tests/fixtures/blocks/core__verse.html
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.html
@@ -1,3 +1,3 @@
-<!-- wp:verse -->
-<pre class="wp-block-verse" style="padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px">A <em>verse</em>…<br>And more!</pre>
-<!-- /wp:verse -->
+<!-- wp:core/verse -->
+<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:core/verse -->

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -4,19 +4,9 @@
         "name": "core/verse",
         "isValid": true,
         "attributes": {
-            "content": "A <em>verse</em>…<br>And more!",
-            "style": {
-                "spacing": {
-                    "padding": {
-                        "top": 20,
-                        "right": 20,
-                        "bottom": 20,
-                        "left": 20
-                    }
-                }
-            }
+            "content": "A <em>verse</em>…<br>And more!"
         },
         "innerBlocks": [],
-        "originalContent": "<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>"
+        "originalContent": "<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__verse.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.parsed.json
@@ -3,9 +3,9 @@
         "blockName": "core/verse",
         "attrs": {},
         "innerBlocks": [],
-        "innerHTML": "\n<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>\n",
+        "innerHTML": "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n",
         "innerContent": [
-            "\n<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>\n"
+            "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n"
         ]
     },
     {

--- a/packages/e2e-tests/fixtures/blocks/core__verse.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:verse -->
-<pre class="wp-block-verse" style="padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px">A <em>verse</em>…<br>And more!</pre>
+<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
 <!-- /wp:verse -->


### PR DESCRIPTION
Reverts WordPress/gutenberg#27341
Fixes https://github.com/WordPress/gutenberg/issues/27562
Related: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2873

An error surfaced on both the web and mobile after WordPress/gutenberg#27341 was merged. 

**@scruffian brought up the option of reverting WordPress/gutenberg#27341 which allows Gutenberg Mobile 1.43.0 release to be cut today – so we decided to go with that option.**

On the mobile side this appears to have broken the Verse block in the Gutenberg Mobile editor content:

| <img src="https://user-images.githubusercontent.com/1898325/101403217-abf20b00-38b3-11eb-86cf-d2f5d3ba8c10.png" alt="Broken verse block" width="350"> |
| - |

On the web it seems to have caused issues in certain themes (e.g. Twenty Twenty-One Blocks) with Verse blocks that are center aligned and have their padding reset:

| <img width="1432" alt="Verse block broken on the web" src="https://user-images.githubusercontent.com/1898325/101403398-f3789700-38b3-11eb-9bc2-c5e62eb586d9.png"> |
| - |

### To test

#### Mobile
1. Run `npm run native start:reset` in one terminal window
2. Run `npm run native ios` (or `npm run native android`) in another
3. Ensure that the Verse block does not break (and there is no red screen) when opening the editor default content

#### Web
1. Run `npm run dev` in one terminal window
2. Run `npm run wp-env start` in another
3. On localhost:8888, switch to the Twenty Twenty-One Blocks theme
4. Add a Verse block, ensure there is no longer an option in Block Settings to add or remove padding

