### PR TITLE
Don't close the block inserter when clicking the scrollbar or an empty area.

### DIFF
--- a/packages/compose/src/hooks/use-dialog/index.js
+++ b/packages/compose/src/hooks/use-dialog/index.js
@@ -57,7 +57,10 @@ function useDialog( options ) {
 			focusOnMountRef,
 			closeOnEscapeRef,
 		] ),
-		focusOutsideProps,
+		{
+			...focusOutsideProps,
+			tabIndex: '-1',
+		},
 	];
 }
 


### PR DESCRIPTION
closes #27943 

This adds the tabIndex="-1"  to dialog wrappers using useDialog matching the previous behavior of the inserters.

**Testing instructions**

 - Open the inserter
 - Click the inserter scrollbar
 - The inserter stays open