### PR TITLE
Add support for border configuration via theme.json

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -92,6 +92,9 @@ class WP_Theme_JSON {
 		'styles'   => array(
 			'border'     => array(
 				'radius' => null,
+				'color'  => null,
+				'style'  => null,
+				'width'  => null,
 			),
 			'color'      => array(
 				'background' => null,
@@ -120,6 +123,9 @@ class WP_Theme_JSON {
 		'settings' => array(
 			'border'     => array(
 				'customRadius' => null,
+				'customColor'  => null,
+				'customStyle'  => null,
+				'customWidth'  => null,
 			),
 			'color'      => array(
 				'custom'         => null,
@@ -250,6 +256,18 @@ class WP_Theme_JSON {
 		'borderRadius'             => array(
 			'value'   => array( 'border', 'radius' ),
 			'support' => array( '__experimentalBorder', 'radius' ),
+		),
+		'borderColor'             => array(
+			'value'   => array( 'border', 'color' ),
+			'support' => array( '__experimentalBorder', 'color' ),
+		),
+		'borderWidth'             => array(
+			'value'   => array( 'border', 'width' ),
+			'support' => array( '__experimentalBorder', 'width' ),
+		),
+		'borderStyle'             => array(
+			'value'   => array( 'border', 'style' ),
+			'support' => array( '__experimentalBorder', 'style' ),
 		),
 		'color'                    => array(
 			'value'   => array( 'color', 'text' ),


### PR DESCRIPTION

## Description
With this change a block can be configured to allow a theme to define
border color, width and style in addition to the already available
radius.


## How has this been tested?
To leverage this change a block must first be configured to support this change.
For my test I did this with the CODE block.  The details of that can be found [here](https://github.com/WordPress/gutenberg/pull/27582/files#diff-777813a76215208c32ae3122e89316e406cc9598e844b677470c54ede40fa434R18).
Specifically to the block.json file the following was added:
```
	"supports": {
		"__experimentalBorder": {
			"radius": true,
			"color": true,
			"width": true,
			"style": true
		},
``` 
With this change in place I added to a Block-based theme (tt1-blocks) the following to the experimental-theme.json:
```
	"core/code": {
		"styles": {
			"border": {
				"radius": "0px",
				"color": "blue",
				"style": "dotted",
				"width": "4px"
			}
```
Which you can see demonstrated [here](https://github.com/WordPress/theme-experiments/pull/113/files#diff-69343a27793ee745a2fc248303a11f836f51b4b1917b4216b528380c2cc64a8fR343).

When a code block was rendered with that theme the results were as the theme was configured:

![image](https://user-images.githubusercontent.com/146530/103928606-146a1d00-50ea-11eb-9451-779c35dfbff0.png)

I am not aware of what unit- or functional-tests should be added to support this change and so have not done so.

## Types of changes
This enhancement allows BLOCKS to add support for border color, style and width.  Unless the block adds support for these features then those border attributes remain un-style-able. 

This enhancement does NOT allow a USER to make stylistic changes to the border attributes, only by way of a theme.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
