### PR TITLE
Add error actions to error boundaries

### DIFF
--- a/packages/block-editor/src/components/block-list/block-crash-boundary.js
+++ b/packages/block-editor/src/components/block-list/block-crash-boundary.js
@@ -13,7 +13,7 @@ class BlockCrashBoundary extends Component {
 		};
 	}
 
-	componentDidCatch( error ) {
+	componentDidCatch( error, errorInfo ) {
 		this.props.onError( error );
 
 		this.setState( {
@@ -21,7 +21,7 @@ class BlockCrashBoundary extends Component {
 		} );
 
 		if ( typeof this.props.errorActionName === 'string' ) {
-			doAction( this.props.errorActionName, error );
+			doAction( this.props.errorActionName, error, errorInfo );
 		}
 	}
 

--- a/packages/block-editor/src/components/block-list/block-crash-boundary.js
+++ b/packages/block-editor/src/components/block-list/block-crash-boundary.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { doAction } from '@wordpress/hooks';
 
 class BlockCrashBoundary extends Component {
 	constructor() {
@@ -18,6 +19,10 @@ class BlockCrashBoundary extends Component {
 		this.setState( {
 			hasError: true,
 		} );
+
+		if ( typeof this.props.errorActionName === 'string' ) {
+			doAction( this.props.errorActionName );
+		}
 	}
 
 	render() {

--- a/packages/block-editor/src/components/block-list/block-crash-boundary.js
+++ b/packages/block-editor/src/components/block-list/block-crash-boundary.js
@@ -21,7 +21,7 @@ class BlockCrashBoundary extends Component {
 		} );
 
 		if ( typeof this.props.errorActionName === 'string' ) {
-			doAction( this.props.errorActionName );
+			doAction( this.props.errorActionName, error );
 		}
 	}
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -260,7 +260,10 @@ function BlockListBlock( {
 
 	return (
 		<BlockListBlockContext.Provider value={ memoizedValue }>
-			<BlockCrashBoundary onError={ onBlockError }>
+			<BlockCrashBoundary
+				onError={ onBlockError }
+				errorActionName="blockList.blockError"
+			>
 				{ block }
 			</BlockCrashBoundary>
 			{ !! hasError && (

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -262,7 +262,7 @@ function BlockListBlock( {
 		<BlockListBlockContext.Provider value={ memoizedValue }>
 			<BlockCrashBoundary
 				onError={ onBlockError }
-				errorActionName="blockList.blockError"
+				errorActionName="blockList.error"
 			>
 				{ block }
 			</BlockCrashBoundary>

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -60,6 +60,7 @@ import * as tagCloud from './tag-cloud';
 import * as classic from './freeform';
 import * as socialLinks from './social-links';
 import * as socialLink from './social-link';
+import * as throwError from './throw-error';
 
 // Full Site Editing Blocks
 import * as siteLogo from './site-logo';
@@ -160,6 +161,7 @@ export const __experimentalGetCoreBlocks = () => [
 	textColumns,
 	verse,
 	video,
+	throwError,
 ];
 
 /**

--- a/packages/block-library/src/throw-error/block.json
+++ b/packages/block-library/src/throw-error/block.json
@@ -1,0 +1,17 @@
+{
+	"apiVersion": 2,
+	"name": "core/throw-error",
+	"category": "widgets",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "html"
+		}
+	},
+	"supports": {
+		"customClassName": false,
+		"className": false,
+		"html": false
+	},
+	"editorStyle": "wp-block-html-editor"
+}

--- a/packages/block-library/src/throw-error/edit.js
+++ b/packages/block-library/src/throw-error/edit.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+export default function ThrowErrorEdit() {
+	const [ err, setError ] = useState( false );
+	return (
+		<div>
+			{ err &&
+				( () => {
+					throw new Error( 'Error in block render!' );
+				} )() }
+			<p>This is where an error will go.</p>
+			<p>
+				<Button
+					isDestructive
+					onClick={ () => {
+						throw new Error( 'Error in block callback!' );
+					} }
+				>
+					Trigger a non-render error.
+				</Button>
+			</p>
+			<p>
+				<Button isDestructive onClick={ () => setError( true ) }>
+					Trigger a render error!
+				</Button>
+			</p>
+		</div>
+	);
+}

--- a/packages/block-library/src/throw-error/index.js
+++ b/packages/block-library/src/throw-error/index.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { html as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Throw an error' ),
+	description: __( 'Demonstrate an error in the block.' ),
+	icon,
+	keywords: [ __( 'error' ) ],
+	edit,
+	save: () => null,
+};

--- a/packages/edit-navigation/src/components/error-boundary/index.js
+++ b/packages/edit-navigation/src/components/error-boundary/index.js
@@ -18,11 +18,11 @@ class ErrorBoundary extends Component {
 		};
 	}
 
-	componentDidCatch( error ) {
+	componentDidCatch( error, errorInfo ) {
 		this.setState( { error } );
 
 		if ( typeof this.props.errorActionName === 'string' ) {
-			doAction( this.props.errorActionName, error );
+			doAction( this.props.errorActionName, error, errorInfo );
 		}
 	}
 

--- a/packages/edit-navigation/src/components/error-boundary/index.js
+++ b/packages/edit-navigation/src/components/error-boundary/index.js
@@ -22,7 +22,7 @@ class ErrorBoundary extends Component {
 		this.setState( { error } );
 
 		if ( typeof this.props.errorActionName === 'string' ) {
-			doAction( this.props.errorActionName );
+			doAction( this.props.errorActionName, error );
 		}
 	}
 

--- a/packages/edit-navigation/src/components/error-boundary/index.js
+++ b/packages/edit-navigation/src/components/error-boundary/index.js
@@ -5,6 +5,7 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Warning } from '@wordpress/block-editor';
+import { doAction } from '@wordpress/hooks';
 
 class ErrorBoundary extends Component {
 	constructor() {
@@ -19,6 +20,10 @@ class ErrorBoundary extends Component {
 
 	componentDidCatch( error ) {
 		this.setState( { error } );
+
+		if ( typeof this.props.errorActionName === 'string' ) {
+			doAction( this.props.errorActionName );
+		}
 	}
 
 	reboot() {

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	Button,
 	DropZoneProvider,
 	Popover,
 	SlotFillProvider,
@@ -10,6 +11,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -47,6 +49,7 @@ export default function Layout( { blockEditorSettings } ) {
 					<BlockEditorKeyboardShortcuts.Register />
 					<NavigationEditorShortcuts.Register />
 
+					<ThrowAnError />
 					<Notices />
 
 					<div className="edit-navigation-layout">
@@ -71,6 +74,7 @@ export default function Layout( { blockEditorSettings } ) {
 								isPending={ ! navigationPost }
 								navigationPost={ navigationPost }
 							/>
+
 							<Editor
 								isPending={ ! navigationPost }
 								blocks={ blocks }
@@ -88,3 +92,20 @@ export default function Layout( { blockEditorSettings } ) {
 		</ErrorBoundary>
 	);
 }
+
+const ThrowAnError = () => {
+	const [ err, setError ] = useState( false );
+	return (
+		<>
+			<p>
+				<Button isDestructive onClick={ () => setError( true ) }>
+					Trigger a render error!
+				</Button>
+			</p>
+			{ err &&
+				( () => {
+					throw new Error( 'Error in navigation render!' );
+				} )() }
+		</>
+	);
+};

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -41,7 +41,7 @@ export default function Layout( { blockEditorSettings } ) {
 	useMenuNotifications( selectedMenuId );
 
 	return (
-		<ErrorBoundary>
+		<ErrorBoundary errorActionName="editNavigation.error">
 			<SlotFillProvider>
 				<DropZoneProvider>
 					<BlockEditorKeyboardShortcuts.Register />

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -176,8 +176,14 @@ function Layout( { settings } ) {
 		onClose: () => setIsInserterOpened( false ),
 	} );
 
+	const [ err, setError ] = useState( false );
+
 	return (
 		<>
+			{ err &&
+				( () => {
+					throw new Error( 'Error in editor render!' );
+				} )() }
 			<FullscreenMode isActive={ isFullscreenActive } />
 			<BrowserURL />
 			<UnsavedChangesWarning />
@@ -250,6 +256,18 @@ function Layout( { settings } ) {
 				}
 				content={
 					<>
+						{ err &&
+							( () => {
+								throw new Error( 'Error in editor render!' );
+							} )() }
+						<p>
+							<Button
+								isDestructive
+								onClick={ () => setError( true ) }
+							>
+								Trigger a render error!
+							</Button>
+						</p>
 						<EditorNotices />
 						{ ( mode === 'text' || ! isRichEditingEnabled ) && (
 							<TextEditor />

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -170,7 +170,10 @@ function Editor( {
 							}
 							{ ...props }
 						>
-							<ErrorBoundary onError={ onError }>
+							<ErrorBoundary
+								onError={ onError }
+								errorActionName="editPost.editorError"
+							>
 								<EditorInitialization postId={ postId } />
 								<Layout settings={ settings } />
 								<KeyboardShortcuts

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -172,7 +172,7 @@ function Editor( {
 						>
 							<ErrorBoundary
 								onError={ onError }
-								errorActionName="editPost.editorError"
+								errorActionName="editPost.error"
 							>
 								<EditorInitialization postId={ postId } />
 								<Layout settings={ settings } />

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, ClipboardButton } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { Warning } from '@wordpress/block-editor';
+import { doAction } from '@wordpress/hooks';
 
 class ErrorBoundary extends Component {
 	constructor() {
@@ -21,6 +22,10 @@ class ErrorBoundary extends Component {
 
 	componentDidCatch( error ) {
 		this.setState( { error } );
+
+		if ( typeof this.props.errorActionName === 'string' ) {
+			doAction( this.props.errorActionName );
+		}
 	}
 
 	reboot() {

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -24,7 +24,7 @@ class ErrorBoundary extends Component {
 		this.setState( { error } );
 
 		if ( typeof this.props.errorActionName === 'string' ) {
-			doAction( this.props.errorActionName );
+			doAction( this.props.errorActionName, error );
 		}
 	}
 

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -20,11 +20,11 @@ class ErrorBoundary extends Component {
 		};
 	}
 
-	componentDidCatch( error ) {
+	componentDidCatch( error, errorInfo ) {
 		this.setState( { error } );
 
 		if ( typeof this.props.errorActionName === 'string' ) {
-			doAction( this.props.errorActionName, error );
+			doAction( this.props.errorActionName, error, errorInfo );
 		}
 	}
 


### PR DESCRIPTION
## Description

React error boundaries are used to catch render errors and prevent the app from becoming unusable by e.g. a single block breaking. The downside is that these errors are difficult to track.

Add error actions to error boundaries. By adding an action, any plugin should be able to listen to render errors from the various editors. By doing so, logs can be gathered and issues with sites can be detected.

Watch error actions being triggered from the following pages:

- `/wp-admin/post-new.php`
  - Use the "trigger an error" button button from the editor
  - Add a "Throw an error" block and click its trigger buttons
- `/wp-admin/admin.php?page=gutenberg-navigation` Click the page error-trigger button. Requires the experiment be enabled.

Listen to error from the console with something like the following:

```js
wp.hooks.addAction( 'blockList.error', 'show-me-the-errors', ( err, info ) => { console.log( 'Got block error:\n%o\nInfo:\n%o', err, info ); } );
wp.hooks.addAction( 'editPost.error', 'show-me-the-errors', ( err, info ) => { console.log( 'Got editor error:\n%o\nInfo:\n%o', err, info); } );
wp.hooks.addAction( 'editNavigation.error', 'show-me-the-errors', ( err, info ) => { console.log( 'Got navigation error:\n%o\nInfo:\n%o', err, info ); } );
```

## Questions

- The initial implementation is with a `@wordpress/hooks` action.
- All of the actions are different, which means that an action needs to be added for each individual error boundary. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
