### PR TITLE
Use clientWidth when no width is available for cropper

### DIFF
--- a/packages/block-library/src/image/image-editing/cropper.js
+++ b/packages/block-library/src/image/image-editing/cropper.js
@@ -48,7 +48,7 @@ export default function ImageCropper( {
 				'is-applying': isInProgress,
 			} ) }
 			style={ {
-				width,
+				width: width || clientWidth,
 				height: editedHeight,
 			} }
 		>


### PR DESCRIPTION
Fixes #27145

When the image has an align property the crop container's width becomes zero. When the image is having a set width the crop container inherits it, but when it has no width, the crop container is 100% of zero, because of the float, so it results in a zero width.

With this small change, we make the crop container always have at least the clientWidth value.