### PR TITLE
[Mobile] - Link settings - Fix updating settings when closing the bottom sheet

### DIFF
--- a/packages/components/src/mobile/link-settings/index.native.js
+++ b/packages/components/src/mobile/link-settings/index.native.js
@@ -89,7 +89,7 @@ function LinkSettings( {
 
 	const { onHandleClosingBottomSheet } = useContext( BottomSheetContext );
 	useEffect( () => {
-		if ( ! onLinkCellPressed ) {
+		if ( onHandleClosingBottomSheet ) {
 			onHandleClosingBottomSheet( onCloseSettingsSheet );
 		}
 	}, [ urlInputValue, labelInputValue, linkRelInputValue ] );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/27996

## Description
Fixes an issue where the link rel value is not being updated when closing the bottom sheet. 

## How has this been tested?
1. Add a `Buttons` block
2. Open the toolbar link settings
3. Set a link
4. Set a link rel value
5. Close the bottom sheet
6. Open the link setting again
7. **Expect** to see the link rel value

## Screenshots 
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/103654255-ebb91a80-4f65-11eb-985d-66f89cd797d4.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/103654251-e9ef5700-4f65-11eb-83d3-354bbecd07f9.gif" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
