### PR TITLE
Site Editor: Template parts not loading when block theme has parent directory

### DIFF
--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -138,7 +138,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 		$tax_query   = isset( $args['tax_query'] ) ? $args['tax_query'] : array();
 		$tax_query[] = array(
 			'taxonomy' => 'wp_theme',
-			'field'    => 'slug',
+			'field'    => 'name',
 			'terms'    => $request['theme'],
 		);
 

--- a/packages/block-library/src/template-part/edit/use-template-part-post.js
+++ b/packages/block-library/src/template-part/edit/use-template-part-post.js
@@ -24,13 +24,14 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 			// relevant file.
 			if ( slug && theme ) {
 				const cleanedSlug = cleanForSlug( slug );
+				const themeSlug = `pub-${ theme }`;
 				const posts = select( 'core' ).getEntityRecords(
 					'postType',
 					'wp_template_part',
 					{
 						status: [ 'publish', 'auto-draft' ],
 						slug: cleanedSlug,
-						theme,
+						themeSlug,
 					}
 				);
 

--- a/packages/block-library/src/template-part/edit/use-template-part-post.js
+++ b/packages/block-library/src/template-part/edit/use-template-part-post.js
@@ -23,15 +23,17 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 			// load the auto-draft created from the
 			// relevant file.
 			if ( slug && theme ) {
+				const currentTheme = select( 'core' ).getCurrentTheme()
+					?.stylesheet;
 				const cleanedSlug = cleanForSlug( slug );
-				const themeSlug = `pub-${ theme }`;
+				const themeSlug = currentTheme.replace( '/', '-' );
 				const posts = select( 'core' ).getEntityRecords(
 					'postType',
 					'wp_template_part',
 					{
 						status: [ 'publish', 'auto-draft' ],
 						slug: cleanedSlug,
-						themeSlug,
+						theme: themeSlug,
 					}
 				);
 

--- a/packages/block-library/src/template-part/edit/use-template-part-post.js
+++ b/packages/block-library/src/template-part/edit/use-template-part-post.js
@@ -26,14 +26,13 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 				const currentTheme = select( 'core' ).getCurrentTheme()
 					?.stylesheet;
 				const cleanedSlug = cleanForSlug( slug );
-				const themeSlug = currentTheme?.replace( '/', '-' );
 				const posts = select( 'core' ).getEntityRecords(
 					'postType',
 					'wp_template_part',
 					{
 						status: [ 'publish', 'auto-draft' ],
 						slug: cleanedSlug,
-						theme: themeSlug,
+						theme: currentTheme,
 					}
 				);
 

--- a/packages/block-library/src/template-part/edit/use-template-part-post.js
+++ b/packages/block-library/src/template-part/edit/use-template-part-post.js
@@ -26,7 +26,7 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 				const currentTheme = select( 'core' ).getCurrentTheme()
 					?.stylesheet;
 				const cleanedSlug = cleanForSlug( slug );
-				const themeSlug = currentTheme.replace( '/', '-' );
+				const themeSlug = currentTheme?.replace( '/', '-' );
 				const posts = select( 'core' ).getEntityRecords(
 					'postType',
 					'wp_template_part',

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -28,7 +28,7 @@ function render_block_core_template_part( $attributes ) {
 				'tax_query'      => array(
 					array(
 						'taxonomy' => 'wp_theme',
-						'field'    => 'slug',
+						'field'    => 'name',
 						'terms'    => $attributes['theme'],
 					),
 				),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
After latest Gutenberg plugin updates (v9.5.1), template parts are no longer loading properly when using themes that have a parent directory

### Cause
  - [The template file remains unresolved](https://github.com/WordPress/gutenberg/blob/87171eb27d8bd346388944b5a448a846d64d352f/packages/block-library/src/template-part/edit/index.js#L145), which is caused by an [undefined template part post id](https://github.com/WordPress/gutenberg/blob/87171eb27d8bd346388944b5a448a846d64d352f/packages/block-library/src/template-part/edit/index.js#L97)
  - The postId is undefined because, [when trying to fetch template part information](https://github.com/WordPress/gutenberg/blob/87171eb27d8bd346388944b5a448a846d64d352f/packages/block-library/src/template-part/edit/use-template-part-post.js#L33), it isn't querying by the correct theme slug
    - To elaborate, theme provided, auto-drafted template parts have a `theme` block attribute (see [twentytwentyone-blocks](https://github.com/WordPress/theme-experiments/blob/f92bd1ea84d0c1441faa6bbed4b6f6cb4d967b68/twentytwentyone-blocks/block-templates/index.html#L1)) which resolves to something like `twentytwentyone-blocks`
    - For auto-drafted template parts, this `theme` attribute [is used in a template parts query on load](https://github.com/WordPress/gutenberg/blob/87171eb27d8bd346388944b5a448a846d64d352f/packages/block-library/src/template-part/edit/use-template-part-post.js#L27-L35)
    - The `theme` provided value is, however, incorrect. It doesn't account for themes, and their slugs, with a parent directory. As a result, we query by `twentytwentyone-blocks`, when in reality, we need to query by `[PARENT_DIRECTORY]-twentytwentyone-blocks`
  - No template parts are found, and postId stays undefined, hence the infinite spinner

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Create a WordPress instance **where block themes live within a parent directory**
2. Spin up the WordPress instance with Gutenberg
3. Enable the block theme
4. Navigate to the site editor
5. Ensure that template parts load

## Screenshots <!-- if applicable -->
### Before
<img width="1680" alt="Screenshot 2020-12-08 at 23 57 51" src="https://user-images.githubusercontent.com/1182160/101551397-33717400-39b1-11eb-8e31-91cfa8cd745d.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for #48145

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
