### PR TITLE
Fix: Add Image style settings for hotlinked images

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -419,9 +419,7 @@ export class ImageEdit extends React.Component {
 			<InspectorControls>
 				<PanelBody title={ __( 'Image settings' ) } />
 				<PanelBody style={ styles.panelBody }>
-					{ image && (
-						<BlockStyles clientId={ clientId } url={ url } />
-					) }
+					<BlockStyles clientId={ clientId } url={ url } />
 				</PanelBody>
 				<PanelBody>
 					{ image && sizeOptionsValid && (


### PR DESCRIPTION
## Description
Currently when the image is hotlinked the Image style settings are not present. 
This PR fixes this my making sure that the settings can still be applied. 

Before:
<img width="398" alt="Screen Shot 2021-01-05 at 4 24 35 PM" src="https://user-images.githubusercontent.com/115071/103714482-9b48b980-4f73-11eb-9ff5-7226c91a79cb.png">
(Notice the missing Image styles for the border (default and rounded)

After:
<img width="395" alt="Screen Shot 2021-01-05 at 4 22 22 PM" src="https://user-images.githubusercontent.com/115071/103714501-a3a0f480-4f73-11eb-8035-2f93aa2e2a85.png">
Notice that the image styles are there.

Note: The web editor already support this for hot linked images.

## How has this been tested?
Apply this patch. 

Open up the iOS Mobile editor in the simulator. 
Add a new page for a WordPress.com site using the page templates. 
Notice that the images in the image blocks are actually hotlinked and are not imported. So the Image styles are not there. This PR fixes this. 

## Screenshots <!-- if applicable -->
<img width="398" alt="Screen Shot 2021-01-05 at 4 23 18 PM" src="https://user-images.githubusercontent.com/115071/103714996-4ce7ea80-4f74-11eb-8e38-b0e891060bf4.png">

## Types of changes
Bug fix, a non breaking change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
