### PR TITLE
Restore removed rootClientId prop

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -121,6 +121,7 @@ function Items( {
 						value={ ! isBlockInSelection }
 					>
 						<BlockListBlock
+							rootClientId={ rootClientId }
 							clientId={ clientId }
 							// This prop is explicitely computed and passed down
 							// to avoid being impacted by the async mode


### PR DESCRIPTION
Related #27503 
Fixes one part of #27891 
 
The removal of the rootClientId prop breaks a number of things:

 - nested template locking
 - onInsertBlocksAfter