### PR TITLE
Strip directory from theme taxonomy

### DIFF
--- a/lib/edit-site-export.php
+++ b/lib/edit-site-export.php
@@ -23,7 +23,7 @@ function gutenberg_edit_site_export() {
 	$zip->addEmptyDir( 'theme/block-templates' );
 	$zip->addEmptyDir( 'theme/block-template-parts' );
 
-	$theme = wp_get_theme()->get_stylesheet();
+	$theme = basename( wp_get_theme()->get_stylesheet() );
 
 	// Load templates into the zip file.
 	$template_query = new WP_Query(
@@ -34,7 +34,7 @@ function gutenberg_edit_site_export() {
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'slug',
-					'terms'    => $theme,
+					'terms'    => basename( $theme ),
 				),
 			),
 			'posts_per_page' => -1,
@@ -58,7 +58,7 @@ function gutenberg_edit_site_export() {
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'slug',
-					'terms'    => $theme,
+					'terms'    => basename( $theme ),
 				),
 			),
 			'posts_per_page' => -1,

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -137,7 +137,7 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'slug',
-					'terms'    => wp_get_theme()->get_stylesheet(),
+					'terms'    => basename( wp_get_theme()->get_stylesheet() ),
 				),
 			),
 		)

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -134,7 +134,9 @@ add_filter( 'rest_wp_template_part_collection_params', 'filter_rest_wp_template_
  * @return array Filtered $args.
  */
 function filter_rest_wp_template_part_query( $args, $request ) {
-	if ( $request['theme'] ) {
+	if ( isset( $request['theme'] ) ) {
+		$theme = empty( $request['theme'] ) ? get_current_theme()->get_stylesheet() : $request['theme'];
+
 		$tax_query   = isset( $args['tax_query'] ) ? $args['tax_query'] : array();
 		$tax_query[] = array(
 			'taxonomy' => 'wp_theme',

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -135,7 +135,7 @@ add_filter( 'rest_wp_template_part_collection_params', 'filter_rest_wp_template_
  */
 function filter_rest_wp_template_part_query( $args, $request ) {
 	if ( isset( $request['theme'] ) ) {
-		$theme = empty( $request['theme'] ) ? get_current_theme()->get_stylesheet() : $request['theme'];
+		$theme = empty( $request['theme'] ) ? wp_get_theme()->get_stylesheet() : $request['theme'];
 
 		$tax_query   = isset( $args['tax_query'] ) ? $args['tax_query'] : array();
 		$tax_query[] = array(

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -139,7 +139,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 		$tax_query[] = array(
 			'taxonomy' => 'wp_theme',
 			'field'    => 'slug',
-			'terms'    => $request['theme'],
+			'terms'    => basename( $request['theme'] ),
 		);
 
 		$args['tax_query'] = $tax_query;

--- a/lib/templates-sync.php
+++ b/lib/templates-sync.php
@@ -31,7 +31,7 @@ function _gutenberg_create_auto_draft_for_template( $post_type, $slug, $theme, $
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'slug',
-					'terms'    => $theme,
+					'terms'    => basename( $theme ),
 				),
 			),
 			'posts_per_page' => 1,
@@ -46,7 +46,7 @@ function _gutenberg_create_auto_draft_for_template( $post_type, $slug, $theme, $
 			'post_status'  => 'auto-draft',
 			'post_type'    => $post_type,
 			'post_name'    => $slug,
-			'tax_input'    => array( 'wp_theme' => array( $theme, '_wp_file_based' ) ),
+			'tax_input'    => array( 'wp_theme' => array( basename( $theme ), '_wp_file_based' ) ),
 		);
 
 		if ( 'wp_template' === $post_type ) {

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -116,7 +116,7 @@ add_action( 'init', 'gutenberg_register_wp_theme_taxonomy' );
 function gutenberg_set_template_and_template_part_post_theme( $post_id ) {
 	$themes = wp_get_post_terms( $post_id, 'wp_theme' );
 	if ( ! $themes ) {
-		wp_set_post_terms( $post_id, array( wp_get_theme()->get_stylesheet() ), 'wp_theme', true );
+		wp_set_post_terms( $post_id, array( basename( wp_get_theme()->get_stylesheet() ) ), 'wp_theme', true );
 	}
 }
 add_action( 'save_post_wp_template', 'gutenberg_set_template_and_template_part_post_theme', 10, 3 );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Removes the directory prefix from the theme taxonomy value used in templates and template parts.

Currently if a theme is in a nested directory `parent-directory`, the value is saved using the path `parent-directory/some-theme` and ends up `parent-directory-some-theme`.  

This can be problematic since it makes template and template part CPTs dependent on not only their theme, but also where it is located:
* If a site goes through a process where the theme changes directories, the existing CPTs would no longer correspond to the same theme.  
* Similarly, a current issue with templates not resolving template part auto drafts since the `theme` attribute added in markup obviously cannot account for what directory it will be installed in.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local environment and on a multisite install with themes in nested directories.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Fixes an issue with template part auto-drafts not loading for themes installed in nested directories.

Breaking change (fix or feature that would cause existing functionality to not work as expected)
- FSE Sites using a theme installed in a nested directory will break.  The site editor will not load the expected template and previously existing CPTs will have an outdated value for the theme taxonomy.  The correct auto-drafts can be recreated by deleting the old ones (wp-admin -> appearance -> templates and template parts).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
