### PR TITLE
LinkControl: Fix horizontal scrollbar within block toolbar

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -172,6 +172,7 @@ $block-editor-link-control-number-of-actions: 1;
 		display: block;
 		margin-bottom: 0.2em;
 		font-weight: 500;
+		position: relative;
 
 		mark {
 			font-weight: 700;


### PR DESCRIPTION
## Description

The `.components-visually-hidden` element within the control, stating the link will open in a new tab, is absolutely positioned however the link control has no position: relative set. The end result is the hidden element causes a horizontal scrollbar. This fixes that.

## How has this been tested?
Manually.

#### Testing Instruction

1. Create a post and drag and audio file or image into the editor to create the blocks
2. Select each block, click the "Replace" button in the block toolbar and notice the horizontal scroll in the popover
3. Save the post, checkout this PR and reload the editor
4. Select each block again and confirm that there is no horizontal scrollbar

## Screenshots <!-- if applicable -->

#### Before

| Image | Audio | 
|-------|-------|
| <img width="706" alt="Screen Shot 2020-12-17 at 7 48 09 pm" src="https://user-images.githubusercontent.com/60436221/102474299-31d83800-40a4-11eb-9b41-af643b8c1079.png"> | <img width="700" alt="Screen Shot 2020-12-17 at 7 47 59 pm" src="https://user-images.githubusercontent.com/60436221/102474329-38ff4600-40a4-11eb-980c-638a8ceb7470.png"> |

#### After

| Image | Audio | 
|-------|-------|
| <img width="802" alt="Screen Shot 2020-12-17 at 7 34 41 pm" src="https://user-images.githubusercontent.com/60436221/102474137-005f6c80-40a4-11eb-9b6f-544cc50395bd.png"> | <img width="791" alt="Screen Shot 2020-12-17 at 7 34 34 pm" src="https://user-images.githubusercontent.com/60436221/102474200-1a994a80-40a4-11eb-81a5-ccd7283a67dc.png"> |

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile 
Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
