### PR TITLE
Testing: Fix randomly failing E2E test

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -203,7 +203,7 @@ describe( 'Multi-entity editor states', () => {
 			await Promise.all( [
 				saveAllEntities(),
 
-				// Waiting the save request and the subsequent query to be
+				// Wait for the save request and the subsequent query to be
 				// fulfilled - both are requests made to /index.php route.
 				// Without that, clicked elements can lose focus sometimes
 				// when the response is received.

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -200,7 +200,27 @@ describe( 'Multi-entity editor states', () => {
 		} );
 
 		afterEach( async () => {
-			await saveAllEntities();
+			await Promise.all( [
+				saveAllEntities(),
+
+				// Waiting the save request and the subsequent query to be
+				// fulfilled - both are requests made to /index.php route.
+				// Without that, clicked elements can lose focus sometimes
+				// when the response is received.
+				page.waitForResponse( ( response ) => {
+					return (
+						response.url().includes( 'index.php' ) &&
+						response.request().method() === 'POST'
+					);
+				} ),
+
+				page.waitForResponse( ( response ) => {
+					return (
+						response.url().includes( 'index.php' ) &&
+						response.request().method() === 'GET'
+					);
+				} ),
+			] );
 			removeErrorMocks();
 		} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The E2E tests for the `multi-entity-editing.test.js` file were failing very often, in a random sort (like [here](https://github.com/WordPress/gutenberg/runs/1672074371?check_suite_focus=true#step:7:99), [here](https://github.com/WordPress/gutenberg/runs/1672843287?check_suite_focus=true#step:7:94), and [here](https://github.com/WordPress/gutenberg/runs/1669854380?check_suite_focus=true#step:7:63)). When testing locally, I found that the issue was happening due to the tested HTML element's focus being lost. This PR fixes this error.

For better understanding, check the ["How has this been tested?"](#how-i-tested) section 😸.


## <a name="how-i-tested"></a>How has this been tested? 
**⚠️ This is going to be a long read. Get ready first, grab something to eat, or a cup of water... ⚠️**

In short - this test consists of editing the entities and asserting whether they have been correctly dirtied, so, the basic flow for each closure of the test is:
- `edit` the target element;
- `assert` obtained results;
- `save` changes (`afterEach` method call).

The error was happening due to a bug between the `assert` and the `save` step: 
After asserting the results for a previous test closure, the `save` step calls the `saveAllEntities` function: 
https://github.com/WordPress/gutenberg/blob/a7fb6bbf56089eb3a181d7ad7bb2b241e3d4e77b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js#L202-L205

Which would be basically clicking the "Save" button on the tested page:

<img src="https://user-images.githubusercontent.com/18705930/104112973-d4668e00-52d3-11eb-876a-dfc7d0ef139f.png" width="65%"/>

https://github.com/WordPress/gutenberg/blob/a7fb6bbf56089eb3a181d7ad7bb2b241e3d4e77b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js#L68-L72

**The problem**: calling `await` on the button click just waits for the returned click promise to be resolved; it doesn't wait for the whole save process to be completed. 
Therefore, sometimes, when the save process was not yet completed and the test continued, after the save request completed, the `edit` step would try to change the element value - but it would fail, due to the focus change that would happen in the page. I find this very hard to explain only using words, so maybe these screenshots might help:

![manual_test_browser](https://user-images.githubusercontent.com/18705930/104113518-3e356680-52d9-11eb-8fc0-8ec606f66c41.png)
This is the **exact** moment where the error happens: right after saving the changes, about to focus on the next tested element.

I simulated the behavior in the console: 

![manual_test_browser_console](https://user-images.githubusercontent.com/18705930/104113539-7b015d80-52d9-11eb-83b7-8e384a0a10b9.png)

I made a `setInterval` call to keep logging the active element (the one currently focused) - and right after, the default test behavior: click the save button and start the next test closure. As shown, the block element would lose its focus right after the save request completed, causing the error.

In addition, I ran the test 60 times, comparing the outputs before and after the changes:
[Before](https://pastebin.com/raw/A5HNZDMj) - Failing 70% of the time (42 failures out of 60 runs) - failures related to the error that was being fixed (`Node is not visible/Node is detached from document`).
[After](https://pastebin.com/raw/tCya7HqR) - No failures. 🥳🎉🎉🎉🎉😸 

## Types of changes
Bugfix to the E2E tests.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
