### PR TITLE
Popover/Modal: remove and deprecate IsolatedEventContainer

### DIFF
--- a/packages/components/src/isolated-event-container/README.md
+++ b/packages/components/src/isolated-event-container/README.md
@@ -1,5 +1,7 @@
 # Isolated Event Container
 
+**Deprecated**
+
 This is a container that prevents certain events from propagating outside of the container. This is used to wrap
 UI elements such as modals and popovers where the propagated event can cause problems. The event continues to work
 inside the component.

--- a/packages/components/src/isolated-event-container/index.js
+++ b/packages/components/src/isolated-event-container/index.js
@@ -2,12 +2,15 @@
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 function stopPropagation( event ) {
 	event.stopPropagation();
 }
 
 export default forwardRef( ( { children, ...props }, ref ) => {
+	deprecated( 'wp.components.IsolatedEventContainer' );
+
 	// Disable reason: this stops certain events from propagating outside of the component.
 	//   - onMouseDown is disabled as this can cause interactions with other DOM elements
 	/* eslint-disable jsx-a11y/no-static-element-interactions */

--- a/packages/components/src/isolated-event-container/test/index.js
+++ b/packages/components/src/isolated-event-container/test/index.js
@@ -16,6 +16,7 @@ describe( 'IsolatedEventContainer', () => {
 
 		expect( isolated.hasClass( 'test' ) ).toBe( true );
 		expect( isolated.prop( 'onClick' ) ).toBe( 'click' );
+		expect( console ).toHaveWarned();
 	} );
 
 	it( 'should stop mousedown event propagation', () => {

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -19,7 +19,6 @@ import {
 /**
  * Internal dependencies
  */
-import IsolatedEventContainer from '../isolated-event-container';
 import withFocusOutside from '../higher-order/with-focus-outside';
 
 function ModalFrameContent( {
@@ -49,7 +48,8 @@ function ModalFrameContent( {
 	const focusReturnRef = useFocusReturn();
 
 	return (
-		<IsolatedEventContainer
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
 			className={ classnames(
 				'components-modal__screen-overlay',
 				overlayClassName
@@ -72,7 +72,7 @@ function ModalFrameContent( {
 			>
 				{ children }
 			</div>
-		</IsolatedEventContainer>
+		</div>
 	);
 }
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -27,7 +27,6 @@ import withFocusReturn from '../higher-order/with-focus-return';
 import withConstrainedTabbing from '../higher-order/with-constrained-tabbing';
 import Button from '../button';
 import ScrollLock from '../scroll-lock';
-import IsolatedEventContainer from '../isolated-event-container';
 import { Slot, Fill, useSlot } from '../slot-fill';
 import { getAnimateClassName } from '../animate';
 
@@ -503,7 +502,9 @@ const Popover = ( {
 	// within popover as inferring close intent.
 
 	let content = (
-		<IsolatedEventContainer
+		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
 			className={ classnames(
 				'components-popover',
 				className,
@@ -539,7 +540,7 @@ const Popover = ( {
 					{ children }
 				</div>
 			</div>
-		</IsolatedEventContainer>
+		</div>
 	);
 
 	// Apply focus to element as long as focusOnMount is truthy; false is


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Originally added in #11753.

This fix is no longer necessary.

* Writing flow related logic should only listen for events in the DOM subtree, not the React subtree. This was fixed in #27489.
* Multi selection now works differently, based on selection instead of mouse events.

I think we should deprecate this component. Not sure why it was made a public API.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
