### PR TITLE
Include block CSS in the plugin ZIP

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -111,8 +111,11 @@ mv gutenberg.tmp.php gutenberg.php
 
 build_files=$(
 	ls build/*/*.{js,css,asset.php} \
-	build/block-library/blocks/*.php build/block-library/blocks/*/block.json \
-	build/edit-widgets/blocks/*.php build/edit-widgets/blocks/*/block.json \
+	build/block-library/blocks/*.php \
+	build/block-library/blocks/*/block.json \
+	build/block-library/blocks/*/*.css \
+	build/edit-widgets/blocks/*.php \
+	build/edit-widgets/blocks/*/block.json \
 )
 
 


### PR DESCRIPTION
It was reported in [core-editor slack](https://wordpress.slack.com/archives/C02QB2JS7/p1608785108267600) that no blocks had CSS applied when an FSE was active using the latest 9.6 release from the repository. Using `master` or `release/9.6` everything worked fine.

It looks like https://github.com/WordPress/gutenberg/pull/25220 introduced code-splitting for CSS, so core only enqueues the block's CSS when the block is used. We adapted our building processes to accommodate the new way block assets are generated. This PR adapts the plugin ZIP creation to include the block's CSS as well.

## Test

- Check out the `release/9.6` branch.
- Run `./bin/build-plugin-zip.sh`.
- Upload the generated ZIP to a site.
- Activate a FSE theme.
- Verify that the front-end and the site editor correctly load the block's CSS.

