### PR TITLE
Fix footnote links broken when pasting from Word

### DIFF
--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -63,5 +63,10 @@ export default function phrasingContentReducer( node, doc ) {
 		}
 		// Remove name attribute in any case: the use of the name attribute in a elements is obsolete: https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features
 		node.removeAttribute( 'name' );
+
+		// Search for common footnote and endnote ID structure (Word, LibreOffice). If doesn't match, remove ID parameter.
+		if ( node.id && !/^_?(?:ftn|edn|sdfootnote|sdendnote)/i.test( node.id ) ) {
+			node.removeAttribute( 'id' );
+		}
 	}
 }

--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { wrap, replaceTag } from '@wordpress/dom';
+import { wrap, unwrap, replaceTag } from '@wordpress/dom';
 
 export default function phrasingContentReducer( node, doc ) {
 	// In jsdom-jscore, 'node.style' can be null.
@@ -56,17 +56,25 @@ export default function phrasingContentReducer( node, doc ) {
 			node.removeAttribute( 'target' );
 			node.removeAttribute( 'rel' );
 		}
-		
+
 		// Save anchor elements' name attribute as id
-		if ( node.name && !node.id ) {
+		if ( node.name && ! node.id ) {
 			node.id = node.name;
 		}
 		// Remove name attribute in any case: the use of the name attribute in a elements is obsolete: https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features
 		node.removeAttribute( 'name' );
 
 		// Search for common footnote and endnote ID structure (Word, LibreOffice). If doesn't match, remove ID parameter.
-		if ( node.id && !/^_?(?:ftn|edn|sdfootnote|sdendnote)/i.test( node.id ) ) {
+		if (
+			node.id &&
+			! /^_?(?:ftn|edn|sdfootnote|sdendnote)/i.test( node.id )
+		) {
 			node.removeAttribute( 'id' );
+		}
+
+		// Remove a tag if no link nor id
+		if ( ! node.id && ! node.href ) {
+			unwrap( node );
 		}
 	}
 }

--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -56,5 +56,12 @@ export default function phrasingContentReducer( node, doc ) {
 			node.removeAttribute( 'target' );
 			node.removeAttribute( 'rel' );
 		}
+		
+		// Save anchor elements' name attribute as id
+		if ( node.name && !node.id ) {
+			node.id = node.name;
+		}
+		// Remove name attribute in any case: the use of the name attribute in a elements is obsolete: https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features
+		node.removeAttribute( 'name' );
 	}
 }

--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -57,6 +57,7 @@ export default function phrasingContentReducer( node, doc ) {
 			node.removeAttribute( 'rel' );
 		}
 
+		// Handle footnote and endnote links
 		// Save anchor elements' name attribute as id
 		if ( node.name && ! node.id ) {
 			node.id = node.name;
@@ -64,7 +65,7 @@ export default function phrasingContentReducer( node, doc ) {
 		// Remove name attribute in any case: the use of the name attribute in a elements is obsolete: https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features
 		node.removeAttribute( 'name' );
 
-		// Search for common footnote and endnote ID structure (Word, LibreOffice). If doesn't match, remove ID parameter.
+		// Search for common footnote and endnote id structure (Word, LibreOffice). If doesn't match, remove id attribute.
 		if (
 			node.id &&
 			! /^_?(?:ftn|edn|sdfootnote|sdendnote)/i.test( node.id )
@@ -72,7 +73,7 @@ export default function phrasingContentReducer( node, doc ) {
 			node.removeAttribute( 'id' );
 		}
 
-		// Remove a tag if no link nor id
+		// Remove anchor tag if no href nor id
 		if ( ! node.id && ! node.href ) {
 			unwrap( node );
 		}

--- a/packages/blocks/src/api/raw-handling/readme.md
+++ b/packages/blocks/src/api/raw-handling/readme.md
@@ -4,23 +4,25 @@ This folder contains all paste specific logic (filters, converters, normalisers.
 
 ## Support table
 
-| Source           | Formatting | Headings | Lists | Image | Separator | Table |
-| ---------------- | ---------- | -------- | ----- | ----- | --------- | ----- |
-| Google Docs      | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     |
-| Apple Pages      | ✓          | ✘ [1]    | ✓     | ✘ [1] | n/a       | ✓     |
-| MS Word          | ✓          | ✓        | ✓     | ✘ [2] | n/a       | ✓     |
-| MS Word Online   | ✓          | ✘ [3]    | ✓     | ✓     | n/a       | ✓     |
-| Evernote         | ✓          | ✘ [4]    | ✓     | ✓     | ✓         | ✓     |
-| Markdown         | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     |
-| Legacy WordPress | ✓          | ✓        | ✓     | … [5] | ✓         | ✓     |
-| Web              | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     |
+| Source           | Formatting | Headings | Lists | Image | Separator | Table | Footnotes, endnotes |
+| ---------------- | ---------- | -------- | ----- | ----- | --------- | ----- | ------------------- |
+| Google Docs      | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | ✘ [1]               |
+| Apple Pages      | ✓          | ✘ [2]    | ✓     | ✘ [2] | n/a       | ✓     | ✘ [1]               |
+| MS Word          | ✓          | ✓        | ✓     | ✘ [3] | n/a       | ✓     | ✓                   |
+| MS Word Online   | ✓          | ✘ [4]    | ✓     | ✓     | n/a       | ✓     | ✘ [1]               |
+| LibreOffice      | ✓          | ✓        | ✓     | ✘ [3] | ✓         | ✓     | ✓                   |
+| Evernote         | ✓          | ✘ [5]    | ✓     | ✓     | ✓         | ✓     | n/a                 |
+| Markdown         | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | n/a                 |
+| Legacy WordPress | ✓          | ✓        | ✓     | … [6] | ✓         | ✓     | n/a                 |
+| Web              | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | n/a                 |
 
 
-1. Apple Pages does not pass heading and image information.
-2. MS Word only provides a local file path, which cannot be accessed in JavaScript for security reasons. Image placeholders will be provided instead. Single images, however, _can_ be copied and pasted without any problem.
-3. Still to do for MS Word Online.
-4. Evernote does not have headings.
-5. For caption and gallery shortcodes, see #2874.
+1. Google Docs, Apple Pages and MS Word online don't pass footnote nor endnote information.
+2. Apple Pages does not pass heading and image information.
+3. MS Word and LibreOffice only provide a local file path, which cannot be accessed in JavaScript for security reasons. Image placeholders will be provided instead. Single images, however, _can_ be copied and pasted without any problem.
+4. Still to do for MS Word Online.
+5. Evernote does not have headings.
+6. For caption and gallery shortcodes, see #2874.
 
 ## Other notable capabilities
 

--- a/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
@@ -78,4 +78,23 @@ describe( 'phrasingContentReducer', () => {
 			deepFilterHTML( input, [ phrasingContentReducer ], {} )
 		).toEqual( output );
 	} );
+
+	it( 'should remove name attribute in links', () => {
+		const input =
+			'<a href="#ftn_1" id="_ftnref1" name="_ftnref1">footnote link</a>';
+		const output = '<a href="#ftn_1" id="_ftnref1">footnote link</a>';
+		expect(
+			deepFilterHTML( input, [ phrasingContentReducer ], {} )
+		).toEqual( output );
+	} );
+
+	it( 'should remove links with id but without href that are not footnotes nor endnotes', () => {
+		const input =
+			'<a id="#randomId">link with random id</a>, <a href="#ftn_1" id="_ftnref1">footnote link</a>';
+		const output =
+			'link with random id, <a href="#ftn_1" id="_ftnref1">footnote link</a>';
+		expect(
+			deepFilterHTML( input, [ phrasingContentReducer ], {} )
+		).toEqual( output );
+	} );
 } );

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -20,7 +20,7 @@ const textContentSchema = {
 	s: {},
 	del: {},
 	ins: {},
-	a: { attributes: [ 'href', 'target', 'rel' ] },
+	a: { attributes: [ 'href', 'target', 'rel', 'name' ] },
 	code: {},
 	abbr: { attributes: [ 'title' ] },
 	sub: {},

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -20,7 +20,7 @@ const textContentSchema = {
 	s: {},
 	del: {},
 	ins: {},
-	a: { attributes: [ 'href', 'target', 'rel', 'name' ] },
+	a: { attributes: [ 'href', 'target', 'rel', 'id' ] },
 	code: {},
 	abbr: { attributes: [ 'title' ] },
 	sub: {},

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -20,7 +20,7 @@ const textContentSchema = {
 	s: {},
 	del: {},
 	ins: {},
-	a: { attributes: [ 'href', 'target', 'rel', 'id' ] },
+	a: { attributes: [ 'href', 'target', 'rel', 'id', 'name' ] },
 	code: {},
 	abbr: { attributes: [ 'title' ] },
 	sub: {},

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -20,7 +20,7 @@ const textContentSchema = {
 	s: {},
 	del: {},
 	ins: {},
-	a: { attributes: [ 'href', 'target', 'rel', 'id', 'name' ] },
+	a: { attributes: [ 'href', 'target', 'rel', 'id', 'name' ] }, // id and name needed for pasting footnotes and endnotes, see /packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
 	code: {},
 	abbr: { attributes: [ 'title' ] },
 	sub: {},


### PR DESCRIPTION
By adding 'name' to allowed attributes for 'a' elements
Fixes #12784

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
When copying text with footnotes, Word links footnote numbers and footnotes to each other with anchors that make use of the `name` attribute, as explained [here](https://stigmortenmyre.no/mso/html/word/wdconfootnotesandendnotes.htm). The file I edited, phrasing-content.js, was removing all attributes that were not in that array, including `name`, so I just added `, 'name'` to it. This solves the issue.

It's maybe worth noting though that the use of the `name` attribute for `a` elements [is obsolete in HTML5](https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features); use of `id` is recommended instead. [W3C Markup Validator](https://validator.w3.org/) also shows a warning. An alternate solution would therefore be to save the content of the `name` attribute as the element's `id`. Maybe this is just overcomplicating things, though.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested on a WordPress 5.5.3 installation.
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md --> (Not sure about this)
