### PR TITLE
Add opacity 0 to for loop

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -65,7 +65,7 @@
 	}
 
 
-	@for $i from 1 through 10 {
+	@for $i from 0 through 10 {
 		&.has-background-dim.has-background-dim-#{ $i * 10 } {
 			&:not(.has-background-gradient)::before,
 			.wp-block-cover__gradient-background {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #27495
Add opacity 0 to for loop

## How has this been tested?
1. Create a cover block image.
1. If set opacity 0 - 4, should return class `.has-background-dim-0`, and opacity: 0
1. If set opacity 5 - 14, should return class `.has-background-dim-10`, and opacity: 0.1
1. If set opacity 15 - 24, should return class `.has-background-dim-20`, and opacity: 0.2
1. Check if the image renders as expected.

## Screenshots <!-- if applicable -->
<img width="1440" alt="test_opacity" src="https://user-images.githubusercontent.com/56378160/101514502-52d5b600-394b-11eb-90d5-4d4eb8a1a7c4.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
