### PR TITLE
Update `npm run native start` to include cleanup

### DIFF
--- a/docs/contributors/getting-started-native-mobile.md
+++ b/docs/contributors/getting-started-native-mobile.md
@@ -72,7 +72,7 @@ To see a list of all of your available iOS devices, use `xcrun simctl list devic
 
 ### Troubleshooting
 
-Some times, and especially when tweaking anything in the `package.json`, Babel configuration (`.babelrc`) or the Jest configuration (`jest.config.js`), your changes might seem to not take effect as expected. On those times, you might need to clean various caches before starting the packager. To do that, run the script: `npm run native start:reset`. Other times, you might want to reinstall the NPM packages from scratch and the `npm run native clean:install` script can be handy.
+Some times, and especially when tweaking anything in the `package.json`, Babel configuration (`.babelrc`) or the Jest configuration (`jest.config.js`), your changes might seem to not take effect as expected. On those times, you might need to stop the metro bunder process and restart it with `npm run native start`. Other times, you might want to reinstall the NPM packages from scratch and the `npm run native clean:install` script can be handy.
 
 ## Developing with Visual Studio Code
 

--- a/docs/contributors/getting-started-native-mobile.md
+++ b/docs/contributors/getting-started-native-mobile.md
@@ -33,7 +33,7 @@ npm ci
 ## Run
 
 ```
-npm run native start
+npm run native start:reset
 ```
 
 Runs the packager (Metro) in development mode. The packager stays running to serve the app bundle to the clients that request it.
@@ -72,7 +72,7 @@ To see a list of all of your available iOS devices, use `xcrun simctl list devic
 
 ### Troubleshooting
 
-Some times, and especially when tweaking anything in the `package.json`, Babel configuration (`.babelrc`) or the Jest configuration (`jest.config.js`), your changes might seem to not take effect as expected. On those times, you might need to stop the metro bunder process and restart it with `npm run native start`. Other times, you might want to reinstall the NPM packages from scratch and the `npm run native clean:install` script can be handy.
+Some times, and especially when tweaking anything in the `package.json`, Babel configuration (`.babelrc`) or the Jest configuration (`jest.config.js`), your changes might seem to not take effect as expected. On those times, you might need to stop the metro bunder process and restart it with `npm run native start:reset`. Other times, you might want to reinstall the NPM packages from scratch and the `npm run native clean:install` script can be handy.
 
 ## Developing with Visual Studio Code
 

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -79,9 +79,10 @@
 		"access": "public"
 	},
 	"scripts": {
-		"start": "react-native start",
-		"start:reset": "npm run clean:runtime && npm run start -- --reset-cache",
+		"start": "npm run clean:runtime && npm run start:quick -- --reset-cache",
 		"start:debug": "node --inspect-brk node_modules/.bin/react-native start",
+		"start:quick": "react-native start",
+        "start:reset": "echo '`start:reset` is deprecated. Please use `start`, which does the same thing that `start:reset` used to do.'",
 		"prern-bundle": "cd ../.. && patch-package --patch-dir packages/react-native-editor/metro-patch",
 		"rn-bundle": "react-native bundle",
 		"postrn-bundle": "cd ../.. && patch-package --reverse --patch-dir packages/react-native-editor/metro-patch",

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -79,10 +79,10 @@
 		"access": "public"
 	},
 	"scripts": {
-		"start": "npm run clean:runtime && npm run start:quick -- --reset-cache",
+        "start": "echo 'The start command is not available in this project. It is strongly recommended to use start:reset to perform some cleanup when starting the metro bundler. Or you may use start:quick for a quicker startup, but this may lead to unexpected javascript errors when running the app.'",
 		"start:debug": "node --inspect-brk node_modules/.bin/react-native start",
+		"start:reset": "npm run clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start",
-        "start:reset": "echo '`start:reset` is deprecated. Please use `start`, which does the same thing that `start:reset` used to do.'",
 		"prern-bundle": "cd ../.. && patch-package --patch-dir packages/react-native-editor/metro-patch",
 		"rn-bundle": "react-native bundle",
 		"postrn-bundle": "cd ../.. && patch-package --reverse --patch-dir packages/react-native-editor/metro-patch",

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -79,7 +79,7 @@
 		"access": "public"
 	},
 	"scripts": {
-        "start": "echo 'The start command is not available in this project. It is strongly recommended to use start:reset to perform some cleanup when starting the metro bundler. Or you may use start:quick for a quicker startup, but this may lead to unexpected javascript errors when running the app.'",
+        "start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:debug": "node --inspect-brk node_modules/.bin/react-native start",
 		"start:reset": "npm run clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start",


### PR DESCRIPTION
## Description
This changes the `start` script to also do the cleanup previously done by the now-deprected `start:reset` script. This is done to make the default script safer and to keep these commands consistent with gutenberg-mobile.

## How has this been tested?
Ensure that `npm run native start:reset` and `npm run native start:quick` both start the metro bundler. Also check that `npm run native start` outputs an error message directing the user to the `npm run native start:reset` command.

## Types of changes
Tweaking the build setup

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
