### PR TITLE
Readme: Increase tested Version up to WP 5.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Gutenberg ===
 Contributors: matveb, joen, karmatosed
 Requires at least: 5.5.0
-Tested up to: 5.5
+Tested up to: 5.6
 Requires PHP: 5.6
 Stable tag: V.V.V
 License: GPLv2 or later


### PR DESCRIPTION
## Description
Increases the tested Version in readme.txt up to WP 5.6

Current Backend:
<img width="528" alt="Bildschirmfoto 2021-01-07 um 19 58 13" src="https://user-images.githubusercontent.com/695201/103933034-08e71800-5123-11eb-8c3e-792b25087a81.png">
Current Plugin Directory:
<img width="316" alt="Bildschirmfoto 2021-01-07 um 20 01 36" src="https://user-images.githubusercontent.com/695201/103933167-3a5fe380-5123-11eb-9266-8be11a86163c.png">

Thanks to @SergeyBiryukov for reporting this issue.
