### PR TITLE
Scope image block style variations to only the image block

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -58,32 +58,32 @@
 	figcaption {
 		@include caption-style();
 	}
-}
 
-// Variations
-.is-style-rounded img {
-	// We use an absolute pixel to prevent the oval shape that a value of 50% would give
-	// to rectangular images. A pill-shape is better than otherwise.
-	border-radius: 9999px;
-}
+	// Variations
+	&.is-style-rounded img {
+		// We use an absolute pixel to prevent the oval shape that a value of 50% would give
+		// to rectangular images. A pill-shape is better than otherwise.
+		border-radius: 9999px;
+	}
 
-// The following variation is deprecated.
-// The CSS is kept here for the time being, to support blocks using the old variation.
-.is-style-circle-mask img {
-	// We use an absolute pixel to prevent the oval shape that a value of 50% would give
-	// to rectangular images. A pill-shape is better than otherwise.
-	border-radius: 9999px;
+	// The following variation is deprecated.
+	// The CSS is kept here for the time being, to support blocks using the old variation.
+	&.is-style-circle-mask img {
+		// We use an absolute pixel to prevent the oval shape that a value of 50% would give
+		// to rectangular images. A pill-shape is better than otherwise.
+		border-radius: 9999px;
 
-	// If a browser supports it, we will switch to using a circular SVG mask.
-	// The stylelint override is necessary to use the SVG inline here.
-	@supports (mask-image: none) or (-webkit-mask-image: none) {
-		/* stylelint-disable */
-		mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');
-		/* stylelint-enable */
-		mask-mode: alpha;
-		mask-repeat: no-repeat;
-		mask-size: contain;
-		mask-position: center;
-		border-radius: 0;
+		// If a browser supports it, we will switch to using a circular SVG mask.
+		// The stylelint override is necessary to use the SVG inline here.
+		@supports (mask-image: none) or (-webkit-mask-image: none) {
+			/* stylelint-disable */
+			mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');
+			/* stylelint-enable */
+			mask-mode: alpha;
+			mask-repeat: no-repeat;
+			mask-size: contain;
+			mask-position: center;
+			border-radius: 0;
+		}
 	}
 }


### PR DESCRIPTION
As per conversation in https://github.com/WordPress/gutenberg/pull/27621#discussion_r539522211:

The image block's block style variation CSS was not scoped to the image block itself. This isn't a huge problem, but we should change this this to ensure proper specificity and keep individual block CSS self-contained. 

This PR changes the following rules: 


- `.is-style-rounded img` ➡️ `.wp-block-image.is-style-rounded img` 
- `.is-style-circle-mask img` ➡️ `.wp-block-image.is-style-circle-mask img`

Should have no effect on anything, unless themes or other blocks were using the improperly scoped rules (which is unlikely). 