### PR TITLE
[Embed block]: Add html and reusable support back

### DIFF
--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -31,9 +31,7 @@
 		}
 	},
 	"supports": {
-		"align": true,
-		"reusable": false,
-		"html": false
+		"align": true
 	},
 	"editorStyle": "wp-block-embed-editor",
 	"style": "wp-block-embed"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/27339

In the[ PR to make `embeds` block variations]( https://github.com/WordPress/gutenberg/pull/24090/) there was a mistake of mine that has slipped, which removed `html` and `reusable` support for `embed` block.

This PR add the support for `html` and `reusable` back.

FYI there is still an open issue for `embeds` in front-end: https://github.com/WordPress/gutenberg/issues/14608.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
