### PR TITLE
Fix unexpected autosave for published posts

### DIFF
--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -29,15 +29,11 @@ export class AutosaveMonitor extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if (
-			this.props.disableIntervalChecks &&
-			this.props.editsReference !== prevProps.editsReference
-		) {
-			this.props.autosave();
+		if ( this.props.disableIntervalChecks ) {
 			return;
 		}
 
-		if ( ! this.props.isDirty && prevProps.isDirty ) {
+		if ( ! this.props.isDirty ) {
 			this.needsAutosave = false;
 			return;
 		}

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -30,6 +30,9 @@ export class AutosaveMonitor extends Component {
 
 	componentDidUpdate( prevProps ) {
 		if ( this.props.disableIntervalChecks ) {
+			if ( this.props.editsReference !== prevProps.editsReference ) {
+				this.props.autosave();
+			}
 			return;
 		}
 

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -14,7 +14,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
  *
  * There are two caveats:
  * * If `props.isAutosaveable` happens to be false at a time of checking for changes, the check is retried every second.
- * * The timer may be disabled by setting `props.disableIntervalChecks` to `false`. In that mode, any change will immediately trigger `props.autosave()`.
+ * * The timer may be disabled by setting `props.disableIntervalChecks` to `true`. In that mode, any change will immediately trigger `props.autosave()`.
  */
 export class AutosaveMonitor extends Component {
 	constructor( props ) {

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -17,7 +17,7 @@ describe( 'AutosaveMonitor', () => {
 			AutosaveMonitor.prototype,
 			'setAutosaveTimer'
 		);
-		wrapper = shallow( <AutosaveMonitor />, {
+		wrapper = shallow( <AutosaveMonitor isDirty />, {
 			lifecycleExperimental: true,
 		} );
 	} );
@@ -36,7 +36,7 @@ describe( 'AutosaveMonitor', () => {
 	} );
 
 	describe( '#componentDidUpdate()', () => {
-		it( 'should set needsAutosave=true when editReference changes and other props stay the same (1)', () => {
+		it( 'should set needsAutosave=true when editReference changes', () => {
 			expect( wrapper.instance().needsAutosave ).toBe( false );
 			wrapper.setProps( {
 				editsReference: [],


### PR DESCRIPTION
closes #27939 

I was not able to understand exactly where the  regression happened but for me, autosave shouldn't happen at all when the post is not dirty, this PR makes that change which fixes the issue reported in #27939 

See testing instructions in  #27939 