### PR TITLE
Fix: Block crashes if font family is not found

### DIFF
--- a/packages/block-editor/src/hooks/font-family.js
+++ b/packages/block-editor/src/hooks/font-family.js
@@ -20,9 +20,12 @@ export const FONT_FAMILY_SUPPORT_KEY = '__experimentalFontFamily';
 const getFontFamilyFromAttributeValue = ( fontFamilies, value ) => {
 	const attributeParsed = /var:preset\|font-family\|(.+)/.exec( value );
 	if ( attributeParsed && attributeParsed[ 1 ] ) {
-		return find( fontFamilies, ( { slug } ) => {
+		const fontFamilyObject = find( fontFamilies, ( { slug } ) => {
 			return slug === attributeParsed[ 1 ];
-		} ).fontFamily;
+		} );
+		if ( fontFamilyObject ) {
+			return fontFamilyObject.fontFamily;
+		}
 	}
 	return value;
 };


### PR DESCRIPTION
This PR fixes a bug that makes blocks crash if a font family they are using is not available,

## How has this been tested?
I added a verse block.
I selected a font family.
I saved the post.
I removed that font family from theme.json.
I reloaded the post and I verified the post does not crshes.
