### PR TITLE
Fix duplicate reusable blocks loading in Safari

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -163,7 +163,7 @@ export default function useBlockSync( {
 			__unstableIsLastBlockChangeIgnored,
 		} = registry.select( 'core/block-editor' );
 
-		let blocks;
+		let blocks = getBlocks( clientId );
 		let isPersistent = isLastBlockChangePersistent();
 		let previousAreBlocksDifferent = false;
 

--- a/packages/e2e-test-utils/src/save-draft.js
+++ b/packages/e2e-test-utils/src/save-draft.js
@@ -5,6 +5,7 @@
  * @return {Promise} Promise resolving when draft save is complete.
  */
 export async function saveDraft() {
+	await page.waitForSelector( '.editor-post-save-draft' );
 	await page.click( '.editor-post-save-draft' );
 	return page.waitForSelector( '.editor-post-saved-state.is-saved' );
 }

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -13,6 +13,7 @@ import {
 	visitAdminPage,
 	toggleGlobalBlockInserter,
 	openDocumentSettingsSidebar,
+	saveDraft,
 } from '@wordpress/e2e-test-utils';
 
 const reusableBlockNameInputSelector =
@@ -271,5 +272,41 @@ describe( 'Reusable blocks', () => {
 		await toggleGlobalBlockInserter();
 
 		expect( console ).not.toHaveErrored();
+	} );
+
+	it( 'should be able to insert a reusable block twice', async () => {
+		await createReusableBlock(
+			'Awesome Paragraph',
+			'Random reusable block'
+		);
+		await saveAll();
+		await clearAllBlocks();
+		await insertReusableBlock( 'Random reusable block' );
+		await insertReusableBlock( 'Random reusable block' );
+		await saveDraft();
+		await page.reload();
+
+		// Replace the content of the  first paragraph
+		const paragraphBlock = await page.waitForSelector(
+			'.block-editor-block-list__block[data-type="core/paragraph"]'
+		);
+		paragraphBlock.focus();
+		await pressKeyWithModifier( 'primary', 'a' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.type( '*' );
+
+		// Wait for async mode to dispatch the update.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 1000 );
+
+		// Check that the content of the second reusable block has been updated.
+		const reusableBlocks = await page.$$( '.wp-block-block' );
+		reusableBlocks.forEach( async ( paragraph ) => {
+			const content = await paragraph.$eval(
+				'p',
+				( element ) => element.textContent
+			);
+			expect( content ).toEqual( 'Awesome Paragraph*' );
+		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -277,12 +277,12 @@ describe( 'Reusable blocks', () => {
 	it( 'should be able to insert a reusable block twice', async () => {
 		await createReusableBlock(
 			'Awesome Paragraph',
-			'Random reusable block'
+			'Duplicated reusable block'
 		);
 		await saveAll();
 		await clearAllBlocks();
-		await insertReusableBlock( 'Random reusable block' );
-		await insertReusableBlock( 'Random reusable block' );
+		await insertReusableBlock( 'Duplicated reusable block' );
+		await insertReusableBlock( 'Duplicated reusable block' );
 		await saveDraft();
 		await page.reload();
 


### PR DESCRIPTION
Follow-up #27887 
closes #27932 

When duplicating a reusable block, sometimes its content would get emptied. I was only able to reproduce this in Safari personally but it could be possible in any browser in theory.

This PR fixes that bug.