### PR TITLE
URL: Remove redundant array coercion

### DIFF
--- a/packages/url/src/build-query-string.js
+++ b/packages/url/src/build-query-string.js
@@ -25,7 +25,7 @@
 export function buildQueryString( data ) {
 	let string = '';
 
-	const stack = Array.from( Object.entries( data ) );
+	const stack = Object.entries( data );
 
 	let pair;
 	while ( ( pair = stack.shift() ) ) {


### PR DESCRIPTION
Previously: #20693

`Object.entries` already returns an array. The `Array.from` may have been from earlier iterations in desiring to create a copy of an array for subsequent mutation in the `while` loop (`stack.shift()`), but since `Object.entries` creates a new array anyways, it's not necessary.

**Testing Instructions:**

```
npm test-unit packages/url
```