### PR TITLE
Change the week header and left button style to meet the date spacing

### DIFF
--- a/packages/components/src/date-time/datepicker.scss
+++ b/packages/components/src/date-time/datepicker.scss
@@ -432,7 +432,7 @@
 }
 .CalendarMonthGrid__horizontal {
 	position: absolute;
-	left: 9px;
+	left: 0;
 }
 .CalendarMonthGrid__vertical {
 	margin: 0 auto;
@@ -573,7 +573,7 @@
 	position: relative;
 }
 .DayPicker_weekHeaders__horizontal {
-	margin-left: 9px;
+	margin-left: 13px;
 }
 .DayPicker_weekHeader {
 	color: #757575;
@@ -581,6 +581,7 @@
 	top: 62px;
 	z-index: 2;
 	text-align: left;
+	padding: 0 !important;
 }
 .DayPicker_weekHeader__vertical {
 	left: 50%;
@@ -605,6 +606,7 @@
 .DayPicker_weekHeader_li {
 	display: inline-block;
 	text-align: center;
+	margin: 0 1px;
 }
 .DayPicker_transitionContainer {
 	position: relative;

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -48,6 +48,7 @@
 
 	// Override external DatePicker styles.
 	.DayPickerNavigation_leftButton__horizontalDefault {
+		/* rtl:ignore */
 		left: 13px;
 	}
 

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -48,8 +48,9 @@
 
 	// Override external DatePicker styles.
 	.DayPickerNavigation_leftButton__horizontalDefault {
-		/* rtl:ignore */
+		/*!rtl:begin:ignore*/
 		left: 13px;
+		/*!rtl:end:ignore*/
 	}
 
 	.CalendarMonth_caption {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -48,7 +48,7 @@
 
 	// Override external DatePicker styles.
 	.DayPickerNavigation_leftButton__horizontalDefault {
-		left: 0;
+		left: 13px;
 	}
 
 	.CalendarMonth_caption {
@@ -98,7 +98,7 @@
 	.DayPicker_weekHeader {
 		top: 50px;
 		.DayPicker_weekHeader_ul {
-			margin: 1px 0;
+			margin: 1px;
 			padding-left: 0;
 			padding-right: 0;
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #27536 
Change the week header and left button style to meet the date spacing.

## How has this been tested?
Tested in English and in Arabic (rtl), both render as expected

## Screenshots <!-- if applicable -->
1. Before
<img width="291" alt="before_change" src="https://user-images.githubusercontent.com/56378160/102154304-0f95ae80-3e47-11eb-909d-6559224399d7.png">
1. After
<img width="468" alt="change_spacing" src="https://user-images.githubusercontent.com/56378160/102154319-14f2f900-3e47-11eb-83d6-1e1f75666359.png">

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
