### PR TITLE
Fix path to theme experiments git repo

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,9 +1,7 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [
-		"."
-	],
-	"themes": [ "WordPress/theme-experiments/twentytwentyone-blocks" ],
+	"plugins": [ "." ],
+	"themes": [ "WordPress/theme-experiments" ],
 	"env": {
 		"tests": {
 			"mappings": {


### PR DESCRIPTION

## Description
Fixes #27567 by using the correct git URL for `WordPress/theme-experiments`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- run `wp-env destroy` or `cd` to the container directory and remove the `theme-experiments` directory 
- running `wp-env start` does not fail 
- `twentytwentyone-blocks` theme is available on the local WP install

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
