### PR TITLE
Revert "Visual editor: remove focusable div wrapper (#27468)"

### DIFF
--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -19,19 +19,14 @@ export function useBlockSelectionClearer( ref ) {
 			return;
 		}
 
-		function onMouseDown( event ) {
-			// Only handle clicks on the canvas, not the content.
-			if ( event.target.closest( '.wp-block' ) ) {
-				return;
-			}
-
+		function onFocus() {
 			clearSelectedBlock();
 		}
 
-		ref.current.addEventListener( 'mousedown', onMouseDown );
+		ref.current.addEventListener( 'focus', onFocus );
 
 		return () => {
-			ref.current.removeEventListener( 'mousedown', onMouseDown );
+			ref.current.removeEventListener( 'focus', onFocus );
 		};
 	}, [ hasSelection, clearSelectedBlock ] );
 }
@@ -39,5 +34,5 @@ export function useBlockSelectionClearer( ref ) {
 export default function BlockSelectionClearer( props ) {
 	const ref = useRef();
 	useBlockSelectionClearer( ref );
-	return <div ref={ ref } { ...props } />;
+	return <div tabIndex={ -1 } ref={ ref } { ...props } />;
 }

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -108,10 +108,10 @@ describe( 'Order of block keyboard navigation', () => {
 			await page.keyboard.type( paragraphBlock );
 		}
 
-		// Clear the selected block.
-		const paragraph = await page.$( '[data-type="core/paragraph"]' );
-		const box = await paragraph.boundingBox();
-		await page.mouse.click( box.x - 1, box.y );
+		// Clear the selected block and put focus in front of the block list.
+		await page.evaluate( () => {
+			document.querySelector( '.editor-styles-wrapper' ).focus();
+		} );
 
 		await page.keyboard.press( 'Tab' );
 		await expect(
@@ -143,13 +143,9 @@ describe( 'Order of block keyboard navigation', () => {
 			await page.keyboard.type( paragraphBlock );
 		}
 
-		// Clear the selected block.
-		const paragraph = await page.$( '[data-type="core/paragraph"]' );
-		const box = await paragraph.boundingBox();
-		await page.mouse.click( box.x - 1, box.y );
-
-		// Put focus behind the block list.
+		// Clear the selected block and put focus behind the block list.
 		await page.evaluate( () => {
+			document.querySelector( '.editor-styles-wrapper' ).focus();
 			document
 				.querySelector( '.interface-interface-skeleton__sidebar' )
 				.focus();

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -65,6 +65,7 @@ export default function VisualEditor() {
 			<div
 				ref={ ref }
 				className="editor-styles-wrapper"
+				tabIndex="-1"
 				style={ resizedCanvasStyles || desktopCanvasStyles }
 			>
 				<WritingFlow>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	BlockEditorProvider,
@@ -12,7 +12,6 @@ import {
 	WritingFlow,
 	ObserveTyping,
 	BlockList,
-	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 } from '@wordpress/block-editor';
 
 /**
@@ -40,11 +39,8 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		'postType',
 		templateType
 	);
+
 	const { setPage } = useDispatch( 'core/edit-site' );
-	const ref = useRef();
-
-	useBlockSelectionClearer( ref );
-
 	return (
 		<BlockEditorProvider
 			settings={ settings }
@@ -70,10 +66,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			<SidebarInspectorFill>
 				<BlockInspector />
 			</SidebarInspectorFill>
-			<div
-				ref={ ref }
-				className="editor-styles-wrapper edit-site-block-editor__editor-styles-wrapper"
-			>
+			<div className="editor-styles-wrapper edit-site-block-editor__editor-styles-wrapper">
 				<WritingFlow>
 					<ObserveTyping>
 						<BlockList className="edit-site-block-editor__block-list" />

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -18,6 +18,7 @@ import {
 import { EntityProvider } from '@wordpress/core-data';
 import {
 	BlockContextProvider,
+	BlockSelectionClearer,
 	BlockBreadcrumb,
 	__unstableUseEditorStyles as useEditorStyles,
 	__experimentalUseResizeCanvas as useResizeCanvas,
@@ -251,7 +252,7 @@ function Editor() {
 												/>
 											}
 											content={
-												<div
+												<BlockSelectionClearer
 													className="edit-site-visual-editor"
 													style={ inlineStyles }
 												>
@@ -265,7 +266,7 @@ function Editor() {
 														/>
 													) }
 													<KeyboardShortcuts />
-												</div>
+												</BlockSelectionClearer>
 											}
 											actions={
 												<>


### PR DESCRIPTION
closes #27468 
 
Revert #27468 temporarily to solve the issues in the widgets screen (unblock a patch release). We can do another attempt later.