### PR TITLE
Remove CSS Custom Property in code block

### DIFF
--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -1,6 +1,6 @@
 // Provide a minimum of overflow handling.
 .wp-block-code {
-	font-size: var(--wp--preset--font-size--extra-small, 0.9em);
+	font-size: 0.9em;
 
 	code {
 		display: block;


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/27294 introduced the use of a CSS Custom Property to set the font size of the code block.

However, the property `--wp--preset--font-size--extra-small` is theme dependant, it doesn't exist unless a particular theme adds it. The mechanism for a theme to set the value of the font-size of a block is via theme.json:

```js
"core/code": {
  "styles": {
    "typography": {
      "fontSize": "var(--wp--preset--font-size--extra-small)"
    }
  }
}
```

This PR reverts that change.