### PR TITLE
Edit Widgets: Replace store name string with exposed store definition

### DIFF
--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -28,6 +28,7 @@ import LegacyWidgetEditHandler from './handler';
 import WidgetSelectControl from './widget-select-control';
 import WidgetPreview from './widget-preview';
 import LegacyWidgetInspectorCard from './inspector-card';
+import { store as editWidgetsStore } from '../../../store';
 
 function LegacyWidgetEdit( {
 	attributes,
@@ -191,11 +192,11 @@ function LegacyWidgetEdit( {
 
 export default withSelect( ( select, { clientId, attributes } ) => {
 	const { widgetClass, referenceWidgetName } = attributes;
-	let widgetId = select( 'core/edit-widgets' ).getWidgetIdForClientId(
+	let widgetId = select( editWidgetsStore ).getWidgetIdForClientId(
 		clientId
 	);
-	const widget = select( 'core/edit-widgets' ).getWidget( widgetId );
-	const widgetArea = select( 'core/edit-widgets' ).getWidgetAreaForClientId(
+	const widget = select( editWidgetsStore ).getWidget( widgetId );
+	const widgetArea = select( editWidgetsStore ).getWidgetAreaForClientId(
 		clientId
 	);
 	const editorSettings = select( 'core/block-editor' ).getSettings();
@@ -214,7 +215,7 @@ export default withSelect( ( select, { clientId, attributes } ) => {
 	let isDuplicateReferenceWidget = false;
 	if ( referenceWidgetName ) {
 		const referenceWidgetBlocks = select(
-			'core/edit-widgets'
+			editWidgetsStore
 		).getReferenceWidgetBlocks( referenceWidgetName );
 		if ( clientId !== referenceWidgetBlocks[ 0 ].clientId ) {
 			isDuplicateReferenceWidget = true;

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/widget-select-control.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/widget-select-control.js
@@ -11,6 +11,11 @@ import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { store as editWidgetsStore } from '../../../store';
+
 export default function WidgetSelectControl( {
 	availableLegacyWidgets,
 	currentWidget,
@@ -19,7 +24,7 @@ export default function WidgetSelectControl( {
 	emptyLabel = __( 'There are no widgets available.' ),
 } ) {
 	const usedReferenceWidgetNames = useSelect( ( select ) =>
-		select( 'core/edit-widgets' )
+		select( editWidgetsStore )
 			.getReferenceWidgetBlocks()
 			.map( ( { attributes } ) => attributes?.referenceWidgetName )
 	);

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -15,6 +15,7 @@ import { Panel, PanelBody } from '@wordpress/components';
  * Internal dependencies
  */
 import WidgetAreaInnerBlocks from './inner-blocks';
+import { store as editWidgetsStore } from '../../../store';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
@@ -25,10 +26,10 @@ export default function WidgetAreaEdit( {
 } ) {
 	const isOpen = useSelect(
 		( select ) =>
-			select( 'core/edit-widgets' ).getIsWidgetAreaOpen( clientId ),
+			select( editWidgetsStore ).getIsWidgetAreaOpen( clientId ),
 		[ clientId ]
 	);
-	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
+	const { setIsWidgetAreaOpen } = useDispatch( editWidgetsStore );
 
 	const wrapper = useRef();
 	const setOpen = useCallback(

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -21,6 +21,7 @@ import SaveButton from '../save-button';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
 import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
+import { store as editWidgetsStore } from '../../store';
 
 function Header() {
 	const inserterButton = useRef();
@@ -28,16 +29,16 @@ function Header() {
 	const widgetAreaClientId = useLastSelectedWidgetArea();
 	const isLastSelectedWidgetAreaOpen = useSelect(
 		( select ) =>
-			select( 'core/edit-widgets' ).getIsWidgetAreaOpen(
+			select( editWidgetsStore ).getIsWidgetAreaOpen(
 				widgetAreaClientId
 			),
 		[ widgetAreaClientId ]
 	);
 	const isInserterOpened = useSelect( ( select ) =>
-		select( 'core/edit-widgets' ).isInserterOpened()
+		select( editWidgetsStore ).isInserterOpened()
 	);
 	const { setIsWidgetAreaOpen, setIsInserterOpened } = useDispatch(
-		'core/edit-widgets'
+		editWidgetsStore
 	);
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const handleClick = () => {

--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -9,9 +9,14 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { store as editWidgetsStore } from '../../store';
+
 function KeyboardShortcuts() {
 	const { redo, undo } = useDispatch( 'core' );
-	const { saveEditedWidgetAreas } = useDispatch( 'core/edit-widgets' );
+	const { saveEditedWidgetAreas } = useDispatch( editWidgetsStore );
 
 	useShortcut(
 		'core/edit-widgets/undo',

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -26,6 +26,7 @@ import { __ } from '@wordpress/i18n';
 import Header from '../header';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
 import useWidgetLibraryInsertionPoint from '../../hooks/use-widget-library-insertion-point';
+import { store as editWidgetsStore } from '../../store';
 
 const interfaceLabels = {
 	/* translators: accessibility text for the widgets screen top bar landmark region. */
@@ -40,15 +41,15 @@ function Interface( { blockEditorSettings } ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
 	const { setIsInserterOpened, closeGeneralSidebar } = useDispatch(
-		'core/edit-widgets'
+		editWidgetsStore
 	);
 	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
 
 	const { hasSidebarEnabled, isInserterOpened } = useSelect( ( select ) => ( {
 		hasSidebarEnabled: !! select(
 			interfaceStore
-		).getActiveComplementaryArea( 'core/edit-widgets' ),
-		isInserterOpened: !! select( 'core/edit-widgets' ).isInserterOpened(),
+		).getActiveComplementaryArea( editWidgetsStore ),
+		isInserterOpened: !! select( editWidgetsStore ).isInserterOpened(),
 	} ) );
 	const ref = useRef();
 

--- a/packages/edit-widgets/src/components/save-button/index.js
+++ b/packages/edit-widgets/src/components/save-button/index.js
@@ -8,11 +8,12 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { store as editWidgetsStore } from '../../store';
 
 function SaveButton() {
 	const { hasEditedWidgetAreaIds, isSaving } = useSelect( ( select ) => {
 		const { getEditedWidgetAreas, isSavingWidgetAreas } = select(
-			'core/edit-widgets'
+			editWidgetsStore
 		);
 
 		return {
@@ -20,7 +21,7 @@ function SaveButton() {
 			isSaving: isSavingWidgetAreas(),
 		};
 	}, [] );
-	const { saveEditedWidgetAreas } = useDispatch( 'core/edit-widgets' );
+	const { saveEditedWidgetAreas } = useDispatch( editWidgetsStore );
 
 	return (
 		<Button

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -32,13 +32,14 @@ const WIDGET_AREAS_IDENTIFIER = 'edit-widgets/block-areas';
  * Internal dependencies
  */
 import WidgetAreas from './widget-areas';
+import { store as editWidgetsStore } from '../../store';
 
 function ComplementaryAreaTab( { identifier, label, isActive } ) {
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	return (
 		<Button
 			onClick={ () =>
-				enableComplementaryArea( 'core/edit-widgets', identifier )
+				enableComplementaryArea( editWidgetsStore, identifier )
 			}
 			className={ classnames( 'edit-widgets-sidebar__panel-tab', {
 				'is-active': isActive,
@@ -73,7 +74,7 @@ export default function Sidebar() {
 
 		const selectedBlock = getSelectedBlock();
 
-		let activeArea = getActiveComplementaryArea( 'core/edit-widgets' );
+		let activeArea = getActiveComplementaryArea( editWidgetsStore );
 		if ( ! activeArea ) {
 			if ( selectedBlock ) {
 				activeArea = BLOCK_INSPECTOR_IDENTIFIER;
@@ -117,7 +118,7 @@ export default function Sidebar() {
 			isGeneralSidebarOpen
 		) {
 			enableComplementaryArea(
-				'core/edit-widgets',
+				editWidgetsStore,
 				BLOCK_INSPECTOR_IDENTIFIER
 			);
 		}
@@ -127,7 +128,7 @@ export default function Sidebar() {
 			isGeneralSidebarOpen
 		) {
 			enableComplementaryArea(
-				'core/edit-widgets',
+				editWidgetsStore,
 				WIDGET_AREAS_IDENTIFIER
 			);
 		}

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -7,9 +7,14 @@ import { blockDefault } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { store as editWidgetsStore } from '../../store';
+
 export default function WidgetAreas( { selectedWidgetAreaId } ) {
 	const widgetAreas = useSelect(
-		( select ) => select( 'core/edit-widgets' ).getWidgetAreas(),
+		( select ) => select( editWidgetsStore ).getWidgetAreas(),
 		[]
 	);
 

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -23,6 +23,7 @@ import KeyboardShortcuts from '../keyboard-shortcuts';
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../../store/utils';
 import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
+import { store as editWidgetsStore } from '../../store';
 
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,
@@ -35,8 +36,8 @@ export default function WidgetAreasBlockEditorProvider( {
 				select( 'core' ).canUser( 'create', 'media' ),
 				true
 			),
-			widgetAreas: select( 'core/edit-widgets' ).getWidgetAreas(),
-			widgets: select( 'core/edit-widgets' ).getWidgets(),
+			widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
+			widgets: select( editWidgetsStore ).getWidgets(),
 			reusableBlocks: select( 'core' ).getEntityRecords(
 				'postType',
 				'wp_block'
@@ -44,7 +45,7 @@ export default function WidgetAreasBlockEditorProvider( {
 		} ),
 		[]
 	);
-	const { setIsInserterOpened } = useDispatch( 'core/edit-widgets' );
+	const { setIsInserterOpened } = useDispatch( editWidgetsStore );
 
 	const settings = useMemo( () => {
 		let mediaUploadBlockEditor;

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -24,6 +24,7 @@ import {
 	POST_TYPE,
 	WIDGET_AREA_ENTITY_TYPE,
 } from './utils';
+import { STORE_NAME as editWidgetsStoreName } from './constants';
 
 /**
  * Persists a stub post with given ID to core data store. The post is meant to be in-memory only and
@@ -49,7 +50,7 @@ export const persistStubPost = function* ( id, blocks ) {
 
 export function* saveEditedWidgetAreas() {
 	const editedWidgetAreas = yield select(
-		'core/edit-widgets',
+		editWidgetsStoreName,
 		'getEditedWidgetAreas'
 	);
 	if ( ! editedWidgetAreas?.length ) {
@@ -97,7 +98,7 @@ export function* saveWidgetAreas( widgetAreas ) {
 }
 
 export function* saveWidgetArea( widgetAreaId ) {
-	const widgets = yield select( 'core/edit-widgets', 'getWidgets' );
+	const widgets = yield select( editWidgetsStoreName, 'getWidgets' );
 	const widgetIdToClientId = yield getWidgetToClientIdMapping();
 	const clientIdToWidgetId = invert( widgetIdToClientId );
 
@@ -336,6 +337,6 @@ export function* closeGeneralSidebar() {
 	yield dispatch(
 		interfaceStore.name,
 		'disableComplementaryArea',
-		'core/edit-widgets'
+		editWidgetsStoreName
 	);
 }

--- a/packages/edit-widgets/src/store/constants.js
+++ b/packages/edit-widgets/src/store/constants.js
@@ -1,0 +1,4 @@
+/**
+ * Module Constants
+ */
+export const STORE_NAME = 'core/edit-widgets';

--- a/packages/edit-widgets/src/store/controls.js
+++ b/packages/edit-widgets/src/store/controls.js
@@ -12,6 +12,7 @@ import {
 	KIND,
 	WIDGET_AREA_ENTITY_TYPE,
 } from './utils';
+import { STORE_NAME as editWidgetsStoreName } from './constants';
 
 /**
  * Trigger an API Fetch request.
@@ -190,6 +191,6 @@ const controls = {
 };
 
 const getState = ( registry ) =>
-	registry.stores[ 'core/edit-widgets' ].store.getState();
+	registry.stores[ editWidgetsStoreName ].store.getState();
 
 export default controls;

--- a/packages/edit-widgets/src/store/index.js
+++ b/packages/edit-widgets/src/store/index.js
@@ -13,11 +13,7 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import controls from './controls';
 import './batch-support';
-
-/**
- * Module Constants
- */
-const STORE_NAME = 'core/edit-widgets';
+import { STORE_NAME } from './constants';
 
 /**
  * Block editor data store configuration.

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -19,6 +19,7 @@ import {
 	POST_TYPE,
 	WIDGET_AREA_ENTITY_TYPE,
 } from './utils';
+import { STORE_NAME as editWidgetsStoreName } from './constants';
 
 export const getWidgets = createRegistrySelector( ( select ) => () => {
 	const widgets = select( 'core' ).getEntityRecords(
@@ -38,7 +39,7 @@ export const getWidgets = createRegistrySelector( ( select ) => () => {
  */
 export const getWidget = createRegistrySelector(
 	( select ) => ( state, id ) => {
-		const widgets = select( 'core/edit-widgets' ).getWidgets();
+		const widgets = select( editWidgetsStoreName ).getWidgets();
 		return widgets[ id ];
 	}
 );
@@ -66,7 +67,7 @@ export const getWidgetIdForClientId = ( state, clientId ) => {
  */
 export const getWidgetAreaForClientId = createRegistrySelector(
 	( select ) => ( state, clientId ) => {
-		const widgetAreas = select( 'core/edit-widgets' ).getWidgetAreas();
+		const widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();
 		for ( const widgetArea of widgetAreas ) {
 			const post = select( 'core' ).getEditedEntityRecord(
 				KIND,
@@ -83,7 +84,7 @@ export const getWidgetAreaForClientId = createRegistrySelector(
 
 export const getEditedWidgetAreas = createRegistrySelector(
 	( select ) => ( state, ids ) => {
-		let widgetAreas = select( 'core/edit-widgets' ).getWidgetAreas();
+		let widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();
 		if ( ! widgetAreas ) {
 			return [];
 		}
@@ -119,7 +120,7 @@ export const getEditedWidgetAreas = createRegistrySelector(
 export const getReferenceWidgetBlocks = createRegistrySelector(
 	( select ) => ( state, referenceWidgetName = null ) => {
 		const results = [];
-		const widgetAreas = select( 'core/edit-widgets' ).getWidgetAreas();
+		const widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();
 		for ( const _widgetArea of widgetAreas ) {
 			const post = select( 'core' ).getEditedEntityRecord(
 				KIND,
@@ -142,7 +143,7 @@ export const getReferenceWidgetBlocks = createRegistrySelector(
 );
 
 export const isSavingWidgetAreas = createRegistrySelector( ( select ) => () => {
-	const widgetAreasIds = select( 'core/edit-widgets' )
+	const widgetAreasIds = select( editWidgetsStoreName )
 		.getWidgetAreas()
 		?.map( ( { id } ) => id );
 	if ( ! widgetAreasIds ) {
@@ -161,7 +162,7 @@ export const isSavingWidgetAreas = createRegistrySelector( ( select ) => () => {
 	}
 
 	const widgetIds = [
-		...Object.keys( select( 'core/edit-widgets' ).getWidgets() ),
+		...Object.keys( select( editWidgetsStoreName ).getWidgets() ),
 		undefined, // account for new widgets without an ID
 	];
 	for ( const id of widgetIds ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addresses #27088. Replaces the store names (hardcoded strings) with the exposed `store` definitions. 

## How has this been tested?
`npm run test`.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Code refactoring, non-breaking change.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->