### PR TITLE
Site Logo: remove duplicate link

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -33,7 +33,7 @@ function render_block_core_site_logo( $attributes ) {
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
-	$html               = sprintf( '<div %s><a href="' . get_bloginfo( 'url' ) . '" rel="home" title="' . get_bloginfo( 'name' ) . '">%s</a></div>', $wrapper_attributes, $custom_logo );
+	$html               = sprintf( '<div %s>%s</div>', $wrapper_attributes, $custom_logo );
 	remove_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );
 	return $html;
 }


### PR DESCRIPTION
## Description
Fixes #27918

The Site logo block renders the HTML anchor tag twice. It uses the function [get_custom_logo()](https://developer.wordpress.org/reference/functions/get_custom_logo/) which already adds a link to the logo. So this PR removes the second link element from the render function.

