### PR TITLE
Box control units: Ensure custom units are preserved.

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -24,9 +24,6 @@
 		},
 		"spacing": {
 			"padding": true
-		},
-		"__experimentalBorder": {
-			"radius": true
 		}
 	},
 	"editorStyle": "wp-block-group-editor",

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -24,6 +24,9 @@
 		},
 		"spacing": {
 			"padding": true
+		},
+		"__experimentalBorder": {
+			"radius": true
 		}
 	},
 	"editorStyle": "wp-block-group-editor",

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -60,7 +60,7 @@ function mode( arr ) {
  * @return {string} A value + unit for the 'all' input.
  */
 export function getAllValue( values = {} ) {
-	const parsedValues = Object.values( values ).map( parseUnit );
+	const parsedValues = Object.values( values ).map( value => parseUnit( value ) );
 
 	const allValues = parsedValues.map( ( value ) => value[ 0 ] );
 	const allUnits = parsedValues.map( ( value ) => value[ 1 ] );

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -60,7 +60,9 @@ function mode( arr ) {
  * @return {string} A value + unit for the 'all' input.
  */
 export function getAllValue( values = {} ) {
-	const parsedValues = Object.values( values ).map( value => parseUnit( value ) );
+	const parsedValues = Object.values( values ).map( ( value ) =>
+		parseUnit( value )
+	);
 
 	const allValues = parsedValues.map( ( value ) => value[ 0 ] );
 	const allUnits = parsedValues.map( ( value ) => value[ 1 ] );


### PR DESCRIPTION
## Description
This is broken out of https://github.com/WordPress/gutenberg/pull/27579 since that PR is blocked.

## How has this been tested?
- Set custom padding on a block using a non-px value
- Ensure that when the box control loads it has the correct units

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
