### PR TITLE
Create block: Add support for static assets

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Increase the minimum Node.js version to 12 ([#27934](https://github.com/WordPress/gutenberg/pull/27934)).
 
+### New Features
+
+-   Add support for handling static assets with the `assetsPath` field in the external template configuration ([#28038](https://github.com/WordPress/gutenberg/pull/28038)).
+
 ### Internal
 
 -   Update the demo included in the README file ([#28037](https://github.com/WordPress/gutenberg/pull/28037)).

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -138,7 +138,7 @@ module.exports = {
 
 #### `assetsPath`
 
-This setting is useful when your template scaffolds a block that uses static assets like images or fonts, which should not be processed. It provides the path pointing to the location where assets are located.
+This setting is useful when your template scaffolds a block that uses static assets like images or fonts, which should not be processed. It provides the path pointing to the location where assets are located. They will be copied to the `assets` subfolder in the generated plugin.
 
 _Example:_
 

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -120,17 +120,39 @@ Since version `0.19.0` it is possible to use external templates hosted on npm. T
 
 ### Template Configuration
 
-It is mandatory to provide the main file for the package that returns a configuration object. It must containing at least `templatesPath` field with the path pointing to the location where template files live (nested folders are also supported).
+It is mandatory to provide the main file (`index.js` by default) for the package that returns a configuration object. It must contain at least the `templatesPath` field.
+
+#### `templatesPath`
+
+A mandatory field with the path pointing to the location where template files live (nested folders are also supported). All files without the `.mustache` extension will be ignored.
 
 _Example:_
 
 ```js
+const { join } = require( 'path' );
+
 module.exports = {
-	templatesPath: __dirname,
+	templatesPath: join( __dirname, 'templates' ),
 };
 ```
 
-It is also possible to override the default template configuration using the `defaultValues` field.
+#### `assetsPath`
+
+This setting is useful when your template scaffolds a block that uses static assets like images or fonts, which should not be processed. It provides the path pointing to the location where assets are located.
+
+_Example:_
+
+```js
+const { join } = require( 'path' );
+
+module.exports = {
+	assetsPath: join( __dirname, 'assets' ),
+};
+```
+
+#### `defaultValues`
+
+It is possible to override the default template configuration using the `defaultValues` field.
 
 _Example:_
 

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -5,7 +5,7 @@ const { writeFile } = require( 'fs' ).promises;
 const { snakeCase } = require( 'lodash' );
 const makeDir = require( 'make-dir' );
 const { render } = require( 'mustache' );
-const { dirname } = require( 'path' );
+const { dirname, join } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ module.exports = async (
 	info( '' );
 	info( `Creating a new WordPress block in "${ slug }" folder.` );
 
-	const { outputTemplates } = blockTemplate;
+	const { outputTemplates, outputAssets } = blockTemplate;
 	const view = {
 		apiVersion,
 		namespace,
@@ -67,15 +67,23 @@ module.exports = async (
 	await Promise.all(
 		Object.keys( outputTemplates ).map( async ( outputFile ) => {
 			// Output files can have names that depend on the slug provided.
-			const outputFilePath = `${ slug }/${ outputFile.replace(
-				/\$slug/g,
-				slug
-			) }`;
+			const outputFilePath = join(
+				slug,
+				outputFile.replace( /\$slug/g, slug )
+			);
 			await makeDir( dirname( outputFilePath ) );
 			writeFile(
 				outputFilePath,
 				render( outputTemplates[ outputFile ], view )
 			);
+		} )
+	);
+
+	await Promise.all(
+		Object.keys( outputAssets ).map( async ( outputFile ) => {
+			const outputFilePath = join( slug, 'assets', outputFile );
+			await makeDir( dirname( outputFilePath ) );
+			writeFile( outputFilePath, outputAssets[ outputFile ] );
 		} )
 	);
 

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -77,8 +77,7 @@ const getOutputAssets = async ( outputAssetsPath ) => {
 		await Promise.all(
 			outputAssetFiles.map( async ( outputAssetFile ) => {
 				const outputAsset = await readFile(
-					join( outputAssetsPath, outputAssetFile ),
-					'utf8'
+					join( outputAssetsPath, outputAssetFile )
 				);
 				return [ outputAssetFile, outputAsset ];
 			} )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Related to #27881. The issue was described by @jessynd as follows:

> The original intent of this package was to create a final version of the gutenpride template that would help showcase how third-party templates can be used with `create-block`. However, as you can see above, we encountered the issue of the otf font being either deleted or modified: 
> 
> 1. The font is deleted by create-block if it doesn't have the .mustache extension. 
> 2. The font is modified by create-block if does have the .mustache extension, making it unusable. 
> 
> I hope this draft PR might help troubleshoot this issue. Ideally it would be great for third-party templates, if developers could include files without a .mustache extension. This was a good experiment to help us figure that out. 

This PR add support for handling static assets with the `assetsPath` field in the external template configuration.

#### `assetsPath`

This setting is useful when your template scaffolds a block that uses static assets like images or fonts, which should not be processed. It provides the path pointing to the location where assets are located.

_Example:_

```js
const { join } = require( 'path' );

module.exports = {
	assetsPath: join( __dirname, 'assets' ),
};
```

## How has this been tested?
It requires a 3rd party template for testing. I tested locally with tweaking the local template, but we need to validate with a package published to npm as follows:
`npx wp-create-block --template name-of-the-template`

## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
