### PR TITLE
RichText: bypass paste filters for internal paste

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -55,6 +55,19 @@ import { store as blockEditorStore } from '../../store';
 const wrapperClasses = 'block-editor-rich-text';
 const classes = 'block-editor-rich-text__editable';
 
+function addActiveFormats( value, activeFormats ) {
+	if ( activeFormats.length ) {
+		let index = value.formats.length;
+
+		while ( index-- ) {
+			value.formats[ index ] = [
+				...activeFormats,
+				...( value.formats[ index ] || [] ),
+			];
+		}
+	}
+}
+
 /**
  * Get the multiline tag based on the multiline prop.
  *
@@ -412,7 +425,31 @@ function RichTextWrapper(
 	);
 
 	const onPaste = useCallback(
-		( { value, onChange, html, plainText, files, activeFormats } ) => {
+		( {
+			value,
+			onChange,
+			html,
+			plainText,
+			isInternal,
+			files,
+			activeFormats,
+		} ) => {
+			// If the data comes from a rich text instance, we can directly use it
+			// without filtering the data. The filters are only meant for externally
+			// pasted content and remove inline styles.
+			if ( isInternal ) {
+				const pastedValue = create( {
+					html,
+					multilineTag,
+					multilineWrapperTags:
+						multilineTag === 'li' ? [ 'ul', 'ol' ] : undefined,
+					preserveWhiteSpace,
+				} );
+				addActiveFormats( pastedValue, activeFormats );
+				onChange( insert( value, pastedValue ) );
+				return;
+			}
+
 			if ( pastePlainText ) {
 				onChange( insert( value, create( { text: plainText } ) ) );
 				return;
@@ -474,21 +511,11 @@ function RichTextWrapper(
 			if ( typeof content === 'string' ) {
 				let valueToInsert = create( { html: content } );
 
-				// If there are active formats, merge them with the pasted formats.
-				if ( activeFormats.length ) {
-					let index = valueToInsert.formats.length;
-
-					while ( index-- ) {
-						valueToInsert.formats[ index ] = [
-							...activeFormats,
-							...( valueToInsert.formats[ index ] || [] ),
-						];
-					}
-				}
+				addActiveFormats( valueToInsert, activeFormats );
 
 				// If the content should be multiline, we should process text
 				// separated by a line break as separate lines.
-				if ( multiline ) {
+				if ( multilineTag ) {
 					valueToInsert = replace(
 						valueToInsert,
 						/\n+/g,
@@ -511,7 +538,7 @@ function RichTextWrapper(
 			onSplit,
 			splitValue,
 			__unstableEmbedURLOnPaste,
-			multiline,
+			multilineTag,
 			preserveWhiteSpace,
 			pastePlainText,
 		]

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -121,7 +121,6 @@ async function emulateClipboard( type ) {
 
 			window._clipboardData.setData( 'text/plain', plainText );
 			window._clipboardData.setData( 'text/html', html );
-			window._clipboardData.setData( 'wp-e2e-test', 'true' );
 		}
 
 		document.activeElement.dispatchEvent(

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -121,6 +121,7 @@ async function emulateClipboard( type ) {
 
 			window._clipboardData.setData( 'text/plain', plainText );
 			window._clipboardData.setData( 'text/html', html );
+			window._clipboardData.setData( 'wp-e2e-test', 'true' );
 		}
 
 		document.activeElement.dispatchEvent(

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -82,6 +82,22 @@ exports[`RichText should only mutate text data on input 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should preserve internal formatting 1`] = `
+"<!-- wp:paragraph -->
+<p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should preserve internal formatting 2`] = `
+"<!-- wp:paragraph -->
+<p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should return focus when pressing formatting button 1`] = `
 "<!-- wp:paragraph -->
 <p>Some <strong>bold</strong>.</p>

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -8,6 +8,7 @@ import {
 	clickBlockAppender,
 	pressKeyWithModifier,
 	showBlockToolbar,
+	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'RichText', () => {
@@ -370,6 +371,46 @@ describe( 'RichText', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowLeft' );
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should preserve internal formatting', async () => {
+		await clickBlockAppender();
+
+		// Add text and select to color.
+		await page.keyboard.type( '1' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await clickBlockToolbarButton( 'More' );
+
+		const button = await page.waitForXPath(
+			`//button[contains(text(), 'Text color')]`
+		);
+		// Clicks may fail if the button is out of view. Assure it is before click.
+		await button.evaluate( ( element ) => element.scrollIntoView() );
+		await button.click();
+
+		// Select color other than black.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// Navigate to the block.
+		await page.keyboard.press( 'Tab' );
+		await pressKeyWithModifier( 'primary', 'a' );
+
+		// Copy the colored text.
+		await pressKeyWithModifier( 'primary', 'c' );
+
+		// Collapsed the selection to the end.
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Create a new paragraph.
+		await page.keyboard.press( 'Enter' );
+
+		// Paste the colored text.
 		await pressKeyWithModifier( 'primary', 'v' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -315,7 +315,10 @@ function RichText(
 
 	function handleCopy( event ) {
 		// Something other than the browser already set data.
-		if ( event.clipboardData.getData( 'text/plain' ) ) {
+		if (
+			event.clipboardData.getData( 'text/plain' ) &&
+			event.clipboardData.getData( 'wp-e2e-test' ) !== 'true'
+		) {
 			return;
 		}
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -314,11 +314,7 @@ function RichText(
 	}
 
 	function handleCopy( event ) {
-		// Something other than the browser already set data.
-		if (
-			event.clipboardData.getData( 'text/plain' ) &&
-			event.clipboardData.getData( 'wp-e2e-test' ) !== 'true'
-		) {
+		if ( isCollapsed( record.current ) ) {
 			return;
 		}
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -314,6 +314,11 @@ function RichText(
 	}
 
 	function handleCopy( event ) {
+		// Something other than the browser already set data.
+		if ( event.clipboardData.getData( 'text/plain' ) ) {
+			return;
+		}
+
 		const selectedRecord = slice( record.current );
 		const plainText = getTextContent( selectedRecord );
 		const html = toHTMLString( {
@@ -393,22 +398,16 @@ function RichText(
 			return;
 		}
 
-		// If the data comes from a rich text instance, we can directly use it
-		// without filtering the data. The filters are only meant for externally
-		// pasted content and remove inline styles.
-		if ( clipboardData.getData( 'rich-text' ) === 'true' ) {
-			handleChange( insert( record.current, formatToValue( html ) ) );
-			return;
-		}
-
 		if ( onPaste ) {
 			const files = getFilesFromDataTransfer( clipboardData );
+			const isInternal = clipboardData.getData( 'rich-text' ) === 'true';
 
 			onPaste( {
 				value: removeEditorOnlyFormats( record.current ),
 				onChange: handleChange,
 				html,
 				plainText,
+				isInternal,
 				files: [ ...files ],
 				activeFormats,
 			} );

--- a/packages/rich-text/src/get-text-content.js
+++ b/packages/rich-text/src/get-text-content.js
@@ -1,3 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import {
+	OBJECT_REPLACEMENT_CHARACTER,
+	LINE_SEPARATOR,
+} from './special-characters';
+
 /** @typedef {import('./create').RichTextValue} RichTextValue */
 
 /**
@@ -9,5 +17,7 @@
  * @return {string} The text content.
  */
 export function getTextContent( { text } ) {
-	return text;
+	return text
+		.replace( new RegExp( OBJECT_REPLACEMENT_CHARACTER, 'g' ), '' )
+		.replace( new RegExp( LINE_SEPARATOR, 'g' ), '\n' );
 }

--- a/packages/rich-text/src/insert-line-separator.js
+++ b/packages/rich-text/src/insert-line-separator.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 
-import { getTextContent } from './get-text-content';
 import { insert } from './insert';
 import { LINE_SEPARATOR } from './special-characters';
 
@@ -24,7 +23,7 @@ export function insertLineSeparator(
 	startIndex = value.start,
 	endIndex = value.end
 ) {
-	const beforeText = getTextContent( value ).slice( 0, startIndex );
+	const beforeText = value.text.slice( 0, startIndex );
 	const previousLineSeparatorIndex = beforeText.lastIndexOf( LINE_SEPARATOR );
 	const previousLineSeparatorFormats =
 		value.replacements[ previousLineSeparatorIndex ];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Currently copy paste between rich text fields is completely handled by the browser, which comes with some downsides:

* The data copied to the clipboard is not "clean". The browser will insert a lot of garbage HTML like inlining global styles.
* The pasted data into a rich text field receives this data from the browser and needs to clean it again through the past filters.

This is all useful when copy pasting external data, but not for internal data it can result in data loss. In rich text we allow a lot of custom and legacy formatting, which we don't allow through our paste filters for external data. Rich text should not run internally copied data through the paste filters and just accept it the way it was copied.

N.b.: setting clipboard data during copy/cut is not unprecedented. We already do this for selected blocks where we don't allow the browser to set unclean HTML.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
