### PR TITLE
Reusable blocks: Fix dismiss notice after error

### DIFF
--- a/packages/list-reusable-blocks/src/components/import-form/index.js
+++ b/packages/list-reusable-blocks/src/components/import-form/index.js
@@ -30,7 +30,7 @@ class ImportForm extends Component {
 	}
 
 	onChangeFile( event ) {
-		this.setState( { file: event.target.files[ 0 ] } );
+		this.setState( { file: event.target.files[ 0 ], error: null } );
 	}
 
 	onSubmit( event ) {
@@ -71,6 +71,10 @@ class ImportForm extends Component {
 			} );
 	}
 
+	onDismissError() {
+		this.setState( { error: null } );
+	}
+
 	render() {
 		const { instanceId } = this.props;
 		const { file, isLoading, error } = this.state;
@@ -80,7 +84,14 @@ class ImportForm extends Component {
 				className="list-reusable-blocks-import-form"
 				onSubmit={ this.onSubmit }
 			>
-				{ error && <Notice status="error">{ error }</Notice> }
+				{ error && (
+					<Notice
+						status="error"
+						onRemove={ () => this.onDismissError() }
+					>
+						{ error }
+					</Notice>
+				) }
 				<label
 					htmlFor={ inputId }
 					className="list-reusable-blocks-import-form__label"

--- a/packages/list-reusable-blocks/src/components/import-form/style.scss
+++ b/packages/list-reusable-blocks/src/components/import-form/style.scss
@@ -4,10 +4,18 @@
 }
 
 .list-reusable-blocks-import-form__button {
-	margin-top: 20px;
+	margin-top: 10px;
+	margin-bottom: 10px;
 	float: right;
 }
 
-.list-reusable-blocks-import-form .components-notice__content {
-	margin: 0;
+.list-reusable-blocks-import-form {
+	.components-notice__content {
+		margin: 0;
+	}
+
+	.components-notice.is-dismissible {
+		padding-right: 0;
+		margin: 5px 0;
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/27981

This PR fixes the dismissal of `Notice` after an error, when trying to import Reusable blocks from a json file. It also makes some minor style improvements.

## Testing instructions
1. Navigate to Options → Manage all reusable blocks
2. Click Import from JSON
3. Select an invalid file e.g. an image
4. Click Import
5. Try to dismiss the popover
<!-- Please describe what you have changed or added -->

### Before
![noticeBefore](https://user-images.githubusercontent.com/16275880/103775516-d2cc6a00-5036-11eb-806e-a69e1d75f2c9.gif)

### After
![noticeAfter](https://user-images.githubusercontent.com/16275880/103775523-d5c75a80-5036-11eb-8fe6-7238bc87039c.gif)


