### PR TITLE
Fix the border radius in the site editor.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -63,7 +63,7 @@
 			// Everything else.
 			// 2px outside.
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 
 			// Windows High Contrast mode will show this outline.
 			outline: 2px solid transparent;
@@ -185,7 +185,7 @@
 
 			// 2px outside.
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 
 			// Show a light color for dark themes.
 			.is-dark-theme & {
@@ -201,7 +201,7 @@
 			left: $border-width;
 			right: $border-width;
 			bottom: $border-width;
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 		}
 
 		&:focus {
@@ -220,7 +220,7 @@
 			right: $border-width;
 			bottom: $border-width;
 			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 		}
 	}
 
@@ -591,7 +591,7 @@
 
 		// Block UI appearance.
 		box-shadow: 0 0 0 $border-width $gray-900;
-		border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+		border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 		background-color: $white;
 
 		// When button is focused, it receives a box-shadow instead of the border.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -201,6 +201,7 @@
 			left: $border-width;
 			right: $border-width;
 			bottom: $border-width;
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 		}
 
 		&:focus {
@@ -219,6 +220,7 @@
 			right: $border-width;
 			bottom: $border-width;
 			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 		}
 	}
 


### PR DESCRIPTION
File under "subtle but important". The border radius of selected blocks in the site editor was wrong. It was 3px instead of 2. This PR fixes that.

Before:

<img width="408" alt="Screenshot 2021-01-05 at 10 52 08" src="https://user-images.githubusercontent.com/1204802/103634127-f31cfb80-4f46-11eb-82da-1c18a21c1c65.png">

<img width="366" alt="Screenshot 2021-01-05 at 10 52 12" src="https://user-images.githubusercontent.com/1204802/103634135-f57f5580-4f46-11eb-9a16-2b1ae973ec64.png">

After:

<img width="540" alt="Screenshot 2021-01-05 at 11 00 56" src="https://user-images.githubusercontent.com/1204802/103634156-fc0dcd00-4f46-11eb-8992-bdc4e98718a1.png">

<img width="547" alt="Screenshot 2021-01-05 at 11 00 59" src="https://user-images.githubusercontent.com/1204802/103634162-fca66380-4f46-11eb-940b-86b2e5914919.png">
