### PR TITLE
Change the block editor inserter quick inserter border color

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -16,6 +16,29 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
+.block-editor-inserter__popover.is-quick {
+	.components-popover__content {
+		border: none;
+
+		.block-editor-inserter__quick-inserter > * {
+			border-left: 1px solid $gray-400;
+			border-right: 1px solid $gray-400;
+
+			&:first-child {
+				border-top: 1px solid $gray-400;
+			}
+
+			&:last-child {
+				border-bottom: 1px solid $gray-400;
+			}
+
+			&.components-button {
+				border: 1px solid $gray-900;
+			}
+		}
+	}
+}
+
 .block-editor-inserter__popover .block-editor-inserter__menu {
 	margin: -$grid-unit-15;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #27772 
Change the block editor inserter quick inserter border color so the inserter button does not have a gray border.

## How has this been tested?
Click on the add block button on both post and page, and check if it renders as expected

## Screenshots <!-- if applicable -->
1. Before
<img width="521" alt="before" src="https://user-images.githubusercontent.com/56378160/102940493-7259fc00-447e-11eb-8bac-aa279c98a5a4.png">

2. After
<img width="385" alt="after" src="https://user-images.githubusercontent.com/56378160/102943729-e13b5300-4486-11eb-9b54-a04b113add85.png">

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
