### PR TITLE
Show the insertion point indicator bellow the inbetween inserter

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -139,7 +139,9 @@ function InsertionPointPopover( {
 				className={ className }
 				style={ { width: element?.offsetWidth } }
 			>
-				{ showInsertionPoint && (
+				{ ( showInsertionPoint ||
+					isInserterShown ||
+					isInserterForced ) && (
 					<div className="block-editor-block-list__insertion-point-indicator" />
 				) }
 				{ ( isInserterShown || isInserterForced ) && (

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -394,6 +394,10 @@
 	left: 0;
 	right: 0;
 	background: var(--wp-admin-theme-color);
+
+	animation: block-editor-inserter__toggle__fade-in-animation 0.3s ease;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
 }
 
 // This is the clickable plus.


### PR DESCRIPTION
closes #26946
Related #27650 

This PR just shows the insertion point indicator when you hover the in-between inserter. It clarifies what this inserter is for.