### PR TITLE
Allow using multiple controlled inner blocks refering to the same entity

### DIFF
--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -118,7 +118,8 @@ describe( 'useBlockSync hook', () => {
 		expect( onChange ).not.toHaveBeenCalled();
 		expect( onInput ).not.toHaveBeenCalled();
 		expect( resetBlocks ).not.toHaveBeenCalled();
-		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'test', testBlocks );
+		// We can't check the args because the blocks are cloned.
+		expect( replaceInnerBlocks ).toHaveBeenCalled();
 	} );
 
 	it( 'does not add the controlled blocks to the block-editor store if the store already contains them', async () => {
@@ -200,7 +201,6 @@ describe( 'useBlockSync hook', () => {
 	it( 'calls onInput when a non-persistent block change occurs', async () => {
 		const onChange = jest.fn();
 		const onInput = jest.fn();
-
 		const value1 = [
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
 		];

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -98,7 +98,6 @@ export default function useBlockSync( {
 		if ( clientId ) {
 			setHasControlledInnerBlocks( clientId, true );
 			__unstableMarkNextChangeAsNotPersistent();
-			// This needs to be called after the setHasControlledInnerBlocks call
 			const storeBlocks = controlledBlocks.map( ( block ) =>
 				cloneBlock( block )
 			);


### PR DESCRIPTION
closes #22639

This uses a very simple trick to solve the duplicated controller inner blocks bug (duplicate a template part and edit one of them and see it reflected properly).

The main issue was that the block-editor is meant to only work with unique block ids, the block tree can't contain duplications. To solve this, the trick used in this PR is that for each "controlled inner blocks", instead of editing the controlled blocks directly, clone these blocks when there's an "external" change for these blocks (initialization, changing coming from a duplicated block...) and only pass to the editor clones which means the IDs are different. 

Now, this can create infinite loops: an edit in one block, is going to cause changes in the other blocks too. We need to stop  the edits in the second block from triggering back an edit on the original block. Fortunately, this is already handled in useBlockSync by saying: "The first change after an external change is ignored.

Also, there might be a small performance impact: All the other duplicated blocks will remount (all blocks change) on a change happening on one of them. That said, I believe this impact is acceptable for two reasons:

 - The  "cloning" (remounting) only happens for the clones, not the block being currently edited which means it happens only for unselected blocks which means it's async thanks to async mode.
 - The cloning is not performed unless we're in a controlled inner blocks, and this is limitted to template parts and potentially reusable blocks, I don't expect these reusable entities to be very big (like a long post for instance).