### PR TITLE
Adjust mobile margins for the Query block's grid view

### DIFF
--- a/packages/block-library/src/query-loop/style.scss
+++ b/packages/block-library/src/query-loop/style.scss
@@ -13,11 +13,15 @@
 		flex-wrap: wrap;
 
 		li {
-			margin: 0 1.25em 1.25em 0;
+			margin: 0 0 1.25em 0;
 			width: 100%;
 		}
 
 		@include break-small {
+			li {
+				margin-right: 1.25em;
+			}
+
 			@for $i from 2 through 6 {
 				&.is-flex-container.columns-#{ $i } > li {
 					width: calc((100% / #{ $i }) - 1.25em + (1.25em / #{ $i }));


### PR DESCRIPTION
The Query block's grid view (#27067) includes unnecessary right margin for each list item on mobile. This PR moves that CSS rule to larger breakpoints only, allowing posts to take up the entire width of the mobile screen as expected. 

Before|After
---|---
![Screen Shot 2020-12-09 at 12 09 33 PM](https://user-images.githubusercontent.com/1202812/101662479-91d13d80-3a17-11eb-8fab-65a4429d3851.png)|![Screen Shot 2020-12-09 at 12 08 23 PM](https://user-images.githubusercontent.com/1202812/101662489-94339780-3a17-11eb-8637-5a7f50f8706e.png)
