### PR TITLE
Render `InlineUI` only if modal is closed and object is active

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -168,7 +168,7 @@ function Edit( {
 					} }
 				/>
 			) }
-			{ isObjectActive && (
+			{ ! isModalOpen && isObjectActive && (
 				<InlineUI
 					value={ value }
 					onChange={ onChange }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #27608 
Render `InlineUI` only if the modal is closed and the object is active

## How has this been tested?
1. Insert an inline image, click on the image, and click on `inline image` on the editor.
1. Check if the modal and `InlineUI` render as expected.

## Screenshots <!-- if applicable -->
1. Before
<img width="850" alt="before" src="https://user-images.githubusercontent.com/56378160/102298702-974eec00-3f1f-11eb-93de-bb66ebd3e4d7.png">

2. After
<img width="829" alt="test" src="https://user-images.githubusercontent.com/56378160/102298714-9cac3680-3f1f-11eb-9539-5498c4a353df.png">
<img width="933" alt="after" src="https://user-images.githubusercontent.com/56378160/102298717-a03fbd80-3f1f-11eb-92b8-c1430fe8d75c.png">

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
