### PR TITLE
RSS Block: Add border-box CSS

### DIFF
--- a/packages/block-library/src/rss/editor.scss
+++ b/packages/block-library/src/rss/editor.scss
@@ -1,9 +1,3 @@
-.wp-block-rss {
-	padding-left: 2.5em;
-	&.is-grid {
-		padding-left: 0;
-	}
-}
 .wp-block-rss li a > div {
 	display: inline;
 }

--- a/packages/block-library/src/rss/style.scss
+++ b/packages/block-library/src/rss/style.scss
@@ -1,4 +1,6 @@
 .wp-block-rss {
+	box-sizing: border-box;
+
 	&.alignleft {
 		/*rtl:ignore*/
 		margin-right: 2em;

--- a/packages/block-library/src/rss/style.scss
+++ b/packages/block-library/src/rss/style.scss
@@ -1,5 +1,5 @@
 .wp-block-rss {
-	box-sizing: border-box;
+	box-sizing: border-box !important; // The important is needed because of the reset mixin on the parent: https://github.com/WordPress/gutenberg/blob/a250e9e5fe00dd5195624f96a3d924e7078951c3/packages/edit-post/src/style.scss#L54
 
 	&.alignleft {
 		/*rtl:ignore*/

--- a/packages/block-library/src/rss/style.scss
+++ b/packages/block-library/src/rss/style.scss
@@ -1,5 +1,8 @@
 .wp-block-rss {
-	box-sizing: border-box !important; // The important is needed because of the reset mixin on the parent: https://github.com/WordPress/gutenberg/blob/a250e9e5fe00dd5195624f96a3d924e7078951c3/packages/edit-post/src/style.scss#L54
+	// This needs extra specificity due to the reset mixin on the parent: https://github.com/WordPress/gutenberg/blob/a250e9e5fe00dd5195624f96a3d924e7078951c3/packages/edit-post/src/style.scss#L54
+	&.wp-block-rss {
+		box-sizing: border-box;
+	}
 
 	&.alignleft {
 		/*rtl:ignore*/


### PR DESCRIPTION
## Description
I think we should add `box-sizing: border-box` to the RSS block. The block has a fairly large amount of padding. If we set the block to be full width with `width: 100%` then we'll get horizontal scrollbars on the page because of the padding. This CSS will fix that.

## How has this been tested?
In TT1 Blocks

## Types of changes
Breaking change - this could potentially break existing implementations, although I think it is more likely to fix them.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
