### PR TITLE
[Table Block] Add border-collapse to default block styles

### DIFF
--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -28,10 +28,6 @@
 		}
 	}
 
-	table {
-		border-collapse: collapse;
-	}
-
 	td,
 	th {
 		border: $border-width solid;

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -7,6 +7,7 @@
 	overflow-x: auto;
 
 	table {
+		border-collapse: collapse;
 		width: 100%;
 	}
 

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -1,6 +1,4 @@
 .wp-block-table {
-	border-collapse: collapse;
-
 	thead {
 		border-bottom: 3px solid;
 	}


### PR DESCRIPTION
This PR moves the border-collapse style attribute to the default table block styles, fixing two issues:

1. A mismatch between front-end and editor default table block styles.

2. The attribute is incorrectly applied in the themes stylesheet — the user agent stylesheet overrides the inherited style from the theme stylesheet on the front-end:

<img width="751" alt="Screen Shot 2020-12-09 at 5 33 16 PM" src="https://user-images.githubusercontent.com/5375500/101696886-ce675e00-3a44-11eb-8d58-6fabd2ff8b3c.png">