### PR TITLE
[RNMobile] Set and reference heading anchors

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -394,7 +394,7 @@ Undocumented declaration.
 
 _Related_
 
--   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-controls-advanced/README.md>
+-   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-advanced-controls/README.md>
 
 <a name="InspectorControls" href="#InspectorControls">#</a> **InspectorControls**
 

--- a/packages/block-editor/src/components/inspector-advanced-controls/index.js
+++ b/packages/block-editor/src/components/inspector-advanced-controls/index.js
@@ -20,6 +20,6 @@ InspectorAdvancedControls.slotName = name;
 InspectorAdvancedControls.Slot = Slot;
 
 /**
- * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-controls-advanced/README.md
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-advanced-controls/README.md
  */
 export default InspectorAdvancedControls;

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -111,6 +111,12 @@ export const withInspectorControl = createHigherOrderComponent(
 								{ textControl }
 							</InspectorAdvancedControls>
 						) }
+						{ /*
+						 * We plan to remove scoping anchors to 'core/heading' to support
+						 * anchors for all eligble blocks. Additionally we plan to explore
+						 * leveraging InspectorAdvancedControls instead of a custom
+						 * PanelBody title. https://git.io/Jtcov
+						 */ }
 						{ ! isWeb && props.name === 'core/heading' && (
 							<InspectorControls>
 								<PanelBody title={ __( 'Heading settings' ) }>

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -7,15 +7,16 @@ import { has } from 'lodash';
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { TextControl, ExternalLink } from '@wordpress/components';
+import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { InspectorAdvancedControls } from '../components';
+import { InspectorControls, InspectorAdvancedControls } from '../components';
 
 /**
  * Regular expression matching invalid anchor characters for replacement.
@@ -67,41 +68,56 @@ export const withInspectorControl = createHigherOrderComponent(
 			const hasAnchor = hasBlockSupport( props.name, 'anchor' );
 
 			if ( hasAnchor && props.isSelected ) {
+				const isWeb = Platform.OS === 'web';
+				const textControl = (
+					<TextControl
+						className="html-anchor-control"
+						label={ __( 'HTML anchor' ) }
+						help={
+							<>
+								{ __(
+									'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
+								) }
+
+								<ExternalLink
+									href={
+										'https://wordpress.org/support/article/page-jumps/'
+									}
+								>
+									{ __( 'Learn more about anchors' ) }
+								</ExternalLink>
+							</>
+						}
+						value={ props.attributes.anchor || '' }
+						valuePlaceholder={
+							! isWeb ? __( 'Add an anchor' ) : null
+						}
+						onChange={ ( nextValue ) => {
+							nextValue = nextValue.replace( ANCHOR_REGEX, '-' );
+							props.setAttributes( {
+								anchor: nextValue,
+							} );
+						} }
+						autoCapitalize="none"
+						autoComplete="off"
+					/>
+				);
+
 				return (
 					<>
 						<BlockEdit { ...props } />
-						<InspectorAdvancedControls>
-							<TextControl
-								className="html-anchor-control"
-								label={ __( 'HTML anchor' ) }
-								help={
-									<>
-										{ __(
-											'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
-										) }
-
-										<ExternalLink
-											href={
-												'https://wordpress.org/support/article/page-jumps/'
-											}
-										>
-											{ __( 'Learn more about anchors' ) }
-										</ExternalLink>
-									</>
-								}
-								value={ props.attributes.anchor || '' }
-								onChange={ ( nextValue ) => {
-									nextValue = nextValue.replace(
-										ANCHOR_REGEX,
-										'-'
-									);
-									props.setAttributes( {
-										anchor: nextValue,
-									} );
-								} }
-								autoComplete="off"
-							/>
-						</InspectorAdvancedControls>
+						{ isWeb && (
+							<InspectorAdvancedControls>
+								{ textControl }
+							</InspectorAdvancedControls>
+						) }
+						{ ! isWeb && props.name === 'core/heading' && (
+							<InspectorControls>
+								<PanelBody title={ __( 'Heading settings' ) }>
+									{ textControl }
+								</PanelBody>
+							</InspectorControls>
+						) }
 					</>
 				);
 			}

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -11,10 +11,11 @@ import { createBlock } from '@wordpress/blocks';
 import {
 	AlignmentToolbar,
 	BlockControls,
+	InspectorControls,
 	RichText,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { ToolbarGroup } from '@wordpress/components';
+import { PanelBody, TextControl, ToolbarGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -28,7 +29,7 @@ function HeadingEdit( {
 	onReplace,
 	mergedStyle,
 } ) {
-	const { textAlign, content, level, placeholder } = attributes;
+	const { anchor, textAlign, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -55,6 +56,18 @@ function HeadingEdit( {
 					} }
 				/>
 			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Advanced' ) }>
+					<TextControl
+						label={ __( 'HTML Anchor' ) }
+						value={ anchor || '' }
+						valuePlaceholder={ __( 'None' ) }
+						onChangeValue={ ( value ) =>
+							setAttributes( { anchor: value } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<RichText
 				identifier="content"
 				tagName={ tagName }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -59,6 +59,7 @@ function HeadingEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Advanced' ) }>
 					<TextControl
+						autoCapitalize="none"
 						label={ __( 'HTML Anchor' ) }
 						value={ anchor || '' }
 						valuePlaceholder={ __( 'None' ) }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -57,12 +57,12 @@ function HeadingEdit( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Advanced' ) }>
+				<PanelBody title={ __( 'Heading settings' ) }>
 					<TextControl
 						autoCapitalize="none"
 						label={ __( 'HTML Anchor' ) }
 						value={ anchor || '' }
-						valuePlaceholder={ __( 'None' ) }
+						valuePlaceholder={ __( 'Add an anchor' ) }
 						onChangeValue={ ( value ) =>
 							setAttributes( { anchor: value } )
 						}

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -11,11 +11,10 @@ import { createBlock } from '@wordpress/blocks';
 import {
 	AlignmentToolbar,
 	BlockControls,
-	InspectorControls,
 	RichText,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToolbarGroup } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -29,7 +28,7 @@ function HeadingEdit( {
 	onReplace,
 	mergedStyle,
 } ) {
-	const { anchor, textAlign, content, level, placeholder } = attributes;
+	const { textAlign, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -56,19 +55,6 @@ function HeadingEdit( {
 					} }
 				/>
 			</BlockControls>
-			<InspectorControls>
-				<PanelBody title={ __( 'Heading settings' ) }>
-					<TextControl
-						autoCapitalize="none"
-						label={ __( 'HTML Anchor' ) }
-						value={ anchor || '' }
-						valuePlaceholder={ __( 'Add an anchor' ) }
-						onChangeValue={ ( value ) =>
-							setAttributes( { anchor: value } )
-						}
-					/>
-				</PanelBody>
-			</InspectorControls>
 			<RichText
 				identifier="content"
 				tagName={ tagName }

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+* [**] Add support for setting heading anchors
 
 
 #### Bug Fix
@@ -27,7 +28,6 @@ For each user feature we should also add a importance categorization label  to i
 
 * [***] Add support for cross-posting between sites
 * [***] Full-width and wide alignment support for Columns
-* [**] Add support for setting heading anchors
 
 ## 1.43.0
 * [***] New Block: File [#27228]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -27,6 +27,7 @@ For each user feature we should also add a importance categorization label  to i
 
 * [***] Add support for cross-posting between sites
 * [***] Full-width and wide alignment support for Columns
+* [**] Add support for setting heading anchors
 
 ## 1.43.0
 * [***] New Block: File [#27228]


### PR DESCRIPTION
## Description
Address wordpress-mobile/gutenberg-mobile#1816 by adding the ability to set and reference Heading block anchors

- **Guntenberg Mobile:** wordpress-mobile/gutenberg-mobile#2947
- ~**WordPress iOS:** wordpress-mobile/WordPress-iOS#15567~
- ~**WordPress Android:** wordpress-mobile/WordPress-Android#13705~

## How has this been tested?
1. Edit a post and add Heading block.
1. Tap block settings button (i.e. settings cog icon).
1. Set value for "HTML Anchor" control.
1. Dismiss block settings.
1. Add Paragraph block with text including a link to the HTML Anchor from
   earlier step.
1. Publish post.
1. Visit published post in a web browser.
1. Tap link.

**Outcome:** Browser should scroll to Heading anchor.

## Screenshots

<details>
<summary>UI Examples</summary>

| iOS | Android |
| --- | --- |
| <img width="584" alt="ios-heading-selected" src="https://user-images.githubusercontent.com/438664/103777276-41d59e80-4ff6-11eb-9a37-905020c7333f.png"> | <img width="602" alt="android-heading-selected" src="https://user-images.githubusercontent.com/438664/103777296-48641600-4ff6-11eb-891a-cf443ab8b960.png"> |
| <img width="495" alt="ios-without-heading-anchor" src="https://user-images.githubusercontent.com/438664/104748406-53febd80-5717-11eb-8a24-f861da70b074.png"> | <img width="602" alt="android-without-heading-anchor" src="https://user-images.githubusercontent.com/438664/104748420-595c0800-5717-11eb-9b82-8242a52e360e.png"> |
| <img width="495" alt="ios-with-heading-anchor" src="https://user-images.githubusercontent.com/438664/104748468-65e06080-5717-11eb-898b-31bb59b2daf3.png"> | <img width="602" alt="android-with-heading-anchor" src="https://user-images.githubusercontent.com/438664/104748483-6b3dab00-5717-11eb-9ea3-551c9ec99d4a.png"> |

</details>

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
