### PR TITLE
Fix for bug  #21989, #21650

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -281,7 +281,7 @@ function GalleryEdit( props ) {
 			};
 		} );
 
-		setAttributes( { images: updatedImages, newSizeSlug } );
+		setAttributes( { images: updatedImages, sizeSlug: newSizeSlug } );
 	}
 
 	useEffect( () => {


### PR DESCRIPTION
### Related PR:

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2897

I found a bug in gallery block and I've fixed it. The bug is following: when adding images to gallery block and changing image size via inspector panel from drop down menu box, the content of the box does not get updated (it is always 'large'). It is a bug - wrong property is used for setting sizeSlug on change (see my proposed replacement in line 284).

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
sizeSlug: newSizeSlug was added in setAttributes call. Previously it was just newSizeSlug, which means newSizeSlug:newSizeSlug, which is erroneous and does not change sizeSlug attribute

## How has this been tested?
Teste on local environment - WAMP stack
Tests showed that now block appears to work OK.
Change does not affect other code

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix 
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
