### PR TITLE
Prevent focus loss on reusable block edition

### DIFF
--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -293,7 +293,7 @@ describe( 'Reusable blocks', () => {
 		paragraphBlock.focus();
 		await pressKeyWithModifier( 'primary', 'a' );
 		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.type( '*' );
+		await page.keyboard.type( ' modified' );
 
 		// Wait for async mode to dispatch the update.
 		// eslint-disable-next-line no-restricted-syntax
@@ -306,7 +306,7 @@ describe( 'Reusable blocks', () => {
 				'p',
 				( element ) => element.textContent
 			);
-			expect( content ).toEqual( 'Awesome Paragraph*' );
+			expect( content ).toEqual( 'Awesome Paragraph modified' );
 		} );
 	} );
 } );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -90,7 +90,7 @@ export function* __unstableSetupTemplate( template ) {
 		{
 			blocks,
 		},
-		{ __unstableShouldCreateUndoLevel: false }
+		{ undoIgnore: true }
 	);
 }
 


### PR DESCRIPTION
Follow-up to #27887 

The recent reusable block refactoring highlighted a bug in the `useEntityBlockEditor` hook where the first time blocks are edited, you first get a `[]` value and then you get the edited value. This was due to hooks order of execution. The fact that sometimes the block came from the edited value and sometimes from the parsed "content" value, caused this issue.

This PR updates that hook to always retrieve the blocks value from the "edits" by adding an initialization to that value when the "content" changes.

This should make the "reusable-blocks" e2e test more stable as well.