### PR TITLE
Allow Query Loop only inside Query block

### DIFF
--- a/packages/block-library/src/query-loop/index.js
+++ b/packages/block-library/src/query-loop/index.js
@@ -19,4 +19,5 @@ export const settings = {
 	icon: loop,
 	edit,
 	save,
+	parent: [ 'core/query' ],
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/27585
This PR just allows Query Loop only inside a Query block.
<!-- Please describe what you have changed or added -->
