### PR TITLE
Apply hover class in outline mode

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -15,14 +15,15 @@ import { useSelect } from '@wordpress/data';
  */
 export function useIsHovered( ref ) {
 	const [ isHovered, setHovered ] = useState( false );
-	const isNavigationMode = useSelect(
-		( select ) => select( 'core/block-editor' ).isNavigationMode(),
-		[]
-	);
 
-	const { isOutlineMode } = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
+	const { isNavigationMode, isOutlineMode } = useSelect( ( select ) => {
+		const {
+			isNavigationMode: selectIsNavigationMode,
+			getSettings,
+		} = select( 'core/block-editor' );
+
 		return {
+			isNavigationMode: selectIsNavigationMode(),
 			isOutlineMode: getSettings().outlineMode,
 		};
 	}, [] );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -7,24 +7,30 @@ import { useSelect } from '@wordpress/data';
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
 /**
- * Returns true when the block is hovered and in navigation mode, false if not.
+ * Returns true when the block is hovered and in navigation or outline mode, false if not.
  *
  * @param {RefObject} ref React ref with the block element.
  *
  * @return {boolean} Hovered state.
  */
-export function useIsHovered( ref ) {
+export function useIsHovered( ref, clientId ) {
 	const [ isHovered, setHovered ] = useState( false );
 	const isNavigationMode = useSelect(
 		( select ) => select( 'core/block-editor' ).isNavigationMode(),
 		[]
 	);
 
-	useEffect( () => {
-		if ( ! isNavigationMode ) {
-			return;
-		}
+	const { isOutlineMode } = useSelect(
+		( select ) => {
+			const { getSettings } = select( 'core/block-editor' );
+			return {
+				isOutlineMode: getSettings().outlineMode,
+			};
+		},
+		[ clientId ]
+	);
 
+	useEffect( () => {
 		function addListener( eventType, value ) {
 			function listener( event ) {
 				if ( event.defaultPrevented ) {
@@ -45,8 +51,10 @@ export function useIsHovered( ref ) {
 			return addListener( 'mouseout', false );
 		}
 
-		return addListener( 'mouseover', true );
-	}, [ isNavigationMode, isHovered, setHovered ] );
+		if ( isOutlineMode || isNavigationMode ) {
+			return addListener( 'mouseover', true );
+		}
+	}, [ isNavigationMode, isOutlineMode, isHovered, setHovered ] );
 
 	return isHovered;
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -20,15 +20,12 @@ export function useIsHovered( ref ) {
 		[]
 	);
 
-	const { isOutlineMode } = useSelect(
-		( select ) => {
-			const { getSettings } = select( 'core/block-editor' );
-			return {
-				isOutlineMode: getSettings().outlineMode,
-			};
-		},
-		[]
-	);
+	const { isOutlineMode } = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		return {
+			isOutlineMode: getSettings().outlineMode,
+		};
+	}, [] );
 
 	useEffect( () => {
 		function addListener( eventType, value ) {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -13,7 +13,7 @@ import { useSelect } from '@wordpress/data';
  *
  * @return {boolean} Hovered state.
  */
-export function useIsHovered( ref, clientId ) {
+export function useIsHovered( ref ) {
 	const [ isHovered, setHovered ] = useState( false );
 	const isNavigationMode = useSelect(
 		( select ) => select( 'core/block-editor' ).isNavigationMode(),
@@ -27,7 +27,7 @@ export function useIsHovered( ref, clientId ) {
 				isOutlineMode: getSettings().outlineMode,
 			};
 		},
-		[ clientId ]
+		[]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
Closes #27543 

Restores the outline effect on hover when Site Editing:

![hover](https://user-images.githubusercontent.com/846565/102078410-cc195100-3e02-11eb-9edd-ff2897dae3c1.gif)

**To test:**

* Edit a post and ensure the `is-hovered` class is **not** applied when hovering a block
* Zoom out to template view  and ensure the `is-hovered` class **is** applied when hovering a block
* Ensure Navigation mode behaviour is unchanged