### PR TITLE
Performance tests: Fix

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -148,7 +148,7 @@ async function setUpGitBranch( branch, environmentDirectory ) {
 
 	log( '>> Building the ' + formats.success( branch ) + ' branch' );
 	await runShellScript(
-		'npm run distclean && npm install && npm run build',
+		'rm -rf node_modules packages/*/node_modules && npm install && npm run build',
 		environmentDirectory
 	);
 }

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -148,7 +148,7 @@ async function setUpGitBranch( branch, environmentDirectory ) {
 
 	log( '>> Building the ' + formats.success( branch ) + ' branch' );
 	await runShellScript(
-		'rm -rf node_modules && npm install && npm run build',
+		'npm run distclean && npm install && npm run build',
 		environmentDirectory
 	);
 }

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
 		"check-local-changes": "( git diff -U0 | xargs -0 node bin/process-git-diff ) || ( echo \"There are local uncommitted changes after one or both of 'npm install' or 'npm run docs:build'!\" && git diff --exit-code && exit 1 );",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "node ./bin/packages/watch.js",
+		"distclean": "rimraf node_modules packages/*/node_modules",
 		"docs:build": "node ./docs/tool/index.js && node ./bin/api-docs/update-api-docs.js",
 		"fixtures:clean": "rimraf \"packages/e2e-tests/fixtures/blocks/*.+(json|serialized.html)\"",
 		"fixtures:generate": "cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",

--- a/package.json
+++ b/package.json
@@ -217,7 +217,6 @@
 		"check-local-changes": "( git diff -U0 | xargs -0 node bin/process-git-diff ) || ( echo \"There are local uncommitted changes after one or both of 'npm install' or 'npm run docs:build'!\" && git diff --exit-code && exit 1 );",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "node ./bin/packages/watch.js",
-		"distclean": "rimraf node_modules packages/*/node_modules",
 		"docs:build": "node ./docs/tool/index.js && node ./bin/api-docs/update-api-docs.js",
 		"fixtures:clean": "rimraf \"packages/e2e-tests/fixtures/blocks/*.+(json|serialized.html)\"",
 		"fixtures:generate": "cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",


### PR DESCRIPTION
## Description
Purports to fix an issue that @youknowriad shared via Slack:

```
./bin/plugin/cli.js perf wp/5.6 release/9.6 release/9.7
```

> when it switches to `release/5.6` for some reason, there’s a “module not found error” on `npm run build` (even if just before there’s `rm -rf node_modules && npm install`

Specifically, the module that can't be found is `levenary` (which is required by babel).

I was able to reproduce by following those steps manually. It seems like the problem is with nested `node_modules/` directories, e.g. `packages/babel-preset-default/node_modules/`. Consequently, this PR adds a new `distclean` command to `package.json` to also remove those nested `node_modules/`, and uses that command in the perf test script.

## How has this been tested?
It hasn't really -- I'm having trouble running the perf tests on my Linux box :grimacing: 

The command to test them is

```
./bin/plugin/cli.js perf wp/5.6 release/9.6 release/9.7
```

## Types of changes
Bug fix