### PR TITLE
Fixes a regression in setting the font-size of the code block

### DIFF
--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -1,10 +1,6 @@
 // Provide a minimum of overflow handling.
-.wp-block-code {
-	font-size: 0.9em;
-
-	code {
-		display: block;
-		white-space: pre-wrap;
-		overflow-wrap: break-word;
-	}
+.wp-block-code code {
+	display: block;
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/27827

https://github.com/WordPress/gutenberg/pull/27294 introduced the font size support for the code block. It also added these styles to the block's CSS:

```css
.wp-block-code {
  font-size: var(--wp--preset--font-size--extra-small, 0.9em);
}
```

This was problematic so in https://github.com/WordPress/gutenberg/pull/27672 the CSS Custom Property was removed. However, that PR didn't remove the whole declaration, only removed the CSS Custom Property, hence introduced a regression. This is the current CSS of the block:

```css
.wp-block-code {
  font-size: 0.9em;
}
```

https://github.com/WordPress/gutenberg/pull/27672 should have removed the font-size declaration from the code block's CSS instead.
