### PR TITLE
Create Block: Print the block class name in the `save` method

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bug Fix
 
--   Print the block class name in the `save` method in scaffolded templates.
+-   Print the block class name in the `save` method in scaffolded templates ([#27988](https://github.com/WordPress/gutenberg/pull/27988)).
 
 ## 1.0.2 (2020-12-17)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   Adds the `npmPackages` field to the template configuration. It allows listing remote npm packages that will be installed in the scaffolded project ([#27880](https://github.com/WordPress/gutenberg/pull/27880)).
 -   Installs WordPress npm dependencies used in the `esnext` template during the scaffolding process ([#27880](https://github.com/WordPress/gutenberg/pull/27880)).
 
+### Bug Fix
+
+-   Print the block class name in the `save` method in scaffolded templates.
+
 ## 1.0.2 (2020-12-17)
 
 ### Bug Fix

--- a/packages/create-block/lib/templates/es5/index.js.mustache
+++ b/packages/create-block/lib/templates/es5/index.js.mustache
@@ -107,7 +107,7 @@
 		save: function() {
 			return el(
 				'p',
-				{},
+				useBlockProps.save(),
 				__( '{{title}} – hello from the saved content!', '{{textdomain}}' )
 			);
 		},

--- a/packages/create-block/lib/templates/esnext/src/save.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/save.js.mustache
@@ -6,6 +6,14 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/packages/packages-block-editor/#useBlockProps
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
  * The save function defines the way in which the different attributes should
  * be combined into the final markup, which is then serialized by the block
  * editor into `post_content`.
@@ -16,7 +24,7 @@ import { __ } from '@wordpress/i18n';
  */
 export default function save() {
 	return (
-		<p>
+		<p { ...useBlockProps.save() }>
 			{ __(
 				'{{title}} – hello from the saved content!',
 				'{{textdomain}}'


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

It brings the old behavior that was implicit in block API version 1. In version 2, the class name for the block is generated only when explicitly using `useBlockProps.save` method call.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This part is tricky but it's definitely possible. It has to follow CI job for Gutenberg that verifies `@wordpress/create-block`:
https://github.com/WordPress/gutenberg/blob/e389aeb94385822073190cf7e57d502921e9790f/bin/test-create-block.sh#L25-L32

You need to create two blocks (one with es5 and one with esnext template) with the latest Gutenberg that don't install `@wordpress/scripts`:

```bash
npx wp-create-block my-block-1 --no-wp-scripts
npx wp-create-block my-block-2 --no-wp-scripts
cd my-block-1
../node_modules/.bin/wp-scripts build
```

Now you need to put both blocks (plugins) in the WordPress plugins directory and verify they are activated. Next step is injecting both blocks in the post and checking it the class name is generated and CSS applied on the front-end.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: htps://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
