### PR TITLE
Button: is-busy state candybar animation fixed

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -91,10 +91,10 @@
 			/* stylelint-disable */
 			background-image: linear-gradient(
 				-45deg,
-				var(--wp-admin-theme-color) 28%,
-				var(--wp-admin-theme-color-darker-20) 28%,
-				var(--wp-admin-theme-color-darker-20) 72%,
-				var(--wp-admin-theme-color)  72%
+				var(--wp-admin-theme-color) 33%,
+				var(--wp-admin-theme-color-darker-20) 33%,
+				var(--wp-admin-theme-color-darker-20) 70%,
+				var(--wp-admin-theme-color) 70%
 			);
 			/* stylelint-enable */
 			border-color: var(--wp-admin-theme-color);
@@ -255,10 +255,10 @@
 		/* stylelint-disable */
 		background-image: linear-gradient(
 			-45deg,
-			darken($white, 2%) 28%,
-			darken($white, 12%) 28%,
-			darken($white, 12%) 72%,
-			darken($white, 2%) 72%
+			darken($white, 2%) 33%,
+			darken($white, 12%) 33%,
+			darken($white, 12%) 70%,
+			darken($white, 2%) 70%
 		);
 		/* stylelint-enable */
 	}


### PR DESCRIPTION
The length of the two colored bands was different, this fix makes them the same length.
It's a small detail, but since the [original animation](https://codepen.io/folletto/pen/ZeXzVM) was something I designed 3 years ago and the CSS is still being used... it was up to me to fix it.

Codepen for quick reference:
https://codepen.io/folletto/pen/mdrEZPE?editors=1100


### How has this been tested?
Try clicking to publish or update a post, and check the animation. 
The length of the light and dark bands should be the same.

### Screenshots
Exaggerated example to show they are the same:
<img width="539" alt="Screenshot 2020-12-08 at 18 52 20" src="https://user-images.githubusercontent.com/4389/101528763-9b12c980-3987-11eb-9b15-f3fd892536cf.png">


