### PR TITLE
HTML Block: Fix editor styles

### DIFF
--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -10,7 +10,7 @@
 	},
 	"supports": {
 		"customClassName": false,
-		"className": false,
+		"className": true,
 		"html": false
 	},
 	"editorStyle": "wp-block-html-editor"

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -10,7 +10,7 @@
 	},
 	"supports": {
 		"customClassName": false,
-		"className": true,
+		"className": false,
 		"html": false
 	},
 	"editorStyle": "wp-block-html-editor"

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -49,7 +49,7 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 	}
 
 	return (
-		<div { ...useBlockProps() }>
+		<div { ...useBlockProps( { className: 'block-library-html__edit' } ) }>
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -1,4 +1,4 @@
-.wp-block-html {
+.block-library-html__edit {
 	margin-bottom: $default-block-margin;
 
 	.block-library-html__preview-overlay {


### PR DESCRIPTION
Fixes #27455 — Before #26055, the `wp-block-html` class was been manually added to the container. This is the class used to style the HTML block in `editor.scss`. It should have been added by `useBlockProps`, but the block disabled className support. This PR just enables `className` in block.json, to bring that wrapper class back.

## How has this been tested?

Using Twenty Nineteen, so that theme styles don't interfere, I added an HTML block to a post. See screenshots.

## Screenshots

master:

![Screen Shot 2020-12-09 at 5 04 43 PM](https://user-images.githubusercontent.com/541093/101694146-a7a72880-3a40-11eb-9dcf-6f4ae96cafeb.png)

this branch:

![Screen Shot 2020-12-09 at 5 00 34 PM](https://user-images.githubusercontent.com/541093/101694145-a70e9200-3a40-11eb-887b-bb02ea0c27bd.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)
