### PR TITLE
Release script: Set draft status, and only remove after uploading asset

### DIFF
--- a/bin/plugin/commands/release.js
+++ b/bin/plugin/commands/release.js
@@ -393,45 +393,51 @@ async function runGithubReleaseStep(
 ) {
 	let octokit;
 	let release;
-	await runStep( 'Creating the GitHub release', abortMessage, async () => {
-		await askForConfirmation(
-			'Proceed with the creation of the GitHub release?',
-			true,
-			abortMessage
-		);
+	await runStep(
+		'Creating the GitHub release draft',
+		abortMessage,
+		async () => {
+			await askForConfirmation(
+				'Proceed with the creation of the GitHub release draft?',
+				true,
+				abortMessage
+			);
 
-		const { token } = await inquirer.prompt( [
-			{
-				type: 'input',
-				name: 'token',
-				message:
-					'Please enter a GitHub personal authentication token.\n' +
-					'You can create one by navigating to ' +
-					formats.success(
-						'https://github.com/settings/tokens/new?scopes=repo,admin:org,write:packages'
-					) +
-					'.\nToken:',
-			},
-		] );
+			const { token } = await inquirer.prompt( [
+				{
+					type: 'input',
+					name: 'token',
+					message:
+						'Please enter a GitHub personal authentication token.\n' +
+						'You can create one by navigating to ' +
+						formats.success(
+							'https://github.com/settings/tokens/new?scopes=repo,admin:org,write:packages'
+						) +
+						'.\nToken:',
+				},
+			] );
 
-		octokit = new Octokit( {
-			auth: token,
-		} );
+			octokit = new Octokit( {
+				auth: token,
+			} );
 
-		const releaseData = await octokit.repos.createRelease( {
-			owner: config.githubRepositoryOwner,
-			repo: config.githubRepositoryName,
-			tag_name: 'v' + version,
-			name: versionLabel,
-			body: changelog,
-			prerelease: isPrerelease,
-		} );
-		release = releaseData.data;
+			const releaseData = await octokit.repos.createRelease( {
+				owner: config.githubRepositoryOwner,
+				repo: config.githubRepositoryName,
+				tag_name: 'v' + version,
+				name: versionLabel,
+				body: changelog,
+				prerelease: isPrerelease,
+				draft: true,
+			} );
+			release = releaseData.data;
 
-		log( '>> The GitHub release has been created.' );
-	} );
+			log( '>> The GitHub release draft has been created.' );
+		}
+	);
 	abortMessage =
-		abortMessage + ' Make sure to remove the the GitHub release as well.';
+		abortMessage +
+		' Make sure to remove the the GitHub release draft as well.';
 
 	// Uploading the Zip to the Github release
 	await runStep( 'Uploading the plugin ZIP', abortMessage, async () => {
@@ -446,6 +452,17 @@ async function runGithubReleaseStep(
 			file: fs.createReadStream( zipPath ),
 		} );
 		log( '>> The plugin ZIP has been successfully uploaded.' );
+	} );
+
+	// Remove draft status from the Github release
+	await runStep( 'Publishing the Github release', abortMessage, async () => {
+		await octokit.repos.updateRelease( {
+			owner: config.githubRepositoryOwner,
+			repo: config.githubRepositoryName,
+			release_id: release.id,
+			draft: false,
+		} );
+		log( '>> The GitHub release has been published.' );
 	} );
 
 	log(


### PR DESCRIPTION
## Description

In the release script, rather than creating a GH release, and then attaching the plugin zip release asset, this PR creates a release _draft_ first, attaches the plugin zip, and only then removes the draft state.

This is a prerequisite for GH action-based automation such as #27591.

Spun off from #27591 to allow for more isolated review and testing.

## How has this been tested?

- Create your own fork of the `gutenberg` repo (if you haven't already), and make sure it's up-to-date.
- Set the owner accordingly in `bin/plugin/config.js` (e.g. mine is `ockham`). **This is important, as you don't want to accidentally create a release in the official repo!**

```diff
diff --git a/bin/plugin/config.js b/bin/plugin/config.js
index e920af08cd..931948a243 100644
--- a/bin/plugin/config.js
+++ b/bin/plugin/config.js
@@ -1,4 +1,4 @@
-const gitRepoOwner = 'WordPress';
+const gitRepoOwner = 'ockham';
 
 /**
  * @typedef WPPluginCLIConfig
```
- Run `./bin/plugin/cli.js stable` and follow through the steps.
- You'll be given a link to the newly created GH release at the end. Visit it to verify that the plugin zip has been attached.

Here's an example: https://github.com/ockham/gutenberg/releases/tag/v9.5.2

## Types of changes
Release tooling.