### PR TITLE
Verse Block: Add padding control

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -344,6 +344,7 @@ These are the current color properties supported by blocks:
 | --- | --- |
 | Cover | Yes |
 | Group | Yes |
+| Verse | Yes |
 
 #### Typography Properties
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
-import { getBlockSupport } from '@wordpress/blocks';
+import { getBlockSupport, getBlockType } from '@wordpress/blocks';
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 
 /**
@@ -69,6 +69,15 @@ export function PaddingEdit( props ) {
 		} );
 	};
 
+	const onReset = () => {
+		const blockType = getBlockType( blockName );
+		const defaultSettings = blockType?.attributes?.style?.default;
+
+		setAttributes( {
+			style: cleanEmptyObject( defaultSettings ),
+		} );
+	};
+
 	return Platform.select( {
 		web: (
 			<>
@@ -76,6 +85,7 @@ export function PaddingEdit( props ) {
 					values={ style?.spacing?.padding }
 					onChange={ onChange }
 					onChangeShowVisualizer={ onChangeShowVisualizer }
+					onReset={ onReset }
 					label={ __( 'Padding' ) }
 					units={ units }
 				/>

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -69,13 +69,18 @@ export function PaddingEdit( props ) {
 		} );
 	};
 
-	const onReset = () => {
+	const onReset = ( initialValues ) => {
 		const blockType = getBlockType( blockName );
-		const defaultSettings = blockType?.attributes?.style?.default;
+		let defaultSettings = blockType?.attributes?.style?.default;
+		if ( ! defaultSettings ) {
+			defaultSettings = initialValues;
+		}
 
 		setAttributes( {
 			style: cleanEmptyObject( defaultSettings ),
 		} );
+
+		return true;
 	};
 
 	return Platform.select( {

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -14,7 +14,10 @@
 			"default": {
 				"spacing": {
 					"padding": {
-						"default": 20
+						"top": 20,
+						"right": 20,
+						"bottom": 20,
+						"left": 20
 					}
 				}
 			}

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -14,10 +14,10 @@
 			"default": {
 				"spacing": {
 					"padding": {
-						"top": 20,
-						"right": 20,
-						"bottom": 20,
-						"left": 20
+						"top": "1em",
+						"right": "1em",
+						"bottom": "1em",
+						"left": "1em"
 					}
 				}
 			}
@@ -29,7 +29,10 @@
 	"supports": {
 		"anchor": true,
 		"__experimentalFontFamily": true,
-		"fontSize": true
+		"fontSize": true,
+		"spacing": {
+			"padding": true
+		}
 	},
 	"style": "wp-block-verse",
 	"editorStyle": "wp-block-verse-editor"

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -10,6 +10,15 @@
 			"default": "",
 			"__unstablePreserveWhiteSpace": true
 		},
+		"style": {
+			"default": {
+				"spacing": {
+					"padding": {
+						"default": 20
+					}
+				}
+			}
+		},
 		"textAlign": {
 			"type": "string"
 		}

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -13,6 +13,8 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
+const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
 export default function VerseEdit( {
 	attributes,
@@ -36,6 +38,10 @@ export default function VerseEdit( {
 					} }
 				/>
 			</BlockControls>
+			<BoxControlVisualizer
+				values={ attributes.style?.spacing?.padding }
+				showValues={ attributes.style?.visualizers?.padding }
+			/>
 			<RichText
 				tagName="pre"
 				identifier="content"

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,4 +1,3 @@
 pre.wp-block-verse {
 	color: $gray-900;
-	padding: 1em;
 }

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -48,6 +48,7 @@ export default function BoxControl( {
 	inputProps = defaultInputProps,
 	onChange = noop,
 	onChangeShowVisualizer = noop,
+	onReset = noop,
 	label = __( 'Box Control' ),
 	values: valuesProp,
 	units,
@@ -94,7 +95,7 @@ export default function BoxControl( {
 	const handleOnReset = () => {
 		const initialValues = DEFAULT_VALUES;
 
-		onChange( initialValues );
+		onReset();
 		setValues( initialValues );
 		setIsDirty( false );
 	};

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -94,8 +94,10 @@ export default function BoxControl( {
 
 	const handleOnReset = () => {
 		const initialValues = DEFAULT_VALUES;
-
-		onReset();
+		const success = onReset( initialValues );
+		if ( ! success ) {
+			onChange( initialValues );
+		}
 		setValues( initialValues );
 		setIsDirty( false );
 	};

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -60,7 +60,7 @@ function mode( arr ) {
  * @return {string} A value + unit for the 'all' input.
  */
 export function getAllValue( values = {} ) {
-	const parsedValues = Object.values( values ).map( parseUnit );
+	const parsedValues = Object.values( values ).map( value => parseUnit( value ) );
 
 	const allValues = parsedValues.map( ( value ) => value[ 0 ] );
 	const allUnits = parsedValues.map( ( value ) => value[ 1 ] );

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -60,7 +60,9 @@ function mode( arr ) {
  * @return {string} A value + unit for the 'all' input.
  */
 export function getAllValue( values = {} ) {
-	const parsedValues = Object.values( values ).map( value => parseUnit( value ) );
+	const parsedValues = Object.values( values ).map( ( value ) =>
+		parseUnit( value )
+	);
 
 	const allValues = parsedValues.map( ( value ) => value[ 0 ] );
 	const allUnits = parsedValues.map( ( value ) => value[ 1 ] );

--- a/packages/e2e-tests/fixtures/blocks/core__verse.html
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.html
@@ -1,3 +1,3 @@
-<!-- wp:core/verse -->
-<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
-<!-- /wp:core/verse -->
+<!-- wp:verse -->
+<pre class="wp-block-verse" style="padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -4,7 +4,14 @@
         "name": "core/verse",
         "isValid": true,
         "attributes": {
-            "content": "A <em>verse</em>…<br>And more!"
+            "content": "A <em>verse</em>…<br>And more!",
+            "style": {
+                "spacing": {
+                    "padding": {
+                        "default": 20
+                    }
+                }
+            }
         },
         "innerBlocks": [],
         "originalContent": "<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -8,10 +8,10 @@
             "style": {
                 "spacing": {
                     "padding": {
-						"top": 20,
-						"right": 20,
-						"bottom": 20,
-						"left": 20
+                        "top": 20,
+                        "right": 20,
+                        "bottom": 20,
+                        "left": 20
                     }
                 }
             }

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -17,6 +17,6 @@
             }
         },
         "innerBlocks": [],
-        "originalContent": "<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"
+        "originalContent": "<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__verse.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.json
@@ -8,7 +8,10 @@
             "style": {
                 "spacing": {
                     "padding": {
-                        "default": 20
+						"top": 20,
+						"right": 20,
+						"bottom": 20,
+						"left": 20
                     }
                 }
             }

--- a/packages/e2e-tests/fixtures/blocks/core__verse.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.parsed.json
@@ -3,9 +3,9 @@
         "blockName": "core/verse",
         "attrs": {},
         "innerBlocks": [],
-        "innerHTML": "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n",
+        "innerHTML": "\n<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>\n",
         "innerContent": [
-            "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n"
+            "\n<pre class=\"wp-block-verse\" style=\"padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px\">A <em>verse</em>…<br>And more!</pre>\n"
         ]
     },
     {

--- a/packages/e2e-tests/fixtures/blocks/core__verse.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__verse.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:verse -->
-<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<pre class="wp-block-verse" style="padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px">A <em>verse</em>…<br>And more!</pre>
 <!-- /wp:verse -->


### PR DESCRIPTION
Another attempt at https://github.com/WordPress/gutenberg/pull/27341

## Description
This reimplements a custom padding control for the verse block. It also includes a couple of other fixes:

- Adds a padding visualizer to the block in edit mode
- Changes the behaviour of the reset button to recall the default for the block rather then setting it to zero. (https://github.com/WordPress/gutenberg/issues/27483)

This is necessary to address the errors found in the previous PR: https://github.com/WordPress/gutenberg/pull/27561

We also need to add custom units to the BoxControl, so we can support other units: https://github.com/WordPress/gutenberg/issues/27615

## How has this been tested?
In TT1 Blocks

## Screenshots <!-- if applicable -->
<img width="610" alt="Screenshot 2020-12-08 at 18 56 45" src="https://user-images.githubusercontent.com/275961/101528364-217adb80-3987-11eb-9eac-8b9791f96e17.png">

There seems to be an issue with the visualizer component.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
