### PR TITLE
Sort block editor block types list items alphabetically

### DIFF
--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -42,7 +42,9 @@ function BlockTypesList( {
 			className="block-editor-block-types-list"
 			aria-label={ label }
 		>
-			{ items.map( ( item ) => {
+			{ items.sort( ( item1, item2 ) => {
+				return item1.title > item2.title ? 1 : -1;
+			} ).map( ( item ) => {
 				return (
 					<InserterListItem
 						key={ item.id }

--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -42,21 +42,25 @@ function BlockTypesList( {
 			className="block-editor-block-types-list"
 			aria-label={ label }
 		>
-			{ items.sort( ( item1, item2 ) => {
-				return item1.title > item2.title ? 1 : -1;
-			} ).map( ( item ) => {
-				return (
-					<InserterListItem
-						key={ item.id }
-						item={ item }
-						className={ getBlockMenuDefaultClassName( item.id ) }
-						onSelect={ onSelect }
-						onHover={ onHover }
-						composite={ composite }
-						isDraggable={ isDraggable }
-					/>
-				);
-			} ) }
+			{ items
+				.sort( ( item1, item2 ) => {
+					return item1.title > item2.title ? 1 : -1;
+				} )
+				.map( ( item ) => {
+					return (
+						<InserterListItem
+							key={ item.id }
+							item={ item }
+							className={ getBlockMenuDefaultClassName(
+								item.id
+							) }
+							onSelect={ onSelect }
+							onHover={ onHover }
+							composite={ composite }
+							isDraggable={ isDraggable }
+						/>
+					);
+				} ) }
 			{ children }
 		</Composite>
 		/* eslint-enable jsx-a11y/no-redundant-roles */

--- a/packages/block-editor/src/components/inserter/test/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/test/block-types-tab.js
@@ -115,8 +115,8 @@ describe( 'InserterMenu', () => {
 
 		expect( embedTabTitle.textContent ).toBe( 'Embeds' );
 		expect( blocks ).toHaveLength( 2 );
-		expect( blocks[ 0 ].textContent ).toBe( 'YouTube' );
-		expect( blocks[ 1 ].textContent ).toBe( 'A Paragraph Embed' );
+		expect( blocks[ 0 ].textContent ).toBe( 'A Paragraph Embed' );
+		expect( blocks[ 1 ].textContent ).toBe( 'YouTube' );
 	} );
 
 	it( 'should show the common category blocks', () => {
@@ -133,8 +133,8 @@ describe( 'InserterMenu', () => {
 
 		expect( commonTabTitle.textContent ).toBe( 'Text' );
 		expect( blocks ).toHaveLength( 3 );
-		expect( blocks[ 0 ].textContent ).toBe( 'Paragraph' );
-		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Paragraph' );
+		expect( blocks[ 0 ].textContent ).toBe( 'Advanced Paragraph' );
+		expect( blocks[ 1 ].textContent ).toBe( 'Paragraph' );
 		expect( blocks[ 2 ].textContent ).toBe( 'Some Other Block' );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #27904 
Sort block editor block types list items alphabetically

## How has this been tested?
Click on the add block and check if the inserter panel items render as expected.

## Screenshots <!-- if applicable -->
1. Before
<img width="263" alt="before" src="https://user-images.githubusercontent.com/56378160/103249901-64552100-493f-11eb-9a3c-80e25966f17a.png">
2. After
<img width="277" alt="after" src="https://user-images.githubusercontent.com/56378160/103249910-6ae39880-493f-11eb-9606-68e1bce945eb.png">

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
