### PR TITLE
Add FSE query args for taxonomy and handle Query preview on category selection

### DIFF
--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -6,6 +6,7 @@
 		"queryId",
 		"query",
 		"queryContext",
+		"templateContext",
 		"layout"
 	],
 	"supports": {

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -52,7 +52,7 @@ export default function QueryLoopEdit( {
 
 	const { posts, blocks } = useSelect(
 		( select ) => {
-			const { getEntityRecords } = select( 'core' );
+			const { getEntityRecord, getEntityRecords } = select( 'core' );
 			const { getBlocks } = select( 'core/block-editor' );
 			const query = {
 				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
@@ -86,12 +86,13 @@ export default function QueryLoopEdit( {
 			// This creates a cycle dependency.
 			if ( inherit && select( 'core/edit-site' ) ) {
 				// This should be passed from the context exposed by edit site.
-				const { getEditedPostType, getEditedPostId } = select(
+
+				const { getEditedPostType, getEditedPostId, getPage } = select(
 					'core/edit-site'
 				);
 
 				if ( 'wp_template' === getEditedPostType() ) {
-					const { slug } = select( 'core' ).getEntityRecord(
+					const { slug } = getEntityRecord(
 						'postType',
 						'wp_template',
 						getEditedPostId()
@@ -102,6 +103,11 @@ export default function QueryLoopEdit( {
 						query.postType = slug.replace( 'archive-', '' );
 						postType = query.postType;
 					}
+				}
+				const { context: { taxonomy, termId } = {} } = getPage() || {};
+				// Handle categories previews.
+				if ( taxonomy === 'category' && termId ) {
+					query.categories = [ termId ];
 				}
 			}
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -128,13 +128,9 @@ function Editor() {
 		setIsEntitiesSavedStatesOpen( false );
 	}, [] );
 
-	// Set default query for misplaced Query Loop blocks, and
-	// provide the root `queryContext` for top-level Query Loop
-	// and Query Pagination blocks.
 	const blockContext = useMemo(
 		() => ( {
 			...page?.context,
-			query: page?.context.query || { categoryIds: [], tagIds: [] },
 			queryContext: [
 				page?.context.queryContext || { page: 1 },
 				( newQueryContext ) =>

--- a/packages/edit-site/src/components/navigate-to-link/index.js
+++ b/packages/edit-site/src/components/navigate-to-link/index.js
@@ -36,7 +36,7 @@ export default function NavigateToLink( {
 				pageEntity.link,
 				registry.__experimentalResolveSelect( 'core' ).getEntityRecords
 			).then(
-				( newTemplateId ) => setTemplateId( newTemplateId ),
+				( { id: newTemplateId } ) => setTemplateId( newTemplateId ),
 				() => setTemplateId( null )
 			);
 	}, [ pageEntity?.link, registry ] );

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-posts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-posts.js
@@ -29,7 +29,6 @@ export default function ContentPostsMenu() {
 			type: 'page',
 			path: '/',
 			context: {
-				query: { categoryIds: [] },
 				queryContext: { page: 1 },
 			},
 		} );

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation-entity-items.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation-entity-items.js
@@ -21,9 +21,14 @@ export default function NavigationEntityItems( { kind, name, query = {} } ) {
 	}
 
 	const onActivateItem = ( { type, slug, link, id, taxonomy } ) => {
-		const context = taxonomy
-			? { taxonomy, termId: id }
-			: { postType: type, postId: id };
+		let context = { postType: type, postId: id };
+		if ( taxonomy ) {
+			context = { taxonomy, termId: id };
+			if ( taxonomy === 'category' ) {
+				context.queryContext = { categoryIds: [ id ] };
+			}
+		}
+
 		setPage( {
 			type,
 			slug,

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation-entity-items.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation-entity-items.js
@@ -20,15 +20,15 @@ export default function NavigationEntityItems( { kind, name, query = {} } ) {
 		return null;
 	}
 
-	const onActivateItem = ( { type, slug, link, id } ) => {
+	const onActivateItem = ( { type, slug, link, id, taxonomy } ) => {
+		const context = taxonomy
+			? { taxonomy, termId: id }
+			: { postType: type, postId: id };
 		setPage( {
 			type,
 			slug,
 			path: getPathAndQueryString( link ),
-			context: {
-				postType: type,
-				postId: id,
-			},
+			context,
 		} );
 	};
 

--- a/packages/edit-site/src/components/url-query-controller/index.js
+++ b/packages/edit-site/src/components/url-query-controller/index.js
@@ -22,7 +22,11 @@ export default function URLQueryController() {
 		if ( [ 'page', 'post' ].includes( postType ) ) {
 			setPage( { context: { postType, postId } } ); // Resolves correct template based on ID.
 		} else if ( taxonomy && termId ) {
-			setPage( { context: { taxonomy, termId } } );
+			const context = { taxonomy, termId };
+			if ( taxonomy === 'category' ) {
+				context.queryContext = { categoryIds: [ termId ] };
+			}
+			setPage( { context } );
 		} else if ( 'wp_template' === postType ) {
 			setTemplate( postId );
 		} else if ( 'wp_template_part' === postType ) {

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -115,7 +115,8 @@ export function setHomeTemplateId( homeTemplateId ) {
 
 /**
  * Resolves the template for a page and displays both. If no path is given, attempts
- * to use the postId to generate a path like `?p=${ postId }`.
+ * to use the postId to generate a path like `?p=${ postId }` or the `category` for
+ * a path like `?cat=${ termId }.
  *
  * @param {Object}  page         The page object.
  * @param {string}  page.type    The page type.
@@ -134,10 +135,23 @@ export function* setPage( page ) {
 			page.path = `?cat=${ termId }`;
 		}
 	}
-	const templateId = yield findTemplate( page.path );
+	const { id: templateId, slug: templateSlug } = yield findTemplate(
+		page.path
+	);
 	yield {
 		type: 'SET_PAGE',
-		page,
+		page: ! templateSlug
+			? page
+			: {
+					...page,
+					context: {
+						...page.context,
+						templateContext: {
+							...page.context?.templateContext,
+							slug: templateSlug,
+						},
+					},
+			  },
 		templateId,
 	};
 	return templateId;

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -126,8 +126,13 @@ export function setHomeTemplateId( homeTemplateId ) {
  * @return {number} The resolved template ID for the page route.
  */
 export function* setPage( page ) {
-	if ( ! page.path && page.context?.postId ) {
-		page.path = `?p=${ page.context.postId }`;
+	if ( ! page.path ) {
+		const { context: { postId, termId, taxonomy } = {} } = page;
+		if ( postId ) {
+			page.path = `?p=${ postId }`;
+		} else if ( termId && taxonomy === 'category' ) {
+			page.path = `?cat=${ termId }`;
+		}
 	}
 	const templateId = yield findTemplate( page.path );
 	yield {

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -104,7 +104,7 @@ describe( 'actions', () => {
 				type: 'FIND_TEMPLATE',
 				path: page.path,
 			} );
-			expect( it.next( templateId ).value ).toEqual( {
+			expect( it.next( { id: templateId } ).value ).toEqual( {
 				type: 'SET_PAGE',
 				page,
 				templateId,
@@ -134,7 +134,7 @@ describe( 'actions', () => {
 				type: 'FIND_TEMPLATE',
 				path: page.path,
 			} );
-			expect( it.next( templateId ).value ).toEqual( {
+			expect( it.next( { id: templateId } ).value ).toEqual( {
 				type: 'SET_PAGE',
 				page,
 				templateId,
@@ -173,7 +173,7 @@ describe( 'actions', () => {
 				type: 'FIND_TEMPLATE',
 				path: page.path,
 			} );
-			expect( it.next( templateId ).value ).toEqual( {
+			expect( it.next( { id: templateId } ).value ).toEqual( {
 				type: 'SET_PAGE',
 				page,
 				templateId,

--- a/packages/edit-site/src/utils/find-template.js
+++ b/packages/edit-site/src/utils/find-template.js
@@ -9,12 +9,18 @@ import { addQueryArgs } from '@wordpress/url';
 const { fetch } = window;
 
 /**
+ * @typedef {Object} TemplateInfo
+ * @property {number} id The template's id.
+ * @property {string} slug The template's slug.
+ */
+
+/**
  * Find the template for a given page path.
  *
  * @param {string}   path The page path.
  * @param {Function} getEntityRecords The promise-returning `getEntityRecords` selector to use.
  *
- * @return {number} The found template ID.
+ * @return {TemplateInfo} The found template information.
  */
 export default async function findTemplate( path, getEntityRecords ) {
 	const { data } = await fetch(
@@ -23,17 +29,17 @@ export default async function findTemplate( path, getEntityRecords ) {
 		} )
 	).then( ( res ) => res.json() );
 
-	let newTemplateId = data.ID;
+	const { ID: newTemplateId, post_name: slug } = data;
+	const templateInfo = { id: newTemplateId, slug };
 	if ( newTemplateId === null ) {
-		newTemplateId = (
-			await getEntityRecords( 'postType', 'wp_template', {
-				resolved: true,
-				slug: data.post_name,
-			} )
-		 )[ 0 ].id;
+		const [ newTemplate ] = await getEntityRecords(
+			'postType',
+			'wp_template',
+			{ resolved: true, slug }
+		);
+		templateInfo.id = newTemplate.id;
 	}
-
-	return newTemplateId;
+	return templateInfo;
 }
 
 findTemplate.siteUrl = '';

--- a/packages/edit-site/src/utils/test/find-template.js
+++ b/packages/edit-site/src/utils/test/find-template.js
@@ -18,7 +18,7 @@ describe( 'findTemplate()', () => {
 		const mockFetch = createMockFetch( { data: { ID: 1 } } );
 		expect(
 			await require( '../find-template' ).default( '/path?query=true' )
-		).toBe( 1 );
+		).toEqual( { id: 1, slug: undefined } );
 		expect( mockFetch ).toHaveBeenCalledWith(
 			'/path?query=true&_wp-find-template=true'
 		);
@@ -36,7 +36,7 @@ describe( 'findTemplate()', () => {
 				'/path?query=true',
 				getEntityRecords
 			)
-		).toBe( 2 );
+		).toEqual( { id: 2, slug: 'post-name' } );
 		expect( getEntityRecords ).toHaveBeenCalledWith(
 			'postType',
 			'wp_template',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->




## Description



This PR adds more query args (taxonomy, termId) for setting the proper context when viewing the `categories` in the site editor.

First implementation of query args was here: https://github.com/WordPress/gutenberg/pull/27124.

It also adds the proper settings (category ids) in `QueryLoop` through `queryContext`, so as its preview includes the correct `posts`.
Additionally decouples the `edit-site` with `QueryLoop` by setting a new context `templateContext` inside `blockContext` that contains the `template slug` for now.

<!-- Please describe what you have changed or added -->

## How has this been tested?
- Load the site editor as you would normally.
- Select a `category` entity in the nav panel and verify query args are added to the url and posts are of the selected category.
- Reload the browser, verify the editor loads to entity corresponding to the query args.
