### PR TITLE
Save editors value on change

### DIFF
--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,12 +7,13 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
+export const THROTTLE_TIME = 300;
 export default function PostTextEditor() {
 	const postContent = useSelect(
 		( select ) => select( 'core/editor' ).getEditedPostContent(),
@@ -29,6 +30,18 @@ export default function PostTextEditor() {
 		setValue( postContent );
 	}
 
+	const saveText = () => {
+		const blocks = parse( value );
+		resetEditorBlocks( blocks );
+	};
+
+	useEffect( () => {
+		const timeoutId = setTimeout( saveText, THROTTLE_TIME );
+		return () => {
+			clearTimeout( timeoutId );
+		};
+	}, [ value ] );
+
 	/**
 	 * Handles a textarea change event to notify the onChange prop callback and
 	 * reflect the new value in the component's own state. This marks the start
@@ -42,9 +55,7 @@ export default function PostTextEditor() {
 	 */
 	const onChange = ( event ) => {
 		const newValue = event.target.value;
-
 		editPost( { content: newValue } );
-
 		setValue( newValue );
 		setIsDirty( true );
 	};
@@ -56,9 +67,7 @@ export default function PostTextEditor() {
 	 */
 	const stopEditing = () => {
 		if ( isDirty ) {
-			const blocks = parse( value );
-			resetEditorBlocks( blocks );
-
+			saveText();
 			setIsDirty( false );
 		}
 	};

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,10 +7,10 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useInstanceId, useThrottle } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
 export const THROTTLE_TIME = 300;
@@ -35,7 +35,12 @@ export default function PostTextEditor() {
 		resetEditorBlocks( blocks );
 	};
 
-	useThrottle( saveText, THROTTLE_TIME );
+	useEffect( () => {
+		const timeoutId = setTimeout( saveText, THROTTLE_TIME );
+		return () => {
+			clearTimeout( timeoutId );
+		};
+	}, [ value ] );
 
 	/**
 	 * Handles a textarea change event to notify the onChange prop callback and

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,10 +7,10 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, useThrottle } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
 export const THROTTLE_TIME = 300;
@@ -35,12 +35,7 @@ export default function PostTextEditor() {
 		resetEditorBlocks( blocks );
 	};
 
-	useEffect( () => {
-		const timeoutId = setTimeout( saveText, THROTTLE_TIME );
-		return () => {
-			clearTimeout( timeoutId );
-		};
-	}, [ value ] );
+	useThrottle( saveText, THROTTLE_TIME );
 
 	/**
 	 * Handles a textarea change event to notify the onChange prop callback and

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -13,7 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
-export const THROTTLE_TIME = 300;
+export const DEBOUNCE_TIME = 300;
 export default function PostTextEditor() {
 	const postContent = useSelect(
 		( select ) => select( 'core/editor' ).getEditedPostContent(),
@@ -36,7 +36,7 @@ export default function PostTextEditor() {
 	};
 
 	useEffect( () => {
-		const timeoutId = setTimeout( saveText, THROTTLE_TIME );
+		const timeoutId = setTimeout( saveText, DEBOUNCE_TIME );
 		return () => {
 			clearTimeout( timeoutId );
 		};

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -182,22 +182,17 @@ describe( 'PostTextEditor', () => {
 			wrapper = create( <PostTextEditor /> );
 		} );
 		const mockDispatchFn = jest.fn();
-		const useDispatchSpy = new Proxy( wp, {
-			get( target, prop ) {
-				if ( prop === 'useDispatch' ) {
-					return {
-						editPost: jest.fn(),
-						resetEditorBlocks: mockDispatchFn,
-					};
-				}
-			},
-		} );
+		jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+			useDispatch: () => ( {
+				editPost: jest.fn(),
+				resetEditorBlocks: mockDispatchFn,
+			} ),
+		} ) );
 
 		const textarea = wrapper.root.findByType( Textarea );
 		act( () => textarea.props.onChange( { target: { value: 'text' } } ) );
 		setTimeout( () => {
 			expect( mockDispatchFn ).toHaveBeenCalled();
-			useDispatchSpy.mockClear();
 		}, THROTTLE_TIME );
 	} );
 } );

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -12,7 +12,7 @@ import * as wp from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import PostTextEditor, { THROTTLE_TIME } from '../';
+import PostTextEditor, { DEBOUNCE_TIME } from '../';
 
 const useSelect = wp.useSelect;
 // "Downgrade" ReactAutosizeTextarea to a regular textarea. Assumes aligned
@@ -176,7 +176,7 @@ describe( 'PostTextEditor', () => {
 
 		expect( textarea.props.value ).toBe( 'Goodbye World' );
 	} );
-	it( 'throttle value update after given time', () => {
+	it( 'debounce value update after given time', () => {
 		let wrapper;
 		act( () => {
 			wrapper = create( <PostTextEditor /> );
@@ -193,6 +193,6 @@ describe( 'PostTextEditor', () => {
 		act( () => textarea.props.onChange( { target: { value: 'text' } } ) );
 		setTimeout( () => {
 			expect( mockDispatchFn ).toHaveBeenCalled();
-		}, THROTTLE_TIME );
+		}, DEBOUNCE_TIME );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolving the issue https://github.com/WordPress/gutenberg/issues/9512 
The problem was the lack of updates when a user makes a change in an editor but only when the editor lost focus. This was causing situations when users were losing their input when using key shortcuts to change editor mode.

The solution is to add debounced updates after every change made in the editor. The same mechanics are used to save the text as it was done in stopEditting function (which is called when the editor is losing focus).
The function is debounced in order to minimize the number of dispatches.



<!-- Please describe what you have changed or added -->

## How has this been tested?
Unit test to cover this case added
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Bugfix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
