### PR TITLE
Add hooks to modify theme.json structure

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -310,6 +310,7 @@ class WP_Theme_JSON {
 			return;
 		}
 
+		$schema   = self::get_schema();
 		$metadata = $this->get_blocks_metadata();
 		foreach ( $contexts as $key => $context ) {
 			if ( ! isset( $metadata[ $key ] ) ) {
@@ -319,14 +320,14 @@ class WP_Theme_JSON {
 			}
 
 			// Filter out top-level keys that aren't valid according to the schema.
-			$context = array_intersect_key( $context, self::SCHEMA );
+			$context = array_intersect_key( $context, $schema );
 
 			// Process styles subtree.
-			$this->process_key( 'styles', $context, self::SCHEMA );
+			$this->process_key( 'styles', $context, $schema );
 			if ( isset( $context['styles'] ) ) {
-				$this->process_key( 'color', $context['styles'], self::SCHEMA['styles'] );
-				$this->process_key( 'spacing', $context['styles'], self::SCHEMA['styles'] );
-				$this->process_key( 'typography', $context['styles'], self::SCHEMA['styles'] );
+				$this->process_key( 'color', $context['styles'], $schema['styles'] );
+				$this->process_key( 'spacing', $context['styles'], $schema['styles'] );
+				$this->process_key( 'typography', $context['styles'], $schema['styles'] );
 
 				if ( empty( $context['styles'] ) ) {
 					unset( $context['styles'] );
@@ -336,11 +337,11 @@ class WP_Theme_JSON {
 			}
 
 			// Process settings subtree.
-			$this->process_key( 'settings', $context, self::SCHEMA );
+			$this->process_key( 'settings', $context, $schema );
 			if ( isset( $context['settings'] ) ) {
-				$this->process_key( 'color', $context['settings'], self::SCHEMA['settings'] );
-				$this->process_key( 'spacing', $context['settings'], self::SCHEMA['settings'] );
-				$this->process_key( 'typography', $context['settings'], self::SCHEMA['settings'] );
+				$this->process_key( 'color', $context['settings'], $schema['settings'] );
+				$this->process_key( 'spacing', $context['settings'], $schema['settings'] );
+				$this->process_key( 'typography', $context['settings'], $schema['settings'] );
 
 				if ( empty( $context['settings'] ) ) {
 					unset( $context['settings'] );
@@ -358,9 +359,17 @@ class WP_Theme_JSON {
 	 * @return array Properties metadata.
 	 */
 	private static function get_properties_metadata() {
-		$result = apply_filters( 'theme_json_properties_metadata', self::PROPERTIES_METADATA );
-		error_log( 'result is ' . print_r( $result, true ) );
-		return $result;
+		return apply_filters( 'theme_json_properties_metadata', self::PROPERTIES_METADATA );
+	}
+
+	/**
+	 * Returns the schema to be used to validate the contexts
+	 * after having called the filter for 3rd party to hook into.
+	 *
+	 * @return array Schema.
+	 */
+	private static function get_schema() {
+		return apply_filters( 'theme_json_schema', self::SCHEMA );
 	}
 
 	/**
@@ -938,6 +947,7 @@ class WP_Theme_JSON {
 	 */
 	public function merge( $theme_json ) {
 		$incoming_data = $theme_json->get_raw_data();
+		$schema        = self::get_schema();
 
 		foreach ( array_keys( $incoming_data ) as $context ) {
 			foreach ( array( 'settings', 'styles' ) as $subtree ) {
@@ -950,7 +960,7 @@ class WP_Theme_JSON {
 					continue;
 				}
 
-				foreach ( array_keys( self::SCHEMA[ $subtree ] ) as $leaf ) {
+				foreach ( array_keys( $schema[ $subtree ] ) as $leaf ) {
 					if ( ! isset( $incoming_data[ $context ][ $subtree ][ $leaf ] ) ) {
 						continue;
 					}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -351,6 +351,18 @@ class WP_Theme_JSON {
 	}
 
 	/**
+	 * Returns the metadata for the properties that we support
+	 * after having called the filter for 3rd party to hook into.
+	 *
+	 * @return array Properties metadata.
+	 */
+	private static function get_properties_metadata() {
+		$result = apply_filters( 'theme_json_properties_metadata', self::PROPERTIES_METADATA );
+		error_log( 'result is ' . print_r( $result, true ) );
+		return $result;
+	}
+
+	/**
 	 * Returns the metadata for each block.
 	 *
 	 * Example:
@@ -398,8 +410,9 @@ class WP_Theme_JSON {
 			/*
 			 * Extract block support keys that are related to the style properties.
 			 */
-			$block_supports = array();
-			foreach ( self::PROPERTIES_METADATA as $key => $metadata ) {
+			$block_supports      = array();
+			$properties_metadata = self::get_properties_metadata();
+			foreach ( $properties_metadata as $key => $metadata ) {
 				if ( gutenberg_experimental_get( $block_type->supports, $metadata['support'] ) ) {
 					$block_supports[] = $key;
 				}
@@ -628,7 +641,8 @@ class WP_Theme_JSON {
 			return;
 		}
 
-		foreach ( self::PROPERTIES_METADATA as $name => $metadata ) {
+		$properties_metadata = self::get_properties_metadata();
+		foreach ( $properties_metadata as $name => $metadata ) {
 			if ( ! in_array( $name, $context_supports, true ) ) {
 				continue;
 			}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -325,6 +325,7 @@ class WP_Theme_JSON {
 			$this->process_key( 'styles', $context, self::SCHEMA );
 			if ( isset( $context['styles'] ) ) {
 				$this->process_key( 'color', $context['styles'], self::SCHEMA['styles'] );
+				$this->process_key( 'spacing', $context['styles'], self::SCHEMA['styles'] );
 				$this->process_key( 'typography', $context['styles'], self::SCHEMA['styles'] );
 
 				if ( empty( $context['styles'] ) ) {

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -174,5 +174,12 @@
 				"customRadius": true
 			}
 		}
+	},
+	"core/group": {
+		"styles": {
+			"spacing": {
+				"boxShadow": "10px 5px 5px red"
+			}
+		}
 	}
 }

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -177,7 +177,7 @@
 	},
 	"core/group": {
 		"styles": {
-			"spacing": {
+			"box": {
 				"boxShadow": "10px 5px 5px red"
 			}
 		}

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -24,7 +24,8 @@
 		},
 		"spacing": {
 			"padding": true
-		}
+		},
+		"__experimentalBoxShadow": true
 	},
 	"editorStyle": "wp-block-group-editor",
 	"style": "wp-block-group"


### PR DESCRIPTION
Implements part of https://github.com/WordPress/gutenberg/issues/27504

Now that we're looking into merging the "global styles" mechanism into WordPress core, we need a way to iterate on the theme.json structure from the Gutenberg plugin. The main use case is to add new style properties, although removing existing ones should also be considered.

TODO:

- [ ] client: add hooks to extend `__EXPERIMENTAL_STYLE_PROPERTY`, so it works in the site editor.
- [ ] server: make sure the leaf in the schema (e.g.: `fontSize`) matches. Currently, it validates the section instead (`typography`). This can perhaps be a follow-up, as it something pre-existing.

## Test

- Install and activate the demo plugin that makes use of the new filters https://github.com/nosolosw/gutenberg-theme-json-plugin
- Install and activate a blocks-based theme. Go to the site editor and add a group block with some content in some template.
- Visit that template in the front-end of your site and verify that the group has a red box-shadow.
