### PR TITLE
Scripts: Add support for static assets in build commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12611,6 +12611,7 @@
 				"dir-glob": "^3.0.1",
 				"eslint": "^7.17.0",
 				"eslint-plugin-markdown": "^1.0.2",
+				"file-loader": "^6.2.0",
 				"ignore-emit-webpack-plugin": "^2.0.6",
 				"jest": "^26.6.3",
 				"jest-puppeteer": "^4.4.0",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   `wordpress` subfolder is no longer ignored when detecting files for testing, linting or formatting.
 -   The bundled `eslint` dependency has been updated from requiring `^7.1.0` to requiring `^7.17.0` ([#27965](https://github.com/WordPress/gutenberg/pull/27965)).
 -   Make it possible to transpile `.jsx` files with `build` and `start` commands ([#28002](https://github.com/WordPress/gutenberg/pull/28002)).
+-   Add support for static assets (fonts and images) for `build` and `start` commands ([#28043](https://github.com/WordPress/gutenberg/pull/28043)).
 
 ### Internal
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -282,7 +282,7 @@ By default, files located in `build`, `node_modules`, and `vendor` folders are i
 
 #### Advanced information
 
-It uses [stylelint](https://github.com/stylelint/stylelint) with the [@wordpress/stylelint-config]((https://www.npmjs.com/package/@wordpress/stylelint-config) ) configuration per the [WordPress CSS Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/). You can override them with your own rules as described in [stylelint user guide](https://stylelint.io/user-guide/configure). Learn more in the [Advanced Usage](#advanced-usage) section.
+It uses [stylelint](https://github.com/stylelint/stylelint) with the [@wordpress/stylelint-config](<(https://www.npmjs.com/package/@wordpress/stylelint-config)>) configuration per the [WordPress CSS Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/). You can override them with your own rules as described in [stylelint user guide](https://stylelint.io/user-guide/configure). Learn more in the [Advanced Usage](#advanced-usage) section.
 
 ### `packages-update`
 
@@ -539,6 +539,24 @@ wp-scripts start entry-one.js entry-two.js --output-path=custom
 If you do so, then CSS files generated will follow the names of the entry points: `entry-one.css` and `entry-two.css`.
 
 Avoid using `style` keyword in an entry point name, this might break your build process.
+
+#### Using fonts and images
+
+It is possible to reference font (`woff`, `woff2`, `eot`, `ttf` and `otf`) and image (`bmp`, `png`, `jpg`, `jpeg` and `gif`) files from CSS that is controlled by webpack as explained in the previous section.
+
+_Example:_
+
+```css
+/* style.css */
+@font-face {
+	font-family: Gilbert;
+	src: url( ../assets/gilbert-color.otf );
+}
+.wp-block-my-block {
+	background-color: url( ../assets/block-background.png );
+	font-family: Gilbert;
+}
+```
 
 #### Using SVG
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -158,10 +158,6 @@ const config = {
 				],
 			},
 			{
-				test: /\.svg$/,
-				use: [ '@svgr/webpack', 'url-loader' ],
-			},
-			{
 				test: /\.css$/,
 				use: cssLoaders,
 			},
@@ -177,12 +173,41 @@ const config = {
 					},
 				],
 			},
+			{
+				test: /\.svg$/,
+				use: [ '@svgr/webpack', 'url-loader' ],
+			},
+			{
+				test: /\.(bmp|png|jpe?g|gif)$/i,
+				// "url" loader works like "file" loader except that it embeds assets
+				// smaller than specified limit in bytes as data URLs to avoid requests.
+				loader: require.resolve( 'url-loader' ),
+				options: {
+					limit: 5000,
+					name: 'images/[name].[hash:8].[ext]',
+				},
+			},
+			{
+				test: /\.(woff|woff2|eot|ttf|otf)$/,
+				use: [
+					{
+						loader: 'file-loader',
+						options: {
+							name: 'fonts/[name].[hash:8].[ext]',
+						},
+					},
+				],
+			},
 		],
 	},
 	plugins: [
-		// During rebuilds, all webpack assets that are not used anymore
-		// will be removed automatically.
-		new CleanWebpackPlugin(),
+		// During rebuilds, all webpack assets that are not used anymore will be
+		// removed automatically. There is an exception added in watch mode for
+		// fonts and images. It is a known limitations.
+		// @see https://github.com/johnagan/clean-webpack-plugin/issues/159
+		new CleanWebpackPlugin( {
+			cleanAfterEveryBuildPatterns: [ '!fonts/**', '!images/**' ],
+		} ),
 		// The WP_BUNDLE_ANALYZER global variable enables a utility that represents
 		// bundle content as a convenient interactive zoomable treemap.
 		process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -203,8 +203,8 @@ const config = {
 	plugins: [
 		// During rebuilds, all webpack assets that are not used anymore will be
 		// removed automatically. There is an exception added in watch mode for
-		// fonts and images. It is a known limitations.
-		// @see https://github.com/johnagan/clean-webpack-plugin/issues/159
+		// fonts and images. It is a known limitations:
+		// https://github.com/johnagan/clean-webpack-plugin/issues/159
 		new CleanWebpackPlugin( {
 			cleanAfterEveryBuildPatterns: [ '!fonts/**', '!images/**' ],
 		} ),

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -179,11 +179,8 @@ const config = {
 			},
 			{
 				test: /\.(bmp|png|jpe?g|gif)$/i,
-				// "url" loader works like "file" loader except that it embeds assets
-				// smaller than specified limit in bytes as data URLs to avoid requests.
-				loader: require.resolve( 'url-loader' ),
+				loader: require.resolve( 'file-loader' ),
 				options: {
-					limit: 5000,
 					name: 'images/[name].[hash:8].[ext]',
 				},
 			},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -51,6 +51,7 @@
 		"dir-glob": "^3.0.1",
 		"eslint": "^7.17.0",
 		"eslint-plugin-markdown": "^1.0.2",
+		"file-loader": "^6.2.0",
 		"ignore-emit-webpack-plugin": "^2.0.6",
 		"jest": "^26.6.3",
 		"jest-puppeteer": "^4.4.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #27581.
Related to #27749.

As explained by @kimmenbert:

> So far using it in theme, with both .js files and .scss files as entry points I have encountered these issues:
> 
> If you add a png/jpg etc image as background image in css, the build fails because missing rules for those kind of files.
> If you include local font files in the css, the build fails because missing rules for those kind of files

> My addition to the webpack config:
> 
> ```
> rules: [
>   ...WordPressConfig.module.rules,
>   {
>     test: /\.(png|jp(e*)g|gif)$/,
>     use: [
>       {
>         loader: 'file-loader',
>         options: {
>           name: 'images/[name].[ext]',
>         },
>       },
>     ],
>   },
>   {
>     test: /\.(woff|woff2|eot|ttf|otf)$/,
>     use: [
>       {
>         loader: 'file-loader',
>         options: {
>           name: 'fonts/[name].[ext]', // TODO: if multiple folders inside the fonts folder with the same filename inside the folders. this will override files with the latest compiled file
>         },
>       },
>     ],
>   },
> ],
> ```

With this PR is possible to reference font (`woff`, `woff2`, `eot`, `ttf` and `otf`) and image (`bmp`, `png`, `jpg`, `jpeg` and `gif`) files from CSS that is controlled by webpack as explained in the previous section.

_Example:_

```css
/* style.css */
@font-face {
	font-family: Gilbert;
	src: url( ../assets/gilbert-color.otf );
}
.wp-block-my-block {
	background-color: url( ../assets/block-background.png );
	font-family: Gilbert;
}
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

You can create a test block with the following local command:

```bash
npx wp-create-block my-block --no-wp-scripts
cd my-block
```

Then you can modify one of the CSS/SCSS files and add references to fonts and images.
To build with the modified version of `wp-scripts` you need to run it as follows:

```bash
../node_modules/.bin/wp-scripts build
```
and
```bash
../node_modules/.bin/wp-scripts start
```

## Screenshots <!-- if applicable -->

#### Source file

<img width="1105" alt="Screen Shot 2021-01-07 at 15 09 46" src="https://user-images.githubusercontent.com/699132/103911458-5b660b80-5106-11eb-8aed-41cc068879f4.png">

#### Build file

<img width="1021" alt="Screen Shot 2021-01-07 at 15 09 16" src="https://user-images.githubusercontent.com/699132/103911454-599c4800-5106-11eb-97d8-ae32f5755c3f.png">

### Build folder

<img width="287" alt="Screen Shot 2021-01-07 at 15 09 54" src="https://user-images.githubusercontent.com/699132/103911461-5bfea200-5106-11eb-888d-294255cf909f.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
