### PR TITLE
Refactor the edit-site store to clarify the purpose of templateId and templatePartId

### DIFF
--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -82,17 +82,19 @@ export default function QueryLoopEdit( {
 
 			// When you insert this block outside of the edit site then store
 			// does not exist therefore we check for its existence.
+			// TODO: remove this code, edit-site shouldn't be called in block-library.
+			// This creates a cycle dependency.
 			if ( inherit && select( 'core/edit-site' ) ) {
 				// This should be passed from the context exposed by edit site.
-				const { getTemplateId, getTemplateType } = select(
+				const { getEditedPostType, getEditedPostId } = select(
 					'core/edit-site'
 				);
 
-				if ( 'wp_template' === getTemplateType() ) {
+				if ( 'wp_template' === getEditedPostType() ) {
 					const { slug } = select( 'core' ).getEntityRecord(
 						'postType',
 						'wp_template',
-						getTemplateId()
+						getEditedPostId()
 					);
 
 					// Change the post-type if needed.

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -25,12 +25,12 @@ import { SidebarInspectorFill } from '../sidebar';
 export default function BlockEditor( { setIsInserterOpen } ) {
 	const { settings, templateType, page } = useSelect(
 		( select ) => {
-			const { getSettings, getTemplateType, getPage } = select(
+			const { getSettings, getEditedPostType, getPage } = select(
 				'core/edit-site'
 			);
 			return {
 				settings: getSettings( setIsInserterOpen ),
-				templateType: getTemplateType(),
+				templateType: getEditedPostType(),
 				page: getPage(),
 			};
 		},

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -72,23 +72,15 @@ function Editor() {
 			isInserterOpened,
 			__experimentalGetPreviewDeviceType,
 			getSettings,
-			getTemplateId,
-			getTemplatePartId,
-			getTemplateType,
+			getEditedPostType,
+			getEditedPostId,
 			getPage,
 			isNavigationOpened,
 		} = select( 'core/edit-site' );
-		const _templateId = getTemplateId();
-		const _templatePartId = getTemplatePartId();
-		const _templateType = getTemplateType();
+		const postType = getEditedPostType();
+		const postId = getEditedPostId();
 
 		// The currently selected entity to display. Typically template or template part.
-		let _entityId;
-		if ( _templateType ) {
-			_entityId =
-				_templateType === 'wp_template' ? _templateId : _templatePartId;
-		}
-
 		return {
 			isInserterOpen: isInserterOpened(),
 			isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
@@ -97,17 +89,16 @@ function Editor() {
 				'core/interface'
 			).getActiveComplementaryArea( 'core/edit-site' ),
 			settings: getSettings(),
-			templateType: _templateType,
+			templateType: postType,
 			page: getPage(),
-			template:
-				_templateType && _entityId
-					? select( 'core' ).getEntityRecord(
-							'postType',
-							_templateType,
-							_entityId
-					  )
-					: null,
-			entityId: _entityId,
+			template: postId
+				? select( 'core' ).getEntityRecord(
+						'postType',
+						postType,
+						postId
+				  )
+				: null,
+			entityId: postId,
 			isNavigationOpen: isNavigationOpened(),
 		};
 	}, [] );

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -36,9 +36,8 @@ export default function Header( { openEntitiesSavedStates } ) {
 		const {
 			__experimentalGetPreviewDeviceType,
 			isFeatureActive,
-			getTemplateId,
-			getTemplatePartId,
-			getTemplateType,
+			getEditedPostType,
+			getEditedPostId,
 			isInserterOpened,
 		} = select( 'core/edit-site' );
 		const { getEntityRecord } = select( 'core' );
@@ -46,9 +45,8 @@ export default function Header( { openEntitiesSavedStates } ) {
 			'core/editor'
 		);
 
-		const postType = getTemplateType();
-		const postId =
-			postType === 'wp_template' ? getTemplateId() : getTemplatePartId();
+		const postType = getEditedPostType();
+		const postId = getEditedPostId();
 		const record = getEntityRecord( 'postType', postType, postId );
 		const _entityTitle =
 			'wp_template' === postType

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/templates-navigation.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/templates-navigation.js
@@ -19,34 +19,25 @@ import MainDashboardButton from '../../main-dashboard-button';
 import { MENU_ROOT, MENU_TEMPLATE_PARTS, MENU_TEMPLATES } from './constants';
 
 export default function TemplatesNavigation() {
-	const { templateId, templatePartId, templateType, activeMenu } = useSelect(
-		( select ) => {
-			const {
-				getTemplateId,
-				getTemplatePartId,
-				getTemplateType,
-				getNavigationPanelActiveMenu,
-			} = select( 'core/edit-site' );
+	const { postId, postType, activeMenu } = useSelect( ( select ) => {
+		const {
+			getEditedPostType,
+			getEditedPostId,
+			getNavigationPanelActiveMenu,
+		} = select( 'core/edit-site' );
 
-			return {
-				templateId: getTemplateId(),
-				templatePartId: getTemplatePartId(),
-				templateType: getTemplateType(),
-				activeMenu: getNavigationPanelActiveMenu(),
-			};
-		},
-		[]
-	);
+		return {
+			postId: getEditedPostId(),
+			postType: getEditedPostType(),
+			activeMenu: getNavigationPanelActiveMenu(),
+		};
+	}, [] );
 
 	const { setNavigationPanelActiveMenu } = useDispatch( 'core/edit-site' );
 
 	return (
 		<Navigation
-			activeItem={
-				'wp_template' === templateType
-					? `${ templateType }-${ templateId }`
-					: `${ templateType }-${ templatePartId }`
-			}
+			activeItem={ `${ postType }-${ postId }` }
 			activeMenu={ activeMenu }
 			onActivateMenu={ setNavigationPanelActiveMenu }
 		>

--- a/packages/edit-site/src/components/url-query-controller/index.js
+++ b/packages/edit-site/src/components/url-query-controller/index.js
@@ -47,28 +47,19 @@ export default function URLQueryController() {
 
 function useCurrentPageContext() {
 	return useSelect( ( select ) => {
-		const {
-			getTemplateId,
-			getTemplatePartId,
-			getTemplateType,
-			getPage,
-		} = select( 'core/edit-site' );
+		const { getEditedPostType, getEditedPostId, getPage } = select(
+			'core/edit-site'
+		);
 
 		const page = getPage();
-		const templateType = getTemplateType();
-		const templateId = getTemplateId();
-		const templatePartId = getTemplatePartId();
-
-		let _postId, _postType;
+		let _postId = getEditedPostId(),
+			_postType = getEditedPostType();
+		// This doesn't seem right to me,
+		// we shouldn't be using the "page" and the "template" in the same way.
+		// This need to be investigated.
 		if ( page?.context?.postId && page?.context?.postType ) {
 			_postId = page.context.postId;
 			_postType = page.context.postType;
-		} else if ( templateType === 'wp_template' && templateId ) {
-			_postId = templateId;
-			_postType = templateType;
-		} else if ( templateType === 'wp_template_part' && templatePartId ) {
-			_postId = templatePartId;
-			_postType = templateType;
 		}
 
 		if ( _postId && _postType ) {

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -77,7 +77,7 @@ export function settings( state = {}, action ) {
  *
  * @return {Object} Updated state.
  */
-export function editedPost( state, action ) {
+export function editedPost( state = {}, action ) {
 	switch ( action.type ) {
 		case 'SET_TEMPLATE':
 		case 'SET_PAGE':

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -69,79 +69,28 @@ export function settings( state = {}, action ) {
 }
 
 /**
- * Reducer returning the template ID.
+ * Reducer keeping track of the currently edited Post Type,
+ * Post Id and the context provided to fill the content of the block editor.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
  * @return {Object} Updated state.
  */
-export function templateId( state, action ) {
+export function editedPost( state, action ) {
 	switch ( action.type ) {
 		case 'SET_TEMPLATE':
 		case 'SET_PAGE':
-			return action.templateId;
+			return {
+				type: 'wp_template',
+				id: action.templateId,
+				page: action.page,
+			};
 		case 'SET_TEMPLATE_PART':
-			return undefined;
-	}
-
-	return state;
-}
-
-/**
- * Reducer returning the template part ID.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function templatePartId( state, action ) {
-	switch ( action.type ) {
-		case 'SET_TEMPLATE_PART':
-			return action.templatePartId;
-		case 'SET_TEMPLATE':
-		case 'SET_PAGE':
-			return undefined;
-	}
-
-	return state;
-}
-
-/**
- * Reducer returning the template type.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function templateType( state = 'wp_template', action ) {
-	switch ( action.type ) {
-		case 'SET_TEMPLATE':
-		case 'SET_PAGE':
-			return 'wp_template';
-		case 'SET_TEMPLATE_PART':
-			return 'wp_template_part';
-	}
-
-	return state;
-}
-
-/**
- * Reducer returning the page being edited.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function page( state, action ) {
-	switch ( action.type ) {
-		case 'SET_PAGE':
-			return action.page;
-		case 'SET_TEMPLATE_PART':
-			return undefined;
+			return {
+				type: 'wp_template_part',
+				id: action.templatePartId,
+			};
 	}
 
 	return state;
@@ -231,10 +180,7 @@ export default combineReducers( {
 	preferences,
 	deviceType,
 	settings,
-	templateId,
-	templatePartId,
-	templateType,
-	page,
+	editedPost,
 	homeTemplateId,
 	navigationPanel,
 	blockInserterPanel,

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -96,36 +96,25 @@ export function getHomeTemplateId( state ) {
 }
 
 /**
- * Returns the current template ID.
+ * Returns the current edited post type (wp_template or wp_template_part).
  *
  * @param {Object} state Global application state.
  *
  * @return {number?} Template ID.
  */
-export function getTemplateId( state ) {
-	return state.templateId;
+export function getEditedPostType( state ) {
+	return state.editedPost.type;
 }
 
 /**
- * Returns the current template part ID.
+ * Returns the ID of the currently edited template or template part.
  *
  * @param {Object} state Global application state.
  *
- * @return {number?} Template part ID.
+ * @return {number?} Post ID.
  */
-export function getTemplatePartId( state ) {
-	return state.templatePartId;
-}
-
-/**
- * Returns the current template type.
- *
- * @param {Object} state Global application state.
- *
- * @return {string?} Template type.
- */
-export function getTemplateType( state ) {
-	return state.templateType;
+export function getEditedPostId( state ) {
+	return state.editedPost.id;
 }
 
 /**
@@ -136,7 +125,7 @@ export function getTemplateType( state ) {
  * @return {Object} Page.
  */
 export function getPage( state ) {
-	return state.page;
+	return state.editedPost.page;
 }
 
 /**

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -10,10 +10,7 @@ import {
 	preferences,
 	settings,
 	homeTemplateId,
-	templateId,
-	templatePartId,
-	templateType,
-	page,
+	editedPost,
 	navigationPanel,
 	blockInserterPanel,
 } from '../reducer';
@@ -87,108 +84,51 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'templateId()', () => {
+	describe( 'editedPost()', () => {
 		it( 'should apply default state', () => {
-			expect( templateId( undefined, {} ) ).toEqual( undefined );
+			expect( editedPost( undefined, {} ) ).toEqual( {} );
 		} );
 
 		it( 'should default to returning the same state', () => {
 			const state = {};
-			expect( templateId( state, {} ) ).toBe( state );
+			expect( editedPost( state, {} ) ).toBe( state );
 		} );
 
 		it( 'should update when a template is set', () => {
 			expect(
-				templateId( 1, {
-					type: 'SET_TEMPLATE',
-					templateId: 2,
-				} )
-			).toEqual( 2 );
+				editedPost(
+					{ id: 1, type: 'wp_template' },
+					{
+						type: 'SET_TEMPLATE',
+						templateId: 2,
+					}
+				)
+			).toEqual( { id: 2, type: 'wp_template' } );
 		} );
 
 		it( 'should update when a page is set', () => {
 			expect(
-				templateId( 1, {
-					type: 'SET_PAGE',
-					templateId: 2,
-				} )
-			).toEqual( 2 );
-		} );
-	} );
-
-	describe( 'templatePartId()', () => {
-		it( 'should apply default state', () => {
-			expect( templatePartId( undefined, {} ) ).toEqual( undefined );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			const state = {};
-			expect( templatePartId( state, {} ) ).toBe( state );
+				editedPost(
+					{ id: 1, type: 'wp_template' },
+					{
+						type: 'SET_PAGE',
+						templateId: 2,
+						page: {},
+					}
+				)
+			).toEqual( { id: 2, type: 'wp_template', page: {} } );
 		} );
 
 		it( 'should update when a template part is set', () => {
 			expect(
-				templatePartId( 1, {
-					type: 'SET_TEMPLATE_PART',
-					templatePartId: 2,
-				} )
-			).toEqual( 2 );
-		} );
-	} );
-
-	describe( 'templateType()', () => {
-		it( 'should apply default state', () => {
-			expect( templateType( undefined, {} ) ).toEqual( 'wp_template' );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			const state = {};
-			expect( templateType( state, {} ) ).toBe( state );
-		} );
-
-		it( 'should update when a template is set', () => {
-			expect(
-				templateType( undefined, {
-					type: 'SET_TEMPLATE',
-				} )
-			).toEqual( 'wp_template' );
-		} );
-
-		it( 'should update when a page is set', () => {
-			expect(
-				templateType( undefined, {
-					type: 'SET_PAGE',
-				} )
-			).toEqual( 'wp_template' );
-		} );
-
-		it( 'should update when a template part is set', () => {
-			expect(
-				templateType( undefined, {
-					type: 'SET_TEMPLATE_PART',
-				} )
-			).toEqual( 'wp_template_part' );
-		} );
-	} );
-
-	describe( 'page()', () => {
-		it( 'should apply default state', () => {
-			expect( page( undefined, {} ) ).toEqual( undefined );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			const state = {};
-			expect( page( state, {} ) ).toBe( state );
-		} );
-
-		it( 'should set the page', () => {
-			const newPage = {};
-			expect(
-				page( undefined, {
-					type: 'SET_PAGE',
-					page: newPage,
-				} )
-			).toBe( newPage );
+				editedPost(
+					{ id: 1, type: 'wp_template' },
+					{
+						type: 'SET_TEMPLATE_PART',
+						templatePartId: 2,
+					}
+				)
+			).toEqual( { id: 2, type: 'wp_template_part' } );
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -6,9 +6,8 @@ import {
 	getCanUserCreateMedia,
 	getSettings,
 	getHomeTemplateId,
-	getTemplateId,
-	getTemplatePartId,
-	getTemplateType,
+	getEditedPostType,
+	getEditedPostId,
 	getPage,
 	getNavigationPanelActiveMenu,
 	isNavigationOpened,
@@ -119,31 +118,25 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getTemplateId', () => {
+	describe( 'getEditedPostId', () => {
 		it( 'returns the template ID', () => {
-			const state = { templateId: {} };
-			expect( getTemplateId( state ) ).toBe( state.templateId );
+			const state = { editedPost: { id: 10 } };
+			expect( getEditedPostId( state ) ).toBe( 10 );
 		} );
 	} );
 
-	describe( 'getTemplatePartId', () => {
-		it( 'returns the template part ID', () => {
-			const state = { templatePartId: {} };
-			expect( getTemplatePartId( state ) ).toBe( state.templatePartId );
-		} );
-	} );
-
-	describe( 'getTemplateType', () => {
+	describe( 'getEditedPostType', () => {
 		it( 'returns the template type', () => {
-			const state = { templateType: {} };
-			expect( getTemplateType( state ) ).toBe( state.templateType );
+			const state = { editedPost: { type: 'wp_template' } };
+			expect( getEditedPostType( state ) ).toBe( 'wp_template' );
 		} );
 	} );
 
 	describe( 'getPage', () => {
 		it( 'returns the page object', () => {
-			const state = { page: {} };
-			expect( getPage( state ) ).toBe( state.page );
+			const page = {};
+			const state = { editedPost: { page } };
+			expect( getPage( state ) ).toBe( page );
 		} );
 	} );
 


### PR DESCRIPTION
The site editor has only a single top-level template or template part being edited at the same time and can't have both. This small refactoring consolidates these two reducers/selectors into one `getEditedPostType` and `getEditedPostId` to avoid the duplicated logic across components.