### PR TITLE
Block Directory: Fix "missing" block when the block can be installed from the directory

### DIFF
--- a/packages/block-directory/src/plugins/get-install-missing/index.js
+++ b/packages/block-directory/src/plugins/get-install-missing/index.js
@@ -6,7 +6,7 @@ import { Button } from '@wordpress/components';
 import { createBlock, getBlockType } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Warning } from '@wordpress/block-editor';
+import { Warning, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ import InstallButton from './install-button';
 import { store as blockDirectoryStore } from '../../store';
 
 const getInstallMissing = ( OriginalComponent ) => ( props ) => {
-	const { originalName, originalUndelimitedContent } = props.attributes;
+	const { originalName } = props.attributes;
 	// Disable reason: This is a valid component, but it's mistaken for a callback.
 	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const { block, hasPermission } = useSelect(
@@ -35,6 +35,16 @@ const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 		[ originalName ]
 	);
 
+	// The user can't install blocks, or the block isn't available for download.
+	if ( ! hasPermission || ! block ) {
+		return <OriginalComponent { ...props } />;
+	}
+
+	return <ModifiedWarning { ...props } originalBlock={ block } />;
+};
+
+const ModifiedWarning = ( { originalBlock, ...props } ) => {
+	const { originalName, originalUndelimitedContent } = props.attributes;
 	const { replaceBlock } = useDispatch( 'core/block-editor' );
 	const convertToHTML = () => {
 		replaceBlock(
@@ -45,24 +55,20 @@ const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 		);
 	};
 
-	if ( ! hasPermission || ! block ) {
-		return <OriginalComponent { ...props } />;
-	}
-
 	const hasContent = !! originalUndelimitedContent;
 	const hasHTMLBlock = getBlockType( 'core/html' );
 
 	let messageHTML = sprintf(
 		/* translators: %s: block name */
 		__(
-			'Your site doesn’t include support for the %s block. You can try installing the block or remove it entirely.'
+			'Your site doesn’t include support for the %s block. You can try installing the block or remove it entirely!'
 		),
-		block.title || originalName
+		originalBlock.title || originalName
 	);
 	const actions = [
 		<InstallButton
 			key="install"
-			block={ block }
+			block={ originalBlock }
 			attributes={ props.attributes }
 			clientId={ props.clientId }
 		/>,
@@ -74,7 +80,7 @@ const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 			__(
 				'Your site doesn’t include support for the %s block. You can try installing the block, convert it to a Custom HTML block, or remove it entirely.'
 			),
-			block.title || originalName
+			originalBlock.title || originalName
 		);
 		actions.push(
 			<Button key="convert" onClick={ convertToHTML } isLink>
@@ -84,10 +90,10 @@ const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 	}
 
 	return (
-		<>
+		<div { ...useBlockProps() }>
 			<Warning actions={ actions }>{ messageHTML }</Warning>
 			<RawHTML>{ originalUndelimitedContent }</RawHTML>
-		</>
+		</div>
 	);
 };
 


### PR DESCRIPTION
## Description
When blocks were updated to use API v2/`useBlockProps`, it caused a bug with the modified missing block. See #25264 & #22631 for history, but basically if a missing block is found in the block directory, we modify the "Missing" message to let users install that block. When the block API was changed, the wrapper no longer applied correctly to the modified message, and it caused the breaking described in #27916 & #27287.

Fixes #27916.

## How has this been tested?

Manual testing, using the following code to trigger a request to install the Star Rating block

```
<!-- wp:ideabox/star-rating -->
<p>test</p>
<!-- /wp:ideabox/star-rating -->
```

You can test the no HTML case with this block code:

```
<!-- wp:ideabox/star-rating /-->
```

Once the "Install Start Rating" button shows up, you should be able to click the missing block container. It should highlight, show the block toolbar, and you should be able to delete it.

## Types of changes
Bug fix (non-breaking change which fixes an issue)
