### PR TITLE
When a block inside a template part is selected, display the template part outline on the canvas

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -14,6 +14,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 	Spinner,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronUp, chevronDown } from '@wordpress/icons';
@@ -42,7 +43,7 @@ export default function TemplatePartEdit( {
 	// Set the postId block attribute if it did not exist,
 	// but wait until the inner blocks have loaded to allow
 	// new edits to trigger this.
-	const { innerBlocks, expectedContent } = useSelect(
+	const { innerBlocks, expectedContent, title } = useSelect(
 		( select ) => {
 			const { getBlocks } = select( 'core/block-editor' );
 			const entityRecord = select( 'core' ).getEntityRecord(
@@ -54,6 +55,7 @@ export default function TemplatePartEdit( {
 			return {
 				innerBlocks: getBlocks( clientId ),
 				expectedContent: entityRecord?.content.raw,
+				title: entityRecord?.title.raw,
 			};
 		},
 		[ clientId, postId ]
@@ -171,6 +173,13 @@ export default function TemplatePartEdit( {
 					/>
 				) }
 				{ isUnresolvedTemplateFile && <Spinner /> }
+				<Text
+					variant="body.small"
+					className="wp-block-template-part__title-chip"
+					as="div"
+				>
+					{ title }
+				</Text>
 			</TagName>
 		</>
 	);

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -14,7 +14,6 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 	Spinner,
-	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronUp, chevronDown } from '@wordpress/icons';
@@ -43,7 +42,7 @@ export default function TemplatePartEdit( {
 	// Set the postId block attribute if it did not exist,
 	// but wait until the inner blocks have loaded to allow
 	// new edits to trigger this.
-	const { innerBlocks, expectedContent, title } = useSelect(
+	const { innerBlocks, expectedContent } = useSelect(
 		( select ) => {
 			const { getBlocks } = select( 'core/block-editor' );
 			const entityRecord = select( 'core' ).getEntityRecord(
@@ -55,7 +54,6 @@ export default function TemplatePartEdit( {
 			return {
 				innerBlocks: getBlocks( clientId ),
 				expectedContent: entityRecord?.content.raw,
-				title: entityRecord?.title.raw,
 			};
 		},
 		[ clientId, postId ]
@@ -173,13 +171,6 @@ export default function TemplatePartEdit( {
 					/>
 				) }
 				{ isUnresolvedTemplateFile && <Spinner /> }
-				<Text
-					variant="body.small"
-					className="wp-block-template-part__title-chip"
-					as="div"
-				>
-					{ title }
-				</Text>
 			</TagName>
 		</>
 	);

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -89,3 +89,44 @@
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 }
+
+.wp-block-template-part {
+	&.is-selected {
+		.wp-block-template-part__title-chip {
+			display: inline-flex;
+		}
+	}
+
+	&.has-child-selected {
+		.wp-block-template-part__title-chip {
+			display: inline-flex;
+			background: $gray-900;
+		}
+
+		&::after {
+			outline: 1px dotted $gray-900;
+		}
+
+		&.is-hovered {
+			&::after {
+				outline: none;
+			}
+
+			.wp-block-template-part__title-chip {
+				display: inline-flex;
+				background: var(--wp-admin-theme-color);
+			}
+		}
+	}
+}
+
+.wp-block-template-part__title-chip {
+	background: var(--wp-admin-theme-color);
+	color: $white;
+	padding: $grid-unit-05 $grid-unit-10;
+	border-radius: 2px;
+	position: absolute;
+	top: calc(100% + 4px);
+	right: 4px;
+	display: none;
+}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -111,22 +111,6 @@
 			&::after {
 				outline: none;
 			}
-
-			.wp-block-template-part__title-chip {
-				display: inline-flex;
-				background: var(--wp-admin-theme-color);
-			}
 		}
 	}
-}
-
-.wp-block-template-part__title-chip {
-	background: var(--wp-admin-theme-color);
-	color: $white;
-	padding: $grid-unit-05 $grid-unit-10;
-	border-radius: 2px;
-	position: absolute;
-	top: calc(100% + 4px);
-	right: 4px;
-	display: none;
 }


### PR DESCRIPTION
Currently when a template part (or innerblock) is selected, the name is displayed in the Top Bar like so:

<img width="216" alt="Screenshot 2020-12-16 at 17 56 25" src="https://user-images.githubusercontent.com/846565/102492460-a0e46b00-4069-11eb-93b8-904843c4c195.png">

This can be easy to miss and doesn't visually explain the relationship between the template part and the selected innerblock. 

In this PR I'm exploring how it feels to also display the template part name on the canvas as a small chip absolutely positioned in the bottom right corner of the block. This treatment would persist as you navigate down the tree, so that you're easily able to identify the parent template part boundaries, and select it via click.

![tp-chip](https://user-images.githubusercontent.com/846565/102492654-e86af700-4069-11eb-8ae0-2c83895e2c65.gif)
