### PR TITLE
Gallery Block Refactor: Account for null image ids in gallery migrations

### DIFF
--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -80,6 +80,26 @@ export function getHrefAndDestination( image, destination ) {
 	return {};
 }
 
+/**
+ * Gets an Image block from gallery image data
+ *
+ * Used to migrate Galleries to nested Image InnerBlocks.
+ *
+ * @param  {Object} image    Image properties.
+ * @param  {string} sizeSlug Gallery sizeSlug attribute.
+ * @param  {string} linkTo   Gallery linkTo attribute.
+ * @return {Object}          Image block.
+ */
+export function getImageBlock( image, sizeSlug, linkTo ) {
+	return createBlock( 'core/image', {
+		...( image.id && image.id !== null && { id: parseInt( image.id ) } ),
+		url: image.url,
+		alt: image.alt,
+		caption: image.caption,
+		sizeSlug,
+		...getHrefAndDestination( image, linkTo ),
+	} );
+}
 const v1 = {
 	attributes: {
 		images: {
@@ -173,15 +193,7 @@ const v1 = {
 	},
 	migrate( { images, imageCrop, linkTo, sizeSlug, columns, caption } ) {
 		const imageBlocks = images.map( ( image ) => {
-			return createBlock( 'core/image', {
-				...( image.id &&
-					image.id !== null && { id: parseInt( image.id ) } ),
-				url: image.url,
-				alt: image.alt,
-				caption: image.caption,
-				sizeSlug,
-				...getHrefAndDestination( image, linkTo ),
-			} );
+			return getImageBlock( image, sizeSlug, linkTo );
 		} );
 		return [
 			{
@@ -457,15 +469,7 @@ const v3 = {
 	},
 	migrate( { images, imageCrop, linkTo, sizeSlug, columns, caption } ) {
 		const imageBlocks = images.map( ( image ) => {
-			return createBlock( 'core/image', {
-				...( image.id &&
-					image.id !== null && { id: parseInt( image.id ) } ),
-				url: image.url,
-				alt: image.alt,
-				caption: image.caption,
-				sizeSlug,
-				...getHrefAndDestination( image, linkTo ),
-			} );
+			return getImageBlock( image, sizeSlug, linkTo );
 		} );
 
 		return [
@@ -554,15 +558,7 @@ const v4 = {
 	},
 	migrate( { images, imageCrop, linkTo, sizeSlug, columns, caption } ) {
 		const imageBlocks = images.map( ( image ) => {
-			return createBlock( 'core/image', {
-				...( image.id &&
-					image.id !== null && { id: parseInt( image.id ) } ),
-				url: image.url,
-				alt: image.alt,
-				caption: image.caption,
-				sizeSlug,
-				...getHrefAndDestination( image, linkTo ),
-			} );
+			return getImageBlock( image, sizeSlug, linkTo );
 		} );
 
 		return [
@@ -746,15 +742,7 @@ const v5 = {
 			linkTo = 'none';
 		}
 		const imageBlocks = attributes.images.map( ( image ) => {
-			return createBlock( 'core/image', {
-				...( image.id &&
-					image.id !== null && { id: parseInt( image.id ) } ),
-				url: image.url,
-				alt: image.alt,
-				caption: image.caption,
-				sizeSlug: attributes.sizeSlug,
-				...getHrefAndDestination( image, linkTo ),
-			} );
+			return getImageBlock( image, attributes.sizeSlug, linkTo );
 		} );
 		return [
 			{
@@ -1008,15 +996,7 @@ const v6 = {
 			linkTo = 'media';
 		}
 		const imageBlocks = images.map( ( image ) => {
-			return createBlock( 'core/image', {
-				...( image.id &&
-					image.id !== null && { id: parseInt( image.id ) } ),
-				url: image.url,
-				alt: image.alt,
-				caption: image.caption,
-				sizeSlug,
-				...getHrefAndDestination( image, linkTo ),
-			} );
+			return getImageBlock( image, sizeSlug, linkTo );
 		} );
 		return [
 			{

--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -174,7 +174,8 @@ const v1 = {
 	migrate( { images, imageCrop, linkTo, sizeSlug, columns, caption } ) {
 		const imageBlocks = images.map( ( image ) => {
 			return createBlock( 'core/image', {
-				id: parseInt( image.id ),
+				...( image.id &&
+					image.id !== null && { id: parseInt( image.id ) } ),
 				url: image.url,
 				alt: image.alt,
 				caption: image.caption,
@@ -457,7 +458,8 @@ const v3 = {
 	migrate( { images, imageCrop, linkTo, sizeSlug, columns, caption } ) {
 		const imageBlocks = images.map( ( image ) => {
 			return createBlock( 'core/image', {
-				id: parseInt( image.id ),
+				...( image.id &&
+					image.id !== null && { id: parseInt( image.id ) } ),
 				url: image.url,
 				alt: image.alt,
 				caption: image.caption,
@@ -553,7 +555,8 @@ const v4 = {
 	migrate( { images, imageCrop, linkTo, sizeSlug, columns, caption } ) {
 		const imageBlocks = images.map( ( image ) => {
 			return createBlock( 'core/image', {
-				id: parseInt( image.id ),
+				...( image.id &&
+					image.id !== null && { id: parseInt( image.id ) } ),
 				url: image.url,
 				alt: image.alt,
 				caption: image.caption,
@@ -744,7 +747,8 @@ const v5 = {
 		}
 		const imageBlocks = attributes.images.map( ( image ) => {
 			return createBlock( 'core/image', {
-				id: parseInt( image.id ),
+				...( image.id &&
+					image.id !== null && { id: parseInt( image.id ) } ),
 				url: image.url,
 				alt: image.alt,
 				caption: image.caption,
@@ -1005,7 +1009,8 @@ const v6 = {
 		}
 		const imageBlocks = images.map( ( image ) => {
 			return createBlock( 'core/image', {
-				id: parseInt( image.id ),
+				...( image.id &&
+					image.id !== null && { id: parseInt( image.id ) } ),
 				url: image.url,
 				alt: image.alt,
 				caption: image.caption,

--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -92,7 +92,7 @@ export function getHrefAndDestination( image, destination ) {
  */
 export function getImageBlock( image, sizeSlug, linkTo ) {
 	return createBlock( 'core/image', {
-		...( image.id && image.id !== null && { id: parseInt( image.id ) } ),
+		...( image.id && { id: parseInt( image.id ) } ),
 		url: image.url,
 		alt: image.alt,
 		caption: image.caption,


### PR DESCRIPTION
## Description
The Gallery block migrations were not accounting for images with no id - ie. those added via url as individual images and then converted to a Gallery.

Also moves the createBlock call to a method to avoid duplication of code

## Testing

On master create two image blocks with the `Insert from URL` option
Select the two images and use the convert to gallery option
Check out this branch and reload editor
Make sure that the gallery converts ok, and that you don't see `NaN` in the image toolbar

Before:
<img width="387" alt="Screen Shot 2020-12-22 at 12 06 25 PM" src="https://user-images.githubusercontent.com/3629020/102830770-f5fbf480-444e-11eb-8285-63eb5147bf13.png">

After:
<img width="371" alt="Screen Shot 2020-12-22 at 12 07 14 PM" src="https://user-images.githubusercontent.com/3629020/102830786-001df300-444f-11eb-918f-6a60340548bc.png">

