### PR TITLE
Precise that element ref returned by the hooks that return a ref can change between function or object

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -155,7 +155,7 @@ const ConstrainedTabbingExample = () => {
 
 _Returns_
 
--   `Function`: Element Ref.
+-   `(Object|Function)`: Element Ref.
 
 <a name="useCopyOnClick" href="#useCopyOnClick">#</a> **useCopyOnClick**
 
@@ -212,7 +212,7 @@ _Parameters_
 
 _Returns_
 
--   `Function`: Element Ref.
+-   `(Function|Object)`: Element Ref.
 
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 

--- a/packages/compose/src/hooks/use-constrained-tabbing/README.md
+++ b/packages/compose/src/hooks/use-constrained-tabbing/README.md
@@ -7,7 +7,7 @@ In Dialogs/modals, the tabbing must be constrained to the content of the wrapper
 
 ### `ref`
 
-- Type: `Function`
+- Type: `Object|Function`
 
 A function reference that must be passed to the DOM element where constrained tabbing should be enabled.
 

--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -9,7 +9,7 @@ import { focus } from '@wordpress/dom';
  * In Dialogs/modals, the tabbing must be constrained to the content of
  * the wrapper element. This hook adds the behavior to the returned ref.
  *
- * @return {Function} Element Ref.
+ * @return {Object|Function} Element Ref.
  *
  * @example
  * ```js

--- a/packages/compose/src/hooks/use-focus-on-mount/README.md
+++ b/packages/compose/src/hooks/use-focus-on-mount/README.md
@@ -7,7 +7,7 @@ Hook used to focus the first tabbable element on mount.
 
 ### `ref`
 
-- Type: `Function`
+- Type: `Object|Function`
 
 A React ref that must be passed to the DOM element where the behavior should be attached.
 

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -8,7 +8,7 @@ import { useEffect, useRef } from '@wordpress/element';
  * Hook used to focus the first tabbable element on mount.
  *
  * @param {boolean|string} focusOnMount Focus on mount mode.
- * @return {Function} Element Ref.
+ * @return {Function|Object} Element Ref.
  *
  * @example
  * ```js


### PR DESCRIPTION
I wanted to type these files intially but some of there dependencies are not yet typed making this hard for the moment (@wordpress/dom and @wordpress/keycodes) 