### PR TITLE
Fix for: Interface Skeleton: Limit the editor width to prevent some blocks to grow infinitely wide

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -37,6 +37,7 @@ html.interface-interface-skeleton__html-container {
 	display: flex;
 	flex-direction: column;
 	flex: 0 1 100%;
+	max-width: 100%;
 }
 
 @include editor-left(".interface-interface-skeleton");


### PR DESCRIPTION
Fixes #27622 

## Description
Added
```css
.interface-interface-skeleton__editor {
  ...
  max-width: 100%;
}
```
which was previously removed as part of IE11 compatibility fix. It should not affect previous IE11 fix, as it does'n conflict with it. I previously removed it because I mistakenly thought `flex: 0 1 100%` was enough to limit the width to 100%.

## How has this been tested?
Tested on Chrome 87, Windows 11 accoding to steps from #27622
Jetpack Blocks seem not to work in IE11, so on IE11 I tested with Full-width Pullquote

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->