### PR TITLE
Add primary destructive button style

### DIFF
--- a/packages/components/src/button/stories/index.js
+++ b/packages/components/src/button/stories/index.js
@@ -57,6 +57,23 @@ export const isDestructive = () => {
 	);
 };
 
+export const isPrimaryDestructive = () => {
+	const label = text( 'Label', 'Destructive Primary Button' );
+	const isSmall = boolean( 'isSmall', false );
+	const disabled = boolean( 'disabled', false );
+
+	return (
+		<Button
+			isPrimary
+			isDestructive
+			isSmall={ isSmall }
+			disabled={ disabled }
+		>
+			{ label }
+		</Button>
+	);
+};
+
 export const small = () => {
 	const label = text( 'Label', 'Small Button' );
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -183,6 +183,19 @@
 		}
 	}
 
+	&.is-destructive.is-primary {
+		color: #fff;
+		background: $alert-red;
+		box-shadow: inset 0 0 0 $border-width $alert-red;
+
+		&:hover:not(:disabled) {
+			color: #fff;
+			background: darken($alert-red, 20%);
+			box-shadow: inset 0 0 0 $border-width darken($alert-red, 20%);
+		}
+	}
+
+
 	/**
 	 * Link buttons.
 	 */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #27587 
Add primary destructive button style

## How has this been tested?
1. `npm run storybook: dev`
1. Go to isPrimaryDestructive button story
1. Check if the button renders as expected
2. Go to isDestructive and primary button stories, check there are no regressions

## Screenshots <!-- if applicable -->
1. Before
<img width="191" alt="before" src="https://user-images.githubusercontent.com/56378160/102441524-6f7b8900-3ff0-11eb-9a98-aeb8055e6267.png">

2. After
<img width="191" alt="after" src="https://user-images.githubusercontent.com/56378160/102441531-773b2d80-3ff0-11eb-99f3-0648d00dd386.png">

3. Hover
<img width="195" alt="hover" src="https://user-images.githubusercontent.com/56378160/102441537-7aceb480-3ff0-11eb-9886-18e0d2c6b61e.png">

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
