### PR TITLE
Update performance of global styles code

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -270,6 +270,10 @@ class WP_Theme_JSON_Resolver {
 	 * @return WP_Theme_JSON
 	 */
 	public function get_origin( $theme_support_data = array(), $origin = 'user', $merged = true ) {
+		if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
+			$result = new WP_Theme_JSON();
+			$result->merge( self::get_core_origin() );
+		}
 
 		if ( ( 'user' === $origin ) && $merged ) {
 			$result = new WP_Theme_JSON();
@@ -337,6 +341,10 @@ class WP_Theme_JSON_Resolver {
 	 * @return integer
 	 */
 	public static function get_user_custom_post_type_id() {
+		if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
+			return null;
+		}
+
 		if ( null !== self::$user_custom_post_type_id ) {
 			return self::$user_custom_post_type_id;
 		}

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -180,6 +180,10 @@ class WP_Theme_JSON_Resolver {
 	 * @return array Custom Post Type for the user's origin config.
 	 */
 	private static function get_user_data_from_custom_post_type( $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
+		if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
+			return array();
+		}
+
 		$user_cpt         = array();
 		$post_type_filter = 'wp_global_styles';
 		$post_name_filter = 'wp-global-styles-' . urlencode( wp_get_theme()->get_stylesheet() );

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -237,7 +237,7 @@ class WP_Theme_JSON_Resolver {
 				$config = $decoded_data;
 			}
 		}
-		self::$user = new WP_Theme_JSON( $config );
+		self::$user = new WP_Theme_JSON( $config, true );
 
 		return self::$user;
 	}

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -180,10 +180,6 @@ class WP_Theme_JSON_Resolver {
 	 * @return array Custom Post Type for the user's origin config.
 	 */
 	private static function get_user_data_from_custom_post_type( $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
-		if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
-			return array();
-		}
-
 		$user_cpt         = array();
 		$post_type_filter = 'wp_global_styles';
 		$post_name_filter = 'wp-global-styles-' . urlencode( wp_get_theme()->get_stylesheet() );
@@ -274,11 +270,6 @@ class WP_Theme_JSON_Resolver {
 	 * @return WP_Theme_JSON
 	 */
 	public function get_origin( $theme_support_data = array(), $origin = 'user', $merged = true ) {
-		if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
-			$result = new WP_Theme_JSON();
-			$result->merge( self::get_core_origin() );
-		}
-
 		if ( ( 'user' === $origin ) && $merged ) {
 			$result = new WP_Theme_JSON();
 			$result->merge( self::get_core_origin() );
@@ -309,10 +300,6 @@ class WP_Theme_JSON_Resolver {
 	 * Registers a Custom Post Type to store the user's origin config.
 	 */
 	public static function register_user_custom_post_type() {
-		if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
-			return;
-		}
-
 		$args = array(
 			'label'        => __( 'Global Styles', 'gutenberg' ),
 			'description'  => 'CPT to store user design tokens',
@@ -345,10 +332,6 @@ class WP_Theme_JSON_Resolver {
 	 * @return integer
 	 */
 	public static function get_user_custom_post_type_id() {
-		if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
-			return null;
-		}
-
 		if ( null !== self::$user_custom_post_type_id ) {
 			return self::$user_custom_post_type_id;
 		}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -339,6 +339,7 @@ class WP_Theme_JSON {
 			// Process settings subtree.
 			$this->process_key( 'settings', $context, self::SCHEMA );
 			if ( isset( $context['settings'] ) ) {
+				$this->process_key( 'border', $context['settings'], self::SCHEMA['settings'] );
 				$this->process_key( 'color', $context['settings'], self::SCHEMA['settings'] );
 				$this->process_key( 'spacing', $context['settings'], self::SCHEMA['settings'] );
 				$this->process_key( 'typography', $context['settings'], self::SCHEMA['settings'] );

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -135,8 +135,8 @@ class WP_Theme_JSON {
 				'dropCap'               => null,
 				'fontFamilies'          => null,
 				'fontSizes'             => null,
-				'customFontStyle'      => null,
-				'customFontWeight'     => null,
+				'customFontStyle'       => null,
+				'customFontWeight'      => null,
 				'customTextDecorations' => null,
 				'customTextTransforms'  => null,
 			),
@@ -511,7 +511,7 @@ class WP_Theme_JSON {
 		// by testing its value with "background" as the property name.
 		if ( $should_escape ) {
 			$subtree = $input[ $key ];
-			foreach( $subtree as $property => $value ) {
+			foreach ( $subtree as $property => $value ) {
 				$name = 'background-color';
 				if ( 'gradient' === $property ) {
 					$name = 'background';

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -302,8 +302,9 @@ class WP_Theme_JSON {
 	 * Constructor.
 	 *
 	 * @param array $contexts A structure that follows the theme.json schema.
+	 * @param boolean $should_escape_styles Whether the incoming styles should be escaped using kses.
 	 */
-	public function __construct( $contexts = array() ) {
+	public function __construct( $contexts = array(), $should_escape_styles = false ) {
 		$this->contexts = array();
 
 		if ( ! is_array( $contexts ) ) {
@@ -324,8 +325,9 @@ class WP_Theme_JSON {
 			// Process styles subtree.
 			$this->process_key( 'styles', $context, self::SCHEMA );
 			if ( isset( $context['styles'] ) ) {
-				$this->process_key( 'color', $context['styles'], self::SCHEMA['styles'] );
-				$this->process_key( 'typography', $context['styles'], self::SCHEMA['styles'] );
+				$this->process_key( 'color', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
+				$this->process_key( 'spacing', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
+				$this->process_key( 'typography', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
 
 				if ( empty( $context['styles'] ) ) {
 					unset( $context['styles'] );
@@ -472,8 +474,9 @@ class WP_Theme_JSON {
 	 * @param string $key Key of the subtree to normalize.
 	 * @param array  $input Whole tree to normalize.
 	 * @param array  $schema Schema to use for normalization.
+	 * @param boolean $should_escape Whether the subproperties should be escaped with kses.
 	 */
-	private static function process_key( $key, &$input, $schema ) {
+	private static function process_key( $key, &$input, $schema, $should_escape = false ) {
 		if ( ! isset( $input[ $key ] ) ) {
 			return;
 		}
@@ -492,6 +495,35 @@ class WP_Theme_JSON {
 			$input[ $key ],
 			$schema[ $key ]
 		);
+
+		// Use kses to escape invalid values.
+		//
+		// kses maintains an allowed list of properties.
+		// "background-color" is one of them,
+		// so we use it for testing the property's value.
+		//
+		// For a subset of the above properties,
+		// kses is more permissive and also allows
+		// using some CSS functions such as linear-gradient or rgba.
+		// "background" is one of these gradient-enabled properties.
+		// So, when we're processing gradients,
+		// we tell kses to allow gradient CSS functions
+		// by testing its value with "background" as the property name.
+		if ( $should_escape ) {
+			$subtree = $input[ $key ];
+			foreach( $subtree as $property => $value ) {
+				$name = 'background-color';
+				if ( 'gradient' === $property ) {
+					$name = 'background';
+				}
+				$result = safecss_filter_attr( "$name: $value" );
+
+				// If kses didn't like it, we neither.
+				if ( '' === $result ) {
+					unset( $input[ $key ][ $property ] );
+				}
+			}
+		}
 
 		if ( 0 === count( $input[ $key ] ) ) {
 			unset( $input[ $key ] );

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -301,7 +301,7 @@ class WP_Theme_JSON {
 	/**
 	 * Constructor.
 	 *
-	 * @param array $contexts A structure that follows the theme.json schema.
+	 * @param array   $contexts A structure that follows the theme.json schema.
 	 * @param boolean $should_escape_styles Whether the incoming styles should be escaped.
 	 */
 	public function __construct( $contexts = array(), $should_escape_styles = false ) {
@@ -472,9 +472,9 @@ class WP_Theme_JSON {
 	 * This function modifies the given input by removing
 	 * the nodes that aren't valid per the schema.
 	 *
-	 * @param string $key Key of the subtree to normalize.
-	 * @param array  $input Whole tree to normalize.
-	 * @param array  $schema Schema to use for normalization.
+	 * @param string  $key Key of the subtree to normalize.
+	 * @param array   $input Whole tree to normalize.
+	 * @param array   $schema Schema to use for normalization.
 	 * @param boolean $should_escape Whether the subproperties should be escaped.
 	 */
 	private static function process_key( $key, &$input, $schema, $should_escape = false ) {

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -302,7 +302,7 @@ class WP_Theme_JSON {
 	 * Constructor.
 	 *
 	 * @param array $contexts A structure that follows the theme.json schema.
-	 * @param boolean $should_escape_styles Whether the incoming styles should be escaped using kses.
+	 * @param boolean $should_escape_styles Whether the incoming styles should be escaped.
 	 */
 	public function __construct( $contexts = array(), $should_escape_styles = false ) {
 		$this->contexts = array();
@@ -474,7 +474,7 @@ class WP_Theme_JSON {
 	 * @param string $key Key of the subtree to normalize.
 	 * @param array  $input Whole tree to normalize.
 	 * @param array  $schema Schema to use for normalization.
-	 * @param boolean $should_escape Whether the subproperties should be escaped with kses.
+	 * @param boolean $should_escape Whether the subproperties should be escaped.
 	 */
 	private static function process_key( $key, &$input, $schema, $should_escape = false ) {
 		if ( ! isset( $input[ $key ] ) ) {
@@ -496,19 +496,6 @@ class WP_Theme_JSON {
 			$schema[ $key ]
 		);
 
-		// Use kses to escape invalid values.
-		//
-		// kses maintains an allowed list of properties.
-		// "background-color" is one of them,
-		// so we use it for testing the property's value.
-		//
-		// For a subset of the above properties,
-		// kses is more permissive and also allows
-		// using some CSS functions such as linear-gradient or rgba.
-		// "background" is one of these gradient-enabled properties.
-		// So, when we're processing gradients,
-		// we tell kses to allow gradient CSS functions
-		// by testing its value with "background" as the property name.
 		if ( $should_escape ) {
 			$subtree = $input[ $key ];
 			foreach ( $subtree as $property => $value ) {
@@ -518,7 +505,6 @@ class WP_Theme_JSON {
 				}
 				$result = safecss_filter_attr( "$name: $value" );
 
-				// If kses didn't like it, we neither.
 				if ( '' === $result ) {
 					unset( $input[ $key ][ $property ] );
 				}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -195,9 +195,17 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	unset( $settings['fontSizes'] );
 	unset( $settings['gradients'] );
 
-	$resolver = new WP_Theme_JSON_Resolver();
-	$all      = $resolver->get_origin( $theme_support_data );
-	$base     = $resolver->get_origin( $theme_support_data, 'theme' );
+	$resolver    = new WP_Theme_JSON_Resolver();
+	$all_origin  = 'user';
+	$base_origin = 'theme';
+	if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
+		// This makes sure we don't consume resources looking up for
+		// the theme.json file (theme) or the CPT for user.
+		$all_origin  = 'core';
+		$base_origin = 'core';
+	}
+	$all      = $resolver->get_origin( $theme_support_data, $all_origin );
+	$base     = $resolver->get_origin( $theme_support_data, $base_origin );
 
 	// STEP 1: ADD FEATURES
 	// These need to be added to settings always.

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -235,6 +235,9 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	return $settings;
 }
 
-add_action( 'init', array( 'WP_Theme_JSON_Resolver', 'register_user_custom_post_type' ) );
+if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
+	add_action( 'init', array( 'WP_Theme_JSON_Resolver', 'register_user_custom_post_type' ) );
+	add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
+}
+
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
-add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -256,5 +256,5 @@ function gutenberg_experimental_global_styles_register_user_cpt() {
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_user_cpt' );
-add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
+add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -162,6 +162,10 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
+	if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
+		return;
+	}
+
 	$settings           = gutenberg_get_common_block_editor_settings();
 	$theme_support_data = gutenberg_experimental_global_styles_get_theme_support_settings( $settings );
 
@@ -243,9 +247,6 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	return $settings;
 }
 
-if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
-	add_action( 'init', array( 'WP_Theme_JSON_Resolver', 'register_user_custom_post_type' ) );
-	add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
-}
-
+add_action( 'init', array( 'WP_Theme_JSON_Resolver', 'register_user_custom_post_type' ) );
+add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -227,7 +227,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		gutenberg_is_edit_site_page( $screen->id ) &&
 		gutenberg_experimental_global_styles_has_theme_json_support()
 	) {
-		$settings['__experimentalGlobalStylesUserEntityId'] = $custom_post_type_id;
+		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $base->get_raw_data();
 	} else {
 		// STEP 3 - OTHERWISE, ADD STYLES

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -247,6 +247,14 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	return $settings;
 }
 
-add_action( 'init', array( 'WP_Theme_JSON_Resolver', 'register_user_custom_post_type' ) );
+function gutenberg_experimental_global_styles_register_user_cpt() {
+	if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
+		return;
+	}
+
+	WP_Theme_JSON_Resolver::register_user_custom_post_type();
+}
+
+add_action( 'init', 'gutenberg_experimental_global_styles_register_user_cpt' );
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -248,6 +248,11 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	return $settings;
 }
 
+/**
+ * Register CPT to store/access user data.
+ *
+ * @return array|undefined
+ */
 function gutenberg_experimental_global_styles_register_user_cpt() {
 	if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
 		return;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -200,16 +200,17 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	unset( $settings['gradients'] );
 
 	$resolver    = new WP_Theme_JSON_Resolver();
-	$all_origin  = 'user';
-	$base_origin = 'theme';
-	if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
-		// This makes sure we don't consume resources looking up for
-		// the theme.json file (theme) or the CPT for user.
-		$all_origin  = 'core';
-		$base_origin = 'core';
+	$all_origin  = 'core';
+	$base_origin = 'core';
+	// Do not lookup for the theme.json file (theme)
+	// or the user's CPT unless we need it.
+	if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
+		$all_origin  = 'user';
+		$base_origin = 'theme';
+		$user_cpt_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
 	}
-	$all      = $resolver->get_origin( $theme_support_data, $all_origin );
-	$base     = $resolver->get_origin( $theme_support_data, $base_origin );
+	$all  = $resolver->get_origin( $theme_support_data, $all_origin );
+	$base = $resolver->get_origin( $theme_support_data, $base_origin );
 
 	// STEP 1: ADD FEATURES
 	// These need to be added to settings always.
@@ -226,7 +227,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		gutenberg_is_edit_site_page( $screen->id ) &&
 		gutenberg_experimental_global_styles_has_theme_json_support()
 	) {
-		$settings['__experimentalGlobalStylesUserEntityId'] = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
+		$settings['__experimentalGlobalStylesUserEntityId'] = $custom_post_type_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $base->get_raw_data();
 	} else {
 		// STEP 3 - OTHERWISE, ADD STYLES

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -206,9 +206,9 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		gutenberg_is_fse_theme()
 	) {
 		// Only lookup for the user data if we need it.
-		$origin  = 'user';
+		$origin = 'user';
 	}
-	$tree     = $resolver->get_origin( $theme_support_data, $origin );
+	$tree = $resolver->get_origin( $theme_support_data, $origin );
 
 	// STEP 1: ADD FEATURES
 	//
@@ -233,9 +233,10 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	) {
 		$user_cpt_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
 		$base_styles = $resolver->get_origin( $theme_support_data, 'theme' )->get_raw_data();
+
 		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $base_styles;
-	} else if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
+	} elseif ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
 		// STEP 3 - ADD STYLES IF THEME HAS SUPPORT
 		//
 		// If we are in a block editor context, but not in edit-site,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -11,14 +11,14 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	function test_user_data_is_escaped() {
 		$theme_json = new WP_Theme_JSON(
 			array(
-				'global'       => array(
+				'global' => array(
 					'styles' => array(
 						'color' => array(
 							'background' => 'green',
 							'gradient'   => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
 							'link'       => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
 							'text'       => 'var:preset|color|dark-gray',
-						)
+						),
 					),
 				),
 			),
@@ -31,8 +31,8 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				'styles' => array(
 					'color' => array(
 						'background' => 'green',
-						'gradient' => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
-						'text' => 'var:preset|color|dark-gray',
+						'gradient'   => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
+						'text'       => 'var:preset|color|dark-gray',
 					),
 				),
 			),
@@ -331,13 +331,13 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						),
 					),
 					'typography' => array(
-						'fontSizes'       => array(
+						'fontSizes'    => array(
 							array(
 								'slug' => 'fontSize',
 								'size' => 'fontSize',
 							),
 						),
-						'fontFamilies'    => array(
+						'fontFamilies' => array(
 							array(
 								'slug'       => 'fontFamily',
 								'fontFamily' => 'fontFamily',
@@ -368,13 +368,13 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						),
 					),
 					'typography' => array(
-						'fontSizes'       => array(
+						'fontSizes'    => array(
 							array(
 								'slug' => 'fontSize',
 								'size' => 'fontSize',
 							),
 						),
-						'fontFamilies'    => array(
+						'fontFamilies' => array(
 							array(
 								'slug'       => 'fontFamily',
 								'fontFamily' => 'fontFamily',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -8,6 +8,39 @@
 
 class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
+	function test_user_data_is_escaped() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'global'       => array(
+					'styles' => array(
+						'color' => array(
+							'background' => 'green',
+							'gradient'   => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
+							'link'       => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
+							'text'       => 'var:preset|color|dark-gray',
+						)
+					),
+				),
+			),
+			true
+		);
+		$result     = $theme_json->get_raw_data();
+
+		$expected = array(
+			'global' => array(
+				'styles' => array(
+					'color' => array(
+						'background' => 'green',
+						'gradient' => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
+						'text' => 'var:preset|color|dark-gray',
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $result );
+	}
+
 	function test_contexts_not_valid_are_skipped() {
 		$theme_json = new WP_Theme_JSON(
 			array(


### PR DESCRIPTION
This PR improves the performance of global styles by not looking up for resources we don't need.

What this means in practice:

- Styles: we no longer enqueue the global styles stylesheet if a theme doesn't have theme.json. We used to do that to make the presets available (both CSS Custom Properties & classes) for all themes automatically. People have reported this is not ideal and may interfere with their themes' CSS.

- Settings: whether or not the theme has a theme.json, we need to enqueue the settings to the editors to control design tools visibility, etc. This is now bounded to not require user data lookup if it has no support.

### Test

- Themes that support FSE & Global Styles work as expected ― theme example: TT1-blocks
  - site-editor: changes in the user styles are reflected in the front-end
  - post-editor: still works as expected (presets are present, etc)

- Themes that don't support FSE and/or Global Styles work as expected ― theme example: TwentyTwentyOne, TwentyTwenty.
  - site-editor: is not loaded for them
  - post-editor: still works as expected (presets are present, etc) 
