### PR TITLE
Upgrade Reakit to version 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11699,7 +11699,7 @@
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"react-spring": "^8.0.19",
-				"reakit": "1.3.3",
+				"reakit": "1.3.2",
 				"redux-multi": "^0.1.12",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
@@ -11744,7 +11744,7 @@
 				"memize": "^1.1.0",
 				"moment": "^2.22.1",
 				"react-easy-crop": "^3.0.0",
-				"reakit": "1.3.3",
+				"reakit": "1.3.2",
 				"tinycolor2": "^1.4.1"
 			}
 		},
@@ -11827,7 +11827,7 @@
 				"react-resize-aware": "^3.0.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.15",
-				"reakit": "^1.3.3",
+				"reakit": "1.3.2",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^8.3.0"
@@ -12128,7 +12128,7 @@
 				"@wordpress/url": "file:packages/url",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
-				"reakit": "^1.3.3",
+				"reakit": "1.3.2",
 				"rememo": "^3.0.0",
 				"uuid": "^8.3.0"
 			}
@@ -47705,9 +47705,9 @@
 			}
 		},
 		"reakit": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.3.tgz",
-			"integrity": "sha512-qw+WdM2mU6hLLbwd0qrZMhuJ3LLJKNjnw/wJuLaocsc1PXC1RaO5kZiiXOJl0Ee5B9fAZ6E+C7Q5SN7SE63OTw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.2.tgz",
+			"integrity": "sha512-QsN5bpLw7trknvEMsiZUV3WYmZxpQ0TyoWxmDlxX3Oq89TH9WAd4jKC4uyTGsYKp40syuTfadp0lu5UkHvOZkw==",
 			"requires": {
 				"@popperjs/core": "^2.5.4",
 				"body-scroll-lock": "^3.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6633,9 +6633,9 @@
 			}
 		},
 		"@popperjs/core": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.2.tgz",
-			"integrity": "sha512-JlGTGRYHC2QK+DDbePyXdBdooxFq2+noLfWpRqJtkxcb/oYWzOF0kcbfvvbWrwevCC1l6hLUg1wHYT+ona5BWQ=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
+			"integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
 		},
 		"@reach/router": {
 			"version": "1.3.4",
@@ -11699,7 +11699,7 @@
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"react-spring": "^8.0.19",
-				"reakit": "1.1.0",
+				"reakit": "1.3.3",
 				"redux-multi": "^0.1.12",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
@@ -11744,7 +11744,7 @@
 				"memize": "^1.1.0",
 				"moment": "^2.22.1",
 				"react-easy-crop": "^3.0.0",
-				"reakit": "1.1.0",
+				"reakit": "1.3.3",
 				"tinycolor2": "^1.4.1"
 			}
 		},
@@ -11827,7 +11827,7 @@
 				"react-resize-aware": "^3.0.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.15",
-				"reakit": "^1.1.0",
+				"reakit": "^1.3.3",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^8.3.0"
@@ -12128,7 +12128,7 @@
 				"@wordpress/url": "file:packages/url",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
-				"reakit": "^1.1.0",
+				"reakit": "^1.3.3",
 				"rememo": "^3.0.0",
 				"uuid": "^8.3.0"
 			}
@@ -22725,9 +22725,9 @@
 			}
 		},
 		"body-scroll-lock": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.0.3.tgz",
-			"integrity": "sha512-EUryImgD6Gv87HOjJB/yB2WIGECiZMhmcUK+DrqVRFDDa64xR+FsK0LgvLPnBxZDTxIl+W80/KJ8i6gp2IwOHQ=="
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+			"integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -47705,36 +47705,36 @@
 			}
 		},
 		"reakit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.1.0.tgz",
-			"integrity": "sha512-d/ERtwgBndBPsyPBPUl5jueyfFgsglIfQCnLMKuxM0PaWiIZ6Ys3XsYaNy/AaG8k46Ee5cQPMdRrR30nVcSToQ==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.3.tgz",
+			"integrity": "sha512-qw+WdM2mU6hLLbwd0qrZMhuJ3LLJKNjnw/wJuLaocsc1PXC1RaO5kZiiXOJl0Ee5B9fAZ6E+C7Q5SN7SE63OTw==",
 			"requires": {
-				"@popperjs/core": "^2.4.2",
-				"body-scroll-lock": "^3.0.2",
-				"reakit-system": "^0.13.0",
-				"reakit-utils": "^0.13.0",
-				"reakit-warning": "^0.4.0"
+				"@popperjs/core": "^2.5.4",
+				"body-scroll-lock": "^3.1.5",
+				"reakit-system": "^0.15.1",
+				"reakit-utils": "^0.15.1",
+				"reakit-warning": "^0.6.1"
 			}
 		},
 		"reakit-system": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.13.0.tgz",
-			"integrity": "sha512-33HCSab1WS08H8P4aFU7X7sf089B383GKWilyj+Z0U5XNJPzRklbqdsfsyasEm9vr/gQyu9ZMLxX1YJBN/iekw==",
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.1.tgz",
+			"integrity": "sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==",
 			"requires": {
-				"reakit-utils": "^0.13.0"
+				"reakit-utils": "^0.15.1"
 			}
 		},
 		"reakit-utils": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.13.0.tgz",
-			"integrity": "sha512-/Ll+D4WllB6s2dNuWHTO32JNgdSHl1jf5y6QK3aCU4OEMtSCGz0TpXXHslWgRXWEQjKItVY640A8wugVQmKgWQ=="
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.1.tgz",
+			"integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q=="
 		},
 		"reakit-warning": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.4.0.tgz",
-			"integrity": "sha512-p5/dGY2AlWTV33AS9JPlm9Y5u0YUUyg53MIC90vl3p4J4VI2cxMnu42eCck1g0nwYgiEYLPU/90NNrAQf/Ck6g==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.1.tgz",
+			"integrity": "sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==",
 			"requires": {
-				"reakit-utils": "^0.13.0"
+				"reakit-utils": "^0.15.1"
 			}
 		},
 		"rechoir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11699,7 +11699,7 @@
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"react-spring": "^8.0.19",
-				"reakit": "1.3.2",
+				"reakit": "1.3.4",
 				"redux-multi": "^0.1.12",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
@@ -11744,7 +11744,7 @@
 				"memize": "^1.1.0",
 				"moment": "^2.22.1",
 				"react-easy-crop": "^3.0.0",
-				"reakit": "1.3.2",
+				"reakit": "1.3.4",
 				"tinycolor2": "^1.4.1"
 			}
 		},
@@ -11827,7 +11827,7 @@
 				"react-resize-aware": "^3.0.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.15",
-				"reakit": "1.3.2",
+				"reakit": "^1.3.4",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^8.3.0"
@@ -12128,7 +12128,7 @@
 				"@wordpress/url": "file:packages/url",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
-				"reakit": "1.3.2",
+				"reakit": "^1.3.4",
 				"rememo": "^3.0.0",
 				"uuid": "^8.3.0"
 			}
@@ -47705,9 +47705,9 @@
 			}
 		},
 		"reakit": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.2.tgz",
-			"integrity": "sha512-QsN5bpLw7trknvEMsiZUV3WYmZxpQ0TyoWxmDlxX3Oq89TH9WAd4jKC4uyTGsYKp40syuTfadp0lu5UkHvOZkw==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.4.tgz",
+			"integrity": "sha512-aLR0GBOc9vELTk4PKK/zndBbIs4RSw4B7GSGY6yoMHQ/vna0iLNd5BMhjtXspD/B7hhkYERlT6di8pIyD3HSPw==",
 			"requires": {
 				"@popperjs/core": "^2.5.4",
 				"body-scroll-lock": "^3.1.5",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -61,7 +61,7 @@
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"react-spring": "^8.0.19",
-		"reakit": "1.3.3",
+		"reakit": "1.3.2",
 		"redux-multi": "^0.1.12",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -61,7 +61,7 @@
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"react-spring": "^8.0.19",
-		"reakit": "1.1.0",
+		"reakit": "1.3.3",
 		"redux-multi": "^0.1.12",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -61,7 +61,7 @@
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"react-spring": "^8.0.19",
-		"reakit": "1.3.2",
+		"reakit": "1.3.4",
 		"redux-multi": "^0.1.12",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",

--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -7,7 +7,6 @@ import { Composite, useCompositeState } from 'reakit';
  * WordPress dependencies
  */
 import { getBlockMenuDefaultClassName } from '@wordpress/blocks';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,13 +22,6 @@ function BlockTypesList( {
 	isDraggable = true,
 } ) {
 	const composite = useCompositeState();
-	const orderId = items.reduce( ( acc, item ) => acc + '--' + item.id, '' );
-
-	// This ensures the composite state refreshes when the list order changes.
-	useEffect( () => {
-		composite.unstable_sort();
-	}, [ composite.unstable_sort, orderId ] );
-
 	return (
 		/*
 		 * Disable reason: The `list` ARIA role is redundant but

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -61,7 +61,7 @@
 		"memize": "^1.1.0",
 		"moment": "^2.22.1",
 		"react-easy-crop": "^3.0.0",
-		"reakit": "1.3.2",
+		"reakit": "1.3.4",
 		"tinycolor2": "^1.4.1"
 	},
 	"publishConfig": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -61,7 +61,7 @@
 		"memize": "^1.1.0",
 		"moment": "^2.22.1",
 		"react-easy-crop": "^3.0.0",
-		"reakit": "1.3.3",
+		"reakit": "1.3.2",
 		"tinycolor2": "^1.4.1"
 	},
 	"publishConfig": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -61,7 +61,7 @@
 		"memize": "^1.1.0",
 		"moment": "^2.22.1",
 		"react-easy-crop": "^3.0.0",
-		"reakit": "1.1.0",
+		"reakit": "1.3.3",
 		"tinycolor2": "^1.4.1"
 	},
 	"publishConfig": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -58,7 +58,7 @@
 		"react-resize-aware": "^3.0.1",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",
-		"reakit": "^1.3.3",
+		"reakit": "1.3.2",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^8.3.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -58,7 +58,7 @@
 		"react-resize-aware": "^3.0.1",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",
-		"reakit": "^1.1.0",
+		"reakit": "^1.3.3",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^8.3.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -58,7 +58,7 @@
 		"react-resize-aware": "^3.0.1",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",
-		"reakit": "1.3.2",
+		"reakit": "^1.3.4",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^8.3.0"

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/url": "file:../url",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.19",
-		"reakit": "^1.1.0",
+		"reakit": "^1.3.3",
 		"rememo": "^3.0.0",
 		"uuid": "^8.3.0"
 	},

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/url": "file:../url",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.19",
-		"reakit": "^1.3.3",
+		"reakit": "1.3.2",
 		"rememo": "^3.0.0",
 		"uuid": "^8.3.0"
 	},

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/url": "file:../url",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.19",
-		"reakit": "1.3.2",
+		"reakit": "^1.3.4",
 		"rememo": "^3.0.0",
 		"uuid": "^8.3.0"
 	},


### PR DESCRIPTION
This PR upgrades Reakit to version 1.3.4.

The most relevant feature is that composite items are now automatically sorted when their position change in the DOM, so we don't need to call `unstable_sort()` manually anymore.

<details><summary>Changelog since v1.1.0</summary>

## [1.3.4](https://github.com/reakit/reakit/compare/reakit@1.3.3...reakit@1.3.4) (2021-01-06)


### Bug Fixes

* Revert `CompositeItem` tabIndex fix ([#821](https://github.com/reakit/reakit/issues/821)) ([1390d31](https://github.com/reakit/reakit/commit/1390d31a3d0b1f5e1b0555001e6d6d096b57ec0e))





## [1.3.3](https://github.com/reakit/reakit/compare/reakit@1.3.2...reakit@1.3.3) (2021-01-03)


### Bug Fixes

* Fix `CompositeItem` with `tabindex=0` on the first render ([#817](https://github.com/reakit/reakit/issues/817)) ([3d81514](https://github.com/reakit/reakit/commit/3d815148d74e333ec975ff871a92f39aaa307fa8))





## [1.3.2](https://github.com/reakit/reakit/compare/reakit@1.3.1...reakit@1.3.2) (2020-12-11)


### Bug Fixes

* Accept other option props together with the `state` prop ([#799](https://github.com/reakit/reakit/issues/799)) ([a21bb2b](https://github.com/reakit/reakit/commit/a21bb2b22780121125bbf3dfc6160ac29e1a0741)), closes [#798](https://github.com/reakit/reakit/issues/798)
* Add React 17 to peer dependencies ([#807](https://github.com/reakit/reakit/issues/807)) ([411b5aa](https://github.com/reakit/reakit/commit/411b5aa8adf63f3149b40db6a499e65b58929b29)), closes [#776](https://github.com/reakit/reakit/issues/776)
* Fix `Menu` scroll jump ([#801](https://github.com/reakit/reakit/issues/801)) ([96f5dd5](https://github.com/reakit/reakit/commit/96f5dd52704444862d16167db3c82fb89838e3ae)), closes [#751](https://github.com/reakit/reakit/issues/751)
* Fix badly positioned popover on click + minValueLength ([#809](https://github.com/reakit/reakit/issues/809)) ([2c847da](https://github.com/reakit/reakit/commit/2c847da75edebae2f511fb5f50c516dfcfa71981)), closes [#808](https://github.com/reakit/reakit/issues/808)





## [1.3.1](https://github.com/reakit/reakit/compare/reakit@1.3.0...reakit@1.3.1) (2020-11-26)


### Bug Fixes

* Add missing quote in querySelector in `Dialog` ([#793](https://github.com/reakit/reakit/issues/793)) ([d9a49ef](https://github.com/reakit/reakit/commit/d9a49efa432b4dc8df51dc62f0d1b5023236dff4))
* Native radio input firing onChange callback twice on click ([#791](https://github.com/reakit/reakit/issues/791)) ([6a436bb](https://github.com/reakit/reakit/commit/6a436bb5adccd53e37604195980bd67e7119972e)), closes [#790](https://github.com/reakit/reakit/issues/790)





# [1.3.0](https://github.com/reakit/reakit/compare/reakit@1.2.6...reakit@1.3.0) (2020-11-12)


### Features

* Add `Role` component ([#728](https://github.com/reakit/reakit/issues/728)) ([5fa51a7](https://github.com/reakit/reakit/commit/5fa51a7891085aeeb6a0e3ea44ef3d294fccc8ba))
* Add `shift` option to `useCompositeState` ([#727](https://github.com/reakit/reakit/issues/727)) ([7861395](https://github.com/reakit/reakit/commit/7861395ac8c1eaf979b5e4835ae99c001c39f312))
* Add experimental `Combobox` component ([#688](https://github.com/reakit/reakit/issues/688)) ([ad7063b](https://github.com/reakit/reakit/commit/ad7063b0096c19e3295a74213a4ec821683f12ff))
* Add experimental `includesBaseElement` option to `useCompositeState` ([#726](https://github.com/reakit/reakit/issues/726)) ([cf3ba56](https://github.com/reakit/reakit/commit/cf3ba5687ea339de0f8917d2b1e83797403cdddc))
* Show warning if disclosure stopAnimation is not called in time ([#701](https://github.com/reakit/reakit/issues/701)) ([0dd2683](https://github.com/reakit/reakit/commit/0dd2683c99f68ae0f3b32b25b9c989dc4b012ba6)), closes [#698](https://github.com/reakit/reakit/issues/698)
* Trigger `onChange` when setting `CompositeItemWidget` value ([0b5b3cb](https://github.com/reakit/reakit/commit/0b5b3cb64ba5cc6cba000d0cdc972ab81fe4247e))





## [1.2.6](https://github.com/reakit/reakit/compare/reakit@1.2.5...reakit@1.2.6) (2020-11-12)


### Bug Fixes

* Fix Composite `unstable_virtual` option on mobile devices ([#783](https://github.com/reakit/reakit/issues/783)) ([ecdc4ef](https://github.com/reakit/reakit/commit/ecdc4ef8ddd72ef136d8c72d969a3fe73505fd74))
* Stop warning when using invalid composite roles on `Composite` ([#784](https://github.com/reakit/reakit/issues/784)) ([9bcbfe6](https://github.com/reakit/reakit/commit/9bcbfe6740c6e5e3e7ff6d51bb081a7ecc7af08d))





## [1.2.5](https://github.com/reakit/reakit/compare/reakit@1.2.4...reakit@1.2.5) (2020-09-22)


### Bug Fixes

* Fix `Composite` infinite loop on Firefox ([#748](https://github.com/reakit/reakit/issues/748)) ([4a1c644](https://github.com/reakit/reakit/commit/4a1c644a758264f4da77a3f4e2bc28aed6a16a48)), closes [#747](https://github.com/reakit/reakit/issues/747)
* Fix `disabled` prop being passed to elements that don't support it ([#725](https://github.com/reakit/reakit/issues/725)) ([d982a61](https://github.com/reakit/reakit/commit/d982a61074bf3ed899ebe4a6e4744cec32191b57)), closes [#722](https://github.com/reakit/reakit/issues/722)
* Fix disabled events when using the `as` prop ([#736](https://github.com/reakit/reakit/issues/736)) ([c594166](https://github.com/reakit/reakit/commit/c5941668d0ebc69f04171f2f6cfb44ecf8917495))





## [1.2.4](https://github.com/reakit/reakit/compare/reakit@1.2.3...reakit@1.2.4) (2020-09-03)


### Bug Fixes

* Fix internal dependency versions ([3d4cb42](https://github.com/reakit/reakit/commit/3d4cb4217a52ec719e8a2823d21e08c7cc42dd30))





## [1.2.3](https://github.com/reakit/reakit/compare/reakit@1.2.2...reakit@1.2.3) (2020-08-24)


### Bug Fixes

* Fix SSR check ([#717](https://github.com/reakit/reakit/issues/717)) ([1f09fc9](https://github.com/reakit/reakit/commit/1f09fc9879ecd9516d514c7a848b7a62a1b93358))





## [1.2.2](https://github.com/reakit/reakit/compare/reakit@1.2.1...reakit@1.2.2) (2020-08-17)


### Bug Fixes

* Assert `focus` method exists on the dialog disclosure element ([#710](https://github.com/reakit/reakit/issues/710)) ([85dd073](https://github.com/reakit/reakit/commit/85dd073a4f3e5832340c4a05d9af6bb4798c69a1))
* Fix blur event on `Composite` for React 17 ([#711](https://github.com/reakit/reakit/issues/711)) ([0ad76e6](https://github.com/reakit/reakit/commit/0ad76e61560da5f25e99a01d9842bf53e18d7993))
* Fix disclosure detection when `unstable_virtual` is `true` on React 17 ([#715](https://github.com/reakit/reakit/issues/715)) ([81ec3a3](https://github.com/reakit/reakit/commit/81ec3a31c2e5fec4a8817acd3e10361247d95377))
* Fix intermediate `focus`/`blur` event order in `Composite` ([#713](https://github.com/reakit/reakit/issues/713)) ([891976b](https://github.com/reakit/reakit/commit/891976b047aebe93e802a16b7aaf25708cc5c65a))





## [1.2.1](https://github.com/reakit/reakit/compare/reakit@1.2.0...reakit@1.2.1) (2020-08-13)


### Bug Fixes

* Fix tabbing between multiple `RadioGroup`s ([#703](https://github.com/reakit/reakit/issues/703)) ([212adbd](https://github.com/reakit/reakit/commit/212adbd292702948ab71a44a22d9862117468668)), closes [#702](https://github.com/reakit/reakit/issues/702)





# [1.2.0](https://github.com/reakit/reakit/compare/reakit@1.1.2...reakit@1.2.0) (2020-08-06)


### Features

* Add experimental `Grid` component ([#685](https://github.com/reakit/reakit/issues/685)) ([51e17fb](https://github.com/reakit/reakit/commit/51e17fbaab188a501dc267863f363e880cbba717))
* Add stable `composite.sort` method ([#690](https://github.com/reakit/reakit/issues/690)) ([1f66168](https://github.com/reakit/reakit/commit/1f6616883800eb2e367cbcee12dce7399d25e159))
* Add stable `id.setBaseId` method ([#691](https://github.com/reakit/reakit/issues/691)) ([5c52c71](https://github.com/reakit/reakit/commit/5c52c712395c63f73284558dd84a230c6e2026c7))
* Automatically sort composite items based on DOM position ([#696](https://github.com/reakit/reakit/issues/696)) ([bdaab5d](https://github.com/reakit/reakit/commit/bdaab5df2f6fd3445320a6f98975301ab7a84971))
* Focus `Menu` instead of `MenuItem` on mouse click on `MenuButton` ([#694](https://github.com/reakit/reakit/issues/694)) ([d57b97f](https://github.com/reakit/reakit/commit/d57b97f2f64c883a95c73acf7ad0275dfdbd642a))





## [1.1.2](https://github.com/reakit/reakit/compare/reakit@1.1.1...reakit@1.1.2) (2020-07-18)


### Bug Fixes

* Fix `composite.unstable_sort` on Firefox ([f973f77](https://github.com/reakit/reakit/commit/f973f77ea58811ee009f2de649b6426aa98617c9))
* Fix `Dialog` focus loss ([#682](https://github.com/reakit/reakit/issues/682)) ([8ae0da7](https://github.com/reakit/reakit/commit/8ae0da741ca45fed6bc1a7c25a3fc9aa60340b44)), closes [#677](https://github.com/reakit/reakit/issues/677)
* Fix `MenuButton` not receiving focus after `Menu` closes ([#692](https://github.com/reakit/reakit/issues/692)) ([e649f20](https://github.com/reakit/reakit/commit/e649f203334468ceb23ef33be49b24098b4a0eab))





## [1.1.1](https://github.com/reakit/reakit/compare/reakit@1.1.0...reakit@1.1.1) (2020-06-21)


### Bug Fixes

* Restore missing `Composite` references ([9d9eff2](https://github.com/reakit/reakit/commit/9d9eff216328038b34af50cea03f45f8297e0756)), closes [#667 (comment)](https://github.com/reakit/reakit/pull/667#issuecomment-647108385)

</details>