### PR TITLE
Fix non static method WP_Block_Parser::freeform called statically

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -300,7 +300,7 @@ class WP_Block_Parser {
 				 */
 				if ( 0 === $stack_depth ) {
 					if ( isset( $leading_html_start ) ) {
-						$this->output[] = (array) self::freeform(
+						$this->output[] = (array) $this->freeform(
 							substr(
 								$this->document,
 								$leading_html_start,
@@ -492,7 +492,7 @@ class WP_Block_Parser {
 			return;
 		}
 
-		$this->output[] = (array) self::freeform( substr( $this->document, $this->offset, $length ) );
+		$this->output[] = (array) $this->freeform( substr( $this->document, $this->offset, $length ) );
 	}
 
 	/**
@@ -541,7 +541,7 @@ class WP_Block_Parser {
 		}
 
 		if ( isset( $stack_top->leading_html_start ) ) {
-			$this->output[] = (array) self::freeform(
+			$this->output[] = (array) $this->freeform(
 				substr(
 					$this->document,
 					$stack_top->leading_html_start,


### PR DESCRIPTION
## Description
In `WP_Block_Parser` the method `freeform` called statically in three places, but the method freeform is not static. This PR fixes this issue.

## How has this been tested?
1. Tested by running `npm run test`.
2. Call `parse_blocks( $block_content )` function.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
