### PR TITLE
Ref merging: fix memory leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,30 +1155,6 @@
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
-		"@babel/polyfill": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-			"integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.4"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-					"dev": true
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
-			}
-		},
 		"@babel/preset-env": {
 			"version": "7.12.7",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.7.tgz",
@@ -13371,7 +13347,6 @@
 				"moment": "^2.22.1",
 				"re-resizable": "^6.4.0",
 				"react-dates": "^17.1.1",
-				"react-merge-refs": "^1.0.0",
 				"react-resize-aware": "^3.0.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.15",
@@ -13394,6 +13369,7 @@
 				"clipboard": "^2.0.1",
 				"lodash": "^4.17.19",
 				"mousetrap": "^1.6.5",
+				"react-merge-refs": "^1.0.0",
 				"react-resize-aware": "^3.0.1",
 				"use-memo-one": "^1.1.1"
 			}
@@ -14832,6 +14808,33 @@
 						"clone": "^1.0.2",
 						"deep-eql": "^0.1.3",
 						"keypather": "^1.10.2"
+					}
+				},
+				"@babel/polyfill": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.4.tgz",
+					"integrity": "sha512-8BYcnVqQ5kMD2HXoHInBH7H1b/uP3KdnwCYXOqFnXqguOyuu443WXusbIUbWEfY3Z0Txk0M1uG/8YuAMhNl6zg==",
+					"dev": true,
+					"requires": {
+						"core-js": "^2.6.5",
+						"regenerator-runtime": "^0.13.4"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.6.11",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+							"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+							"dev": true
+						}
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+					"integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
 					}
 				},
 				"@dabh/diagnostics": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,6 @@
 		"moment": "^2.22.1",
 		"re-resizable": "^6.4.0",
 		"react-dates": "^17.1.1",
-		"react-merge-refs": "^1.0.0",
 		"react-resize-aware": "^3.0.1",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import mergeRefs from 'react-merge-refs';
 
 /**
  * WordPress dependencies
@@ -14,6 +13,7 @@ import {
 	useFocusReturn,
 	useFocusOnMount,
 	useConstrainedTabbing,
+	useMergeRefs,
 } from '@wordpress/compose';
 
 /**
@@ -47,6 +47,11 @@ function ModalFrameContent( {
 	);
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
+	const mergedRefs = useMergeRefs(
+		focusOnMountRef,
+		constrainedTabbingRef,
+		focusReturnRef
+	);
 
 	return (
 		<IsolatedEventContainer
@@ -59,11 +64,7 @@ function ModalFrameContent( {
 			<div
 				className={ classnames( 'components-modal__frame', className ) }
 				style={ style }
-				ref={ mergeRefs( [
-					focusOnMountRef,
-					constrainedTabbingRef,
-					focusReturnRef,
-				] ) }
+				ref={ mergedRefs }
 				role={ role }
 				aria-label={ contentLabel }
 				aria-labelledby={ contentLabel ? null : labelledby }

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -3,12 +3,11 @@
  */
 import classnames from 'classnames';
 import { noop } from 'lodash';
-import mergeRefs from 'react-merge-refs';
 
 /**
  * WordPress dependencies
  */
-import { useReducedMotion } from '@wordpress/compose';
+import { useReducedMotion, useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useRef } from '@wordpress/element';
 import { chevronUp, chevronDown } from '@wordpress/icons';
 
@@ -36,6 +35,7 @@ export function PanelBody(
 		initial: initialOpen === undefined ? true : initialOpen,
 	} );
 	const nodeRef = useRef();
+	const mergedRefs = useMergeRefs( nodeRef, ref );
 
 	// Defaults to 'smooth' scrolling
 	// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
@@ -76,7 +76,7 @@ export function PanelBody(
 	} );
 
 	return (
-		<div className={ classes } ref={ mergeRefs( [ nodeRef, ref ] ) }>
+		<div className={ classes } ref={ mergedRefs }>
 			<PanelBodyTitle
 				icon={ icon }
 				isOpened={ isOpened }

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import mergeRefs from 'react-merge-refs';
 
 /**
  * WordPress dependencies
@@ -15,6 +14,7 @@ import {
 	useViewportMatch,
 	useResizeObserver,
 	useFocusOnMount,
+	useMergeRefs,
 } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
 
@@ -418,6 +418,7 @@ const Popover = ( {
 	] );
 
 	const focusOnMountRef = useFocusOnMount( focusOnMount );
+	const mergedRefs = useMergeRefs( contentRef, focusOnMountRef );
 
 	// Event handlers
 	const maybeClose = ( event ) => {
@@ -532,7 +533,7 @@ const Popover = ( {
 					</div>
 				) }
 				<div
-					ref={ mergeRefs( [ contentRef, focusOnMountRef ] ) }
+					ref={ mergedRefs }
 					className="components-popover__content"
 					tabIndex="-1"
 				>

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -276,6 +276,19 @@ _Returns_
 
 -   `boolean`: return value of the media query.
 
+<a name="useMergeRefs" href="#useMergeRefs">#</a> **useMergeRefs**
+
+Merges the given refs into a new ref, which will persist for the full
+lifetime of the component, as a ref should be.
+
+_Parameters_
+
+-   _refs_ `...(RefObject|Function)`: Ref objects or callbacks to merge.
+
+_Returns_
+
+-   `Function`: A new ref callback.
+
 <a name="usePrevious" href="#usePrevious">#</a> **usePrevious**
 
 Use something's value from the previous render.

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -35,6 +35,7 @@
 		"clipboard": "^2.0.1",
 		"lodash": "^4.17.19",
 		"mousetrap": "^1.6.5",
+		"react-merge-refs": "^1.0.0",
 		"react-resize-aware": "^3.0.1",
 		"use-memo-one": "^1.1.1"
 	},

--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -27,10 +27,11 @@ import { focus } from '@wordpress/dom';
  * ```
  */
 function useConstrainedTabbing() {
-	const ref = useCallback( ( node ) => {
+	return useCallback( ( node ) => {
 		if ( ! node ) {
 			return;
 		}
+
 		node.addEventListener( 'keydown', ( event ) => {
 			if ( event.keyCode !== TAB ) {
 				return;
@@ -59,8 +60,6 @@ function useConstrainedTabbing() {
 			}
 		} );
 	}, [] );
-
-	return ref;
 }
 
 export default useConstrainedTabbing;

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import mergeRefs from 'react-merge-refs';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/** @typedef {import('@wordpress/element').RefObject} RefObject */
+
+/**
+ * Merges the given refs into a new ref, which will persist for the full
+ * lifetime of the component, as a ref should be.
+ *
+ * @param  {...RefObject|Function} refs Ref objects or callbacks to merge.
+ *
+ * @return {Function} A new ref callback.
+ */
+export default function useMergeRefs( ...refs ) {
+	return useCallback( mergeRefs( refs ), [] );
+}

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -11,6 +11,14 @@ import { useCallback } from '@wordpress/element';
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
 /**
+ * A ref should persist throughout a component's lifecycle, so it should not
+ * have any dependencies. If dependencies are needed in a ref callback, assign
+ * them to refs with `useRef` and use the ref in the callback or use
+ * `useEffect`.
+ */
+const DEPENDENCIES = [];
+
+/**
  * Merges the given refs into a new ref, which will persist for the full
  * lifetime of the component, as a ref should be.
  *
@@ -19,5 +27,5 @@ import { useCallback } from '@wordpress/element';
  * @return {Function} A new ref callback.
  */
 export default function useMergeRefs( ...refs ) {
-	return useCallback( mergeRefs( refs ), [] );
+	return useCallback( mergeRefs( refs ), DEPENDENCIES );
 }

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -30,3 +30,4 @@ export { default as useAsyncList } from './hooks/use-async-list';
 export { default as useWarnOnChange } from './hooks/use-warn-on-change';
 export { default as useDebounce } from './hooks/use-debounce';
 export { default as useThrottle } from './hooks/use-throttle';
+export { default as useMergeRefs } from './hooks/use-merge-refs';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Currently, in `useConstrainedTabbing` (and probably other hooks returning a ref), code is executed multiple times on the same node. In `useConstrainedTabbing` this results in event listeners being added multiple times.

It's assumed that a ref callback will only be called when the node changes or the component unmounts, but that's not the case if callbacks are merged with `mergeRefs` and directly passed as the ref. `mergeRefs` returns a new function on every render, while it should return a persistent callback.

## How has this been tested?

In `master`, log the `node` right before `node.addEventListener` in the `useConstrainedTabbing` hook. Open the editor, then "Options" in the top right corner and then click "Preferences" to open a modal. Observe that the modal node is logged twice, which means the event listener is added twice.

Now check out this branch and follow the steps again. The modal node will only be logged once.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
