### PR TITLE
Fix useFocusOnMount

### DIFF
--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -41,7 +41,7 @@ function ModalFrameContent( {
 			}
 		}
 	}
-	const focusOnMountRef = useFocusOnMount();
+	const focusOnMountRef = useFocusOnMount( focusOnMount );
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
 
@@ -60,7 +60,7 @@ function ModalFrameContent( {
 				ref={ mergeRefs( [
 					constrainedTabbingRef,
 					focusReturnRef,
-					focusOnMount ? focusOnMountRef : null,
+					focusOnMountRef,
 				] ) }
 				role={ role }
 				aria-label={ contentLabel }

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -1,8 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import useCallbackRef from '../use-callback-ref';
 
 /**
  * Hook used to focus the first tabbable element on mount.
@@ -25,14 +30,16 @@ import { focus } from '@wordpress/dom';
  * }
  * ```
  */
-export default function useFocusOnMount( focusOnMount ) {
-	const didMount = useRef( false );
-	return useCallback( ( node ) => {
-		if ( ! node || didMount.current === true ) {
+export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
+	const focusOnMountRef = useRef( focusOnMount );
+	useEffect( () => {
+		focusOnMountRef.current = focusOnMount;
+	}, [ focusOnMount ] );
+
+	return useCallbackRef( ( node ) => {
+		if ( ! node || focusOnMountRef.current === false ) {
 			return;
 		}
-
-		didMount.current = true;
 
 		if ( node.contains( node.ownerDocument.activeElement ) ) {
 			return;
@@ -40,7 +47,7 @@ export default function useFocusOnMount( focusOnMount ) {
 
 		let target = node;
 
-		if ( focusOnMount === 'firstElement' ) {
+		if ( focusOnMountRef.current === 'firstElement' ) {
 			const firstTabbable = focus.tabbable.find( node )[ 0 ];
 
 			if ( firstTabbable ) {


### PR DESCRIPTION
#27699 introduced a few regressions in useFocusOnMount:

 - Changed the default value causing the inserter to  not focus the input on mount
 - It's not working properly if the "node" changes. (it  only cares about the first node)
 - It doesn't use the right focusOnMount config (it only uses the initial value)
 - Cosmetic change: it removed the handling of the "false" config which I believe is good to avoid unnecessary checks on the parents.


**Testing instructions**

 - Check that the inserter focuses the input properly on mount and closes if you click outside.