### PR TITLE
Site Logo: Add a rounded block style

### DIFF
--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -17,6 +17,14 @@ export const settings = {
 	title: __( 'Site Logo' ),
 	description: __( 'Show a site logo' ),
 	icon,
+	styles: [
+		{
+			name: 'default',
+			label: _x( 'Default', 'block style' ),
+			isDefault: true,
+		},
+		{ name: 'rounded', label: _x( 'Rounded', 'block style' ) },
+	],
 	supports: {
 		align: true,
 		alignWide: false,

--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -2,4 +2,11 @@
 	.aligncenter {
 		display: table;
 	}
+
+	// Variations
+	&.is-style-rounded img {
+		// We use an absolute pixel to prevent the oval shape that a value of 50% would give
+		// to rectangular images. A pill-shape is better than otherwise.
+		border-radius: 9999px;
+	}
 }


### PR DESCRIPTION
This PR adds a "Rounded" block style to the site logo block, to bring it more on par with the existing Image block functionality. 

(This PR is basically just a copy/paste of that [existing](https://github.com/WordPress/gutenberg/blob/c043d0f6cd737caddf626925097034903fce5974/packages/block-library/src/image/index.js#L37-L44) [code](https://github.com/WordPress/gutenberg/blob/c043d0f6cd737caddf626925097034903fce5974/packages/block-library/src/image/style.scss#L63-L68) for the Image block). 

![rounded](https://user-images.githubusercontent.com/1202812/101666967-c398d300-3a1c-11eb-9a73-f0cf657aa6a4.gif)