### PR TITLE
Fix PHPCS warning: undefined variable $i

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -78,7 +78,6 @@ function gutenberg_experimental_set( &$array, $path, $value = null ) {
 		}
 	}
 
-	$i;
 	for ( $i = 0; $i < $path_length - 1; ++$i ) {
 		$path_element = $path[ $i ];
 		if (


### PR DESCRIPTION
## Description
Fix PHPCS warning:

```
FILE: /app/lib/utils.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 81 | WARNING | Variable $i is undefined.
    |         | (VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable)
----------------------------------------------------------------------
```