### PR TITLE
Create Block: Fix support for external templates hosted on npm

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix support for external templates hosted on npm.
+
 ## 1.0.0 (2020-12-17)
 
 ### Breaking Changes

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -8,11 +8,6 @@ const { fromPairs, isObject } = require( 'lodash' );
 const { join } = require( 'path' );
 
 /**
- * WordPress dependencies
- */
-const lazyImport = require( '@wordpress/lazy-import' );
-
-/**
  * Internal dependencies
  */
 const CLIError = require( './cli-error' );
@@ -98,9 +93,9 @@ const getBlockTemplate = async ( templateName ) => {
 		info( '' );
 		info( 'Downloading template files. It might take some time...' );
 
-		const { defaultValues = {}, templatesPath } = await lazyImport(
-			templateName
-		);
+		await command( `npm install ${ templateName } --no-save` );
+
+		const { defaultValues = {}, templatesPath } = require( templateName );
 		if ( ! isObject( defaultValues ) || ! templatesPath ) {
 			throw new Error();
 		}


### PR DESCRIPTION
## Description
Instead of using @wordpress/lazy-import that doesn't work when invoked with `npm init` or `npx`, the idea is to use `npm install --no-save` and a `require` call.

This fixes the following issue:

```
$ npm init @wordpress/block --template wp-block-directory-template 
npx: installed 215 in 6.078s
Downloading template files. It might take some time...
Invalid template definition provided in "wp-block-directory-template" package.
$ npx @wordpress/create-block --template wp-block-directory-template 
npx: installed 215 in 6.737s
Downloading template files. It might take some time...
Invalid template definition provided in "wp-block-directory-template" package.
```

## How has this been tested?
`npx wp-create-block --template wp-block-directory-template`