### PR TITLE
Fix for: [Interface Skeleton] Limit the editor width to prevent some blocks to grow infinitely wide

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -37,6 +37,7 @@ html.interface-interface-skeleton__html-container {
 	display: flex;
 	flex-direction: column;
 	flex: 0 1 100%;
+	overflow: hidden;
 }
 
 @include editor-left(".interface-interface-skeleton");


### PR DESCRIPTION
Fixes #27622. Another try to prevent interface from overflowing browser window when Jetpack Slideshow block is used.

## Description
```css
.interface-interface-skeleton__editor {
        ...
	flex: 0 1 100%; 
        overflow: hidden; /* <- added */
}
```
When a large non-breaking element (width>100% of its container) is placed inside of a flex element, by default flex element grows beyond 100% trying to become as large as the content, even ignoring `flex-grow:0`. _I think_ there is some kind of inifine loop created by Swiper code (used in Jetpack Slideshow) and browser flex layout logic: Swiper tries to take all available space => flex element grows to embrace the content. `overflow: hidden;`  breaks the loop.

## How has this been tested?
Tested according to steps from #27622 
* Chrome (latest), Firefox (latest), Opera (latest), IE11 on Windows 10

Also checked that the solution works well with the Full Site Editing drawer.

Latest Jetpack Slideshow doesn't work in IE11. In IE11 I tested with jetpack 8.5 (it seems to be the last working version in IE11)
Can be downloaded here https://wordpress.org/plugins/jetpack/advanced/ (bottom of the page)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
