### PR TITLE
Compose: Export useIsomorphicLayoutEffect and use it

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Add the `useIsomorphicLayoutEffect` hook.
+
 ## 3.4.0 (2019-06-12)
 
 ### New Features

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -256,7 +256,9 @@ _Parameters_
 
 <a name="useIsomorphicLayoutEffect" href="#useIsomorphicLayoutEffect">#</a> **useIsomorphicLayoutEffect**
 
-Undocumented declaration.
+Preferred over direct usage of `useLayoutEffect` when supporting
+server rendered components (SSR) because currently React
+throws a warning when using useLayoutEffect in that environment.
 
 <a name="useKeyboardShortcut" href="#useKeyboardShortcut">#</a> **useKeyboardShortcut**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -254,6 +254,10 @@ _Parameters_
 -   _object_ `Object`: Object reference to create an id for.
 -   _prefix_ `string`: Prefix for the unique id.
 
+<a name="useIsomorphicLayoutEffect" href="#useIsomorphicLayoutEffect">#</a> **useIsomorphicLayoutEffect**
+
+Undocumented declaration.
+
 <a name="useKeyboardShortcut" href="#useKeyboardShortcut">#</a> **useKeyboardShortcut**
 
 Attach a keyboard shortcut handler.

--- a/packages/compose/src/hooks/use-dragging/index.js
+++ b/packages/compose/src/hooks/use-dragging/index.js
@@ -1,16 +1,12 @@
 /**
  * WordPress dependencies
  */
-import {
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
-const useIsomorphicLayoutEffect =
-	typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+/**
+ * Internal dependencies
+ */
+import useIsomorphicLayoutEffect from '../use-isomorphic-layout-effect';
 
 export default function useDragging( { onDragStart, onDragMove, onDragEnd } ) {
 	const [ isDragging, setIsDragging ] = useState( false );

--- a/packages/compose/src/hooks/use-isomorphic-layout-effect/index.js
+++ b/packages/compose/src/hooks/use-isomorphic-layout-effect/index.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useLayoutEffect } from '@wordpress/element';
+
+export default typeof window !== 'undefined' ? useLayoutEffect : useEffect;

--- a/packages/compose/src/hooks/use-isomorphic-layout-effect/index.js
+++ b/packages/compose/src/hooks/use-isomorphic-layout-effect/index.js
@@ -3,4 +3,12 @@
  */
 import { useEffect, useLayoutEffect } from '@wordpress/element';
 
-export default typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+/**
+ * Preferred over direct usage of `useLayoutEffect` when supporting
+ * server rendered components (SSR) because currently React
+ * throws a warning when using useLayoutEffect in that environment.
+ */
+const useIsomorphicLayoutEffect =
+	typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -21,6 +21,7 @@ export { default as useFocusOnMount } from './hooks/use-focus-on-mount';
 export { default as __experimentalUseFocusOutside } from './hooks/use-focus-outside';
 export { default as useFocusReturn } from './hooks/use-focus-return';
 export { default as useInstanceId } from './hooks/use-instance-id';
+export { default as useIsomorphicLayoutEffect } from './hooks/use-isomorphic-layout-effect';
 export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
 export { default as useMediaQuery } from './hooks/use-media-query';
 export { default as usePrevious } from './hooks/use-previous';

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -17,6 +17,7 @@ export { default as useConstrainedTabbing } from './hooks/use-constrained-tabbin
 export { default as __experimentalUseDragging } from './hooks/use-dragging';
 export { default as __experimentalUseFocusOutside } from './hooks/use-focus-outside';
 export { default as useInstanceId } from './hooks/use-instance-id';
+export { default as useIsomorphicLayoutEffect } from './hooks/use-isomorphic-layout-effect';
 export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
 export { default as useMediaQuery } from './hooks/use-media-query';
 export { default as useReducedMotion } from './hooks/use-reduced-motion';

--- a/packages/data/src/components/use-dispatch/use-dispatch-with-map.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch-with-map.js
@@ -6,29 +6,13 @@ import { mapValues } from 'lodash';
 /**
  * WordPress dependencies
  */
-import {
-	useMemo,
-	useRef,
-	useEffect,
-	useLayoutEffect,
-} from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
+import { useIsomorphicLayoutEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import useRegistry from '../registry-provider/use-registry';
-
-/**
- * Favor useLayoutEffect to ensure the store subscription callback always has
- * the dispatchMap from the latest render. If a store update happens between
- * render and the effect, this could cause missed/stale updates or
- * inconsistent state.
- *
- * Fallback to useEffect for server rendered components because currently React
- * throws a warning when using useLayoutEffect in that environment.
- */
-const useIsomorphicLayoutEffect =
-	typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * Custom react hook for returning aggregate dispatch actions using the provided

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -7,32 +7,15 @@ import { useMemoOne } from 'use-memo-one';
  * WordPress dependencies
  */
 import { createQueue } from '@wordpress/priority-queue';
-import {
-	useLayoutEffect,
-	useRef,
-	useCallback,
-	useEffect,
-	useReducer,
-	useMemo,
-} from '@wordpress/element';
+import { useRef, useCallback, useReducer, useMemo } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
+import { useIsomorphicLayoutEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import useRegistry from '../registry-provider/use-registry';
 import useAsyncMode from '../async-mode-provider/use-async-mode';
-
-/**
- * Favor useLayoutEffect to ensure the store subscription callback always has
- * the selector from the latest render. If a store update happens between render
- * and the effect, this could cause missed/stale updates or inconsistent state.
- *
- * Fallback to useEffect for server rendered components because currently React
- * throws a warning when using useLayoutEffect in that environment.
- */
-const useIsomorphicLayoutEffect =
-	typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 const renderQueue = createQueue();
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This is part of https://github.com/WordPress/gutenberg/issues/28020. It exports the already existing `useIsomorphicLayoutEffect` hook from the `compose` package and then updates various places that duplicated this code to use the exported function from `compose`. We're doing this because it is a dependency of the `context` package from G2.

## How has this been tested?
Manually tested in components and Gutenberg in the places where it is used.

* Tested `AnglePickerControl` and `GradientPicker` in storybook
* Tested `useSelect` and `useDispatch` by just using Gutenberg for a little bit to create and edit a post


## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
