### PR TITLE
Code block: Add support for padding, color & border styles

### DIFF
--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -17,6 +17,20 @@
 		"__experimentalSelector": ".wp-block-code > code",
 		"typography": {
 			"fontSize": true
+		},
+		"spacing": {
+			"padding": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
+		},
+		"color": {
+			"text": true,
+			"background": true,
+			"gradients": true
 		}
 	},
 	"style": "wp-block-code"

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -19,6 +19,7 @@
 			"fontSize": true
 		},
 		"spacing": {
+			"margin": [ "top", "bottom" ],
 			"padding": true
 		},
 		"__experimentalBorder": {


### PR DESCRIPTION
This is needed to resolve https://github.com/WordPress/theme-experiments/issues/94 to support TwentyTwentyOne-blocks theme.

## Description
* Added spacing.padding support option to core/code block's block.json to signal support of customizing the padding values of the block allowing themes and users to customize the padding values of CODE blocks.

* Added color supports options to core/code block's JSON to allow support of customizing color values in theme.json and by users.

* Added border supports options to core/code blocks's JSON to allow theme.json support for customizing that block's border

* Updated documentation to reflect that the CODE block includes padding controls.
* Added style.border controls to CODE block's block.json to signal support of border settings
* Added style.color to CODE block's block.json to signal support of color settings

## How has this been tested?
* Adding the following JSON to the TT1-blocks' theme.json file ([as demonstrated here](https://github.com/WordPress/theme-experiments/pull/113/files#diff-cb8339d045026b11d242450601968ce67496780a194f7dec6f085c75c9418ac7R298)):
```javascript
		"core/code": {
			"typography": {
				"fontSize": "var(--wp--preset--font-size--extra-small)"
			},
			"spacing": {
				"padding": {
					"top": "var(--wp--custom--spacing--unit)",
					"bottom": "var(--wp--custom--spacing--unit)",
					"left": "var(--wp--custom--spacing--unit)",
					"right": "var(--wp--custom--spacing--unit)"
				}
			},
			"border": {
				"radius": "0px",
				"color": "var(--wp--preset--color--dark-gray)",
				"style": "solid",
				"width": "1.5px"
			}
	
		}
```  
Resulting in a wp-block-code class that includes the padding variables as expected
![image](https://user-images.githubusercontent.com/146530/101539773-0dc27b80-396d-11eb-883c-8bffff1f16ab.png)

* Add and select a CODE block in the block editor
  * note that the SPACING panel has been added to the interface
* Using the SPACING panel modify the padding values for the CODE block and save the page/post.
  * observe the rendered page and observe that the border properties defined in the interface are set on the block's style attribute.

![image](https://user-images.githubusercontent.com/146530/101540170-9f31ed80-396d-11eb-884d-f28c7866b76a.png)

```html
<pre class="wp-block-code" style="padding-bottom:20px;padding-left:20px;padding-right:20px;padding-top:20px"><code>This is a code block.
&lt;div fancy="true"&gt;
{ super: "duper" } </code></pre>
```

## Types of changes
New feature
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
