### PR TITLE
Search Block: Add border radius support using CSS variable approach

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -317,6 +317,12 @@ h4 {
 }
 ```
 
+#### Border Properties
+
+| Context | Radius |
+| --- | --- |
+| Search | Yes |
+
 #### Color Properties
 
 These are the current color properties supported by blocks:

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -46,6 +46,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		if ( isset( $block_attributes['style']['border']['radius'] ) ) {
 			$border_radius = intval( $block_attributes['style']['border']['radius'] );
 			$styles[]      = sprintf( 'border-radius: %dpx;', $border_radius );
+			$styles[]      = sprintf( '--wp--style--border--radius: %dpx;', $border_radius );
 		}
 	}
 

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -235,6 +235,10 @@ class WP_Theme_JSON {
 	 * - 'support': path to the block support in block.json.
 	 */
 	const PROPERTIES_METADATA = array(
+		'--wp--style--border--radius' => array(
+			'value'   => array( 'border', 'radius' ),
+			'support' => array( '__experimentalBorder', 'radius' ),
+		),
 		'--wp--style--color--link' => array(
 			'value'   => array( 'color', 'link' ),
 			'support' => array( 'color', 'link' ),

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -36,16 +36,18 @@ export function BorderRadiusEdit( props ) {
 			...style,
 			border: {
 				...style?.border,
-				radius: newRadius,
+				radius: newRadius && `${ newRadius }px`,
 			},
 		};
 
 		setAttributes( { style: cleanEmptyObject( newStyle ) } );
 	};
 
+	const value = style?.border?.radius.replace( 'px', '' );
+
 	return (
 		<RangeControl
-			value={ style?.border?.radius }
+			value={ value && parseInt( value ) }
 			label={ __( 'Border radius' ) }
 			min={ MIN_BORDER_RADIUS_VALUE }
 			max={ MAX_BORDER_RADIUS_VALUE }

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -20,6 +20,7 @@ describe( 'getInlineStyles', () => {
 				border: { radius: 10 },
 			} )
 		).toEqual( {
+			'--wp--style--border--radius': 10,
 			backgroundColor: 'black',
 			borderRadius: 10,
 			color: 'red',

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -34,7 +34,10 @@
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],
-		"html": false
+		"html": false,
+		"__experimentalBorder": {
+			"radius": true
+		}
 	},
 	"editorStyle": "wp-block-search-editor",
 	"style": "wp-block-search"

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -9,7 +9,6 @@
 
 	.wp-block-search__button {
 		height: auto;
-		border-radius: initial;
 
 		// This needs high specificity because it otherwise inherits styles from `components-button`.
 		// stylelint-disable-line no-duplicate-selectors

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -7,6 +7,7 @@
 		color: #32373c;
 		margin-left: 0.625em;
 		word-break: normal;
+		border-radius: var(--wp--style--border--radius);
 
 		&.has-icon {
 			line-height: 0;
@@ -23,6 +24,7 @@
 		flex: auto;
 		flex-wrap: nowrap;
 		max-width: 100%;
+		border-radius: var(--wp--style--border--radius);
 	}
 
 	.wp-block-search__label {
@@ -33,6 +35,7 @@
 		flex-grow: 1;
 		min-width: 3em;
 		border: 1px solid $gray-600;
+		border-radius: var(--wp--style--border--radius);
 	}
 
 	&.wp-block-search__button-only {
@@ -44,9 +47,14 @@
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		padding: $grid-unit-05;
 		border: 1px solid $gray-600;
+		// Determine what the minimum inner border radius should be. No outer radius equals 0, otherwise 1px.
+		// Must be 0px so max() can actually compare values later.
+		--wp--search--min-border-radius: clamp(0px, var(--wp--style--border--radius, 0px), 1px); /* stylelint-disable-line length-zero-no-unit */
 
 		.wp-block-search__input {
-			border-radius: 0;
+			// Adjust inner radius so it is visually consistent with outer radius. i.e. no "fat" corners.
+			// Maximum out of the outer radius minus padding or the minimum radius --wp--search--min-border-radius.
+			border-radius: max(var(--wp--style--border--radius, 0) - #{$grid-unit-05}, var(--wp--search--min-border-radius, 1px));
 			border: none;
 			padding: 0 0 0 0.25em;
 
@@ -56,6 +64,9 @@
 		}
 
 		.wp-block-search__button {
+			// Adjust inner radius so it is visually consistent with outer radius. i.e. no "fat" corners.
+			// Maximum out of the outer radius minus padding or the minimum radius --wp--search--min-border-radius.
+			border-radius: max(var(--wp--style--border--radius, 0) - #{$grid-unit-05}, var(--wp--search--min-border-radius, 1px));
 			padding: 0.125em 0.5em;
 		}
 	}

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -13,6 +13,10 @@ export const DEPRECATED_ENTRY_KEYS = [
 ];
 
 export const __EXPERIMENTAL_STYLE_PROPERTY = {
+	'--wp--style--border--radius': {
+		value: [ 'border', 'radius' ],
+		support: [ '__experimentalBorder', 'radius' ],
+	},
 	'--wp--style--color--link': {
 		value: [ 'color', 'link' ],
 		support: [ 'color', 'link' ],


### PR DESCRIPTION
## Description

This PR adds a CSS variable (aka custom property) to the border radius block support and leverages this to apply border radii to the search block and its inner elements as needed.

The updates also handle adjusting the border radius when the search button is placed "inside" the search container. This allows the inner border radius to visually match the outer container without appearing to have "fat corners" as [illustrated here](https://github.com/WordPress/gutenberg/pull/25203#issuecomment-689870244).

As per current recommendations, this will not introduce any border radius controls into the editor's sidebar. It is also an alternative approach to https://github.com/WordPress/gutenberg/pull/27664

## How has this been tested?
Manually and unit test: `npm run test-unit:watch packages/block-editor/src/hooks/test/style.js`

### Testing Instructions

1. Checkout this PR 
2. Activate a theme that uses a theme.json file or copy the `lib/experiment-default-theme.json` file into a theme's root folder as `experimental-theme.json`
3. Create a new post and add a search block to it
4. Select the search block and confirm no border radius controls show in the sidebar
5. Edit the `experimental-theme.json` file from step 2 and the following context at the JSON's top level. ([example gist](https://gist.github.com/aaronrobertshaw/54bb38df9668174ae3afc35da1b2bfe4))
```
    "core/search": {
        "styles": {
            "border": {
                "radius": "10px"
            }
        }
    }
```
6. Reload the editor and confirm the search block has a 10px border radius
7. Change the layout for the search block, moving the button "inside", and confirm the inner elements get appropriate border radius values applied
8. Edit the `experimental-theme.json` file again, this time turning on the `border.customRadius` flag
```
    "border": {
        "customRadius": true
    }
```
9. Reload the editor and select the search block again. This time the border radius controls will show in the sidebar (this is only for ease in testing that the border radius can be applied via block attributes)
10. Adjust the border radius value via the sidebar controls and confirm its values take precedence over the theme.json value.

## Screenshots <!-- if applicable -->

#### Search Block with attribute set
<img width="1219" alt="Screen Shot 2021-01-05 at 9 11 13 pm" src="https://user-images.githubusercontent.com/60436221/103639941-e4603400-4f9a-11eb-9b19-914265b52935.png">

#### Search Block testing with controls turned on
![SearchBorderRadius2](https://user-images.githubusercontent.com/60436221/103640266-6ea89800-4f9b-11eb-8b1e-c5a6bd7d44b7.gif)

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
