### PR TITLE
[Mobile] Use react-native URL implementation in native URL tests - DO NOT MERGE

### DIFF
--- a/packages/url/src/get-query-string.js
+++ b/packages/url/src/get-query-string.js
@@ -14,7 +14,10 @@ export function getQueryString( url ) {
 	let query;
 	try {
 		query = new URL( url, 'http://example.com' ).search.substring( 1 );
-	} catch ( error ) {}
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.log( error );
+	}
 
 	if ( query ) {
 		return query;

--- a/packages/url/src/test/index.native.js
+++ b/packages/url/src/test/index.native.js
@@ -3,6 +3,13 @@
  */
 import './index.test';
 
+/**
+ * External dependencies
+ */
+import { URL as CoreURL } from 'react-native/Libraries/Blob/URL';
+
+global.URL = CoreURL;
+
 jest.mock( './fixtures/wpt-data.json', () => {
 	const data = jest.requireActual( './fixtures/wpt-data.json' );
 


### PR DESCRIPTION
## Description
This PR is only to demonstrate the failure of URL unit tests in the native environment when we use the default URL implementation provided by the react-native runtime.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
