### PR TITLE
Fix RadioGroup to support zero as a Radio value

### DIFF
--- a/packages/components/src/radio-group/index.js
+++ b/packages/components/src/radio-group/index.js
@@ -26,8 +26,8 @@ function RadioGroup(
 		...radioState,
 		disabled,
 		// controlled or uncontrolled
-		state: checked || radioState.state,
-		setState: onChange || radioState.setState,
+		state: checked ?? radioState.state,
+		setState: onChange ?? radioState.setState,
 	};
 
 	return (

--- a/packages/components/src/radio-group/stories/index.js
+++ b/packages/components/src/radio-group/stories/index.js
@@ -47,7 +47,7 @@ export const disabled = () => {
 };
 
 const ControlledRadioGroupWithState = () => {
-	const [ checked, setChecked ] = useState( 'option2' );
+	const [ checked, setChecked ] = useState( 1 );
 
 	/* eslint-disable no-restricted-syntax */
 	return (
@@ -58,9 +58,9 @@ const ControlledRadioGroupWithState = () => {
 			checked={ checked }
 			onChange={ setChecked }
 		>
-			<Radio value="option1">Option 1</Radio>
-			<Radio value="option2">Option 2</Radio>
-			<Radio value="option3">Option 3</Radio>
+			<Radio value={ 0 }>Option 1</Radio>
+			<Radio value={ 1 }>Option 2</Radio>
+			<Radio value={ 2 }>Option 3</Radio>
 		</RadioGroup>
 	);
 	/* eslint-enable no-restricted-syntax */


### PR DESCRIPTION
There's an oversight in the RadioGroup component that makes it fail to allow a Radio with a `value` of `0` to be `checked`. Since the component does not appear to be used anywhere I've updated one of its Storybook stories to demonstrate the use case. 

## Screen recordings
**Before** fails to “check” the Radio with the zero value.

https://user-images.githubusercontent.com/9000376/103187950-58079000-487b-11eb-92fa-115ac694a216.mp4

**After**

https://user-images.githubusercontent.com/9000376/103188041-af0d6500-487b-11eb-9b36-ae49b502e02d.mp4

## How has this been tested?
In a custom block using WP 5.6 and in Storybook 

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
