### PR TITLE
Remove expect.assertions count from multi-entity-saving tests.

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -83,7 +83,6 @@ describe( 'Multi-entity save flow', () => {
 		};
 
 		it( 'Save flow should work as expected.', async () => {
-			expect.assertions( 26 );
 			await createNewPost();
 			// Edit the page some.
 			await page.click( '.editor-post-title' );
@@ -185,7 +184,6 @@ describe( 'Multi-entity save flow', () => {
 		const saveA11ySelector = '.edit-site-editor__toggle-save-panel-button';
 
 		it( 'Save flow should work as expected', async () => {
-			expect.assertions( 5 );
 			// Navigate to site editor.
 			const query = addQueryArgs( '', {
 				page: 'gutenberg-edit-site',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
When co-dependent tests where consolidated in multi-entity-saving, we initially added an `expect.assertions` for how many assertions were expected in the test.

This seems to have been problematic as it has caused e2e failures at times.  Previously, when I added this line I personally counted 26 assertions while the test kept failing saying 27 had happened.  Figuring the computer was just more accurate at counting than me I went with it.  Now, tests were failing based on this saying there were only 26 assertions as we would expect (#27802).

This seems a bit fragile, and we don't get much out of it.  Really, `expect.assertions` is useful when we are testing whether or not callback functions are being fired, which is not the case here.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
