### PR TITLE
Rich Text: Replace store name string with exposed store definition

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -43,6 +43,7 @@ import { removeLineSeparator } from '../remove-line-separator';
 import { isCollapsed } from '../is-collapsed';
 import { remove } from '../remove';
 import styles from './style.scss';
+import { store as richTextStore } from '../store';
 
 const unescapeSpaces = ( text ) => {
 	return text.replace( /&nbsp;|&#160;/gi, ' ' );
@@ -955,7 +956,7 @@ export default compose( [
 			get( parentBlock, [ 'attributes', 'childrenStyles' ] ) || {};
 
 		return {
-			formatTypes: select( 'core/rich-text' ).getFormatTypes(),
+			formatTypes: select( richTextStore ).getFormatTypes(),
 			isMentionsSupported:
 				getSettings( 'capabilities' ).mentions === true,
 			...{ parentBlockStyles },

--- a/packages/rich-text/src/component/use-format-types.js
+++ b/packages/rich-text/src/component/use-format-types.js
@@ -2,9 +2,13 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { store as richTextStore } from '../store';
 
 function formatTypesSelector( select ) {
-	return select( 'core/rich-text' ).getFormatTypes();
+	return select( richTextStore ).getFormatTypes();
 }
 
 /**

--- a/packages/rich-text/src/get-format-type.js
+++ b/packages/rich-text/src/get-format-type.js
@@ -2,6 +2,10 @@
  * WordPress dependencies
  */
 import { select } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { store as richTextStore } from './store';
 
 /** @typedef {import('./register-format-type').RichTextFormatType} RichTextFormatType */
 
@@ -13,5 +17,5 @@ import { select } from '@wordpress/data';
  * @return {RichTextFormatType|undefined} Format type.
  */
 export function getFormatType( name ) {
-	return select( 'core/rich-text' ).getFormatType( name );
+	return select( richTextStore ).getFormatType( name );
 }

--- a/packages/rich-text/src/get-format-types.js
+++ b/packages/rich-text/src/get-format-types.js
@@ -2,6 +2,10 @@
  * WordPress dependencies
  */
 import { select } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { store as richTextStore } from './store';
 
 /** @typedef {import('./register-format-type').RichTextFormatType} RichTextFormatType */
 
@@ -11,5 +15,5 @@ import { select } from '@wordpress/data';
  * @return {Array<RichTextFormatType>} Format settings.
  */
 export function getFormatTypes() {
-	return select( 'core/rich-text' ).getFormatTypes();
+	return select( richTextStore ).getFormatTypes();
 }

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
-
+/**
+ * Internal dependencies
+ */
+import { store as richTextStore } from './store';
 /**
  * @typedef {Object} WPFormat
  *
@@ -44,7 +47,7 @@ export function registerFormatType( name, settings ) {
 		return;
 	}
 
-	if ( select( 'core/rich-text' ).getFormatType( settings.name ) ) {
+	if ( select( richTextStore ).getFormatType( settings.name ) ) {
 		window.console.error(
 			'Format "' + settings.name + '" is already registered.'
 		);
@@ -76,7 +79,7 @@ export function registerFormatType( name, settings ) {
 
 	if ( settings.className === null ) {
 		const formatTypeForBareElement = select(
-			'core/rich-text'
+			richTextStore
 		).getFormatTypeForBareElement( settings.tagName );
 
 		if ( formatTypeForBareElement ) {
@@ -87,7 +90,7 @@ export function registerFormatType( name, settings ) {
 		}
 	} else {
 		const formatTypeForClassName = select(
-			'core/rich-text'
+			richTextStore
 		).getFormatTypeForClassName( settings.className );
 
 		if ( formatTypeForClassName ) {
@@ -119,7 +122,7 @@ export function registerFormatType( name, settings ) {
 		return;
 	}
 
-	dispatch( 'core/rich-text' ).addFormatTypes( settings );
+	dispatch( richTextStore ).addFormatTypes( settings );
 
 	return settings;
 }

--- a/packages/rich-text/src/test/register-format-type.js
+++ b/packages/rich-text/src/test/register-format-type.js
@@ -9,6 +9,7 @@ import { select } from '@wordpress/data';
 import { registerFormatType } from '../register-format-type';
 import { unregisterFormatType } from '../unregister-format-type';
 import { getFormatType } from '../get-format-type';
+import { store as richTextStore } from '../store';
 
 describe( 'registerFormatType', () => {
 	beforeAll( () => {
@@ -17,7 +18,7 @@ describe( 'registerFormatType', () => {
 	} );
 
 	afterEach( () => {
-		select( 'core/rich-text' )
+		select( richTextStore )
 			.getFormatTypes()
 			.forEach( ( { name } ) => {
 				unregisterFormatType( name );

--- a/packages/rich-text/src/unregister-format-type.js
+++ b/packages/rich-text/src/unregister-format-type.js
@@ -3,6 +3,11 @@
  */
 import { select, dispatch } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as richTextStore } from './store';
+
 /** @typedef {import('./register-format-type').RichTextFormatType} RichTextFormatType */
 
 /**
@@ -15,14 +20,14 @@ import { select, dispatch } from '@wordpress/data';
  *                                        otherwise `undefined`.
  */
 export function unregisterFormatType( name ) {
-	const oldFormat = select( 'core/rich-text' ).getFormatType( name );
+	const oldFormat = select( richTextStore ).getFormatType( name );
 
 	if ( ! oldFormat ) {
 		window.console.error( `Format ${ name } is not registered.` );
 		return;
 	}
 
-	dispatch( 'core/rich-text' ).removeFormatTypes( name );
+	dispatch( richTextStore ).removeFormatTypes( name );
 
 	return oldFormat;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addresses #27088. Replaces the store names (hardcoded strings) with the exposed `store` definitions. 

## How has this been tested?
Just `npm run test`.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Code refactoring, non-breaking change.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->