### PR TITLE
Remove the gradient and put caption under image if is-rounded style applied

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -74,19 +74,24 @@
 			}
 
 			&.is-style-rounded {
-				// Apply to IE in this context as using flex: 1 1 auto makes it a happy camper.
-				flex-direction: column;
 				> div,
 				> a {
-					flex: 1 1 auto;
+					// Not supported in IE11.
+					@supports ( position: sticky ) {
+						flex: 1 1 auto;
+					}
 				}
 				figcaption {
-					flex: initial;
 					background: none;
-					color: inherit;
-					margin: 0;
-					padding: 10px 10px 9px;
-					position: relative;
+					// Not supported in IE11.
+					@supports ( position: sticky ) {
+						flex: initial;
+						background: none;
+						color: inherit;
+						margin: 0;
+						padding: 10px 10px 9px;
+						position: relative;
+					}
 				}
 			}
 		}

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -83,14 +83,10 @@
 				figcaption {
 					flex: initial;
 					background: none;
-					bottom: initial;
 					color: inherit;
-					font-size: $default-font-size;
 					margin: 0;
 					padding: 10px 10px 9px;
 					position: relative;
-					text-align: center;
-					width: 100%;
 				}
 			}
 		}

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -24,7 +24,8 @@
 			flex-grow: 1;
 			justify-content: center;
 			position: relative;
-
+			margin-top: auto;
+			margin-bottom: auto;
 			// IE11 doesn't like the "flex-direction: column;" here.
 			@supports ( position: sticky ) {
 				flex-direction: column;
@@ -99,6 +100,23 @@
 
 	figcaption {
 		flex-grow: 1;
+	}
+
+	// Non cropped images.
+	&:not(.is-cropped) {
+		figure.blocks-gallery-grid {
+			figure.wp-block-image:not(#individual-image) {
+				margin-top: auto;
+				margin-bottom: auto;
+				img {
+					margin-bottom: $grid-unit-20;
+				}
+
+				figcaption {
+					bottom: $grid-unit-20;
+				}
+			}
+		}
 	}
 
 	// Cropped Images.

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -72,6 +72,27 @@
 					display: inline;
 				}
 			}
+
+			&.is-style-rounded {
+				// Apply to IE in this context as using flex: 1 1 auto makes it a happy camper.
+				flex-direction: column;
+				> div,
+				> a {
+					flex: 1 1 auto;
+				}
+				figcaption {
+					flex: initial;
+					background: none;
+					bottom: initial;
+					color: inherit;
+					font-size: $default-font-size;
+					margin: 0;
+					padding: 10px 10px 9px;
+					position: relative;
+					text-align: center;
+					width: 100%;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
If is-style-rounded is applied to an image in gallery the gradient overflows and there is not much room within rounded image for the caption.

This PR removes the gradient and and puts caption under the image if image is rounded:

<img width="654" alt="Screen Shot 2020-12-23 at 4 57 22 PM" src="https://user-images.githubusercontent.com/3629020/102957783-3b4c1f00-4540-11eb-802d-18671779a000.png">
