### PR TITLE
Try: simplify focus return

### DIFF
--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -41,10 +41,20 @@ function useFocusReturn( onFocusReturn ) {
 	}, [ onFocusReturn ] );
 
 	return useCallbackRef( ( node ) => {
-		if ( ! node ) {
-			const isFocused =
-				ref.current &&
-				ref.current.contains( ref.current.ownerDocument.activeElement );
+		if ( node ) {
+			// Set ref to be used when unmounting.
+			ref.current = node;
+
+			// Only set when the node mounts.
+			if ( focusedBeforeMount.current ) {
+				return;
+			}
+
+			focusedBeforeMount.current = node.ownerDocument.activeElement;
+		} else if ( focusedBeforeMount.current ) {
+			const isFocused = ref.current.contains(
+				ref.current.ownerDocument.activeElement
+			);
 
 			if ( ! isFocused ) {
 				return;
@@ -59,17 +69,7 @@ function useFocusReturn( onFocusReturn ) {
 			} else {
 				focusedBeforeMount.current.focus();
 			}
-
-			return;
 		}
-
-		ref.current = node;
-
-		if ( focusedBeforeMount.current ) {
-			return;
-		}
-
-		focusedBeforeMount.current = node.ownerDocument.activeElement;
 	}, [] );
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

The focus event listener seems unnecessary to me because at the time of a component unmounting, we can check the active element.

The behaviour should be exactly the same otherwise.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
