### PR TITLE
BoxControl: Add custom units

### DIFF
--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -10,7 +10,7 @@ import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import { cleanEmptyObject } from './utils';
-import { useCustomUnits } from '../components/unit-control';
+import useEditorFeature from '../components/use-editor-feature';
 
 export const SPACING_SUPPORT_KEY = 'spacing';
 
@@ -33,7 +33,8 @@ export function PaddingEdit( props ) {
 		setAttributes,
 	} = props;
 
-	const units = useCustomUnits();
+	const customUnits = useEditorFeature( 'spacing.units' );
+	const units = customUnits?.map( ( unit ) => ( { value: unit, label: unit } ) );
 
 	if ( ! hasPaddingSupport( blockName ) ) {
 		return null;

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -34,7 +34,10 @@ export function PaddingEdit( props ) {
 	} = props;
 
 	const customUnits = useEditorFeature( 'spacing.units' );
-	const units = customUnits?.map( ( unit ) => ( { value: unit, label: unit } ) );
+	const units = customUnits?.map( ( unit ) => ( {
+		value: unit,
+		label: unit,
+	} ) );
 
 	if ( ! hasPaddingSupport( blockName ) ) {
 		return null;


### PR DESCRIPTION
## Description
Adds support for custom units to the box control component when the theme declares support for it.

Fixes #27615

## How has this been tested?
In TwentyTwentyOne Blocks

## Screenshots <!-- if applicable -->
<img width="307" alt="Screenshot 2020-12-09 at 21 29 12" src="https://user-images.githubusercontent.com/275961/101690743-96bcde00-3a65-11eb-8fee-d362764e7c35.png">


## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
