### PR TITLE
Remove unused redux-optimist dependency

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -568,6 +568,8 @@ _Related_
 
 <a name="getStateBeforeOptimisticTransaction" href="#getStateBeforeOptimisticTransaction">#</a> **getStateBeforeOptimisticTransaction**
 
+> **Deprecated** since Gutenberg 9.7.0.
+
 Returns state object prior to a specified optimist transaction ID, or `null`
 if the transaction corresponding to the given ID cannot be found.
 
@@ -686,6 +688,8 @@ _Related_
 -   hasSelectedInnerBlock in core/block-editor store.
 
 <a name="inSomeHistory" href="#inSomeHistory">#</a> **inSomeHistory**
+
+> **Deprecated** since Gutenberg 9.7.0.
 
 Returns true if an optimistic transaction is pending commit, for which the
 before state satisfies the given predicate function.
@@ -1471,6 +1475,8 @@ _Related_
 Undocumented declaration.
 
 <a name="updatePost" href="#updatePost">#</a> **updatePost**
+
+> **Deprecated** since Gutenberg 9.7.0.
 
 Returns an action object used in signalling that a patch of updates for the
 latest version of the post have been received.

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -571,15 +571,6 @@ _Related_
 Returns state object prior to a specified optimist transaction ID, or `null`
 if the transaction corresponding to the given ID cannot be found.
 
-_Parameters_
-
--   _state_ `Object`: Current global application state.
--   _transactionId_ `Object`: Optimist transaction ID.
-
-_Returns_
-
--   `Object`: Global application state prior to transaction.
-
 <a name="getSuggestedPostFormat" href="#getSuggestedPostFormat">#</a> **getSuggestedPostFormat**
 
 Returns a suggested post format for the current post, inferred only if there
@@ -698,15 +689,6 @@ _Related_
 
 Returns true if an optimistic transaction is pending commit, for which the
 before state satisfies the given predicate function.
-
-_Parameters_
-
--   _state_ `Object`: Editor state.
--   _predicate_ `Function`: Function given state, returning true if match.
-
-_Returns_
-
--   `boolean`: Whether predicate matches for some history.
 
 <a name="isAncestorMultiSelected" href="#isAncestorMultiSelected">#</a> **isAncestorMultiSelected**
 
@@ -1492,10 +1474,6 @@ Undocumented declaration.
 
 Returns an action object used in signalling that a patch of updates for the
 latest version of the post have been received.
-
-_Parameters_
-
--   _edits_ `Object`: Updated post fields.
 
 _Returns_
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13691,7 +13691,6 @@
 				"lodash": "^4.17.19",
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"redux-optimist": "^1.0.0",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0"
 			}
@@ -50934,11 +50933,6 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/redux-multi/-/redux-multi-0.1.12.tgz",
 			"integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI="
-		},
-		"redux-optimist": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redux-optimist/-/redux-optimist-1.0.0.tgz",
-			"integrity": "sha512-AG1v8o6UZcGXTEH2jVcWG6KD+gEix+Cj9JXAAzln9MPkauSVd98H7N7EOOyT/v4c9N1mJB4sm1zfspGlLDkUEw=="
 		},
 		"reflect.ownkeys": {
 			"version": "0.2.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -59,7 +59,6 @@
 		"lodash": "^4.17.19",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
-		"redux-optimist": "^1.0.0",
 		"refx": "^3.0.0",
 		"rememo": "^3.0.0"
 	},

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -15,11 +15,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import {
-	STORE_NAME,
-	POST_UPDATE_TRANSACTION_ID,
-	TRASH_POST_NOTICE_ID,
-} from './constants';
+import { STORE_NAME, TRASH_POST_NOTICE_ID } from './constants';
 import {
 	getNotificationArgumentsForSaveSuccess,
 	getNotificationArgumentsForSaveFail,
@@ -178,14 +174,14 @@ export function __experimentalRequestPostUpdateFinish( options = {} ) {
  * Returns an action object used in signalling that a patch of updates for the
  * latest version of the post have been received.
  *
- * @param {Object} edits Updated post fields.
- *
  * @return {Object} Action object.
  */
-export function updatePost( edits ) {
+export function updatePost() {
+	deprecated( "wp.data.dispatch( 'core/editor' ).updatePost", {
+		alternative: 'User the core entitires store instead',
+	} );
 	return {
-		type: 'UPDATE_POST',
-		edits,
+		type: 'DO_NOTHING',
 	};
 }
 
@@ -224,21 +220,6 @@ export function* editPost( edits, options ) {
 		edits,
 		options
 	);
-}
-
-/**
- * Returns action object produced by the updatePost creator augmented by
- * an optimist option that signals optimistically applying updates.
- *
- * @param {Object} edits  Updated post fields.
- *
- * @return {Object} Action object.
- */
-export function __experimentalOptimisticUpdatePost( edits ) {
-	return {
-		...updatePost( edits ),
-		optimist: { id: POST_UPDATE_TRANSACTION_ID },
-	};
 }
 
 /**

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -175,6 +175,7 @@ export function __experimentalRequestPostUpdateFinish( options = {} ) {
  * latest version of the post have been received.
  *
  * @return {Object} Action object.
+ * @deprecated since Gutenberg 9.7.0.
  */
 export function updatePost() {
 	deprecated( "wp.data.dispatch( 'core/editor' ).updatePost", {

--- a/packages/editor/src/store/constants.js
+++ b/packages/editor/src/store/constants.js
@@ -13,7 +13,6 @@ export const EDIT_MERGE_PROPERTIES = new Set( [ 'meta' ] );
  */
 export const STORE_NAME = 'core/editor';
 
-export const POST_UPDATE_TRANSACTION_ID = 'post-update';
 export const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
 export const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 export const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import optimist from 'redux-optimist';
 import { omit, keys, isEqual } from 'lodash';
 
 /**
@@ -86,7 +85,6 @@ export function postId( state = null, action ) {
 	switch ( action.type ) {
 		case 'SETUP_EDITOR_STATE':
 		case 'RESET_POST':
-		case 'UPDATE_POST':
 			return action.post.id;
 	}
 
@@ -97,7 +95,6 @@ export function postType( state = null, action ) {
 	switch ( action.type ) {
 		case 'SETUP_EDITOR_STATE':
 		case 'RESET_POST':
-		case 'UPDATE_POST':
 			return action.post.type;
 	}
 
@@ -284,17 +281,15 @@ export function editorSettings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
 	return state;
 }
 
-export default optimist(
-	combineReducers( {
-		postId,
-		postType,
-		preferences,
-		saving,
-		postLock,
-		template,
-		postSavingLock,
-		isReady,
-		editorSettings,
-		postAutosavingLock,
-	} )
-);
+export default combineReducers( {
+	postId,
+	postType,
+	preferences,
+	saving,
+	postLock,
+	template,
+	postSavingLock,
+	isReady,
+	editorSettings,
+	postAutosavingLock,
+} );

--- a/packages/editor/src/store/reducer.native.js
+++ b/packages/editor/src/store/reducer.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import optimist from 'redux-optimist';
-
-/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -85,19 +80,17 @@ export function notices( state = [], action ) {
 	return state;
 }
 
-export default optimist(
-	combineReducers( {
-		postId,
-		postType,
-		postTitle,
-		preferences,
-		saving,
-		postLock,
-		postSavingLock,
-		template,
-		isReady,
-		editorSettings,
-		clipboard,
-		notices,
-	} )
-);
+export default combineReducers( {
+	postId,
+	postType,
+	postTitle,
+	preferences,
+	saving,
+	postLock,
+	postSavingLock,
+	template,
+	isReady,
+	editorSettings,
+	clipboard,
+	notices,
+} );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1265,6 +1265,8 @@ export function getEditorSettings( state ) {
 /**
  * Returns state object prior to a specified optimist transaction ID, or `null`
  * if the transaction corresponding to the given ID cannot be found.
+ *
+ * @deprecated since Gutenberg 9.7.0.
  */
 export function getStateBeforeOptimisticTransaction() {
 	deprecated( "select('core/editor').getStateBeforeOptimisticTransaction", {
@@ -1276,6 +1278,8 @@ export function getStateBeforeOptimisticTransaction() {
 /**
  * Returns true if an optimistic transaction is pending commit, for which the
  * before state satisfies the given predicate function.
+ *
+ * @deprecated since Gutenberg 9.7.0.
  */
 export function inSomeHistory() {
 	deprecated( "select('core/editor').inSomeHistory", {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -33,7 +33,6 @@ import { Platform } from '@wordpress/element';
 import { PREFERENCES_DEFAULTS } from './defaults';
 import {
 	EDIT_MERGE_PROPERTIES,
-	POST_UPDATE_TRANSACTION_ID,
 	PERMALINK_POSTNAME_REGEX,
 	ONE_MINUTE_IN_MS,
 	AUTOSAVE_PROPERTIES,
@@ -1002,56 +1001,16 @@ export const getEditedPostContent = createRegistrySelector(
 );
 
 /**
- * Returns state object prior to a specified optimist transaction ID, or `null`
- * if the transaction corresponding to the given ID cannot be found.
- *
- * @param {Object} state         Current global application state.
- * @param {Object} transactionId Optimist transaction ID.
- *
- * @return {Object} Global application state prior to transaction.
- */
-export function getStateBeforeOptimisticTransaction( state, transactionId ) {
-	const transaction = find(
-		state.optimist,
-		( entry ) =>
-			entry.beforeState &&
-			get( entry.action, [ 'optimist', 'id' ] ) === transactionId
-	);
-
-	return transaction ? transaction.beforeState : null;
-}
-
-/**
  * Returns true if the post is being published, or false otherwise.
  *
  * @param {Object} state Global application state.
  *
  * @return {boolean} Whether post is being published.
  */
-export function isPublishingPost( state ) {
-	if ( ! isSavingPost( state ) ) {
-		return false;
-	}
-
-	// Saving is optimistic, so assume that current post would be marked as
-	// published if publishing
-	if ( ! isCurrentPostPublished( state ) ) {
-		return false;
-	}
-
-	// Use post update transaction ID to retrieve the state prior to the
-	// optimistic transaction
-	const stateBeforeRequest = getStateBeforeOptimisticTransaction(
-		state,
-		POST_UPDATE_TRANSACTION_ID
-	);
-
-	// Consider as publishing when current post prior to request was not
-	// considered published
-	return (
-		!! stateBeforeRequest &&
-		! isCurrentPostPublished( null, stateBeforeRequest.currentPost )
-	);
+export function isPublishingPost() {
+	// TODO: this selector always returns false
+	// After the removal of the optimistic saving, we will be able to fix it.
+	return false;
 }
 
 /**
@@ -1140,28 +1099,6 @@ export function getPermalinkParts( state ) {
 		postName,
 		suffix,
 	};
-}
-
-/**
- * Returns true if an optimistic transaction is pending commit, for which the
- * before state satisfies the given predicate function.
- *
- * @param {Object}   state     Editor state.
- * @param {Function} predicate Function given state, returning true if match.
- *
- * @return {boolean} Whether predicate matches for some history.
- */
-export function inSomeHistory( state, predicate ) {
-	const { optimist } = state;
-
-	// In recursion, optimist state won't exist. Assume exhausted options.
-	if ( ! optimist ) {
-		return false;
-	}
-
-	return optimist.some(
-		( { beforeState } ) => beforeState && predicate( beforeState )
-	);
 }
 
 /**
@@ -1324,6 +1261,28 @@ export function getEditorSettings( state ) {
 /*
  * Backward compatibility
  */
+
+/**
+ * Returns state object prior to a specified optimist transaction ID, or `null`
+ * if the transaction corresponding to the given ID cannot be found.
+ */
+export function getStateBeforeOptimisticTransaction() {
+	deprecated( "select('core/editor').getStateBeforeOptimisticTransaction", {
+		hint: 'No state history is kept on this store anymore',
+	} );
+
+	return null;
+}
+/**
+ * Returns true if an optimistic transaction is pending commit, for which the
+ * before state satisfies the given predicate function.
+ */
+export function inSomeHistory() {
+	deprecated( "select('core/editor').inSomeHistory", {
+		hint: 'No state history is kept on this store anymore',
+	} );
+	return false;
+}
 
 function getBlockEditorSelector( name ) {
 	return createRegistrySelector( ( select ) => ( state, ...args ) => {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1007,10 +1007,12 @@ export const getEditedPostContent = createRegistrySelector(
  *
  * @return {boolean} Whether post is being published.
  */
-export function isPublishingPost() {
-	// TODO: this selector always returns false
-	// After the removal of the optimistic saving, we will be able to fix it.
-	return false;
+export function isPublishingPost( state ) {
+	return (
+		isSavingPost( state ) &&
+		! isCurrentPostPublished( state ) &&
+		getEditedPostAttribute( state, 'status' ) === 'publish'
+	);
 }
 
 /**

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -9,11 +9,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import * as actions from '../actions';
-import {
-	STORE_NAME,
-	TRASH_POST_NOTICE_ID,
-	POST_UPDATE_TRANSACTION_ID,
-} from '../constants';
+import { STORE_NAME, TRASH_POST_NOTICE_ID } from '../constants';
 
 const postType = {
 	rest_base: 'posts',
@@ -459,17 +455,6 @@ describe( 'Editor actions', () => {
 		} );
 	} );
 
-	describe( 'updatePost', () => {
-		it( 'should return the UPDATE_POST action', () => {
-			const edits = {};
-			const result = actions.updatePost( edits );
-			expect( result ).toEqual( {
-				type: 'UPDATE_POST',
-				edits,
-			} );
-		} );
-	} );
-
 	describe( 'editPost', () => {
 		it( 'should edit the relevant entity record', () => {
 			const edits = { format: 'sample' };
@@ -494,18 +479,6 @@ describe( 'Editor actions', () => {
 			expect( fulfillment.next() ).toEqual( {
 				done: true,
 				value: undefined,
-			} );
-		} );
-	} );
-
-	describe( 'optimisticUpdatePost', () => {
-		it( 'should return the UPDATE_POST action with optimist property', () => {
-			const edits = {};
-			const result = actions.__experimentalOptimisticUpdatePost( edits );
-			expect( result ).toEqual( {
-				type: 'UPDATE_POST',
-				edits,
-				optimist: { id: POST_UPDATE_TRANSACTION_ID },
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -22,7 +22,6 @@ import { RawHTML } from '@wordpress/element';
  */
 import * as _selectors from '../selectors';
 import { PREFERENCES_DEFAULTS } from '../defaults';
-import { POST_UPDATE_TRANSACTION_ID } from '../constants';
 
 const selectors = { ..._selectors };
 const selectorNames = Object.keys( selectors );
@@ -161,8 +160,6 @@ const {
 	didPostSaveRequestFail,
 	getSuggestedPostFormat,
 	getEditedPostContent,
-	getStateBeforeOptimisticTransaction,
-	isPublishingPost,
 	isPublishSidebarEnabled,
 	isPermalinkEditable,
 	getPermalink,
@@ -415,7 +412,6 @@ describe( 'selectors', () => {
 	describe( 'isEditedPostDirty', () => {
 		it( 'should return false when blocks state not dirty nor edits exist', () => {
 			const state = {
-				optimist: [],
 				editor: {
 					present: {
 						blocks: {
@@ -432,7 +428,6 @@ describe( 'selectors', () => {
 
 		it( 'should return true when blocks state dirty', () => {
 			const state = {
-				optimist: [],
 				editor: {
 					present: {
 						blocks: {
@@ -449,7 +444,6 @@ describe( 'selectors', () => {
 
 		it( 'should return true when edits exist', () => {
 			const state = {
-				optimist: [],
 				editor: {
 					present: {
 						blocks: {
@@ -2500,163 +2494,6 @@ describe( 'selectors', () => {
 			expect( isPublishSidebarEnabled( state ) ).toBe(
 				PREFERENCES_DEFAULTS.isPublishSidebarEnabled
 			);
-		} );
-	} );
-
-	describe( 'getStateBeforeOptimisticTransaction', () => {
-		it( 'should return null if no transaction can be found', () => {
-			const beforeState = getStateBeforeOptimisticTransaction(
-				{
-					optimist: [],
-				},
-				'foo'
-			);
-
-			expect( beforeState ).toBe( null );
-		} );
-
-		it( 'should return null if a transaction with ID can be found, but lacks before state', () => {
-			const beforeState = getStateBeforeOptimisticTransaction(
-				{
-					optimist: [
-						{
-							action: {
-								optimist: {
-									id: 'foo',
-								},
-							},
-						},
-					],
-				},
-				'foo'
-			);
-
-			expect( beforeState ).toBe( null );
-		} );
-
-		it( 'should return the before state matching the given transaction id', () => {
-			const expectedBeforeState = {};
-			const beforeState = getStateBeforeOptimisticTransaction(
-				{
-					optimist: [
-						{
-							beforeState: expectedBeforeState,
-							action: {
-								optimist: {
-									id: 'foo',
-								},
-							},
-						},
-					],
-				},
-				'foo'
-			);
-
-			expect( beforeState ).toBe( expectedBeforeState );
-		} );
-	} );
-
-	describe( 'isPublishingPost', () => {
-		it( 'should return false if the post is not being saved', () => {
-			const isPublishing = isPublishingPost( {
-				optimist: [],
-				saving: {
-					requesting: false,
-				},
-				currentPost: {
-					status: 'publish',
-				},
-			} );
-
-			expect( isPublishing ).toBe( false );
-		} );
-
-		it( 'should return false if the current post is not considered published', () => {
-			const isPublishing = isPublishingPost( {
-				optimist: [],
-				saving: {
-					requesting: true,
-				},
-				currentPost: {
-					status: 'draft',
-				},
-			} );
-
-			expect( isPublishing ).toBe( false );
-		} );
-
-		it( 'should return false if the optimistic transaction cannot be found', () => {
-			const isPublishing = isPublishingPost( {
-				optimist: [],
-				saving: {
-					requesting: true,
-				},
-				currentPost: {
-					status: 'publish',
-				},
-			} );
-
-			expect( isPublishing ).toBe( false );
-		} );
-
-		it( 'should return false if the current post prior to request was already published', () => {
-			const isPublishing = isPublishingPost( {
-				optimist: [
-					{
-						beforeState: {
-							saving: {
-								requesting: false,
-							},
-							currentPost: {
-								status: 'publish',
-							},
-						},
-						action: {
-							optimist: {
-								id: POST_UPDATE_TRANSACTION_ID,
-							},
-						},
-					},
-				],
-				saving: {
-					requesting: true,
-				},
-				currentPost: {
-					status: 'publish',
-				},
-			} );
-
-			expect( isPublishing ).toBe( false );
-		} );
-
-		it( 'should return true if the current post prior to request was not published', () => {
-			const isPublishing = isPublishingPost( {
-				optimist: [
-					{
-						beforeState: {
-							saving: {
-								requesting: false,
-							},
-							currentPost: {
-								status: 'draft',
-							},
-						},
-						action: {
-							optimist: {
-								id: POST_UPDATE_TRANSACTION_ID,
-							},
-						},
-					},
-				],
-				saving: {
-					requesting: true,
-				},
-				currentPost: {
-					status: 'publish',
-				},
-			} );
-
-			expect( isPublishing ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
When we moved from the "editor" store to "core" store (something like in WP 5.3 maybe), we stopped using `redux-optimist` but it was kept in several places of our code base. This PR removes this unused code and also deprecates the selectors/actions that are useless.