### PR TITLE
Template-part padding: use variables

### DIFF
--- a/packages/block-library/src/template-part/theme.scss
+++ b/packages/block-library/src/template-part/theme.scss
@@ -2,8 +2,7 @@
 .wp-block-template-part {
 	&.has-background {
 		// Matches paragraph Block padding
-		// Todo: normalise with variables
-		padding: 20px 30px;
+		padding: $block-bg-padding--v $block-bg-padding--h;
 		margin-top: 0;
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
Changes the template-part block to use the same padding as paragraph blocks (as documented inline in the scss file).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
