### PR TITLE
Making the sidebar inspector's tabs stick when scrolling.

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -57,11 +57,6 @@
 	}
 }
 
-.interface-interface-skeleton__sidebar > div {
-	height: 100%;
-	padding-bottom: $grid-unit-60;
-}
-
 .edit-post-layout .editor-post-publish-panel__header-publish-button {
 	justify-content: center;
 }

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -4,9 +4,6 @@
 	padding-right: $grid-unit-20;
 	border-top: 0;
 	margin-top: 0;
-	position: sticky;
-	z-index: 1;
-	top: 0;
 
 	ul {
 		display: flex;

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -4,6 +4,9 @@
 	padding-right: $grid-unit-20;
 	border-top: 0;
 	margin-top: 0;
+	position: sticky;
+	z-index: 1;
+	top: 0;
 
 	ul {
 		display: flex;

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -18,6 +18,14 @@
 		position: sticky;
 		top: 0;
 		z-index: z-index(".components-panel__header");
+
+		&.edit-post-sidebar__panel-tabs {
+			top: 48px;
+
+			@include break-medium() {
+				top: 0;
+			}
+		}
 	}
 
 	p {

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -4,9 +4,6 @@
 	overflow: visible;
 
 	@include break-small() {
-		z-index: auto;
-		height: 100%;
-		overflow: auto;
 		-webkit-overflow-scrolling: touch;
 	}
 
@@ -24,12 +21,6 @@
 		margin-top: -1px;
 		margin-bottom: -1px;
 		position: relative;
-
-		@include break-small() {
-			overflow: visible;
-			height: auto;
-			max-height: none;
-		}
 	}
 
 	> .components-panel .components-panel__header {
@@ -39,13 +30,6 @@
 		left: 0;
 		right: 0;
 		height: $panel-header-height;
-
-		@include break-small() {
-			position: inherit;
-			top: auto;
-			left: auto;
-			right: auto;
-		}
 	}
 
 	p {

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -1,7 +1,6 @@
 .interface-complementary-area {
 	background: $white;
 	color: $gray-900;
-	overflow: visible;
 
 	@include break-small() {
 		-webkit-overflow-scrolling: touch;
@@ -11,25 +10,14 @@
 		width: $sidebar-width;
 	}
 
-	> .components-panel {
-		border-left: none;
-		border-right: none;
-		overflow: auto;
-		-webkit-overflow-scrolling: touch;
-		height: auto;
-		max-height: calc(100vh - #{ $admin-bar-height-big + $panel-header-height + $panel-header-height });
-		margin-top: -1px;
-		margin-bottom: -1px;
-		position: relative;
+	.components-panel {
+		border: none;
 	}
 
-	> .components-panel .components-panel__header {
-		position: fixed;
-		z-index: z-index(".components-panel__header");
+	.components-panel__header {
+		position: sticky;
 		top: 0;
-		left: 0;
-		right: 0;
-		height: $panel-header-height;
+		z-index: z-index(".components-panel__header");
 	}
 
 	p {

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -20,7 +20,7 @@
 		z-index: z-index(".components-panel__header");
 
 		&.edit-post-sidebar__panel-tabs {
-			top: 48px;
+			top: $panel-header-height;
 
 			@include break-medium() {
 				top: 0;

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -106,8 +106,9 @@ html.interface-interface-skeleton__html-container {
 }
 
 .interface-interface-skeleton__sidebar {
+	overflow: auto;
+
 	@include break-medium() {
-		overflow: auto;
 		border-left: $border-width solid $gray-200;
 	}
 }


### PR DESCRIPTION
When the editor's inspector sidebar is open the tabs will now remain at the top while scrolling the sidebar.

![Sticky Tabs](https://user-images.githubusercontent.com/191598/103697890-8d446a00-4f6e-11eb-8485-8dfb5706f85b.gif)

This comes from (and resolves) #27873 