### PR TITLE
[wip] Add experimental global grid support

### DIFF
--- a/lib/global-grid.php
+++ b/lib/global-grid.php
@@ -1,0 +1,7 @@
+<?php
+	function gutenberg_experimental_global_grid( $settings ) {
+		$settings['__experimentalGlobalGrid'] = true;
+		return $settings;
+	}
+
+	add_filter( 'block_editor_settings', 'gutenberg_experimental_global_grid' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -96,6 +96,7 @@ require __DIR__ . '/navigation-page.php';
 require __DIR__ . '/experiments-page.php';
 require __DIR__ . '/class-wp-theme-json.php';
 require __DIR__ . '/class-wp-theme-json-resolver.php';
+require __DIR__ . '/global-grid.php';
 require __DIR__ . '/global-styles.php';
 
 if ( ! class_exists( 'WP_Block_Supports' ) ) {

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -33,7 +33,12 @@ import { store as editPostStore } from '../../store';
 
 const MODAL_NAME = 'edit-post/preferences';
 
-export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
+export function PreferencesModal( {
+	isModalActive,
+	isViewable,
+	closeModal,
+	__experimentalGlobalGrid,
+} ) {
 	if ( ! isModalActive ) {
 		return null;
 	}
@@ -58,6 +63,13 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 					) }
 					label={ __( 'Show most used blocks' ) }
 				/>
+				{ __experimentalGlobalGrid && (
+					<EnableFeature
+						featureName="__experimentalGlobalGrid"
+						help={ __( 'Enables the Global Grid Layout' ) }
+						label={ __( 'Enable Global Grid' ) }
+					/>
+				) }
 			</Section>
 			<Section title={ __( 'Keyboard' ) }>
 				<EnableFeature
@@ -151,12 +163,16 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 export default compose(
 	withSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { __experimentalGlobalGrid } = select(
+			'core/block-editor'
+		).getSettings();
 		const { getPostType } = select( 'core' );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 		return {
 			isModalActive: select( editPostStore ).isModalActive( MODAL_NAME ),
 			isViewable: get( postType, [ 'viewable' ], false ),
+			__experimentalGlobalGrid,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/edit-post/src/components/visual-editor/grid-preview.js
+++ b/packages/edit-post/src/components/visual-editor/grid-preview.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+export default function GridPreview() {
+	const [ gridStyles, setGridStlyes ] = useState( {
+		columnWidth: 0,
+		columnCount: 0,
+		columnGap: 0,
+		rowHeights: [],
+	} );
+
+	// Divide index by column number; the result is the zero-indexed row number
+	const getHeightByIndex = ( index ) =>
+		gridStyles.rowHeights[ Math.floor( index / 12 ) ];
+	const rootContainer = document.querySelector(
+		'.is-root-container.is-grid'
+	);
+
+	useEffect( () => {
+		if ( rootContainer ) {
+			const rootContainerStyles = window.getComputedStyle(
+				rootContainer,
+				null
+			);
+			const {
+				columnGap,
+				gridTemplateColumns,
+				gridTemplateRows,
+			} = rootContainerStyles;
+			const columns = Array.from(
+				gridTemplateColumns.matchAll( /\d+(.\d+)?px/g )
+			);
+			const [ [ width ] ] = columns;
+
+			setGridStlyes( {
+				columnWidth: width,
+				columnCount: columns.length,
+				columnGap,
+				rowHeights: gridTemplateRows.split( ' ' ),
+				rowCount: gridTemplateRows.split( ' ' ).length,
+			} );
+		}
+	}, [ rootContainer ] );
+
+	return (
+		<div className="grid-preview is-grid">
+			{ Array.from( {
+				length: gridStyles.columnCount * gridStyles.rowCount,
+			} ).map( ( _, index ) => (
+				<div
+					className="grid-cell-placeholder"
+					style={ {
+						width: gridStyles.columnWidth,
+						height: getHeightByIndex( index ),
+					} }
+					key={ index }
+				>
+					{ index + 1 }
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+/**
  * WordPress dependencies
  */
 import {
@@ -43,6 +47,9 @@ export default function VisualEditor() {
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
+	const useExperimentalGlobalGrid = useSelect( ( select ) =>
+		select( editPostStore ).isFeatureActive( '__experimentalGlobalGrid' )
+	);
 	const desktopCanvasStyles = {
 		height: '100%',
 		// Add a constant padding for the typewritter effect. When typing at the
@@ -50,6 +57,9 @@ export default function VisualEditor() {
 		paddingBottom: hasMetaBoxes ? null : '40vh',
 	};
 	const resizedCanvasStyles = useResizeCanvas( deviceType );
+	const className = classnames( {
+		'is-grid': useExperimentalGlobalGrid,
+	} );
 
 	useScrollMultiSelectionIntoView( ref );
 	useBlockSelectionClearer( ref );
@@ -74,7 +84,7 @@ export default function VisualEditor() {
 							<PostTitle />
 						</div>
 					) }
-					<BlockList />
+					<BlockList className={ className } />
 				</WritingFlow>
 			</div>
 			<__experimentalBlockSettingsMenuFirstItem>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -30,6 +30,7 @@ import { useRef } from '@wordpress/element';
 import BlockInspectorButton from './block-inspector-button';
 import { useSelect } from '@wordpress/data';
 import { store as editPostStore } from '../../store';
+import GridPreview from './grid-preview';
 
 export default function VisualEditor() {
 	const ref = useRef();
@@ -49,6 +50,9 @@ export default function VisualEditor() {
 	);
 	const useExperimentalGlobalGrid = useSelect( ( select ) =>
 		select( editPostStore ).isFeatureActive( '__experimentalGlobalGrid' )
+	);
+	const isDraggingBlocks = useSelect( ( select ) =>
+		select( 'core/block-editor' ).isDraggingBlocks()
 	);
 	const desktopCanvasStyles = {
 		height: '100%',
@@ -83,6 +87,9 @@ export default function VisualEditor() {
 						<div className="edit-post-visual-editor__post-title-wrapper">
 							<PostTitle />
 						</div>
+					) }
+					{ useExperimentalGlobalGrid && isDraggingBlocks && (
+						<GridPreview parent={ ref } />
 					) }
 					<BlockList className={ className } />
 				</WritingFlow>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -89,7 +89,7 @@ export default function VisualEditor() {
 						</div>
 					) }
 					{ useExperimentalGlobalGrid && isDraggingBlocks && (
-						<GridPreview parent={ ref } />
+						<GridPreview />
 					) }
 					<BlockList className={ className } />
 				</WritingFlow>

--- a/packages/edit-post/src/store/defaults.js
+++ b/packages/edit-post/src/store/defaults.js
@@ -15,4 +15,5 @@ export const PREFERENCES_DEFAULTS = {
 	hiddenBlockTypes: [],
 	preferredStyleVariations: {},
 	localAutosaveInterval: 15,
+	__experimentalGlobalGrid: false,
 };

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -150,6 +150,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'__experimentalBlockPatterns',
 				'__experimentalBlockPatternCategories',
 				'__experimentalFeatures',
+				'__experimentalGlobalGrid',
 				'__experimentalGlobalStylesUserEntityId',
 				'__experimentalGlobalStylesBaseStyles',
 				'__experimentalPreferredStyleVariations',


### PR DESCRIPTION
## Description

Adds the scaffolding necessary to build support for a Global Grid Layout for the Visual Editor.
- Preferences menu Feature Toggle.
- Extends the base `BlockList` to include grid-specific classnames. This extension is also required in order to implement features that require extra markup at this level—for example, a grid preview.

## Preview

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/1157901/104062473-51f9a380-51d9-11eb-9c27-3f07235fe996.png">


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
