### PR TITLE
[Mobile] Treat a string that only contains the formatting marker as empty for block formatting

### DIFF
--- a/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -41,11 +41,11 @@ import com.facebook.react.views.text.DefaultStyleValuesUtil;
 import com.facebook.react.views.text.ReactFontManager;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.textinput.ReactContentSizeChangedEvent;
-import com.facebook.react.views.textinput.ReactTextChangedEvent;
 import com.facebook.react.views.textinput.ReactTextInputEvent;
 import com.facebook.react.views.textinput.ReactTextInputManager;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
+import org.wordpress.aztec.Constants;
 import org.wordpress.aztec.formatting.LinkFormatter;
 import org.wordpress.aztec.glideloader.GlideImageLoader;
 import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader;
@@ -677,7 +677,7 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
 
 
             if (mPreviousText.length() == 0
-                    && !TextUtils.isEmpty(newText)
+                    && !isTextEmpty(newText)
                     && !TextUtils.isEmpty(mEditText.getTagName())
                     && mEditText.getSelectedStyles().isEmpty()) {
 
@@ -689,6 +689,12 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
                     mEditText.toggleFormatting(reactAztecTextFormat.getAztecTextFormat());
                 }
             }
+        }
+
+        // This accounts for the END_OF_BUFFER_MARKER that is added to blocks to maintain the styling, if the only char
+        // is the zero width marker then it is considered "empty"
+        private boolean isTextEmpty(String text) {
+            return text.length() == 0 || (text.length() == 1 && text.charAt(0) == Constants.INSTANCE.getEND_OF_BUFFER_MARKER());
         }
 
         @Override

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -15,6 +15,7 @@ For each user feature we should also add a importance categorization label  to i
 * [**] Button block - Add link picker to the block settings [#26206]
 * [**] Support to render background/text colors in Group, Paragraph and Quote blocks [#25994]
 * [*] Fix theme colors syncing with the editor [#26821]
+* [**] Fix issue where a blocks would disappear when deleting all of the text inside without requiring the extra backspace to remove the block. [#27583]
 
 ## 1.41.0
 


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2863

**Related PRs**
- `gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2877
- `WordPress-Android (For testing)`: https://github.com/wordpress-mobile/WordPress-Android/pull/13566


## Description
When opening a post with an existing Heading Block and choosing to delete the text the block formatting would be triggered on the text that has the zero space character already applied. This would trigger an extra run of hitting delete.

## How has this been tested?

### Existing Block
1. Open a post with an existing Heading Block
1. Select the text and hit delete
    - Alternatively, delete each character one by one
1. **Expect** to see the placeholder text return after the last character is deleted and for the block to remain

### New Heading Block 
1. Open a post and add a new heading block
1. Type some text
    - **Expect** The text to be formatted like a heading block
1. Select the text and hit delete
    - Alternatively, delete each character one by one
1. **Expect** to see the placeholder text return after the last character is deleted and for the block to remain

### Regression test cases

Taken from https://github.com/wordpress-mobile/AztecEditor-Android/pull/928

<details>
<summary>Regression test cases</summary>

### Heading block
1. Open the Gutenberg Editor 
1. Create a Heading block containing some text
1. Press backspace until all of the text has been deleted
**Expect** to see the placeholder text return after the last character is deleted

### Paragraph block
1. Open the Gutenberg Editor 
1. Create a Paragraph block containing some text
1. Select the full text and apply some styling like bold
1. Press backspace until all of the text has been deleted
**Expect** to see the placeholder text return after the last character is deleted

</details>

## Types of changes
Bug Fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
