### PR TITLE
Update the popover component to rely on useDialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13312,7 +13312,6 @@
 				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"clipboard": "^2.0.1",
 				"lodash": "^4.17.21",
-				"memize": "^1.1.0",
 				"mousetrap": "^1.6.5",
 				"react-resize-aware": "^3.1.0",
 				"use-memo-one": "^1.1.1"

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -520,6 +520,8 @@ const Popover = (
 				since: '5.3',
 				alternative: 'onFocusOutside',
 			} );
+
+			onClickOutside( clickEvent );
 		} else if ( onClose ) {
 			onClose();
 		}

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -483,9 +483,7 @@ const Popover = (
 	const onDialogClose = ( type, event ) => {
 		// Ideally the popover should have just a single onClose prop and
 		// not three props that potentially do the same thing.
-		if ( onClose ) {
-			onClose();
-		} else if ( type === 'focusoutside' && onFocusOutside ) {
+		if ( type === 'focusoutside' && onFocusOutside ) {
 			onFocusOutside( event );
 		} else if ( type === 'focusoutside' && onClickOutside ) {
 			// Simulate MouseEvent using FocusEvent#relatedTarget as emulated click
@@ -522,6 +520,8 @@ const Popover = (
 				since: '5.3',
 				alternative: 'onFocusOutside',
 			} );
+		} else if ( onClose ) {
+			onClose();
 		}
 	};
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -486,8 +486,7 @@ const Popover = (
 		if ( type === 'focus-outside' && onFocusOutside ) {
 			onFocusOutside( event );
 		} else if ( type === 'focus-outside' && onClickOutside ) {
-			// Simulate MouseEvent using FocusEvent#relatedTarget as emulated click
-			// target. MouseEvent constructor is unsupported in Internet Explorer.
+			// Simulate MouseEvent using FocusEvent#relatedTarget as emulated click target.
 			const clickEvent = new window.MouseEvent( 'click' );
 
 			Object.defineProperty( clickEvent, 'target', {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -483,34 +483,12 @@ const Popover = (
 	const onDialogClose = ( type, event ) => {
 		// Ideally the popover should have just a single onClose prop and
 		// not three props that potentially do the same thing.
-		if ( type === 'focusoutside' && onFocusOutside ) {
+		if ( type === 'focus-outside' && onFocusOutside ) {
 			onFocusOutside( event );
-		} else if ( type === 'focusoutside' && onClickOutside ) {
+		} else if ( type === 'focus-outside' && onClickOutside ) {
 			// Simulate MouseEvent using FocusEvent#relatedTarget as emulated click
 			// target. MouseEvent constructor is unsupported in Internet Explorer.
-			let clickEvent;
-			try {
-				clickEvent = new window.MouseEvent( 'click' );
-			} catch ( error ) {
-				clickEvent = document.createEvent( 'MouseEvent' );
-				clickEvent.initMouseEvent(
-					'click',
-					true,
-					true,
-					window,
-					0,
-					0,
-					0,
-					0,
-					0,
-					false,
-					false,
-					false,
-					false,
-					0,
-					null
-				);
-			}
+			const clickEvent = new window.MouseEvent( 'click' );
 
 			Object.defineProperty( clickEvent, 'target', {
 				get: () => event.relatedTarget,

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -15,29 +15,6 @@ describe( 'Popover', () => {
 		}
 	} );
 
-	it( 'should focus when opening in response to keyboard event', () => {
-		// As in the real world, these occur in sequence before the popover
-		// has been mounted. Keyup's resetting is deferred.
-		document.dispatchEvent( new window.KeyboardEvent( 'keydown' ) );
-		document.dispatchEvent( new window.KeyboardEvent( 'keyup' ) );
-
-		expect( document.activeElement ).toBe( document.body );
-
-		// An ideal test here would mount with an input child and focus the
-		// child, but in context of JSDOM the inputs are not visible and
-		// are therefore skipped as tabbable, defaulting to popover.
-		let result;
-		act( () => {
-			result = render( <Popover /> );
-
-			jest.advanceTimersByTime( 1 );
-		} );
-
-		expect( document.activeElement ).toBe(
-			result.container.querySelector( '.components-popover' )
-		);
-	} );
-
 	it( 'should allow focus-on-open behavior to be disabled', () => {
 		expect( document.activeElement ).toBe( document.body );
 

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -38,7 +38,6 @@
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"clipboard": "^2.0.1",
 		"lodash": "^4.17.21",
-		"memize": "^1.1.0",
 		"mousetrap": "^1.6.5",
 		"react-resize-aware": "^3.1.0",
 		"use-memo-one": "^1.1.1"

--- a/packages/compose/src/hooks/use-dialog/index.js
+++ b/packages/compose/src/hooks/use-dialog/index.js
@@ -55,9 +55,9 @@ function useDialog( options ) {
 
 	return [
 		useMergeRefs( [
-			constrainedTabbingRef,
-			focusReturnRef,
-			focusOnMountRef,
+			options.focusOnMount !== false ? constrainedTabbingRef : null,
+			options.focusOnMount !== false ? focusReturnRef : null,
+			options.focusOnMount !== false ? focusOnMountRef : null,
 			closeOnEscapeRef,
 		] ),
 		{

--- a/packages/compose/src/hooks/use-dialog/index.js
+++ b/packages/compose/src/hooks/use-dialog/index.js
@@ -26,7 +26,7 @@ function useDialog( options ) {
 	const currentOptions = useRef();
 	useEffect( () => {
 		currentOptions.current = options;
-	}, [ options.onClose ] );
+	}, Object.values( options ) );
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusOnMountRef = useFocusOnMount( options.focusOnMount );
 	const focusReturnRef = useFocusReturn();

--- a/packages/compose/src/hooks/use-dialog/index.js
+++ b/packages/compose/src/hooks/use-dialog/index.js
@@ -23,14 +23,22 @@ import useMergeRefs from '../use-merge-refs';
  * @param {Object} options Dialog Options.
  */
 function useDialog( options ) {
-	const onClose = useRef();
+	const currentOptions = useRef();
 	useEffect( () => {
-		onClose.current = options.onClose;
+		currentOptions.current = options;
 	}, [ options.onClose ] );
 	const constrainedTabbingRef = useConstrainedTabbing();
-	const focusOnMountRef = useFocusOnMount();
+	const focusOnMountRef = useFocusOnMount( options.focusOnMount );
 	const focusReturnRef = useFocusReturn();
-	const focusOutsideProps = useFocusOutside( options.onClose );
+	const focusOutsideProps = useFocusOutside( ( event ) => {
+		// This unstable prop  is here only to manage backward compatibility
+		// for the Popover component otherwise, the onClose should be enough.
+		if ( currentOptions.current.__unstableOnClose ) {
+			currentOptions.current.__unstableOnClose( 'focus-outside', event );
+		} else if ( currentOptions.current.onClose ) {
+			currentOptions.current.onClose();
+		}
+	} );
 	const closeOnEscapeRef = useCallback( ( node ) => {
 		if ( ! node ) {
 			return;
@@ -38,9 +46,9 @@ function useDialog( options ) {
 
 		node.addEventListener( 'keydown', ( event ) => {
 			// Close on escape
-			if ( event.keyCode === ESCAPE && onClose.current ) {
+			if ( event.keyCode === ESCAPE && currentOptions.current.onClose ) {
 				event.stopPropagation();
-				onClose.current();
+				currentOptions.current.onClose();
 			}
 		} );
 	}, [] );


### PR DESCRIPTION
Follow-up to #27643 

Updates the Popover component to rely on useDialog and remove the duplicated code. I noticed that we have three props in Popover to do the same thing (close the popover): onClickOutside,  onFocusOutside and onClose. Ideally we should deprecate the first two ones. The code to keep BC here is not straightforward. 