### PR TITLE
Code quality: Remove overrides for JSDoc rules downgraded to warnings (take 2)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,10 +121,6 @@ module.exports = {
 					'Avoid truthy checks on length property rendering, as zero length is rendered verbatim.',
 			},
 		],
-		// Temporarily converted to warning until all errors are resolved.
-		// See https://github.com/WordPress/gutenberg/pull/22771 for the eslint-plugin-jsdoc update.
-		'jsdoc/check-param-names': 'warn',
-		'jsdoc/require-param': 'warn',
 	},
 	overrides: [
 		{

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -205,8 +205,8 @@ async function runTestSuite( testSuite, performanceTestDirectory ) {
 /**
  * Runs the performances tests on an array of branches and output the result.
  *
- * @param {WPPerformanceCommandOptions} options Command options.
  * @param {string[]}                    branches Branches to compare
+ * @param {WPPerformanceCommandOptions} options Command options.
  */
 async function runPerformanceTests( branches, options ) {
 	// The default value doesn't work because commander provides an array.

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -22,17 +22,10 @@ import BlockIcon from '../components/block-icon';
 
 const SHOWN_BLOCK_TYPES = 9;
 
-/** @typedef {import('@wordpress/block-editor').WPEditorInserterItem} WPEditorInserterItem */
-
 /** @typedef {import('@wordpress/components').WPCompleter} WPCompleter */
 
 /**
  * Creates a blocks repeater for replacing the current block with a selected block type.
- *
- * @param {Object} props                                   Component props.
- * @param {string} [props.getBlockInsertionParentClientId] Client ID of the parent.
- * @param {string} [props.getInserterItems]                Inserter items for parent.
- * @param {string} [props.getSelectedBlockName]            Name of selected block or null.
  *
  * @return {WPCompleter} A blocks completer.
  */

--- a/packages/rich-text/src/component/toolbar-button-with-options.native.js
+++ b/packages/rich-text/src/component/toolbar-button-with-options.native.js
@@ -8,6 +8,9 @@ import { Icon } from '@wordpress/icons';
 /**
  * Toolbar button component that, upon a long press, opens a Picker
  * to allow selecting from among multiple options.
+ *
+ * @param {Object} props         Component props.
+ * @param {Object} props.options Options to pick from.
  */
 function ToolbarButtonWithOptions( { options } ) {
 	const picker = useRef();


### PR DESCRIPTION
Reverts WordPress/gutenberg#27908 that reverted #27879 because of the new ESLint violations added (see https://github.com/WordPress/gutenberg/runs/1616294144) before PR was merged ...

The last part to resolve all the issues related to the missing params in JSDoc detected by ESLint.

## How has this been tested?
`npm run lint-js`