### PR TITLE
Create block: Allow to list npm dependencies to be installed in the template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12299,6 +12299,7 @@
 				"lodash": "^4.17.19",
 				"make-dir": "^3.0.0",
 				"mustache": "^4.0.0",
+				"npm-package-arg": "^8.0.1",
 				"rimraf": "^3.0.2",
 				"write-pkg": "^4.0.0"
 			}

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Adds the `npmPackages` field to the template configuration. It allows listing remote npm packages that will be installed in the scaffolded project ([#27880](https://github.com/WordPress/gutenberg/pull/27880)).
+-   Installs WordPress npm dependencies used in the `esnext` template during the scaffolding process ([#27880](https://github.com/WordPress/gutenberg/pull/27880)).
+
 ## 1.0.2 (2020-12-17)
 
 ### Bug Fix

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -160,6 +160,7 @@ The following configurable variables are used with the template files. Template 
 -   `licenseURI` (default: `'https://www.gnu.org/licenses/gpl-2.0.html'`)
 -   `version` (default: `'0.1.0'`)
 -   `wpScripts` (default: `true`)
+-   `npmDependencies` (default: `[]`) – the list of remote npm packages to be installed in the project with [`npm install`](https://docs.npmjs.com/cli/v6/commands/npm-install).
 -   `editorScript` (default: `'file:./build/index.js'`)
 -   `editorStyle` (default: `'file:./build/index.css'`)
 -   `style` (default: `'file:./build/style-index.css'`)

--- a/packages/create-block/lib/init-wp-scripts.js
+++ b/packages/create-block/lib/init-wp-scripts.js
@@ -13,7 +13,9 @@ module.exports = async ( { slug } ) => {
 	const cwd = join( process.cwd(), slug );
 
 	info( '' );
-	info( 'Installing packages. It might take a couple of minutes...' );
+	info(
+		'Installing `@wordpress/scripts` package. It might take a couple of minutes...'
+	);
 	await command( 'npm install @wordpress/scripts --save-dev', {
 		cwd,
 	} );

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -30,6 +30,7 @@ module.exports = async (
 		licenseURI,
 		version,
 		wpScripts,
+		npmDependencies,
 		editorScript,
 		editorStyle,
 		style,
@@ -57,10 +58,11 @@ module.exports = async (
 		license,
 		licenseURI,
 		textdomain: slug,
+		wpScripts,
+		npmDependencies,
 		editorScript,
 		editorStyle,
 		style,
-		wpScripts,
 	};
 	await Promise.all(
 		Object.keys( outputTemplates ).map( async ( outputFile ) => {

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -37,6 +37,11 @@ const predefinedBlockTemplates = {
 			description:
 				'Example block written with ESNext standard and JSX support – build step required.',
 			dashicon: 'smiley',
+			npmDependencies: [
+				'@wordpress/block-editor',
+				'@wordpress/blocks',
+				'@wordpress/i18n',
+			],
 		},
 	},
 };
@@ -138,6 +143,7 @@ const getDefaultValues = ( blockTemplate ) => {
 		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
 		version: '0.1.0',
 		wpScripts: true,
+		npmDependencies: [],
 		editorScript: 'file:./build/index.js',
 		editorStyle: 'file:./build/index.css',
 		style: 'file:./build/style-index.css',

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -41,6 +41,7 @@
 		"lodash": "^4.17.19",
 		"make-dir": "^3.0.0",
 		"mustache": "^4.0.0",
+		"npm-package-arg": "^8.0.1",
 		"rimraf": "^3.0.2",
 		"write-pkg": "^4.0.0"
 	},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

- Adds to the template configuration `npmDependencies` field. It allows listing npm packages that will be installed for the scaffolded project.
- Installs WordPress dependencies used by `esnext` template during the scaffolding process.

## How has this been tested?
`npx wp-create-block`

When wrong strings are provided for npm packages installation then the following message is printed:

<img width="1525" alt="Screen Shot 2020-12-23 at 18 37 57" src="https://user-images.githubusercontent.com/699132/103024521-49a23700-4550-11eb-814e-edd6664d1e4f.png">

