### PR TITLE
RN: Fixes rel link stickiness issue

### DIFF
--- a/packages/components/src/mobile/link-settings/index.native.js
+++ b/packages/components/src/mobile/link-settings/index.native.js
@@ -158,10 +158,10 @@ function LinkSettings( {
 	function onChangeOpenInNewTab( value ) {
 		const newLinkTarget = value ? '_blank' : undefined;
 
-		let updatedRel = rel;
-		if ( newLinkTarget && ! rel ) {
+		let updatedRel = linkRelInputValue;
+		if ( newLinkTarget && ! linkRelInputValue ) {
 			updatedRel = NEW_TAB_REL;
-		} else if ( ! newLinkTarget && rel === NEW_TAB_REL ) {
+		} else if ( ! newLinkTarget && linkRelInputValue === NEW_TAB_REL ) {
 			updatedRel = undefined;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2879

## Description
Currently when you go and modify the rel link text of the button component and toggle the "Open in new tab" toggle the text either gets completely removed or overwritten by the text "noreferrer noopener" which is not expected for me. 

This PR fixes it so that it works more like expected.

This PR fixes this my using the most up to date value of the "Rel" input instead of the one that exists when the "Link Setting" are shown.

## How has this been tested?
I tested this in the demo app. 

## Screenshots <!-- if applicable -->
https://cloudup.com/cNHD2ns__oK

## Types of changes
Bug fix. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
