### PR TITLE
[RNMobile] Fix onLongPress prop in toolbar button

### DIFF
--- a/packages/rich-text/src/component/toolbar-button-with-options.native.js
+++ b/packages/rich-text/src/component/toolbar-button-with-options.native.js
@@ -43,7 +43,7 @@ function ToolbarButtonWithOptions( { options } ) {
 					title={ firstOption.title }
 					icon={ <Icon icon={ firstOption.icon } /> }
 					onClick={ firstOption.onClick }
-					onLongPress={ enablePicker && presentPicker }
+					onLongPress={ enablePicker ? presentPicker : undefined }
 				/>
 			</ToolbarGroup>
 			{ enablePicker && (


### PR DESCRIPTION
## Description
The `onLongPress` should be a function. In the current implementation, we set boolean or function which causes a warning

`Warning: Failed prop type: Invalid prop 'onLongPress' of type 'boolean' supplied to 'TouchableOpacity', expected 'function'.`

In this PR I set `undefined` instead of `boolean`.

## How has this been tested?
- Everything should work as before
- Check if there is the possibility to use the "mention" mechanism in the paragraph


## Types of changes
bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
