### PR TITLE
Site Logo: Remove line height

### DIFF
--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -1,4 +1,6 @@
 .wp-block-custom-logo {
+	line-height: 0;
+
 	.aligncenter {
 		display: table;
 	}


### PR DESCRIPTION
Since the Site Logo block is a `div` with some `a` links inside of it, it's effected by global line height rules: if the line height is tall, the container div will get larger, if it's short, it'll get smaller.  This leads to some extra space around the image, which upsets visual alignment: 

![Screen Shot 2020-12-09 at 1 06 55 PM](https://user-images.githubusercontent.com/1202812/101669144-8da91e00-3a1f-11eb-92c7-ea28d62e5ded.png)

![Screen Shot 2020-12-09 at 1 07 08 PM](https://user-images.githubusercontent.com/1202812/101669145-8e41b480-3a1f-11eb-8ef4-7aac15923869.png)

Since it's never actually meant to contain text, we can zero out the line height there, trimming the space down to the minimum size of the image itself: 

![Screen Shot 2020-12-09 at 1 07 22 PM](https://user-images.githubusercontent.com/1202812/101669179-9ac60d00-3a1f-11eb-896e-7814462d1660.png)

![Screen Shot 2020-12-09 at 1 07 29 PM](https://user-images.githubusercontent.com/1202812/101669176-9ac60d00-3a1f-11eb-9102-cc6e7248df59.png)


