### PR TITLE
UI Tests for Block Mover

### DIFF
--- a/packages/block-editor/src/components/block-mover/test/index.native.js
+++ b/packages/block-editor/src/components/block-mover/test/index.native.js
@@ -6,15 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import {
-	BlockMover,
-	BLOCK_MOVER_DIRECTION_TOP,
-	// BLOCK_MOVER_DIRECTION_BOTTOM,
-} from '../index';
-/**
- * WordPress dependencies
- */
-import { Picker, ToolbarButton } from '@wordpress/components';
+import { BlockMover } from '../index';
 
 describe( 'Block Mover Picker', () => {
 	it( 'renders without crashing', () => {
@@ -28,7 +20,7 @@ describe( 'Block Mover Picker', () => {
 
 				onMoveDown: jest.fn(),
 				onMoveUp: jest.fn(),
-				onLongMove: jest.fn(),
+				onLongPress: jest.fn(),
 
 				rootClientId: '',
 				isStackedHorizontally: true,
@@ -37,7 +29,7 @@ describe( 'Block Mover Picker', () => {
 		expect( wrapper ).toBeTruthy();
 	} );
 
-	it( 'shows "Move to top" on picker when long pressing move up mover', () => {
+	it( 'should match snapshot', () => {
 		const wrapper = shallow( <BlockMover />, {
 			context: {
 				isFirst: false,
@@ -48,38 +40,12 @@ describe( 'Block Mover Picker', () => {
 
 				onMoveDown: jest.fn(),
 				onMoveUp: jest.fn(),
-				onLongMove: jest.fn(),
+				onLongPress: jest.fn(),
 
 				rootClientId: '',
 				isStackedHorizontally: true,
 			},
 		} );
-		console.log( wrapper.debug() );
-		console.log( wrapper.find( ToolbarButton ).first().debug() );
-		// jest.mock( wrapper.showBlockPageMover, () => {} );
-		// jest.mock(
-		// 	wrapper.blockPageMoverState,
-		// 	() => 'blockPageMoverOptions-moveToTop'
-		// );
-
-		// expect( wrapper.blockPageMoverOptions.length ).toEqual( 1 );
-		// expect( wrapper.blockPageMoverOptions[ 0 ].value ).toEqual(
-		// 	BLOCK_MOVER_DIRECTION_TOP
-		// );
+		expect( wrapper ).toMatchSnapshot();
 	} );
-
-	// it( 'moves block to first in list when pressing "Move to top"', () => {
-	// 	// mock two blocks
-	// 	// selected block should be on bottom
-	// 	// long press up mover
-	// 	// press move up button
-	// } );
-	//
-	// it( 'shows "Move to bottom" on picker when long pressing move down mover', () => {} );
-	//
-	// it( 'moves block to last in list when pressing "Move to bottom"', () => {} );
-	//
-	// it( "can't long press move up when block is already first", () => {} );
-	//
-	// it( "can't long press move down when block is already last", () => {} );
 } );

--- a/packages/block-editor/src/components/block-mover/test/index.native.js
+++ b/packages/block-editor/src/components/block-mover/test/index.native.js
@@ -6,7 +6,15 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { BlockMover } from '../index';
+import {
+	BlockMover,
+	BLOCK_MOVER_DIRECTION_TOP,
+	// BLOCK_MOVER_DIRECTION_BOTTOM,
+} from '../index';
+/**
+ * WordPress dependencies
+ */
+import { Picker, ToolbarButton } from '@wordpress/components';
 
 describe( 'Block Mover Picker', () => {
 	it( 'renders without crashing', () => {
@@ -20,7 +28,7 @@ describe( 'Block Mover Picker', () => {
 
 				onMoveDown: jest.fn(),
 				onMoveUp: jest.fn(),
-				onLongPress: jest.fn(),
+				onLongMove: jest.fn(),
 
 				rootClientId: '',
 				isStackedHorizontally: true,
@@ -29,7 +37,7 @@ describe( 'Block Mover Picker', () => {
 		expect( wrapper ).toBeTruthy();
 	} );
 
-	it( 'should match snapshot', () => {
+	it( 'shows "Move to top" on picker when long pressing move up mover', () => {
 		const wrapper = shallow( <BlockMover />, {
 			context: {
 				isFirst: false,
@@ -40,12 +48,38 @@ describe( 'Block Mover Picker', () => {
 
 				onMoveDown: jest.fn(),
 				onMoveUp: jest.fn(),
-				onLongPress: jest.fn(),
+				onLongMove: jest.fn(),
 
 				rootClientId: '',
 				isStackedHorizontally: true,
 			},
 		} );
-		expect( wrapper ).toMatchSnapshot();
+		console.log( wrapper.debug() );
+		console.log( wrapper.find( ToolbarButton ).first().debug() );
+		// jest.mock( wrapper.showBlockPageMover, () => {} );
+		// jest.mock(
+		// 	wrapper.blockPageMoverState,
+		// 	() => 'blockPageMoverOptions-moveToTop'
+		// );
+
+		// expect( wrapper.blockPageMoverOptions.length ).toEqual( 1 );
+		// expect( wrapper.blockPageMoverOptions[ 0 ].value ).toEqual(
+		// 	BLOCK_MOVER_DIRECTION_TOP
+		// );
 	} );
+
+	// it( 'moves block to first in list when pressing "Move to top"', () => {
+	// 	// mock two blocks
+	// 	// selected block should be on bottom
+	// 	// long press up mover
+	// 	// press move up button
+	// } );
+	//
+	// it( 'shows "Move to bottom" on picker when long pressing move down mover', () => {} );
+	//
+	// it( 'moves block to last in list when pressing "Move to bottom"', () => {} );
+	//
+	// it( "can't long press move up when block is already first", () => {} );
+	//
+	// it( "can't long press move down when block is already last", () => {} );
 } );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-move-block.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-move-block.test.js
@@ -1,0 +1,198 @@
+/**
+ * Internal dependencies
+ */
+import EditorPage from './pages/editor-page';
+import {
+	setupDriver,
+	isLocalEnvironment,
+	stopDriver,
+	isAndroid,
+} from './helpers/utils';
+
+jest.setTimeout( 1000000 );
+
+describe( 'Gutenberg Editor Block Mover tests', () => {
+	let driver;
+	let editorPage;
+	let allPassed = true;
+	const paragraphBlockName = 'Paragraph';
+	const headerBlockName = 'Heading';
+	const cancelButtonName = 'Cancel';
+	const buttonIosType = 'Button';
+	const moveTopButtonName = 'Move to top';
+	const moveBottomButtonName = 'Move to bottom';
+
+	// Use reporter for setting status for saucelabs Job
+	if ( ! isLocalEnvironment() ) {
+		const reporter = {
+			specDone: async ( result ) => {
+				allPassed = allPassed && result.status !== 'failed';
+			},
+		};
+
+		// eslint-disable-next-line jest/no-jasmine-globals
+		jasmine.getEnv().addReporter( reporter );
+	}
+
+	async function setupBlocks( text = 'p1' ) {
+		await editorPage.addNewBlock( paragraphBlockName );
+		const paragraphBlock = await editorPage.getBlockAtPosition(
+			paragraphBlockName
+		);
+		await editorPage.typeTextToParagraphBlock( paragraphBlock, text );
+
+		await editorPage.addNewBlock( headerBlockName );
+		const headerBlock = await editorPage.getBlockAtPosition(
+			headerBlockName,
+			2
+		);
+		await editorPage.typeTextToParagraphBlock( headerBlock, text );
+	}
+
+	async function removeBlocks( blockOrder ) {
+		for ( let i = blockOrder.length; i > 0; i-- ) {
+			await editorPage.removeBlockAtPosition( blockOrder[ i - 1 ], i );
+		}
+	}
+
+	async function cancelActionSheet( ePage ) {
+		if ( isAndroid() ) {
+			await ePage.tapCoordinates( 100, 100 );
+		} else {
+			await ePage.selectElement( cancelButtonName, buttonIosType );
+		}
+	}
+
+	beforeAll( async () => {
+		driver = await setupDriver();
+		editorPage = new EditorPage( driver );
+	} );
+
+	it( 'should be able to see visual editor', async () => {
+		await expect( editorPage.getBlockList() ).resolves.toBe( true );
+	} );
+
+	it( 'should be able to see move block to top when long pressing up and change nothing when pressing cancel', async () => {
+		await setupBlocks( 'p1-up-cancel' );
+
+		await editorPage.longPressToolBarButton(
+			'Move block up from row 2 to row 1'
+		);
+		const moveUpAction = await editorPage.findElement(
+			moveTopButtonName,
+			buttonIosType
+		);
+
+		expect( moveUpAction ).toBeTruthy();
+
+		await cancelActionSheet( editorPage );
+		const paragraphIsFirst = await editorPage.hasBlockAtPosition(
+			1,
+			paragraphBlockName
+		);
+
+		expect( paragraphIsFirst ).toBe( true );
+
+		await removeBlocks( [ paragraphBlockName, headerBlockName ] );
+	} );
+
+	it( 'should be able to move block to first block when pressing move block to top', async () => {
+		await setupBlocks( 'p1-up' );
+
+		await editorPage.longPressToolBarButton(
+			'Move block up from row 2 to row 1'
+		);
+		await editorPage.selectElement( moveTopButtonName, buttonIosType );
+		const headerIsFirst = await editorPage.hasBlockAtPosition(
+			1,
+			headerBlockName
+		);
+
+		expect( headerIsFirst ).toBe( true );
+
+		await editorPage.selectBlock( paragraphBlockName, 2 );
+		await removeBlocks( [ headerBlockName, paragraphBlockName ] );
+	} );
+
+	it( 'should have move up disabled when on top', async () => {
+		await setupBlocks( 'p1-disabled-top' );
+		await editorPage.selectBlock( paragraphBlockName );
+
+		await editorPage.longPressToolBarButton( 'Move block up' );
+		const moveUpAction = await editorPage.findElement(
+			moveTopButtonName,
+			buttonIosType
+		);
+
+		expect( moveUpAction ).toBe( undefined );
+
+		await editorPage.selectBlock( headerBlockName, 2 );
+		await removeBlocks( [ paragraphBlockName, headerBlockName ] );
+	} );
+
+	it( 'should be able to see move block to bottom when long pressing down and change nothing when pressing cancel', async () => {
+		await setupBlocks( 'p1-down-cancel' );
+		await editorPage.selectBlock( paragraphBlockName );
+
+		await editorPage.longPressToolBarButton(
+			'Move block down from row 1 to row 2'
+		);
+		const moveDownAction = await editorPage.findElement(
+			moveBottomButtonName,
+			buttonIosType
+		);
+
+		expect( moveDownAction ).toBeTruthy();
+
+		await cancelActionSheet( editorPage );
+		const paragraphIsFirst = await editorPage.hasBlockAtPosition(
+			1,
+			paragraphBlockName
+		);
+
+		expect( paragraphIsFirst ).toBe( true );
+
+		await editorPage.selectBlock( headerBlockName, 2 );
+		await removeBlocks( [ paragraphBlockName, headerBlockName ] );
+	} );
+
+	it( 'should be able to move block to last block when pressing move block to bottom', async () => {
+		await setupBlocks( 'p1-down' );
+		await editorPage.selectBlock( paragraphBlockName );
+
+		await editorPage.longPressToolBarButton(
+			'Move block down from row 1 to row 2'
+		);
+
+		await editorPage.selectElement( moveBottomButtonName, buttonIosType );
+		const headerIsFirst = await editorPage.hasBlockAtPosition(
+			1,
+			headerBlockName
+		);
+
+		expect( headerIsFirst ).toBe( true );
+
+		await removeBlocks( [ headerBlockName, paragraphBlockName ] );
+	} );
+
+	it( 'should have move down disabled when on bottom', async () => {
+		await setupBlocks( 'p1-disabled-down' );
+
+		await editorPage.longPressToolBarButton( 'Move block down' );
+		const moveDownAction = await editorPage.findElement(
+			moveBottomButtonName,
+			buttonIosType
+		);
+
+		expect( moveDownAction ).toBe( undefined );
+
+		await removeBlocks( [ paragraphBlockName, headerBlockName ] );
+	} );
+
+	afterAll( async () => {
+		if ( ! isLocalEnvironment() ) {
+			driver.sauceJobStatus( allPassed );
+		}
+		await stopDriver( driver );
+	} );
+} );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-move-block.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-move-block.test.js
@@ -1,49 +1,25 @@
 /**
  * Internal dependencies
  */
-import EditorPage from './pages/editor-page';
-import {
-	setupDriver,
-	isLocalEnvironment,
-	stopDriver,
-	isAndroid,
-} from './helpers/utils';
-
-jest.setTimeout( 1000000 );
+import { isAndroid } from './helpers/utils';
+import { blockNames } from './pages/editor-page';
 
 describe( 'Gutenberg Editor Block Mover tests', () => {
-	let driver;
-	let editorPage;
-	let allPassed = true;
-	const paragraphBlockName = 'Paragraph';
-	const headerBlockName = 'Heading';
 	const cancelButtonName = 'Cancel';
 	const buttonIosType = 'Button';
 	const moveTopButtonName = 'Move to top';
 	const moveBottomButtonName = 'Move to bottom';
 
-	// Use reporter for setting status for saucelabs Job
-	if ( ! isLocalEnvironment() ) {
-		const reporter = {
-			specDone: async ( result ) => {
-				allPassed = allPassed && result.status !== 'failed';
-			},
-		};
-
-		// eslint-disable-next-line jest/no-jasmine-globals
-		jasmine.getEnv().addReporter( reporter );
-	}
-
 	async function setupBlocks( text = 'p1' ) {
-		await editorPage.addNewBlock( paragraphBlockName );
+		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlock = await editorPage.getBlockAtPosition(
-			paragraphBlockName
+			blockNames.paragraph
 		);
 		await editorPage.typeTextToParagraphBlock( paragraphBlock, text );
 
-		await editorPage.addNewBlock( headerBlockName );
+		await editorPage.addNewBlock( blockNames.heading );
 		const headerBlock = await editorPage.getBlockAtPosition(
-			headerBlockName,
+			blockNames.heading,
 			2
 		);
 		await editorPage.typeTextToParagraphBlock( headerBlock, text );
@@ -63,22 +39,13 @@ describe( 'Gutenberg Editor Block Mover tests', () => {
 		}
 	}
 
-	beforeAll( async () => {
-		driver = await setupDriver();
-		editorPage = new EditorPage( driver );
-	} );
-
-	it( 'should be able to see visual editor', async () => {
-		await expect( editorPage.getBlockList() ).resolves.toBe( true );
-	} );
-
 	it( 'should be able to see move block to top when long pressing up and change nothing when pressing cancel', async () => {
 		await setupBlocks( 'p1-up-cancel' );
 
 		await editorPage.longPressToolBarButton(
 			'Move block up from row 2 to row 1'
 		);
-		const moveUpAction = await editorPage.findElement(
+		const moveUpAction = await editorPage.findElementByXPath(
 			moveTopButtonName,
 			buttonIosType
 		);
@@ -88,12 +55,12 @@ describe( 'Gutenberg Editor Block Mover tests', () => {
 		await cancelActionSheet( editorPage );
 		const paragraphIsFirst = await editorPage.hasBlockAtPosition(
 			1,
-			paragraphBlockName
+			blockNames.paragraph
 		);
 
 		expect( paragraphIsFirst ).toBe( true );
 
-		await removeBlocks( [ paragraphBlockName, headerBlockName ] );
+		await removeBlocks( [ blockNames.paragraph, blockNames.heading ] );
 	} );
 
 	it( 'should be able to move block to first block when pressing move block to top', async () => {
@@ -105,39 +72,39 @@ describe( 'Gutenberg Editor Block Mover tests', () => {
 		await editorPage.selectElement( moveTopButtonName, buttonIosType );
 		const headerIsFirst = await editorPage.hasBlockAtPosition(
 			1,
-			headerBlockName
+			blockNames.heading
 		);
 
 		expect( headerIsFirst ).toBe( true );
 
-		await editorPage.selectBlock( paragraphBlockName, 2 );
-		await removeBlocks( [ headerBlockName, paragraphBlockName ] );
+		await editorPage.selectBlock( blockNames.paragraph, 2 );
+		await removeBlocks( [ blockNames.heading, blockNames.paragraph ] );
 	} );
 
 	it( 'should have move up disabled when on top', async () => {
 		await setupBlocks( 'p1-disabled-top' );
-		await editorPage.selectBlock( paragraphBlockName );
+		await editorPage.selectBlock( blockNames.paragraph );
 
 		await editorPage.longPressToolBarButton( 'Move block up' );
-		const moveUpAction = await editorPage.findElement(
+		const moveUpAction = await editorPage.findElementByXPath(
 			moveTopButtonName,
 			buttonIosType
 		);
 
 		expect( moveUpAction ).toBe( undefined );
 
-		await editorPage.selectBlock( headerBlockName, 2 );
-		await removeBlocks( [ paragraphBlockName, headerBlockName ] );
+		await editorPage.selectBlock( blockNames.heading, 2 );
+		await removeBlocks( [ blockNames.paragraph, blockNames.heading ] );
 	} );
 
 	it( 'should be able to see move block to bottom when long pressing down and change nothing when pressing cancel', async () => {
 		await setupBlocks( 'p1-down-cancel' );
-		await editorPage.selectBlock( paragraphBlockName );
+		await editorPage.selectBlock( blockNames.paragraph );
 
 		await editorPage.longPressToolBarButton(
 			'Move block down from row 1 to row 2'
 		);
-		const moveDownAction = await editorPage.findElement(
+		const moveDownAction = await editorPage.findElementByXPath(
 			moveBottomButtonName,
 			buttonIosType
 		);
@@ -147,18 +114,18 @@ describe( 'Gutenberg Editor Block Mover tests', () => {
 		await cancelActionSheet( editorPage );
 		const paragraphIsFirst = await editorPage.hasBlockAtPosition(
 			1,
-			paragraphBlockName
+			blockNames.paragraph
 		);
 
 		expect( paragraphIsFirst ).toBe( true );
 
-		await editorPage.selectBlock( headerBlockName, 2 );
-		await removeBlocks( [ paragraphBlockName, headerBlockName ] );
+		await editorPage.selectBlock( blockNames.heading, 2 );
+		await removeBlocks( [ blockNames.paragraph, blockNames.heading ] );
 	} );
 
 	it( 'should be able to move block to last block when pressing move block to bottom', async () => {
 		await setupBlocks( 'p1-down' );
-		await editorPage.selectBlock( paragraphBlockName );
+		await editorPage.selectBlock( blockNames.paragraph );
 
 		await editorPage.longPressToolBarButton(
 			'Move block down from row 1 to row 2'
@@ -167,32 +134,25 @@ describe( 'Gutenberg Editor Block Mover tests', () => {
 		await editorPage.selectElement( moveBottomButtonName, buttonIosType );
 		const headerIsFirst = await editorPage.hasBlockAtPosition(
 			1,
-			headerBlockName
+			blockNames.heading
 		);
 
 		expect( headerIsFirst ).toBe( true );
 
-		await removeBlocks( [ headerBlockName, paragraphBlockName ] );
+		await removeBlocks( [ blockNames.heading, blockNames.paragraph ] );
 	} );
 
 	it( 'should have move down disabled when on bottom', async () => {
 		await setupBlocks( 'p1-disabled-down' );
 
 		await editorPage.longPressToolBarButton( 'Move block down' );
-		const moveDownAction = await editorPage.findElement(
+		const moveDownAction = await editorPage.findElementByXPath(
 			moveBottomButtonName,
 			buttonIosType
 		);
 
 		expect( moveDownAction ).toBe( undefined );
 
-		await removeBlocks( [ paragraphBlockName, headerBlockName ] );
-	} );
-
-	afterAll( async () => {
-		if ( ! isLocalEnvironment() ) {
-			driver.sauceJobStatus( allPassed );
-		}
-		await stopDriver( driver );
+		await removeBlocks( [ blockNames.paragraph, blockNames.heading ] );
 	} );
 } );

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -5,6 +5,7 @@ const {
 	setupDriver,
 	stopDriver,
 	isAndroid,
+	longPressMiddleOfElement,
 	swipeUp,
 	swipeDown,
 	typeString,
@@ -299,11 +300,7 @@ class EditorPage {
 			);
 		}
 
-		const action = new wd.TouchAction( this.driver );
-		action.press( { el: toolBarButton } );
-		action.wait( 1000 );
-		action.release();
-		await action.perform();
+		await longPressMiddleOfElement( this.driver, toolBarButton );
 	}
 
 	// =========================
@@ -594,11 +591,11 @@ class EditorPage {
 	async sauceJobStatus( allPassed ) {
 		await this.driver.sauceJobStatus( allPassed );
 	}
-	
+
 	// =============================
 	// Misc functions
 	// =============================
-	async findElement( name, iosElementType ) {
+	async findElementByXPath( name, iosElementType ) {
 		const elementName = isAndroid()
 			? '//*'
 			: `//XCUIElementType${ iosElementType }`;
@@ -608,7 +605,7 @@ class EditorPage {
 	}
 
 	async selectElement( name, iosElementType ) {
-		const el = await this.findElement( name, iosElementType );
+		const el = await this.findElementByXPath( name, iosElementType );
 		el.click();
 	}
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -288,6 +288,24 @@ class EditorPage {
 		await toolBarButton.click();
 	}
 
+	async longPressToolBarButton( buttonName ) {
+		let toolBarButton;
+		if ( isAndroid() ) {
+			const blockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, "${ buttonName }")]`;
+			toolBarButton = await this.driver.elementByXPath( blockLocator );
+		} else {
+			toolBarButton = await this.driver.elementByAccessibilityId(
+				buttonName
+			);
+		}
+
+		const action = new wd.TouchAction( this.driver );
+		action.press( { el: toolBarButton } );
+		action.wait( 1000 );
+		action.release();
+		await action.perform();
+	}
+
 	// =========================
 	// Inline toolbar functions
 	// =========================
@@ -384,11 +402,15 @@ class EditorPage {
 	}
 
 	async typeTextToParagraphBlock( block, text, clear ) {
-		const textViewElement = await this.getTextViewForParagraphBlock(
-			block
-		);
-		await typeString( this.driver, textViewElement, text, clear );
-		await this.driver.sleep( 1000 ); // Give time for the block to rerender (such as for accessibility)
+		if ( ! isAndroid() ) {
+			block.type( text );
+		} else {
+			const textViewElement = await this.getTextViewForParagraphBlock(
+				block
+			);
+			await typeString( this.driver, textViewElement, text, clear );
+			await this.driver.sleep( 1000 ); // Give time for the block to rerender (such as for accessibility)
+		}
 	}
 
 	async sendTextToParagraphBlock( position, text, clear ) {
@@ -571,6 +593,46 @@ class EditorPage {
 
 	async sauceJobStatus( allPassed ) {
 		await this.driver.sauceJobStatus( allPassed );
+	}
+	
+	// =============================
+	// Misc functions
+	// =============================
+	async findElement( name, iosElementType ) {
+		const elementName = isAndroid()
+			? '//*'
+			: `//XCUIElementType${ iosElementType }`;
+		const blockLocator = `${ elementName }[contains(@${ this.accessibilityIdXPathAttrib }, "${ name }")]`;
+		const elements = await this.driver.elementsByXPath( blockLocator );
+		return elements[ 0 ];
+	}
+
+	async selectElement( name, iosElementType ) {
+		const el = await this.findElement( name, iosElementType );
+		el.click();
+	}
+
+	async selectBlock(
+		blockName,
+		position = 1,
+		options = { autoscroll: false }
+	) {
+		const block = await this.getBlockAtPosition(
+			blockName,
+			position,
+			options
+		);
+		block.click();
+	}
+
+	async tapCoordinates( x, y, longPress = false ) {
+		const action = new wd.TouchAction( this.driver );
+		action.press( { x, y } );
+		if ( longPress ) {
+			action.wait( 1000 );
+		}
+		action.release();
+		await action.perform();
 	}
 }
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -11,8 +11,13 @@ const {
 	typeString,
 	toggleHtmlMode,
 	swipeFromTo,
-	longPressMiddleOfElement,
 } = require( '../helpers/utils' );
+
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+const wd = require( 'wd' );
 
 const initializeEditorPage = async () => {
 	const driver = await setupDriver();


### PR DESCRIPTION
## Description
`Original issue link:` [1191](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1191)
`Gutenberg-mobile link:` [PR 2930](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2930)

UI Tests for move to top/bottom block mover functionality.

## Types of changes
New feature added.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
