### PR TITLE
Keep initial formatting on paste for Preformatted and Verse components

### DIFF
--- a/packages/block-library/src/preformatted/edit.js
+++ b/packages/block-library/src/preformatted/edit.js
@@ -29,6 +29,7 @@ export default function PreformattedEdit( {
 			placeholder={ __( 'Write preformatted text…' ) }
 			onMerge={ mergeBlocks }
 			{ ...blockProps }
+			__unstablePastePlainText
 		/>
 	);
 }

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -51,6 +51,7 @@ export default function VerseEdit( {
 				onMerge={ mergeBlocks }
 				textAlign={ textAlign }
 				{ ...blockProps }
+				__unstablePastePlainText
 			/>
 		</>
 	);


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Regarding https://github.com/WordPress/gutenberg/issues/27660 there was an issue that when text with predefined formatting (like with line separation) was pasted, it was losing the formatting. 
The solution to the problem seems to be to add __unstablePastePlainText as an attribute.
<!-- Please describe what you have changed or added -->

## How has this been tested?
Tested visually. The introduced change does not break e2e tests.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


## Types of changes
Bug fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
