### PR TITLE
Mobile - Link settings - Check for onClose

### DIFF
--- a/packages/components/src/mobile/link-settings/index.native.js
+++ b/packages/components/src/mobile/link-settings/index.native.js
@@ -152,7 +152,10 @@ function LinkSettings( {
 
 	function onCloseSettingsSheet() {
 		onSetAttributes();
-		onClose();
+
+		if ( onClose ) {
+			onClose();
+		}
 	}
 
 	function onChangeOpenInNewTab( value ) {


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/27996

## Description
After https://github.com/WordPress/gutenberg/pull/27997 was merged, opening the `Image` block settings and closing it would throw an error. This PR adds an extra check for the `onClose` prop before triggering it.

## How has this been tested?
- Open the editor
- Add an `Image` block
- Upload an image
- Open the block settings
- Close the bottom sheet
- **Expect** the bottom sheet to be closed without any error

## Screenshots <!-- if applicable -->
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/103878394-aa944800-50d6-11eb-9208-4834375338ee.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/103878408-aec06580-50d6-11eb-97ab-d9d22cd3914b.gif" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
