### PR TITLE
Search block: use em values for padding

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -3,7 +3,7 @@
 	.wp-block-search__button {
 		background: #f7f7f7;
 		border: 1px solid #ccc;
-		padding: 6px 10px;
+		padding: 0.375em 0.625em;
 		color: #32373c;
 		margin-left: 0.625em;
 		word-break: normal;


### PR DESCRIPTION
All blocks use em values for paddings, font-sizes etc. This PR changes the padding of our search-block to use `em` instead of `px` values for consistency.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
