### PR TITLE
Fix the RTL editor styles and the theme styles option

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -579,7 +579,9 @@ function gutenberg_register_vendor_script( $scripts, $handle, $src, $deps = arra
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_block_editor_styles( $settings ) {
-	$editor_styles_file = gutenberg_dir_path() . 'build/editor/editor-styles.css';
+	$editor_styles_file = is_rtl() ?
+		gutenberg_dir_path() . 'build/editor/editor-styles-rtl.css' :
+		gutenberg_dir_path() . 'build/editor/editor-styles.css';
 
 	/*
 	 * If, for whatever reason, the built editor styles do not exist, avoid
@@ -601,7 +603,9 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 		 */
 
 		$default_styles = file_get_contents(
-			ABSPATH . WPINC . '/css/dist/editor/editor-styles.css'
+			is_rtl() ?
+				ABSPATH . WPINC . '/css/dist/editor/editor-styles-rtl.css' :
+				ABSPATH . WPINC . '/css/dist/editor/editor-styles.css'
 		);
 
 		/*
@@ -640,7 +644,9 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_block_editor_settings_with_default_editor_styles( $settings ) {
-	$editor_styles_file              = gutenberg_dir_path() . 'build/editor/editor-styles.css';
+	$editor_styles_file              = is_rtl() ?
+		gutenberg_dir_path() . 'build/editor/editor-styles-rtl.css' :
+		gutenberg_dir_path() . 'build/editor/editor-styles.css';
 	$settings['defaultEditorStyles'] = array(
 		array(
 			'css' => file_get_contents( $editor_styles_file ),

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -71,7 +71,7 @@ const interfaceLabels = {
 	footer: __( 'Editor footer' ),
 };
 
-function Layout( { settings } ) {
+function Layout( { styles } ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
 	const {
@@ -171,7 +171,7 @@ function Layout( { settings } ) {
 	const ref = useRef();
 
 	useDrop( ref );
-	useEditorStyles( ref, settings.styles );
+	useEditorStyles( ref, styles );
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 	} );

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -99,9 +99,7 @@ function Editor( {
 
 	const editorSettings = useMemo( () => {
 		const result = {
-			...( hasThemeStyles
-				? settings
-				: omit( settings, [ 'defaultEditorStyles' ] ) ),
+			...omit( settings, [ 'defaultEditorStyles', 'styles' ] ),
 			__experimentalPreferredStyleVariations: {
 				value: preferredStyleVariations,
 				onChange: updatePreferredStyleVariations,
@@ -114,9 +112,6 @@ function Editor( {
 			// This is marked as experimental to give time for the quick inserter to mature.
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			keepCaretInsideBlock,
-			styles: hasThemeStyles
-				? settings.styles
-				: settings.defaultEditorStyles,
 		};
 
 		// Omit hidden block types if exists and non-empty.
@@ -141,7 +136,6 @@ function Editor( {
 		hasFixedToolbar,
 		focusMode,
 		hasReducedUI,
-		hasThemeStyles,
 		hiddenBlockTypes,
 		blockTypes,
 		preferredStyleVariations,
@@ -150,6 +144,10 @@ function Editor( {
 		updatePreferredStyleVariations,
 		keepCaretInsideBlock,
 	] );
+
+	const styles = useMemo( () => {
+		return hasThemeStyles ? settings.styles : settings.defaultEditorStyles;
+	}, [ settings, hasThemeStyles ] );
 
 	if ( ! post ) {
 		return null;
@@ -172,7 +170,7 @@ function Editor( {
 						>
 							<ErrorBoundary onError={ onError }>
 								<EditorInitialization postId={ postId } />
-								<Layout settings={ settings } />
+								<Layout styles={ styles } />
 								<KeyboardShortcuts
 									shortcuts={ preventEventDiscovery }
 								/>


### PR DESCRIPTION
closes #27937 

This fixes two bugs:

 - The wrong editor styles were being loaded if the local was RTL.
 - The  "use theme styles" options that regressed in #27080 

**Testing instructions**

 - Check that the "use theme styles" option is working properly
 - Check that the padding is on the right for lists in RTL languages (disable theme styles for accurate results)