### PR TITLE
Save the draft so we don't get browser dialogs about leaving an unsaved page.

### DIFF
--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -143,6 +143,9 @@ describe( 'Post Editor Performance', () => {
 			}
 		}
 
+		// Save the draft so we don't get browser dialogs about leaving unsaved page.
+		await saveDraft();
+
 		// Measuring block selection performance
 		await createNewPost();
 		await page.evaluate( () => {


### PR DESCRIPTION
## Description
I'm trying to use packages/e2e-tests/specs/performance/post-editor.test.js as the basis for a new test, but as far as I can see it is currently broken. 

Example:
```
$ wp-scripts test-e2e  packages/e2e-tests/specs/performance/post-editor.test.js
Chromium is already in /Users/lee/sites/wc/wp-content/plugins/gutenberg/node_modules/puppeteer/.local-chromium/mac-737027; skipping download.
 FAIL  packages/e2e-tests/specs/performance/post-editor.test.js (55.993s)
  Post Editor Performance
    ✕ Loading, typing and selecting blocks (55025ms)
  ● Post Editor Performance › Loading, typing and selecting blocks
    TimeoutError: Navigation timeout of 30000 ms exceeded
      at node_modules/puppeteer/lib/LifecycleWatcher.js:126:25
      at FrameManager.navigateFrame (node_modules/puppeteer/lib/FrameManager.js:83:21)
      at Frame.goto (node_modules/puppeteer/lib/FrameManager.js:367:16)
      at Page.goto (node_modules/puppeteer/lib/Page.js:615:16)
        -- ASYNC --
      at Frame.<anonymous> (node_modules/puppeteer/lib/helper.js:105:23)
      at Page.goto (node_modules/puppeteer/lib/Page.js:615:53)
      at Page.page (node_modules/puppeteer/lib/helper.js:106:31)
      at _callee$ (packages/e2e-test-utils/build/@wordpress/e2e-test-utils/src/visit-admin-page.js:21:8)
      at tryCatch (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:293:22)
      at Generator.next (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:118:21)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:32:7
        -- ASYNC --
      at Page.page (node_modules/puppeteer/lib/helper.js:105:23)
      at _callee$ (packages/e2e-test-utils/build/@wordpress/e2e-test-utils/src/visit-admin-page.js:21:8)
      at tryCatch (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:293:22)
      at Generator.next (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:118:21)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:32:7
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:21:12
Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        56.18s
Ran all test suites matching /packages\/e2e-tests\/specs\/performance\/post-editor.test.js/i
```

I re-ran the test interactively, and it appears that the test tries to navigate away from the post edit screen after making changes, causing a browser dialog to pop up flagging about unsaved changes. Since nothing in the test confirms that, the test hangs. 

This PR resolves this by saving the post as a draft before attempting to navigate away. After this change, the test runs to completion and passes.

```
$ wp-scripts test-e2e  packages/e2e-tests/specs/performance/post-editor.test.js 
Chromium is already in /Users/lee/sites/wc/wp-content/plugins/gutenberg/node_modules/puppeteer/.local-chromium/mac-737027; skipping download.
 PASS  packages/e2e-tests/specs/performance/post-editor.test.js (35.506s)
  Post Editor Performance
    ✓ Loading, typing and selecting blocks (34506ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        35.671s, estimated 121s
Ran all test suites matching /packages\/e2e-tests\/specs\/performance\/post-editor.test.js/i.
```