### PR TITLE
CI: Run date test timezone and locale variations using bash script

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -52,12 +52,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        timezone: ['EST', 'GMT', 'CET']
-        locale: ['en_US', 'ja_JP']
-
     steps:
     - uses: actions/checkout@v2
 
@@ -88,13 +82,9 @@ jobs:
         npx lerna run build
 
     - name: Running the tests
-      env:
-        TZ: ${{ matrix.timezone }}
-        LANG: ${{ matrix.locale }}
 
       run: |
-        npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache" \
-          --testPathPattern="packages/date/"
+        npm run test-unit:date -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
   unit-php:
     name: PHP

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,9 +45,10 @@ jobs:
         npx lerna run build
 
     - name: Running the tests
-      run: |
-        npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
-        npm run test-unit:date -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
+      run: npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
+
+    - name: Running the date tests
+      run: npm run test-unit:date -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
   unit-php:
     name: PHP

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,45 +45,8 @@ jobs:
         npx lerna run build
 
     - name: Running the tests
-      run: npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
-
-  unit-js-date:
-    name: JavaScript / Date functions
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    - name: Use Node.js 14.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-
-    - name: Npm install and build
-      # It's not necessary to run the full build, since Jest can interpret
-      # source files with `babel-jest`. Some packages have their own custom
-      # build tasks, however. These must be run.
       run: |
-        npm ci
-        npx lerna run build
-
-    - name: Running the tests
-
-      run: |
+        npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
         npm run test-unit:date -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
   unit-php:

--- a/bin/unit-test-date.sh
+++ b/bin/unit-test-date.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+pids=()
+pidsTimezones=()
+pidsLocales=()
+
+timezones=(EST GMT CET)
+locales=(en_US ja_JP)
+
+for timezone in "${timezones[@]}"; do
+    for locale in "${locales[@]}"; do
+        TZ=$timezone LANG=$locale npm run test-unit -- packages/date &
+        pids+=($!)
+        pidsTimezones+=($timezone)
+        pidsLocales+=($locale)
+    done
+done
+
+for i in "${!pids[@]}"; do
+    pid=${pids[i]}
+    timezone=${pidsTimezones[i]}
+    locale=${pidsLocales[i]}
+    wait "$pid" || echo "Date tests failed with timezone = $timezone and locale = $locale"
+done

--- a/bin/unit-test-date.sh
+++ b/bin/unit-test-date.sh
@@ -11,7 +11,7 @@ locales=(en_US ja_JP)
 
 for timezone in "${timezones[@]}"; do
     for locale in "${locales[@]}"; do
-        TZ=$timezone LANG=$locale npm run test-unit -- packages/date &
+        TZ=$timezone LANG=$locale npm run test-unit -- packages/date "$@" &
         pids+=($!)
         pidsTimezones+=($timezone)
         pidsLocales+=($locale)

--- a/bin/unit-test-date.sh
+++ b/bin/unit-test-date.sh
@@ -22,5 +22,8 @@ for i in "${!pids[@]}"; do
     pid=${pids[i]}
     timezone=${pidsTimezones[i]}
     locale=${pidsLocales[i]}
-    wait "$pid" || echo "Date tests failed with timezone = $timezone and locale = $locale"
+    wait "$pid" || (
+        echo "Date tests failed with timezone = $timezone and locale = $locale"
+        exit 1
+    )
 done

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
 		"test-php": "npm run lint-php && npm run test-unit-php",
 		"test-php:watch": "wp-env run composer run-script test:watch",
 		"test-unit": "wp-scripts test-unit-js --config test/unit/jest.config.js",
+		"test-unit:date": "./bin/unit-test-date.sh",
 		"test-unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache --verbose --config test/unit/jest.config.js ",
 		"test-unit:update": "npm run test-unit -- --updateSnapshot",
 		"test-unit:watch": "npm run test-unit -- --watch",

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -18,6 +18,10 @@ describe( 'isInTheFuture', () => {
 		const date = new Date( Number( getDate() ) + 1000 * 60 );
 
 		expect( isInTheFuture( date ) ).toBe( true );
+
+		if ( process.env.TZ === 'EST' && process.env.LANG === 'ja_JP' ) {
+			expect( false ).toBe( true );
+		}
 	} );
 
 	it( 'should return false if the date is in the past', () => {

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -18,10 +18,6 @@ describe( 'isInTheFuture', () => {
 		const date = new Date( Number( getDate() ) + 1000 * 60 );
 
 		expect( isInTheFuture( date ) ).toBe( true );
-
-		if ( process.env.TZ === 'EST' && process.env.LANG === 'ja_JP' ) {
-			expect( false ).toBe( true );
-		}
 	} );
 
 	it( 'should return false if the date is in the past', () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related discussion: https://github.com/WordPress/gutenberg/pull/27552#discussion_r538618820

To reduce jobs and CI entries, run date tests in different timezones and locales with a bash script.

## How has this been tested?
* Check CI below
* Or you can run tests locally: `npm run test-unit:date`

## Screenshots <!-- if applicable -->
A failing date test will report the timezone and locale it failed with:
See line 7371
![image](https://user-images.githubusercontent.com/2256104/101625749-2ccc1680-3a1c-11eb-9073-1095c112c08e.png)


## Types of changes
non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
