### PR TITLE
[RNMobile] Fix File block E2E test

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-file-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-file-@canary.test.js
@@ -3,6 +3,7 @@
  */
 import { blockNames } from './pages/editor-page';
 import testData from './helpers/test-data';
+import { isAndroid } from './helpers/utils';
 
 describe( 'Gutenberg Editor File Block tests', () => {
 	it( 'should be able to add a file block', async () => {
@@ -15,7 +16,13 @@ describe( 'Gutenberg Editor File Block tests', () => {
 		const block = await editorPage.getFirstBlockVisible();
 
 		block.click();
-		await editorPage.driver.sleep( 1000 );
+
+		if ( isAndroid ) {
+			await editorPage.driver.sleep( 5000 );
+		} else {
+			await editorPage.driver.sleep( 1000 );
+		}
+
 		await editorPage.chooseMediaLibrary();
 
 		const html = await editorPage.getHtmlContent();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This is an attempt to resolve the File Block test flakiness that occurs. 

The primary solutions I have thought of so far are as follows: 

1. The current approach of increasing the sleep time before the media source is chosen. 
2. Utilizing the  `browser.waitForElementBy` that is described in the [wd](https://github.com/admc/wd) docs. This function would ensure that the element is available before clicking.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
