### PR TITLE
Add support for publishing React Native Android bridge to Bintray

### DIFF
--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -143,7 +143,24 @@ repositories {
 }
 
 dependencies {
-    implementation project(':@wordpress_react-native-aztec')
+    // Embedding Aztec seems to break the build from source when running from
+    // the WordPress Android project. That shouldn't be the case. While we
+    // investigate, embed only when making a binary build.
+    //
+    // Note that this also means that we cannot run an `assemble` task for
+    // WordPress Android while building from source, because that would result
+    // in an unsupported "direct local AAR file dependency". That shouldn't be
+    // a blocker becuase CI runs `assemble` tasks and should always do so
+    // without building dependencies from source, for performance and
+    // correctness reasons (as building from source should only be used while
+    // developing changes, right?)
+    if (rootProject.ext.buildGutenbergFromSource) {
+        implementation project(':@wordpress_react-native-aztec')
+    } else {
+        // embed is a method from the fat-aar plugin that will the Aztec project
+        // dependency into the generated AAR
+        embed project(':@wordpress_react-native-aztec')
+    }
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -364,3 +364,64 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         delete nodeModulesFolders
     }
 }
+
+// Allows to override the artifact version by passing a -PbintrayVersion
+// parameter when calling Gradle
+def getBintrayVersion() {
+  return project.properties['bintrayVersion'] ?: android.defaultConfig.versionName
+}
+
+bintray {
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_KEY')
+    publications = ['GutenbergMobilePublication']
+    publish = true
+    pkg {
+        repo = 'maven'
+        name = 'react-native-gutenberg-bridge'
+        licenses = ['GPL-2.0']
+        // FIXME: Once this works properly poit to 'wordpress-mobile'
+        userOrg = 'mokagio'
+        // FIXME: Once this works properly poit to the original gutenberg (or gutenberg-mobile) repo. See also: https://github.com/oguzkocer/gutenberg/commit/0ca71b1abe3ea22b77abb3f390534e66e39161d5#diff-320e7dacc9e9a83ac8128d299319f82cf6dfa2609e0ebbc043d13de33ea92773R350-R353
+        vcsUrl = 'https://github.com/wordpress-mobile/gutenberg-mobile.git'
+        version {
+            name = getBintrayVersion()
+            released  = new Date()
+        }
+    }
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            GutenbergMobilePublication(MavenPublication) {
+                artifact bundleReleaseAar
+
+                groupId 'com.github.wordpress-mobile.gutenberg-mobile'
+                artifactId 'react-native-gutenberg-bridge'
+                version getBintrayVersion()
+
+                addDependenciesToPom(pom)
+            }
+        }
+    }
+}
+
+// This is a workaround for adding the dependencies of the library. It's brought from the
+// plugin's README file: https://github.com/bintray/gradle-bintray-plugin/blob/1.8.5/README.md
+def addDependenciesToPom(pom) {
+    pom.withXml {
+        def dependenciesNode = asNode().getAt('dependencies')[0] ?: asNode().appendNode('dependencies')
+
+        // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+        configurations.implementation.allDependencies.each {
+            // Ensure dependencies such as fileTree are not included.
+            if (it.name != 'unspecified') {
+                def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+            }
+        }
+    }
+}

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -121,6 +121,10 @@ android {
         main {
             assets.srcDirs += buildAssetsFolder
             assets.srcDirs += '../../../../src/block-support'
+            // Despite being in a folder called "resources", the files in
+            // unsupported-block-editor are accessed as assets by their
+            // consumers: the WordPressEditor library.
+            assets.srcDirs += '../../../../resources/unsupported-block-editor'
         }
     }
 }

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -120,6 +120,7 @@ android {
     sourceSets {
         main {
             assets.srcDirs += buildAssetsFolder
+            assets.srcDirs += '../../../../src/block-support'
         }
     }
 }

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -21,6 +21,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
 
         if (buildGutenbergMobileJSBundle) {
             classpath 'com.github.node-gradle:gradle-node-plugin:3.0.0-rc2'
@@ -31,6 +32,8 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish' // this enables publishing via Bintray
 
 def buildGutenbergMobileJSBundle =
         System.getenv('SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD').asBoolean()

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -22,6 +22,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        // Allows embedding other dependencies into the AAR for this one
+        classpath 'com.kezong:fat-aar:1.2.20'
 
         if (buildGutenbergMobileJSBundle) {
             classpath 'com.github.node-gradle:gradle-node-plugin:3.0.0-rc2'
@@ -34,6 +36,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish' // this enables publishing via Bintray
+apply plugin: 'com.kezong.fat-aar'
 
 def buildGutenbergMobileJSBundle =
         System.getenv('SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD').asBoolean()

--- a/packages/react-native-bridge/android/metro.config.js
+++ b/packages/react-native-bridge/android/metro.config.js
@@ -5,5 +5,13 @@
 // - Where this this suggested: https://stackoverflow.com/a/56027775/809944
 // - Example of failing build: https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/9720/workflows/3688f362-78bf-4804-ad60-88762a30f6d3/jobs/51519
 module.exports = {
+	transformer: {
+		getTransformOptions: async () => ({
+			transform: {
+				experimentalImportSupport: false,
+				inlineRequires: false,
+			},
+		}),
+	},
 	maxWorkers: 1
 }

--- a/packages/react-native-bridge/android/metro.config.js
+++ b/packages/react-native-bridge/android/metro.config.js
@@ -1,0 +1,9 @@
+// This is so that when CI calls npm through Gradle, it won't fail because of
+// lack of memory.
+//
+// See:
+// - Where this this suggested: https://stackoverflow.com/a/56027775/809944
+// - Example of failing build: https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/9720/workflows/3688f362-78bf-4804-ad60-88762a30f6d3/jobs/51519
+module.exports = {
+	maxWorkers: 2
+}

--- a/packages/react-native-bridge/android/metro.config.js
+++ b/packages/react-native-bridge/android/metro.config.js
@@ -5,5 +5,5 @@
 // - Where this this suggested: https://stackoverflow.com/a/56027775/809944
 // - Example of failing build: https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/9720/workflows/3688f362-78bf-4804-ad60-88762a30f6d3/jobs/51519
 module.exports = {
-	maxWorkers: 2
+	maxWorkers: 1
 }

--- a/packages/react-native-bridge/android/settings.gradle
+++ b/packages/react-native-bridge/android/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = '@wordpress/react-native-bridge'
+rootProject.name = '@wordpress_react-native-bridge'
 
 include ':@wordpress_react-native-aztec'
 project(':@wordpress_react-native-aztec').projectDir = new File(rootProject.projectDir, '../../react-native-aztec/android')

--- a/packages/react-native-bridge/android/src/main/res/values/colors.xml
+++ b/packages/react-native-bridge/android/src/main/res/values/colors.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <color name="status_bar_color">#006088</color>
+    <color name="white">@android:color/white</color>
 
 </resources>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
As part of an ongoing work to improve the developer experience of the WordPress Android team, we decided to move away from a submodule-based setup for Gutenberg in the Android app in favor of distributing the package as an AAR via [Bintray](http://bintray.com/), with the option to still build locally.

The changes in this PR represent the first step towards that goal: they enable publishing a generated AAR for the package to Bintray.

### Known limitations

- The setup in `build.gradle` expects this repository to be a subfolder of `mobile-gutenber`.
- Eventually, we'll perform the publishing via CI, but till the point above hasn't been addressed, that won't be possible

## How has this been tested?

The easiest way to test this is to checkout this branch in the `gutenberg` submodule of the `mobile-gutenberg` submodule (🙃) in the WordPress Android project.

From there, hack `build.gradle` to force the JS bundle to be generated so that the resulting AAR has all of the required "_stuff_" for the Android app to use.
To do so, [make `isBundleUpToDate()` return `false`](https://github.com/mokagio/gutenberg/pull/1/commits/b3c9517923397279a6ffc13d8d4c05c1fc556ebe#diff-320e7dacc9e9a83ac8128d299319f82cf6dfa2609e0ebbc043d13de33ea92773L200-R204) and hardcode _both_ `buildGutenbergMobileJSBundle` definitions to `true` ([here's one](https://github.com/mokagio/gutenberg/pull/1/commits/8cc19d71c48ea7bafaf9c77c8831a16d1d578ac7#diff-320e7dacc9e9a83ac8128d299319f82cf6dfa2609e0ebbc043d13de33ea92773L2-R7))

After that, `export` your Bintray username and [API key](https://www.jfrog.com/confluence/display/BT/Uploading#Uploading-GettingyourAPIKey) as `BINTRAY_USER` and `BINTRAY_KEY` and run

```
./gradlew assembleRelease bintrayUpload -PbintrayVersion=$(date "+%Y%m%d-%H%M%S")
```

You can obviously use any value you want for `-PbintrayVersion`.

The tasks should succeeds and you should see a new package on your Bintray account matching the version you set.

You should then be able to test this AAR work on the Android app following the same steps as [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13642).

## Types of changes

New feature: allow to publish the React Native Android bridge as an AAR to Bintray.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested (only manually, unfortunately).
- [ ] ~~My code follows the WordPress code style.~~ <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] ~~My code follows the accessibility standards.~~ <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] ~~My code has proper inline documentation.~~ <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->