### PR TITLE
Scripts: Make it possible to transpile `.jsx` files with build command

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 -   `wordpress` subfolder is no longer ignored when detecting files for testing, linting or formatting.
 -   The bundled `eslint` dependency has been updated from requiring `^7.1.0` to requiring `^7.17.0` ([#27965](https://github.com/WordPress/gutenberg/pull/27965)).
+-   Make it possible to transpile `.jsx` files with `build` and `start` commands ([#28002](https://github.com/WordPress/gutenberg/pull/28002)).
 
 ### Internal
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -129,7 +129,7 @@ const config = {
 	module: {
 		rules: [
 			{
-				test: /\.js$/,
+				test: /\.jsx?$/,
 				exclude: /node_modules/,
 				use: [
 					require.resolve( 'thread-loader' ),


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Closes #21009 based on the proposal from @cliffordp.

> **Is your feature request related to a problem? Please describe.**
> `.jsx` files aren't processed by wordpress/scripts' webpack file, but `.js` files are.
> 
> **Describe the solution you'd like**
> Is it as simple as changing https://github.com/WordPress/gutenberg/blob/v7.7.1/packages/scripts/config/webpack.config.js#L38
> 
> from:
> `test: /\.js$/,`
> to:
> `test: /\.jsx?$/,`

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

This change aligns with other commands that already work with `.jsx`:
- `format-js`
- `lint-js`
- `test-unit`

## Testing

CI job that verifies whether create block build should be enough to verify it still works for regular JS files:
https://github.com/WordPress/gutenberg/pull/28002/checks?check_run_id=1651791361

<img width="686" alt="Screen Shot 2021-01-05 at 19 34 43" src="https://user-images.githubusercontent.com/699132/103685191-14a0d600-4f8d-11eb-9ba0-9a5701ff00f7.png">
