### PR TITLE
Post excerpt block: Fix incorrect quotes for the class attribute in the wrapper

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -34,7 +34,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
-	$output = sprintf( '<div %1$s>', esc_attr( $wrapper_attributes ) ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
+	$output = sprintf( '<div %1$s>', $wrapper_attributes ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
 	if ( ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'] ) {
 		$output .= '</p>' . '<p class="wp-block-post-excerpt__more-text">' . $more_text . '</p></div>';
 	} else {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closes https://github.com/WordPress/gutenberg/issues/27893

In index.php, removes the escaping from wrapper_attributes to ensure that the value of the class attribute is output correctly.
(`get_block_wrapper_attributes` already escapes the value in https://github.com/WordPress/gutenberg/blob/master/lib/class-wp-block-supports.php#L193)

Result: The value is output without encoded quotes.
 `<div class="wp-block-post-excerpt">`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I have added the post excerpt block in the post editor, saved and viewed the resulting HTML output on the front.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
