### PR TITLE
Verse Block: Update CSS for frontend and editor

### DIFF
--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,6 +1,4 @@
 pre.wp-block-verse {
 	color: $gray-900;
-	white-space: nowrap;
 	padding: 1em;
-	overflow: auto;
 }

--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,3 +1,5 @@
 pre.wp-block-verse {
 	font-family: inherit;
+	overflow: auto;
+	white-space: nowrap;
 }


### PR DESCRIPTION
## Description
This consolidates the CSS for the frontend and the editor, so that the block looks the same in the editor and the front end. I think ultimately we'll be able to remove the editor.scss file altogether by moving font-size and padding to Global Styles.

## How has this been tested?
In TT1 Blocks

## Screenshots <!-- if applicable -->
Frontend
<img width="974" alt="Screenshot 2020-12-15 at 11 12 16" src="https://user-images.githubusercontent.com/275961/102207816-82923a00-3ec6-11eb-8560-9433c8ecea0b.png">

Editor
<img width="683" alt="Screenshot 2020-12-15 at 11 12 39" src="https://user-images.githubusercontent.com/275961/102207826-84f49400-3ec6-11eb-84dd-bc2b617d79ea.png">


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
