### PR TITLE
GH Actions: Compare Performance upon Release

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -52,7 +52,7 @@ jobs:
         PREVIOUS_VERSION_BASE_10=$(expr ${PLUGIN_VERSION_ARRAY[0]} \* 10 + ${PLUGIN_VERSION_ARRAY[1]} - 1)
         PREVIOUS_RELEASE_BRANCH="release/$(expr $PREVIOUS_VERSION_BASE_10 / 10).$(expr $PREVIOUS_VERSION_BASE_10 % 10)"
         TESTED_UP_TO_REGEX="Tested up to: \K([0-9]+)\.([0-9]+)\.?([0-9]?)"
-        WP_VERSION=$(grep -oP "$STABLE_TAG_REGEX" ./readme.txt)
+        WP_VERSION=$(grep -oP "$TESTED_UP_TO_REGEX" ./readme.txt)
         IFS='.' read -r -a WP_VERSION_ARRAY <<< "$WP_VERSION"
         WP_BRANCH="wp/${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
         ./bin/plugin/cli.js perf --ci $WP_BRANCH $PREVIOUS_RELEASE_BRANCH $CURRENT_RELEASE_BRANCH

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
     - '**.md'
   release:
-    types: [released]
+    types: [created]
 
 jobs:
   performance:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths-ignore:
     - '**.md'
+  release:
+    types: [released]
 
 jobs:
   performance:
-    name: Compare performance with master
+    name: Run performance tests
 
     runs-on: ubuntu-latest
 
@@ -36,5 +38,23 @@ jobs:
       run: |
         npm ci
 
-    - name: Run the performance tests
+    - name: Compare performance with master
+      if: github.event_name == 'pull_request'
       run: ./bin/plugin/cli.js perf --ci $GITHUB_SHA master --tests-branch $GITHUB_SHA
+
+    - name: Compare performance with current WordPress Core and previous Gutenberg versions
+      if: github.event_name == 'release'
+      env:
+        PLUGIN_VERSION: ${{ github.event.release.name }}
+      run: |
+        IFS='.' read -r -a PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
+        CURRENT_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
+        PREVIOUS_VERSION_BASE_10=$(expr ${PLUGIN_VERSION_ARRAY[0]} \* 10 + ${PLUGIN_VERSION_ARRAY[1]} - 1)
+        PREVIOUS_RELEASE_BRANCH="release/$(expr $PREVIOUS_VERSION_BASE_10 / 10).$(expr $PREVIOUS_VERSION_BASE_10 % 10)"
+        TESTED_UP_TO_REGEX="Tested up to: \K([0-9]+)\.([0-9]+)\.?([0-9]?)"
+        WP_VERSION=$(grep -oP "$STABLE_TAG_REGEX" ./readme.txt)
+        IFS='.' read -r -a WP_VERSION_ARRAY <<< "$WP_VERSION"
+        WP_BRANCH="wp/${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
+        ./bin/plugin/cli.js perf --ci $WP_BRANCH $PREVIOUS_RELEASE_BRANCH $CURRENT_RELEASE_BRANCH
+      
+


### PR DESCRIPTION
## Description

Run the performance test workflow (GH action) upon release, to compare performance for 3 branches:
- The new Gutenberg plugin `release/` branch
- The previous Gutenberg plugin `release/` branch
- The current `wp/` branch (i.e. Gutenberg as it was merged into the current WP Core version)

The first two are computed based on the release, the latter based on the `Tested up to:` line in `readme.txt`. _Note that the latter is currently outdated (points to 5.5) and needs updating! However, that is no blocker to this PR._ https://github.com/WordPress/gutenberg/blob/28cbd29dd563bbbf091041d374350284879677f8/readme.txt#L4

This is handy as we need this data to include with the GB release announcement post on https://make.wordpress.org/core/

## How has this been tested?

See here for an example run: https://github.com/ockham/gutenberg/runs/1664698713?check_suite_focus=true

Or use the following instructions to test for yourself:

- Make sure you have your own fork of the Gutenberg repo, and that you've added it locally as a remote (E.g. `git remote add ockham git@github.com:ockham/gutenberg.git` if your GH username is `ockham` :slightly_smiling_face: ).
- Check out this PR's branch, and push the contents to your fork's `master` branch (you can reset later):
```
git push ockham add/performance-workflow-on-release:master
```
- Note the latest GB plugin release version (9.7.0 at the time of this writing).
- Create a new tag (on this branch), using the `v` prefix, and next minor release number. In this case: `git tag v9.8.0`. Push it to your fork (`git push --tags ockham`).
- Create a new branch (forking from this PR's branch), using the `release/` prefix, and next minor release number, with no patch release number. In this case: `git branch release/9.8`. Push it to your fork (`git push ockham`).
- Publish a release in your fork for the newly created tag (under 'Releases', e.g. https://github.com/ockham/gutenberg/releases). (You don't need to attach any files to it). For the release name, use the new version number without the `v` prefix, e.g. `9.8.0`.
- Go to the 'Actions' tab of your fork's GH page (e.g. https://github.com/ockham/gutenberg/actions).
- Locate the action whose description reads "Performances Tests", and click on it.
- Inspect the individual steps of the workflow (by expanding them) to verify that they worked.
- Don't forget to clean up tags after running these commands, so you won't accidentally push tags that you solely created for testing to the actual Gutenberg repo later. See e.g. https://stackoverflow.com/questions/1841341/remove-local-git-tags-that-are-no-longer-on-the-remote-repository

(I've used my Gutenberg fork as an example, you can see the relevant action and release drafts from previous runs there.)
