### PR TITLE
Try alternate block highlight/selection styles

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -86,7 +86,8 @@
 	}
 
 	.is-navigate-mode & .block-editor-block-list__block.is-hovered:not(.is-selected)::after {
-		box-shadow: 0 0 0 1px $gray-600;
+		box-shadow: inset 0 0 0 1px $gray-600;
+		opacity: 1;
 	}
 
 	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected {
@@ -590,13 +591,13 @@
 		top: -$border-width;
 
 		// Block UI appearance.
-		box-shadow: 0 0 0 $border-width $gray-900;
-		border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+		box-shadow: inset 0 0 0 $border-width $gray-900;
+		border-radius: $radius-block-ui;
 		background-color: $white;
 
 		// When button is focused, it receives a box-shadow instead of the border.
 		&:focus {
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -55,22 +55,25 @@
 			z-index: 1;
 			pointer-events: none;
 			content: "";
-			top: $border-width;
-			bottom: $border-width;
-			left: $border-width;
-			right: $border-width;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
 
 			// Everything else.
-			// 2px outside.
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+			// 2px inside.
+			box-shadow: inset 0 0 0 ceil($border-width-focus) var(--wp-admin-theme-color);
+			border-radius: $radius-block-ui;
+
+			// Emulate the line-weight of $border-width-focus (1.5px) by reducing opacity.
+			opacity: 0.85;
 
 			// Windows High Contrast mode will show this outline.
 			outline: 2px solid transparent;
 
 			// Show a lighter color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+				box-shadow: inset 0 0 0 ceil($border-width-focus) $dark-theme-focus;
 			}
 		}
 
@@ -178,18 +181,21 @@
 			z-index: 1;
 			pointer-events: none;
 			content: "";
-			top: $border-width;
-			bottom: $border-width;
-			left: $border-width;
-			right: $border-width;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
 
-			// 2px outside.
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+			// 2px inside.
+			box-shadow: inset 0 0 0 ceil($border-width-focus) var(--wp-admin-theme-color);
+			border-radius: $radius-block-ui;
+
+			// Emulate the line-weight of $border-width-focus (1.5px) by reducing opacity.
+			opacity: 0.85;
 
 			// Show a light color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+				box-shadow: inset 0 0 0 ceil($border-width-focus) $dark-theme-focus;
 			}
 		}
 	}


### PR DESCRIPTION
To fix #27925, this PR revises the styles for block highlight/selection indicators. Besides addressing the points in that issue, there is a minor change here to improve the alignment of the block select button in the editor's Select mode.

## How has this been tested?
In WP 5.6, by selecting various blocks in both Select and Edit modes.

## Screenshots
### Select mode (Firefox)
The cursor is not captured but it is over the paragraph in both before and after screenshots.
**Before**
![select-mode-block-halos-firefox-before](https://user-images.githubusercontent.com/9000376/103326082-9cbe3300-4a03-11eb-8b6a-5d5d3d15f505.png)
**After**
![select-mode-block-halos-firefox](https://user-images.githubusercontent.com/9000376/103326085-9def6000-4a03-11eb-8165-9cead596a846.png)

### Multi-select (Firefox)
**Before**
![block-halos-multi-firefox-before](https://user-images.githubusercontent.com/9000376/103326285-849ae380-4a04-11eb-9aac-c1972078d93c.png)
**After**
![block-halos-multi-firefox](https://user-images.githubusercontent.com/9000376/103326287-8664a700-4a04-11eb-85bc-c2f58672b114.png)

### Multi-select (Chrome)
**Before**
![block-halo-alignment-chrome-before](https://user-images.githubusercontent.com/9000376/103326351-d3e11400-4a04-11eb-8524-197a197be394.png)
**After**
![block-halo-alignment-chrome](https://user-images.githubusercontent.com/9000376/103326353-d5124100-4a04-11eb-9fed-eecd5f422e9b.png)

## Types of changes
Polish, non-breaking design changes

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
