### PR TITLE
Move "spacing" block out of topography

### DIFF
--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -169,10 +169,10 @@
 			"spacing": {
 				"customPadding": false,
 				"units": [ "px", "em", "rem", "vh", "vw" ]
-			},
-			"border": {
-				"customRadius": true
-			}
+			},	
+		},
+		"border": {
+			"customRadius": true
 		}
 	}
 }


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The "spacing" block was in the "typography" block and should be one level higher in order to properly control the setting.

## How has this been tested?
I'm afraid I'm not sure how this file comes into play, I was just using it as an example for how to control the support via a theme and noticed that it was incorrect.  When using the value as shown in this change in my theme.json I was able to control the support as expected

## Screenshots <!-- if applicable -->

## Types of changes
Bug-fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
