### PR TITLE
Scripts: Fix multiple build runtimes conflicting when using globals

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 -   The bundled `webpack-bundle-analyzer` dependency has been updated from requiring `^3.6.1` to requiring `^4.2.0`.
 
+### Bug Fix
+
+-   Fix multiple build (`build` command) runtimes conflicting when using globals ([#27985](https://github.com/WordPress/gutenberg/pull/27985)).
+
 ## 12.6.0 (2020-12-17)
 
 ### Enhancements

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -17,7 +17,11 @@ const postcssPlugins = require( '@wordpress/postcss-plugins-preset' );
 /**
  * Internal dependencies
  */
-const { hasBabelConfig, hasPostCSSConfig } = require( '../utils' );
+const {
+	getPackageProp,
+	hasBabelConfig,
+	hasPostCSSConfig,
+} = require( '../utils' );
 const FixStyleWebpackPlugin = require( './fix-style-webpack-plugin' );
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -46,6 +50,32 @@ const cssLoaders = [
 	},
 ];
 
+/**
+ * Gets a unique identifier for the webpack build to avoid multiple webpack
+ * runtimes to conflict when using globals.
+ * This is polyfill and it is based on the default webpack 5 implementation.
+ *
+ * @see https://github.com/webpack/webpack/blob/bbb16e7af2eddba4cd77ca739904c2aa238a2b7b/lib/config/defaults.js#L374-L376
+ *
+ * @return {string} The generated identifier.
+ */
+const getJsonpFunctionIdentifier = () => {
+	const jsonpFunction = 'webpackJsonp_';
+	const packageName = getPackageProp( 'name' );
+	if ( typeof packageName !== 'string' || ! packageName ) {
+		return jsonpFunction;
+	}
+	const IDENTIFIER_NAME_REPLACE_REGEX = /^([^a-zA-Z$_])/;
+	const IDENTIFIER_ALPHA_NUMERIC_NAME_REPLACE_REGEX = /[^a-zA-Z0-9$]+/g;
+
+	return (
+		jsonpFunction +
+		packageName
+			.replace( IDENTIFIER_NAME_REPLACE_REGEX, '_$1' )
+			.replace( IDENTIFIER_ALPHA_NUMERIC_NAME_REPLACE_REGEX, '_' )
+	);
+};
+
 const config = {
 	mode,
 	entry: {
@@ -54,6 +84,10 @@ const config = {
 	output: {
 		filename: '[name].js',
 		path: path.resolve( process.cwd(), 'build' ),
+		// Prevents conflicts when multiple webpack runtimes (from different apps)
+		// are used on the same page.
+		// @see https://github.com/WordPress/gutenberg/issues/23607
+		jsonpFunction: getJsonpFunctionIdentifier(),
 	},
 	resolve: {
 		alias: {

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -19,7 +19,7 @@ const {
 	hasPostCSSConfig,
 } = require( './config' );
 const { fromProjectRoot, fromConfigRoot, hasProjectFile } = require( './file' );
-const { hasPackageProp } = require( './package' );
+const { getPackageProp, hasPackageProp } = require( './package' );
 
 module.exports = {
 	fromProjectRoot,
@@ -27,16 +27,17 @@ module.exports = {
 	getArgFromCLI,
 	getArgsFromCLI,
 	getFileArgsFromCLI,
-	getNodeArgsFromCLI,
-	getWebpackArgs,
-	hasBabelConfig,
-	hasArgInCLI,
-	hasFileArgInCLI,
 	getJestOverrideConfigFile,
+	getNodeArgsFromCLI,
+	getPackageProp,
+	getWebpackArgs,
+	hasArgInCLI,
+	hasBabelConfig,
+	hasFileArgInCLI,
 	hasJestConfig,
 	hasPackageProp,
-	hasPrettierConfig,
 	hasPostCSSConfig,
+	hasPrettierConfig,
 	hasProjectFile,
 	spawnScript,
 };

--- a/packages/scripts/utils/package.js
+++ b/packages/scripts/utils/package.js
@@ -15,9 +15,12 @@ const { pkg, path: pkgPath } = readPkgUp( {
 
 const getPackagePath = () => pkgPath;
 
+const getPackageProp = ( prop ) => pkg && pkg[ prop ];
+
 const hasPackageProp = ( prop ) => pkg && pkg.hasOwnProperty( prop );
 
 module.exports = {
 	getPackagePath,
+	getPackageProp,
 	hasPackageProp,
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #23607.
Fixes #24321.
Fixes #27432.
Fixes #27969.

This PR adds the polyfill for the default behavior that was added in webpack 5. We are still on webpack 4 that had `output.jsonpFunction` field that allowed us to define a unique identifier for the build runtime.

This patch prevents conflicts when multiple webpack runtimes (from different apps) are used on the same page. The only requirement is that project needs to have `package.json` defined with a unique name.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This part is tricky but it's definitely possible. It has to follow CI job for Gutenberg that verifies `@wordpress/create-block`:
https://github.com/WordPress/gutenberg/blob/e389aeb94385822073190cf7e57d502921e9790f/bin/test-create-block.sh#L25-L32

You need to create two blocks with the latest Gutenberg that don't install `@wordpress/scripts` and use the patched version of `@wordpress/scripts` from this branch.

```bash
npx wp-create-block my-block-1 --no-wp-scripts
cd my-block-1
../node_modules/.bin/wp-scripts build
cd ..
npx wp-create-block my-block-2 --no-wp-scripts
cd my-block-1
../node_modules/.bin/wp-scripts build
```

Now you need to put both blocks (plugins) in the WordPress plugins directory and verify they load.

You can also verify that the unique name  is used in the `build/index.js` file:

<img width="1345" alt="Screen Shot 2021-01-05 at 11 25 32" src="https://user-images.githubusercontent.com/699132/103635452-d2ee3c00-4f48-11eb-868c-dc864da62846.png">

<img width="1517" alt="Screen Shot 2021-01-05 at 11 28 24" src="https://user-images.githubusercontent.com/699132/103635669-26f92080-4f49-11eb-84ca-40b47b186086.png">

Now you can confirm that both blocks can work at the same time 🎉 

<img width="806" alt="Screen Shot 2021-01-05 at 11 34 19" src="https://user-images.githubusercontent.com/699132/103636273-08dff000-4f4a-11eb-8cdc-be1008755186.png">


## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
