### PR TITLE
Remove default style information from the documentation.

### DIFF
--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -338,24 +338,6 @@ supports: {
 }
 ```
 
-When the block declares support for a specific spacing property, the attributes definition is extended to include some attributes.
+When the block declares support for a specific spacing property, the attributes definition is extended to include the `style` attribute.
 
-- `style`: attribute of `object` type with no default assigned. This is added when `padding` support is declared. It stores the custom values set by the user. The block can apply a default style by specifying its own `style` attribute with a default e.g.:
-
-```js
-attributes: {
-    style: {
-        type: 'object',
-        default: {
-            spacing: {
-                padding: {
-                    top: 'value',
-                    right: 'value',
-                    bottom: 'value',
-                    left: 'value'
-                }
-            }
-        }
-    }
-}
-```
+- `style`: attribute of `object` type with no default assigned. This is added when `padding` support is declared. It stores the custom values set by the user.


### PR DESCRIPTION
The documentation refers that we can set default styles of a block using the default of the style attribute. I think that should never be done because of the following reasons:

- Making the attribute have a default, will create inline styles for every block. Theme.json will never be able to change the defaults of the block because theme.json styles don't "beat" an inline style. This makes our global styles system useless for any block with a default set in this way.

- We always tried to avoid inline styles and tried to use things like classes etc. Setting defaults in this way makes sure even if the user did not change anything on the bock we are adding inline styles.

- When we change the default styles of a block or add defaults to a block that was already in production, all the blocks that existed without a style specially set would come invalid right way because their makeup reflects the old default which is different from the new one.

For now, the current way to set the defaults at the block level is by using CSS. We should consider having something equivalent to theme.json at the block level that does not rely on inline styles as referred to in https://github.com/WordPress/gutenberg/issues/27796 but that system does not exist yet.

cc: @scruffian, @nosolosw 