### PR TITLE
Add a useFocusOnMount hook to the @wordpress/compose package.

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -186,6 +186,34 @@ _Returns_
 
 -   `Function`: Debounced function.
 
+<a name="useFocusOnMount" href="#useFocusOnMount">#</a> **useFocusOnMount**
+
+Hook used to focus the first tabbable element on mount.
+
+_Usage_
+
+```js
+import { useFocusOnMount } from '@wordpress/compose';
+
+const WithFocusOnMount = () => {
+    const ref = useFocusOnMount()
+    return (
+        <div ref={ ref }>
+            <Button />
+            <Button />
+        </div>
+    );
+}
+```
+
+_Parameters_
+
+-   _focusOnMount_ `(boolean|string)`: Focus on mount mode.
+
+_Returns_
+
+-   `Function`: Element Ref.
+
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 
 Provides a unique instance ID.

--- a/packages/compose/src/hooks/use-focus-on-mount/README.md
+++ b/packages/compose/src/hooks/use-focus-on-mount/README.md
@@ -1,0 +1,28 @@
+`useFocusOnMount`
+=================
+
+Hook used to focus the first tabbable element on mount.
+
+## Return Object Properties
+
+### `ref`
+
+- Type: `Function`
+
+A function reference that must be passed to the DOM element where constrained tabbing should be enabled.
+
+## Usage
+
+```jsx
+import { useFocusOnMount } from '@wordpress/compose';
+
+const WithFocusOnMount = () => {
+	const ref = useFocusOnMount()
+	return (
+		<div ref={ ref }>
+			<Button />
+			<Button />
+		</div> 
+	);
+};
+```

--- a/packages/compose/src/hooks/use-focus-on-mount/README.md
+++ b/packages/compose/src/hooks/use-focus-on-mount/README.md
@@ -9,7 +9,7 @@ Hook used to focus the first tabbable element on mount.
 
 - Type: `Function`
 
-A function reference that must be passed to the DOM element where constrained tabbing should be enabled.
+A React ref that must be passed to the DOM element where the behavior should be attached.
 
 ## Usage
 

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { focus } from '@wordpress/dom';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Hook used to focus the first tabbable element on mount.
+ *
+ * @param {boolean|string} focusOnMount Focus on mount mode.
+ * @return {Function} Element Ref.
+ *
+ * @example
+ * ```js
+ * import { useFocusOnMount } from '@wordpress/compose';
+ *
+ * const WithFocusOnMount = () => {
+ *     const ref = useFocusOnMount()
+ *     return (
+ *         <div ref={ ref }>
+ *             <Button />
+ *             <Button />
+ *         </div>
+ *     );
+ * }
+ * ```
+ */
+function useFocusOnMount( focusOnMount = 'firstElement' ) {
+	// Focus handling
+	const ref = useCallback( ( node ) => {
+		if ( ! node ) {
+			return;
+		}
+		/*
+		 * Without the setTimeout, the dom node is not being focused. Related:
+		 * https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
+		 *
+		 * TODO: Treat the cause, not the symptom.
+		 */
+		setTimeout( () => {
+			if ( focusOnMount === 'firstElement' ) {
+				// Find first tabbable node within content and shift focus, falling
+				// back to the popover panel itself.
+				const firstTabbable = focus.tabbable.find( node )[ 0 ];
+				if ( firstTabbable ) {
+					firstTabbable.focus();
+				} else {
+					node.focus();
+				}
+
+				return;
+			}
+
+			if ( focusOnMount === 'container' ) {
+				// Focus the popover panel itself so items in the popover are easily
+				// accessed via keyboard navigation.
+				node.focus();
+			}
+		}, 0 );
+	}, [] );
+
+	return ref;
+}
+
+export default useFocusOnMount;

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -16,6 +16,7 @@ export { default as withState } from './higher-order/with-state';
 export { default as useConstrainedTabbing } from './hooks/use-constrained-tabbing';
 export { default as useCopyOnClick } from './hooks/use-copy-on-click';
 export { default as __experimentalUseDragging } from './hooks/use-dragging';
+export { default as useFocusOnMount } from './hooks/use-focus-on-mount';
 export { default as useInstanceId } from './hooks/use-instance-id';
 export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
 export { default as useMediaQuery } from './hooks/use-media-query';


### PR DESCRIPTION
Follow-up to #27502 
Similar to #27544 

This extracts the existing useFocusOnMount hook from the popover component into the compose package in order to be used in the existing PopoverWrapper components.
The goal here is to be able to remove the PopoverWrapper component that is duplicated across three packages and reuse a single hook. 