### PR TITLE
Refactor rich-text to match the `react-hooks/exhaustive-deps` eslint rules

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -127,7 +127,10 @@ function BlockListBlock( {
 		[ clientId ]
 	);
 	const { removeBlock } = useDispatch( 'core/block-editor' );
-	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
+	const onRemove = useCallback( () => removeBlock( clientId ), [
+		clientId,
+		removeBlock,
+	] );
 
 	// Handling the error state
 	const [ hasError, setErrorState ] = useState( false );
@@ -215,22 +218,39 @@ function BlockListBlock( {
 		);
 	}
 
-	const value = {
-		clientId,
-		isSelected,
-		isFirstMultiSelected,
-		isLastMultiSelected,
-		isPartOfMultiSelection,
-		enableAnimation,
-		index,
-		className: wrapperClassName,
-		isLocked,
-		name,
-		mode,
-		blockTitle: blockType.title,
-		wrapperProps: omit( wrapperProps, [ 'data-align' ] ),
-	};
-	const memoizedValue = useMemo( () => value, Object.values( value ) );
+	const wrapperPropsOmitAlign = omit( wrapperProps, [ 'data-align' ] );
+	const memoizedValue = useMemo(
+		() => ( {
+			clientId,
+			isSelected,
+			isFirstMultiSelected,
+			isLastMultiSelected,
+			isPartOfMultiSelection,
+			enableAnimation,
+			index,
+			className: wrapperClassName,
+			isLocked,
+			name,
+			mode,
+			blockTitle: blockType.title,
+			wrapperProps: wrapperPropsOmitAlign,
+		} ),
+		[
+			clientId,
+			isSelected,
+			isFirstMultiSelected,
+			isLastMultiSelected,
+			isPartOfMultiSelection,
+			enableAnimation,
+			index,
+			wrapperClassName,
+			isLocked,
+			name,
+			mode,
+			blockType.title,
+			wrapperPropsOmitAlign,
+		]
+	);
 
 	let block;
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -186,6 +186,16 @@ _Returns_
 
 -   `Function`: Debounced function.
 
+<a name="useDidMount" href="#useDidMount">#</a> **useDidMount**
+
+A drop-in replacement of the hook version of `componentDidMount`.
+Like `useEffect` but only called once when the component is mounted.
+This hook is only used for backward-compatibility reason. Consider using `useEffect` wherever possible.
+
+_Parameters_
+
+-   _effect_ `Function`: The effect callback passed to `useEffect`.
+
 <a name="useFocusOnMount" href="#useFocusOnMount">#</a> **useFocusOnMount**
 
 Hook used to focus the first tabbable element on mount.
@@ -264,6 +274,22 @@ _Parameters_
 -   _callback_ `Function`: Shortcut callback.
 -   _options_ `WPKeyboardShortcutConfig`: Shortcut options.
 
+<a name="useLazyRef" href="#useLazyRef">#</a> **useLazyRef**
+
+Like `useRef` but only run the initializer once.
+
+_Parameters_
+
+-   _initializer_ `Function`: A function to return the ref object.
+
+_Returns_
+
+-   `MutableRefObject`: The returned ref object.
+
+_Type Definition_
+
+-   _MutableRefObject_ (unknown type)
+
 <a name="useMediaQuery" href="#useMediaQuery">#</a> **useMediaQuery**
 
 Runs a media query and returns its value when it changes.
@@ -320,6 +346,17 @@ const App = () => {
 _Returns_
 
 -   `Array`: An array of {Element} `resizeListener` and {?Object} `sizes` with properties `width` and `height`
+
+<a name="useShallowCompareEffect" href="#useShallowCompareEffect">#</a> **useShallowCompareEffect**
+
+Like `useEffect` but call the effect when the dependencies are not shallowly equal.
+Useful when the size of the dependency array might change during re-renders.
+This hook is only used for backward-compatibility reason. Consider using `useEffect` wherever possible.
+
+_Parameters_
+
+-   _effect_ `Function`: The effect callback passed to `useEffect`.
+-   _deps_ `Array`: The dependency array that is compared against shallowly.
 
 <a name="useThrottle" href="#useThrottle">#</a> **useThrottle**
 

--- a/packages/compose/src/hooks/use-did-mount/index.js
+++ b/packages/compose/src/hooks/use-did-mount/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { useLayoutEffect, useRef } from '@wordpress/element';
+
+/**
+ * A drop-in replacement of the hook version of `componentDidMount`.
+ * Like `useEffect` but only called once when the component is mounted.
+ * This hook is only used for backward-compatibility reason. Consider using `useEffect` wherever possible.
+ *
+ * @param {Function} effect The effect callback passed to `useEffect`.
+ */
+function useDidMount( effect ) {
+	const effectRef = useRef( effect );
+	effectRef.current = effect;
+
+	// `useLayoutEffect` because that's closer to how the `componentDidMount` works.
+	useLayoutEffect( () => effectRef.current(), [] );
+}
+
+export default useDidMount;

--- a/packages/compose/src/hooks/use-did-mount/test/index.js
+++ b/packages/compose/src/hooks/use-did-mount/test/index.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import React, { Component, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useDidMount from '../';
+
+describe( 'useDidMount', () => {
+	it( 'should call the effect when did mount', () => {
+		const mountEffect = jest.fn();
+
+		function TestComponent() {
+			useDidMount( mountEffect );
+			return null;
+		}
+
+		render( <TestComponent /> );
+
+		expect( mountEffect ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should call the cleanup function when unmount', () => {
+		const unmountCallback = jest.fn();
+
+		function TestComponent() {
+			useDidMount( () => unmountCallback );
+			return null;
+		}
+
+		const { unmount } = render( <TestComponent /> );
+
+		expect( unmountCallback ).not.toHaveBeenCalled();
+
+		unmount();
+
+		expect( unmountCallback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should match the calling order of componentDidMount', async () => {
+		const mountEffectCallback = jest.fn();
+		const effectCallback = jest.fn();
+
+		const didMountCallback = jest.fn(
+			() =>
+				new Promise( ( resolve ) => {
+					expect( mountEffectCallback ).toHaveBeenCalled();
+					expect( effectCallback ).not.toHaveBeenCalled();
+
+					resolve();
+				} )
+		);
+
+		let promise;
+
+		class DidMount extends Component {
+			componentDidMount() {
+				promise = didMountCallback();
+			}
+			render() {
+				return null;
+			}
+		}
+
+		function Hook() {
+			useDidMount( mountEffectCallback );
+			useEffect( effectCallback );
+			return null;
+		}
+
+		function TestComponent() {
+			return (
+				<>
+					<Hook />
+					<DidMount />
+				</>
+			);
+		}
+
+		render( <TestComponent /> );
+
+		await promise;
+	} );
+} );

--- a/packages/compose/src/hooks/use-lazy-ref/index.js
+++ b/packages/compose/src/hooks/use-lazy-ref/index.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+const INITIAL_TAG = Symbol( 'INITIAL_TAG' );
+
+/**
+ * Like `useRef` but only run the initializer once.
+ *
+ * @typedef {import('@types/react').MutableRefObject} MutableRefObject
+ *
+ * @param {Function} initializer A function to return the ref object.
+ * @return {MutableRefObject} The returned ref object.
+ */
+function useLazyRef( initializer ) {
+	const ref = useRef( INITIAL_TAG );
+
+	if ( ref.current === INITIAL_TAG ) {
+		ref.current = initializer();
+	}
+
+	return ref;
+}
+
+export default useLazyRef;

--- a/packages/compose/src/hooks/use-lazy-ref/test/index.js
+++ b/packages/compose/src/hooks/use-lazy-ref/test/index.js
@@ -1,0 +1,82 @@
+/**
+ * WordPress dependencies
+ */
+import React, { useReducer } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { render, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useLazyRef from '..';
+
+describe( 'useLazyRef', () => {
+	it( 'should lazily initialize the initializer only once', () => {
+		const initializer = jest.fn( () => 87 );
+		let result;
+		let forceUpdate = () => {};
+
+		function TestComponent() {
+			const ref = useLazyRef( initializer );
+
+			forceUpdate = useReducer( ( c ) => c + 1, 0 )[ 1 ];
+
+			result = ref.current;
+
+			return null;
+		}
+
+		render( <TestComponent /> );
+
+		expect( initializer ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toBe( 87 );
+
+		act( () => {
+			forceUpdate();
+		} );
+
+		expect( initializer ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toBe( 87 );
+	} );
+
+	it( 'should not accept falsy values', () => {
+		const initializer = jest.fn( () => 87 );
+		let result;
+		let ref = { current: null };
+		let forceUpdate = () => {};
+
+		function TestComponent() {
+			ref = useLazyRef( initializer );
+
+			forceUpdate = useReducer( ( c ) => c + 1, 0 )[ 1 ];
+
+			result = ref.current;
+
+			return null;
+		}
+
+		render( <TestComponent /> );
+
+		expect( initializer ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toBe( 87 );
+
+		ref.current = undefined;
+		act( () => {
+			forceUpdate();
+		} );
+
+		expect( initializer ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toBe( undefined );
+
+		ref.current = null;
+		act( () => {
+			forceUpdate();
+		} );
+
+		expect( initializer ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toBe( null );
+	} );
+} );

--- a/packages/compose/src/hooks/use-shallow-compare-effect/index.js
+++ b/packages/compose/src/hooks/use-shallow-compare-effect/index.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import isShallowEqual from '@wordpress/is-shallow-equal';
+
+/**
+ * Like `useEffect` but call the effect when the dependencies are not shallowly equal.
+ * Useful when the size of the dependency array might change during re-renders.
+ * This hook is only used for backward-compatibility reason. Consider using `useEffect` wherever possible.
+ *
+ * @param {Function} effect The effect callback passed to `useEffect`.
+ * @param {Array}    deps   The dependency array that is compared against shallowly.
+ */
+function useShallowCompareEffect( effect, deps ) {
+	const ref = useRef();
+
+	if ( ! isShallowEqual( ref.current, deps ) ) {
+		ref.current = deps;
+	}
+
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	useEffect( effect, [ ref.current ] );
+}
+
+export default useShallowCompareEffect;

--- a/packages/compose/src/hooks/use-shallow-compare-effect/test/index.js
+++ b/packages/compose/src/hooks/use-shallow-compare-effect/test/index.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import React from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useShallowCompareEffect from '../';
+
+describe( 'useShallowCompareEffect', () => {
+	it( 'should call the effect when the dependencies are not shallowly equal', () => {
+		const effectCallback = jest.fn();
+
+		let deps = [ 1, 2, 3 ];
+
+		function TestComponent() {
+			useShallowCompareEffect( effectCallback, deps );
+			return null;
+		}
+
+		const { rerender } = render( <TestComponent /> );
+
+		expect( effectCallback ).toHaveBeenCalledTimes( 1 );
+
+		deps = [ 4, 5, 6 ];
+
+		rerender( <TestComponent /> );
+
+		expect( effectCallback ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'should not call the effect when the dependencies are shallowly equal', () => {
+		const effectCallback = jest.fn();
+
+		let deps = [ 1, 2, 3 ];
+
+		function TestComponent() {
+			useShallowCompareEffect( effectCallback, deps );
+			return null;
+		}
+
+		const { rerender } = render( <TestComponent /> );
+
+		expect( effectCallback ).toHaveBeenCalledTimes( 1 );
+
+		deps = [ 1, 2, 3 ]; // Different instance
+
+		rerender( <TestComponent /> );
+
+		expect( effectCallback ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -31,3 +31,6 @@ export { default as useAsyncList } from './hooks/use-async-list';
 export { default as useWarnOnChange } from './hooks/use-warn-on-change';
 export { default as useDebounce } from './hooks/use-debounce';
 export { default as useThrottle } from './hooks/use-throttle';
+export { default as useLazyRef } from './hooks/use-lazy-ref';
+export { default as useShallowCompareEffect } from './hooks/use-shallow-compare-effect';
+export { default as useDidMount } from './hooks/use-did-mount';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

It's the same as in #25064, I accidentally merged it into a wrong base branch. Since it's been a while, reopen this to get a fresh round of reviews.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Enable the `react-hooks/exhaustive-deps` rule by rebasing this branch onto #24914.
2. Run `npm run lint-js`
3. Tests should pass

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
