### PR TITLE
Mobile: Remove RN CHANGELOGs from npm release automation

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -108,8 +108,18 @@ async function updatePackages(
 	const changelogFiles = await glob(
 		path.resolve( gitWorkingDirectoryPath, 'packages/*/CHANGELOG.md' )
 	);
+	const changelogFilesPublicPackages = changelogFiles.filter(
+		( changelogPath ) => {
+			const pkg = require( path.join(
+				path.dirname( changelogPath ),
+				'package.json'
+			) );
+			return pkg.private !== true;
+		}
+	);
+
 	const processedPackages = await Promise.all(
-		changelogFiles.map( async ( changelogPath ) => {
+		changelogFilesPublicPackages.map( async ( changelogPath ) => {
 			const fileStream = fs.createReadStream( changelogPath );
 
 			const rl = readline.createInterface( {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up for #28042.
Partially improves #28079.

It looks like React Native packages use their own CHANGELOG updates cadence and npm releases cause issues. This PR tries to fix that by skipping CHANGELOG files updates to all private npm packages.

Testing this functionality is very difficult because it uses a repository clone and applies commits to `wp/trunk` branch 😱 

I applied the following changes to the codebase to print the list of CHANGELOG files that are going to be processed:

```diff
diff --git a/bin/plugin/commands/packages.js b/bin/plugin/commands/packages.js
index 7625bb8a71..91766164bf 100644
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -117,6 +117,9 @@ async function updatePackages(
 			return pkg.private !== true;
 		}
 	);
+	console.log( changelogFilesPublicPackages );
+
+	process.exit();
 
 	const processedPackages = await Promise.all(
 		changelogFilesPublicPackages.map( async ( changelogPath ) => {
@@ -272,10 +275,10 @@ async function prepareForPackageRelease( isPrerelease ) {
 	temporaryFolders.push( gitWorkingDirectoryPath );
 
 	// Checking out the WordPress release branch and doing sync with the last plugin release.
-	const { releaseBranch } = await runWordPressReleaseBranchSyncStep(
+	/*const { releaseBranch } = await runWordPressReleaseBranchSyncStep(
 		gitWorkingDirectoryPath,
 		abortMessage
-	);
+	);*/
 
 	const { minimumVersionBump } = await prompt( [
 		{
```

It didn't contain private packages anymore.
