### PR TITLE
Verse Block: Add support for Font Size

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -368,6 +368,6 @@ These are the current typography properties supported by blocks:
 | Post Title | Yes | Yes | - | - | Yes | - | - |
 | Site Tagline | Yes | Yes | - | - | Yes | - | - |
 | Site Title | Yes | Yes | - | - | Yes | - | - |
-| Verse | Yes | - | - | - | - | - | - |
+| Verse | Yes | Yes | - | - | - | - | - |
 
 [1] The heading block represents 6 distinct HTML elements: H1-H6. It comes with selectors to target each individual element (ex: core/heading/h1 for H1, etc).

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -16,7 +16,8 @@
 	},
 	"supports": {
 		"anchor": true,
-		"__experimentalFontFamily": true
+		"__experimentalFontFamily": true,
+		"fontSize": true
 	},
 	"style": "wp-block-verse",
 	"editorStyle": "wp-block-verse-editor"

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,7 +1,6 @@
 pre.wp-block-verse {
 	color: $gray-900;
 	white-space: nowrap;
-	font-size: inherit;
 	padding: 1em;
 	overflow: auto;
 }


### PR DESCRIPTION
## Description
Adds support for font size to the Verse Block

## How has this been tested?
In TT1 Blocks

## Screenshots <!-- if applicable -->
<img width="975" alt="Screenshot 2020-12-15 at 11 48 48" src="https://user-images.githubusercontent.com/275961/102211426-81174080-3ecb-11eb-93f3-97ee8b208a2a.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
