### PR TITLE
[RNMobile] Avoid rerenders in gallery, improve android KeyboardAvoidingView

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -353,7 +353,8 @@ export default compose( [
 			return {
 				blockClientIds,
 				blockCount,
-				isBlockInsertionPointVisible: isBlockInsertionPointVisible(),
+				isBlockInsertionPointVisible:
+					Platform.OS === 'ios' && isBlockInsertionPointVisible(),
 				isReadOnly,
 				isRootList: rootClientId === undefined,
 				isFloatingToolbarVisible,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -30,7 +30,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { Platform, useEffect, useState } from '@wordpress/element';
+import { Platform, useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { useDispatch, withSelect } from '@wordpress/data';
@@ -414,45 +414,47 @@ export default compose( [
 		const { getSettings } = select( 'core/block-editor' );
 		const { imageSizes, mediaUpload } = getSettings();
 
-		let resizedImages = {};
-
-		if ( isSelected ) {
-			resizedImages = reduce(
-				ids,
-				( currentResizedImages, id ) => {
-					if ( ! id ) {
-						return currentResizedImages;
-					}
-					const image = getMedia( id );
-					const sizes = reduce(
-						imageSizes,
-						( currentSizes, size ) => {
-							const defaultUrl = get( image, [
-								'sizes',
-								size.slug,
-								'url',
-							] );
-							const mediaDetailsUrl = get( image, [
-								'media_details',
-								'sizes',
-								size.slug,
-								'source_url',
-							] );
-							return {
-								...currentSizes,
-								[ size.slug ]: defaultUrl || mediaDetailsUrl,
-							};
-						},
-						{}
-					);
-					return {
-						...currentResizedImages,
-						[ parseInt( id, 10 ) ]: sizes,
-					};
-				},
-				{}
-			);
-		}
+		const resizedImages = useMemo( () => {
+			if ( isSelected ) {
+				return reduce(
+					ids,
+					( currentResizedImages, id ) => {
+						if ( ! id ) {
+							return currentResizedImages;
+						}
+						const image = getMedia( id );
+						const sizes = reduce(
+							imageSizes,
+							( currentSizes, size ) => {
+								const defaultUrl = get( image, [
+									'sizes',
+									size.slug,
+									'url',
+								] );
+								const mediaDetailsUrl = get( image, [
+									'media_details',
+									'sizes',
+									size.slug,
+									'source_url',
+								] );
+								return {
+									...currentSizes,
+									[ size.slug ]:
+										defaultUrl || mediaDetailsUrl,
+								};
+							},
+							{}
+						);
+						return {
+							...currentResizedImages,
+							[ parseInt( id, 10 ) ]: sizes,
+						};
+					},
+					{}
+				);
+			}
+			return {};
+		}, [ isSelected, ids, imageSizes ] );
 
 		return {
 			imageSizes,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This PR introduces performance improvements, especially for Android platform. It's fixing two redundant rerenders:

1. `BlockList [update]` when opening the `Inserter`

The reason is recreating `isBlockInsertionPointVisible` which is used within `shouldFlatListPreventAutomaticScroll` passed then to `KeyboardAwareFlatList`. However, it's used only in iOS component, so there is no need to pass it to Android equivalent.

before | after
--- | ---
<img width="1167" alt="Screenshot 2020-12-07 at 14 19 19" src="https://user-images.githubusercontent.com/22746080/101466266-3896da80-3941-11eb-8f69-59c67fa33038.png"> | <img width="1167" alt="Screenshot 2020-12-07 at 14 52 06" src="https://user-images.githubusercontent.com/22746080/101466304-4187ac00-3941-11eb-9614-31360adde94d.png">

_block list update step is removed, but there is still gallery update_

2. `Gallery` rerender

The root of the issue is located within gallery compose where reference to `let resizedImages = {};` is recreated each time any store data changes:

<img src="https://user-images.githubusercontent.com/22746080/101467467-a263b400-3942-11eb-9140-269e36dba3d7.gif" width="300" />

Wrapping `resizedImages` into `useMemo` solved the issue:

before | after
--- | ---
<img width="1167" alt="Screenshot 2020-12-07 at 14 52 06" src="https://user-images.githubusercontent.com/22746080/101467417-92e46b00-3942-11eb-86ef-172c8be90212.png"> | <img width="1167" alt="Screenshot 2020-12-07 at 16 10 54" src="https://user-images.githubusercontent.com/22746080/101467418-9546c500-3942-11eb-9fc8-18d8a60df25f.png">
 
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

##### INSERTER

1. Open mobile app 
2. Press the inserter
**Expect there is an insertion point**
3. Create some nested structure
**Expect there is an insertion point in nested structure as well**

##### GALLERY

1. Do sanity testing for gallery block


## Screenshots <!-- if applicable -->

## Types of changes

* Bug fix, performance improvements

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
