### PR TITLE
Update linting and formatting for test plugin files.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,6 @@ build-module
 build-types
 node_modules
 packages/block-serialization-spec-parser/parser.js
-packages/e2e-tests/plugins
 packages/react-native-editor/bundle
 vendor
 !.*.js

--- a/packages/e2e-tests/plugins/align-hook/index.js
+++ b/packages/e2e-tests/plugins/align-hook/index.js
@@ -1,23 +1,18 @@
-( function() {
-	var registerBlockType = wp.blocks.registerBlockType;
-	var el = wp.element.createElement;
-	var InnerBlocks = wp.blockEditor.InnerBlocks;
-	var __ = wp.i18n.__;
-	var TEMPLATE = [
-		[ 'core/paragraph', { fontSize: 'large', content: __( 'Content…' ) } ],
-	];
+( function () {
+	const registerBlockType = wp.blocks.registerBlockType;
+	const el = wp.element.createElement;
 
-	var baseBlock = {
+	const baseBlock = {
 		icon: 'cart',
 		category: 'text',
-		edit: function( props ) {
+		edit() {
 			return el(
 				'div',
 				{ style: { outline: '1px solid gray', padding: 5 } },
 				'Test Align Hook'
 			);
 		},
-		save: function() {
+		save() {
 			return el(
 				'div',
 				{ style: { outline: '1px solid gray', padding: 5 } },

--- a/packages/e2e-tests/plugins/block-icons/index.js
+++ b/packages/e2e-tests/plugins/block-icons/index.js
@@ -1,8 +1,8 @@
-( function() {
-	var registerBlockType = wp.blocks.registerBlockType;
-	var el = wp.element.createElement;
-	var InnerBlocks = wp.blockEditor.InnerBlocks;
-	var circle = el( 'circle', {
+( function () {
+	const registerBlockType = wp.blocks.registerBlockType;
+	const el = wp.element.createElement;
+	const InnerBlocks = wp.blockEditor.InnerBlocks;
+	const circle = el( 'circle', {
 		cx: 10,
 		cy: 10,
 		r: 10,
@@ -10,7 +10,7 @@
 		stroke: 'blue',
 		strokeWidth: '10',
 	} );
-	var svg = el(
+	const svg = el(
 		'svg',
 		{ width: 20, height: 20, viewBox: '0 0 20 20' },
 		circle
@@ -21,7 +21,7 @@
 		icon: svg,
 		category: 'text',
 
-		edit: function() {
+		edit() {
 			return el(
 				'div',
 				{
@@ -42,7 +42,7 @@
 			);
 		},
 
-		save: function() {
+		save() {
 			return el(
 				'div',
 				{
@@ -59,7 +59,7 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit: function() {
+		edit() {
 			return el(
 				'div',
 				{
@@ -80,7 +80,7 @@
 			);
 		},
 
-		save: function() {
+		save() {
 			return el(
 				'div',
 				{
@@ -94,12 +94,12 @@
 
 	registerBlockType( 'test/test-function-icon', {
 		title: 'TestFunctionIcon',
-		icon: function() {
+		icon() {
 			return svg;
 		},
 		category: 'text',
 
-		edit: function() {
+		edit() {
 			return el(
 				'div',
 				{
@@ -120,7 +120,7 @@
 			);
 		},
 
-		save: function() {
+		save() {
 			return el(
 				'div',
 				{
@@ -141,7 +141,7 @@
 		},
 		category: 'text',
 
-		edit: function() {
+		edit() {
 			return el(
 				'div',
 				{
@@ -162,7 +162,7 @@
 			);
 		},
 
-		save: function() {
+		save() {
 			return el(
 				'div',
 				{
@@ -182,7 +182,7 @@
 		},
 		category: 'text',
 
-		edit: function() {
+		edit() {
 			return el(
 				'div',
 				{
@@ -203,7 +203,7 @@
 			);
 		},
 
-		save: function() {
+		save() {
 			return el(
 				'div',
 				{

--- a/packages/e2e-tests/plugins/block-variations/index.js
+++ b/packages/e2e-tests/plugins/block-variations/index.js
@@ -1,11 +1,11 @@
-( function() {
-	var el = wp.element.createElement;
-	var registerBlockVariation = wp.blocks.registerBlockVariation;
-	var __ = wp.i18n.__;
-	var Circle = wp.primitives.Circle;
-	var SVG = wp.primitives.SVG;
+( function () {
+	const el = wp.element.createElement;
+	const registerBlockVariation = wp.blocks.registerBlockVariation;
+	const __ = wp.i18n.__;
+	const Circle = wp.primitives.Circle;
+	const SVG = wp.primitives.SVG;
 
-	var redCircle = el( Circle, {
+	const redCircle = el( Circle, {
 		cx: 24,
 		cy: 24,
 		r: 15,
@@ -13,7 +13,8 @@
 		stroke: 'blue',
 		strokeWidth: '10',
 	} );
-	var redCircleIcon = el(
+
+	const redCircleIcon = el(
 		SVG,
 		{ width: 48, height: 48, viewBox: '0 0 48 48' },
 		redCircle

--- a/packages/e2e-tests/plugins/child-blocks/index.js
+++ b/packages/e2e-tests/plugins/child-blocks/index.js
@@ -1,4 +1,4 @@
-( function() {
+( function () {
 	const { InnerBlocks } = wp.blockEditor;
 	const { createElement: el } = wp.element;
 	const { registerBlockType } = wp.blocks;
@@ -9,19 +9,11 @@
 		category: 'text',
 
 		edit() {
-			return el(
-				'div',
-				{},
-				el( InnerBlocks )
-			);
+			return el( 'div', {}, el( InnerBlocks ) );
 		},
 
 		save() {
-			return el(
-				'div',
-				{},
-				el( InnerBlocks.Content )
-			);
+			return el( 'div', {}, el( InnerBlocks.Content ) );
 		},
 	} );
 
@@ -34,19 +26,14 @@
 			return el(
 				'div',
 				{},
-				el(
-					InnerBlocks,
-					{ allowedBlocks: [ 'core/paragraph', 'core/image' ] }
-				)
+				el( InnerBlocks, {
+					allowedBlocks: [ 'core/paragraph', 'core/image' ],
+				} )
 			);
 		},
 
 		save() {
-			return el(
-				'div',
-				{},
-				el( InnerBlocks.Content )
-			);
+			return el( 'div', {}, el( InnerBlocks.Content ) );
 		},
 	} );
 
@@ -61,19 +48,11 @@
 		],
 
 		edit() {
-			return el(
-				'div',
-				{},
-				'Child'
-			);
+			return el( 'div', {}, 'Child' );
 		},
 
 		save() {
-			return el(
-				'div',
-				{},
-				'Child'
-			);
+			return el( 'div', {}, 'Child' );
 		},
 	} );
 } )();

--- a/packages/e2e-tests/plugins/container-without-paragraph/index.js
+++ b/packages/e2e-tests/plugins/container-without-paragraph/index.js
@@ -1,4 +1,4 @@
-( function() {
+( function () {
 	wp.blocks.registerBlockType( 'test/container-without-paragraph', {
 		title: 'Container without paragraph',
 		category: 'text',

--- a/packages/e2e-tests/plugins/custom-grouping-block/index.js
+++ b/packages/e2e-tests/plugins/custom-grouping-block/index.js
@@ -1,4 +1,4 @@
-( function() {
+( function () {
 	wp.blocks.registerBlockType( 'test/alternative-group-block', {
 		title: 'Alternative Group Block',
 		category: 'design',

--- a/packages/e2e-tests/plugins/deprecated-node-matcher/index.js
+++ b/packages/e2e-tests/plugins/deprecated-node-matcher/index.js
@@ -1,7 +1,7 @@
-( function() {
-	var registerBlockType = wp.blocks.registerBlockType;
-	var RichText = wp.blockEditor.RichText;
-	var el = wp.element.createElement;
+( function () {
+	const registerBlockType = wp.blocks.registerBlockType;
+	const RichText = wp.blockEditor.RichText;
+	const el = wp.element.createElement;
 
 	registerBlockType( 'core/deprecated-children-matcher', {
 		title: 'Deprecated Children Matcher',
@@ -13,16 +13,16 @@
 			},
 		},
 		category: 'text',
-		edit: function( { attributes, setAttributes } ) {
+		edit( { attributes, setAttributes } ) {
 			return el( RichText, {
 				tagName: 'p',
 				value: attributes.value,
-				onChange: function( nextValue ) {
+				onChange( nextValue ) {
 					setAttributes( { value: nextValue } );
 				},
 			} );
 		},
-		save: function( { attributes } ) {
+		save( { attributes } ) {
 			return el( RichText.Content, {
 				tagName: 'p',
 				value: attributes.value,
@@ -31,13 +31,15 @@
 	} );
 
 	function toRichTextValue( value ) {
-		return _.map( value, function( subValue ) {
+		// eslint-disable-next-line no-undef
+		return _.map( value, function ( subValue ) {
 			return subValue.children;
 		} );
 	}
 
 	function fromRichTextValue( value ) {
-		return _.map( value, function( subValue ) {
+		// eslint-disable-next-line no-undef
+		return _.map( value, function ( subValue ) {
 			return {
 				children: subValue,
 			};
@@ -59,14 +61,14 @@
 			},
 		},
 		category: 'text',
-		edit: function( { attributes, setAttributes } ) {
+		edit( { attributes, setAttributes } ) {
 			return el(
 				'blockquote',
 				{},
 				el( RichText, {
 					multiline: 'p',
 					value: toRichTextValue( attributes.value ),
-					onChange: function( nextValue ) {
+					onChange( nextValue ) {
 						setAttributes( {
 							value: fromRichTextValue( nextValue ),
 						} );
@@ -74,7 +76,7 @@
 				} )
 			);
 		},
-		save: function( { attributes } ) {
+		save( { attributes } ) {
 			return el(
 				'blockquote',
 				{},

--- a/packages/e2e-tests/plugins/format-api/index.js
+++ b/packages/e2e-tests/plugins/format-api/index.js
@@ -1,33 +1,30 @@
-( function() {
-	wp.richText.registerFormatType(
-		'my-plugin/link', {
-			title: 'Custom Link',
-			tagName: 'a',
-			attributes: {
-				url: 'href',
-			},
-			className: 'my-plugin-link',
-			edit: function( props ) {
-				return wp.element.createElement(
-					wp.blockEditor.RichTextToolbarButton, {
-						icon: 'admin-links',
-						title: 'Custom Link',
-						onClick: function() {
-							props.onChange(
-								wp.richText.toggleFormat(
-									props.value, {
-										type: 'my-plugin/link',
-										attributes: {
-											url: 'https://example.com',
-										}
-									}
-								)
-							);
-						},
-						isActive: props.isActive,
-					}
-				);
-			}
-		}
-	);
+( function () {
+	wp.richText.registerFormatType( 'my-plugin/link', {
+		title: 'Custom Link',
+		tagName: 'a',
+		attributes: {
+			url: 'href',
+		},
+		className: 'my-plugin-link',
+		edit( props ) {
+			return wp.element.createElement(
+				wp.blockEditor.RichTextToolbarButton,
+				{
+					icon: 'admin-links',
+					title: 'Custom Link',
+					onClick() {
+						props.onChange(
+							wp.richText.toggleFormat( props.value, {
+								type: 'my-plugin/link',
+								attributes: {
+									url: 'https://example.com',
+								},
+							} )
+						);
+					},
+					isActive: props.isActive,
+				}
+			);
+		},
+	} );
 } )();

--- a/packages/e2e-tests/plugins/hooks-api/index.js
+++ b/packages/e2e-tests/plugins/hooks-api/index.js
@@ -1,12 +1,12 @@
-( function() {
-	var el = wp.element.createElement;
-	var Fragment = wp.element.Fragment;
-	var Button = wp.components.Button;
-	var PanelBody = wp.components.PanelBody;
-	var InspectorControls = wp.blockEditor.InspectorControls;
-	var addFilter = wp.hooks.addFilter;
-	var createBlock = wp.blocks.createBlock;
-	var __ = wp.i18n.__;
+( function () {
+	const el = wp.element.createElement;
+	const Fragment = wp.element.Fragment;
+	const Button = wp.components.Button;
+	const PanelBody = wp.components.PanelBody;
+	const InspectorControls = wp.blockEditor.InspectorControls;
+	const addFilter = wp.hooks.addFilter;
+	const createBlock = wp.blocks.createBlock;
+	const __ = wp.i18n.__;
 
 	function ResetBlockButton( props ) {
 		return el(
@@ -18,10 +18,10 @@
 					className: 'e2e-reset-block-button',
 					variant: "secondary",
 					isLarge: true,
-					onClick: function() {
-						var emptyBlock = createBlock( props.name );
+					onClick() {
+						const emptyBlock = createBlock( props.name );
 						props.onReplace( emptyBlock );
-					}
+					},
 				},
 				__( 'Reset Block' )
 			)
@@ -29,25 +29,19 @@
 	}
 
 	function addResetBlockButton( BlockEdit ) {
-		return function( props ) {
+		return function ( props ) {
 			return el(
 				Fragment,
 				{},
 				el(
 					InspectorControls,
 					{},
-					el(
-						ResetBlockButton,
-						{
-							name: props.name,
-							onReplace: props.onReplace
-						}
-					)
+					el( ResetBlockButton, {
+						name: props.name,
+						onReplace: props.onReplace,
+					} )
 				),
-				el(
-					BlockEdit,
-					props
-				)
+				el( BlockEdit, props )
 			);
 		};
 	}

--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
@@ -1,4 +1,4 @@
-( function() {
+( function () {
 	const { withSelect } = wp.data;
 	const { registerBlockType } = wp.blocks;
 	const { createElement: el } = wp.element;
@@ -16,7 +16,7 @@
 	const allowedBlocksWhenSingleEmptyChild = [ 'core/image', 'core/list' ];
 	const allowedBlocksWhenMultipleChildren = [ 'core/gallery', 'core/video' ];
 
-	const save = function() {
+	const save = function () {
 		return el( 'div', divProps, el( InnerBlocks.Content ) );
 	};
 	registerBlockType( 'test/allowed-blocks-unset', {
@@ -61,12 +61,12 @@
 		icon: 'carrot',
 		category: 'text',
 
-		edit: withSelect( function( select, ownProps ) {
-			var getBlockOrder = select( 'core/block-editor' ).getBlockOrder;
+		edit: withSelect( function ( select, ownProps ) {
+			const getBlockOrder = select( 'core/block-editor' ).getBlockOrder;
 			return {
 				numberOfChildren: getBlockOrder( ownProps.clientId ).length,
 			};
-		} )( function( props ) {
+		} )( function ( props ) {
 			return el(
 				'div',
 				{

--- a/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
@@ -1,9 +1,9 @@
-( function() {
-	var registerBlockType = wp.blocks.registerBlockType;
-	var el = wp.element.createElement;
-	var InnerBlocks = wp.blockEditor.InnerBlocks;
-	var __ = wp.i18n.__;
-	var TEMPLATE = [
+( function () {
+	const registerBlockType = wp.blocks.registerBlockType;
+	const el = wp.element.createElement;
+	const InnerBlocks = wp.blockEditor.InnerBlocks;
+	const __ = wp.i18n.__;
+	const TEMPLATE = [
 		[
 			'core/paragraph',
 			{
@@ -14,7 +14,7 @@
 		[ 'core/embed' ],
 	];
 
-	var save = function() {
+	const save = function () {
 		return el( InnerBlocks.Content );
 	};
 
@@ -23,7 +23,7 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit: function( props ) {
+		edit() {
 			return el( InnerBlocks, {
 				template: TEMPLATE,
 				templateLock: 'all',

--- a/packages/e2e-tests/plugins/inner-blocks-render-appender/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-render-appender/index.js
@@ -1,11 +1,11 @@
-( function() {
+( function () {
 	const { wp } = window;
 	const { registerBlockType } = wp.blocks;
 	const { createElement: el } = wp.element;
 	const { InnerBlocks } = wp.blockEditor;
 	const { useSelect } = wp.data;
 
-	var allowedBlocks = [ 'core/quote', 'core/video' ];
+	const allowedBlocks = [ 'core/quote', 'core/video' ];
 
 	function myCustomAppender() {
 		return el(
@@ -64,7 +64,7 @@
 				'div',
 				{ style: { outline: '1px solid gray', padding: 5 } },
 				el( InnerBlocks, {
-					allowedBlocks: allowedBlocks,
+					allowedBlocks,
 					renderAppender: myCustomAppender,
 				} )
 			);
@@ -85,6 +85,9 @@
 		category: 'text',
 
 		edit( props ) {
+			// Disable reason: this is a react component, but the rule of hook
+			// fails because the block's edit function has a lowercase 'e'.
+			// eslint-disable-next-line react-hooks/rules-of-hooks
 			const numberOfChildren = useSelect(
 				( select ) => {
 					const { getBlockOrder } = select( 'core/block-editor' );
@@ -92,6 +95,7 @@
 				},
 				[ props.clientId ]
 			);
+			let renderAppender;
 			switch ( numberOfChildren ) {
 				case 0:
 					renderAppender = emptyBlockAppender;

--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -1,10 +1,9 @@
 ( function () {
-	var registerBlockType = wp.blocks.registerBlockType;
-	var createBlock = wp.blocks.createBlock;
-	var el = wp.element.createElement;
-	var InnerBlocks = wp.blockEditor.InnerBlocks;
-	var __ = wp.i18n.__;
-	var TEMPLATE = [
+	const registerBlockType = wp.blocks.registerBlockType;
+	const createBlock = wp.blocks.createBlock;
+	const el = wp.element.createElement;
+	const InnerBlocks = wp.blockEditor.InnerBlocks;
+	const TEMPLATE = [
 		[
 			'core/paragraph',
 			{
@@ -14,7 +13,7 @@
 		],
 	];
 
-	var TEMPLATE_PARAGRAPH_PLACEHOLDER = [
+	const TEMPLATE_PARAGRAPH_PLACEHOLDER = [
 		[
 			'core/paragraph',
 			{
@@ -24,7 +23,7 @@
 		],
 	];
 
-	var TEMPLATE_TWO_PARAGRAPHS = [
+	const TEMPLATE_TWO_PARAGRAPHS = [
 		[
 			'core/paragraph',
 			{
@@ -41,7 +40,7 @@
 		],
 	];
 
-	var save = function () {
+	const save = function () {
 		return el( InnerBlocks.Content );
 	};
 
@@ -50,7 +49,7 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit: function ( props ) {
+		edit() {
 			return el( InnerBlocks, {
 				template: TEMPLATE,
 			} );
@@ -64,7 +63,7 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit: function ( props ) {
+		edit() {
 			return el( InnerBlocks, {
 				template: TEMPLATE,
 				templateLock: 'all',
@@ -86,35 +85,36 @@
 			},
 		},
 
-		edit: function ( props ) {
+		edit( props ) {
 			const hasUpdatedTemplated = props.attributes.hasUpdatedTemplate;
-			return el(
-				'div',
-				null,
-				[
-					el( 'button', {
-						onClick: function () {
-							props.setAttributes( { hasUpdatedTemplate: true } )
+			return el( 'div', null, [
+				el(
+					'button',
+					{
+						onClick() {
+							props.setAttributes( { hasUpdatedTemplate: true } );
 						},
-					}, 'Update template' ),
-					el( InnerBlocks, {
-						template: hasUpdatedTemplated ? TEMPLATE_TWO_PARAGRAPHS : TEMPLATE,
-						templateLock: 'all',
-					} ),
-				]
-			);
+					},
+					'Update template'
+				),
+				el( InnerBlocks, {
+					template: hasUpdatedTemplated
+						? TEMPLATE_TWO_PARAGRAPHS
+						: TEMPLATE,
+					templateLock: 'all',
+				} ),
+			] );
 		},
 
 		save,
 	} );
-
 
 	registerBlockType( 'test/test-inner-blocks-paragraph-placeholder', {
 		title: 'Test Inner Blocks Paragraph Placeholder',
 		icon: 'cart',
 		category: 'text',
 
-		edit: function ( props ) {
+		edit() {
 			return el( InnerBlocks, {
 				template: TEMPLATE_PARAGRAPH_PLACEHOLDER,
 				templateInsertUpdatesSelection: true,
@@ -139,7 +139,7 @@
 						'test/test-inner-blocks-locking-all',
 						'test/test-inner-blocks-paragraph-placeholder',
 					],
-					transform: function ( attributes, innerBlocks ) {
+					transform( attributes, innerBlocks ) {
 						return createBlock(
 							'test/test-inner-blocks-transformer-target',
 							attributes,
@@ -152,7 +152,7 @@
 				{
 					type: 'block',
 					blocks: [ 'test/i-dont-exist' ],
-					transform: function ( attributes, innerBlocks ) {
+					transform( attributes, innerBlocks ) {
 						return createBlock(
 							'test/test-inner-blocks-transformer-target',
 							attributes,
@@ -163,7 +163,7 @@
 			],
 		},
 
-		edit: function ( props ) {
+		edit() {
 			return el( InnerBlocks, {
 				template: TEMPLATE,
 			} );

--- a/packages/e2e-tests/plugins/meta-attribute-block/early.js
+++ b/packages/e2e-tests/plugins/meta-attribute-block/early.js
@@ -1,6 +1,6 @@
-( function() {
-	var registerBlockType = wp.blocks.registerBlockType;
-	var el = wp.element.createElement;
+( function () {
+	const registerBlockType = wp.blocks.registerBlockType;
+	const el = wp.element.createElement;
 
 	registerBlockType( 'test/test-meta-attribute-block-early', {
 		title: 'Test Meta Attribute Block (Early Registration)',
@@ -15,17 +15,17 @@
 			},
 		},
 
-		edit: function( props ) {
+		edit( props ) {
 			return el( 'input', {
 				className: 'my-meta-input',
 				value: props.attributes.content,
-				onChange: function( event ) {
+				onChange( event ) {
 					props.setAttributes( { content: event.target.value } );
 				},
 			} );
 		},
 
-		save: function() {
+		save() {
 			return null;
 		},
 	} );

--- a/packages/e2e-tests/plugins/meta-attribute-block/late.js
+++ b/packages/e2e-tests/plugins/meta-attribute-block/late.js
@@ -1,6 +1,6 @@
-( function() {
-	var registerBlockType = wp.blocks.registerBlockType;
-	var el = wp.element.createElement;
+( function () {
+	const registerBlockType = wp.blocks.registerBlockType;
+	const el = wp.element.createElement;
 
 	registerBlockType( 'test/test-meta-attribute-block-late', {
 		title: 'Test Meta Attribute Block (Late Registration)',
@@ -15,17 +15,17 @@
 			},
 		},
 
-		edit: function( props ) {
+		edit( props ) {
 			return el( 'input', {
 				className: 'my-meta-input',
 				value: props.attributes.content,
-				onChange: function( event ) {
+				onChange( event ) {
 					props.setAttributes( { content: event.target.value } );
 				},
 			} );
 		},
 
-		save: function() {
+		save() {
 			return null;
 		},
 	} );

--- a/packages/e2e-tests/plugins/plugins-api/annotations-sidebar.js
+++ b/packages/e2e-tests/plugins/plugins-api/annotations-sidebar.js
@@ -1,20 +1,15 @@
-( function() {
-	var Button = wp.components.Button;
-	var PanelBody = wp.components.PanelBody;
-	var PanelRow = wp.components.PanelRow;
-	var compose = wp.compose.compose;
-	var withDispatch = wp.data.withDispatch;
-	var withSelect = wp.data.withSelect;
-	var select = wp.data.select;
-	var dispatch = wp.data.dispatch;
-	var PlainText = wp.blockEditor.PlainText;
-	var Fragment = wp.element.Fragment;
-	var el = wp.element.createElement;
-	var Component = wp.element.Component;
-	var __ = wp.i18n.__;
-	var registerPlugin = wp.plugins.registerPlugin;
-	var PluginSidebar = wp.editPost.PluginSidebar;
-	var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
+( function () {
+	const Button = wp.components.Button;
+	const PanelBody = wp.components.PanelBody;
+	const select = wp.data.select;
+	const dispatch = wp.data.dispatch;
+	const Fragment = wp.element.Fragment;
+	const el = wp.element.createElement;
+	const Component = wp.element.Component;
+	const __ = wp.i18n.__;
+	const registerPlugin = wp.plugins.registerPlugin;
+	const PluginSidebar = wp.editPost.PluginSidebar;
+	const PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
 
 	class SidebarContents extends Component {
 		constructor( props ) {
@@ -23,47 +18,45 @@
 			this.state = {
 				start: 0,
 				end: 0,
-			}
+			};
 		}
 
 		render() {
 			return el(
 				PanelBody,
 				{},
-				el(
-					'input',
-					{
-						type: 'number',
-						id: 'annotations-tests-range-start',
-						onChange: ( reactEvent ) => {
-							this.setState( {
-								start: reactEvent.target.value,
-							} );
-						},
-						value: this.state.start,
-					}
-				),
-				el(
-					'input',
-					{
-						type: 'number',
-						id: 'annotations-tests-range-end',
-						onChange: ( reactEvent ) => {
-							this.setState( {
-								end: reactEvent.target.value,
-							} );
-						},
-						value: this.state.end,
-					}
-				),
+				el( 'input', {
+					type: 'number',
+					id: 'annotations-tests-range-start',
+					onChange: ( reactEvent ) => {
+						this.setState( {
+							start: reactEvent.target.value,
+						} );
+					},
+					value: this.state.start,
+				} ),
+				el( 'input', {
+					type: 'number',
+					id: 'annotations-tests-range-end',
+					onChange: ( reactEvent ) => {
+						this.setState( {
+							end: reactEvent.target.value,
+						} );
+					},
+					value: this.state.end,
+				} ),
 				el(
 					Button,
 					{
 						variant: "primary",
 						onClick: () => {
-							dispatch( 'core/annotations' ).__experimentalAddAnnotation( {
+							dispatch(
+								'core/annotations'
+							).__experimentalAddAnnotation( {
 								source: 'e2e-tests',
-								blockClientId: select( 'core/block-editor' ).getBlockOrder()[ 0 ],
+								blockClientId: select(
+									'core/block-editor'
+								).getBlockOrder()[ 0 ],
 								richTextIdentifier: 'content',
 								range: {
 									start: parseInt( this.state.start, 10 ),
@@ -79,8 +72,12 @@
 					{
 						variant: "primary",
 						onClick: () => {
-							dispatch( 'core/annotations' ).__experimentalRemoveAnnotationsBySource( 'e2e-tests' );
-						}
+							dispatch(
+								'core/annotations'
+							).__experimentalRemoveAnnotationsBySource(
+								'e2e-tests'
+							);
+						},
 					},
 
 					__( 'Remove annotations' )
@@ -97,17 +94,14 @@
 				PluginSidebar,
 				{
 					name: 'annotations-sidebar',
-					title: __( 'Annotations Sidebar' )
+					title: __( 'Annotations Sidebar' ),
 				},
-				el(
-					SidebarContents,
-					{}
-				)
+				el( SidebarContents, {} )
 			),
 			el(
 				PluginSidebarMoreMenuItem,
 				{
-					target: 'annotations-sidebar'
+					target: 'annotations-sidebar',
 				},
 				__( 'Annotations Sidebar' )
 			)
@@ -116,6 +110,6 @@
 
 	registerPlugin( 'annotations-sidebar', {
 		icon: 'text',
-		render: AnnotationsSidebar
+		render: AnnotationsSidebar,
 	} );
 } )();

--- a/packages/e2e-tests/plugins/plugins-api/document-setting.js
+++ b/packages/e2e-tests/plugins/plugins-api/document-setting.js
@@ -1,8 +1,8 @@
-( function() {
-	var el = wp.element.createElement;
-	var __ = wp.i18n.__;
-	var registerPlugin = wp.plugins.registerPlugin;
-	var PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;
+( function () {
+	const el = wp.element.createElement;
+	const __ = wp.i18n.__;
+	const registerPlugin = wp.plugins.registerPlugin;
+	const PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;
 
 	function MyDocumentSettingPlugin() {
 		return el(
@@ -10,13 +10,13 @@
 			{
 				className: 'my-document-setting-plugin',
 				title: 'My Custom Panel',
-				name: 'my-custom-panel'
+				name: 'my-custom-panel',
 			},
 			__( 'My Document Setting Panel' )
 		);
 	}
 
 	registerPlugin( 'my-document-setting-plugin', {
-		render: MyDocumentSettingPlugin
+		render: MyDocumentSettingPlugin,
 	} );
 } )();

--- a/packages/e2e-tests/plugins/plugins-api/post-status-info.js
+++ b/packages/e2e-tests/plugins/plugins-api/post-status-info.js
@@ -1,8 +1,8 @@
-( function() {
-	var el = wp.element.createElement;
-	var __ = wp.i18n.__;
-	var registerPlugin = wp.plugins.registerPlugin;
-	var PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;
+( function () {
+	const el = wp.element.createElement;
+	const __ = wp.i18n.__;
+	const registerPlugin = wp.plugins.registerPlugin;
+	const PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;
 
 	function MyPostStatusInfoPlugin() {
 		return el(
@@ -15,6 +15,6 @@
 	}
 
 	registerPlugin( 'my-post-status-info-plugin', {
-		render: MyPostStatusInfoPlugin
+		render: MyPostStatusInfoPlugin,
 	} );
 } )();

--- a/packages/e2e-tests/plugins/plugins-api/publish-panel.js
+++ b/packages/e2e-tests/plugins/plugins-api/publish-panel.js
@@ -1,17 +1,13 @@
-( function() {
-	var el = wp.element.createElement;
-	var Fragment = wp.element.Fragment;
-	var __ = wp.i18n.__;
-	var registerPlugin = wp.plugins.registerPlugin;
-	var PluginPostPublishPanel = wp.editPost.PluginPostPublishPanel;
-	var PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;
+( function () {
+	const el = wp.element.createElement;
+	const Fragment = wp.element.Fragment;
+	const __ = wp.i18n.__;
+	const registerPlugin = wp.plugins.registerPlugin;
+	const PluginPostPublishPanel = wp.editPost.PluginPostPublishPanel;
+	const PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;
 
 	function PanelContent() {
-		return el(
-			'p',
-			{},
-			__( 'Here is the panel content!' )
-		);
+		return el( 'p', {}, __( 'Here is the panel content!' ) );
 	}
 
 	function MyPublishPanelPlugin() {
@@ -22,28 +18,22 @@
 				PluginPrePublishPanel,
 				{
 					className: 'my-publish-panel-plugin__pre',
-					title: __( 'My pre publish panel' )
+					title: __( 'My pre publish panel' ),
 				},
-				el(
-					PanelContent,
-					{}
-				)
+				el( PanelContent, {} )
 			),
 			el(
 				PluginPostPublishPanel,
 				{
 					className: 'my-publish-panel-plugin__post',
-					title: __( 'My post publish panel' )
+					title: __( 'My post publish panel' ),
 				},
-				el(
-					PanelContent,
-					{}
-				)
+				el( PanelContent, {} )
 			)
 		);
 	}
 
 	registerPlugin( 'my-publish-panel-plugin', {
-		render: MyPublishPanelPlugin
+		render: MyPublishPanelPlugin,
 	} );
 } )();

--- a/packages/e2e-tests/plugins/plugins-api/sidebar.js
+++ b/packages/e2e-tests/plugins/plugins-api/sidebar.js
@@ -1,21 +1,32 @@
 ( function () {
-	var Button = wp.components.Button;
-	var PanelBody = wp.components.PanelBody;
-	var PanelRow = wp.components.PanelRow;
-	var compose = wp.compose.compose;
-	var withDispatch = wp.data.withDispatch;
-	var withSelect = wp.data.withSelect;
-	var select = wp.data.select;
-	var dispatch = wp.data.dispatch;
-	var PlainText = wp.blockEditor.PlainText;
-	var Fragment = wp.element.Fragment;
-	var el = wp.element.createElement;
-	var __ = wp.i18n.__;
-	var registerPlugin = wp.plugins.registerPlugin;
-	var PluginSidebar = wp.editPost.PluginSidebar;
-	var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
+	const Button = wp.components.Button;
+	const PanelBody = wp.components.PanelBody;
+	const PanelRow = wp.components.PanelRow;
+	const editorStore = wp.editor.store;
+	const useDispatch = wp.data.useDispatch;
+	const useSelect = wp.data.useSelect;
+	const PlainText = wp.blockEditor.PlainText;
+	const Fragment = wp.element.Fragment;
+	const el = wp.element.createElement;
+	const __ = wp.i18n.__;
+	const registerPlugin = wp.plugins.registerPlugin;
+	const PluginSidebar = wp.editPost.PluginSidebar;
+	const PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
 
-	function SidebarContents( props ) {
+	function SidebarContents() {
+		const postTitle = useSelect( ( select ) =>
+			select( editorStore ).getEditedPostAttribute( 'title' )
+		);
+		const editPost = useDispatch( editorStore ).editPost;
+
+		function resetTitle() {
+			editPost( { title: '' } );
+		}
+
+		function updateTitle( title ) {
+			editPost( { title } );
+		}
+
 		return el(
 			PanelBody,
 			{ className: 'sidebar-title-plugin-panel' },
@@ -31,9 +42,9 @@
 				),
 				el( PlainText, {
 					id: 'title-plain-text',
-					onChange: props.updateTitle,
+					onChange: updateTitle,
 					placeholder: __( '(no title)' ),
-					value: props.title,
+					value: postTitle,
 				} )
 			),
 			el(
@@ -42,40 +53,14 @@
 				el(
 					Button,
 					{
-						variant:"primary",
-						onClick: props.resetTitle,
+						variant: 'primary',
+						onClick: resetTitle,
 					},
 					__( 'Reset' )
 				)
 			)
 		);
 	}
-
-	var SidebarContentsWithDataHandling = compose( [
-		withSelect( function ( select ) {
-			return {
-				title: select( 'core/editor' ).getEditedPostAttribute(
-					'title'
-				),
-			};
-		} ),
-		withDispatch( function ( dispatch ) {
-			function editPost( title ) {
-				dispatch( 'core/editor' ).editPost( {
-					title: title,
-				} );
-			}
-
-			return {
-				updateTitle: function ( title ) {
-					editPost( title );
-				},
-				resetTitle: function () {
-					editPost( '' );
-				},
-			};
-		} ),
-	] )( SidebarContents );
 
 	function MySidebarPlugin() {
 		return el(
@@ -87,7 +72,7 @@
 					name: 'title-sidebar',
 					title: __( 'Plugin sidebar title' ),
 				},
-				el( SidebarContentsWithDataHandling, {} )
+				el( SidebarContents, {} )
 			),
 			el(
 				PluginSidebarMoreMenuItem,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In #28007 I committed one of the e2e test plugins with the non-WordPressy coding standards that my editor automatically applied. I was unsure why that happened. Thanks to some help on slack I realised this is due to the files being in the project's .eslintignore file. My editor was misconfigured so wasn't picking up the ignored files, and was for some reason prettifying them to non-WP standards.

I don't know the motivation behind not formatting or linting the files. Perhaps they were written before some modern standards were available in Chrome? Or maybe they were written for future where e2e tests might be able to run in IE11?

It seems like it'd be ok to lint/format them, so I've done that. If it works, the e2e tests should pass.