### PR TITLE
Refactor focus on mount

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -60,6 +60,7 @@
 		"lodash": "^4.17.19",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
+		"react-merge-refs": "^1.0.0",
 		"react-spring": "^8.0.19",
 		"reakit": "1.1.0",
 		"redux-multi": "^0.1.12",

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -19,6 +19,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { keyboardReturn } from '@wordpress/icons';
+import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ const InsertFromURLPopover = ( { src, onChange, onSubmit, onClose } ) => (
 			onSubmit={ onSubmit }
 		>
 			<input
+				ref={ useFocusOnMount() }
 				className="block-editor-media-placeholder__url-input-field"
 				type="url"
 				aria-label={ __( 'URL' ) }

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -4,6 +4,7 @@
 import { debounce, isFunction } from 'lodash';
 import classnames from 'classnames';
 import scrollIntoView from 'dom-scroll-into-view';
+import mergeRefs from 'react-merge-refs';
 
 /**
  * WordPress dependencies
@@ -18,7 +19,12 @@ import {
 	withSpokenMessages,
 	Popover,
 } from '@wordpress/components';
-import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
+import {
+	withInstanceId,
+	withSafeTimeout,
+	compose,
+	useFocusOnMount,
+} from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { isURL } from '@wordpress/url';
 
@@ -392,6 +398,7 @@ class URLInput extends Component {
 			placeholder = __( 'Paste URL or type to search' ),
 			__experimentalRenderControl: renderControl,
 			value = '',
+			forwardedRef,
 		} = this.props;
 
 		const {
@@ -428,7 +435,7 @@ class URLInput extends Component {
 				selectedSuggestion !== null
 					? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
 					: undefined,
-			ref: this.inputRef,
+			ref: mergeRefs( [ this.inputRef, forwardedRef ] ),
 		};
 
 		if ( renderControl ) {
@@ -537,10 +544,7 @@ class URLInput extends Component {
 	}
 }
 
-/**
- * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-input/README.md
- */
-export default compose(
+const ComposedURLInput = compose(
 	withSafeTimeout,
 	withSpokenMessages,
 	withInstanceId,
@@ -557,3 +561,13 @@ export default compose(
 		};
 	} )
 )( URLInput );
+
+function URLInputWithFocusOnMount( props ) {
+	const ref = useFocusOnMount();
+	return <ComposedURLInput { ...props } forwardedRef={ ref } />;
+}
+
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-input/README.md
+ */
+export default URLInputWithFocusOnMount;

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -17,7 +17,7 @@ function URLPopover( {
 	children,
 	renderSettings,
 	position = 'bottom center',
-	focusOnMount = 'firstElement',
+	focusOnMount,
 	...popoverProps
 } ) {
 	const [ isSettingsExpanded, setIsSettingsExpanded ] = useState( false );

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -42,9 +42,7 @@ function ModalFrameContent( {
 			}
 		}
 	}
-	const focusOnMountRef = useFocusOnMount(
-		focusOnMount ? 'container' : false
-	);
+	const focusOnMountRef = useFocusOnMount( focusOnMount );
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -56,13 +56,13 @@ The component accepts the following props. Props not included in this set will b
 
 ### focusOnMount
 
-By default, the *first tabblable element* in the popover will receive focus when it mounts. This is the same as setting `focusOnMount` to `"firstElement"`. If you want to focus the container instead, you can set `focusOnMount` to `"container"`.
+By default, the the popover container will receive focus when it mounts. 
 
 Set this prop to `false` to disable focus changing entirely. This should only be set when an appropriately accessible substitute behavior exists.
 
-- Type: `String` or `Boolean`
+- Type: `Boolean`
 - Required: No
-- Default: `"firstElement"`
+- Default: `true`
 
 ### position
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -212,7 +212,7 @@ const Popover = ( {
 	/* eslint-disable no-unused-vars */
 	position = 'bottom right',
 	range,
-	focusOnMount = 'firstElement',
+	focusOnMount = true,
 	anchorRef,
 	shouldAnchorIncludePadding,
 	anchorRect,

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 
 /**
  * WordPress dependencies
@@ -21,21 +21,12 @@ export const _default = () => {
 	const show = boolean( 'Example: Show', true );
 	const children = text( 'children', 'Popover Content' );
 	const animate = boolean( 'animate', false );
-	const focusOnMount = select(
-		'focusOnMount',
-		{
-			firstElement: 'firstElement',
-			container: 'container',
-		},
-		'firstElement'
-	);
 	const noArrow = boolean( 'noArrow', false );
 	const isAlternate = boolean( 'isAlternate', false );
 
 	const props = {
 		animate,
 		children,
-		focusOnMount,
 		noArrow,
 		isAlternate,
 	};

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -188,7 +188,7 @@ _Returns_
 
 <a name="useFocusOnMount" href="#useFocusOnMount">#</a> **useFocusOnMount**
 
-Hook used to focus the first tabbable element on mount.
+Hook used to focus the element on mount.
 
 _Usage_
 
@@ -198,21 +198,18 @@ import { useFocusOnMount } from '@wordpress/compose';
 const WithFocusOnMount = () => {
     const ref = useFocusOnMount()
     return (
-        <div ref={ ref }>
-            <Button />
-            <Button />
-        </div>
+        <div tabIndex="-1" ref={ ref }></div>
     );
 }
 ```
 
 _Parameters_
 
--   _focusOnMount_ `(boolean|string)`: Focus on mount mode.
+-   _focusOnMount_ `boolean`: Whether to set focus on mount.
 
 _Returns_
 
--   `(Function|Object)`: Element Ref.
+-   `(Function|undefined)`: Ref callback.
 
 <a name="useFocusReturn" href="#useFocusReturn">#</a> **useFocusReturn**
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withSpokenMessages, Popover } from '@wordpress/components';
 import { prependHTTP } from '@wordpress/url';
@@ -125,14 +125,9 @@ function InlineLinkUI( {
 
 	const anchorRef = useAnchorRef( { ref: contentRef, value, settings } );
 
-	// The focusOnMount prop shouldn't evolve during render of a Popover
-	// otherwise it causes a render of the content.
-	const focusOnMount = useRef( addingLink ? 'firstElement' : false );
-
 	return (
 		<Popover
 			anchorRef={ anchorRef }
-			focusOnMount={ focusOnMount.current }
 			onClose={ stopAddingLink }
 			position="bottom center"
 		>

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -44,7 +44,6 @@ export function DotTip( {
 			className="nux-dot-tip"
 			position={ position }
 			noArrow
-			focusOnMount="container"
 			shouldAnchorIncludePadding
 			role="dialog"
 			aria-label={ __( 'Editor tips' ) }

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -4,7 +4,6 @@ exports[`DotTip should render correctly 1`] = `
 <Popover
   aria-label="Editor tips"
   className="nux-dot-tip"
-  focusOnMount="container"
   noArrow={true}
   onClick={[Function]}
   onFocusOutside={[Function]}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Currently we have a setting on `Popover` and similar components to focus the first element on mount. For this, some DOM querying is required and a timeout because the child nodes are not immediately available.

This is all unnecessary if the component that needs to be focussed takes care of that itself. In the whole codebase, it's only needed for the URL input in various popovers for different components.

I've change `focusOnMount` on `Popover` to accept a boolean value.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
