### PR TITLE
Theme JSON: Add border radius to the theme styles schema

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -56,12 +56,14 @@ Every context has the same structure, divided in two sections: `settings` and `s
 {
   "some/context": {
     "settings": {
+      "border": [ ... ],
       "color": [ ... ],
       "custom": [ ... ],
       "spacing": [ ... ],
       "typography": [ ... ]
     },
     "styles": {
+      "border": { ... },
       "color": { ... },
       "typography": { ... }
     }
@@ -79,6 +81,9 @@ The settings section has the following structure and default values:
 {
   "some/context": {
     "settings": {
+      "border": {
+        "customRadius": true /* false to opt-out */
+      },
       "color": {
         "custom": true, /* false to opt-out, as in add_theme_support('disable-custom-colors') */
         "customGradient": true, /* false to opt-out, as in add_theme_support('disable-custom-gradients') */
@@ -241,6 +246,9 @@ Each block declares which style properties it exposes. This has been coined as "
 {
   "some/context": {
     "styles": {
+      "border": {
+        "radius": "value"
+      },
       "color": {
         "background": "value",
         "gradient": "value",

--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -82,7 +82,7 @@ The settings section has the following structure and default values:
   "some/context": {
     "settings": {
       "border": {
-        "customRadius": true /* false to opt-out */
+        "customRadius": false /* true to opt-in */
       },
       "color": {
         "custom": true, /* false to opt-out, as in add_theme_support('disable-custom-colors') */

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -90,6 +90,9 @@ class WP_Theme_JSON {
 	 */
 	const SCHEMA = array(
 		'styles'   => array(
+			'border'     => array(
+				'radius' => null,
+			),
 			'color'      => array(
 				'background' => null,
 				'gradient'   => null,
@@ -246,7 +249,7 @@ class WP_Theme_JSON {
 		),
 		'borderRadius'             => array(
 			'value'   => array( 'border', 'radius' ),
-			'support' => array( '__experimentalBorder' ),
+			'support' => array( '__experimentalBorder', 'radius' ),
 		),
 		'color'                    => array(
 			'value'   => array( 'color', 'text' ),
@@ -325,6 +328,7 @@ class WP_Theme_JSON {
 			// Process styles subtree.
 			$this->process_key( 'styles', $context, self::SCHEMA );
 			if ( isset( $context['styles'] ) ) {
+				$this->process_key( 'border', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
 				$this->process_key( 'color', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
 				$this->process_key( 'spacing', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
 				$this->process_key( 'typography', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -171,7 +171,7 @@
 				"units": [ "px", "em", "rem", "vh", "vw" ]
 			},
 			"border": {
-				"customRadius": true
+				"customRadius": false
 			}
 		}
 	}

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -64,7 +64,7 @@ export function BorderRadiusEdit( props ) {
  */
 export function hasBorderRadiusSupport( blockType ) {
 	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
-	return true === support || ( support && !! support.radius );
+	return !! ( true === support || support?.radius );
 }
 
 /**

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -46,7 +46,7 @@ export function hasBorderSupport( blockName ) {
 
 	// Further border properties to be added in future iterations.
 	// e.g. support && ( support.radius || support.width || support.style )
-	return true === support || ( support && support.radius );
+	return !! ( true === support || support?.radius );
 }
 
 /**
@@ -63,5 +63,5 @@ const useIsBorderDisabled = ( props = {} ) => {
 	//		useIsBorderWidthDisabled( props ),
 	// ];
 	const configs = [ useIsBorderRadiusDisabled( props ) ];
-	return configs.filter( Boolean ).length === configs.length;
+	return configs.every( Boolean );
 };


### PR DESCRIPTION
## Description
* Adds border radius to the theme JSON styles schema
* Tidies up a couple of the border radius block support checks
* Disables custom border radius support in theme.json. Prevents the display of the border radius controls (still allows themes and patterns to specify border radii)

## How has this been tested?
Manually.

1. Apply this PR branch
2. Create a new post and add a group block also setting its background color. Confirm no border radius style on the block
3. Opt into the border radius support for the group block
```
  "__experimentalBorder": {
    "radius": true
  }
```
4. Reload the editor and confirm border radius controls are **not** present in the sidebar
5. Update theme.json or `experimental-default-theme.json` with a new block context adding a style for border radius
```
  "core/group": {
    "styles": {
      "border": {
        "radius": "50px"
      }
    }
  }
```
6. Reload the editor and confirm the new style added has been added. Both visually and under the `.wp-block-group` CSS class
7. Confirm style on frontend
8. Switch to the code editor view and add a style attribute to the group block and matching inline style
```
<!-- wp:group {"backgroundColor":"accent","style":{"border":{"radius":11}}} -->
<div class="wp-block-group has-accent-background-color has-background" style="border-radius: 11px;"><div class="wp-block-group__inner-container"></div></div>
<!-- /wp:group -->
```
9. Save post, reload editor and frontend confirming block specific value is in effect
10. Confirm that altering the block's border radius attribute value independent of the inline style does actually invalidate the block.
11. Remove the custom border radius attribute and inline style. Save post.
11. Add an invalid border style property to the theme JSON context added in step 5 and ensure that isn't added to the CSS class styles

## Screenshots <!-- if applicable -->

Editor: 

| Via Theme.json | Via Block Attributes |
|----------------|----------------------|
| <img width="1389" alt="Screen Shot 2020-12-23 at 5 40 43 pm" src="https://user-images.githubusercontent.com/60436221/102972085-3c804a80-4546-11eb-81dd-4979f3173aa9.png"> | <img width="1389" alt="Screen Shot 2020-12-23 at 5 38 59 pm" src="https://user-images.githubusercontent.com/60436221/102972108-430ec200-4546-11eb-903c-9a3b3700b196.png"> |

Frontend:

| Via Theme.json | Via Block Attributes |
|----------------|----------------------|
| <img width="1694" alt="Screen Shot 2020-12-23 at 5 42 06 pm" src="https://user-images.githubusercontent.com/60436221/102972136-50c44780-4546-11eb-9738-f294292fc10f.png"> | <img width="1717" alt="Screen Shot 2020-12-23 at 5 41 41 pm" src="https://user-images.githubusercontent.com/60436221/102972142-528e0b00-4546-11eb-8090-13e779a28478.png"> |


## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
