### PR TITLE
Add a role prop to MenuGroup

### DIFF
--- a/packages/components/src/menu-group/index.js
+++ b/packages/components/src/menu-group/index.js
@@ -9,7 +9,12 @@ import classnames from 'classnames';
 import { Children } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 
-export function MenuGroup( { children, className = '', label } ) {
+export function MenuGroup( {
+	children,
+	className = '',
+	label,
+	role = 'group',
+} ) {
 	const instanceId = useInstanceId( MenuGroup );
 
 	if ( ! Children.count( children ) ) {
@@ -30,7 +35,7 @@ export function MenuGroup( { children, className = '', label } ) {
 					{ label }
 				</div>
 			) }
-			<div role="group" aria-labelledby={ label ? labelId : null }>
+			<div role={ role } aria-labelledby={ label ? labelId : null }>
 				{ children }
 			</div>
 		</div>

--- a/packages/components/src/menu-group/test/index.js
+++ b/packages/components/src/menu-group/test/index.js
@@ -24,4 +24,15 @@ describe( 'MenuGroup', () => {
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
+
+	test( 'should render given role', () => {
+		const wrapper = shallow(
+			<MenuGroup label="My group" instanceId="1" role="menu">
+				<p>My item</p>
+			</MenuGroup>
+		);
+
+		const menu = wrapper.find( '[role="menu"]' );
+		expect( menu.length ).toBe( 1 );
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Add a role prop to MenuGroup so other components like https://github.com/woocommerce/woocommerce-admin/issues/3642 can pass down the role they need.



## How has this been tested?
`npm run test-unit menu-group`

## Types of changes
<!-- New feature (non-breaking change which adds functionality) -->

## Checklist:
- [X] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
