### PR TITLE
Docs: A wether, as it turns out, is a castrated ram

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -81,7 +81,7 @@ export function isNavigationCandidate( element, keyCode, hasModifier ) {
  * @param {Element} target           Currently focused text field.
  * @param {boolean} isReverse        True if considering as the first field.
  * @param {Element} containerElement Element containing all blocks.
- * @param {boolean} onlyVertical     Wether to only consider tabbable elements
+ * @param {boolean} onlyVertical     Whether to only consider tabbable elements
  *                                   that are visually above or under the
  *                                   target.
  *

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -85,12 +85,12 @@ export function getBlockContentSchema( context ) {
 }
 
 /**
- * Checks wether HTML can be considered plain text. That is, it does not contain
+ * Checks whether HTML can be considered plain text. That is, it does not contain
  * any elements that are not line breaks.
  *
  * @param {string} HTML The HTML to check.
  *
- * @return {boolean} Wether the HTML can be considered plain text.
+ * @return {boolean} Whether the HTML can be considered plain text.
  */
 export function isPlain( HTML ) {
 	return ! /<(?!br[ />])/i.test( HTML );

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -169,7 +169,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: Wether or not the element is empty.
+-   `boolean`: Whether or not the element is empty.
 
 <a name="isEntirelySelected" href="#isEntirelySelected">#</a> **isEntirelySelected**
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -156,7 +156,7 @@ _Parameters_
 
 _Returns_
 
--   `void`:
+-   `void`: 
 
 <a name="isEmpty" href="#isEmpty">#</a> **isEmpty**
 
@@ -288,7 +288,7 @@ _Parameters_
 
 _Returns_
 
--   `void`:
+-   `void`: 
 
 <a name="removeInvalidHTML" href="#removeInvalidHTML">#</a> **removeInvalidHTML**
 
@@ -315,7 +315,7 @@ _Parameters_
 
 _Returns_
 
--   `void`:
+-   `void`: 
 
 <a name="replaceTag" href="#replaceTag">#</a> **replaceTag**
 
@@ -340,7 +340,7 @@ _Parameters_
 
 _Returns_
 
--   `void`:
+-   `void`: 
 
 <a name="wrap" href="#wrap">#</a> **wrap**
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -156,7 +156,7 @@ _Parameters_
 
 _Returns_
 
--   `void`: 
+-   `void`:
 
 <a name="isEmpty" href="#isEmpty">#</a> **isEmpty**
 
@@ -169,7 +169,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: Wether or not the element is empty.
+-   `boolean`: Whether or not the element is empty.
 
 <a name="isEntirelySelected" href="#isEntirelySelected">#</a> **isEntirelySelected**
 
@@ -288,7 +288,7 @@ _Parameters_
 
 _Returns_
 
--   `void`: 
+-   `void`:
 
 <a name="removeInvalidHTML" href="#removeInvalidHTML">#</a> **removeInvalidHTML**
 
@@ -315,7 +315,7 @@ _Parameters_
 
 _Returns_
 
--   `void`: 
+-   `void`:
 
 <a name="replaceTag" href="#replaceTag">#</a> **replaceTag**
 
@@ -340,7 +340,7 @@ _Parameters_
 
 _Returns_
 
--   `void`: 
+-   `void`:
 
 <a name="wrap" href="#wrap">#</a> **wrap**
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -169,7 +169,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: Whether or not the element is empty.
+-   `boolean`: Wether or not the element is empty.
 
 <a name="isEntirelySelected" href="#isEntirelySelected">#</a> **isEntirelySelected**
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -958,7 +958,7 @@ function cleanNodeList( nodeList, doc, schema, inline ) {
  *
  * @param {Element} element The element to check.
  *
- * @return {boolean} Wether or not the element is empty.
+ * @return {boolean} Whether or not the element is empty.
  */
 export function isEmpty( element ) {
 	if ( ! element.hasChildNodes() ) {

--- a/packages/rich-text/src/is-active-list-type.js
+++ b/packages/rich-text/src/is-active-list-type.js
@@ -7,7 +7,7 @@ import { getLineIndex } from './get-line-index';
 /** @typedef {import('./create').RichTextValue} RichTextValue */
 
 /**
- * Wether or not the selected list has the given tag name.
+ * Whether or not the selected list has the given tag name.
  *
  * @param {RichTextValue} value    The value to check.
  * @param {string}        type     The tag name the list should have.

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -19,9 +19,9 @@ import {
  * @param  {Object}  $1.attributes             The format attributes.
  * @param  {Object}  $1.unregisteredAttributes The unregistered format
  *                                             attributes.
- * @param  {boolean} $1.object                 Wether or not it is an object
+ * @param  {boolean} $1.object                 Whether or not it is an object
  *                                             format.
- * @param  {boolean} $1.boundaryClass          Wether or not to apply a boundary
+ * @param  {boolean} $1.boundaryClass          Whether or not to apply a boundary
  *                                             class.
  * @return {Object}                            Information to be used for
  *                                             element creation.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
A simple documentation change, updating several instances of a mis-applied word throughout the codebase.

## How has this been tested?
Nothing functional changed, only documentation. 

## Types of changes
Only docs.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
