### PR TITLE
Add translation context to all block's titles

### DIFF
--- a/packages/block-library/src/archives/index.js
+++ b/packages/block-library/src/archives/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { archive as icon } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Archives' ),
+	title: _x( 'Archives', 'block title' ),
 	description: __( 'Display a monthly archive of your posts.' ),
 	icon,
 	example: {},

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
 
 /**
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Audio' ),
+	title: _x( 'Audio', 'block title' ),
 	description: __( 'Embed a simple audio player.' ),
 	keywords: [
 		__( 'music' ),

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Reusable Block' ),
+	title: _x( 'Reusable Block', 'block title' ),
 	description: __(
 		'Create and save content to reuse across your site. Update the block, and the changes apply everywhere it’s used.'
 	),

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { button as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Button' ),
+	title: _x( 'Button', 'block title' ),
 	description: __(
 		'Prompt visitors to take action with a button-style link.'
 	),

--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { button as icon } from '@wordpress/icons';
 
 /**
@@ -19,7 +19,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Buttons' ),
+	title: _x( 'Buttons', 'block title' ),
 	description: __(
 		'Prompt visitors to take action with a group of button-style links.'
 	),

--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { calendar as icon } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Calendar' ),
+	title: _x( 'Calendar', 'block title' ),
 	description: __( 'A calendar of your site’s posts.' ),
 	icon,
 	keywords: [ __( 'posts' ), __( 'archive' ) ],

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { category as icon } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Categories' ),
+	title: _x( 'Categories', 'block title' ),
 	description: __( 'Display a list of all categories.' ),
 	icon,
 	example: {},

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { code as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Code' ),
+	title: _x( 'Code', 'block title' ),
 	description: __(
 		'Display code snippets that respect your spacing and tabs.'
 	),

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { column as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Column' ),
+	title: _x( 'Column', 'block title' ),
 	icon,
 	description: __( 'A single column within a columns block.' ),
 	edit,

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { columns as icon } from '@wordpress/icons';
 
 /**
@@ -19,7 +19,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Columns' ),
+	title: _x( 'Columns', 'block title' ),
 	icon,
 	description: __(
 		'Add a block that displays content in multiple columns, then add whatever content blocks you’d like.'

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { cover as icon } from '@wordpress/icons';
 
 /**
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Cover' ),
+	title: _x( 'Cover', 'block title' ),
 	description: __(
 		'Add an image or video with a text overlay — great for headers.'
 	),

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'File' ),
+	title: _x( 'File', 'block title' ),
 	description: __( 'Add a link to a downloadable file.' ),
 	icon,
 	keywords: [ __( 'document' ), __( 'pdf' ), __( 'download' ) ],

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { gallery as icon } from '@wordpress/icons';
 
 /**
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Gallery' ),
+	title: _x( 'Gallery', 'block title' ),
 	description: __( 'Display multiple images in a rich gallery.' ),
 	icon,
 	keywords: [ __( 'images' ), __( 'photos' ) ],

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { group as icon } from '@wordpress/icons';
 
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Group' ),
+	title: _x( 'Group', 'block title' ),
 	icon,
 	description: __( 'Combine blocks into a group.' ),
 	keywords: [

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -7,7 +7,7 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { heading as icon } from '@wordpress/icons';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -23,7 +23,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Heading' ),
+	title: _x( 'Heading', 'block title' ),
 	description: __(
 		'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.'
 	),

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { html as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Custom HTML' ),
+	title: _x( 'Custom HTML', 'block title' ),
 	description: __( 'Add custom HTML code and preview it as you edit.' ),
 	icon,
 	keywords: [ __( 'embed' ) ],

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Image' ),
+	title: _x( 'Image', 'block title' ),
 	description: __( 'Insert an image to make a visual statement.' ),
 	icon,
 	keywords: [

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { comment as icon } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Latest Comments' ),
+	title: _x( 'Latest Comments', 'block title' ),
 	description: __( 'Display a list of your most recent comments.' ),
 	icon,
 	keywords: [ __( 'recent comments' ) ],

--- a/packages/block-library/src/latest-posts/index.js
+++ b/packages/block-library/src/latest-posts/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postList as icon } from '@wordpress/icons';
 
 /**
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Latest Posts' ),
+	title: _x( 'Latest Posts', 'block title' ),
 	description: __( 'Display a list of your most recent posts.' ),
 	icon,
 	keywords: [ __( 'recent posts' ) ],

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { list as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'List' ),
+	title: _x( 'List', 'block title' ),
 	description: __( 'Create a bulleted or numbered list.' ),
 	icon,
 	keywords: [

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { mediaAndText as icon } from '@wordpress/icons';
 
 /**
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Media & Text' ),
+	title: _x( 'Media & Text', 'block title' ),
 	description: __( 'Set media and words side-by-side for a richer layout.' ),
 	icon,
 	keywords: [ __( 'image' ), __( 'video' ) ],

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 
 /**
@@ -17,7 +17,7 @@ export { metadata, name };
 
 export const settings = {
 	name,
-	title: __( 'Unsupported' ),
+	title: _x( 'Unsupported', 'block title' ),
 	description: __( 'Your site doesn’t include support for this block.' ),
 	__experimentalLabel( attributes, { context } ) {
 		if ( context === 'accessibility' ) {

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'More', 'block name' ),
+	title: _x( 'More', 'block title' ),
 	description: __(
 		'Content before this block will be shown in the excerpt on your archives page.'
 	),

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	category as categoryIcon,
 	mapMarker as linkIcon,
@@ -23,7 +23,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Link' ),
+	title: _x( 'Link', 'block title' ),
 
 	icon: linkIcon,
 

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { navigation as icon } from '@wordpress/icons';
 
 /**
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Navigation' ),
+	title: _x( 'Navigation', 'block title' ),
 	icon,
 	description: __(
 		'A collection of blocks that allow visitors to get around your site.'

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { pageBreak as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Page Break' ),
+	title: _x( 'Page Break', 'block title' ),
 	description: __( 'Separate your content into a multi-page experience.' ),
 	icon,
 	keywords: [ __( 'next page' ), __( 'pagination' ) ],

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -6,7 +6,7 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { paragraph as icon } from '@wordpress/icons';
 
 /**
@@ -23,7 +23,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Paragraph' ),
+	title: _x( 'Paragraph', 'block title' ),
 	description: __( 'Start with the building block of all narrative.' ),
 	icon,
 	keywords: [ __( 'text' ) ],

--- a/packages/block-library/src/post-author/index.js
+++ b/packages/block-library/src/post-author/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Author' ),
+	title: _x( 'Post Author', 'block title' ),
 	description: __( 'Add the author of this post.' ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-comment-author/index.js
+++ b/packages/block-library/src/post-comment-author/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Comment Author' ),
+	title: _x( 'Post Comment Author', 'block title' ),
 	description: __( 'Post Comment Author' ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-comment-content/index.js
+++ b/packages/block-library/src/post-comment-content/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { alignJustify as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Comment Content' ),
+	title: _x( 'Post Comment Content', 'block title' ),
 	description: __( 'Post Comment Content' ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-comment-date/index.js
+++ b/packages/block-library/src/post-comment-date/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postDate as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Comment Date' ),
+	title: _x( 'Post Comment Date', 'block title' ),
 	description: __( 'Post Comment Date' ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-comment/index.js
+++ b/packages/block-library/src/post-comment/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { comment as icon } from '@wordpress/icons';
 
 /**
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Comment' ),
+	title: _x( 'Post Comment', 'block title' ),
 	description: __( 'Post Comment' ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-comments-count/index.js
+++ b/packages/block-library/src/post-comments-count/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postCommentsCount as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Comments Count' ),
+	title: _x( 'Post Comments Count', 'block title' ),
 	description: __( "Display a post's comments count." ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-comments-form/index.js
+++ b/packages/block-library/src/post-comments-form/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postCommentsForm as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Comments Form' ),
+	title: _x( 'Post Comments Form', 'block title' ),
 	description: __( "Display a post's comments form." ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-comments/index.js
+++ b/packages/block-library/src/post-comments/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postComments as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Comments' ),
+	title: _x( 'Post Comments', 'block title' ),
 	description: __( "Display a post's comments." ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { alignJustify as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Content' ),
+	title: _x( 'Post Content', 'block title' ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-date/index.js
+++ b/packages/block-library/src/post-date/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postDate as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Date' ),
+	title: _x( 'Post Date', 'block title' ),
 	description: __( 'Add the date of this post.' ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-excerpt/index.js
+++ b/packages/block-library/src/post-excerpt/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postExcerpt as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Excerpt' ),
+	title: _x( 'Post Excerpt', 'block title' ),
 	description: __( "Display a post's excerpt." ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-featured-image/index.js
+++ b/packages/block-library/src/post-featured-image/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postFeaturedImage as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Featured Image' ),
+	title: _x( 'Post Featured Image', 'block title' ),
 	description: __( "Display a post's featured image." ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-hierarchical-terms/index.js
+++ b/packages/block-library/src/post-hierarchical-terms/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Hierarchical Terms' ),
+	title: _x( 'Post Hierarchical Terms', 'block title' ),
 	variations,
 	edit,
 };

--- a/packages/block-library/src/post-tags/index.js
+++ b/packages/block-library/src/post-tags/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { tag as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Tags' ),
+	title: _x( 'Post Tags', 'block title' ),
 	description: __( "Display a post's tags." ),
 	icon,
 	edit,

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postTitle as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Title' ),
+	title: _x( 'Post Title', 'block title' ),
 	description: __( 'Add the title of your post.' ),
 	icon,
 	edit,

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { preformatted as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Preformatted' ),
+	title: _x( 'Preformatted', 'block title' ),
 	description: __(
 		'Add text that respects your spacing and tabs, and also allows styling.'
 	),

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -19,7 +19,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Pullquote' ),
+	title: _x( 'Pullquote', 'block title' ),
 	description: __(
 		'Give special visual emphasis to a quote from your text.'
 	),

--- a/packages/block-library/src/query-loop/index.js
+++ b/packages/block-library/src/query-loop/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { loop } from '@wordpress/icons';
 
 /**
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Query Loop' ),
+	title: _x( 'Query Loop', 'block title' ),
 	icon: loop,
 	edit,
 	save,

--- a/packages/block-library/src/query-pagination/index.js
+++ b/packages/block-library/src/query-pagination/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -13,6 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Query Pagination' ),
+	title: _x( 'Query Pagination', 'block title' ),
 	edit,
 };

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { loop as icon } from '@wordpress/icons';
 
 /**
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Query' ),
+	title: _x( 'Query', 'block title' ),
 	icon,
 	description: __( 'Displays a list of posts as a result of a query.' ),
 	edit,

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Quote' ),
+	title: _x( 'Quote', 'block title' ),
 	description: __(
 		'Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar'
 	),

--- a/packages/block-library/src/rss/index.js
+++ b/packages/block-library/src/rss/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { rss as icon } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'RSS' ),
+	title: _x( 'RSS', 'block title' ),
 	description: __( 'Display entries from any RSS or Atom feed.' ),
 	icon,
 	keywords: [ __( 'atom' ), __( 'feed' ) ],

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { search as icon } from '@wordpress/icons';
 
 /**
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Search' ),
+	title: _x( 'Search', 'block title' ),
 	description: __( 'Help visitors find your content.' ),
 	icon,
 	keywords: [ __( 'find' ) ],

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { separator as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Separator' ),
+	title: _x( 'Separator', 'block title' ),
 	description: __(
 		'Create a break between ideas or sections with a horizontal separator.'
 	),

--- a/packages/block-library/src/shortcode/index.js
+++ b/packages/block-library/src/shortcode/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { shortcode as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Shortcode' ),
+	title: _x( 'Shortcode', 'block title' ),
 	description: __(
 		'Insert additional custom elements with a WordPress shortcode.'
 	),

--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Site Logo' ),
+	title: _x( 'Site Logo', 'block title' ),
 	description: __( 'Show a site logo' ),
 	icon,
 	styles: [

--- a/packages/block-library/src/site-tagline/index.js
+++ b/packages/block-library/src/site-tagline/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Site Tagline' ),
+	title: _x( 'Site Tagline', 'block title' ),
 	description: __( 'In a few words, what this site is about.' ),
 	keywords: [ __( 'description' ) ],
 	icon,

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { mapMarker as icon } from '@wordpress/icons';
 
 /**
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Site Title' ),
+	title: _x( 'Site Title', 'block title' ),
 	description: __(
 		'Displays and allows editing the name of the site. The site title usually appears in the browser title bar, in search results, and more. Also available in Settings > General.'
 	),

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { share as icon } from '@wordpress/icons';
 
 /**
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Social Icon' ),
+	title: _x( 'Social Icon', 'block title' ),
 	icon,
 	edit,
 	description: __(

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Social Icons' ),
+	title: _x( 'Social Icons', 'block title' ),
 	description: __(
 		'Display icons linking to your social media profiles or websites.'
 	),

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { resizeCornerNE as icon } from '@wordpress/icons';
 
 /**
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Spacer' ),
+	title: _x( 'Spacer', 'block title' ),
 	description: __(
 		'Add white space between blocks and customize its height.'
 	),

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { SVG, Path } from '@wordpress/components';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Subheading (deprecated)' ),
+	title: _x( 'Subheading (deprecated)', 'block title' ),
 	description: __(
 		'This block is deprecated. Please use the Paragraph block instead.'
 	),

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Table' ),
+	title: _x( 'Table', 'block title' ),
 	description: __( 'Insert a table — perfect for sharing charts and data.' ),
 	icon,
 	example: {

--- a/packages/block-library/src/tag-cloud/index.js
+++ b/packages/block-library/src/tag-cloud/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { tag as icon } from '@wordpress/icons';
 
 /**
@@ -15,7 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Tag Cloud' ),
+	title: _x( 'Tag Cloud', 'block title' ),
 	description: __( 'A cloud of your most used tags.' ),
 	icon,
 	example: {},

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -6,7 +6,7 @@ import { startCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Template Part' ),
+	title: _x( 'Template Part', 'block title' ),
 	keywords: [ __( 'template part' ) ],
 	__experimentalLabel: ( { slug } ) => startCase( slug ),
 	edit,

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Text Columns (deprecated)' ),
+	title: _x( 'Text Columns (deprecated)', 'block title' ),
 	description: __(
 		'This block is deprecated. Please use the Columns block instead.'
 	),

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { verse as icon } from '@wordpress/icons';
 
 /**
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Verse' ),
+	title: _x( 'Verse', 'block title' ),
 	description: __(
 		'Insert poetry. Use special spacing formats. Or quote song lyrics.'
 	),

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { video as icon } from '@wordpress/icons';
 
 /**
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Video' ),
+	title: _x( 'Video', 'block title' ),
 	description: __(
 		'Embed a video from your media library or upload a new one.'
 	),


### PR DESCRIPTION
This PR adds the context in which a string is used to all block's titles, so translators know where these are used.

After translating a few strings myself via GlotPress for the Gutenberg plugin I realized some block titles were actually translated as verbs, not nouns. For example, _Query Loop_ was translated in the Spanish locale as "Consultar el loop" (verb, like "query the loop"), instead of "Bucle de Consulta" (a compound noun). The example is just one of many that I also found in different languages and it's not meant to diminish any particular translation. If anything, this PR is an empathetic effort to make translators' life easier by giving them more context.

The blocks with compound nouns (post page, query loop) can be more prone to this kind of error, but there's also single-noun names that can be affected (quote => cita as noun, citar as verb), hence why I decided to set it up for all the blocks.
