### PR TITLE
Fix editor crash when registering a block pattern without `categories`

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -31,7 +31,7 @@ function BlockPatternsCategory( {
 		() =>
 			allCategories.filter( ( category ) =>
 				allPatterns.some( ( pattern ) =>
-					pattern.categories.includes( category.name )
+					pattern.categories?.includes( category.name )
 				)
 			),
 		[ allPatterns, allCategories ]


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/27249

This PR fixes the crash when registering a block pattern without `categories`.


## Testing instructions

1. Register a block pattern without `categories`
```
register_block_pattern(
	'test/test-case-block-pattern',
	array(
		'title'       => __( 'a simple heading', 'what should this be' ),
		'description' => _x( 'mmm..cake', ' this is slang and has more nuance in english', ''),
		'content'     => '<!-- wp:heading --><h2>The history of cake</h2><!-- /wp:heading -->',
	)
);
```
2. In a post/page open the `Inseter` and go to `Patterns` tab.
3. Observe that the editor doesn't crash and works as expected.

