### PR TITLE
Try: Make focus width a CSS variable.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -118,7 +118,7 @@
  */
 
 @mixin block-toolbar-button-style__focus() {
-	box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 4px $white;
+	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 4px $white;
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
@@ -454,6 +454,13 @@
 	// Darker shades.
 	--wp-admin-theme-color-darker-10: #{darken($color-primary, 5%)};
 	--wp-admin-theme-color-darker-20: #{darken($color-primary, 10%)};
+
+	// Focus style width.
+	// Avoid rounding issues by showing a whole 2px for 1x screens, and 1.5px on high resolution screens.
+	--wp-admin-border-width-focus: 2px;
+	@media ( -webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+		--wp-admin-border-width-focus: 1.5px;
+	}
 }
 
 @mixin wordpress-admin-schemes() {

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -83,7 +83,7 @@ $widget-area-width: 700px;
 
 $block-toolbar-height: $grid-unit-60;
 $border-width: 1px;
-$border-width-focus: 1.5px;
+$border-width-focus: 2px; // This exists as a fallback, and is ideally overridden by var(--wp-admin-border-width-focus) unless in some SASS math cases.
 $border-width-tab: 4px;
 $helptext-font-size: 12px;
 $radius-round: 50%;

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -37,7 +37,7 @@
 		right: $border-width;
 		bottom: $border-width;
 		left: $border-width;
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -62,7 +62,7 @@
 
 			// Everything else.
 			// 2px outside.
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 
 			// Windows High Contrast mode will show this outline.
@@ -70,7 +70,7 @@
 
 			// Show a lighter color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
 			}
 		}
 
@@ -87,8 +87,8 @@
 	}
 
 	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-		outline: $border-width-focus solid transparent;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		outline: var(--wp-admin-border-width-focus) solid transparent;
 	}
 
 	& .is-block-moving-mode.block-editor-block-list__block.is-selected {
@@ -184,12 +184,12 @@
 			right: $border-width;
 
 			// 2px outside.
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 
 			// Show a light color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
 			}
 		}
 	}
@@ -205,7 +205,7 @@
 
 		&:focus {
 			&::after {
-				box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			}
 		}
 	}
@@ -246,7 +246,7 @@
 		bottom: 0;
 		left: 0;
 		border-radius: $radius-block-ui;
-		box-shadow: 0 0 0 $border-width-focus transparent;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) transparent;
 	}
 
 	// Warnings
@@ -390,7 +390,7 @@
 .block-editor-block-list__insertion-point-indicator {
 	position: absolute;
 	top: calc(50% - #{ $border-width });
-	height: $border-width-focus;
+	height: var(--wp-admin-border-width-focus);
 	left: 0;
 	right: 0;
 	background: var(--wp-admin-theme-color);
@@ -518,7 +518,7 @@
 	@include reduce-motion("transition");
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 }
 
@@ -594,7 +594,7 @@
 
 		// When button is focused, it receives a box-shadow instead of the border.
 		&:focus {
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -16,7 +16,7 @@
 	flex-direction: column;
 
 	&:focus {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -20,7 +20,7 @@
 
 		&:focus:not(:disabled) {
 			border-color: var(--wp-admin-theme-color);
-			box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 (var(--wp-admin-border-width-focus) - $border-width) var(--wp-admin-theme-color);
 		}
 
 		svg {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -95,7 +95,7 @@ $block-inserter-tabs-height: 44px;
 
 		&:focus {
 			background: $white;
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 
 		&::placeholder {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -129,7 +129,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 	// The added specificity is needed to override.
 	&:focus:not(:disabled) {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color) inset;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) inset;
 	}
 
 	&.is-selected {

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -29,7 +29,7 @@
 		}
 
 		&:focus {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -29,7 +29,7 @@
 	// Focus.
 	// See https://github.com/WordPress/gutenberg/issues/13267 for more context on these selectors.
 	&:focus:not(:disabled) {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 3px solid transparent;
@@ -61,7 +61,7 @@
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 
 		&:disabled,
@@ -215,7 +215,7 @@
 			color: #124964;
 			box-shadow:
 				0 0 0 $border-width #5b9dd9,
-				0 0 $border-width-focus $border-width rgba(30, 140, 190, 0.8);
+				0 0 var(--wp-admin-border-width-focus) $border-width rgba(30, 140, 190, 0.8);
 		}
 
 		// Link buttons that are red to indicate destructive behavior.
@@ -302,7 +302,7 @@
 		background: $gray-900;
 
 		&:focus:not(:disabled) {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -36,7 +36,7 @@ $components-custom-gradient-picker__padding: 6px; // 36px container, 24px handle
 
 	.components-custom-gradient-picker__control-point-button {
 		border: 2px solid transparent;
-		box-shadow: inset 0 0 0 $border-width-focus $white;
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white;
 		border-radius: 50%;
 		height: $button-size-small;
 		width: $button-size-small;

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -68,7 +68,7 @@
 		text-align: center;
 
 		&:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 #{ $border-width-focus + $border-width } $white;
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 #{ $border-width-focus + $border-width } $white;
 			outline: 2px solid transparent; // Shown in Windows 10 high contrast mode.
 		}
 	}

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -89,7 +89,7 @@
 	height: auto;
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		border-radius: 0;
 	}
 

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -29,13 +29,13 @@
 	}
 
 	&:focus:not(:disabled) {
-		box-shadow: inset 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 
 
 	&.is-active {
 		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 		position: relative;
 
 		// This border appears in Windows High Contrast mode instead of the box-shadow.
@@ -51,10 +51,10 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 	}
 }

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -23,7 +23,7 @@
 		}
 
 		&:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 ($border-width-focus + 1px) $white;
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 ($border-width-focus + 1px) $white;
 		}
 	}
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -39,7 +39,7 @@
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
 			outline: 1px solid transparent;
 		}
 

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -25,7 +25,7 @@
 
 	&.is-active {
 		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 		position: relative;
 		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 
@@ -42,12 +42,12 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		position: relative;
 		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 	}
 }

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -29,7 +29,7 @@
 
 			&:focus {
 				border-color: var(--wp-admin-theme-color);
-				box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			}
 		}
 

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -36,7 +36,7 @@
 			color: $white;
 		}
 		&:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 3px $white;
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 3px $white;
 		}
 	}
 }

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -48,7 +48,7 @@
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
 			outline: 1px solid transparent;
 		}
 

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -49,7 +49,7 @@
 
 	&.is-active {
 		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 		font-weight: 600;
 		position: relative;
 
@@ -66,11 +66,11 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -58,7 +58,7 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/editor/src/components/post-last-revision/style.scss
+++ b/packages/editor/src/components/post-last-revision/style.scss
@@ -17,7 +17,7 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		border-radius: 0;
 	}
 }

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -27,7 +27,7 @@
 
 	&:focus {
 		border-color: var(--wp-admin-theme-color);
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 		// Elevate the z-index on focus so the focus style is uncropped.
 		position: relative;

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -31,7 +31,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 }
 
 .table-of-contents__counts {


### PR DESCRIPTION
Alternative to #27926, and also aims to fix #27925. CC and props: @stokesman 

The most urgent issue is that on 1x normal resolution screens, the 1.5px focus style rounds badly, causing the issues outlined in #27925. 

This PR adds the following base style:

```
--wp-admin-border-width-focus: 2px;
@media ( -webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
	--wp-admin-border-width-focus: 1.5px;
}
```

In other words, it makes the thickness of the focus style a CSS variable. This CSS variable is then overridden on high resolution screens. In my testing (Chrome, Safari, Firefox), it works as advertised:

2x screen:

<img width="1205" alt="Screenshot 2021-01-04 at 12 19 24" src="https://user-images.githubusercontent.com/1204802/103530970-b7bbf780-4e88-11eb-8d75-03095c7a2c5e.png">

1x Firefox (note, emulated):

<img width="635" alt="Screenshot 2021-01-04 at 12 23 38" src="https://user-images.githubusercontent.com/1204802/103530985-bab6e800-4e88-11eb-964c-abea867c8d73.png">

As far as I can tell, this solves the rounding issue, but lets us keep the more balanced but still thicker focus style for high resolution screens.

In addition to this, the move to making the focus style a CSS variable means that users can override these easily, whether through plugins or even a future option in settings, should you want a thicker focus style:

<img width="1093" alt="Screenshot 2021-01-04 at 12 32 09" src="https://user-images.githubusercontent.com/1204802/103531116-fce02980-4e88-11eb-8c26-4111e6ce4b7e.png">

This needs good testing. In addition, the placement of these rules in the mixin means the CSS variables are duplicated many times. This appears to be an existing issue, but I'm happy to move the initial definition somewhere else, for example to the block-list stylesheet.