### PR TITLE
Update font-weight names

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -18,11 +18,11 @@ const FONT_STYLES = [
 
 const FONT_WEIGHTS = [
 	{
-		name: __( 'Ultralight' ),
+		name: __( 'Thin' ),
 		value: '100',
 	},
 	{
-		name: __( 'Thin' ),
+		name: __( 'Extra Light' ),
 		value: '200',
 	},
 	{
@@ -38,7 +38,7 @@ const FONT_WEIGHTS = [
 		value: '500',
 	},
 	{
-		name: __( 'Semibold' ),
+		name: __( 'Semi Bold' ),
 		value: '600',
 	},
 	{
@@ -46,7 +46,7 @@ const FONT_WEIGHTS = [
 		value: '700',
 	},
 	{
-		name: __( 'Heavy' ),
+		name: __( 'Extra Bold' ),
 		value: '800',
 	},
 	{


### PR DESCRIPTION
This PR updates the names of font-weight to follow the  [standard](https://www.w3.org/TR/css-fonts-3/#font-weight-prop) as it was discussed https://github.com/WordPress/gutenberg/pull/27555#discussion_r540864198:

Value | New name | Current name
--------|--------------- |-----------------
100   | Thin           | Ultralight
200   | Extra Light | Thin
300   | Light          | Light
400   | Regular     | Regular
500   | Medium     | Medium
600   | Semi Bold | Semibold
700   | Bold          | Bold
800   | Extra Bold | Heavy
900   | Black         | Black
