### PR TITLE
E2E Tests: Document Settings

### DIFF
--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	visitAdminPage,
+	trashAllPosts,
+	activateTheme,
+} from '@wordpress/e2e-test-utils';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { navigationPanel } from '../../experimental-features';
+
+describe( 'Document Settings', () => {
+	beforeAll( async () => {
+		await activateTheme( 'twentytwentyone-blocks' );
+		await trashAllPosts( 'wp_template' );
+		await trashAllPosts( 'wp_template_part' );
+	} );
+	afterAll( async () => {
+		await trashAllPosts( 'wp_template' );
+		await trashAllPosts( 'wp_template_part' );
+		await activateTheme( 'twentytwentyone' );
+	} );
+
+	beforeEach( async () => {
+		await visitAdminPage(
+			'admin.php',
+			addQueryArgs( '', {
+				page: 'gutenberg-edit-site',
+			} ).slice( 1 )
+		);
+		await page.waitForSelector( '.edit-site-visual-editor' );
+	} );
+
+	describe( 'when a template is selected from the navigation sidebar', () => {
+		it( 'should display the selected templates name in the document header', async () => {
+			// Navigate to a template
+			await navigationPanel.open();
+			await navigationPanel.backToRoot();
+			await navigationPanel.navigate( 'Templates' );
+			await navigationPanel.clickItemByText( 'Index' );
+
+			// Evaluate the document settings title
+			await page.waitForSelector( '.edit-site-document-actions__title' );
+			const actual = await page.$eval(
+				'.edit-site-document-actions__title',
+				( el ) => el.innerText
+			);
+
+			expect( actual ).toEqual( 'Index' );
+		} );
+
+		describe( 'and a template part is clicked in the template', () => {
+			it( "should display the selected template part's name in the document header", async () => {
+				// Click on a template part in the template
+				await page.waitForSelector(
+					'.site-header[data-type="core/template-part"]'
+				);
+				await page.click(
+					'.site-header[data-type="core/template-part"]'
+				);
+
+				// Evaluate the document settings secondary title
+				await page.waitForSelector(
+					'.edit-site-document-actions__secondary-item'
+				);
+				const actual = await page.$eval(
+					'.edit-site-document-actions__secondary-item',
+					( el ) => el.innerText
+				);
+
+				expect( actual ).toEqual( 'Header' );
+			} );
+		} );
+	} );
+
+	describe( 'when a template part is selected from the navigation sidebar', () => {
+		it( "should display the selected template part's name in the document header", async () => {
+			// Navigate to a template part
+			await navigationPanel.open();
+			await navigationPanel.backToRoot();
+			await navigationPanel.navigate( 'Template Parts' );
+			await navigationPanel.clickItemByText( 'header' );
+
+			// TODO: Remove when toolbar supports text fields
+			expect( console ).toHaveWarnedWith(
+				'Using custom components as toolbar controls is deprecated. Please use ToolbarItem or ToolbarButton components instead. See: https://developer.wordpress.org/block-editor/components/toolbar-button/#inside-blockcontrols'
+			);
+
+			// Evaluate the document settings title
+			await page.waitForSelector( '.edit-site-document-actions__title' );
+			const actual = await page.$eval(
+				'.edit-site-document-actions__title',
+				( el ) => el.innerText
+			);
+
+			expect( actual ).toEqual( 'header' );
+		} );
+	} );
+} );

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -33,7 +33,7 @@ async function getDocumentSettingsSecondaryTitle() {
 
 describe( 'Document Settings', () => {
 	beforeAll( async () => {
-		await activateTheme( 'twentytwentyone-blocks' );
+		await activateTheme( 'tt1-blocks' );
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
 	} );

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -62,7 +62,6 @@ describe( 'Document Settings', () => {
 			await navigationPanel.clickItemByText( 'Index' );
 
 			// Evaluate the document settings title
-			await page.waitForSelector( '.edit-site-document-actions__title' );
 			const actual = await getDocumentSettingsTitle();
 
 			expect( actual ).toEqual( 'Index' );
@@ -79,9 +78,6 @@ describe( 'Document Settings', () => {
 				);
 
 				// Evaluate the document settings secondary title
-				await page.waitForSelector(
-					'.edit-site-document-actions__secondary-item'
-				);
 				const actual = await getDocumentSettingsSecondaryTitle();
 
 				expect( actual ).toEqual( 'Header' );

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -59,12 +59,12 @@ describe( 'Document Settings', () => {
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
-			await navigationPanel.clickItemByText( 'Index' );
+			await navigationPanel.clickItemByText( 'Front Page' );
 
 			// Evaluate the document settings title
 			const actual = await getDocumentSettingsTitle();
 
-			expect( actual ).toEqual( 'Index' );
+			expect( actual ).toEqual( 'Front Page' );
 		} );
 
 		describe( 'and a template part is clicked in the template', () => {

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -99,11 +99,7 @@ describe( 'Document Settings', () => {
 			);
 
 			// Evaluate the document settings title
-			await page.waitForSelector( '.edit-site-document-actions__title' );
-			const actual = await page.$eval(
-				'.edit-site-document-actions__title',
-				( el ) => el.innerText
-			);
+			const actual = await getDocumentSettingsTitle();
 
 			expect( actual ).toEqual( 'header' );
 		} );

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -13,6 +13,24 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { navigationPanel } from '../../experimental-features';
 
+async function getDocumentSettingsTitle() {
+	await page.waitForSelector( '.edit-site-document-actions__title' );
+
+	return page.$eval(
+		'.edit-site-document-actions__title',
+		( el ) => el.innerText
+	);
+}
+
+async function getDocumentSettingsSecondaryTitle() {
+	await page.waitForSelector( '.edit-site-document-actions__secondary-item' );
+
+	return page.$eval(
+		'.edit-site-document-actions__secondary-item',
+		( el ) => el.innerText
+	);
+}
+
 describe( 'Document Settings', () => {
 	beforeAll( async () => {
 		await activateTheme( 'twentytwentyone-blocks' );
@@ -45,10 +63,7 @@ describe( 'Document Settings', () => {
 
 			// Evaluate the document settings title
 			await page.waitForSelector( '.edit-site-document-actions__title' );
-			const actual = await page.$eval(
-				'.edit-site-document-actions__title',
-				( el ) => el.innerText
-			);
+			const actual = await getDocumentSettingsTitle();
 
 			expect( actual ).toEqual( 'Index' );
 		} );
@@ -67,10 +82,7 @@ describe( 'Document Settings', () => {
 				await page.waitForSelector(
 					'.edit-site-document-actions__secondary-item'
 				);
-				const actual = await page.$eval(
-					'.edit-site-document-actions__secondary-item',
-					( el ) => el.innerText
-				);
+				const actual = await getDocumentSettingsSecondaryTitle();
 
 				expect( actual ).toEqual( 'Header' );
 			} );

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -1,17 +1,12 @@
 /**
  * WordPress dependencies
  */
-import {
-	visitAdminPage,
-	trashAllPosts,
-	activateTheme,
-} from '@wordpress/e2e-test-utils';
-import { addQueryArgs } from '@wordpress/url';
+import { trashAllPosts, activateTheme } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
-import { navigationPanel } from '../../experimental-features';
+import { navigationPanel, siteEditor } from '../../experimental-features';
 
 async function getDocumentSettingsTitle() {
 	const titleElement = await page.waitForSelector(
@@ -42,13 +37,7 @@ describe( 'Document Settings', () => {
 	} );
 
 	beforeEach( async () => {
-		await visitAdminPage(
-			'admin.php',
-			addQueryArgs( '', {
-				page: 'gutenberg-edit-site',
-			} ).slice( 1 )
-		);
-		await page.waitForSelector( '.edit-site-visual-editor' );
+		await siteEditor.visit();
 	} );
 
 	describe( 'when a template is selected from the navigation sidebar', () => {

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -35,8 +35,6 @@ describe( 'Document Settings', () => {
 		await trashAllPosts( 'wp_template_part' );
 	} );
 	afterAll( async () => {
-		await trashAllPosts( 'wp_template' );
-		await trashAllPosts( 'wp_template_part' );
 		await activateTheme( 'twentytwentyone' );
 	} );
 

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -14,21 +14,19 @@ import { addQueryArgs } from '@wordpress/url';
 import { navigationPanel } from '../../experimental-features';
 
 async function getDocumentSettingsTitle() {
-	await page.waitForSelector( '.edit-site-document-actions__title' );
-
-	return page.$eval(
-		'.edit-site-document-actions__title',
-		( el ) => el.innerText
+	const titleElement = await page.waitForSelector(
+		'.edit-site-document-actions__title'
 	);
+
+	return titleElement.evaluate( ( el ) => el.innerText );
 }
 
 async function getDocumentSettingsSecondaryTitle() {
-	await page.waitForSelector( '.edit-site-document-actions__secondary-item' );
-
-	return page.$eval(
-		'.edit-site-document-actions__secondary-item',
-		( el ) => el.innerText
+	const secondaryTitleElement = await page.waitForSelector(
+		'.edit-site-document-actions__secondary-item'
 	);
+
+	return secondaryTitleElement.evaluate( ( el ) => el.innerText );
 }
 
 describe( 'Document Settings', () => {

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { trashAllPosts, activateTheme } from '@wordpress/e2e-test-utils';
+import {
+	canvas,
+	trashAllPosts,
+	activateTheme,
+} from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -57,11 +61,7 @@ describe( 'Document Settings', () => {
 		describe( 'and a template part is clicked in the template', () => {
 			it( "should display the selected template part's name in the document header", async () => {
 				// Click on a template part in the template
-				const frame = await page
-					.frames()
-					.find( ( f ) => f.name() === 'editor-canvas' );
-
-				const header = await frame.$( '.site-header' );
+				const header = await canvas().$( '.site-header' );
 				await header.click();
 
 				// Evaluate the document settings secondary title

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -57,23 +57,23 @@ describe( 'Document Settings', () => {
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
-			await navigationPanel.clickItemByText( 'Front Page' );
+			await navigationPanel.clickItemByText( 'Index' );
 
 			// Evaluate the document settings title
 			const actual = await getDocumentSettingsTitle();
 
-			expect( actual ).toEqual( 'Front Page' );
+			expect( actual ).toEqual( 'Index' );
 		} );
 
 		describe( 'and a template part is clicked in the template', () => {
 			it( "should display the selected template part's name in the document header", async () => {
 				// Click on a template part in the template
-				await page.waitForSelector(
-					'.site-header[data-type="core/template-part"]'
-				);
-				await page.click(
-					'.site-header[data-type="core/template-part"]'
-				);
+				const frame = await page
+					.frames()
+					.find( ( f ) => f.name() === 'editor-canvas' );
+
+				const header = await frame.$( '.site-header' );
+				await header.click();
 
 				// Evaluate the document settings secondary title
 				const actual = await getDocumentSettingsSecondaryTitle();

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -91,11 +91,6 @@ describe( 'Document Settings', () => {
 			await navigationPanel.navigate( 'Template Parts' );
 			await navigationPanel.clickItemByText( 'header' );
 
-			// TODO: Remove when toolbar supports text fields
-			expect( console ).toHaveWarnedWith(
-				'Using custom components as toolbar controls is deprecated. Please use ToolbarItem or ToolbarButton components instead. See: https://developer.wordpress.org/block-editor/components/toolbar-button/#inside-blockcontrols'
-			);
-
 			// Evaluate the document settings title
 			const actual = await getDocumentSettingsTitle();
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
E2E specs were missing for the Full Site Editing document settings feature. This PR tests basic functionality of the document settings dropdown.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Run e2e tests for `packages/e2e-tests/specs/experiments/document-settings.test.js` file locally 

## Screenshots <!-- if applicable -->
<img width="1151" alt="Screen Shot 2020-12-14 at 4 21 17 AM" src="https://user-images.githubusercontent.com/5414230/102080777-df58fc00-3dc3-11eb-83e7-a7dd879eb8cd.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Spec coverage

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
