### PR TITLE
Fix svn add/rm commands for release tool

### DIFF
--- a/bin/plugin/commands/release.js
+++ b/bin/plugin/commands/release.js
@@ -520,11 +520,11 @@ async function runUpdateTrunkContentStep(
 
 		// Commit the content changes
 		runShellScript(
-			"svn st | grep '^?' | awk '{print $2}' | xargs svn add",
+			"svn st | grep '^?' | awk '{print $2}' | xargs -r svn add",
 			svnWorkingDirectoryPath
 		);
 		runShellScript(
-			"svn st | grep '^!' | awk '{print $2}' | xargs svn rm",
+			"svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm",
 			svnWorkingDirectoryPath
 		);
 		await askForConfirmation(

--- a/bin/plugin/commands/release.js
+++ b/bin/plugin/commands/release.js
@@ -6,6 +6,7 @@ const fs = require( 'fs' );
 const semver = require( 'semver' );
 const Octokit = require( '@octokit/rest' );
 const { sprintf } = require( 'sprintf-js' );
+const os = require( 'os' );
 
 /**
  * Internal dependencies
@@ -518,13 +519,27 @@ async function runUpdateTrunkContentStep(
 			newReadmeFileContent.replace( STABLE_TAG_PLACEHOLDER, stableTag )
 		);
 
+		let xargsOpts = '';
+		if ( os.platform === 'linux' ) {
+			// When xargs receives no arguments, it behaves differently in macOS and linux:
+			// - macOS: doesn't run
+			// - linux: run without arguments
+			//
+			// In linux, the -r option teaches xargs not to run if it receives no arguments.
+			xargsOpts = '-r';
+		}
+
 		// Commit the content changes
 		runShellScript(
-			"svn st | grep '^?' | awk '{print $2}' | xargs -r svn add",
+			"svn st | grep '^?' | awk '{print $2}' | xargs " +
+				xargsOpts +
+				' svn add',
 			svnWorkingDirectoryPath
 		);
 		runShellScript(
-			"svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm",
+			"svn st | grep '^!' | awk '{print $2}' | xargs " +
+				xargsOpts +
+				' svn rm',
 			svnWorkingDirectoryPath
 		);
 		await askForConfirmation(

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -199,9 +199,9 @@ You'll need to use Subversion to publish the plugin to WordPress.org.
 6. Add new files/remove deleted files from the repository:
 ```bash
 # Add new files:
-svn st | grep '^\?' | awk '{print $2}' | xargs svn add
+svn st | grep '^\?' | awk '{print $2}' | xargs -r svn add
 # Delete old files:
-svn st | grep '^!' | awk '{print $2}' | xargs svn rm
+svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
 ```
 7. Commit the new version:
 ```bash

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -199,9 +199,9 @@ You'll need to use Subversion to publish the plugin to WordPress.org.
 6. Add new files/remove deleted files from the repository:
 ```bash
 # Add new files:
-svn st | grep '^\?' | awk '{print $2}' | xargs -r svn add
+svn st | grep '^\?' | awk '{print $2}' | xargs svn add # add the -r option to xargs if you use a linux-based OS
 # Delete old files:
-svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
+svn st | grep '^!' | awk '{print $2}' | xargs svn rm # add the -r option to xargs if you use a linux-based OS
 ```
 7. Commit the new version:
 ```bash


### PR DESCRIPTION
This PR fixes the release tool in the use case where no files are to be added or removed for users of linux-based OS.

The commands we use to add and remove files to be committed to the WordPress svn repo for the plugin are:

```sh
svn st | grep '^?' | awk '{print $2}' | xargs svn add
svn st | grep '^!' | awk '{print $2}' | xargs svn rm
```

However, when there are no files to add or remove, xargs still runs the svn commands, and because there are no files to add or remove, they fail and the release tools stops. On non-linux OS this works differently, reportedly on macOS, xargs won't run if it receives no input.

According to [the docs](https://man7.org/linux/man-pages/man1/xargs.1.html), there's an option that prevents the command from being executed if no input is given, `--no-run-if-empty` or `-r`, but not every system supports it. To make sure it runs well in every OS we add the `-r` option for systems that support it.

## How to test

- `svn checkout https://plugins.svn.wordpress.org/gutenberg/trunk test`
- `cd test`
- For users with linux-based OS: run `svn st | grep '^?' | awk '{print $2}' | xargs -r svn add`. The expected behavior is that shouldn't report any message, check that without the `-r` it reports an error like this one:

```sh
svn: E205001: Try 'svn help add' for more information
svn: E205001: Not enough arguments provided
```

- For users with another OS, things will work as before. Run  `svn st | grep '^?' | awk '{print $2}' | xargs svn add`. The expected behavior is that shouldn't report any message.
