### PR TITLE
Decouple Post Blocks Experiment from Site Editor Experiment

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -40,6 +40,7 @@ function gutenberg_get_common_block_editor_settings() {
 
 	$settings = array(
 		'__unstableEnableFullSiteEditingBlocks' => gutenberg_is_fse_theme(),
+		'__unstableEnablePostBlocks'            => gutenberg_is_experiment_enabled( 'gutenberg-post-blocks' ),
 		'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
 		'disableCustomGradients'                => get_theme_support( 'disable-custom-gradients' ),
@@ -77,6 +78,7 @@ function gutenberg_get_common_block_editor_settings() {
  */
 function gutenberg_extend_post_editor_settings( $settings ) {
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_theme();
+	$settings['__unstableEnablePostBlocks']            = gutenberg_is_experiment_enabled( 'gutenberg-post-blocks' );
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -41,6 +41,17 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments'
 	);
 	add_settings_field(
+		'gutenberg-post-blocks',
+		__( 'Post Blocks', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable Post Blocks in block editor', 'gutenberg' ),
+			'id'    => 'gutenberg-post-blocks',
+		)
+	);
+	add_settings_field(
 		'gutenberg-navigation',
 		__( 'Navigation', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -112,6 +112,8 @@ const registerBlock = ( block ) => {
  * const coreBlocks = __experimentalGetCoreBlocks();
  * ```
  */
+// TODO this doesn't need to be a function and check how to remove,
+// since `registerCoreBlocks` API has the blocks param...
 export const __experimentalGetCoreBlocks = () => [
 	// Common blocks are grouped at the top to prioritize their display
 	// in various contexts — like the inserter and auto-complete components.
@@ -162,6 +164,123 @@ export const __experimentalGetCoreBlocks = () => [
 	video,
 ];
 
+const CORE_BLOCKS = [
+	// Common blocks are grouped at the top to prioritize their display
+	// in various contexts — like the inserter and auto-complete components.
+	paragraph,
+	image,
+	heading,
+	gallery,
+	list,
+	quote,
+	// Register all remaining core blocks.
+	audio,
+	button,
+	buttons,
+	code,
+	columns,
+	column,
+	cover,
+	embed,
+	file,
+	group,
+	html,
+	mediaText,
+	missing,
+	preformatted,
+	pullquote,
+	separator,
+	socialLinks,
+	socialLink,
+	spacer,
+	subhead,
+	table,
+	textColumns,
+	verse,
+	video,
+];
+
+/**
+ * Function to register core blocks provided by the block editor.
+ */
+export const __experimentalRegisterCoreBlocks = () => {
+	CORE_BLOCKS.forEach( registerBlock );
+	setDefaultBlockName( paragraph.name );
+	setUnregisteredTypeHandlerName( missing.name );
+	setGroupingBlockName( group.name );
+};
+
+/**
+ * Registers WordPress Post Editor specific blocks.
+ */
+export const __experimentalRegisterWordPressPostEditorBlocks = () => {
+	const wpPostEditorBlocks = [
+		archives,
+		calendar,
+		categories,
+		latestComments,
+		latestPosts,
+		more,
+		nextpage,
+		reusableBlock,
+		rss,
+		search,
+		shortcode,
+		tagCloud,
+	];
+	wpPostEditorBlocks.forEach( registerBlock );
+};
+
+/**
+ * Register classic block only if in WP context.
+ */
+export const __experimentalRegisterClassicBlock = () => {
+	if ( ! window.wp?.oldEditor ) return;
+	registerBlock( classic );
+	setFreeformContentHandlerName( classic.name );
+};
+
+/**
+ * Register WordPress Full Site Editing blocks.
+ *
+ * @param {Object} settings Editor settings object.
+ * @param {boolean} settings.enableFSEBlocks Whether to enable the full site editing blocks.
+ * @param {boolean} settings.enablePostBlocks Whether to enable the post blocks.
+ */
+export const __experimentalRegisterWordPressFullSiteEditingBocks = ( {
+	enableFSEBlocks,
+	enablePostBlocks,
+} = {} ) => {
+	if ( process.env.GUTENBERG_PHASE !== 2 ) return;
+	const postBlocks = [
+		siteLogo,
+		siteTagline,
+		siteTitle,
+		query,
+		queryLoop,
+		queryPagination,
+		postTitle,
+		postContent,
+		postAuthor,
+		postComment,
+		postCommentAuthor,
+		postCommentContent,
+		postCommentDate,
+		postComments,
+		postCommentsCount,
+		postCommentsForm,
+		postDate,
+		postExcerpt,
+		postFeaturedImage,
+		postHierarchicalTerms,
+		postTags,
+	];
+	( enableFSEBlocks
+		? [ templatePart, ...postBlocks ]
+		: ( enablePostBlocks && postBlocks ) || []
+	).forEach( registerBlockType );
+};
+
 /**
  * Function to register core blocks provided by the block editor.
  *
@@ -186,52 +305,30 @@ export const registerCoreBlocks = (
 	setUnregisteredTypeHandlerName( missing.name );
 	setGroupingBlockName( group.name );
 };
+/**
+ * Function to register experimental core blocks.
+ */
+// TODO check all usages of this...
+export const __experimentalRegisterExperimentalCoreBlocks = () => {
+	if ( process.env.GUTENBERG_PHASE !== 2 ) return;
+	[ navigation, navigationLink ].forEach( registerBlock );
+};
 
 /**
- * Function to register experimental core blocks depending on editor settings.
+ * Register all blocks according to editor's settings and
+ * takes into account `process.env.GUTENBERG_PHASE`.
+ * - core blocks
+ * - classic block
+ * - WP post editor blocks
+ * - experimental core blocks
+ * - WP FSE blocks conditionally based on settings.
  *
- * @param {boolean} enableFSEBlocks Whether to enable the full site editing blocks.
- * @param {boolean} enablePostBlocks Whether to enable the post blocks.
- * @example
- * ```js
- * import { __experimentalRegisterExperimentalCoreBlocks } from '@wordpress/block-library';
- *
- * __experimentalRegisterExperimentalCoreBlocks( settings );
- * ```
+ * @param {Object} settings Editor settings object.
  */
-export const __experimentalRegisterExperimentalCoreBlocks =
-	process.env.GUTENBERG_PHASE === 2
-		? ( enableFSEBlocks, enablePostBlocks ) => {
-				const postBlocks = [
-					siteLogo,
-					siteTagline,
-					siteTitle,
-					query,
-					queryLoop,
-					queryPagination,
-					postTitle,
-					postContent,
-					postAuthor,
-					postComment,
-					postCommentAuthor,
-					postCommentContent,
-					postCommentDate,
-					postComments,
-					postCommentsCount,
-					postCommentsForm,
-					postDate,
-					postExcerpt,
-					postFeaturedImage,
-					postHierarchicalTerms,
-					postTags,
-				];
-				[
-					navigation,
-					navigationLink,
-					// Register Full Site Editing Blocks.
-					...( enableFSEBlocks
-						? [ templatePart, ...postBlocks ]
-						: ( enablePostBlocks && postBlocks ) || [] ),
-				].forEach( registerBlock );
-		  }
-		: undefined;
+export const __experimentalRegisterAllBlocks = ( settings ) => {
+	__experimentalRegisterCoreBlocks();
+	__experimentalRegisterClassicBlock();
+	__experimentalRegisterWordPressPostEditorBlocks();
+	__experimentalRegisterExperimentalCoreBlocks();
+	__experimentalRegisterWordPressFullSiteEditingBocks( settings );
+};

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -191,6 +191,7 @@ export const registerCoreBlocks = (
  * Function to register experimental core blocks depending on editor settings.
  *
  * @param {boolean} enableFSEBlocks Whether to enable the full site editing blocks.
+ * @param {boolean} enablePostBlocks Whether to enable the post blocks.
  * @example
  * ```js
  * import { __experimentalRegisterExperimentalCoreBlocks } from '@wordpress/block-library';
@@ -200,38 +201,37 @@ export const registerCoreBlocks = (
  */
 export const __experimentalRegisterExperimentalCoreBlocks =
 	process.env.GUTENBERG_PHASE === 2
-		? ( enableFSEBlocks ) => {
+		? ( enableFSEBlocks, enablePostBlocks ) => {
+				const postBlocks = [
+					siteLogo,
+					siteTagline,
+					siteTitle,
+					query,
+					queryLoop,
+					queryPagination,
+					postTitle,
+					postContent,
+					postAuthor,
+					postComment,
+					postCommentAuthor,
+					postCommentContent,
+					postCommentDate,
+					postComments,
+					postCommentsCount,
+					postCommentsForm,
+					postDate,
+					postExcerpt,
+					postFeaturedImage,
+					postHierarchicalTerms,
+					postTags,
+				];
 				[
 					navigation,
 					navigationLink,
-
 					// Register Full Site Editing Blocks.
 					...( enableFSEBlocks
-						? [
-								siteLogo,
-								siteTagline,
-								siteTitle,
-								templatePart,
-								query,
-								queryLoop,
-								queryPagination,
-								postTitle,
-								postContent,
-								postAuthor,
-								postComment,
-								postCommentAuthor,
-								postCommentContent,
-								postCommentDate,
-								postComments,
-								postCommentsCount,
-								postCommentsForm,
-								postDate,
-								postExcerpt,
-								postFeaturedImage,
-								postHierarchicalTerms,
-								postTags,
-						  ]
-						: [] ),
+						? [ templatePart, ...postBlocks ]
+						: ( enablePostBlocks && postBlocks ) || [] ),
 				].forEach( registerBlock );
 		  }
 		: undefined;

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -6,10 +6,7 @@ import { map, set, flatten, omit, partialRight } from 'lodash';
 /**
  * WordPress dependencies
  */
-import {
-	registerCoreBlocks,
-	__experimentalRegisterExperimentalCoreBlocks,
-} from '@wordpress/block-library';
+import { __experimentalRegisterAllBlocks } from '@wordpress/block-library';
 import { render } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -164,11 +161,7 @@ export function initialize( id, settings ) {
 		removeNavigationBlockEditUnsupportedFeatures
 	);
 
-	registerCoreBlocks();
-
-	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks();
-	}
+	__experimentalRegisterAllBlocks();
 
 	settings.__experimentalFetchLinkSuggestions = partialRight(
 		fetchLinkSuggestions,

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -4,10 +4,7 @@
 import '@wordpress/core-data';
 import '@wordpress/block-editor';
 import '@wordpress/editor';
-import {
-	registerCoreBlocks,
-	__experimentalRegisterExperimentalCoreBlocks,
-} from '@wordpress/block-library';
+import { __experimentalRegisterAllBlocks } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 
 /**
@@ -91,17 +88,8 @@ export function initializeEditor(
 		settings,
 		initialEdits
 	);
-	registerCoreBlocks();
-	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		const {
-			__unstableEnableFullSiteEditingBlocks,
-			__unstableEnablePostBlocks,
-		} = settings;
-		__experimentalRegisterExperimentalCoreBlocks(
-			__unstableEnableFullSiteEditingBlocks,
-			__unstableEnablePostBlocks
-		);
-	}
+
+	__experimentalRegisterAllBlocks( settings );
 
 	// Show a console log warning if the browser is not in Standards rendering mode.
 	const documentMode =

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -93,8 +93,13 @@ export function initializeEditor(
 	);
 	registerCoreBlocks();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
+		const {
+			__unstableEnableFullSiteEditingBlocks,
+			__unstableEnablePostBlocks,
+		} = settings;
 		__experimentalRegisterExperimentalCoreBlocks(
-			settings.__unstableEnableFullSiteEditingBlocks
+			__unstableEnableFullSiteEditingBlocks,
+			__unstableEnablePostBlocks
 		);
 	}
 

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -4,10 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
-import {
-	registerCoreBlocks,
-	__experimentalRegisterExperimentalCoreBlocks,
-} from '@wordpress/block-library';
+import { __experimentalRegisterAllBlocks } from '@wordpress/block-library';
 import { render } from '@wordpress/element';
 
 /**
@@ -58,10 +55,7 @@ export function initialize( id, settings ) {
 
 	registerEditSiteStore( { settings } );
 
-	registerCoreBlocks();
-	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks( true );
-	}
+	__experimentalRegisterAllBlocks( { enableFSEBlocks: true } );
 
 	render( <Editor />, document.getElementById( id ) );
 }

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -3,14 +3,11 @@
  */
 import {
 	registerBlockType,
+	unregisterBlockType,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
 import { render } from '@wordpress/element';
-import {
-	registerCoreBlocks,
-	__experimentalGetCoreBlocks,
-	__experimentalRegisterExperimentalCoreBlocks,
-} from '@wordpress/block-library';
+import { __experimentalRegisterAllBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -28,14 +25,8 @@ import Layout from './components/layout';
  * @param {Object} settings Block editor settings.
  */
 export function initialize( id, settings ) {
-	const coreBlocks = __experimentalGetCoreBlocks().filter(
-		( block ) => ! [ 'core/more' ].includes( block.name )
-	);
-	registerCoreBlocks( coreBlocks );
-
-	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks();
-	}
+	__experimentalRegisterAllBlocks();
+	unregisterBlockType( 'core/more' );
 	registerBlock( createLegacyWidget( settings ) );
 	registerBlock( widgetArea );
 	render(

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -15,10 +15,7 @@ import {
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
 import { parse as grammarParse } from '@wordpress/block-serialization-default-parser';
-import {
-	registerCoreBlocks,
-	__experimentalRegisterExperimentalCoreBlocks,
-} from '@wordpress/block-library';
+import { __experimentalRegisterAllBlocks } from '@wordpress/block-library';
 //eslint-disable-next-line no-restricted-syntax
 import {
 	blockNameToFixtureBasename,
@@ -67,10 +64,7 @@ describe( 'full post content fixture', () => {
 		unstable__bootstrapServerSideBlockDefinitions( blockDefinitions );
 		// Load all hooks that modify blocks
 		require( '../../../packages/editor/src/hooks' );
-		registerCoreBlocks();
-		if ( process.env.GUTENBERG_PHASE === 2 ) {
-			__experimentalRegisterExperimentalCoreBlocks( true );
-		}
+		__experimentalRegisterAllBlocks( { enableFSEBlocks: true } );
 	} );
 
 	blockBasenames.forEach( ( basename ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related:  https://github.com/WordPress/gutenberg/issues/26316

This PR decouples the FSE experiment from Post Blocks.  If you have a FSE theme enabled, all blocks are registered as before.

If you don't have a FSE theme, with this new option enabled, you add to the block editor the following blocks:
- SiteLogo, SiteTagline, SiteTitle
- Query
- PostTitle, PostContent, PostAuthor, PostDate, PostExcerpt, PostFeaturedImage, PostTags
- PostComment, PostCommentAuthor, PostCommentContent, PostCommentDate, PostComments, PostCommentsCount, PostCommentsForm
- PostHierarchicalTerms
				
The sole difference in the current status of this PR is the `template part` block which is enabled only with a FSE theme.
<!-- Please describe what you have changed or added -->

## How has this been tested?
Manually with combinations of FSE themes and the option enabled/disabled.

