### PR TITLE
Make links in gallery captions white

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -64,6 +64,10 @@
 			box-sizing: border-box;
 			margin: 0;
 
+			a {
+				color: $white;
+			}
+
 			img {
 				display: inline;
 			}


### PR DESCRIPTION
This PR makes a small change to links inside image captions in the gallery block.

Since the caption text is white atop the default black gradient, I think the links also be white. Otherwise, they are unreadable when the default link color is a dark color. 

Using TT1: 

Before | After
------ | ------
<img width="1298" alt="Screen Shot 2020-12-15 at 1 32 50 PM" src="https://user-images.githubusercontent.com/5375500/102256962-14f00900-3eda-11eb-8b2a-9e83c345ff1e.png"> | <img width="1311" alt="Screen Shot 2020-12-15 at 1 30 55 PM" src="https://user-images.githubusercontent.com/5375500/102257007-22a58e80-3eda-11eb-88a3-25e83b516c6c.png">

