### PR TITLE
Try: Keep the drawer out of the header area in Interface/FSE

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -87,6 +87,9 @@ $z-layers: (
 	".edit-site-sidebar {greater than small}": 90,
 	".edit-widgets-sidebar {greater than small}": 90,
 
+	// Show the skeleton drawer above the skeleton header (because of top toolbar @ < medium viewports)
+	".interface-interface-skeleton__drawer": 31,
+
 	// Show interface skeleton footer above interface skeleton drawer
 	".interface-interface-skeleton__footer": 90,
 

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -16,13 +16,6 @@
 	}
 
 	flex: 1 1 auto;
-
-	// In IE11 flex-basis: 100% cause a bug where the metaboxes area overlap with the content area.
-	// But it works as expected without it.
-	// The flex-basis is needed for the other browsers to make sure the content area is full-height.
-	@supports (position: sticky) {
-		flex-basis: 100%;
-	}
 }
 
 .editor-styles-wrapper {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -255,6 +255,9 @@ function Editor() {
 												}
 												header={
 													<Header
+														isNavigationOpen={
+															isNavigationOpen
+														}
 														openEntitiesSavedStates={
 															openEntitiesSavedStates
 														}

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -23,8 +23,12 @@ import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
 import DocumentActions from './document-actions';
 import TemplateDetails from '../template-details';
+import NavigationToggle from '../navigation-sidebar/navigation-toggle';
 
-export default function Header( { openEntitiesSavedStates } ) {
+export default function Header( {
+	isNavigationOpen,
+	openEntitiesSavedStates,
+} ) {
 	const {
 		deviceType,
 		entityTitle,
@@ -75,73 +79,76 @@ export default function Header( { openEntitiesSavedStates } ) {
 		! isLargeViewport || deviceType !== 'Desktop' || hasFixedToolbar;
 
 	return (
-		<div className="edit-site-header">
-			<div className="edit-site-header_start">
-				<div className="edit-site-header__toolbar">
-					<Button
-						isPrimary
-						isPressed={ isInserterOpen }
-						className="edit-site-header-toolbar__inserter-toggle"
-						onClick={ () =>
-							setIsInserterOpened( ! isInserterOpen )
-						}
-						icon={ plus }
-						label={ _x(
-							'Add block',
-							'Generic label for block inserter button'
+		<>
+			<NavigationToggle isOpen={ isNavigationOpen } />
+			<div className="edit-site-header">
+				<div className="edit-site-header_start">
+					<div className="edit-site-header__toolbar">
+						<Button
+							isPrimary
+							isPressed={ isInserterOpen }
+							className="edit-site-header-toolbar__inserter-toggle"
+							onClick={ () =>
+								setIsInserterOpened( ! isInserterOpen )
+							}
+							icon={ plus }
+							label={ _x(
+								'Add block',
+								'Generic label for block inserter button'
+							) }
+						/>
+						{ isLargeViewport && (
+							<>
+								<ToolSelector />
+								<UndoButton />
+								<RedoButton />
+								<BlockNavigationDropdown />
+							</>
 						) }
-					/>
-					{ isLargeViewport && (
-						<>
-							<ToolSelector />
-							<UndoButton />
-							<RedoButton />
-							<BlockNavigationDropdown />
-						</>
+						{ displayBlockToolbar && (
+							<div className="edit-site-header-toolbar__block-toolbar">
+								<BlockToolbar hideDragHandle />
+							</div>
+						) }
+					</div>
+				</div>
+
+				<div className="edit-site-header_center">
+					{ 'wp_template' === templateType && (
+						<DocumentActions
+							entityTitle={ entityTitle }
+							entityLabel="template"
+						>
+							{ ( { onClose } ) => (
+								<TemplateDetails
+									template={ template }
+									onClose={ onClose }
+								/>
+							) }
+						</DocumentActions>
 					) }
-					{ displayBlockToolbar && (
-						<div className="edit-site-header-toolbar__block-toolbar">
-							<BlockToolbar hideDragHandle />
-						</div>
+					{ 'wp_template_part' === templateType && (
+						<DocumentActions
+							entityTitle={ entityTitle }
+							entityLabel="template part"
+						/>
 					) }
 				</div>
-			</div>
 
-			<div className="edit-site-header_center">
-				{ 'wp_template' === templateType && (
-					<DocumentActions
-						entityTitle={ entityTitle }
-						entityLabel="template"
-					>
-						{ ( { onClose } ) => (
-							<TemplateDetails
-								template={ template }
-								onClose={ onClose }
-							/>
-						) }
-					</DocumentActions>
-				) }
-				{ 'wp_template_part' === templateType && (
-					<DocumentActions
-						entityTitle={ entityTitle }
-						entityLabel="template part"
-					/>
-				) }
-			</div>
-
-			<div className="edit-site-header_end">
-				<div className="edit-site-header__actions">
-					<PreviewOptions
-						deviceType={ deviceType }
-						setDeviceType={ setPreviewDeviceType }
-					/>
-					<SaveButton
-						openEntitiesSavedStates={ openEntitiesSavedStates }
-					/>
-					<PinnedItems.Slot scope="core/edit-site" />
-					<MoreMenu />
+				<div className="edit-site-header_end">
+					<div className="edit-site-header__actions">
+						<PreviewOptions
+							deviceType={ deviceType }
+							setDeviceType={ setPreviewDeviceType }
+						/>
+						<SaveButton
+							openEntitiesSavedStates={ openEntitiesSavedStates }
+						/>
+						<PinnedItems.Slot scope="core/edit-site" />
+						<MoreMenu />
+					</div>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -1,4 +1,5 @@
 .edit-site-header {
+	position: relative;
 	align-items: center;
 	background-color: $white;
 	display: flex;
@@ -6,16 +7,6 @@
 	box-sizing: border-box;
 	width: 100%;
 	justify-content: space-between;
-
-	@include break-medium() {
-		body.is-fullscreen-mode & {
-			padding-left: 60px;
-			transition: padding-left 20ms linear;
-			transition-delay: 80ms;
-			@include reduce-motion("transition");
-		}
-
-	}
 
 	.edit-site-header_start,
 	.edit-site-header_end {
@@ -35,28 +26,6 @@
 
 	.edit-site-header_end {
 		justify-content: flex-end;
-	}
-}
-
-// Keeps the document title centered when the sidebar is open
-body.is-navigation-sidebar-open {
-	.edit-site-header {
-		padding-left: 0;
-		transition: padding-left 20ms linear;
-		transition-delay: 0ms;
-	}
-}
-
-// Centred document title on small screens with sidebar open
-@media ( max-width: #{ ($break-large - 1) } ) {
-	body.is-navigation-sidebar-open .edit-site-header {
-		.edit-site-header-toolbar__inserter-toggle ~ .components-button,
-		.edit-site-header_end .components-button:not(.is-primary) {
-			display: none;
-		}
-		.edit-site-save-button__button {
-			margin-right: 0;
-		}
 	}
 }
 
@@ -181,6 +150,12 @@ body.is-navigation-sidebar-open {
 			display: block;
 			right: $sidebar-width;
 		}
+	}
+
+	// Keep toolbar on viewport edge at medium to wide breakpoints
+	@media (min-width: #{ $break-medium }) and (max-width: #{ $break-wide - 1 }) {
+		// the Navigation toggle is as wide as the header height
+		left: - $header-height;
 	}
 
 	// Move toolbar into top Editor Bar.

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -8,7 +8,6 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import NavigationPanel from './navigation-panel';
-import NavigationToggle from './navigation-toggle';
 
 export const {
 	Fill: NavigationPanelPreviewFill,
@@ -22,7 +21,6 @@ export default function NavigationSidebar() {
 
 	return (
 		<>
-			<NavigationToggle isOpen={ isNavigationOpen } />
 			<NavigationPanel isOpen={ isNavigationOpen } />
 			<NavigationPanelPreviewSlot />
 		</>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -54,19 +54,16 @@ const NavigationPanel = ( { isOpen } ) => {
 						{ siteTitle }
 					</div>
 				</div>
-
-				<div className="edit-site-navigation-panel__scroll-container">
-					{ ( contentActiveMenu === MENU_ROOT ||
-						templatesActiveMenu !== MENU_ROOT ) && (
-						<TemplatesNavigation />
-					) }
-					{ ( templatesActiveMenu === MENU_ROOT ||
-						contentActiveMenu !== MENU_ROOT ) && (
-						<ContentNavigation
-							onActivateMenu={ setContentActiveMenu }
-						/>
-					) }
-				</div>
+				{ ( contentActiveMenu === MENU_ROOT ||
+					templatesActiveMenu !== MENU_ROOT ) && (
+					<TemplatesNavigation />
+				) }
+				{ ( templatesActiveMenu === MENU_ROOT ||
+					contentActiveMenu !== MENU_ROOT ) && (
+					<ContentNavigation
+						onActivateMenu={ setContentActiveMenu }
+					/>
+				) }
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -6,11 +6,6 @@
 	background: $gray-900;
 	transition: width 100ms linear;
 	@include reduce-motion("transition");
-
-	// Footer is visible from medium so we subtract footer's height
-	@include break-medium() {
-		height: calc(100% - #{$button-size-small + $border-width});
-	}
 }
 
 .edit-site-navigation-panel.is-open {
@@ -21,12 +16,13 @@
 	position: relative;
 	width: $nav-sidebar-width;
 	height: 100%;
-	overflow: hidden;
+	overflow-x: hidden;
+	overflow-y: auto;
 }
 
 .edit-site-navigation-panel__site-title-container {
 	height: $header-height;
-	padding-left: $header-height;
+	padding-left: $grid-unit-20;
 	margin: 0 $grid-unit-20 0 $grid-unit-10;
 	display: flex;
 	align-items: center;
@@ -43,12 +39,6 @@
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
-}
-
-.edit-site-navigation-panel__scroll-container {
-	overflow-x: hidden;
-	overflow-y: auto;
-	height: calc(100% - #{$header-height});
 }
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -3,9 +3,8 @@
 	background: $gray-900;
 	border-radius: 0;
 	display: none;
-	position: absolute;
 	z-index: z-index(".edit-site-navigation-toggle");
-	height: $header-height + $border-width; // Cover header border
+	height: $header-height;
 	width: $header-height;
 
 	@include break-medium() {
@@ -23,6 +22,7 @@
 	color: $white;
 	height: $header-height + $border-width; // Cover header border
 	width: $header-height;
+	border-radius: 0;
 	z-index: 1;
 
 	&.has-icon {

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -50,6 +50,10 @@ body.toplevel_page_gutenberg-edit-site {
 		display: none;
 	}
 
+	.interface-interface-skeleton__header {
+		display: flex;
+	}
+
 	.interface-interface-skeleton__content {
 		background-color: $gray-400;
 	}

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -87,15 +87,6 @@ function InterfaceSkeleton(
 				regionsClassName
 			) }
 		>
-			{ !! drawer && (
-				<div
-					className="interface-interface-skeleton__drawer"
-					role="region"
-					aria-label={ mergedLabels.drawer }
-				>
-					{ drawer }
-				</div>
-			) }
 			<div className="interface-interface-skeleton__editor">
 				{ !! header && (
 					<div
@@ -108,6 +99,15 @@ function InterfaceSkeleton(
 					</div>
 				) }
 				<div className="interface-interface-skeleton__body">
+					{ !! drawer && (
+						<div
+							className="interface-interface-skeleton__drawer"
+							role="region"
+							aria-label={ mergedLabels.drawer }
+						>
+							{ drawer }
+						</div>
+					) }
 					{ !! secondarySidebar && (
 						<div
 							className="interface-interface-skeleton__secondary-sidebar"

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -12,7 +12,7 @@ html.interface-interface-skeleton__html-container {
 
 .interface-interface-skeleton {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	height: auto;
 	max-height: 100%;
 
@@ -37,6 +37,7 @@ html.interface-interface-skeleton__html-container {
 	display: flex;
 	flex-direction: column;
 	flex: 0 1 100%;
+	overflow: hidden;
 }
 
 @include editor-left(".interface-interface-skeleton");
@@ -61,11 +62,6 @@ html.interface-interface-skeleton__html-container {
 	// it is added, it should take care of the issue.
 	// See also: https://drafts.csswg.org/css-overscroll/
 	overscroll-behavior-y: none;
-
-	// Footer overlap prevention
-	@include break-medium() {
-		padding-bottom: $button-size-small + $border-width;
-	}
 }
 
 .interface-interface-skeleton__content {
@@ -141,9 +137,6 @@ html.interface-interface-skeleton__html-container {
 	flex-shrink: 0;
 	border-top: $border-width solid $gray-200;
 	color: $gray-900;
-	position: absolute;
-	bottom: 0;
-	left: 0;
 	width: 100%;
 	background-color: $white;
 	z-index: z-index(".interface-interface-skeleton__footer");

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -64,6 +64,10 @@ html.interface-interface-skeleton__html-container {
 	overscroll-behavior-y: none;
 }
 
+.interface-interface-skeleton__drawer {
+	z-index: z-index(".interface-interface-skeleton__drawer");
+}
+
 .interface-interface-skeleton__content {
 	flex-grow: 1;
 


### PR DESCRIPTION
This PR makes the Navigation Panel in the Site Editor open below the header. Doing so allows the header to remain the same width and so allows removal of the fastidious CSS to adjust for that. It also makes it more consistent with how the sidebars and inserter appear.

While I believe this same result could be achieved with just style changes, to keep the styles a little more dumb I've made some structural changes:
* Nest the drawer more deeply in the interface skeleton (sibling to other sidebars/actions).
* Move the Navigation toggle into the header (out from of NavigationSidebar)

**UPDATE:** I've noticed that because of the structural change in this PR the tabbing order improvements from #25884 are undone. I made a POC repair for that with some manual focus management but haven't yet pushed it as I'm first trying to see if the design change is deemed desirable. If so, I'd be interested in trying an alternate CSS only PR to see if that'd be better. For that reason, I'll suggest to @noahtallen to delay an in-depth review unless you just happen to get enthusiastic about this approach.

## Static comparison at a medium breakpoint
Before | After
-------|-------
![edit-site-open-drawer-medium-before](https://user-images.githubusercontent.com/9000376/101660604-35145980-39fc-11eb-9b78-bfba1e33e055.png) | ![edit-site-open-drawer-medium-after](https://user-images.githubusercontent.com/9000376/101660731-570ddc00-39fc-11eb-8f72-73afeeb651ff.png)



## Screen recordings
### Top toolbar and wide breakpoint
 the lesser end of this breakpoint has issues when a long toolbar (template part in this instance) is present and the drawer is open.
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/9000376/101553807-457bf400-396a-11eb-9dd1-5215b977ef61.gif"/>
</details>
<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/9000376/101554387-62fd8d80-396b-11eb-8049-25f77157ef4f.gif"/>
</details>

###  Medium breakpoint
Hiding some and moving other items while the drawer opens is distracting. 
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/9000376/101554590-c4bdf780-396b-11eb-9400-67104474692e.gif"/>
</details>
<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/9000376/101554596-cb4c6f00-396b-11eb-9be1-6b09b7f9030f.gif"/>
</details>

## Tangential changes
* Footer is no longer fixed position, allowing removal of some CSS elsewhere that was accounting for that

## How has this been tested?
At all breakpoints opening and closing the drawer. With or without top toolbar mode.

## Types of changes
Enhancement?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
