### PR TITLE
Remove optimistic updates to solve the template revert issue

### DIFF
--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -115,16 +115,7 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 
-		// Should select __experimentalGetEntityRecordNoResolver selector (as opposed to getEntityRecord)
-		// see https://github.com/WordPress/gutenberg/pull/19752#discussion_r368498318.
 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		expect( fulfillment.next().value.selectorName ).toBe(
-			'__experimentalGetEntityRecordNoResolver'
-		);
-		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		const receiveItems = fulfillment.next().value;
-		expect( receiveItems.type ).toBe( 'RECEIVE_ITEMS' );
-		expect( receiveItems.invalidateCache ).toBe( false );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts',
@@ -173,11 +164,6 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		const receiveItems = fulfillment.next().value;
-		expect( receiveItems.type ).toBe( 'RECEIVE_ITEMS' );
-		expect( receiveItems.invalidateCache ).toBe( false );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts/10',
@@ -222,9 +208,6 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/types/page',

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -30,7 +30,7 @@ function PostTemplate() {
 			template:
 				isFSEEnabled &&
 				link &&
-				! getCurrentPost().status !== 'auto-draft' &&
+				getCurrentPost().status !== 'auto-draft' &&
 				getCurrentPostType() !== 'wp_template'
 					? __experimentalGetTemplateForLink( link )
 					: null,

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -18,8 +18,8 @@ function PostTemplate() {
 	const { template, isEditing, isFSETheme } = useSelect( ( select ) => {
 		const {
 			getEditedPostAttribute,
-			__unstableIsAutodraftPost,
 			getCurrentPostType,
+			getCurrentPost,
 		} = select( editorStore );
 		const { __experimentalGetTemplateForLink } = select( coreStore );
 		const { isEditingTemplate } = select( editPostStore );
@@ -30,7 +30,7 @@ function PostTemplate() {
 			template:
 				isFSEEnabled &&
 				link &&
-				! __unstableIsAutodraftPost() &&
+				! getCurrentPost().status !== 'auto-draft' &&
 				getCurrentPostType() !== 'wp_template'
 					? __experimentalGetTemplateForLink( link )
 					: null,

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -60,9 +60,7 @@ function Editor( {
 		const { getEntityRecord, __experimentalGetTemplateForLink } = select(
 			'core'
 		);
-		const { getEditorSettings, __unstableIsAutodraftPost } = select(
-			'core/editor'
-		);
+		const { getEditorSettings, getCurrentPost } = select( 'core/editor' );
 		const { getBlockTypes } = select( blocksStore );
 		const postObject = getEntityRecord( 'postType', postType, postId );
 		const isFSETheme = getEditorSettings().isFSETheme;
@@ -87,7 +85,7 @@ function Editor( {
 			template:
 				isFSETheme &&
 				postObject &&
-				! __unstableIsAutodraftPost() &&
+				! getCurrentPost().status === 'auto-draft' &&
 				postType !== 'wp_template'
 					? __experimentalGetTemplateForLink( postObject.link )
 					: null,

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -85,7 +85,7 @@ function Editor( {
 			template:
 				isFSETheme &&
 				postObject &&
-				! getCurrentPost().status === 'auto-draft' &&
+				getCurrentPost().status !== 'auto-draft' &&
 				postType !== 'wp_template'
 					? __experimentalGetTemplateForLink( postObject.link )
 					: null,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1270,20 +1270,6 @@ export function getEditorBlocks( state ) {
 }
 
 /**
- * Checks whether a post is an auto-draft ignoring the optimistic transaction.
- * This selector shouldn't be necessary. It's currently used as a workaround
- * to avoid template resolution for auto-drafts which has a backend bug.
- *
- * @param {Object} state State.
- * @return {boolean} Whether the post is "auto-draft" on the backend.
- */
-export function __unstableIsAutodraftPost( state ) {
-	const post = getCurrentPost( state );
-	const isSaving = isSavingPost( state );
-	return isSaving || post.status === 'auto-draft';
-}
-
-/**
  * A block selection object.
  *
  * @typedef {Object} WPBlockSelection


### PR DESCRIPTION
When we save entities in the saveEntityRecord action, we have some logic to persist optimistic updates to the store before  we receive any reply from the server. This adds a lot of complexity and sometimes creates hidden bugs. (Like when editing in template mode, the template can reset its edits when the auto-saves triggers).

