### PR TITLE
Build Plugin Workflow: Bump node version to 14

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -32,10 +32,10 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Build Gutenberg plugin ZIP file
         run: ./bin/build-plugin-zip.sh


### PR DESCRIPTION
## Description
All other workflows (i.e. GH actions) were updated to Node 14 by #26835. At that time, the Build Plugin workflow was still under development, so it was merged when still using node 12.

## How has this been tested?
Verify that the 'Build Gutenberg Plugin Zip' action at the bottom of this PR still works. Click on it to inspect it, and to verify that it has a working `gutenberg.zip` plugin artifact attached.

For bonus points, `grep` (or use your editor search) to verify that there are no other instances of `node-version: 12` in the project.