### PR TITLE
Allow dragging blocks from the inserter into the canvas

### DIFF
--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -2,8 +2,6 @@
  * WordPress dependencies
  */
 import { _n, sprintf } from '@wordpress/i18n';
-import { getBlockType } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem } from '@wordpress/components';
 import { dragHandle } from '@wordpress/icons';
 
@@ -12,22 +10,7 @@ import { dragHandle } from '@wordpress/icons';
  */
 import BlockIcon from '../block-icon';
 
-export default function BlockDraggableChip( { clientIds } ) {
-	const icon = useSelect(
-		( select ) => {
-			if ( clientIds.length !== 1 ) {
-				return;
-			}
-
-			const { getBlockName } = select( 'core/block-editor' );
-			const [ firstId ] = clientIds;
-			const blockName = getBlockName( firstId );
-
-			return getBlockType( blockName )?.icon;
-		},
-		[ clientIds ]
-	);
-
+export default function BlockDraggableChip( { count, icon } ) {
 	return (
 		<div className="block-editor-block-draggable-chip-wrapper">
 			<div className="block-editor-block-draggable-chip">
@@ -41,8 +24,8 @@ export default function BlockDraggableChip( { clientIds } ) {
 						) : (
 							sprintf(
 								/* translators: %d: Number of blocks. */
-								_n( '%d block', '%d blocks', clientIds.length ),
-								clientIds.length
+								_n( '%d block', '%d blocks', count ),
+								count
 							)
 						) }
 					</FlexItem>

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { getBlockType } from '@wordpress/blocks';
 import { Draggable } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -19,19 +20,23 @@ const BlockDraggable = ( {
 	onDragEnd,
 	elementId,
 } ) => {
-	const { srcRootClientId, isDraggable } = useSelect(
+	const { srcRootClientId, isDraggable, icon } = useSelect(
 		( select ) => {
-			const { getBlockRootClientId, getTemplateLock } = select(
-				'core/block-editor'
-			);
+			const {
+				getBlockRootClientId,
+				getTemplateLock,
+				getBlockName,
+			} = select( 'core/block-editor' );
 			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 			const templateLock = rootClientId
 				? getTemplateLock( rootClientId )
 				: null;
+			const blockName = getBlockName( clientIds[ 0 ] );
 
 			return {
 				srcRootClientId: rootClientId,
 				isDraggable: 'all' !== templateLock,
+				icon: getBlockType( blockName )?.icon,
 			};
 		},
 		[ clientIds ]
@@ -93,14 +98,14 @@ const BlockDraggable = ( {
 				}
 			} }
 			__experimentalDragComponent={
-				<BlockDraggableChip clientIds={ clientIds } />
+				<BlockDraggableChip count={ clientIds.length } icon={ icon } />
 			}
 		>
 			{ ( { onDraggableStart, onDraggableEnd } ) => {
 				return children( {
-					isDraggable: true,
-					onDraggableStart,
-					onDraggableEnd,
+					draggable: true,
+					onDragStart: onDraggableStart,
+					onDragEnd: onDraggableEnd,
 				} );
 			} }
 		</Draggable>

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -59,7 +59,7 @@ function BlockMover( {
 					clientIds={ clientIds }
 					cloneClassname="block-editor-block-mover__drag-clone"
 				>
-					{ ( { isDraggable, onDraggableStart, onDraggableEnd } ) => (
+					{ ( draggableProps ) => (
 						<Button
 							icon={ dragHandle }
 							className="block-editor-block-mover__drag-handle"
@@ -68,9 +68,7 @@ function BlockMover( {
 							// Should not be able to tab to drag handle as this
 							// button can only be used with a pointer device.
 							tabIndex="-1"
-							onDragStart={ onDraggableStart }
-							onDragEnd={ onDraggableEnd }
-							draggable={ isDraggable }
+							{ ...draggableProps }
 						/>
 					) }
 				</BlockDraggable>

--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -91,7 +91,7 @@ const BlockNavigationBlockContents = forwardRef(
 				clientIds={ [ block.clientId ] }
 				elementId={ `block-navigation-block-${ block.clientId }` }
 			>
-				{ ( { isDraggable, onDraggableStart, onDraggableEnd } ) =>
+				{ ( { draggable, onDragStart, onDragEnd } ) =>
 					__experimentalFeatures ? (
 						<BlockNavigationBlockSlot
 							ref={ ref }
@@ -102,9 +102,9 @@ const BlockNavigationBlockContents = forwardRef(
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }
 							level={ level }
-							draggable={ isDraggable && __experimentalFeatures }
-							onDragStart={ onDraggableStart }
-							onDragEnd={ onDraggableEnd }
+							draggable={ draggable && __experimentalFeatures }
+							onDragStart={ onDragStart }
+							onDragEnd={ onDragEnd }
 							{ ...props }
 						/>
 					) : (
@@ -117,9 +117,9 @@ const BlockNavigationBlockContents = forwardRef(
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }
 							level={ level }
-							draggable={ isDraggable && __experimentalFeatures }
-							onDragStart={ onDraggableStart }
-							onDragEnd={ onDraggableEnd }
+							draggable={ draggable && __experimentalFeatures }
+							onDragStart={ onDragStart }
+							onDragEnd={ onDragEnd }
 							{ ...props }
 						/>
 					)

--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -45,18 +45,10 @@ function BlockTypesList( {
 				return (
 					<InserterListItem
 						key={ item.id }
+						item={ item }
 						className={ getBlockMenuDefaultClassName( item.id ) }
-						icon={ item.icon }
-						onClick={ () => {
-							onSelect( item );
-							onHover( null );
-						} }
-						onFocus={ () => onHover( item ) }
-						onMouseEnter={ () => onHover( item ) }
-						onMouseLeave={ () => onHover( null ) }
-						onBlur={ () => onHover( null ) }
-						isDisabled={ item.isDisabled }
-						title={ item.title }
+						onSelect={ onSelect }
+						onHover={ onHover }
 						composite={ composite }
 					/>
 				);

--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -20,6 +20,7 @@ function BlockTypesList( {
 	onHover = () => {},
 	children,
 	label,
+	isDraggable = true,
 } ) {
 	const composite = useCompositeState();
 	const orderId = items.reduce( ( acc, item ) => acc + '--' + item.id, '' );
@@ -50,6 +51,7 @@ function BlockTypesList( {
 						onSelect={ onSelect }
 						onHover={ onHover }
 						composite={ composite }
+						isDraggable={ isDraggable }
 					/>
 				);
 			} ) }

--- a/packages/block-editor/src/components/inserter-list-item/draggable.js
+++ b/packages/block-editor/src/components/inserter-list-item/draggable.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { Draggable } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import BlockDraggableChip from '../block-draggable/draggable-chip';
+
+const InserterListItemDraggable = ( { isEnabled, blocks, icon, children } ) => {
+	const transferData = {
+		type: 'inserter',
+		blocks,
+	};
+
+	return (
+		<Draggable
+			transferData={ transferData }
+			__experimentalDragComponent={
+				<BlockDraggableChip count={ blocks.length } icon={ icon } />
+			}
+		>
+			{ ( { onDraggableStart, onDraggableEnd } ) => {
+				return children( {
+					draggable: isEnabled,
+					onDragStart: isEnabled ? onDraggableStart : undefined,
+					onDragEnd: isEnabled ? onDraggableEnd : undefined,
+				} );
+			} }
+		</Draggable>
+	);
+};
+
+export default InserterListItemDraggable;

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -101,7 +101,7 @@ function InserterListItem( {
 						// Use the CompositeItem `focusable` prop over Button's
 						// isFocusable. The latter was shown to cause an issue
 						// with tab order in the inserter list.
-						focusables
+						focusable
 						{ ...props }
 					>
 						<span

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -8,60 +8,114 @@ import { CompositeItem } from 'reakit';
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
+import {
+	createBlock,
+	createBlocksFromInnerBlocksTemplate,
+} from '@wordpress/blocks';
+import { useMemo, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
+import InserterListItemDraggable from './draggable';
 
 function InserterListItem( {
-	icon,
-	onClick,
-	isDisabled,
-	title,
 	className,
 	composite,
+	item,
+	onSelect,
+	onHover,
 	...props
 } ) {
-	const itemIconStyle = icon
+	const isDragging = useRef( false );
+	const itemIconStyle = item.icon
 		? {
-				backgroundColor: icon.background,
-				color: icon.foreground,
+				backgroundColor: item.icon.background,
+				color: item.icon.foreground,
 		  }
 		: {};
+	const blocks = useMemo( () => {
+		return [
+			createBlock(
+				item.name,
+				item.initialAttributes,
+				createBlocksFromInnerBlocksTemplate( item.innerBlocks )
+			),
+		];
+	}, [ item.name, item.initialAttributes, item.initialAttributes ] );
 
 	return (
-		<div className="block-editor-block-types-list__list-item">
-			<CompositeItem
-				role="option"
-				as={ Button }
-				{ ...composite }
-				className={ classnames(
-					'block-editor-block-types-list__item',
-					className
-				) }
-				onClick={ ( event ) => {
-					event.preventDefault();
-					onClick();
-				} }
-				disabled={ isDisabled }
-				// Use the CompositeItem `focusable` prop over Button's
-				// isFocusable. The latter was shown to cause an issue
-				// with tab order in the inserter list.
-				focusable
-				{ ...props }
-			>
-				<span
-					className="block-editor-block-types-list__item-icon"
-					style={ itemIconStyle }
+		<InserterListItemDraggable
+			isEnabled={ ! item.disabled }
+			blocks={ blocks }
+			icon={ item.icon }
+		>
+			{ ( { draggable, onDragStart, onDragEnd } ) => (
+				<div
+					className="block-editor-block-types-list__list-item"
+					draggable={ draggable }
+					onDragStart={ ( event ) => {
+						isDragging.current = true;
+						if ( onDragStart ) {
+							onHover( null );
+							onDragStart( event );
+						}
+					} }
+					onDragEnd={ ( event ) => {
+						isDragging.current = false;
+						if ( onDragEnd ) {
+							onDragEnd( event );
+						}
+					} }
 				>
-					<BlockIcon icon={ icon } showColors />
-				</span>
-				<span className="block-editor-block-types-list__item-title">
-					{ title }
-				</span>
-			</CompositeItem>
-		</div>
+					<CompositeItem
+						role="option"
+						as={ Button }
+						{ ...composite }
+						className={ classnames(
+							'block-editor-block-types-list__item',
+							className
+						) }
+						disabled={ item.isDisabled }
+						onClick={ ( event ) => {
+							event.preventDefault();
+							onSelect( item );
+							onHover( null );
+						} }
+						onFocus={ () => {
+							if ( isDragging.current ) {
+								return;
+							}
+							onHover( item );
+						} }
+						onMouseEnter={ () => {
+							if ( isDragging.current ) {
+								return;
+							}
+							onHover( item );
+						} }
+						onMouseLeave={ () => onHover( null ) }
+						onBlur={ () => onHover( null ) }
+						// Use the CompositeItem `focusable` prop over Button's
+						// isFocusable. The latter was shown to cause an issue
+						// with tab order in the inserter list.
+						focusables
+						{ ...props }
+					>
+						<span
+							className="block-editor-block-types-list__item-icon"
+							style={ itemIconStyle }
+						>
+							<BlockIcon icon={ item.icon } showColors />
+						</span>
+						<span className="block-editor-block-types-list__item-title">
+							{ item.title }
+						</span>
+					</CompositeItem>
+				</div>
+			) }
+		</InserterListItemDraggable>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -26,6 +26,7 @@ function InserterListItem( {
 	item,
 	onSelect,
 	onHover,
+	isDraggable,
 	...props
 } ) {
 	const isDragging = useRef( false );
@@ -47,7 +48,7 @@ function InserterListItem( {
 
 	return (
 		<InserterListItemDraggable
-			isEnabled={ ! item.disabled }
+			isEnabled={ isDraggable && ! item.disabled }
 			blocks={ blocks }
 			icon={ item.icon }
 		>

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -62,6 +62,10 @@
 		transition: all 0.15s ease-out;
 		@include reduce-motion("transition");
 	}
+
+	.block-editor-block-types-list__list-item[draggable="true"] & {
+		cursor: grab;
+	}
 }
 
 .block-editor-block-types-list__item-title {

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -107,6 +107,7 @@ export default function QuickInserter( {
 					selectBlockOnInsert={ selectBlockOnInsert }
 					maxBlockPatterns={ showPatterns ? SHOWN_BLOCK_PATTERNS : 0 }
 					maxBlockTypes={ SHOWN_BLOCK_TYPES }
+					isDraggable={ false }
 				/>
 			</div>
 

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -36,6 +36,7 @@ function InserterSearchResults( {
 	maxBlockPatterns,
 	maxBlockTypes,
 	showBlockDirectory = false,
+	isDraggable = true,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
@@ -116,6 +117,7 @@ function InserterSearchResults( {
 						onSelect={ onSelectBlockType }
 						onHover={ onHover }
 						label={ __( 'Blocks' ) }
+						isDraggable={ isDraggable }
 					/>
 				</InserterPanel>
 			) }

--- a/packages/block-editor/src/components/inserter/test/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/test/block-types-tab.js
@@ -6,6 +6,7 @@ import { render, fireEvent } from '@testing-library/react';
 /**
  * WordPress dependencies
  */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -57,6 +58,20 @@ const initializeAllClosedMenuState = ( propOverrides ) => {
 };
 
 describe( 'InserterMenu', () => {
+	beforeAll( () => {
+		items.forEach( ( item ) => {
+			registerBlockType( item.name, {
+				save: () => {},
+				title: item.name,
+				edit: () => {},
+			} );
+		} );
+	} );
+	afterAll( () => {
+		items.forEach( ( item ) => {
+			unregisterBlockType( item.name );
+		} );
+	} );
 	beforeEach( () => {
 		debouncedSpeak.mockClear();
 

--- a/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
@@ -6,6 +6,7 @@ import { render, fireEvent } from '@testing-library/react';
 /**
  * WordPress dependencies
  */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -51,6 +52,16 @@ const initializeAllClosedMenuState = ( propOverrides ) => {
 };
 
 describe( 'InserterMenu', () => {
+	beforeAll( () => {
+		registerBlockType( 'core/block', {
+			save: () => {},
+			title: 'reusable block',
+			edit: () => {},
+		} );
+	} );
+	afterAll( () => {
+		unregisterBlockType( 'core/block' );
+	} );
 	beforeEach( () => {
 		debouncedSpeak.mockClear();
 

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -23,6 +23,7 @@ export function parseDropEvent( event ) {
 		srcClientIds: null,
 		srcIndex: null,
 		type: null,
+		blocks: null,
 	};
 
 	if ( ! event.dataTransfer ) {
@@ -49,7 +50,7 @@ export function parseDropEvent( event ) {
  * @param {Function} getBlockIndex             A function that gets the index of a block.
  * @param {Function} getClientIdsOfDescendants A function that gets the client ids of descendant blocks.
  * @param {Function} moveBlocksToPosition      A function that moves blocks.
- *
+ * @param {Function} insertBlocks              A function that inserts blocks.
  * @return {Function} The event handler for a block drop event.
  */
 export function onBlockDrop(
@@ -57,62 +58,67 @@ export function onBlockDrop(
 	targetBlockIndex,
 	getBlockIndex,
 	getClientIdsOfDescendants,
-	moveBlocksToPosition
+	moveBlocksToPosition,
+	insertBlocks
 ) {
 	return ( event ) => {
 		const {
 			srcRootClientId: sourceRootClientId,
 			srcClientIds: sourceClientIds,
 			type: dropType,
+			blocks,
 		} = parseDropEvent( event );
 
-		// If the user isn't dropping a block, return early.
-		if ( dropType !== 'block' ) {
-			return;
+		// If the user is inserting a block
+		if ( dropType === 'inserter' ) {
+			insertBlocks( blocks, targetBlockIndex, targetRootClientId, false );
 		}
 
-		const sourceBlockIndex = getBlockIndex(
-			sourceClientIds[ 0 ],
-			sourceRootClientId
-		);
+		// If the user is moving a block
+		if ( dropType === 'block' ) {
+			const sourceBlockIndex = getBlockIndex(
+				sourceClientIds[ 0 ],
+				sourceRootClientId
+			);
 
-		// If the user is dropping to the same position, return early.
-		if (
-			sourceRootClientId === targetRootClientId &&
-			sourceBlockIndex === targetBlockIndex
-		) {
-			return;
+			// If the user is dropping to the same position, return early.
+			if (
+				sourceRootClientId === targetRootClientId &&
+				sourceBlockIndex === targetBlockIndex
+			) {
+				return;
+			}
+
+			// If the user is attempting to drop a block within its own
+			// nested blocks, return early as this would create infinite
+			// recursion.
+			if (
+				sourceClientIds.includes( targetRootClientId ) ||
+				getClientIdsOfDescendants( sourceClientIds ).some(
+					( id ) => id === targetRootClientId
+				)
+			) {
+				return;
+			}
+
+			const isAtSameLevel = sourceRootClientId === targetRootClientId;
+			const draggedBlockCount = sourceClientIds.length;
+
+			// If the block is kept at the same level and moved downwards,
+			// subtract to take into account that the blocks being dragged
+			// were removed from the block list above the insertion point.
+			const insertIndex =
+				isAtSameLevel && sourceBlockIndex < targetBlockIndex
+					? targetBlockIndex - draggedBlockCount
+					: targetBlockIndex;
+
+			moveBlocksToPosition(
+				sourceClientIds,
+				sourceRootClientId,
+				targetRootClientId,
+				insertIndex
+			);
 		}
-
-		// If the user is attempting to drop a block within its own
-		// nested blocks, return early as this would create infinite
-		// recursion.
-		if (
-			sourceClientIds.includes( targetRootClientId ) ||
-			getClientIdsOfDescendants( sourceClientIds ).some(
-				( id ) => id === targetRootClientId
-			)
-		) {
-			return;
-		}
-
-		const isAtSameLevel = sourceRootClientId === targetRootClientId;
-		const draggedBlockCount = sourceClientIds.length;
-
-		// If the block is kept at the same level and moved downwards,
-		// subtract to take into account that the blocks being dragged
-		// were removed from the block list above the insertion point.
-		const insertIndex =
-			isAtSameLevel && sourceBlockIndex < targetBlockIndex
-				? targetBlockIndex - draggedBlockCount
-				: targetBlockIndex;
-
-		moveBlocksToPosition(
-			sourceClientIds,
-			sourceRootClientId,
-			targetRootClientId,
-			insertIndex
-		);
 	};
 }
 
@@ -217,7 +223,8 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 			targetBlockIndex,
 			getBlockIndex,
 			getClientIdsOfDescendants,
-			moveBlocksToPosition
+			moveBlocksToPosition,
+			insertBlocks
 		),
 		onFilesDrop: onFilesDrop(
 			targetRootClientId,

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -45,12 +45,13 @@ export function parseDropEvent( event ) {
 /**
  * A function that returns an event handler function for block drop events.
  *
- * @param {string}   targetRootClientId        The root client id where the block(s) will be inserted.
- * @param {number}   targetBlockIndex          The index where the block(s) will be inserted.
+ * @param {string} targetRootClientId        The root client id where the block(s) will be inserted.
+ * @param {number} targetBlockIndex          The index where the block(s) will be inserted.
  * @param {Function} getBlockIndex             A function that gets the index of a block.
  * @param {Function} getClientIdsOfDescendants A function that gets the client ids of descendant blocks.
  * @param {Function} moveBlocksToPosition      A function that moves blocks.
  * @param {Function} insertBlocks              A function that inserts blocks.
+ * @param {Function} clearSelectedBlock        A function that clears block selection.
  * @return {Function} The event handler for a block drop event.
  */
 export function onBlockDrop(
@@ -59,7 +60,8 @@ export function onBlockDrop(
 	getBlockIndex,
 	getClientIdsOfDescendants,
 	moveBlocksToPosition,
-	insertBlocks
+	insertBlocks,
+	clearSelectedBlock
 ) {
 	return ( event ) => {
 		const {
@@ -71,6 +73,7 @@ export function onBlockDrop(
 
 		// If the user is inserting a block
 		if ( dropType === 'inserter' ) {
+			clearSelectedBlock();
 			insertBlocks( blocks, targetBlockIndex, targetRootClientId, false );
 		}
 
@@ -215,6 +218,7 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 		insertBlocks,
 		moveBlocksToPosition,
 		updateBlockAttributes,
+		clearSelectedBlock,
 	} = useDispatch( 'core/block-editor' );
 
 	return {
@@ -224,7 +228,8 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 			getBlockIndex,
 			getClientIdsOfDescendants,
 			moveBlocksToPosition,
-			insertBlocks
+			insertBlocks,
+			clearSelectedBlock
 		),
 		onFilesDrop: onFilesDrop(
 			targetRootClientId,

--- a/packages/block-editor/src/components/use-on-block-drop/test/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/test/index.js
@@ -21,6 +21,7 @@ jest.mock( '@wordpress/blocks/src/api/raw-handling', () => ( {
 describe( 'parseDropEvent', () => {
 	it( 'converts an event dataTransfer property from JSON to an object', () => {
 		const rawDataTransfer = {
+			blocks: null,
 			srcRootClientId: '123',
 			srcClientIds: [ 'abc' ],
 			srcIndex: 1,
@@ -53,12 +54,14 @@ describe( 'parseDropEvent', () => {
 		expect( parseDropEvent( event ) ).toEqual( {
 			srcRootClientId: null,
 			srcIndex: null,
+			blocks: null,
 			...rawDataTransfer,
 		} );
 	} );
 
 	it( 'returns an object with null values if the event dataTransfer can not be parsed', () => {
 		const expected = {
+			blocks: null,
 			srcRootClientId: null,
 			srcClientIds: null,
 			srcIndex: null,
@@ -77,6 +80,7 @@ describe( 'parseDropEvent', () => {
 
 	it( 'returns an object with null values if the event has no dataTransfer property', () => {
 		const expected = {
+			blocks: null,
 			srcRootClientId: null,
 			srcClientIds: null,
 			srcIndex: null,


### PR DESCRIPTION
closes #1511 

This PR explores allowing users to drag blocks from the inserter (on the left) to the right position in the canvas.

 - Patterns are not supported yet
 - Scroll on drag hook is not applied too because it's specific to the canvas drag and drop interactions for now. (need a follow-upu)
