### PR TITLE
Only enable the template mode for viewable post types

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -21,17 +21,21 @@ function PostTemplate() {
 			getCurrentPostType,
 			getCurrentPost,
 		} = select( editorStore );
-		const { __experimentalGetTemplateForLink } = select( coreStore );
+		const { __experimentalGetTemplateForLink, getPostType } = select(
+			coreStore
+		);
 		const { isEditingTemplate } = select( editPostStore );
 		const link = getEditedPostAttribute( 'link' );
 		const isFSEEnabled = select( editorStore ).getEditorSettings()
 			.isFSETheme;
+		const isViewable =
+			getPostType( getCurrentPostType() )?.viewable ?? false;
 		return {
 			template:
 				isFSEEnabled &&
+				isViewable &&
 				link &&
-				getCurrentPost().status !== 'auto-draft' &&
-				getCurrentPostType() !== 'wp_template'
+				getCurrentPost().status !== 'auto-draft'
 					? __experimentalGetTemplateForLink( link )
 					: null,
 			isEditing: isEditingTemplate(),

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -57,13 +57,16 @@ function Editor( {
 			__experimentalGetPreviewDeviceType,
 			isEditingTemplate,
 		} = select( editPostStore );
-		const { getEntityRecord, __experimentalGetTemplateForLink } = select(
-			'core'
-		);
+		const {
+			getEntityRecord,
+			__experimentalGetTemplateForLink,
+			getPostType,
+		} = select( 'core' );
 		const { getEditorSettings, getCurrentPost } = select( 'core/editor' );
 		const { getBlockTypes } = select( blocksStore );
 		const postObject = getEntityRecord( 'postType', postType, postId );
 		const isFSETheme = getEditorSettings().isFSETheme;
+		const isViewable = getPostType( postType )?.viewable ?? false;
 
 		return {
 			hasFixedToolbar:
@@ -84,9 +87,9 @@ function Editor( {
 			isTemplateMode: isEditingTemplate(),
 			template:
 				isFSETheme &&
+				isViewable &&
 				postObject &&
-				getCurrentPost().status !== 'auto-draft' &&
-				postType !== 'wp_template'
+				getCurrentPost().status !== 'auto-draft'
 					? __experimentalGetTemplateForLink( postObject.link )
 					: null,
 			post: postObject,


### PR DESCRIPTION
closes #27919 

Right now we only exclude the wp_template from the template mode but in reality we should be excluding all non "viewable" CPTs like the reusable blocks.

**Testing instructions**

 - Create a reusable block
 - Try to edit in its own editor (manage reusable blocks page)
 - The "template" shouldn't show up on the side.