### PR TITLE
[EXPERIMENTAL] react-i18n: client-side locale switching

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1752,6 +1752,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/react-i18n",
+		"slug": "packages-react-i18n",
+		"markdown_source": "../packages/react-i18n/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/react-native-aztec",
 		"slug": "packages-react-native-aztec",
 		"markdown_source": "../packages/react-native-aztec/README.md",

--- a/lib/class-wp-rest-translations-controller.php
+++ b/lib/class-wp-rest-translations-controller.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * REST API: WP_REST_Translations_Controller class
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Core class representing a controller for translations.
+ */
+class WP_REST_Translations_Controller extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = '__experimental';
+		$this->rest_base = 'translations';
+	}
+
+	/**
+	 * Registers the widget routes for the controller.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'locale' => array(
+							'description' => __( 'Locale', 'gutenberg' ),
+							'type'        => 'string',
+						),
+						'handles' => array(
+							'description' => __( 'Script Handles', 'gutenberg' ),
+							'type'        => 'array',
+							'required'    => true,
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
+				),
+				'allow_batch' => array( 'v1' => true ),
+				'schema'      => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	public function get_item_permissions_check( $request ) {
+		return true;
+	}
+
+	public function get_item( $request ) {
+		$switched = $request['locale'] && switch_to_locale( $request['locale'] );
+
+		$result = array();
+
+		foreach( $request['handles'] as $handle ) {
+			if ( ! isset( wp_scripts()->registered[ $handle ] ) ) {
+				continue;
+			}
+
+			/* @var \_WP_Dependency $script */
+			$script = wp_scripts()->registered[ $handle ];
+
+			if( ! $script ) {
+				continue;
+			}
+
+			$translations = load_script_textdomain( $handle, $script->textdomain, $script->translations_path );
+			if ( $translations ) {
+				$result[ $handle ] = json_decode( $translations );
+			}
+		}
+
+		if( $switched ) {
+			restore_previous_locale();
+		}
+
+		return $result;
+	}
+}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -94,6 +94,18 @@ function gutenberg_override_script( $scripts, $handle, $src, $deps = array(), $v
 	 */
 	if ( 'wp-i18n' !== $handle && 'wp-polyfill' !== $handle ) {
 		$scripts->set_translations( $handle, 'default' );
+
+		if ( $script && 'wp-react-i18n' !== $handle ) {
+//			$script->deps[] = 'wp-react-i18n';
+
+			$data = <<<JS
+( function( handle ) {
+	wp?.reactI18n?.addHandle( handle );
+} )( "{$handle}" );
+JS;
+
+			$scripts->add_inline_script( $handle, $data );
+		}
 	}
 }
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -59,6 +59,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_REST_Batch_Controller' ) ) {
 		require_once __DIR__ . '/class-wp-rest-batch-controller.php';
 	}
+	if ( ! class_exists( 'WP_REST_Translations_Controller' ) ) {
+		require_once __DIR__ . '/class-wp-rest-translations-controller.php';
+	}
 	/**
 	* End: Include for phase 2
 	*/

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -52,6 +52,15 @@ function gutenberg_register_batch_endpoint() {
 add_action( 'rest_api_init', 'gutenberg_register_batch_endpoint' );
 
 /**
+ * Registers the Translations REST API routes.
+ */
+function gutenberg_register_translations_endpoint() {
+	$translations = new WP_REST_Translations_Controller();
+	$translations->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_translations_endpoint' );
+
+/**
  * Hook in to the nav menu item post type and enable a post type rest endpoint.
  *
  * @param array  $args Current registered post type args.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1503,6 +1503,17 @@
 				"minimist": "^1.2.0"
 			}
 		},
+		"@dabh/diagnostics": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+			"integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+			"dev": true,
+			"requires": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
+			}
+		},
 		"@egjs/hammerjs": {
 			"version": "2.0.17",
 			"resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
@@ -4241,6 +4252,63 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
+				}
+			}
+		},
+		"@jimp/plugin-circle": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.10.3.tgz",
+			"integrity": "sha512-51GAPIVelqAcfuUpaM5JWJ0iWl4vEjNXB7p4P7SX5udugK5bxXUjO6KA2qgWmdpHuCKtoNgkzWU9fNSuYp7tCA==",
+			"requires": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.10.3",
+				"core-js": "^3.4.1"
+			}
+		},
+		"@jimp/plugin-fisheye": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.10.3.tgz",
+			"integrity": "sha512-RRZb1wqe+xdocGcFtj2xHU7sF7xmEZmIa6BmrfSchjyA2b32TGPWKnP3qyj7p6LWEsXn+19hRYbjfyzyebPElQ==",
+			"requires": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.10.3",
+				"core-js": "^3.4.1"
+			}
+		},
+		"@jimp/plugin-shadow": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.10.3.tgz",
+			"integrity": "sha512-/nkFXpt2zVcdP4ETdkAUL0fSzyrC5ZFxdcphbYBodqD7fXNqChS/Un1eD4xCXWEpW8cnG9dixZgQgStjywH0Mg==",
+			"requires": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.10.3",
+				"core-js": "^3.4.1"
+			}
+		},
+		"@jimp/plugin-threshold": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.10.3.tgz",
+			"integrity": "sha512-Dzh0Yq2wXP2SOnxcbbiyA4LJ2luwrdf1MghNIt9H+NX7B+IWw/N8qA2GuSm9n4BPGSLluuhdAWJqHcTiREriVA==",
+			"requires": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.10.3",
+				"core-js": "^3.4.1"
+			}
+		},
+		"@jimp/utils": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.10.3.tgz",
+			"integrity": "sha512-VcSlQhkil4ReYmg1KkN+WqHyYfZ2XfZxDsKAHSfST1GEz/RQHxKZbX+KhFKtKflnL0F4e6DlNQj3vznMNXCR2w==",
+			"requires": {
+				"@babel/runtime": "^7.7.2",
+				"core-js": "^3.4.1",
+				"regenerator-runtime": "^0.13.3"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.7",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 				}
 			}
 		},
@@ -11060,6 +11128,12 @@
 				"@types/responselike": "*"
 			}
 		},
+		"@types/caseless": {
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+			"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+			"dev": true
+		},
 		"@types/classnames": {
 			"version": "2.2.10",
 			"resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
@@ -11253,8 +11327,7 @@
 		"@types/node": {
 			"version": "12.7.11",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
-			"integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
-			"dev": true
+			"integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw=="
 		},
 		"@types/node-fetch": {
 			"version": "2.5.7",
@@ -11415,6 +11488,31 @@
 			"dev": true,
 			"requires": {
 				"@types/react": "*"
+			}
+		},
+		"@types/request": {
+			"version": "2.48.5",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+			"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+			"dev": true,
+			"requires": {
+				"@types/caseless": "*",
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"form-data": "^2.5.0"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+					"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+					"dev": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				}
 			}
 		},
 		"@types/requestidlecallback": {
@@ -11592,6 +11690,12 @@
 			"integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==",
 			"dev": true
 		},
+		"@types/tough-cookie": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+			"dev": true
+		},
 		"@types/uglify-js": {
 			"version": "3.9.2",
 			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.2.tgz",
@@ -11706,7 +11810,6 @@
 			"version": "2.9.1",
 			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
 			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"@types/node": "*"
@@ -11801,6 +11904,69 @@
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
+			}
+		},
+		"@wdio/config": {
+			"version": "6.1.14",
+			"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.1.14.tgz",
+			"integrity": "sha512-MXHMHwtkAblfnIxONs9aW//T9Fq5XIw3oH+tztcBRvNTTAIXmwHd+4sOjAwjpCdBSGs0C4kM/aTpGfwDZVURvQ==",
+			"dev": true,
+			"requires": {
+				"@wdio/logger": "6.0.16",
+				"deepmerge": "^4.0.0",
+				"glob": "^7.1.2"
+			},
+			"dependencies": {
+				"deepmerge": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+					"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+					"dev": true
+				}
+			}
+		},
+		"@wdio/logger": {
+			"version": "6.0.16",
+			"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.0.16.tgz",
+			"integrity": "sha512-VbH5UnQIG/3sSMV+Y38+rOdwyK9mVA9vuL7iOngoTafHwUjL1MObfN/Cex84L4mGxIgfxCu6GV48iUmSuQ7sqA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"loglevel": "^1.6.0",
+				"loglevel-plugin-prefix": "^0.8.4",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
+		"@wdio/protocols": {
+			"version": "6.1.25",
+			"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.1.25.tgz",
+			"integrity": "sha512-C84qqh5J6nE1zTjwF3svDUah3FvoUzMUGeRe8w//QPBcJIGNRgmVLgeFV7Cp2EwI5ag+BUfXExQ0bFtcZYHIVA==",
+			"dev": true
+		},
+		"@wdio/utils": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.2.0.tgz",
+			"integrity": "sha512-nPx430WPtZts09pcFwkTMO3zm6F7qvPuOcbvCschSW6ay8ebBvS6lkKnAHxCjrslsIF8+lOESuF0QrWycoouRA==",
+			"dev": true,
+			"requires": {
+				"@wdio/logger": "6.0.16"
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -12099,6 +12265,7 @@
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/react-i18n": "file:packages/react-i18n",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"@wordpress/token-list": "file:packages/token-list",
@@ -12469,6 +12636,7 @@
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/primitives": "file:packages/primitives",
+				"@wordpress/react-i18n": "file:packages/react-i18n",
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"@wordpress/warning": "file:packages/warning",
@@ -12572,6 +12740,7 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/react-i18n": "file:packages/react-i18n",
 				"@wordpress/reusable-blocks": "file:packages/reusable-blocks",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/server-side-render": "file:packages/server-side-render",
@@ -12883,6 +13052,16 @@
 				"@actions/core": "^1.0.0",
 				"@actions/github": "^1.0.0",
 				"@babel/runtime": "^7.12.5"
+			}
+		},
+		"@wordpress/react-i18n": {
+			"version": "file:packages/react-i18n",
+			"requires": {
+				"@babel/runtime": "^7.12.5",
+				"@wordpress/api-fetch": "file:packages/api-fetch",
+				"@wordpress/element": "file:packages/element",
+				"@wordpress/i18n": "file:packages/i18n",
+				"@wordpress/url": "file:packages/url"
 			}
 		},
 		"@wordpress/react-native-aztec": {
@@ -13724,27 +13903,14 @@
 					"version": "7.10.4",
 					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
 					"integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
-					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"@dabh/diagnostics": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
-					"integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-					"dev": true,
-					"requires": {
-						"colorspace": "1.1.x",
-						"enabled": "2.0.x",
-						"kuler": "^2.0.0"
 					}
 				},
 				"@jimp/bmp": {
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.10.3.tgz",
 					"integrity": "sha512-keMOc5woiDmONXsB/6aXLR4Z5Q+v8lFq3EY2rcj2FmstbDMhRuGbmcBxlEgOqfRjwvtf/wOtJ3Of37oAWtVfLg==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13756,7 +13922,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.10.3.tgz",
 					"integrity": "sha512-Gd5IpL3U2bFIO57Fh/OA3HCpWm4uW/pU01E75rI03BXfTdz3T+J7TwvyG1XaqsQ7/DSlS99GXtLQPlfFIe28UA==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13776,7 +13941,6 @@
 							"version": "0.5.5",
 							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-							"dev": true,
 							"requires": {
 								"minimist": "^1.2.5"
 							}
@@ -13787,7 +13951,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.10.3.tgz",
 					"integrity": "sha512-nZmSI+jwTi5IRyNLbKSXQovoeqsw+D0Jn0SxW08wYQvdkiWA8bTlDQFgQ7HVwCAKBm8oKkDB/ZEo9qvHJ+1gAQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/core": "^0.10.3",
@@ -13798,7 +13961,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.10.3.tgz",
 					"integrity": "sha512-vjlRodSfz1CrUvvrnUuD/DsLK1GHB/yDZXHthVdZu23zYJIW7/WrIiD1IgQ5wOMV7NocfrvPn2iqUfBP81/WWA==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13810,7 +13972,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.10.3.tgz",
 					"integrity": "sha512-AAANwgUZOt6f6P7LZxY9lyJ9xclqutYJlsxt3JbriXUGJgrrFAIkcKcqv1nObgmQASSAQKYaMV9KdHjMlWFKlQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13822,7 +13983,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.10.3.tgz",
 					"integrity": "sha512-5zlKlCfx4JWw9qUVC7GI4DzXyxDWyFvgZLaoGFoT00mlXlN75SarlDwc9iZ/2e2kp4bJWxz3cGgG4G/WXrbg3Q==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13833,18 +13993,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.10.3.tgz",
 					"integrity": "sha512-cTOK3rjh1Yjh23jSfA6EHCHjsPJDEGLC8K2y9gM7dnTUK1y9NNmkFS23uHpyjgsWFIoH9oRh2SpEs3INjCpZhQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.10.3",
-						"core-js": "^3.4.1"
-					}
-				},
-				"@jimp/plugin-circle": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.10.3.tgz",
-					"integrity": "sha512-51GAPIVelqAcfuUpaM5JWJ0iWl4vEjNXB7p4P7SX5udugK5bxXUjO6KA2qgWmdpHuCKtoNgkzWU9fNSuYp7tCA==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13855,7 +14003,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.10.3.tgz",
 					"integrity": "sha512-RgeHUElmlTH7vpI4WyQrz6u59spiKfVQbsG/XUzfWGamFSixa24ZDwX/yV/Ts+eNaz7pZeIuv533qmKPvw2ujg==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13867,7 +14014,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.10.3.tgz",
 					"integrity": "sha512-bYJKW9dqzcB0Ihc6u7jSyKa3juStzbLs2LFr6fu8TzA2WkMS/R8h+ddkiO36+F9ILTWHP0CIA3HFe5OdOGcigw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13878,7 +14024,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.10.3.tgz",
 					"integrity": "sha512-pOxu0cM0BRPzdV468n4dMocJXoMbTnARDY/EpC3ZW15SpMuc/dr1KhWQHgoQX5kVW1Wt8zgqREAJJCQ5KuPKDA==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13889,7 +14034,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.10.3.tgz",
 					"integrity": "sha512-nB7HgOjjl9PgdHr076xZ3Sr6qHYzeBYBs9qvs3tfEEUeYMNnvzgCCGtUl6eMakazZFCMk3mhKmcB9zQuHFOvkg==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13900,7 +14044,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.10.3.tgz",
 					"integrity": "sha512-8t3fVKCH5IVqI4lewe4lFFjpxxr69SQCz5/tlpDLQZsrNScNJivHdQ09zljTrVTCSgeCqQJIKgH2Q7Sk/pAZ0w==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13911,18 +14054,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.10.3.tgz",
 					"integrity": "sha512-JCX/oNSnEg1kGQ8ffZ66bEgQOLCY3Rn+lrd6v1jjLy/mn9YVZTMsxLtGCXpiCDC2wG/KTmi4862ysmP9do9dAQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.10.3",
-						"core-js": "^3.4.1"
-					}
-				},
-				"@jimp/plugin-fisheye": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.10.3.tgz",
-					"integrity": "sha512-RRZb1wqe+xdocGcFtj2xHU7sF7xmEZmIa6BmrfSchjyA2b32TGPWKnP3qyj7p6LWEsXn+19hRYbjfyzyebPElQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13933,7 +14064,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.10.3.tgz",
 					"integrity": "sha512-0epbi8XEzp0wmSjoW9IB0iMu0yNF17aZOxLdURCN3Zr+8nWPs5VNIMqSVa1Y62GSyiMDpVpKF/ITiXre+EqrPg==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13944,7 +14074,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.10.3.tgz",
 					"integrity": "sha512-25eHlFbHUDnMMGpgRBBeQ2AMI4wsqCg46sue0KklI+c2BaZ+dGXmJA5uT8RTOrt64/K9Wz5E+2n7eBnny4dfpQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13955,7 +14084,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.10.3.tgz",
 					"integrity": "sha512-effYSApWY/FbtlzqsKXlTLkgloKUiHBKjkQnqh5RL4oQxh/33j6aX+HFdDyQKtsXb8CMd4xd7wyiD2YYabTa0g==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13966,7 +14094,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.10.3.tgz",
 					"integrity": "sha512-twrg8q8TIhM9Z6Jcu9/5f+OCAPaECb0eKrrbbIajJqJ3bCUlj5zbfgIhiQIzjPJ6KjpnFPSqHQfHkU1Vvk/nVw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13977,7 +14104,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.10.3.tgz",
 					"integrity": "sha512-xkb5eZI/mMlbwKkDN79+1/t/+DBo8bBXZUMsT4gkFgMRKNRZ6NQPxlv1d3QpRzlocsl6UMxrHnhgnXdLAcgrXw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -13988,7 +14114,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.10.3.tgz",
 					"integrity": "sha512-wjRiI6yjXsAgMe6kVjizP+RgleUCLkH256dskjoNvJzmzbEfO7xQw9g6M02VET+emnbY0CO83IkrGm2q43VRyg==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -14000,7 +14125,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.10.3.tgz",
 					"integrity": "sha512-rf8YmEB1d7Sg+g4LpqF0Mp+dfXfb6JFJkwlAIWPUOR7lGsPWALavEwTW91c0etEdnp0+JB9AFpy6zqq7Lwkq6w==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -14011,7 +14135,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.10.3.tgz",
 					"integrity": "sha512-YXLlRjm18fkW9MOHUaVAxWjvgZM851ofOipytz5FyKp4KZWDLk+dZK1JNmVmK7MyVmAzZ5jsgSLhIgj+GgN0Eg==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -14022,29 +14145,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.10.3.tgz",
 					"integrity": "sha512-5DXD7x7WVcX1gUgnlFXQa8F+Q3ThRYwJm+aesgrYvDOY+xzRoRSdQvhmdd4JEEue3lyX44DvBSgCIHPtGcEPaw==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.10.3",
-						"core-js": "^3.4.1"
-					}
-				},
-				"@jimp/plugin-shadow": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.10.3.tgz",
-					"integrity": "sha512-/nkFXpt2zVcdP4ETdkAUL0fSzyrC5ZFxdcphbYBodqD7fXNqChS/Un1eD4xCXWEpW8cnG9dixZgQgStjywH0Mg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.10.3",
-						"core-js": "^3.4.1"
-					}
-				},
-				"@jimp/plugin-threshold": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.10.3.tgz",
-					"integrity": "sha512-Dzh0Yq2wXP2SOnxcbbiyA4LJ2luwrdf1MghNIt9H+NX7B+IWw/N8qA2GuSm9n4BPGSLluuhdAWJqHcTiREriVA==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -14055,7 +14155,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.10.3.tgz",
 					"integrity": "sha512-jTT3/7hOScf0EIKiAXmxwayHhryhc1wWuIe3FrchjDjr9wgIGNN2a7XwCgPl3fML17DXK1x8EzDneCdh261bkw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/plugin-blit": "^0.10.3",
@@ -14087,7 +14186,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.10.3.tgz",
 					"integrity": "sha512-YKqk/dkl+nGZxSYIDQrqhmaP8tC3IK8H7dFPnnzFVvbhDnyYunqBZZO3SaZUKTichClRw8k/CjBhbc+hifSGWg==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.10.3",
@@ -14098,8 +14196,7 @@
 						"pngjs": {
 							"version": "3.4.0",
 							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
+							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
 						}
 					}
 				},
@@ -14107,7 +14204,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.10.3.tgz",
 					"integrity": "sha512-7EsJzZ5Y/EtinkBGuwX3Bi4S+zgbKouxjt9c82VJTRJOQgLWsE/RHqcyRCOQBhHAZ9QexYmDz34medfLKdoX0g==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"core-js": "^3.4.1",
@@ -14118,7 +14214,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.10.3.tgz",
 					"integrity": "sha512-XGmBakiHZqseSWr/puGN+CHzx0IKBSpsKlmEmsNV96HKDiP6eu8NSnwdGCEq2mmIHe0JNcg1hqg59hpwtQ7Tiw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/bmp": "^0.10.3",
@@ -14134,7 +14229,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.10.3.tgz",
 					"integrity": "sha512-VcSlQhkil4ReYmg1KkN+WqHyYfZ2XfZxDsKAHSfST1GEz/RQHxKZbX+KhFKtKflnL0F4e6DlNQj3vznMNXCR2w==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"core-js": "^3.4.1",
@@ -14142,36 +14236,9 @@
 					}
 				},
 				"@sindresorhus/is": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.0.0.tgz",
-					"integrity": "sha512-kqA5I6Yun7PBHk8WN9BBP1c7FfN2SrD05GuVSEYPqDb4nerv7HqYfgBfMIKmT/EuejURkJKLZuLyGKGs6WEG9w==",
-					"dev": true
-				},
-				"@szmarczak/http-timer": {
-					"version": "4.0.5",
-					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-					"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
-					"dev": true,
-					"requires": {
-						"defer-to-connect": "^2.0.0"
-					}
-				},
-				"@types/cacheable-request": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-					"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
-					"dev": true,
-					"requires": {
-						"@types/http-cache-semantics": "*",
-						"@types/keyv": "*",
-						"@types/node": "*",
-						"@types/responselike": "*"
-					}
-				},
-				"@types/caseless": {
-					"version": "0.12.2",
-					"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-					"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+					"integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
 					"dev": true
 				},
 				"@types/color-name": {
@@ -14180,76 +14247,10 @@
 					"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 					"dev": true
 				},
-				"@types/http-cache-semantics": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-					"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
-					"dev": true
-				},
-				"@types/keyv": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-					"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*"
-					}
-				},
 				"@types/node": {
 					"version": "14.0.23",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-					"integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
-					"dev": true
-				},
-				"@types/request": {
-					"version": "2.48.5",
-					"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
-					"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
-					"dev": true,
-					"requires": {
-						"@types/caseless": "*",
-						"@types/node": "*",
-						"@types/tough-cookie": "*",
-						"form-data": "^2.5.0"
-					},
-					"dependencies": {
-						"form-data": {
-							"version": "2.5.1",
-							"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-							"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-							"dev": true,
-							"requires": {
-								"asynckit": "^0.4.0",
-								"combined-stream": "^1.0.6",
-								"mime-types": "^2.1.12"
-							}
-						}
-					}
-				},
-				"@types/responselike": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-					"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*"
-					}
-				},
-				"@types/tough-cookie": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-					"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
-					"dev": true
-				},
-				"@types/yauzl": {
-					"version": "2.9.1",
-					"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-					"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"@types/node": "*"
-					}
+					"integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw=="
 				},
 				"@wdio/config": {
 					"version": "6.1.14",
@@ -14336,12 +14337,6 @@
 						"yauzl": "^2.7.0"
 					}
 				},
-				"agent-base": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-					"dev": true
-				},
 				"aggregate-error": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -14384,8 +14379,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"ansi-styles": {
 					"version": "4.2.1",
@@ -14406,8 +14400,7 @@
 				"any-base": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-					"integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-					"dev": true
+					"integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
 				},
 				"appium-adb": {
 					"version": "8.6.2",
@@ -14621,6 +14614,655 @@
 						"lodash": "^4.0.0",
 						"source-map-support": "^0.5.5",
 						"teen_process": "^1.11.0"
+					},
+					"dependencies": {
+						"@jimp/bmp": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.9.8.tgz",
+							"integrity": "sha512-CZYQPEC3iUBMuaGWrtIG+GKNl93q/PkdudrCKJR/B96dfNngsmoosEm3LuFgJHEcJIfvnJkNqKw74l+zEiqCbg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"bmp-js": "^0.1.0",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/core": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.9.8.tgz",
+							"integrity": "sha512-N4GCjcXb0QwR5GBABDK2xQ3cKyaF7LlCYeJEG9mV7G/ynBoRqJe4JA6YKU9Ww9imGkci/4A594nQo8tUIqdcBw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"any-base": "^1.1.0",
+								"buffer": "^5.2.0",
+								"core-js": "^3.4.1",
+								"exif-parser": "^0.1.12",
+								"file-type": "^9.0.0",
+								"load-bmfont": "^1.3.1",
+								"mkdirp": "^0.5.1",
+								"phin": "^2.9.1",
+								"pixelmatch": "^4.0.2",
+								"tinycolor2": "^1.4.1"
+							},
+							"dependencies": {
+								"mkdirp": {
+									"version": "0.5.5",
+									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+									"dev": true,
+									"requires": {
+										"minimist": "^1.2.5"
+									}
+								}
+							}
+						},
+						"@jimp/custom": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.9.8.tgz",
+							"integrity": "sha512-1UpJjI7fhX02BWLJ/KEqPwkHH60eNkCNeD6hEd+IZdTwLXfZCfFiM5BVlpgiZYZJSsVoRiAL4ne2Q5mCiKPKyw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/core": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/gif": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.9.8.tgz",
+							"integrity": "sha512-LEbfpcO1sBJIQCJHchZjNlyNxzPjZQQ4X32klpQHZJG58n9FvL7Uuh1rpkrJRbqv3cU3P0ENNtTrsBDxsYwcfA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1",
+								"omggif": "^1.0.9"
+							}
+						},
+						"@jimp/jpeg": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.9.8.tgz",
+							"integrity": "sha512-5u29SUzbZ32ZMmOaz3gO0hXatwSCnsvEAXRCKZoPPgbsPoyFAiZKVxjfLzjkeQF6awkvJ8hZni5chM15SNMg+g==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1",
+								"jpeg-js": "^0.3.4"
+							}
+						},
+						"@jimp/plugin-blit": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.9.8.tgz",
+							"integrity": "sha512-6xTDomxJybhBcby1IUVaPydZFhxf+V0DRgfDlVK81kR9kSCoshJpzWqDuWrMqjNEPspPE7jRQwHMs0FdU7mVwQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-blur": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.9.8.tgz",
+							"integrity": "sha512-dqbxuNFBRbmt35iIRacdgma7nlXklmPThsKcGWNTDmqb/hniK5IC+0xSPzBV4qMI2fLGP39LWHqqDZ0xDz14dA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-circle": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.9.8.tgz",
+							"integrity": "sha512-+UStXUPCzPqzTixLC8eVqcFcEa6TS+BEM/6/hyM11TDb9sbiMGeUtgpwZP/euR5H5gfpAQDA1Ppzqhh5fuMDlw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-color": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.8.tgz",
+							"integrity": "sha512-SDHxOQsJHpt75hk6+sSlCPc2B3UJlXosFW+iLZ11xX1Qr0IdDtbfYlIoPmjKQFIDUNzqLSue/z7sKQ1OMZr/QA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1",
+								"tinycolor2": "^1.4.1"
+							}
+						},
+						"@jimp/plugin-contain": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.9.8.tgz",
+							"integrity": "sha512-oK52CPt7efozuLYCML7qOmpFeDt3zpU8qq8UZlnjsDs15reU6L8EiUbwYpJvzoEnEOh1ZqamB8F/gymViEO5og==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-cover": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.9.8.tgz",
+							"integrity": "sha512-nnamtHzMrNd5j5HRSPd1VzpZ8v9YYtUJPtvCdHOOiIjqG72jxJ2kTBlsS3oG5XS64h/2MJwpl/fmmMs1Tj1CmQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-crop": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.9.8.tgz",
+							"integrity": "sha512-Nv/6AIp4aJmbSIH2uiIqm+kSoShKM8eaX2fyrUTj811kio0hwD3f/vIxrWebvAqwDZjAFIAmMufFoFCVg6caoQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-displace": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.9.8.tgz",
+							"integrity": "sha512-0OgPjkOVa2xdbqI8P6gBKX/UK36RbaYVrFyXL8Jy9oNF69+LYWyTskuCu9YbGxzlCVjY/JFqQOvrKDbxgMYAKA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-dither": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.9.8.tgz",
+							"integrity": "sha512-jGM/4ByniZJnmV2fv8hKwyyydXZe/YzvgBcnB8XxzCq8kVR3Imcn+qnd2PEPZzIPKOTH4Cig/zo9Vk9Bs+m5FQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-fisheye": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.9.8.tgz",
+							"integrity": "sha512-VnsalrD05f4pxG1msjnkwIFi5QveOqRm4y7VkoZKNX+iqs4TvRnH5+HpBnfdMzX/RXBi+Lf/kpTtuZgbOu/QWw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-flip": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.9.8.tgz",
+							"integrity": "sha512-XbiZ4OfHD6woc0f6Sk7XxB6a7IyMjTRQ4pNU7APjaNxsl3L6qZC8qfCQphWVe3DHx7f3y7jEiPMvNnqRDP1xgA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-gaussian": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.9.8.tgz",
+							"integrity": "sha512-ZBl5RA6+4XAD+mtqLfiG7u+qd8W5yqq3RBNca8eFqUSVo1v+eB2tzeLel0CWfVC/z6cw93Awm/nVnm6/CL2Oew==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-invert": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.9.8.tgz",
+							"integrity": "sha512-ESploqCoF6qUv5IWhVLaO5fEcrYZEsAWPFflh6ROiD2mmFKQxfeK+vHnk3IDLHtUwWTkAZQNbk89BVq7xvaNpQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-mask": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.9.8.tgz",
+							"integrity": "sha512-zSvEisTV4iGsBReitEdnQuGJq9/1xB5mPATadYZmIlp8r5HpD72HQb0WdEtb51/pu9Odt8KAxUf0ASg/PRVUiQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-normalize": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.9.8.tgz",
+							"integrity": "sha512-dPFBfwTa67K1tRw1leCidQT25R3ozrTUUOpO4jcGFHqXvBTWaR8sML1qxdfOBWs164mE5YpfdTvu6MM/junvCg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-print": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.9.8.tgz",
+							"integrity": "sha512-nLLPv1/faehRsOjecXXUb6kzhRcZzImO55XuFZ0c90ZyoiHm4UFREwO5sKxHGvpLXS6RnkhvSav4+IWD2qGbEQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1",
+								"load-bmfont": "^1.4.0"
+							}
+						},
+						"@jimp/plugin-resize": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.9.8.tgz",
+							"integrity": "sha512-L80NZ+HKsiKFyeDc6AfneC4+5XACrdL2vnyAVfAAsb3pmamgT/jDInWvvGhyI0Y76vx2w6XikplzEznW/QQvWg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-rotate": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.9.8.tgz",
+							"integrity": "sha512-bpqzQheISYnBXKyU1lIj46uR7mRs0UhgEREWK70HnvFJSlRshdcoNMIrKamyrJeFdJrkYPSfR/a6D0d5zsWf1Q==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-scale": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.9.8.tgz",
+							"integrity": "sha512-QU3ZS4Lre8nN66U9dKCOC4FNfaOh/QJFYUmQPKpPS924oYbtnm4OlmsdfpK2hVMSVVyVOis8M+xpA1rDBnIp7w==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-shadow": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.9.8.tgz",
+							"integrity": "sha512-t/pE+QS3r1ZUxGIQNmwWDI3c5+/hLU+gxXD+C3EEC47/qk3gTBHpj/xDdGQBoObdT/HRjR048vC2BgBfzjj2hg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugin-threshold": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.9.8.tgz",
+							"integrity": "sha512-WWmC3lnIwOTPvkKu55w4DUY8Ehlzf3nU98bY0QtIzkqxkAOZU5m+lvgC/JxO5FyGiA57j9FLMIf0LsWkjARj7g==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1"
+							}
+						},
+						"@jimp/plugins": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.8.tgz",
+							"integrity": "sha512-tD+cxS9SuEZaQ1hhAkNKw9TkUAqfoBAhdWPBrEZDr/GvGPrvJR4pYmmpSYhc5IZmMbXfQayHTTGqjj8D18bToA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/plugin-blit": "^0.9.8",
+								"@jimp/plugin-blur": "^0.9.8",
+								"@jimp/plugin-circle": "^0.9.8",
+								"@jimp/plugin-color": "^0.9.8",
+								"@jimp/plugin-contain": "^0.9.8",
+								"@jimp/plugin-cover": "^0.9.8",
+								"@jimp/plugin-crop": "^0.9.8",
+								"@jimp/plugin-displace": "^0.9.8",
+								"@jimp/plugin-dither": "^0.9.8",
+								"@jimp/plugin-fisheye": "^0.9.8",
+								"@jimp/plugin-flip": "^0.9.8",
+								"@jimp/plugin-gaussian": "^0.9.8",
+								"@jimp/plugin-invert": "^0.9.8",
+								"@jimp/plugin-mask": "^0.9.8",
+								"@jimp/plugin-normalize": "^0.9.8",
+								"@jimp/plugin-print": "^0.9.8",
+								"@jimp/plugin-resize": "^0.9.8",
+								"@jimp/plugin-rotate": "^0.9.8",
+								"@jimp/plugin-scale": "^0.9.8",
+								"@jimp/plugin-shadow": "^0.9.8",
+								"@jimp/plugin-threshold": "^0.9.8",
+								"core-js": "^3.4.1",
+								"timm": "^1.6.1"
+							}
+						},
+						"@jimp/png": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.9.8.tgz",
+							"integrity": "sha512-9CqR8d40zQCDhbnXHqcwkAMnvlV0vk9xSyE6LHjkYHS7x18Unsz5txQdsaEkEcXxCrOQSoWyITfLezlrWXRJAA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.9.8",
+								"core-js": "^3.4.1",
+								"pngjs": "^3.3.3"
+							}
+						},
+						"@jimp/tiff": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.9.8.tgz",
+							"integrity": "sha512-eMxcpJivJqMByn2dZxUHLeh6qvVs5J/52kBF3TFa3C922OJ97D9l1C1h0WKUCBqFMWzMYapQQ4vwnLgpJ5tkow==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"core-js": "^3.4.1",
+								"utif": "^2.0.1"
+							}
+						},
+						"@jimp/types": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.9.8.tgz",
+							"integrity": "sha512-H5y/uqt0lqJ/ZN8pWqFG+pv8jPAppMKkTMByuC8YBIjWSsornwv44hjiWl93sbYhduLZY8ubz/CbX9jH2X6EwA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/bmp": "^0.9.8",
+								"@jimp/gif": "^0.9.8",
+								"@jimp/jpeg": "^0.9.8",
+								"@jimp/png": "^0.9.8",
+								"@jimp/tiff": "^0.9.8",
+								"core-js": "^3.4.1",
+								"timm": "^1.6.1"
+							}
+						},
+						"@jimp/utils": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
+							"integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"core-js": "^3.4.1"
+							}
+						},
+						"appium-support": {
+							"version": "2.43.0",
+							"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.43.0.tgz",
+							"integrity": "sha512-HELlIM6J0CI/ALHKbr8Z8TNjrnyw1QVdzLKCUX/l4Gw/MmaS4QvHNpuy3Bdd0MCxX/aw76q2F58HmCiwzHtAkg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.0.0",
+								"archiver": "^3.1.1",
+								"base64-stream": "^1.0.0",
+								"bluebird": "^3.5.1",
+								"bplist-creator": "^0",
+								"bplist-parser": "^0.2",
+								"extract-zip": "^1.6.0",
+								"glob": "^7.1.2",
+								"jimp": "^0.9.0",
+								"jsftp": "^2.1.2",
+								"klaw": "^3.0.0",
+								"lodash": "^4.2.1",
+								"md5-file": "^4.0.0",
+								"mjpeg-server": "^0.3.0",
+								"mkdirp": "^1.0.0",
+								"moment": "^2.24.0",
+								"mv": "^2.1.1",
+								"ncp": "^2.0.0",
+								"npmlog": "^4.1.2",
+								"plist": "^3.0.1",
+								"pluralize": "^8.0.0",
+								"pngjs": "^3.0.0",
+								"request": "^2.83.0",
+								"request-promise": "^4.2.2",
+								"rimraf": "^3.0.0",
+								"sanitize-filename": "^1.6.1",
+								"semver": "^7.0.0",
+								"shell-quote": "^1.7.2",
+								"source-map-support": "^0.5.5",
+								"teen_process": "^1.5.1",
+								"uuid": "^7.0.2",
+								"which": "^2.0.0",
+								"yauzl": "^2.7.0"
+							}
+						},
+						"archiver": {
+							"version": "3.1.1",
+							"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+							"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"async": "^2.6.3",
+								"buffer-crc32": "^0.2.1",
+								"glob": "^7.1.4",
+								"readable-stream": "^3.4.0",
+								"tar-stream": "^2.1.0",
+								"zip-stream": "^2.1.2"
+							}
+						},
+						"archiver-utils": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+							"dev": true,
+							"requires": {
+								"glob": "^7.1.4",
+								"graceful-fs": "^4.2.0",
+								"lazystream": "^1.0.0",
+								"lodash.defaults": "^4.2.0",
+								"lodash.difference": "^4.5.0",
+								"lodash.flatten": "^4.4.0",
+								"lodash.isplainobject": "^4.0.6",
+								"lodash.union": "^4.6.0",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^2.0.0"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
+							}
+						},
+						"async": {
+							"version": "2.6.3",
+							"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+							"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+							"dev": true,
+							"requires": {
+								"lodash": "^4.17.14"
+							}
+						},
+						"bl": {
+							"version": "4.0.2",
+							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+							"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.5.0",
+								"inherits": "^2.0.4",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"compress-commons": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+							"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+							"dev": true,
+							"requires": {
+								"buffer-crc32": "^0.2.13",
+								"crc32-stream": "^3.0.1",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^2.3.6"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
+							}
+						},
+						"crc32-stream": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+							"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+							"dev": true,
+							"requires": {
+								"crc": "^3.4.4",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"extract-zip": {
+							"version": "1.7.0",
+							"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+							"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+							"dev": true,
+							"requires": {
+								"concat-stream": "^1.6.2",
+								"debug": "^2.6.9",
+								"mkdirp": "^0.5.4",
+								"yauzl": "^2.10.0"
+							},
+							"dependencies": {
+								"mkdirp": {
+									"version": "0.5.5",
+									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+									"dev": true,
+									"requires": {
+										"minimist": "^1.2.5"
+									}
+								}
+							}
+						},
+						"jimp": {
+							"version": "0.9.8",
+							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.9.8.tgz",
+							"integrity": "sha512-DHN4apKMwLIvD/TKO9tFfPuankNuVK98vCwHm/Jv9z5cJnrd38xhi+4I7IAGmDU3jIDlrEVhzTkFH1Ymv5yTQQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/custom": "^0.9.8",
+								"@jimp/plugins": "^0.9.8",
+								"@jimp/types": "^0.9.8",
+								"core-js": "^3.4.1",
+								"regenerator-runtime": "^0.13.3"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						},
+						"normalize-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+							"dev": true
+						},
+						"pngjs": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "3.6.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+							"dev": true,
+							"requires": {
+								"inherits": "^2.0.3",
+								"string_decoder": "^1.1.1",
+								"util-deprecate": "^1.0.1"
+							}
+						},
+						"tar-stream": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+							"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+							"dev": true,
+							"requires": {
+								"bl": "^4.0.1",
+								"end-of-stream": "^1.4.1",
+								"fs-constants": "^1.0.0",
+								"inherits": "^2.0.3",
+								"readable-stream": "^3.1.1"
+							}
+						},
+						"uuid": {
+							"version": "7.0.3",
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+							"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+							"dev": true
+						},
+						"zip-stream": {
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+							"integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"compress-commons": "^2.1.1",
+								"readable-stream": "^3.4.0"
+							}
+						}
 					}
 				},
 				"appium-ios-device": {
@@ -14772,6 +15414,31 @@
 										"validate.js": "^0.13.0",
 										"webdriverio": "^5.10.9",
 										"ws": "^7.0.0"
+									},
+									"dependencies": {
+										"webdriverio": {
+											"version": "5.23.0",
+											"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-5.23.0.tgz",
+											"integrity": "sha512-hxt6Nuu2bBrTsVk7GfoFRTh63l4fRVXlK9U30RtPbHoWO5tcFdyUz2UTgeHEZ54ea1DQEVPfsgFiLnJULkWp1Q==",
+											"dev": true,
+											"requires": {
+												"@wdio/config": "5.22.4",
+												"@wdio/logger": "5.16.10",
+												"@wdio/repl": "5.23.0",
+												"@wdio/utils": "5.23.0",
+												"archiver": "^3.0.0",
+												"css-value": "^0.0.1",
+												"grapheme-splitter": "^1.0.2",
+												"lodash.clonedeep": "^4.5.0",
+												"lodash.isobject": "^3.0.2",
+												"lodash.isplainobject": "^4.0.6",
+												"lodash.zip": "^4.2.0",
+												"resq": "^1.6.0",
+												"rgb2hex": "^0.1.0",
+												"serialize-error": "^5.0.0",
+												"webdriver": "5.23.0"
+											}
+										}
 									}
 								}
 							}
@@ -14839,6 +15506,32 @@
 								}
 							}
 						},
+						"form-data": {
+							"version": "2.5.1",
+							"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+							"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+							"dev": true,
+							"requires": {
+								"asynckit": "^0.4.0",
+								"combined-stream": "^1.0.6",
+								"mime-types": "^2.1.12"
+							}
+						},
+						"node-simctl": {
+							"version": "5.3.0",
+							"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-5.3.0.tgz",
+							"integrity": "sha512-5EJPsorg+ZLxeLk6Cc5Q3hI4WcWkWSWkqQnJEJf3DrM9UekGvpgOUE8uZtr8dTtY/GZCsI30Ksusqm+zGq3NsA==",
+							"requires": {
+								"@babel/runtime": "^7.0.0",
+								"appium-support": "^2.37.0",
+								"appium-xcode": "^3.8.0",
+								"asyncbox": "^2.3.1",
+								"lodash": "^4.2.1",
+								"semver": "^7.0.0",
+								"source-map-support": "^0.5.5",
+								"teen_process": "^1.5.1"
+							}
+						},
 						"rgb2hex": {
 							"version": "0.1.10",
 							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.10.tgz",
@@ -14882,29 +15575,20 @@
 								"@wdio/utils": "5.23.0",
 								"lodash.merge": "^4.6.1",
 								"request": "^2.83.0"
-							}
-						},
-						"webdriverio": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-5.23.0.tgz",
-							"integrity": "sha512-hxt6Nuu2bBrTsVk7GfoFRTh63l4fRVXlK9U30RtPbHoWO5tcFdyUz2UTgeHEZ54ea1DQEVPfsgFiLnJULkWp1Q==",
-							"dev": true,
-							"requires": {
-								"@wdio/config": "5.22.4",
-								"@wdio/logger": "5.16.10",
-								"@wdio/repl": "5.23.0",
-								"@wdio/utils": "5.23.0",
-								"archiver": "^3.0.0",
-								"css-value": "^0.0.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"resq": "^1.6.0",
-								"rgb2hex": "^0.1.0",
-								"serialize-error": "^5.0.0",
-								"webdriver": "5.23.0"
+							},
+							"dependencies": {
+								"@types/request": {
+									"version": "2.48.5",
+									"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+									"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+									"dev": true,
+									"requires": {
+										"@types/caseless": "*",
+										"@types/node": "*",
+										"@types/tough-cookie": "*",
+										"form-data": "^2.5.0"
+									}
+								}
 							}
 						},
 						"xmldom": {
@@ -15019,17 +15703,388 @@
 						"source-map-support": "^0.5.5"
 					},
 					"dependencies": {
+						"@jimp/bmp": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
+							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"bmp-js": "^0.1.0"
+							}
+						},
+						"@jimp/core": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
+							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"any-base": "^1.1.0",
+								"buffer": "^5.2.0",
+								"exif-parser": "^0.1.12",
+								"file-type": "^9.0.0",
+								"load-bmfont": "^1.3.1",
+								"mkdirp": "^0.5.1",
+								"phin": "^2.9.1",
+								"pixelmatch": "^4.0.2",
+								"tinycolor2": "^1.4.1"
+							},
+							"dependencies": {
+								"mkdirp": {
+									"version": "0.5.5",
+									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+									"dev": true,
+									"requires": {
+										"minimist": "^1.2.5"
+									}
+								}
+							}
+						},
+						"@jimp/custom": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
+							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/core": "^0.14.0"
+							}
+						},
+						"@jimp/gif": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
+							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"gifwrap": "^0.9.2",
+								"omggif": "^1.0.9"
+							}
+						},
+						"@jimp/jpeg": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
+							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"jpeg-js": "^0.4.0"
+							}
+						},
+						"@jimp/plugin-blit": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
+							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-blur": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
+							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-circle": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
+							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-color": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
+							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"tinycolor2": "^1.4.1"
+							}
+						},
+						"@jimp/plugin-contain": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
+							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-cover": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
+							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-crop": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
+							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-displace": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
+							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-dither": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
+							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-fisheye": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
+							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-flip": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
+							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-gaussian": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
+							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-invert": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
+							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-mask": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
+							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-normalize": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
+							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-print": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
+							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"load-bmfont": "^1.4.0"
+							}
+						},
+						"@jimp/plugin-resize": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
+							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-rotate": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
+							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-scale": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
+							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-shadow": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
+							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-threshold": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
+							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugins": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
+							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/plugin-blit": "^0.14.0",
+								"@jimp/plugin-blur": "^0.14.0",
+								"@jimp/plugin-circle": "^0.14.0",
+								"@jimp/plugin-color": "^0.14.0",
+								"@jimp/plugin-contain": "^0.14.0",
+								"@jimp/plugin-cover": "^0.14.0",
+								"@jimp/plugin-crop": "^0.14.0",
+								"@jimp/plugin-displace": "^0.14.0",
+								"@jimp/plugin-dither": "^0.14.0",
+								"@jimp/plugin-fisheye": "^0.14.0",
+								"@jimp/plugin-flip": "^0.14.0",
+								"@jimp/plugin-gaussian": "^0.14.0",
+								"@jimp/plugin-invert": "^0.14.0",
+								"@jimp/plugin-mask": "^0.14.0",
+								"@jimp/plugin-normalize": "^0.14.0",
+								"@jimp/plugin-print": "^0.14.0",
+								"@jimp/plugin-resize": "^0.14.0",
+								"@jimp/plugin-rotate": "^0.14.0",
+								"@jimp/plugin-scale": "^0.14.0",
+								"@jimp/plugin-shadow": "^0.14.0",
+								"@jimp/plugin-threshold": "^0.14.0",
+								"timm": "^1.6.1"
+							}
+						},
+						"@jimp/png": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
+							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"pngjs": "^3.3.3"
+							},
+							"dependencies": {
+								"pngjs": {
+									"version": "3.4.0",
+									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+									"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+									"dev": true
+								}
+							}
+						},
+						"@jimp/tiff": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
+							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"utif": "^2.0.1"
+							}
+						},
+						"@jimp/types": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
+							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/bmp": "^0.14.0",
+								"@jimp/gif": "^0.14.0",
+								"@jimp/jpeg": "^0.14.0",
+								"@jimp/png": "^0.14.0",
+								"@jimp/tiff": "^0.14.0",
+								"timm": "^1.6.1"
+							}
+						},
+						"@jimp/utils": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"regenerator-runtime": "^0.13.3"
+							}
+						},
 						"appium-base-driver": {
-							"version": "7.3.0",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.3.0.tgz",
-							"integrity": "sha512-CVrpKPrch52KIDgXjMXfKs0/55R3X8TRkyu7xcun1cjl6nYlMb+wpoDCdlRmSBapMeEk148M7cYmBygJDAaBpw==",
+							"version": "7.4.0",
+							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.4.0.tgz",
+							"integrity": "sha512-+gh03W6XUsKSprw+8O7uG1i07NI7tpoPHMHM57T2oR05KygxqvrLaQrxej50AtKPWmHHiMaMV4lxxf/YKtKp6g==",
 							"dev": true,
 							"requires": {
 								"@babel/runtime": "^7.0.0",
 								"appium-support": "^2.48.0",
 								"async-lock": "^1.0.0",
 								"asyncbox": "^2.3.1",
-								"axios": "^0.20.0",
+								"axios": "^0.21.0",
 								"bluebird": "^3.5.3",
 								"body-parser": "^1.18.2",
 								"colors": "^1.1.2",
@@ -15045,27 +16100,782 @@
 								"validate.js": "^0.13.0",
 								"webdriverio": "^6.0.2",
 								"ws": "^7.0.0"
+							},
+							"dependencies": {
+								"appium-support": {
+									"version": "2.49.0",
+									"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
+									"integrity": "sha512-PtUsfpCjdGqZTTuRyH5U9iOGq9SpEVHg0H6/2HrazkX6ZvSQ+kIVYHTAGIXVeBJecfN9/syqgMmEekVgD15BGA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.0.0",
+										"archiver": "^5.0.0",
+										"axios": "^0.20.0",
+										"base64-stream": "^1.0.0",
+										"bluebird": "^3.5.1",
+										"bplist-creator": "^0",
+										"bplist-parser": "^0.2",
+										"form-data": "^3.0.0",
+										"get-stream": "^6.0.0",
+										"glob": "^7.1.2",
+										"jimp": "^0.14.0",
+										"jsftp": "^2.1.2",
+										"klaw": "^3.0.0",
+										"lockfile": "^1.0.4",
+										"lodash": "^4.2.1",
+										"mjpeg-server": "^0.3.0",
+										"mkdirp": "^1.0.0",
+										"moment": "^2.24.0",
+										"mv": "^2.1.1",
+										"ncp": "^2.0.0",
+										"npmlog": "^4.1.2",
+										"plist": "^3.0.1",
+										"pluralize": "^8.0.0",
+										"pngjs": "^5.0.0",
+										"rimraf": "^3.0.0",
+										"sanitize-filename": "^1.6.1",
+										"semver": "^7.0.0",
+										"shell-quote": "^1.7.2",
+										"source-map-support": "^0.5.5",
+										"teen_process": "^1.5.1",
+										"uuid": "^8.0.0",
+										"which": "^2.0.0",
+										"yauzl": "^2.7.0"
+									},
+									"dependencies": {
+										"axios": {
+											"version": "0.20.0",
+											"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+											"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+											"dev": true,
+											"requires": {
+												"follow-redirects": "^1.10.0"
+											}
+										}
+									}
+								},
+								"archiver": {
+									"version": "5.1.0",
+									"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
+									"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
+									"dev": true,
+									"requires": {
+										"archiver-utils": "^2.1.0",
+										"async": "^3.2.0",
+										"buffer-crc32": "^0.2.1",
+										"readable-stream": "^3.6.0",
+										"readdir-glob": "^1.0.0",
+										"tar-stream": "^2.1.4",
+										"zip-stream": "^4.0.4"
+									}
+								},
+								"bl": {
+									"version": "4.0.3",
+									"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+									"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+									"dev": true,
+									"requires": {
+										"buffer": "^5.5.0",
+										"inherits": "^2.0.4",
+										"readable-stream": "^3.4.0"
+									}
+								},
+								"compress-commons": {
+									"version": "4.0.2",
+									"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+									"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+									"dev": true,
+									"requires": {
+										"buffer-crc32": "^0.2.13",
+										"crc32-stream": "^4.0.1",
+										"normalize-path": "^3.0.0",
+										"readable-stream": "^3.6.0"
+									}
+								},
+								"crc32-stream": {
+									"version": "4.0.1",
+									"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
+									"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
+									"dev": true,
+									"requires": {
+										"crc-32": "^1.2.0",
+										"readable-stream": "^3.4.0"
+									}
+								},
+								"tar-stream": {
+									"version": "2.1.4",
+									"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+									"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+									"dev": true,
+									"requires": {
+										"bl": "^4.0.3",
+										"end-of-stream": "^1.4.1",
+										"fs-constants": "^1.0.0",
+										"inherits": "^2.0.3",
+										"readable-stream": "^3.1.1"
+									}
+								},
+								"uuid": {
+									"version": "8.3.2",
+									"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+									"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+									"dev": true
+								},
+								"zip-stream": {
+									"version": "4.0.4",
+									"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+									"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+									"dev": true,
+									"requires": {
+										"archiver-utils": "^2.1.0",
+										"compress-commons": "^4.0.2",
+										"readable-stream": "^3.6.0"
+									}
+								}
+							}
+						},
+						"appium-support": {
+							"version": "2.43.0",
+							"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.43.0.tgz",
+							"integrity": "sha512-HELlIM6J0CI/ALHKbr8Z8TNjrnyw1QVdzLKCUX/l4Gw/MmaS4QvHNpuy3Bdd0MCxX/aw76q2F58HmCiwzHtAkg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.0.0",
+								"archiver": "^3.1.1",
+								"base64-stream": "^1.0.0",
+								"bluebird": "^3.5.1",
+								"bplist-creator": "^0",
+								"bplist-parser": "^0.2",
+								"extract-zip": "^1.6.0",
+								"glob": "^7.1.2",
+								"jimp": "^0.9.0",
+								"jsftp": "^2.1.2",
+								"klaw": "^3.0.0",
+								"lodash": "^4.2.1",
+								"md5-file": "^4.0.0",
+								"mjpeg-server": "^0.3.0",
+								"mkdirp": "^1.0.0",
+								"moment": "^2.24.0",
+								"mv": "^2.1.1",
+								"ncp": "^2.0.0",
+								"npmlog": "^4.1.2",
+								"plist": "^3.0.1",
+								"pluralize": "^8.0.0",
+								"pngjs": "^3.0.0",
+								"request": "^2.83.0",
+								"request-promise": "^4.2.2",
+								"rimraf": "^3.0.0",
+								"sanitize-filename": "^1.6.1",
+								"semver": "^7.0.0",
+								"shell-quote": "^1.7.2",
+								"source-map-support": "^0.5.5",
+								"teen_process": "^1.5.1",
+								"uuid": "^7.0.2",
+								"which": "^2.0.0",
+								"yauzl": "^2.7.0"
+							},
+							"dependencies": {
+								"@jimp/bmp": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.9.8.tgz",
+									"integrity": "sha512-CZYQPEC3iUBMuaGWrtIG+GKNl93q/PkdudrCKJR/B96dfNngsmoosEm3LuFgJHEcJIfvnJkNqKw74l+zEiqCbg==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"bmp-js": "^0.1.0",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/core": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.9.8.tgz",
+									"integrity": "sha512-N4GCjcXb0QwR5GBABDK2xQ3cKyaF7LlCYeJEG9mV7G/ynBoRqJe4JA6YKU9Ww9imGkci/4A594nQo8tUIqdcBw==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"any-base": "^1.1.0",
+										"buffer": "^5.2.0",
+										"core-js": "^3.4.1",
+										"exif-parser": "^0.1.12",
+										"file-type": "^9.0.0",
+										"load-bmfont": "^1.3.1",
+										"mkdirp": "^0.5.1",
+										"phin": "^2.9.1",
+										"pixelmatch": "^4.0.2",
+										"tinycolor2": "^1.4.1"
+									},
+									"dependencies": {
+										"mkdirp": {
+											"version": "0.5.5",
+											"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+											"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+											"dev": true,
+											"requires": {
+												"minimist": "^1.2.5"
+											}
+										}
+									}
+								},
+								"@jimp/custom": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.9.8.tgz",
+									"integrity": "sha512-1UpJjI7fhX02BWLJ/KEqPwkHH60eNkCNeD6hEd+IZdTwLXfZCfFiM5BVlpgiZYZJSsVoRiAL4ne2Q5mCiKPKyw==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/core": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/gif": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.9.8.tgz",
+									"integrity": "sha512-LEbfpcO1sBJIQCJHchZjNlyNxzPjZQQ4X32klpQHZJG58n9FvL7Uuh1rpkrJRbqv3cU3P0ENNtTrsBDxsYwcfA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1",
+										"omggif": "^1.0.9"
+									}
+								},
+								"@jimp/jpeg": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.9.8.tgz",
+									"integrity": "sha512-5u29SUzbZ32ZMmOaz3gO0hXatwSCnsvEAXRCKZoPPgbsPoyFAiZKVxjfLzjkeQF6awkvJ8hZni5chM15SNMg+g==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1",
+										"jpeg-js": "^0.3.4"
+									}
+								},
+								"@jimp/plugin-blit": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.9.8.tgz",
+									"integrity": "sha512-6xTDomxJybhBcby1IUVaPydZFhxf+V0DRgfDlVK81kR9kSCoshJpzWqDuWrMqjNEPspPE7jRQwHMs0FdU7mVwQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-blur": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.9.8.tgz",
+									"integrity": "sha512-dqbxuNFBRbmt35iIRacdgma7nlXklmPThsKcGWNTDmqb/hniK5IC+0xSPzBV4qMI2fLGP39LWHqqDZ0xDz14dA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-circle": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.9.8.tgz",
+									"integrity": "sha512-+UStXUPCzPqzTixLC8eVqcFcEa6TS+BEM/6/hyM11TDb9sbiMGeUtgpwZP/euR5H5gfpAQDA1Ppzqhh5fuMDlw==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-color": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.8.tgz",
+									"integrity": "sha512-SDHxOQsJHpt75hk6+sSlCPc2B3UJlXosFW+iLZ11xX1Qr0IdDtbfYlIoPmjKQFIDUNzqLSue/z7sKQ1OMZr/QA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1",
+										"tinycolor2": "^1.4.1"
+									}
+								},
+								"@jimp/plugin-contain": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.9.8.tgz",
+									"integrity": "sha512-oK52CPt7efozuLYCML7qOmpFeDt3zpU8qq8UZlnjsDs15reU6L8EiUbwYpJvzoEnEOh1ZqamB8F/gymViEO5og==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-cover": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.9.8.tgz",
+									"integrity": "sha512-nnamtHzMrNd5j5HRSPd1VzpZ8v9YYtUJPtvCdHOOiIjqG72jxJ2kTBlsS3oG5XS64h/2MJwpl/fmmMs1Tj1CmQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-crop": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.9.8.tgz",
+									"integrity": "sha512-Nv/6AIp4aJmbSIH2uiIqm+kSoShKM8eaX2fyrUTj811kio0hwD3f/vIxrWebvAqwDZjAFIAmMufFoFCVg6caoQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-displace": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.9.8.tgz",
+									"integrity": "sha512-0OgPjkOVa2xdbqI8P6gBKX/UK36RbaYVrFyXL8Jy9oNF69+LYWyTskuCu9YbGxzlCVjY/JFqQOvrKDbxgMYAKA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-dither": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.9.8.tgz",
+									"integrity": "sha512-jGM/4ByniZJnmV2fv8hKwyyydXZe/YzvgBcnB8XxzCq8kVR3Imcn+qnd2PEPZzIPKOTH4Cig/zo9Vk9Bs+m5FQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-fisheye": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.9.8.tgz",
+									"integrity": "sha512-VnsalrD05f4pxG1msjnkwIFi5QveOqRm4y7VkoZKNX+iqs4TvRnH5+HpBnfdMzX/RXBi+Lf/kpTtuZgbOu/QWw==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-flip": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.9.8.tgz",
+									"integrity": "sha512-XbiZ4OfHD6woc0f6Sk7XxB6a7IyMjTRQ4pNU7APjaNxsl3L6qZC8qfCQphWVe3DHx7f3y7jEiPMvNnqRDP1xgA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-gaussian": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.9.8.tgz",
+									"integrity": "sha512-ZBl5RA6+4XAD+mtqLfiG7u+qd8W5yqq3RBNca8eFqUSVo1v+eB2tzeLel0CWfVC/z6cw93Awm/nVnm6/CL2Oew==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-invert": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.9.8.tgz",
+									"integrity": "sha512-ESploqCoF6qUv5IWhVLaO5fEcrYZEsAWPFflh6ROiD2mmFKQxfeK+vHnk3IDLHtUwWTkAZQNbk89BVq7xvaNpQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-mask": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.9.8.tgz",
+									"integrity": "sha512-zSvEisTV4iGsBReitEdnQuGJq9/1xB5mPATadYZmIlp8r5HpD72HQb0WdEtb51/pu9Odt8KAxUf0ASg/PRVUiQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-normalize": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.9.8.tgz",
+									"integrity": "sha512-dPFBfwTa67K1tRw1leCidQT25R3ozrTUUOpO4jcGFHqXvBTWaR8sML1qxdfOBWs164mE5YpfdTvu6MM/junvCg==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-print": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.9.8.tgz",
+									"integrity": "sha512-nLLPv1/faehRsOjecXXUb6kzhRcZzImO55XuFZ0c90ZyoiHm4UFREwO5sKxHGvpLXS6RnkhvSav4+IWD2qGbEQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1",
+										"load-bmfont": "^1.4.0"
+									}
+								},
+								"@jimp/plugin-resize": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.9.8.tgz",
+									"integrity": "sha512-L80NZ+HKsiKFyeDc6AfneC4+5XACrdL2vnyAVfAAsb3pmamgT/jDInWvvGhyI0Y76vx2w6XikplzEznW/QQvWg==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-rotate": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.9.8.tgz",
+									"integrity": "sha512-bpqzQheISYnBXKyU1lIj46uR7mRs0UhgEREWK70HnvFJSlRshdcoNMIrKamyrJeFdJrkYPSfR/a6D0d5zsWf1Q==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-scale": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.9.8.tgz",
+									"integrity": "sha512-QU3ZS4Lre8nN66U9dKCOC4FNfaOh/QJFYUmQPKpPS924oYbtnm4OlmsdfpK2hVMSVVyVOis8M+xpA1rDBnIp7w==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-shadow": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.9.8.tgz",
+									"integrity": "sha512-t/pE+QS3r1ZUxGIQNmwWDI3c5+/hLU+gxXD+C3EEC47/qk3gTBHpj/xDdGQBoObdT/HRjR048vC2BgBfzjj2hg==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugin-threshold": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.9.8.tgz",
+									"integrity": "sha512-WWmC3lnIwOTPvkKu55w4DUY8Ehlzf3nU98bY0QtIzkqxkAOZU5m+lvgC/JxO5FyGiA57j9FLMIf0LsWkjARj7g==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1"
+									}
+								},
+								"@jimp/plugins": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.8.tgz",
+									"integrity": "sha512-tD+cxS9SuEZaQ1hhAkNKw9TkUAqfoBAhdWPBrEZDr/GvGPrvJR4pYmmpSYhc5IZmMbXfQayHTTGqjj8D18bToA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/plugin-blit": "^0.9.8",
+										"@jimp/plugin-blur": "^0.9.8",
+										"@jimp/plugin-circle": "^0.9.8",
+										"@jimp/plugin-color": "^0.9.8",
+										"@jimp/plugin-contain": "^0.9.8",
+										"@jimp/plugin-cover": "^0.9.8",
+										"@jimp/plugin-crop": "^0.9.8",
+										"@jimp/plugin-displace": "^0.9.8",
+										"@jimp/plugin-dither": "^0.9.8",
+										"@jimp/plugin-fisheye": "^0.9.8",
+										"@jimp/plugin-flip": "^0.9.8",
+										"@jimp/plugin-gaussian": "^0.9.8",
+										"@jimp/plugin-invert": "^0.9.8",
+										"@jimp/plugin-mask": "^0.9.8",
+										"@jimp/plugin-normalize": "^0.9.8",
+										"@jimp/plugin-print": "^0.9.8",
+										"@jimp/plugin-resize": "^0.9.8",
+										"@jimp/plugin-rotate": "^0.9.8",
+										"@jimp/plugin-scale": "^0.9.8",
+										"@jimp/plugin-shadow": "^0.9.8",
+										"@jimp/plugin-threshold": "^0.9.8",
+										"core-js": "^3.4.1",
+										"timm": "^1.6.1"
+									}
+								},
+								"@jimp/png": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.9.8.tgz",
+									"integrity": "sha512-9CqR8d40zQCDhbnXHqcwkAMnvlV0vk9xSyE6LHjkYHS7x18Unsz5txQdsaEkEcXxCrOQSoWyITfLezlrWXRJAA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/utils": "^0.9.8",
+										"core-js": "^3.4.1",
+										"pngjs": "^3.3.3"
+									}
+								},
+								"@jimp/tiff": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.9.8.tgz",
+									"integrity": "sha512-eMxcpJivJqMByn2dZxUHLeh6qvVs5J/52kBF3TFa3C922OJ97D9l1C1h0WKUCBqFMWzMYapQQ4vwnLgpJ5tkow==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"core-js": "^3.4.1",
+										"utif": "^2.0.1"
+									}
+								},
+								"@jimp/types": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.9.8.tgz",
+									"integrity": "sha512-H5y/uqt0lqJ/ZN8pWqFG+pv8jPAppMKkTMByuC8YBIjWSsornwv44hjiWl93sbYhduLZY8ubz/CbX9jH2X6EwA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/bmp": "^0.9.8",
+										"@jimp/gif": "^0.9.8",
+										"@jimp/jpeg": "^0.9.8",
+										"@jimp/png": "^0.9.8",
+										"@jimp/tiff": "^0.9.8",
+										"core-js": "^3.4.1",
+										"timm": "^1.6.1"
+									}
+								},
+								"@jimp/utils": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
+									"integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"core-js": "^3.4.1"
+									}
+								},
+								"jimp": {
+									"version": "0.9.8",
+									"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.9.8.tgz",
+									"integrity": "sha512-DHN4apKMwLIvD/TKO9tFfPuankNuVK98vCwHm/Jv9z5cJnrd38xhi+4I7IAGmDU3jIDlrEVhzTkFH1Ymv5yTQQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.7.2",
+										"@jimp/custom": "^0.9.8",
+										"@jimp/plugins": "^0.9.8",
+										"@jimp/types": "^0.9.8",
+										"core-js": "^3.4.1",
+										"regenerator-runtime": "^0.13.3"
+									}
+								},
+								"jpeg-js": {
+									"version": "0.3.7",
+									"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
+									"integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
+									"dev": true
+								},
+								"pngjs": {
+									"version": "3.4.0",
+									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+									"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+									"dev": true
+								}
+							}
+						},
+						"archiver": {
+							"version": "3.1.1",
+							"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+							"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"async": "^2.6.3",
+								"buffer-crc32": "^0.2.1",
+								"glob": "^7.1.4",
+								"readable-stream": "^3.4.0",
+								"tar-stream": "^2.1.0",
+								"zip-stream": "^2.1.2"
+							},
+							"dependencies": {
+								"async": {
+									"version": "2.6.3",
+									"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+									"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+									"dev": true,
+									"requires": {
+										"lodash": "^4.17.14"
+									}
+								}
+							}
+						},
+						"archiver-utils": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+							"dev": true,
+							"requires": {
+								"glob": "^7.1.4",
+								"graceful-fs": "^4.2.0",
+								"lazystream": "^1.0.0",
+								"lodash.defaults": "^4.2.0",
+								"lodash.difference": "^4.5.0",
+								"lodash.flatten": "^4.4.0",
+								"lodash.isplainobject": "^4.0.6",
+								"lodash.union": "^4.6.0",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^2.0.0"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
 							}
 						},
 						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+							"version": "0.21.1",
+							"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+							"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
 							"dev": true,
 							"requires": {
 								"follow-redirects": "^1.10.0"
 							}
 						},
-						"follow-redirects": {
-							"version": "1.13.0",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-							"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+						"bl": {
+							"version": "4.0.2",
+							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+							"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.5.0",
+								"inherits": "^2.0.4",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"compress-commons": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+							"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+							"dev": true,
+							"requires": {
+								"buffer-crc32": "^0.2.13",
+								"crc32-stream": "^3.0.1",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^2.3.6"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
+							}
+						},
+						"crc32-stream": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+							"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+							"dev": true,
+							"requires": {
+								"crc": "^3.4.4",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"extract-zip": {
+							"version": "1.7.0",
+							"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+							"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+							"dev": true,
+							"requires": {
+								"concat-stream": "^1.6.2",
+								"debug": "^2.6.9",
+								"mkdirp": "^0.5.4",
+								"yauzl": "^2.10.0"
+							},
+							"dependencies": {
+								"mkdirp": {
+									"version": "0.5.5",
+									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+									"dev": true,
+									"requires": {
+										"minimist": "^1.2.5"
+									}
+								}
+							}
+						},
+						"get-stream": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+							"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
 							"dev": true
 						},
 						"http-status-codes": {
 							"version": "2.1.4",
 							"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
 							"integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg==",
+							"dev": true
+						},
+						"jimp": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
+							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/custom": "^0.14.0",
+								"@jimp/plugins": "^0.14.0",
+								"@jimp/types": "^0.14.0",
+								"regenerator-runtime": "^0.13.3"
+							}
+						},
+						"jpeg-js": {
+							"version": "0.4.2",
+							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+							"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
 							"dev": true
 						},
 						"lru-cache": {
@@ -15077,11 +16887,64 @@
 								"yallist": "^4.0.0"
 							}
 						},
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						},
+						"normalize-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "3.6.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+							"dev": true,
+							"requires": {
+								"inherits": "^2.0.3",
+								"string_decoder": "^1.1.1",
+								"util-deprecate": "^1.0.1"
+							}
+						},
+						"tar-stream": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+							"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+							"dev": true,
+							"requires": {
+								"bl": "^4.0.1",
+								"end-of-stream": "^1.4.1",
+								"fs-constants": "^1.0.0",
+								"inherits": "^2.0.3",
+								"readable-stream": "^3.1.1"
+							}
+						},
+						"uuid": {
+							"version": "7.0.3",
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+							"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+							"dev": true
+						},
 						"yallist": {
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 							"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 							"dev": true
+						},
+						"zip-stream": {
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+							"integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"compress-commons": "^2.1.1",
+								"readable-stream": "^3.4.0"
+							}
 						}
 					}
 				},
@@ -15103,7 +16966,6 @@
 					"version": "2.48.1",
 					"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.48.1.tgz",
 					"integrity": "sha512-vo6e8NdX5k+TFma1cc9uKy83mdyMAbZ0ugZRxyS7MwU11bDuepcd8dUktAI9MDWmiob+KjbOR/dG220pQ/M/xQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
 						"archiver": "^4.0.1",
@@ -15657,6 +17519,17 @@
 								"locate-path": "^3.0.0"
 							}
 						},
+						"form-data": {
+							"version": "2.5.1",
+							"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+							"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+							"dev": true,
+							"requires": {
+								"asynckit": "^0.4.0",
+								"combined-stream": "^1.0.6",
+								"mime-types": "^2.1.12"
+							}
+						},
 						"get-caller-file": {
 							"version": "1.0.3",
 							"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -15804,6 +17677,20 @@
 								"@wdio/utils": "5.23.0",
 								"lodash.merge": "^4.6.1",
 								"request": "^2.83.0"
+							},
+							"dependencies": {
+								"@types/request": {
+									"version": "2.48.5",
+									"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+									"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+									"dev": true,
+									"requires": {
+										"@types/caseless": "*",
+										"@types/node": "*",
+										"@types/tough-cookie": "*",
+										"form-data": "^2.5.0"
+									}
+								}
 							}
 						},
 						"webdriverio": {
@@ -15940,6 +17827,59 @@
 						"source-map-support": "^0.5.5",
 						"teen_process": "^1.3.1",
 						"yargs": "^15.3.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+							"dev": true
+						},
+						"string-width": {
+							"version": "4.2.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+							"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^8.0.0",
+								"is-fullwidth-code-point": "^3.0.0",
+								"strip-ansi": "^6.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^5.0.0"
+							}
+						},
+						"yargs": {
+							"version": "15.4.1",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+							"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+							"dev": true,
+							"requires": {
+								"cliui": "^6.0.0",
+								"decamelize": "^1.2.0",
+								"find-up": "^4.1.0",
+								"get-caller-file": "^2.0.1",
+								"require-directory": "^2.1.1",
+								"require-main-filename": "^2.0.0",
+								"set-blocking": "^2.0.0",
+								"string-width": "^4.2.0",
+								"which-module": "^2.0.0",
+								"y18n": "^4.0.0",
+								"yargs-parser": "^18.1.2"
+							}
+						}
 					}
 				},
 				"appium-uiautomator2-server": {
@@ -15969,16 +17909,16 @@
 					},
 					"dependencies": {
 						"appium-base-driver": {
-							"version": "7.3.0",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.3.0.tgz",
-							"integrity": "sha512-CVrpKPrch52KIDgXjMXfKs0/55R3X8TRkyu7xcun1cjl6nYlMb+wpoDCdlRmSBapMeEk148M7cYmBygJDAaBpw==",
+							"version": "7.4.0",
+							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.4.0.tgz",
+							"integrity": "sha512-+gh03W6XUsKSprw+8O7uG1i07NI7tpoPHMHM57T2oR05KygxqvrLaQrxej50AtKPWmHHiMaMV4lxxf/YKtKp6g==",
 							"dev": true,
 							"requires": {
 								"@babel/runtime": "^7.0.0",
 								"appium-support": "^2.48.0",
 								"async-lock": "^1.0.0",
 								"asyncbox": "^2.3.1",
-								"axios": "^0.20.0",
+								"axios": "^0.21.0",
 								"bluebird": "^3.5.3",
 								"body-parser": "^1.18.2",
 								"colors": "^1.1.2",
@@ -15997,21 +17937,15 @@
 							},
 							"dependencies": {
 								"axios": {
-									"version": "0.20.0",
-									"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-									"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+									"version": "0.21.1",
+									"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+									"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
 									"dev": true,
 									"requires": {
 										"follow-redirects": "^1.10.0"
 									}
 								}
 							}
-						},
-						"follow-redirects": {
-							"version": "1.13.0",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-							"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-							"dev": true
 						},
 						"http-status-codes": {
 							"version": "2.1.4",
@@ -16057,7 +17991,6 @@
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/appium-xcode/-/appium-xcode-3.10.0.tgz",
 					"integrity": "sha512-6Db49w2UjcdMn96nUMS/EGKE/6r/sgIPcw8mr9+e4Oeb5rvROAm/VeIWmwnov3uk2JG3SGkLTQRB9tROKKRDgw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
 						"appium-support": "^2.4.0",
@@ -16102,6 +18035,377 @@
 						"yargs": "^16.0.3"
 					},
 					"dependencies": {
+						"@jimp/bmp": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
+							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"bmp-js": "^0.1.0"
+							}
+						},
+						"@jimp/core": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
+							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"any-base": "^1.1.0",
+								"buffer": "^5.2.0",
+								"exif-parser": "^0.1.12",
+								"file-type": "^9.0.0",
+								"load-bmfont": "^1.3.1",
+								"mkdirp": "^0.5.1",
+								"phin": "^2.9.1",
+								"pixelmatch": "^4.0.2",
+								"tinycolor2": "^1.4.1"
+							},
+							"dependencies": {
+								"mkdirp": {
+									"version": "0.5.5",
+									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+									"dev": true,
+									"requires": {
+										"minimist": "^1.2.5"
+									}
+								}
+							}
+						},
+						"@jimp/custom": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
+							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/core": "^0.14.0"
+							}
+						},
+						"@jimp/gif": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
+							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"gifwrap": "^0.9.2",
+								"omggif": "^1.0.9"
+							}
+						},
+						"@jimp/jpeg": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
+							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"jpeg-js": "^0.4.0"
+							}
+						},
+						"@jimp/plugin-blit": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
+							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-blur": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
+							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-circle": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
+							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-color": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
+							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"tinycolor2": "^1.4.1"
+							}
+						},
+						"@jimp/plugin-contain": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
+							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-cover": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
+							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-crop": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
+							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-displace": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
+							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-dither": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
+							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-fisheye": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
+							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-flip": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
+							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-gaussian": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
+							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-invert": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
+							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-mask": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
+							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-normalize": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
+							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-print": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
+							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"load-bmfont": "^1.4.0"
+							}
+						},
+						"@jimp/plugin-resize": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
+							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-rotate": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
+							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-scale": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
+							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-shadow": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
+							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugin-threshold": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
+							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0"
+							}
+						},
+						"@jimp/plugins": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
+							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/plugin-blit": "^0.14.0",
+								"@jimp/plugin-blur": "^0.14.0",
+								"@jimp/plugin-circle": "^0.14.0",
+								"@jimp/plugin-color": "^0.14.0",
+								"@jimp/plugin-contain": "^0.14.0",
+								"@jimp/plugin-cover": "^0.14.0",
+								"@jimp/plugin-crop": "^0.14.0",
+								"@jimp/plugin-displace": "^0.14.0",
+								"@jimp/plugin-dither": "^0.14.0",
+								"@jimp/plugin-fisheye": "^0.14.0",
+								"@jimp/plugin-flip": "^0.14.0",
+								"@jimp/plugin-gaussian": "^0.14.0",
+								"@jimp/plugin-invert": "^0.14.0",
+								"@jimp/plugin-mask": "^0.14.0",
+								"@jimp/plugin-normalize": "^0.14.0",
+								"@jimp/plugin-print": "^0.14.0",
+								"@jimp/plugin-resize": "^0.14.0",
+								"@jimp/plugin-rotate": "^0.14.0",
+								"@jimp/plugin-scale": "^0.14.0",
+								"@jimp/plugin-shadow": "^0.14.0",
+								"@jimp/plugin-threshold": "^0.14.0",
+								"timm": "^1.6.1"
+							}
+						},
+						"@jimp/png": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
+							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/utils": "^0.14.0",
+								"pngjs": "^3.3.3"
+							},
+							"dependencies": {
+								"pngjs": {
+									"version": "3.4.0",
+									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+									"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+									"dev": true
+								}
+							}
+						},
+						"@jimp/tiff": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
+							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"utif": "^2.0.1"
+							}
+						},
+						"@jimp/types": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
+							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/bmp": "^0.14.0",
+								"@jimp/gif": "^0.14.0",
+								"@jimp/jpeg": "^0.14.0",
+								"@jimp/png": "^0.14.0",
+								"@jimp/tiff": "^0.14.0",
+								"timm": "^1.6.1"
+							}
+						},
+						"@jimp/utils": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"regenerator-runtime": "^0.13.3"
+							}
+						},
 						"@wdio/config": {
 							"version": "5.22.4",
 							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-5.22.4.tgz",
@@ -16157,16 +18461,16 @@
 							"dev": true
 						},
 						"appium-base-driver": {
-							"version": "7.3.0",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.3.0.tgz",
-							"integrity": "sha512-CVrpKPrch52KIDgXjMXfKs0/55R3X8TRkyu7xcun1cjl6nYlMb+wpoDCdlRmSBapMeEk148M7cYmBygJDAaBpw==",
+							"version": "7.4.0",
+							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.4.0.tgz",
+							"integrity": "sha512-+gh03W6XUsKSprw+8O7uG1i07NI7tpoPHMHM57T2oR05KygxqvrLaQrxej50AtKPWmHHiMaMV4lxxf/YKtKp6g==",
 							"dev": true,
 							"requires": {
 								"@babel/runtime": "^7.0.0",
 								"appium-support": "^2.48.0",
 								"async-lock": "^1.0.0",
 								"asyncbox": "^2.3.1",
-								"axios": "^0.20.0",
+								"axios": "^0.21.0",
 								"bluebird": "^3.5.3",
 								"body-parser": "^1.18.2",
 								"colors": "^1.1.2",
@@ -16182,6 +18486,138 @@
 								"validate.js": "^0.13.0",
 								"webdriverio": "^6.0.2",
 								"ws": "^7.0.0"
+							},
+							"dependencies": {
+								"appium-support": {
+									"version": "2.49.0",
+									"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
+									"integrity": "sha512-PtUsfpCjdGqZTTuRyH5U9iOGq9SpEVHg0H6/2HrazkX6ZvSQ+kIVYHTAGIXVeBJecfN9/syqgMmEekVgD15BGA==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.0.0",
+										"archiver": "^5.0.0",
+										"axios": "^0.20.0",
+										"base64-stream": "^1.0.0",
+										"bluebird": "^3.5.1",
+										"bplist-creator": "^0",
+										"bplist-parser": "^0.2",
+										"form-data": "^3.0.0",
+										"get-stream": "^6.0.0",
+										"glob": "^7.1.2",
+										"jimp": "^0.14.0",
+										"jsftp": "^2.1.2",
+										"klaw": "^3.0.0",
+										"lockfile": "^1.0.4",
+										"lodash": "^4.2.1",
+										"mjpeg-server": "^0.3.0",
+										"mkdirp": "^1.0.0",
+										"moment": "^2.24.0",
+										"mv": "^2.1.1",
+										"ncp": "^2.0.0",
+										"npmlog": "^4.1.2",
+										"plist": "^3.0.1",
+										"pluralize": "^8.0.0",
+										"pngjs": "^5.0.0",
+										"rimraf": "^3.0.0",
+										"sanitize-filename": "^1.6.1",
+										"semver": "^7.0.0",
+										"shell-quote": "^1.7.2",
+										"source-map-support": "^0.5.5",
+										"teen_process": "^1.5.1",
+										"uuid": "^8.0.0",
+										"which": "^2.0.0",
+										"yauzl": "^2.7.0"
+									},
+									"dependencies": {
+										"axios": {
+											"version": "0.20.0",
+											"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+											"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+											"dev": true,
+											"requires": {
+												"follow-redirects": "^1.10.0"
+											}
+										}
+									}
+								},
+								"archiver": {
+									"version": "5.1.0",
+									"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
+									"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
+									"dev": true,
+									"requires": {
+										"archiver-utils": "^2.1.0",
+										"async": "^3.2.0",
+										"buffer-crc32": "^0.2.1",
+										"readable-stream": "^3.6.0",
+										"readdir-glob": "^1.0.0",
+										"tar-stream": "^2.1.4",
+										"zip-stream": "^4.0.4"
+									}
+								},
+								"bl": {
+									"version": "4.0.3",
+									"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+									"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+									"dev": true,
+									"requires": {
+										"buffer": "^5.5.0",
+										"inherits": "^2.0.4",
+										"readable-stream": "^3.4.0"
+									}
+								},
+								"compress-commons": {
+									"version": "4.0.2",
+									"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+									"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+									"dev": true,
+									"requires": {
+										"buffer-crc32": "^0.2.13",
+										"crc32-stream": "^4.0.1",
+										"normalize-path": "^3.0.0",
+										"readable-stream": "^3.6.0"
+									}
+								},
+								"crc32-stream": {
+									"version": "4.0.1",
+									"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
+									"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
+									"dev": true,
+									"requires": {
+										"crc-32": "^1.2.0",
+										"readable-stream": "^3.4.0"
+									}
+								},
+								"tar-stream": {
+									"version": "2.1.4",
+									"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+									"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+									"dev": true,
+									"requires": {
+										"bl": "^4.0.3",
+										"end-of-stream": "^1.4.1",
+										"fs-constants": "^1.0.0",
+										"inherits": "^2.0.3",
+										"readable-stream": "^3.1.1"
+									}
+								},
+								"uuid": {
+									"version": "8.3.2",
+									"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+									"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+									"dev": true
+								},
+								"zip-stream": {
+									"version": "4.0.4",
+									"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+									"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+									"dev": true,
+									"requires": {
+										"archiver-utils": "^2.1.0",
+										"compress-commons": "^4.0.2",
+										"readable-stream": "^3.6.0"
+									}
+								}
 							}
 						},
 						"appium-ios-driver": {
@@ -16278,6 +18714,78 @@
 										}
 									}
 								},
+								"archiver": {
+									"version": "3.1.1",
+									"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+									"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+									"dev": true,
+									"requires": {
+										"archiver-utils": "^2.1.0",
+										"async": "^2.6.3",
+										"buffer-crc32": "^0.2.1",
+										"glob": "^7.1.4",
+										"readable-stream": "^3.4.0",
+										"tar-stream": "^2.1.0",
+										"zip-stream": "^2.1.2"
+									}
+								},
+								"async": {
+									"version": "2.6.3",
+									"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+									"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+									"dev": true,
+									"requires": {
+										"lodash": "^4.17.14"
+									}
+								},
+								"axios": {
+									"version": "0.20.0",
+									"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+									"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+									"dev": true,
+									"requires": {
+										"follow-redirects": "^1.10.0"
+									}
+								},
+								"compress-commons": {
+									"version": "2.1.1",
+									"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+									"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+									"dev": true,
+									"requires": {
+										"buffer-crc32": "^0.2.13",
+										"crc32-stream": "^3.0.1",
+										"normalize-path": "^3.0.0",
+										"readable-stream": "^2.3.6"
+									},
+									"dependencies": {
+										"readable-stream": {
+											"version": "2.3.7",
+											"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+											"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+											"dev": true,
+											"requires": {
+												"core-util-is": "~1.0.0",
+												"inherits": "~2.0.3",
+												"isarray": "~1.0.0",
+												"process-nextick-args": "~2.0.0",
+												"safe-buffer": "~5.1.1",
+												"string_decoder": "~1.1.1",
+												"util-deprecate": "~1.0.1"
+											}
+										}
+									}
+								},
+								"crc32-stream": {
+									"version": "3.0.1",
+									"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+									"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+									"dev": true,
+									"requires": {
+										"crc": "^3.4.4",
+										"readable-stream": "^3.4.0"
+									}
+								},
 								"http-status-codes": {
 									"version": "1.4.0",
 									"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
@@ -16327,13 +18835,24 @@
 									"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 									"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 									"dev": true
+								},
+								"zip-stream": {
+									"version": "2.1.3",
+									"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+									"integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+									"dev": true,
+									"requires": {
+										"archiver-utils": "^2.1.0",
+										"compress-commons": "^2.1.1",
+										"readable-stream": "^3.4.0"
+									}
 								}
 							}
 						},
 						"appium-ios-simulator": {
-							"version": "3.24.0",
-							"resolved": "https://registry.npmjs.org/appium-ios-simulator/-/appium-ios-simulator-3.24.0.tgz",
-							"integrity": "sha512-L41PTIik8hzP9Ar98tvM+5jny7J+2pXxJuhi2o/f6Bv1M/gPy6fXcYRLO9cEJjIOz5Qw7orsROxvNM+JvY9Biw==",
+							"version": "3.27.0",
+							"resolved": "https://registry.npmjs.org/appium-ios-simulator/-/appium-ios-simulator-3.27.0.tgz",
+							"integrity": "sha512-JCg1Q98QSLZOpghLPeQ6jhvJg4PCJ6pQm94iDV7n9L8Gq5YP7teLCZTKoTtPHKC5mC5LbOq/JPL3zuAl+/LpkA==",
 							"dev": true,
 							"requires": {
 								"@babel/runtime": "^7.0.0",
@@ -16343,17 +18862,17 @@
 								"asyncbox": "^2.3.1",
 								"bluebird": "^3.5.1",
 								"lodash": "^4.2.1",
-								"node-simctl": "^6.3.0",
-								"openssl-wrapper": "^0.3.4",
+								"node-simctl": "^6.4.0",
 								"semver": "^7.0.0",
 								"source-map-support": "^0.5.3",
-								"teen_process": "^1.3.0"
+								"teen_process": "^1.3.0",
+								"xmldom": "^0.4.0"
 							},
 							"dependencies": {
 								"node-simctl": {
-									"version": "6.3.4",
-									"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-6.3.4.tgz",
-									"integrity": "sha512-kjNtuyuKW5FXJI1hu2YRD+kP4eb9LnuwUWH1NfZYWtkbq/rDki0mhMnUOUtloqaHaLRMPN3ZbHkgJbww6NWJmw==",
+									"version": "6.4.1",
+									"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-6.4.1.tgz",
+									"integrity": "sha512-RkEvbv2SJYDJF5eBJ0rRGZRU/LOypLmUAPLI/s7KqJAk0rSbG45x2OF2eqbK9+pfzL7N9XPorIcqtS75cYIydw==",
 									"dev": true,
 									"requires": {
 										"@babel/runtime": "^7.0.0",
@@ -16368,73 +18887,98 @@
 										"uuid": "^8.0.0",
 										"which": "^2.0.0"
 									}
+								},
+								"xmldom": {
+									"version": "0.4.0",
+									"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
+									"integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
+									"dev": true
+								}
+							}
+						},
+						"appium-support": {
+							"version": "2.49.0",
+							"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
+							"integrity": "sha512-PtUsfpCjdGqZTTuRyH5U9iOGq9SpEVHg0H6/2HrazkX6ZvSQ+kIVYHTAGIXVeBJecfN9/syqgMmEekVgD15BGA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.0.0",
+								"archiver": "^5.0.0",
+								"axios": "^0.20.0",
+								"base64-stream": "^1.0.0",
+								"bluebird": "^3.5.1",
+								"bplist-creator": "^0",
+								"bplist-parser": "^0.2",
+								"form-data": "^3.0.0",
+								"get-stream": "^6.0.0",
+								"glob": "^7.1.2",
+								"jimp": "^0.14.0",
+								"jsftp": "^2.1.2",
+								"klaw": "^3.0.0",
+								"lockfile": "^1.0.4",
+								"lodash": "^4.2.1",
+								"mjpeg-server": "^0.3.0",
+								"mkdirp": "^1.0.0",
+								"moment": "^2.24.0",
+								"mv": "^2.1.1",
+								"ncp": "^2.0.0",
+								"npmlog": "^4.1.2",
+								"plist": "^3.0.1",
+								"pluralize": "^8.0.0",
+								"pngjs": "^5.0.0",
+								"rimraf": "^3.0.0",
+								"sanitize-filename": "^1.6.1",
+								"semver": "^7.0.0",
+								"shell-quote": "^1.7.2",
+								"source-map-support": "^0.5.5",
+								"teen_process": "^1.5.1",
+								"uuid": "^8.0.0",
+								"which": "^2.0.0",
+								"yauzl": "^2.7.0"
+							},
+							"dependencies": {
+								"axios": {
+									"version": "0.20.0",
+									"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+									"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+									"dev": true,
+									"requires": {
+										"follow-redirects": "^1.10.0"
+									}
 								}
 							}
 						},
 						"archiver": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-							"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
+							"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
 							"dev": true,
 							"requires": {
 								"archiver-utils": "^2.1.0",
-								"async": "^2.6.3",
+								"async": "^3.2.0",
 								"buffer-crc32": "^0.2.1",
+								"readable-stream": "^3.6.0",
+								"readdir-glob": "^1.0.0",
+								"tar-stream": "^2.1.4",
+								"zip-stream": "^4.0.4"
+							}
+						},
+						"archiver-utils": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+							"dev": true,
+							"requires": {
 								"glob": "^7.1.4",
-								"readable-stream": "^3.4.0",
-								"tar-stream": "^2.1.0",
-								"zip-stream": "^2.1.2"
-							}
-						},
-						"async": {
-							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-							"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.14"
-							}
-						},
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
-							}
-						},
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"cliui": {
-							"version": "7.0.1",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
-							"integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
-							"dev": true,
-							"requires": {
-								"string-width": "^4.2.0",
-								"strip-ansi": "^6.0.0",
-								"wrap-ansi": "^7.0.0"
-							}
-						},
-						"compress-commons": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-							"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
-							"dev": true,
-							"requires": {
-								"buffer-crc32": "^0.2.13",
-								"crc32-stream": "^3.0.1",
+								"graceful-fs": "^4.2.0",
+								"lazystream": "^1.0.0",
+								"lodash.defaults": "^4.2.0",
+								"lodash.difference": "^4.5.0",
+								"lodash.flatten": "^4.4.0",
+								"lodash.isplainobject": "^4.0.6",
+								"lodash.union": "^4.6.0",
 								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.3.6"
+								"readable-stream": "^2.0.0"
 							},
 							"dependencies": {
 								"readable-stream": {
@@ -16454,16 +18998,73 @@
 								}
 							}
 						},
-						"escalade": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-							"integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
-							"dev": true
+						"axios": {
+							"version": "0.21.1",
+							"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+							"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+							"dev": true,
+							"requires": {
+								"follow-redirects": "^1.10.0"
+							}
 						},
-						"follow-redirects": {
-							"version": "1.13.0",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-							"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+						"bl": {
+							"version": "4.0.3",
+							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+							"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.5.0",
+								"inherits": "^2.0.4",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						},
+						"cliui": {
+							"version": "7.0.4",
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+							"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+							"dev": true,
+							"requires": {
+								"string-width": "^4.2.0",
+								"strip-ansi": "^6.0.0",
+								"wrap-ansi": "^7.0.0"
+							}
+						},
+						"compress-commons": {
+							"version": "4.0.2",
+							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+							"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+							"dev": true,
+							"requires": {
+								"buffer-crc32": "^0.2.13",
+								"crc32-stream": "^4.0.1",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^3.6.0"
+							}
+						},
+						"crc32-stream": {
+							"version": "4.0.1",
+							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
+							"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
+							"dev": true,
+							"requires": {
+								"crc-32": "^1.2.0",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"get-stream": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+							"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
 							"dev": true
 						},
 						"http-status-codes": {
@@ -16476,6 +19077,25 @@
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+							"dev": true
+						},
+						"jimp": {
+							"version": "0.14.0",
+							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
+							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.7.2",
+								"@jimp/custom": "^0.14.0",
+								"@jimp/plugins": "^0.14.0",
+								"@jimp/types": "^0.14.0",
+								"regenerator-runtime": "^0.13.3"
+							}
+						},
+						"jpeg-js": {
+							"version": "0.4.2",
+							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+							"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
 							"dev": true
 						},
 						"lru-cache": {
@@ -16494,6 +19114,23 @@
 							"dev": true,
 							"requires": {
 								"moment": ">= 2.9.0"
+							}
+						},
+						"normalize-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "3.6.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+							"dev": true,
+							"requires": {
+								"inherits": "^2.0.3",
+								"string_decoder": "^1.1.1",
+								"util-deprecate": "^1.0.1"
 							}
 						},
 						"rgb2hex": {
@@ -16529,6 +19166,19 @@
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^5.0.0"
+							}
+						},
+						"tar-stream": {
+							"version": "2.1.4",
+							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+							"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+							"dev": true,
+							"requires": {
+								"bl": "^4.0.3",
+								"end-of-stream": "^1.4.1",
+								"fs-constants": "^1.0.0",
+								"inherits": "^2.0.3",
+								"readable-stream": "^3.1.1"
 							}
 						},
 						"type-fest": {
@@ -16576,9 +19226,9 @@
 							"dev": true
 						},
 						"y18n": {
-							"version": "5.0.1",
-							"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.1.tgz",
-							"integrity": "sha512-/jJ831jEs4vGDbYPQp4yGKDYPSCCEQ45uZWJHE1AoYBzqdZi8+LDWas0z4HrmJXmKdpFsTiowSHXdxyFhpmdMg==",
+							"version": "5.0.5",
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+							"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
 							"dev": true
 						},
 						"yallist": {
@@ -16588,35 +19238,35 @@
 							"dev": true
 						},
 						"yargs": {
-							"version": "16.0.3",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
-							"integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+							"version": "16.2.0",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+							"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
 							"dev": true,
 							"requires": {
-								"cliui": "^7.0.0",
-								"escalade": "^3.0.2",
+								"cliui": "^7.0.2",
+								"escalade": "^3.1.1",
 								"get-caller-file": "^2.0.5",
 								"require-directory": "^2.1.1",
 								"string-width": "^4.2.0",
-								"y18n": "^5.0.1",
-								"yargs-parser": "^20.0.0"
+								"y18n": "^5.0.5",
+								"yargs-parser": "^20.2.2"
 							}
 						},
 						"yargs-parser": {
-							"version": "20.2.0",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.0.tgz",
-							"integrity": "sha512-2agPoRFPoIcFzOIp6656gcvsg2ohtscpw2OINr/q46+Sq41xz2OYLqx5HRHabmFU1OARIPAYH5uteICE7mn/5A==",
+							"version": "20.2.4",
+							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+							"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
 							"dev": true
 						},
 						"zip-stream": {
-							"version": "2.1.3",
-							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
-							"integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+							"version": "4.0.4",
+							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+							"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
 							"dev": true,
 							"requires": {
 								"archiver-utils": "^2.1.0",
-								"compress-commons": "^2.1.1",
-								"readable-stream": "^3.4.0"
+								"compress-commons": "^4.0.2",
+								"readable-stream": "^3.6.0"
 							}
 						}
 					}
@@ -16793,6 +19443,17 @@
 								}
 							}
 						},
+						"form-data": {
+							"version": "2.5.1",
+							"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+							"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+							"dev": true,
+							"requires": {
+								"asynckit": "^0.4.0",
+								"combined-stream": "^1.0.6",
+								"mime-types": "^2.1.12"
+							}
+						},
 						"node-simctl": {
 							"version": "5.3.0",
 							"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-5.3.0.tgz",
@@ -16852,6 +19513,20 @@
 								"@wdio/utils": "5.23.0",
 								"lodash.merge": "^4.6.1",
 								"request": "^2.83.0"
+							},
+							"dependencies": {
+								"@types/request": {
+									"version": "2.48.5",
+									"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+									"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+									"dev": true,
+									"requires": {
+										"@types/caseless": "*",
+										"@types/node": "*",
+										"@types/tough-cookie": "*",
+										"form-data": "^2.5.0"
+									}
+								}
 							}
 						},
 						"webdriverio": {
@@ -16893,14 +19568,12 @@
 				"aproba": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-					"dev": true
+					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 				},
 				"archiver": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/archiver/-/archiver-4.0.2.tgz",
 					"integrity": "sha512-B9IZjlGwaxF33UN4oPbfBkyA4V1SxNLeIhR1qY8sRXSsbdUkEHrrOvwlYFPx+8uQeCe9M+FG6KgO+imDmQ79CQ==",
-					"dev": true,
 					"requires": {
 						"archiver-utils": "^2.1.0",
 						"async": "^3.2.0",
@@ -16915,7 +19588,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
 					"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.4",
 						"graceful-fs": "^4.2.0",
@@ -16933,7 +19605,6 @@
 							"version": "2.3.7",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
 								"inherits": "~2.0.3",
@@ -16950,7 +19621,6 @@
 					"version": "1.1.5",
 					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-					"dev": true,
 					"requires": {
 						"delegates": "^1.0.0",
 						"readable-stream": "^2.0.6"
@@ -16960,7 +19630,6 @@
 							"version": "2.3.7",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
 								"inherits": "~2.0.3",
@@ -17043,8 +19712,7 @@
 				"async": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-					"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-					"dev": true
+					"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
 				},
 				"async-limiter": {
 					"version": "1.0.1",
@@ -17080,7 +19748,6 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-2.6.0.tgz",
 					"integrity": "sha512-x9RDH0Dk4qZIGHQc9KbnDrUnaEbtWJW2DbuSElOFOQ2ppGsT1eFEDsiconZPpRGMW6+Uv724FYaBc8SUvyWVzA==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
 						"bluebird": "^3.5.1",
@@ -17092,8 +19759,7 @@
 				"asynckit": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-					"dev": true
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 				},
 				"aws-sign2": {
 					"version": "0.7.0",
@@ -17106,15 +19772,6 @@
 					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
 					"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
 					"dev": true
-				},
-				"axios": {
-					"version": "0.19.2",
-					"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-					"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-					"dev": true,
-					"requires": {
-						"follow-redirects": "1.5.10"
-					}
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
@@ -17143,20 +19800,17 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"base64-js": {
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-					"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-					"dev": true
+					"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 				},
 				"base64-stream": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/base64-stream/-/base64-stream-1.0.0.tgz",
-					"integrity": "sha512-BQQZftaO48FcE1Kof9CmXMFaAdqkcNorgc8CxesZv9nMbbTF1EFyQe89UOuh//QMmdtfUDXyO8rgUalemL5ODA==",
-					"dev": true
+					"integrity": "sha512-BQQZftaO48FcE1Kof9CmXMFaAdqkcNorgc8CxesZv9nMbbTF1EFyQe89UOuh//QMmdtfUDXyO8rgUalemL5ODA=="
 				},
 				"basic-auth": {
 					"version": "2.0.1",
@@ -17179,14 +19833,12 @@
 				"big-integer": {
 					"version": "1.6.48",
 					"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-					"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-					"dev": true
+					"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
 				},
 				"bl": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
 					"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
-					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",
 						"inherits": "^2.0.4",
@@ -17196,14 +19848,12 @@
 				"bluebird": {
 					"version": "3.7.2",
 					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-					"dev": true
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 				},
 				"bmp-js": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-					"integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM=",
-					"dev": true
+					"integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
 				},
 				"body-parser": {
 					"version": "1.19.0",
@@ -17237,6 +19887,12 @@
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 							"dev": true
+						},
+						"qs": {
+							"version": "6.7.0",
+							"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+							"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+							"dev": true
 						}
 					}
 				},
@@ -17244,7 +19900,6 @@
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
 					"integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-					"dev": true,
 					"requires": {
 						"stream-buffers": "~2.2.0"
 					}
@@ -17253,7 +19908,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
 					"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-					"dev": true,
 					"requires": {
 						"big-integer": "^1.6.44"
 					}
@@ -17262,7 +19916,6 @@
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -17272,29 +19925,44 @@
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
 					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
 					}
 				},
+				"buffer-alloc": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+					"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+					"requires": {
+						"buffer-alloc-unsafe": "^1.1.0",
+						"buffer-fill": "^1.0.0"
+					}
+				},
+				"buffer-alloc-unsafe": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+					"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+				},
 				"buffer-crc32": {
 					"version": "0.2.13",
 					"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-					"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-					"dev": true
+					"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 				},
 				"buffer-equal": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-					"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
-					"dev": true
+					"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+				},
+				"buffer-fill": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+					"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
 				},
 				"buffer-from": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-					"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-					"dev": true
+					"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 				},
 				"bufferpack": {
 					"version": "0.0.6",
@@ -17309,25 +19977,10 @@
 					"dev": true
 				},
 				"cacheable-lookup": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz",
-					"integrity": "sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w==",
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+					"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
 					"dev": true
-				},
-				"cacheable-request": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-					"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-					"dev": true,
-					"requires": {
-						"clone-response": "^1.0.2",
-						"get-stream": "^5.1.0",
-						"http-cache-semantics": "^4.0.0",
-						"keyv": "^4.0.0",
-						"lowercase-keys": "^2.0.0",
-						"normalize-url": "^4.1.0",
-						"responselike": "^2.0.0"
-					}
 				},
 				"camelcase": {
 					"version": "5.3.1",
@@ -17356,37 +20009,6 @@
 					"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 					"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
 					"dev": true
-				},
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				},
-				"chrome-launcher": {
-					"version": "0.13.4",
-					"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
-					"integrity": "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*",
-						"escape-string-regexp": "^1.0.5",
-						"is-wsl": "^2.2.0",
-						"lighthouse-logger": "^1.0.0",
-						"mkdirp": "^0.5.3",
-						"rimraf": "^3.0.2"
-					},
-					"dependencies": {
-						"mkdirp": {
-							"version": "0.5.5",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-							"dev": true,
-							"requires": {
-								"minimist": "^1.2.5"
-							}
-						}
-					}
 				},
 				"circular-json": {
 					"version": "0.5.9",
@@ -17451,26 +20073,15 @@
 					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 					"dev": true
 				},
-				"clone-response": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-					"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-					"dev": true,
-					"requires": {
-						"mimic-response": "^1.0.0"
-					}
-				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"color": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
 					"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.1",
 						"color-string": "^1.5.2"
@@ -17480,7 +20091,6 @@
 							"version": "1.9.3",
 							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 							"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-							"dev": true,
 							"requires": {
 								"color-name": "1.1.3"
 							}
@@ -17488,8 +20098,7 @@
 						"color-name": {
 							"version": "1.1.3",
 							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-							"dev": true
+							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 						}
 					}
 				},
@@ -17505,14 +20114,12 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
 				"color-string": {
 					"version": "1.5.3",
 					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
 					"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-					"dev": true,
 					"requires": {
 						"color-name": "^1.0.0",
 						"simple-swizzle": "^0.2.2"
@@ -17524,6 +20131,11 @@
 					"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 					"dev": true
 				},
+				"colornames": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+					"integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+				},
 				"colors": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -17534,7 +20146,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
 					"integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
-					"dev": true,
 					"requires": {
 						"color": "3.0.x",
 						"text-hex": "1.0.x"
@@ -17544,7 +20155,6 @@
 					"version": "1.0.8",
 					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 					"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-					"dev": true,
 					"requires": {
 						"delayed-stream": "~1.0.0"
 					}
@@ -17565,12 +20175,44 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-3.0.0.tgz",
 					"integrity": "sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==",
-					"dev": true,
 					"requires": {
 						"buffer-crc32": "^0.2.13",
 						"crc32-stream": "^3.0.1",
 						"normalize-path": "^3.0.0",
 						"readable-stream": "^2.3.7"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						}
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"concat-stream": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -17590,17 +20232,10 @@
 						}
 					}
 				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
-				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"content-disposition": {
 					"version": "0.5.3",
@@ -17642,20 +20277,17 @@
 				"core-js": {
 					"version": "3.6.5",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-					"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-					"dev": true
+					"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"dev": true
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 				},
 				"crc": {
 					"version": "3.8.0",
 					"resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
 					"integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-					"dev": true,
 					"requires": {
 						"buffer": "^5.1.0"
 					}
@@ -17664,7 +20296,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
 					"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
-					"dev": true,
 					"requires": {
 						"crc": "^3.4.4",
 						"readable-stream": "^3.4.0"
@@ -17730,14 +20361,6 @@
 					"dev": true,
 					"requires": {
 						"mimic-response": "^3.1.0"
-					},
-					"dependencies": {
-						"mimic-response": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-							"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-							"dev": true
-						}
 					}
 				},
 				"deep-eql": {
@@ -17755,23 +20378,15 @@
 					"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 					"dev": true
 				},
-				"defer-to-connect": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-					"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
-					"dev": true
-				},
 				"delayed-stream": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-					"dev": true
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-					"dev": true
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 				},
 				"depd": {
 					"version": "1.1.2",
@@ -17785,33 +20400,23 @@
 					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
 					"dev": true
 				},
-				"devtools": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.2.0.tgz",
-					"integrity": "sha512-PmDKnIlDdP5+b6VurEnrIiLdzpSuWeWfge8tXJWjvFPhoqvwzdw4j5YSFo/QRWusS37Mk/j/rNUUawYP0u/ZKg==",
-					"dev": true,
+				"diagnostics": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+					"integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
 					"requires": {
-						"@wdio/config": "6.1.14",
-						"@wdio/logger": "6.0.16",
-						"@wdio/protocols": "6.1.25",
-						"@wdio/utils": "6.2.0",
-						"chrome-launcher": "^0.13.1",
-						"puppeteer-core": "^4.0.0",
-						"ua-parser-js": "^0.7.21",
-						"uuid": "^8.0.0"
+						"colorspace": "1.1.x"
 					}
 				},
 				"dom-walk": {
 					"version": "0.1.2",
 					"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-					"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
-					"dev": true
+					"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
 				},
 				"duplexer": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-					"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-					"dev": true
+					"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 				},
 				"ecc-jsbn": {
 					"version": "0.1.2",
@@ -17847,8 +20452,7 @@
 				"enabled": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-					"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-					"dev": true
+					"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
 				},
 				"encodeurl": {
 					"version": "1.0.2",
@@ -17860,10 +20464,14 @@
 					"version": "1.4.4",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 					"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-					"dev": true,
 					"requires": {
 						"once": "^1.4.0"
 					}
+				},
+				"env-variable": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+					"integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
 				},
 				"es6-error": {
 					"version": "4.1.1",
@@ -17875,7 +20483,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/es6-mapify/-/es6-mapify-1.2.0.tgz",
 					"integrity": "sha512-b4QYXTO1HD0MMFs+JtYrQEaynlyuEInBF3anGQK11rQ45akiIBs+3YUyTBq9FLzM7rD5P2xAglEOXz9gcdmdIw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0"
 					}
@@ -17890,12 +20497,6 @@
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"etag": {
@@ -17930,8 +20531,7 @@
 				"exif-parser": {
 					"version": "0.1.12",
 					"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-					"integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI=",
-					"dev": true
+					"integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
 				},
 				"express": {
 					"version": "4.17.1",
@@ -17985,6 +20585,12 @@
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 							"dev": true
+						},
+						"qs": {
+							"version": "6.7.0",
+							"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+							"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+							"dev": true
 						}
 					}
 				},
@@ -17998,12 +20604,45 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
 					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-					"dev": true,
 					"requires": {
 						"@types/yauzl": "^2.9.1",
-						"debug": "^4.1.1",
-						"get-stream": "^5.1.0",
-						"yauzl": "^2.10.0"
+						"get-stream": "^5.1.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"fd-slicer": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+							"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+							"requires": {
+								"pend": "~1.2.0"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+						},
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+						},
+						"yauzl": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+							"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+							"requires": {
+								"fd-slicer": "~1.0.1"
+							}
+						}
 					}
 				},
 				"extsprintf": {
@@ -18027,8 +20666,7 @@
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.1.0",
@@ -18046,7 +20684,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
 					"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-					"dev": true,
 					"requires": {
 						"pend": "~1.2.0"
 					}
@@ -18060,8 +20697,7 @@
 				"file-type": {
 					"version": "9.0.0",
 					"resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
-					"integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
-					"dev": true
+					"integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="
 				},
 				"finalhandler": {
 					"version": "1.1.2",
@@ -18126,37 +20762,11 @@
 						"taskkill": "^3.0.0"
 					}
 				},
-				"fn.name": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-					"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-					"dev": true
-				},
 				"follow-redirects": {
-					"version": "1.5.10",
-					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-					"dev": true,
-					"requires": {
-						"debug": "=3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-							"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
+					"version": "1.13.1",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+					"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
@@ -18168,7 +20778,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
 					"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
 						"combined-stream": "^1.0.8",
@@ -18190,20 +20799,17 @@
 				"fs-constants": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-					"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-					"dev": true
+					"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 				},
 				"ftp-response-parser": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/ftp-response-parser/-/ftp-response-parser-1.0.1.tgz",
 					"integrity": "sha1-O50z+O3V+45HALj3eMRi5bFYH4k=",
-					"dev": true,
 					"requires": {
 						"readable-stream": "^1.0.31"
 					},
@@ -18211,14 +20817,12 @@
 						"isarray": {
 							"version": "0.0.1",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-							"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-							"dev": true
+							"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 						},
 						"readable-stream": {
 							"version": "1.1.14",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 							"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
 								"inherits": "~2.0.1",
@@ -18229,8 +20833,7 @@
 						"string_decoder": {
 							"version": "0.10.31",
 							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-							"dev": true
+							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 						}
 					}
 				},
@@ -18238,7 +20841,6 @@
 					"version": "2.7.4",
 					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"dev": true,
 					"requires": {
 						"aproba": "^1.0.3",
 						"console-control-strings": "^1.0.0",
@@ -18266,7 +20868,6 @@
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
 					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -18284,7 +20885,6 @@
 					"version": "7.1.6",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -18298,26 +20898,25 @@
 					"version": "4.3.2",
 					"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 					"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-					"dev": true,
 					"requires": {
 						"min-document": "^2.19.0",
 						"process": "~0.5.1"
 					}
 				},
 				"got": {
-					"version": "11.5.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-11.5.0.tgz",
-					"integrity": "sha512-vOZEcEaK0b6x11uniY0HcblZObKPRO75Jvz53VKuqGSaKCM/zEt0sj2LGYVdqDYJzO3wYdG+FPQQ1hsgoXy7vQ==",
+					"version": "11.8.1",
+					"resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
+					"integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
 					"dev": true,
 					"requires": {
-						"@sindresorhus/is": "^3.0.0",
+						"@sindresorhus/is": "^4.0.0",
 						"@szmarczak/http-timer": "^4.0.5",
 						"@types/cacheable-request": "^6.0.1",
 						"@types/responselike": "^1.0.0",
 						"cacheable-lookup": "^5.0.3",
 						"cacheable-request": "^7.0.1",
 						"decompress-response": "^6.0.0",
-						"http2-wrapper": "^1.0.0-beta.4.8",
+						"http2-wrapper": "^1.0.0-beta.5.2",
 						"lowercase-keys": "^2.0.0",
 						"p-cancelable": "^2.0.0",
 						"responselike": "^2.0.0"
@@ -18326,8 +20925,7 @@
 				"graceful-fs": {
 					"version": "4.2.4",
 					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-					"dev": true
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
 				},
 				"grapheme-splitter": {
 					"version": "1.0.4",
@@ -18360,14 +20958,7 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-					"dev": true
-				},
-				"http-cache-semantics": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-					"dev": true
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 				},
 				"http-errors": {
 					"version": "1.7.2",
@@ -18407,26 +20998,6 @@
 					"integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==",
 					"dev": true
 				},
-				"http2-wrapper": {
-					"version": "1.0.0-beta.5.2",
-					"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-					"integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
-					"dev": true,
-					"requires": {
-						"quick-lru": "^5.1.1",
-						"resolve-alpn": "^1.0.0"
-					}
-				},
-				"https-proxy-agent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-					"dev": true,
-					"requires": {
-						"agent-base": "5",
-						"debug": "4"
-					}
-				},
 				"human-signals": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -18445,8 +21016,7 @@
 				"ieee754": {
 					"version": "1.1.13",
 					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-					"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-					"dev": true
+					"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 				},
 				"immediate": {
 					"version": "3.0.6",
@@ -18464,7 +21034,6 @@
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -18473,8 +21042,7 @@
 				"inherits": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-					"dev": true
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 				},
 				"interpret": {
 					"version": "1.4.0",
@@ -18503,8 +21071,7 @@
 				"is-arrayish": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-					"dev": true
+					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 				},
 				"is-buffer": {
 					"version": "1.1.6",
@@ -18524,17 +21091,10 @@
 					"integrity": "sha1-4FdFFwW7NOOePjNZjJOpg3KWtzY=",
 					"dev": true
 				},
-				"is-docker": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-					"integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -18542,8 +21102,7 @@
 				"is-function": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-					"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
-					"dev": true
+					"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
 				},
 				"is-number-like": {
 					"version": "1.0.8",
@@ -18566,26 +21125,15 @@
 					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 					"dev": true
 				},
-				"is-wsl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-					"dev": true,
-					"requires": {
-						"is-docker": "^2.0.0"
-					}
-				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"isexe": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-					"dev": true
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -18597,7 +21145,6 @@
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.10.3.tgz",
 					"integrity": "sha512-meVWmDMtyUG5uYjFkmzu0zBgnCvvxwWNi27c4cg55vWNVC9ES4Lcwb+ogx+uBBQE3Q+dLKjXaLl0JVW+nUNwbQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/custom": "^0.10.3",
@@ -18610,8 +21157,7 @@
 				"jpeg-js": {
 					"version": "0.3.7",
 					"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-					"integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
-					"dev": true
+					"integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ=="
 				},
 				"js2xmlparser2": {
 					"version": "0.2.0",
@@ -18629,7 +21175,6 @@
 					"version": "2.1.3",
 					"resolved": "https://registry.npmjs.org/jsftp/-/jsftp-2.1.3.tgz",
 					"integrity": "sha512-r79EVB8jaNAZbq8hvanL8e8JGu2ZNr2bXdHC4ZdQhRImpSPpnWwm5DYVzQ5QxJmtGtKhNNuvqGgbNaFl604fEQ==",
-					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
 						"ftp-response-parser": "^1.0.1",
@@ -18643,18 +21188,11 @@
 							"version": "3.2.6",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
 							"requires": {
 								"ms": "^2.1.1"
 							}
 						}
 					}
-				},
-				"json-buffer": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-					"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-					"dev": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
@@ -18724,20 +21262,10 @@
 						"101": "^1.0.0"
 					}
 				},
-				"keyv": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
-					"integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
-					"dev": true,
-					"requires": {
-						"json-buffer": "3.0.1"
-					}
-				},
 				"klaw": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
 					"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.9"
 					}
@@ -18745,14 +21273,12 @@
 				"kuler": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-					"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-					"dev": true
+					"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
 				},
 				"lazystream": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
 					"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-					"dev": true,
 					"requires": {
 						"readable-stream": "^2.0.5"
 					},
@@ -18761,7 +21287,6 @@
 							"version": "2.3.7",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
 								"inherits": "~2.0.3",
@@ -18792,38 +21317,10 @@
 						"immediate": "~3.0.5"
 					}
 				},
-				"lighthouse-logger": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
-					"integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
-					"dev": true,
-					"requires": {
-						"debug": "^2.6.8",
-						"marky": "^1.2.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
 				"load-bmfont": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
 					"integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-					"dev": true,
 					"requires": {
 						"buffer-equal": "0.0.1",
 						"mime": "^1.3.4",
@@ -18844,20 +21341,10 @@
 						"p-locate": "^4.1.0"
 					}
 				},
-				"lockfile": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-					"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
-					"dev": true,
-					"requires": {
-						"signal-exit": "^3.0.2"
-					}
-				},
 				"lodash": {
 					"version": "4.17.19",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-					"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-					"dev": true
+					"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 				},
 				"lodash.clonedeep": {
 					"version": "4.5.0",
@@ -18868,20 +21355,17 @@
 				"lodash.defaults": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-					"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-					"dev": true
+					"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
 				},
 				"lodash.difference": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-					"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-					"dev": true
+					"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
 				},
 				"lodash.flatten": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-					"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-					"dev": true
+					"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
 				},
 				"lodash.isfinite": {
 					"version": "3.3.2",
@@ -18898,8 +21382,7 @@
 				"lodash.isplainobject": {
 					"version": "4.0.6",
 					"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-					"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-					"dev": true
+					"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 				},
 				"lodash.merge": {
 					"version": "4.6.2",
@@ -18910,8 +21393,7 @@
 				"lodash.union": {
 					"version": "4.6.0",
 					"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-					"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
-					"dev": true
+					"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
 				},
 				"lodash.zip": {
 					"version": "4.2.0",
@@ -18953,12 +21435,6 @@
 						"source-map-support": "0.3.2 - 1.0.0"
 					}
 				},
-				"lowercase-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-					"dev": true
-				},
 				"lru-cache": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -18977,12 +21453,6 @@
 						"p-defer": "^1.0.0"
 					}
 				},
-				"marky": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
-					"integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
-					"dev": true
-				},
 				"md5": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -18993,6 +21463,12 @@
 						"crypt": "~0.0.1",
 						"is-buffer": "~1.1.1"
 					}
+				},
+				"md5-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
+					"integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==",
+					"dev": true
 				},
 				"media-typer": {
 					"version": "0.3.0",
@@ -19061,20 +21537,17 @@
 				"mime": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-					"dev": true
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 				},
 				"mime-db": {
 					"version": "1.44.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-					"dev": true
+					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
 				},
 				"mime-types": {
 					"version": "2.1.27",
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
 					"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-					"dev": true,
 					"requires": {
 						"mime-db": "1.44.0"
 					}
@@ -19086,16 +21559,15 @@
 					"dev": true
 				},
 				"mimic-response": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+					"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
 					"dev": true
 				},
 				"min-document": {
 					"version": "2.19.0",
 					"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 					"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-					"dev": true,
 					"requires": {
 						"dom-walk": "^0.1.0"
 					}
@@ -19104,7 +21576,6 @@
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -19112,38 +21583,22 @@
 				"minimist": {
 					"version": "1.2.5",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				},
-				"mitt": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/mitt/-/mitt-2.0.1.tgz",
-					"integrity": "sha512-FhuJY+tYHLnPcBHQhbUFzscD5512HumCPE4URXZUgPi3IvOJi4Xva5IIgy3xX56GqCmw++MAm5UURG6kDBYTdg==",
-					"dev": true
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 				},
 				"mjpeg-server": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/mjpeg-server/-/mjpeg-server-0.3.0.tgz",
-					"integrity": "sha1-rx3hP3VkJwi6bsFw36xAi9xdlzc=",
-					"dev": true
+					"integrity": "sha1-rx3hP3VkJwi6bsFw36xAi9xdlzc="
 				},
 				"mkdirp": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
-				},
-				"mkdirp-classic": {
-					"version": "0.5.3",
-					"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-					"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-					"dev": true
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				},
 				"moment": {
 					"version": "2.27.0",
 					"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-					"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
-					"dev": true
+					"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
 				},
 				"moment-timezone": {
 					"version": "0.5.31",
@@ -19193,14 +21648,12 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				},
 				"mv": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
 					"integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-					"dev": true,
 					"requires": {
 						"mkdirp": "~0.5.1",
 						"ncp": "~2.0.0",
@@ -19211,7 +21664,6 @@
 							"version": "6.0.4",
 							"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
 							"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-							"dev": true,
 							"requires": {
 								"inflight": "^1.0.4",
 								"inherits": "2",
@@ -19224,7 +21676,6 @@
 							"version": "0.5.5",
 							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-							"dev": true,
 							"requires": {
 								"minimist": "^1.2.5"
 							}
@@ -19233,7 +21684,6 @@
 							"version": "2.4.5",
 							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
 							"integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-							"dev": true,
 							"requires": {
 								"glob": "^6.0.1"
 							}
@@ -19243,8 +21693,7 @@
 				"ncp": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-					"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-					"dev": true
+					"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
 				},
 				"negotiator": {
 					"version": "0.6.2",
@@ -19283,14 +21732,7 @@
 				"normalize-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
-				"normalize-url": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-					"dev": true
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 				},
 				"npm-run-path": {
 					"version": "4.0.1",
@@ -19305,7 +21747,6 @@
 					"version": "4.1.2",
 					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-					"dev": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
 						"console-control-strings": "~1.1.0",
@@ -19316,8 +21757,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"oauth-sign": {
 					"version": "0.9.0",
@@ -19328,14 +21768,12 @@
 				"object-assign": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"dev": true
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 				},
 				"omggif": {
 					"version": "1.0.10",
 					"resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-					"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
-					"dev": true
+					"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
 				},
 				"on-finished": {
 					"version": "2.3.0",
@@ -19356,7 +21794,6 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -19492,12 +21929,6 @@
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true
 				},
-				"p-cancelable": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-					"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
-					"dev": true
-				},
 				"p-defer": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -19543,26 +21974,22 @@
 				"pako": {
 					"version": "1.0.11",
 					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-					"dev": true
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 				},
 				"parse-bmfont-ascii": {
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-					"integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU=",
-					"dev": true
+					"integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU="
 				},
 				"parse-bmfont-binary": {
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-					"integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY=",
-					"dev": true
+					"integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY="
 				},
 				"parse-bmfont-xml": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
 					"integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-					"dev": true,
 					"requires": {
 						"xml-parse-from-string": "^1.0.0",
 						"xml2js": "^0.4.5"
@@ -19571,14 +21998,12 @@
 				"parse-headers": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-					"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
-					"dev": true
+					"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
 				},
 				"parse-listing": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/parse-listing/-/parse-listing-1.1.3.tgz",
-					"integrity": "sha1-qlRvV/3BKc+/mUXNS3V7FLBhgt0=",
-					"dev": true
+					"integrity": "sha1-qlRvV/3BKc+/mUXNS3V7FLBhgt0="
 				},
 				"parse-node-version": {
 					"version": "1.0.1",
@@ -19601,8 +22026,7 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 				},
 				"path-key": {
 					"version": "3.1.1",
@@ -19637,8 +22061,7 @@
 				"pend": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-					"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-					"dev": true
+					"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
 				},
 				"performance-now": {
 					"version": "2.1.0",
@@ -19649,8 +22072,7 @@
 				"phin": {
 					"version": "2.9.3",
 					"resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-					"integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
-					"dev": true
+					"integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
 				},
 				"pid-from-port": {
 					"version": "1.1.3",
@@ -19760,7 +22182,6 @@
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
 					"integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
-					"dev": true,
 					"requires": {
 						"pngjs": "^3.0.0"
 					},
@@ -19768,8 +22189,7 @@
 						"pngjs": {
 							"version": "3.4.0",
 							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
+							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
 						}
 					}
 				},
@@ -19777,7 +22197,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
 					"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-					"dev": true,
 					"requires": {
 						"base64-js": "^1.2.3",
 						"xmlbuilder": "^9.0.7",
@@ -19787,22 +22206,19 @@
 						"xmlbuilder": {
 							"version": "9.0.7",
 							"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-							"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-							"dev": true
+							"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 						}
 					}
 				},
 				"pluralize": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-					"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-					"dev": true
+					"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
 				},
 				"pngjs": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-					"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-					"dev": true
+					"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
 				},
 				"portfinder": {
 					"version": "1.0.26",
@@ -19868,8 +22284,7 @@
 				"process": {
 					"version": "0.5.2",
 					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-					"dev": true
+					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
 				},
 				"process-exists": {
 					"version": "4.0.0",
@@ -19891,14 +22306,7 @@
 				"process-nextick-args": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-					"dev": true
-				},
-				"progress": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-					"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-					"dev": true
+					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 				},
 				"proxy-addr": {
 					"version": "2.0.6",
@@ -19909,12 +22317,6 @@
 						"forwarded": "~0.1.2",
 						"ipaddr.js": "1.9.1"
 					}
-				},
-				"proxy-from-env": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-					"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-					"dev": true
 				},
 				"ps-list": {
 					"version": "7.2.0",
@@ -19938,7 +22340,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -19950,44 +22351,10 @@
 					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 					"dev": true
 				},
-				"puppeteer-core": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-4.0.1.tgz",
-					"integrity": "sha512-8OfHmUkEXU/k7Bmcdm6KRWhIIfmayv/ce1AUDkP0nTLK2IpjulFggxq1dZhWgWHXebeLILbieMvAor7tSf3EqQ==",
-					"dev": true,
-					"requires": {
-						"debug": "^4.1.0",
-						"extract-zip": "^2.0.0",
-						"https-proxy-agent": "^4.0.0",
-						"mime": "^2.0.3",
-						"mitt": "^2.0.1",
-						"progress": "^2.0.1",
-						"proxy-from-env": "^1.0.0",
-						"rimraf": "^3.0.2",
-						"tar-fs": "^2.0.0",
-						"unbzip2-stream": "^1.3.3",
-						"ws": "^7.2.3"
-					},
-					"dependencies": {
-						"mime": {
-							"version": "2.4.6",
-							"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-							"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-							"dev": true
-						}
-					}
-				},
 				"qs": {
 					"version": "6.7.0",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
-				},
-				"quick-lru": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-					"dev": true
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 				},
 				"range-parser": {
 					"version": "1.2.1",
@@ -20011,7 +22378,6 @@
 					"version": "3.6.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -20030,8 +22396,12 @@
 				"regenerator-runtime": {
 					"version": "0.13.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-					"dev": true
+					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 				},
 				"request": {
 					"version": "2.88.2",
@@ -20128,21 +22498,6 @@
 						"path-parse": "^1.0.6"
 					}
 				},
-				"resolve-alpn": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
-					"integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==",
-					"dev": true
-				},
-				"responselike": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-					"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-					"dev": true,
-					"requires": {
-						"lowercase-keys": "^2.0.0"
-					}
-				},
 				"resq": {
 					"version": "1.7.1",
 					"resolved": "https://registry.npmjs.org/resq/-/resq-1.7.1.tgz",
@@ -20150,6 +22505,14 @@
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1"
+					},
+					"dependencies": {
+						"fast-deep-equal": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+							"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+							"dev": true
+						}
 					}
 				},
 				"rgb2hex": {
@@ -20162,7 +22525,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -20208,8 +22570,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -20221,7 +22582,6 @@
 					"version": "1.6.3",
 					"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
 					"integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-					"dev": true,
 					"requires": {
 						"truncate-utf8-bytes": "^1.0.0"
 					}
@@ -20229,8 +22589,7 @@
 				"sax": {
 					"version": "1.2.4",
 					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-					"dev": true
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 				},
 				"selenium-webdriver": {
 					"version": "3.6.0",
@@ -20258,8 +22617,7 @@
 				"semver": {
 					"version": "7.3.2",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
 				"send": {
 					"version": "0.17.1",
@@ -20358,8 +22716,7 @@
 				"set-blocking": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 				},
 				"set-immediate-shim": {
 					"version": "1.0.1",
@@ -20409,8 +22766,7 @@
 				"shell-quote": {
 					"version": "1.7.2",
 					"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-					"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
-					"dev": true
+					"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
 				},
 				"shelljs": {
 					"version": "0.8.4",
@@ -20432,14 +22788,12 @@
 				"signal-exit": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-					"dev": true
+					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 				},
 				"simple-swizzle": {
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
 					"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.3.1"
 					}
@@ -20447,14 +22801,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
 					"version": "0.5.19",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
 					"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -20504,24 +22856,29 @@
 				"stream-buffers": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-					"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
-					"dev": true
+					"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
 				},
 				"stream-combiner": {
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
 					"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-					"dev": true,
 					"requires": {
 						"duplexer": "~0.1.1",
 						"through": "~2.3.4"
+					}
+				},
+				"stream-equal": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-1.1.1.tgz",
+					"integrity": "sha512-SaZxkvxujYBR6NTumhRTg/yztw2p30fzZ/jvSgQtlZFEGI7tdSNDaPbvT47QF92hx6Tar8hAhpr7ErpTNvtuCQ==",
+					"requires": {
+						"@types/node": "*"
 					}
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -20532,7 +22889,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -20541,7 +22897,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -20567,23 +22922,10 @@
 						"has-flag": "^4.0.0"
 					}
 				},
-				"tar-fs": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-					"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
-					"dev": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"mkdirp-classic": "^0.5.2",
-						"pump": "^3.0.0",
-						"tar-stream": "^2.0.0"
-					}
-				},
 				"tar-stream": {
 					"version": "2.1.3",
 					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
 					"integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
-					"dev": true,
 					"requires": {
 						"bl": "^4.0.1",
 						"end-of-stream": "^1.4.1",
@@ -20632,7 +22974,6 @@
 					"version": "1.15.0",
 					"resolved": "https://registry.npmjs.org/teen_process/-/teen_process-1.15.0.tgz",
 					"integrity": "sha512-E8DdTeffAselFMtcE56jNiof7jt+X+KJPpCn4xvbLFy0YVAT24Y9O5jSIzOFfAKIAirKkK0M9YfmQfmxmUdgGA==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
 						"bluebird": "^3.5.1",
@@ -20644,14 +22985,12 @@
 				"text-hex": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-					"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-					"dev": true
+					"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
 				},
 				"through": {
 					"version": "2.3.8",
 					"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-					"dev": true
+					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 				},
 				"time-stamp": {
 					"version": "1.1.0",
@@ -20662,14 +23001,12 @@
 				"timm": {
 					"version": "1.6.2",
 					"resolved": "https://registry.npmjs.org/timm/-/timm-1.6.2.tgz",
-					"integrity": "sha512-IH3DYDL1wMUwmIlVmMrmesw5lZD6N+ZOAFWEyLrtpoL9Bcrs9u7M/vyOnHzDD2SMs4irLkVjqxZbHrXStS/Nmw==",
-					"dev": true
+					"integrity": "sha512-IH3DYDL1wMUwmIlVmMrmesw5lZD6N+ZOAFWEyLrtpoL9Bcrs9u7M/vyOnHzDD2SMs4irLkVjqxZbHrXStS/Nmw=="
 				},
 				"tinycolor2": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-					"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
-					"dev": true
+					"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
 				},
 				"tmp": {
 					"version": "0.0.30",
@@ -20679,6 +23016,11 @@
 					"requires": {
 						"os-tmpdir": "~1.0.1"
 					}
+				},
+				"to-buffer": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+					"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
 				},
 				"toidentifier": {
 					"version": "1.0.0",
@@ -20706,7 +23048,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
 					"integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-					"dev": true,
 					"requires": {
 						"utf8-byte-length": "^1.0.1"
 					}
@@ -20748,27 +23089,16 @@
 						"mime-types": "~2.1.24"
 					}
 				},
-				"ua-parser-js": {
-					"version": "0.7.21",
-					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-					"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+				"typedarray": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 					"dev": true
-				},
-				"unbzip2-stream": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-					"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.2.1",
-						"through": "^2.3.8"
-					}
 				},
 				"unorm": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-					"integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-					"dev": true
+					"integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
 				},
 				"unpipe": {
 					"version": "1.0.0",
@@ -20805,14 +23135,12 @@
 				"utf8-byte-length": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-					"integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
-					"dev": true
+					"integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
 				},
 				"utif": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
 					"integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
-					"dev": true,
 					"requires": {
 						"pako": "^1.0.5"
 					}
@@ -20820,8 +23148,7 @@
 				"util-deprecate": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"dev": true
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				},
 				"utils-merge": {
 					"version": "1.0.1",
@@ -20832,8 +23159,7 @@
 				"uuid": {
 					"version": "8.2.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-					"integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
-					"dev": true
+					"integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
 				},
 				"uuid-js": {
 					"version": "0.7.5",
@@ -20863,6 +23189,11 @@
 						"core-util-is": "1.0.2",
 						"extsprintf": "^1.2.0"
 					}
+				},
+				"walkdir": {
+					"version": "0.0.11",
+					"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+					"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
 				},
 				"webdriver": {
 					"version": "6.2.0",
@@ -20900,13 +23231,29 @@
 						"rgb2hex": "^0.2.0",
 						"serialize-error": "^7.0.0",
 						"webdriver": "6.2.0"
+					},
+					"dependencies": {
+						"archiver": {
+							"version": "4.0.2",
+							"resolved": "https://registry.npmjs.org/archiver/-/archiver-4.0.2.tgz",
+							"integrity": "sha512-B9IZjlGwaxF33UN4oPbfBkyA4V1SxNLeIhR1qY8sRXSsbdUkEHrrOvwlYFPx+8uQeCe9M+FG6KgO+imDmQ79CQ==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"async": "^3.2.0",
+								"buffer-crc32": "^0.2.1",
+								"glob": "^7.1.6",
+								"readable-stream": "^3.6.0",
+								"tar-stream": "^2.1.2",
+								"zip-stream": "^3.0.1"
+							}
+						}
 					}
 				},
 				"which": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -20921,7 +23268,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.2 || 2"
 					}
@@ -20941,6 +23287,25 @@
 						"stack-trace": "0.0.x",
 						"triple-beam": "^1.3.0",
 						"winston-transport": "^4.4.0"
+					},
+					"dependencies": {
+						"is-stream": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+							"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "3.6.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+							"dev": true,
+							"requires": {
+								"inherits": "^2.0.3",
+								"string_decoder": "^1.1.1",
+								"util-deprecate": "^1.0.1"
+							}
+						}
 					}
 				},
 				"winston-transport": {
@@ -21024,8 +23389,7 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				},
 				"ws": {
 					"version": "7.3.1",
@@ -21037,7 +23401,6 @@
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
 					"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
-					"dev": true,
 					"requires": {
 						"global": "~4.3.0",
 						"is-function": "^1.0.1",
@@ -21048,14 +23411,12 @@
 				"xml-parse-from-string": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-					"integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig=",
-					"dev": true
+					"integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
 				},
 				"xml2js": {
 					"version": "0.4.23",
 					"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
 					"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-					"dev": true,
 					"requires": {
 						"sax": ">=0.6.0",
 						"xmlbuilder": "~11.0.0"
@@ -21064,14 +23425,12 @@
 				"xmlbuilder": {
 					"version": "11.0.1",
 					"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-					"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-					"dev": true
+					"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
 				},
 				"xmldom": {
 					"version": "0.1.31",
 					"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-					"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-					"dev": true
+					"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
 				},
 				"xpath": {
 					"version": "0.0.27",
@@ -21082,8 +23441,7 @@
 				"xtend": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-					"dev": true
+					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 				},
 				"y18n": {
 					"version": "4.0.0",
@@ -21164,7 +23522,6 @@
 					"version": "2.10.0",
 					"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
 					"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-					"dev": true,
 					"requires": {
 						"buffer-crc32": "~0.2.3",
 						"fd-slicer": "~1.1.0"
@@ -21174,7 +23531,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-3.0.1.tgz",
 					"integrity": "sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==",
-					"dev": true,
 					"requires": {
 						"archiver-utils": "^2.1.0",
 						"compress-commons": "^3.0.0",
@@ -22019,6 +24375,14 @@
 			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
 			"integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
 			"dev": true
+		},
+		"axios": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+			"requires": {
+				"follow-redirects": "1.5.10"
+			}
 		},
 		"axobject-query": {
 			"version": "2.0.2",
@@ -24325,6 +26689,40 @@
 			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
 			"dev": true
 		},
+		"chrome-launcher": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
+			"integrity": "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"escape-string-regexp": "^1.0.5",
+				"is-wsl": "^2.2.0",
+				"lighthouse-logger": "^1.0.0",
+				"mkdirp": "^0.5.3",
+				"rimraf": "^3.0.2"
+			},
+			"dependencies": {
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				}
+			}
+		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
@@ -24784,6 +27182,28 @@
 			"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
 			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
 			"dev": true
+		},
+		"colorspace": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+			"integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+			"dev": true,
+			"requires": {
+				"color": "3.0.x",
+				"text-hex": "1.0.x"
+			},
+			"dependencies": {
+				"color": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+					"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.1",
+						"color-string": "^1.5.2"
+					}
+				}
+			}
 		},
 		"columnify": {
 			"version": "1.5.4",
@@ -25709,8 +28129,7 @@
 		"core-js": {
 			"version": "3.6.4",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-			"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
-			"dev": true
+			"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
 		},
 		"core-js-pure": {
 			"version": "3.2.1",
@@ -25834,6 +28253,16 @@
 						"ieee754": "^1.1.4"
 					}
 				}
+			}
+		},
+		"crc-32": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+			"integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+			"dev": true,
+			"requires": {
+				"exit-on-epipe": "~1.0.1",
+				"printj": "~1.1.0"
 			}
 		},
 		"crc32-stream": {
@@ -26465,7 +28894,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -26875,6 +29303,30 @@
 				}
 			}
 		},
+		"devtools": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.2.0.tgz",
+			"integrity": "sha512-PmDKnIlDdP5+b6VurEnrIiLdzpSuWeWfge8tXJWjvFPhoqvwzdw4j5YSFo/QRWusS37Mk/j/rNUUawYP0u/ZKg==",
+			"dev": true,
+			"requires": {
+				"@wdio/config": "6.1.14",
+				"@wdio/logger": "6.0.16",
+				"@wdio/protocols": "6.1.25",
+				"@wdio/utils": "6.2.0",
+				"chrome-launcher": "^0.13.1",
+				"puppeteer-core": "^4.0.0",
+				"ua-parser-js": "^0.7.21",
+				"uuid": "^8.0.0"
+			},
+			"dependencies": {
+				"ua-parser-js": {
+					"version": "0.7.23",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+					"integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+					"dev": true
+				}
+			}
+		},
 		"dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -27245,6 +29697,12 @@
 					}
 				}
 			}
+		},
+		"enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+			"dev": true
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -28198,6 +30656,12 @@
 			"version": "0.35.6",
 			"resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.6.tgz",
 			"integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==",
+			"dev": true
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true
 		},
 		"escape-html": {
@@ -29448,6 +31912,12 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
 			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
+		"exit-on-epipe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+			"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
 			"dev": true
 		},
 		"expand-brackets": {
@@ -30707,6 +33177,20 @@
 				"readable-stream": "^2.0.4"
 			}
 		},
+		"fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+			"dev": true
+		},
+		"follow-redirects": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+			"requires": {
+				"debug": "=3.1.0"
+			}
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -31149,6 +33633,16 @@
 			"requires": {
 				"encoding": "^0.1.12",
 				"safe-buffer": "^5.1.1"
+			}
+		},
+		"gifwrap": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.2.tgz",
+			"integrity": "sha512-fcIswrPaiCDAyO8xnWvHSZdWChjKXUanKKpAiWWJ/UTkEi/aYKn5+90e7DE820zbEaVR9CE2y4z9bzhQijZ0BA==",
+			"dev": true,
+			"requires": {
+				"image-q": "^1.1.1",
+				"omggif": "^1.0.10"
 			}
 		},
 		"git-raw-commits": {
@@ -32345,6 +34839,24 @@
 				"sshpk": "^1.7.0"
 			}
 		},
+		"http2-wrapper": {
+			"version": "1.0.0-beta.5.2",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
+			"integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+			"dev": true,
+			"requires": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"dependencies": {
+				"quick-lru": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+					"dev": true
+				}
+			}
+		},
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -32720,6 +35232,12 @@
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
+		},
+		"image-q": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/image-q/-/image-q-1.1.1.tgz",
+			"integrity": "sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY=",
+			"dev": true
 		},
 		"image-size": {
 			"version": "0.6.3",
@@ -39220,6 +41738,12 @@
 			"integrity": "sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA==",
 			"dev": true
 		},
+		"kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"dev": true
+		},
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -39311,6 +41835,27 @@
 			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
 			"requires": {
 				"immediate": "~3.0.5"
+			}
+		},
+		"lighthouse-logger": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+			"integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.8",
+				"marky": "^1.2.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
 			}
 		},
 		"line-height": {
@@ -39784,6 +42329,14 @@
 				"path-exists": "^3.0.0"
 			}
 		},
+		"lockfile": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+			"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+			"requires": {
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"lodash": {
 			"version": "4.17.19",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
@@ -40156,6 +42709,18 @@
 					}
 				}
 			}
+		},
+		"loglevel": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+			"integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
+			"dev": true
+		},
+		"loglevel-plugin-prefix": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+			"integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+			"dev": true
 		},
 		"lolex": {
 			"version": "5.1.2",
@@ -40566,6 +43131,12 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.6.0.tgz",
 			"integrity": "sha512-LiZVAbg9/cqkBHtLNNqHV3xuy4Y2L/KuGU6+ZXqCT9NnCdEkIoxeI5/96t+ExquBY0iHy2CVWxPH16nG1RKQVQ==",
+			"dev": true
+		},
+		"marky": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
+			"integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
 			"dev": true
 		},
 		"material-colors": {
@@ -42194,6 +44765,12 @@
 				"stream-each": "^1.1.0",
 				"through2": "^2.0.0"
 			}
+		},
+		"mitt": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+			"integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==",
+			"dev": true
 		},
 		"mixin-deep": {
 			"version": "1.3.2",
@@ -43920,6 +46497,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
 			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+			"dev": true
+		},
+		"omggif": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+			"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
 			"dev": true
 		},
 		"on-finished": {
@@ -45901,6 +48484,12 @@
 			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
 			"dev": true
 		},
+		"printj": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+			"dev": true
+		},
 		"prismjs": {
 			"version": "1.22.0",
 			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.22.0.tgz",
@@ -46506,6 +49095,188 @@
 					"requires": {
 						"mime-db": "1.44.0"
 					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"tar-fs": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+					"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"mkdirp-classic": "^0.5.2",
+						"pump": "^3.0.0",
+						"tar-stream": "^2.1.4"
+					}
+				},
+				"tar-stream": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+					"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+					"dev": true,
+					"requires": {
+						"bl": "^4.0.3",
+						"end-of-stream": "^1.4.1",
+						"fs-constants": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.1.1"
+					}
+				},
+				"ws": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
+					"integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+					"dev": true
+				},
+				"yauzl": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+					"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+					"dev": true,
+					"requires": {
+						"buffer-crc32": "~0.2.3",
+						"fd-slicer": "~1.1.0"
+					}
+				}
+			}
+		},
+		"puppeteer-core": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-4.0.1.tgz",
+			"integrity": "sha512-8OfHmUkEXU/k7Bmcdm6KRWhIIfmayv/ce1AUDkP0nTLK2IpjulFggxq1dZhWgWHXebeLILbieMvAor7tSf3EqQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"extract-zip": "^2.0.0",
+				"https-proxy-agent": "^4.0.0",
+				"mime": "^2.0.3",
+				"mitt": "^2.0.1",
+				"progress": "^2.0.1",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^3.0.2",
+				"tar-fs": "^2.0.0",
+				"unbzip2-stream": "^1.3.3",
+				"ws": "^7.2.3"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+					"dev": true
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+					"dev": true
+				},
+				"bl": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+					"dev": true,
+					"requires": {
+						"buffer": "^5.5.0",
+						"inherits": "^2.0.4",
+						"readable-stream": "^3.4.0"
+					},
+					"dependencies": {
+						"inherits": {
+							"version": "2.0.4",
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+							"dev": true
+						}
+					}
+				},
+				"buffer": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
+					}
+				},
+				"chownr": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"extract-zip": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+					"dev": true,
+					"requires": {
+						"@types/yauzl": "^2.9.1",
+						"debug": "^4.1.1",
+						"get-stream": "^5.1.0",
+						"yauzl": "^2.10.0"
+					}
+				},
+				"fd-slicer": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+					"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+					"dev": true,
+					"requires": {
+						"pend": "~1.2.0"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "5",
+						"debug": "4"
+					}
+				},
+				"ieee754": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+					"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+					"dev": true
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -49148,6 +51919,15 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
+		"readdir-glob": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
+			"integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+			"dev": true,
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
+		},
 		"readdir-scoped-modules": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
@@ -49946,6 +52726,12 @@
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
+		},
+		"resolve-alpn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
+			"integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==",
+			"dev": true
 		},
 		"resolve-bin": {
 			"version": "0.4.0",
@@ -54005,6 +56791,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
 			"integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
+			"dev": true
+		},
+		"text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
 			"dev": true
 		},
 		"text-table": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"@wordpress/plugins": "file:packages/plugins",
 		"@wordpress/primitives": "file:packages/primitives",
 		"@wordpress/priority-queue": "file:packages/priority-queue",
+		"@wordpress/react-i18n": "file:packages/react-i18n",
 		"@wordpress/react-native-aztec": "file:packages/react-native-aztec",
 		"@wordpress/react-native-bridge": "file:packages/react-native-bridge",
 		"@wordpress/react-native-editor": "file:packages/react-native-editor",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/react-i18n": "file:../react-i18n",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/shortcode": "file:../shortcode",
 		"@wordpress/token-list": "file:../token-list",

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -6,7 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { compose } from '@wordpress/compose';
 import { getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -25,6 +25,8 @@ export function DefaultBlockAppender( {
 	placeholder,
 	rootClientId,
 } ) {
+	const { __ } = useTranslate();
+
 	if ( isLocked || ! isVisible ) {
 		return null;
 	}

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/primitives": "file:../primitives",
+		"@wordpress/react-i18n": "file:../react-i18n",
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/warning": "file:../warning",

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -10,6 +10,8 @@ import { PostSavedState, PostPreviewButton } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
+import { SelectControl } from '@wordpress/components';
+import { useTranslate } from '@wordpress/react-i18n';
 
 /**
  * Internal dependencies
@@ -22,6 +24,31 @@ import { default as DevicePreview } from '../device-preview';
 import MainDashboardButton from './main-dashboard-button';
 import TemplateSaveButton from './template-save-button';
 import { store as editPostStore } from '../../store';
+
+function DemoButton() {
+	const { locale, switchToLocale } = useTranslate();
+
+	return (
+		<SelectControl
+			value={ locale }
+			onChange={ switchToLocale }
+			options={ [
+				{
+					label: 'English (US)',
+					value: 'en_US',
+				},
+				{
+					label: 'Deutsch (Deutschland)',
+					value: 'de_DE',
+				},
+				{
+					label: 'Español',
+					value: 'es_ES',
+				},
+			] }
+		/>
+	);
+}
 
 function Header( { setEntitiesSavedStatesCallback } ) {
 	const {
@@ -64,6 +91,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				<HeaderToolbar />
 			</div>
 			<div className="edit-post-header__settings">
+				<DemoButton />
 				{ ! isEditingTemplate && (
 					<>
 						{ ! isPublishSidebarOpened && (

--- a/packages/edit-post/src/components/sidebar/discussion-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/discussion-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import {
 	PostComments,
@@ -22,6 +22,8 @@ import { store as editPostStore } from '../../../store';
 const PANEL_NAME = 'discussion-panel';
 
 function DiscussionPanel( { isEnabled, isOpened, onTogglePanel } ) {
+	const { __ } = useTranslate();
+
 	if ( ! isEnabled ) {
 		return null;
 	}

--- a/packages/edit-post/src/components/sidebar/featured-image/index.js
+++ b/packages/edit-post/src/components/sidebar/featured-image/index.js
@@ -6,7 +6,7 @@ import { get, partial } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { PanelBody } from '@wordpress/components';
 import { PostFeaturedImage, PostFeaturedImageCheck } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
@@ -23,6 +23,8 @@ import { store as editPostStore } from '../../../store';
 const PANEL_NAME = 'featured-image';
 
 function FeaturedImage( { isEnabled, isOpened, postType, onTogglePanel } ) {
+	const { __ } = useTranslate();
+
 	if ( ! isEnabled ) {
 		return null;
 	}

--- a/packages/edit-post/src/components/sidebar/post-excerpt/index.js
+++ b/packages/edit-post/src/components/sidebar/post-excerpt/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { PanelBody } from '@wordpress/components';
 import {
 	PostExcerpt as PostExcerptForm,
@@ -21,6 +21,8 @@ import { store as editPostStore } from '../../../store';
 const PANEL_NAME = 'post-excerpt';
 
 function PostExcerpt( { isEnabled, isOpened, onTogglePanel } ) {
+	const { __ } = useTranslate();
+
 	if ( ! isEnabled ) {
 		return null;
 	}

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, ifCondition, withState } from '@wordpress/compose';
@@ -36,6 +36,8 @@ function PostLink( {
 	postSlug,
 	postTypeLabel,
 } ) {
+	const { __ } = useTranslate();
+
 	let prefixElement, postNameElement, suffixElement;
 	if ( isEditable ) {
 		prefixElement = permalinkPrefix && (

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { PanelBody } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, ifCondition } from '@wordpress/compose';
@@ -27,6 +27,8 @@ import { store as editPostStore } from '../../../store';
 const PANEL_NAME = 'post-status';
 
 function PostStatus( { isOpened, onTogglePanel } ) {
+	const { __ } = useTranslate();
+
 	return (
 		<PanelBody
 			className="edit-post-post-status"

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import {
 	PostVisibility as PostVisibilityForm,
@@ -10,6 +10,8 @@ import {
 } from '@wordpress/editor';
 
 export function PostVisibility() {
+	const { __ } = useTranslate();
+
 	return (
 		<PostVisibilityCheck
 			render={ ( { canEdit } ) => (

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -19,6 +19,7 @@ import {
 	SlotFillProvider,
 	__unstableDropZoneContextProvider as DropZoneContextProvider,
 } from '@wordpress/components';
+import { LocaleProvider } from '@wordpress/react-i18n';
 
 /**
  * Internal dependencies
@@ -160,25 +161,27 @@ function Editor( {
 			<EditPostSettings.Provider value={ settings }>
 				<SlotFillProvider>
 					<DropZoneContextProvider>
-						<EditorProvider
-							settings={ editorSettings }
-							post={ post }
-							initialEdits={ initialEdits }
-							useSubRegistry={ false }
-							__unstableTemplate={
-								isTemplateMode ? template : undefined
-							}
-							{ ...props }
-						>
-							<ErrorBoundary onError={ onError }>
-								<EditorInitialization postId={ postId } />
-								<Layout settings={ settings } />
-								<KeyboardShortcuts
-									shortcuts={ preventEventDiscovery }
-								/>
-							</ErrorBoundary>
-							<PostLockedModal />
-						</EditorProvider>
+						<LocaleProvider domain="default" locale="en_US">
+							<EditorProvider
+								settings={ editorSettings }
+								post={ post }
+								initialEdits={ initialEdits }
+								useSubRegistry={ false }
+								__unstableTemplate={
+									isTemplateMode ? template : undefined
+								}
+								{ ...props }
+							>
+								<ErrorBoundary onError={ onError }>
+									<EditorInitialization postId={ postId } />
+									<Layout settings={ settings } />
+									<KeyboardShortcuts
+										shortcuts={ preventEventDiscovery }
+									/>
+								</ErrorBoundary>
+								<PostLockedModal />
+							</EditorProvider>
+						</LocaleProvider>
 					</DropZoneContextProvider>
 				</SlotFillProvider>
 			</EditPostSettings.Provider>

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/react-i18n": "file:../react-i18n",
 		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/server-side-render": "file:../server-side-render",

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -6,7 +6,8 @@ import { has, get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { applyFilters } from '@wordpress/hooks';
 import {
 	DropZone,
@@ -27,11 +28,6 @@ import PostFeaturedImageCheck from './check';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
-// Used when labels from post type were not yet loaded or when they are not present.
-const DEFAULT_FEATURE_IMAGE_LABEL = __( 'Featured image' );
-const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
-const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
-
 function PostFeaturedImage( {
 	currentPostId,
 	featuredImageId,
@@ -42,6 +38,13 @@ function PostFeaturedImage( {
 	postType,
 	noticeUI,
 } ) {
+	const { __ } = useTranslate();
+
+	// Used when labels from post type were not yet loaded or when they are not present.
+	const DEFAULT_FEATURE_IMAGE_LABEL = __( 'Featured image' );
+	const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
+	const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
+
 	const postLabel = get( postType, [ 'labels' ], {} );
 	const instructions = (
 		<p>

--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -6,7 +6,7 @@ import { find, get, includes, union } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { Button, SelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
@@ -16,59 +16,73 @@ import { useInstanceId } from '@wordpress/compose';
  */
 import PostFormatCheck from './check';
 
-// All WP post formats, sorted alphabetically by translated name.
-export const POST_FORMATS = [
-	{ id: 'aside', caption: __( 'Aside' ) },
-	{ id: 'audio', caption: __( 'Audio' ) },
-	{ id: 'chat', caption: __( 'Chat' ) },
-	{ id: 'gallery', caption: __( 'Gallery' ) },
-	{ id: 'image', caption: __( 'Image' ) },
-	{ id: 'link', caption: __( 'Link' ) },
-	{ id: 'quote', caption: __( 'Quote' ) },
-	{ id: 'standard', caption: __( 'Standard' ) },
-	{ id: 'status', caption: __( 'Status' ) },
-	{ id: 'video', caption: __( 'Video' ) },
-].sort( ( a, b ) => {
-	const normalizedA = a.caption.toUpperCase();
-	const normalizedB = b.caption.toUpperCase();
+export function usePostFormats() {
+	const { __ } = useTranslate();
 
-	if ( normalizedA < normalizedB ) {
-		return -1;
-	}
-	if ( normalizedA > normalizedB ) {
-		return 1;
-	}
-	return 0;
-} );
+	const { supportedFormats } = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const _postFormat = getEditedPostAttribute( 'format' );
+		const themeSupports = select( 'core' ).getThemeSupports();
+
+		return {
+			// Ensure current format is always in the set.
+			// The current format may not be a format supported by the theme.
+			supportedFormats: union(
+				[ _postFormat ],
+				get( themeSupports, [ 'formats' ], [] )
+			),
+		};
+	}, [] );
+
+	// All WP post formats, sorted alphabetically by translated name.
+	const formats = [
+		{ id: 'aside', caption: __( 'Aside' ) },
+		{ id: 'audio', caption: __( 'Audio' ) },
+		{ id: 'chat', caption: __( 'Chat' ) },
+		{ id: 'gallery', caption: __( 'Gallery' ) },
+		{ id: 'image', caption: __( 'Image' ) },
+		{ id: 'link', caption: __( 'Link' ) },
+		{ id: 'quote', caption: __( 'Quote' ) },
+		{ id: 'standard', caption: __( 'Standard' ) },
+		{ id: 'status', caption: __( 'Status' ) },
+		{ id: 'video', caption: __( 'Video' ) },
+	].sort( ( a, b ) => {
+		const normalizedA = a.caption.toUpperCase();
+		const normalizedB = b.caption.toUpperCase();
+
+		if ( normalizedA < normalizedB ) {
+			return -1;
+		}
+		if ( normalizedA > normalizedB ) {
+			return 1;
+		}
+		return 0;
+	} );
+
+	return formats.filter( ( format ) =>
+		includes( supportedFormats, format.id )
+	);
+}
 
 export default function PostFormat() {
+	const { __ } = useTranslate();
+
 	const instanceId = useInstanceId( PostFormat );
 	const postFormatSelectorId = `post-format-selector-${ instanceId }`;
 
-	const { postFormat, suggestedFormat, supportedFormats } = useSelect(
-		( select ) => {
-			const { getEditedPostAttribute, getSuggestedPostFormat } = select(
-				'core/editor'
-			);
-			const _postFormat = getEditedPostAttribute( 'format' );
-			const themeSupports = select( 'core' ).getThemeSupports();
-			return {
-				postFormat: _postFormat ?? 'standard',
-				suggestedFormat: getSuggestedPostFormat(),
-				// Ensure current format is always in the set.
-				// The current format may not be a format supported by the theme.
-				supportedFormats: union(
-					[ _postFormat ],
-					get( themeSupports, [ 'formats' ], [] )
-				),
-			};
-		},
-		[]
-	);
+	const { postFormat, suggestedFormat } = useSelect( ( select ) => {
+		const { getEditedPostAttribute, getSuggestedPostFormat } = select(
+			'core/editor'
+		);
+		const _postFormat = getEditedPostAttribute( 'format' );
+		return {
+			postFormat: _postFormat ?? 'standard',
+			suggestedFormat: getSuggestedPostFormat(),
+		};
+	}, [] );
 
-	const formats = POST_FORMATS.filter( ( format ) =>
-		includes( supportedFormats, format.id )
-	);
+	const formats = usePostFormats();
+
 	const suggestion = find(
 		formats,
 		( format ) => format.id === suggestedFormat

--- a/packages/editor/src/components/post-pending-status/index.js
+++ b/packages/editor/src/components/post-pending-status/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -12,6 +12,8 @@ import { compose } from '@wordpress/compose';
 import PostPendingStatusCheck from './check';
 
 export function PostPendingStatus( { status, onUpdateStatus } ) {
+	const { __ } = useTranslate();
+
 	const togglePendingStatus = () => {
 		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
 		onUpdateStatus( updatedStatus );

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, includes } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,14 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { POST_FORMATS } from '../post-format';
-
-const getSuggestion = ( supportedFormats, suggestedPostFormat ) => {
-	const formats = POST_FORMATS.filter( ( format ) =>
-		includes( supportedFormats, format.id )
-	);
-	return find( formats, ( format ) => format.id === suggestedPostFormat );
-};
+import { usePostFormats } from '../post-format';
 
 const PostFormatSuggestion = ( {
 	suggestedPostFormat,
@@ -33,25 +26,24 @@ const PostFormatSuggestion = ( {
 );
 
 export default function PostFormatPanel() {
-	const { currentPostFormat, suggestion } = useSelect( ( select ) => {
+	const { currentPostFormat, getSuggestedFormat } = useSelect( ( select ) => {
 		const { getEditedPostAttribute, getSuggestedPostFormat } = select(
 			'core/editor'
 		);
-		const supportedFormats = get(
-			select( 'core' ).getThemeSupports(),
-			[ 'formats' ],
-			[]
-		);
 		return {
 			currentPostFormat: getEditedPostAttribute( 'format' ),
-			suggestion: getSuggestion(
-				supportedFormats,
-				getSuggestedPostFormat()
-			),
+			getSuggestedFormat: getSuggestedPostFormat,
 		};
 	}, [] );
 
 	const { editPost } = useDispatch( 'core/editor' );
+
+	const formats = usePostFormats();
+
+	const suggestion = find(
+		formats,
+		( format ) => format.id === getSuggestedFormat()
+	);
 
 	const onUpdatePostFormat = ( format ) => editPost( { format } );
 

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -1,11 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { format, __experimentalGetSettings } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
 export function PostScheduleLabel( { date, isFloating } ) {
+	const { __ } = useTranslate();
+
 	const settings = __experimentalGetSettings();
 
 	return date && ! isFloating

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -12,6 +12,8 @@ import { compose } from '@wordpress/compose';
 import PostStickyCheck from './check';
 
 export function PostSticky( { onUpdateSticky, postSticky = false } ) {
+	const { __ } = useTranslate();
+
 	return (
 		<PostStickyCheck>
 			<CheckboxControl

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useTranslate } from '@wordpress/react-i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { ENTER } from '@wordpress/keycodes';
@@ -27,6 +27,7 @@ import PostTypeSupportCheck from '../post-type-support-check';
 const REGEXP_NEWLINES = /[\r\n]+/g;
 
 export default function PostTitle() {
+	const { __ } = useTranslate();
 	const instanceId = useInstanceId( PostTitle );
 	const ref = useRef();
 	const [ isSelected, setIsSelected ] = useState( false );

--- a/packages/editor/src/components/post-visibility/label.js
+++ b/packages/editor/src/components/post-visibility/label.js
@@ -7,17 +7,36 @@ import { find } from 'lodash';
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
+import { useTranslate } from '@wordpress/react-i18n';
 
-/**
- * Internal dependencies
- */
-import { visibilityOptions } from './utils';
+export const usePostVisibilityOptions = () => {
+	const { __ } = useTranslate();
+
+	return [
+		{
+			value: 'public',
+			label: __( 'Public' ),
+			info: __( 'Visible to everyone.' ),
+		},
+		{
+			value: 'private',
+			label: __( 'Private' ),
+			info: __( 'Only visible to site admins and editors.' ),
+		},
+		{
+			value: 'password',
+			label: __( 'Password Protected' ),
+			info: __(
+				'Protected with a password you choose. Only those with the password can view this post.'
+			),
+		},
+	];
+};
 
 function PostVisibilityLabel( { visibility } ) {
-	const getVisibilityLabel = () =>
-		find( visibilityOptions, { value: visibility } ).label;
+	const visibilityOptions = usePostVisibilityOptions();
 
-	return getVisibilityLabel( visibility );
+	return find( visibilityOptions, { value: visibility } ).label;
 }
 
 export default withSelect( ( select ) => ( {

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -40,6 +40,23 @@ _Returns_
 
 -   `I18n`: I18n instance
 
+<a name="getLocaleData" href="#getLocaleData">#</a> **getLocaleData**
+
+Returns the current locale data by domain in a
+Jed-formatted JSON object shape.
+
+_Related_
+
+-   <http://messageformat.github.io/Jed/>
+
+_Parameters_
+
+-   _domain_ `[string]`: Domain for which configuration is wanted.
+
+_Returns_
+
+-   `LocaleData`: Locale data.
+
 <a name="isRTL" href="#isRTL">#</a> **isRTL**
 
 Check if current locale is RTL.

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -31,6 +31,13 @@ const DEFAULT_LOCALE_DATA = {
  * @see http://messageformat.github.io/Jed/
  */
 /**
+ * @typedef {(domain?: string) => LocaleData} GetLocaleData
+ * Returns locale data by domain in a
+ * Jed-formatted JSON object shape.
+ *
+ * @see http://messageformat.github.io/Jed/
+ */
+/**
  * @typedef {(text: string, domain?: string) => string} __
  *
  * Retrieve the translation of text.
@@ -78,6 +85,7 @@ const DEFAULT_LOCALE_DATA = {
  * @typedef I18n
  * @property {SetLocaleData} setLocaleData Merges locale data into the Tannin instance by domain. Accepts data in a
  *                                         Jed-formatted JSON object shape.
+ * @property {GetLocaleData} getLocaleData Returns locale data by domain in a Jed-formatted JSON object shape.
  * @property {__} __                       Retrieve the translation of text.
  * @property {_x} _x                       Retrieve translated string with gettext context.
  * @property {_n} _n                       Translates and retrieves the singular or plural form based on the supplied
@@ -117,6 +125,9 @@ export const createI18n = ( initialData, initialDomain ) => {
 			...tannin.data[ domain ][ '' ],
 		};
 	};
+
+	/** @type {GetLocaleData} */
+	const getLocaleData = ( domain = 'default' ) => tannin.data[ domain ];
 
 	/**
 	 * Wrapper for Tannin's `dcnpgettext`. Populates default locale data if not
@@ -178,6 +189,7 @@ export const createI18n = ( initialData, initialDomain ) => {
 
 	return {
 		setLocaleData,
+		getLocaleData,
 		__,
 		_x,
 		_n,

--- a/packages/i18n/src/default-i18n.js
+++ b/packages/i18n/src/default-i18n.js
@@ -26,6 +26,18 @@ const i18n = createI18n();
 export const setLocaleData = i18n.setLocaleData.bind( i18n );
 
 /**
+ * Returns the current locale data by domain in a
+ * Jed-formatted JSON object shape.
+ *
+ * @see http://messageformat.github.io/Jed/
+ *
+ * @param {string} [domain] Domain for which configuration is wanted.
+ *
+ * @return {LocaleData} Locale data.
+ */
+export const getLocaleData = i18n.getLocaleData.bind( i18n );
+
+/**
  * Retrieve the translation of text.
  *
  * @see https://developer.wordpress.org/reference/functions/__/

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -1,3 +1,11 @@
 export { sprintf } from './sprintf';
 export * from './create-i18n';
-export { setLocaleData, __, _x, _n, _nx, isRTL } from './default-i18n';
+export {
+	setLocaleData,
+	getLocaleData,
+	__,
+	_x,
+	_n,
+	_nx,
+	isRTL,
+} from './default-i18n';

--- a/packages/react-i18n/.npmrc
+++ b/packages/react-i18n/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+Initial release.

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -1,0 +1,11 @@
+# `@wordpress/react-i18n`
+
+> TODO: description
+
+## Usage
+
+```
+const reactI18N = require('@wordpress/react-i18n');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@wordpress/react-i18n",
+	"version": "1.0.0-prerelease",
+	"description": "WordPress internationalization (i18n) library for React.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"i18n",
+		"react"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/react-i18n/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/react-i18n"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"react-native": "src/index",
+	"dependencies": {
+		"@babel/runtime": "^7.12.5",
+		"@wordpress/api-fetch": "file:../api-fetch",
+		"@wordpress/element": "file:../element",
+		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/url": "file:../url"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/react-i18n/src/index.js
+++ b/packages/react-i18n/src/index.js
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies
+ */
+import React, {
+	createContext,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+	useCallback,
+} from '@wordpress/element';
+import { createI18n, getLocaleData } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const SCRIPT_HANDLES = [];
+
+const Context = createContext( null );
+
+export function LocaleProvider( { locale: initialLocale, domain, children } ) {
+	const [ locale, setLocale ] = useState( initialLocale );
+	const [ localeMap, setLocaleMap ] = useState( () => {
+		return new Map().set(
+			initialLocale,
+			createI18n( getLocaleData( domain ), domain )
+		);
+	} );
+
+	const switchToLocale = useCallback(
+		( newLocale ) => {
+			if ( ! localeMap.get( newLocale ) ) {
+				setLocaleMap(
+					new Map(
+						localeMap.set( newLocale, createI18n( {}, domain ) )
+					)
+				);
+			}
+			setLocale( newLocale );
+		},
+		[ localeMap ]
+	);
+
+	// Adds new locale data (= translations) and updates the map to force a re-render.
+	const setLocaleData = useCallback(
+		( data ) => {
+			localeMap.get( locale ).setLocaleData( data );
+			setLocaleMap(
+				new Map( localeMap.set( locale, localeMap.get( locale ) ) )
+			);
+		},
+		[ locale, localeMap ]
+	);
+
+	// TODO: Do some caching.
+	useEffect( () => {
+		async function fetchTranslations() {
+			const result = await apiFetch( {
+				path: addQueryArgs( `/__experimental/translations`, {
+					handles: SCRIPT_HANDLES,
+					locale,
+				} ),
+			} );
+
+			for ( const translations of Object.values( result ) ) {
+				const localeData =
+					translations.locale_data[ domain ] ||
+					translations.locale_data.messages;
+				localeData[ '' ].domain = domain;
+
+				localeMap.get( locale ).setLocaleData( localeData );
+			}
+
+			setLocaleMap(
+				new Map( localeMap.set( locale, localeMap.get( locale ) ) )
+			);
+		}
+
+		if ( 'en_US' !== locale ) {
+			fetchTranslations();
+		}
+	}, [ locale, domain ] );
+
+	const value = useMemo( () => {
+		const { __, _x, _n, _nx, isRtl } = localeMap?.get( locale ) || {};
+
+		return {
+			locale,
+			__,
+			_x,
+			_n,
+			_nx,
+			isRtl,
+			setLocaleData,
+			switchToLocale,
+		};
+	}, [ locale, localeMap, setLocaleData ] );
+
+	return <Context.Provider value={ value }>{ children }</Context.Provider>;
+}
+
+/**
+ * React hook used to retrieve the layout config.
+ */
+export function useTranslate() {
+	return useContext( Context );
+}
+
+export function addHandle( handle ) {
+	SCRIPT_HANDLES.push( handle );
+}

--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import '@wordpress/format-library';
+import { LocaleProvider } from '@wordpress/react-i18n';
 
 /**
  * Internal dependencies
@@ -34,25 +35,27 @@ function App() {
 		<div className="playground">
 			<SlotFillProvider>
 				<DropZoneProvider>
-					<BlockEditorProvider
-						value={ blocks }
-						onInput={ updateBlocks }
-						onChange={ updateBlocks }
-					>
-						<div className="playground__sidebar">
-							<BlockInspector />
-						</div>
-						<div className="editor-styles-wrapper">
-							<Popover.Slot name="block-toolbar" />
-							<BlockEditorKeyboardShortcuts />
-							<WritingFlow>
-								<ObserveTyping>
-									<BlockList />
-								</ObserveTyping>
-							</WritingFlow>
-						</div>
-						<Popover.Slot />
-					</BlockEditorProvider>
+					<LocaleProvider locale="en_US" domain="default">
+						<BlockEditorProvider
+							value={ blocks }
+							onInput={ updateBlocks }
+							onChange={ updateBlocks }
+						>
+							<div className="playground__sidebar">
+								<BlockInspector />
+							</div>
+							<div className="editor-styles-wrapper">
+								<Popover.Slot name="block-toolbar" />
+								<BlockEditorKeyboardShortcuts />
+								<WritingFlow>
+									<ObserveTyping>
+										<BlockList />
+									</ObserveTyping>
+								</WritingFlow>
+							</div>
+							<Popover.Slot />
+						</BlockEditorProvider>
+					</LocaleProvider>
 				</DropZoneProvider>
 			</SlotFillProvider>
 		</div>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Explores possibilities of client-side locale switching using a new `react-i18n` package containing a React context provider.

As discussed in #19210

After the fact I learned that this is similar to what Automattic has been working on [here](https://github.com/Automattic/wp-calypso/tree/trunk/packages/react-i18n?rgh-link-date=2021-01-04T14%3A06%3A48Z).

## How has this been tested?

There's some dummy dropdown in there at the moment for easier testing.

## Screenshots <!-- if applicable -->

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->