### PR TITLE
Popover: use a11y hooks instead of HoCs

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -425,7 +425,7 @@ const Popover = ( {
 	const allRefs = [
 		containerRef,
 		focusOnMount ? constrainedTabbingRef : null,
-		focusReturnRef,
+		focusOnMount ? focusReturnRef : null,
 		focusOnMountRef,
 	];
 	const mergedRefs = useCallback( mergeRefs( allRefs ), allRefs );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -424,7 +424,7 @@ const Popover = ( {
 	const focusOutsideProps = useFocusOutside( handleOnFocusOutside );
 	const allRefs = [
 		containerRef,
-		constrainedTabbingRef,
+		focusOnMount ? constrainedTabbingRef : null,
 		focusReturnRef,
 		focusOnMountRef,
 	];

--- a/packages/components/src/popover/test/__snapshots__/index.js.snap
+++ b/packages/components/src/popover/test/__snapshots__/index.js.snap
@@ -3,26 +3,20 @@
 exports[`Popover should pass additional props to portaled element 1`] = `
 <span>
   <div
+    class="components-popover components-animate__appear is-from-top is-from-left is-without-arrow"
+    data-x-axis="right"
+    data-y-axis="bottom"
+    role="tooltip"
+    style="top: 0px; left: 0px;"
     tabindex="-1"
   >
-    <div>
+    <div
+      class="components-popover__content"
+    >
       <div
-        class="components-popover components-animate__appear is-from-top is-from-left is-without-arrow"
-        data-x-axis="right"
-        data-y-axis="bottom"
-        role="tooltip"
-        style="top: 0px; left: 0px;"
-        tabindex="-1"
+        style="position: relative;"
       >
-        <div
-          class="components-popover__content"
-        >
-          <div
-            style="position: relative;"
-          >
-            Hello
-          </div>
-        </div>
+        Hello
       </div>
     </div>
   </div>
@@ -32,25 +26,19 @@ exports[`Popover should pass additional props to portaled element 1`] = `
 exports[`Popover should render content 1`] = `
 <span>
   <div
+    class="components-popover components-animate__appear is-from-top is-from-left is-without-arrow"
+    data-x-axis="right"
+    data-y-axis="bottom"
+    style="top: 0px; left: 0px;"
     tabindex="-1"
   >
-    <div>
+    <div
+      class="components-popover__content"
+    >
       <div
-        class="components-popover components-animate__appear is-from-top is-from-left is-without-arrow"
-        data-x-axis="right"
-        data-y-axis="bottom"
-        style="top: 0px; left: 0px;"
-        tabindex="-1"
+        style="position: relative;"
       >
-        <div
-          class="components-popover__content"
-        >
-          <div
-            style="position: relative;"
-          >
-            Hello
-          </div>
-        </div>
+        Hello
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Replaces the constrained tabbing and focus return HoCs with the new hooks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
