### PR TITLE
Code quality: Remove overrides for JSDoc rules downgraded to warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,10 +121,6 @@ module.exports = {
 					'Avoid truthy checks on length property rendering, as zero length is rendered verbatim.',
 			},
 		],
-		// Temporarily converted to warning until all errors are resolved.
-		// See https://github.com/WordPress/gutenberg/pull/22771 for the eslint-plugin-jsdoc update.
-		'jsdoc/check-param-names': 'warn',
-		'jsdoc/require-param': 'warn',
 	},
 	overrides: [
 		{

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -205,8 +205,8 @@ async function runTestSuite( testSuite, performanceTestDirectory ) {
 /**
  * Runs the performances tests on an array of branches and output the result.
  *
- * @param {WPPerformanceCommandOptions} options Command options.
  * @param {string[]}                    branches Branches to compare
+ * @param {WPPerformanceCommandOptions} options Command options.
  */
 async function runPerformanceTests( branches, options ) {
 	// The default value doesn't work because commander provides an array.

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -22,17 +22,10 @@ import BlockIcon from '../components/block-icon';
 
 const SHOWN_BLOCK_TYPES = 9;
 
-/** @typedef {import('@wordpress/block-editor').WPEditorInserterItem} WPEditorInserterItem */
-
 /** @typedef {import('@wordpress/components').WPCompleter} WPCompleter */
 
 /**
  * Creates a blocks repeater for replacing the current block with a selected block type.
- *
- * @param {Object} props                                   Component props.
- * @param {string} [props.getBlockInsertionParentClientId] Client ID of the parent.
- * @param {string} [props.getInserterItems]                Inserter items for parent.
- * @param {string} [props.getSelectedBlockName]            Name of selected block or null.
  *
  * @return {WPCompleter} A blocks completer.
  */


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closes #22907.

The last part to resolve all the issues related to the missing params in JSDoc detected by ESLint.

## How has this been tested?
`npm run lint-js`