### PR TITLE
Fix adding single use block from main inserter causes focus loss and menu to be stuck open

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -45,7 +45,10 @@ function InserterListItem( {
 					onClick();
 				} }
 				disabled={ isDisabled }
-				__experimentalIsFocusable
+				// Use the CompositeItem `focusable` prop over Button's
+				// isFocusable. The latter was shown to cause an issue
+				// with tab order in the inserter list.
+				focusable
 				{ ...props }
 			>
 				<span

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -45,6 +45,7 @@ function InserterListItem( {
 					onClick();
 				} }
 				disabled={ isDisabled }
+				__experimentalIsFocusable
 				{ ...props }
 			>
 				<span

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -351,6 +351,7 @@ describe( 'adding blocks', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	// Check for regression of https://github.com/WordPress/gutenberg/issues/27586
 	it( 'closes the main inserter after inserting a single-use block, like the More block', async () => {
 		await insertBlock( 'More' );
 		await page.waitForSelector(

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -350,4 +350,15 @@ describe( 'adding blocks', () => {
 		await page.keyboard.type( 'Paragraph inside group' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'closes the main inserter after inserting a single-use block, like the More block', async () => {
+		await insertBlock( 'More' );
+		await page.waitForSelector(
+			'.edit-post-header-toolbar__inserter-toggle:not(.is-pressed)'
+		);
+		const inserterPanels = await page.$$(
+			'.edit-post-layout__inserter-panel'
+		);
+		expect( inserterPanels.length ).toBe( 0 );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -357,9 +357,19 @@ describe( 'adding blocks', () => {
 		await page.waitForSelector(
 			'.edit-post-header-toolbar__inserter-toggle:not(.is-pressed)'
 		);
+
+		// The inserter panel should've closed.
 		const inserterPanels = await page.$$(
 			'.edit-post-layout__inserter-panel'
 		);
 		expect( inserterPanels.length ).toBe( 0 );
+
+		// The editable 'Read More' text should be focused.
+		const isFocusInBlock = await page.evaluate( () =>
+			document
+				.querySelector( '[data-type="core/more"]' )
+				.contains( document.activeElement )
+		);
+		expect( isFocusInBlock ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #27586

When inserting a single-use block like the More block from the main inserter, the panel doesn't close as expected. Afterwards it's actually quite difficult to close the panel at all.

What's happening is that as the More block button is clicked, it changes to a disabled button resulting momentarily in a focus loss (before focus is transferred to the inserted block).

Our 'focus outside' detection doesn't seem to handle this, so could be improved. But on the other hand, the button should probably still be focusable—that seems important for navigation in the menu, and also if the React component were ever used in a different context it shouldn't cause a focus loss.

We already do the same with the Publish button in the editor which can change from enabled to disabled. This PR uses the same technique adding the `__experimentalIsFocusable` prop.

## How has this been tested?
Adds an e2e test.

Manual testing:
1. Add a more block from the main inserter (using the + button in the header)
2. The sidebar should close once the more block is added.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
