### PR TITLE
add useCallbackRef to avoid calling the ref multiple times with the same node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13369,6 +13369,7 @@
 				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"clipboard": "^2.0.1",
 				"lodash": "^4.17.19",
+				"memize": "^1.1.0",
 				"mousetrap": "^1.6.5",
 				"react-merge-refs": "^1.0.0",
 				"react-resize-aware": "^3.0.1",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"clipboard": "^2.0.1",
 		"lodash": "^4.17.19",
+		"memize": "^1.1.0",
 		"mousetrap": "^1.6.5",
 		"react-merge-refs": "^1.0.0",
 		"react-resize-aware": "^3.0.1",

--- a/packages/compose/src/hooks/use-callback-ref/index.js
+++ b/packages/compose/src/hooks/use-callback-ref/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import memize from 'memize';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+function useCallbackRef( callback, deps ) {
+	return useCallback(
+		memize( callback, {
+			maxSize: 1,
+		} ),
+		deps
+	);
+}
+
+export default useCallbackRef;

--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -1,9 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
 import { TAB } from '@wordpress/keycodes';
 import { focus } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import useCallbackRef from '../use-callback-ref';
 
 /**
  * In Dialogs/modals, the tabbing must be constrained to the content of
@@ -27,7 +31,7 @@ import { focus } from '@wordpress/dom';
  * ```
  */
 function useConstrainedTabbing() {
-	const ref = useCallback( ( node ) => {
+	const ref = useCallbackRef( ( node ) => {
 		if ( ! node ) {
 			return;
 		}

--- a/packages/compose/src/hooks/use-dialog/index.js
+++ b/packages/compose/src/hooks/use-dialog/index.js
@@ -6,7 +6,7 @@ import mergeRefs from 'react-merge-refs';
 /**
  * WordPress dependencies
  */
-import { useRef, useCallback, useEffect } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { ESCAPE } from '@wordpress/keycodes';
 
 /**
@@ -16,6 +16,7 @@ import useConstrainedTabbing from '../use-constrained-tabbing';
 import useFocusOnMount from '../use-focus-on-mount';
 import useFocusReturn from '../use-focus-return';
 import useFocusOutside from '../use-focus-outside';
+import useCallbackRef from '../use-callback-ref';
 
 /**
  * Returns a ref and props to apply to a dialog wrapper to enable the following behaviors:
@@ -35,7 +36,7 @@ function useDialog( options ) {
 	const focusOnMountRef = useFocusOnMount();
 	const focusReturnRef = useFocusReturn();
 	const focusOutsideProps = useFocusOutside( options.onClose );
-	const closeOnEscapeRef = useCallback( ( node ) => {
+	const closeOnEscapeRef = useCallbackRef( ( node ) => {
 		if ( ! node ) {
 			return;
 		}

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useCallback, useEffect } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useCallbackRef from '../use-callback-ref';
 
 /**
  * When opening modals/sidebars/dialogs, the focus
@@ -35,7 +40,7 @@ function useFocusReturn( onFocusReturn ) {
 		onFocusReturnRef.current = onFocusReturn;
 	}, [] );
 
-	const ref = useCallback( ( newNode ) => {
+	const ref = useCallbackRef( ( newNode ) => {
 		const updateLastFocusedRef = ( { target } ) => {
 			isFocused.current = newNode && newNode.contains( target );
 		};


### PR DESCRIPTION
This PR adds a  useCallbackRef hook for reusable hooks that generate callback refs and want to avoid the callback being called multiple times with the same node which can happen if used inside mergeRefs.
