### PR TITLE
URL: removeQueryArgs should remove the ? char after removing all args

### DIFF
--- a/packages/url/src/remove-query-args.js
+++ b/packages/url/src/remove-query-args.js
@@ -26,5 +26,6 @@ export function removeQueryArgs( url, ...args ) {
 	const query = getQueryArgs( url );
 	const baseURL = url.substr( 0, queryStringIndex );
 	args.forEach( ( arg ) => delete query[ arg ] );
-	return baseURL + '?' + buildQueryString( query );
+	const queryString = buildQueryString( query );
+	return queryString ? baseURL + '?' + queryString : baseURL;
 }

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -758,6 +758,14 @@ describe( 'removeQueryArgs', () => {
 		);
 	} );
 
+	it( 'should not leave ? char after removing all query args', () => {
+		const url = 'https://andalouses.example/beach?foo=bar&bar=baz';
+
+		expect( removeQueryArgs( url, 'foo', 'bar' ) ).toEqual(
+			'https://andalouses.example/beach'
+		);
+	} );
+
 	it( 'should remove array query arg', () => {
 		const url =
 			'https://andalouses.example/beach?foo[]=bar&foo[]=baz&bar=foobar';


### PR DESCRIPTION
Improves `removeQueryArgs` so that it doesn't leave an orphaned `?` after removing all query args.

**Before:**
```js
removeQueryArgs( 'https://example.com?foo' ) === 'https://example.com?';
```
**After:**
```js
removeQueryArgs( 'https://example.com?foo' ) === 'https://example.com';
```
