### PR TITLE
Components: Expose composite API from Reakit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11694,7 +11694,6 @@
 				"react-autosize-textarea": "^7.1.0",
 				"react-merge-refs": "^1.0.0",
 				"react-spring": "^8.0.19",
-				"reakit": "1.3.4",
 				"redux-multi": "^0.1.12",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
@@ -11739,7 +11738,6 @@
 				"memize": "^1.1.0",
 				"moment": "^2.22.1",
 				"react-easy-crop": "^3.0.0",
-				"reakit": "1.3.4",
 				"tinycolor2": "^1.4.1"
 			}
 		},

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -62,7 +62,6 @@
 		"react-autosize-textarea": "^7.1.0",
 		"react-merge-refs": "^1.0.0",
 		"react-spring": "^8.0.19",
-		"reakit": "1.3.4",
 		"redux-multi": "^0.1.12",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",

--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { Composite, useCompositeState } from 'reakit';
-
-/**
  * WordPress dependencies
  */
 import { getBlockMenuDefaultClassName } from '@wordpress/blocks';
+import { Composite, useCompositeState } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { getBlockMenuDefaultClassName } from '@wordpress/blocks';
-import { Composite, useCompositeState } from '@wordpress/components';
+import {
+	__unstableComposite as Composite,
+	__unstableUseCompositeState as useCompositeState,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -7,7 +7,10 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useMemo, useRef, memo } from '@wordpress/element';
-import { Button, CompositeItem } from '@wordpress/components';
+import {
+	Button,
+	__unstableCompositeItem as CompositeItem,
+} from '@wordpress/components';
 import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { CompositeItem } from 'reakit';
 
 /**
  * WordPress dependencies
  */
 import { useMemo, useRef, memo } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Button, CompositeItem } from '@wordpress/components';
 import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -61,7 +61,6 @@
 		"memize": "^1.1.0",
 		"moment": "^2.22.1",
 		"react-easy-crop": "^3.0.0",
-		"reakit": "1.3.4",
 		"tinycolor2": "^1.4.1"
 	},
 	"publishConfig": {

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -13,10 +13,10 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
 import {
-	Composite,
-	CompositeItem,
+	__unstableComposite as Composite,
+	__unstableCompositeItem as CompositeItem,
 	Icon,
-	useCompositeState,
+	__unstableUseCompositeState as useCompositeState,
 } from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
 import { store as noticesStore } from '@wordpress/notices';

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { groupBy, deburr } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -7,15 +12,14 @@ import { useMemo, useCallback } from '@wordpress/element';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
-import { Icon } from '@wordpress/components';
+import {
+	Composite,
+	CompositeItem,
+	Icon,
+	useCompositeState,
+} from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
 import { store as noticesStore } from '@wordpress/notices';
-
-/**
- * External dependencies
- */
-import { groupBy, deburr } from 'lodash';
-import { Composite, useCompositeState, CompositeItem } from 'reakit';
 
 function PreviewPlaceholder() {
 	return (

--- a/packages/components/src/alignment-matrix-control/cell.js
+++ b/packages/components/src/alignment-matrix-control/cell.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import { CompositeItem } from 'reakit/Composite';
-
-/**
  * Internal dependencies
  */
+import { CompositeItem } from '../composite';
 import Tooltip from '../tooltip';
 import VisuallyHidden from '../visually-hidden';
 

--- a/packages/components/src/alignment-matrix-control/index.js
+++ b/packages/components/src/alignment-matrix-control/index.js
@@ -3,7 +3,6 @@
  */
 import { noop } from 'lodash';
 import classnames from 'classnames';
-import { useCompositeState, Composite, CompositeGroup } from 'reakit';
 
 /**
  * WordPress dependencies
@@ -16,6 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import Cell from './cell';
+import { Composite, CompositeGroup, useCompositeState } from '../composite';
 import { Root, Row } from './styles/alignment-matrix-control-styles';
 import AlignmentMatrixControlIcon from './icon';
 import { GRID, getItemId } from './utils';

--- a/packages/components/src/composite/index.js
+++ b/packages/components/src/composite/index.js
@@ -6,6 +6,9 @@
  * a roving tabindex or aria-activedescendant container.
  *
  * @see https://reakit.io/docs/composite/
+ *
+ * The plan is to build own API that accounts for future breaking changes
+ * in Reakit (https://github.com/WordPress/gutenberg/pull/28085).
  */
 export {
 	Composite,

--- a/packages/components/src/composite/index.js
+++ b/packages/components/src/composite/index.js
@@ -1,0 +1,9 @@
+/**
+ * @see https://reakit.io/docs/composite/
+ */
+export {
+	Composite,
+	CompositeGroup,
+	CompositeItem,
+	useCompositeState,
+} from 'reakit';

--- a/packages/components/src/composite/index.js
+++ b/packages/components/src/composite/index.js
@@ -1,4 +1,10 @@
 /**
+ * Composite is a component that may contain navigable items represented by
+ * CompositeItem. It's inspired by the WAI-ARIA Composite Role and implements
+ * all the keyboard navigation mechanisms to ensure that there's only one
+ * tab stop for the whole Composite element. This means that it can behave as
+ * a roving tabindex or aria-activedescendant container.
+ *
  * @see https://reakit.io/docs/composite/
  */
 export {

--- a/packages/components/src/disclosure/index.js
+++ b/packages/components/src/disclosure/index.js
@@ -1,0 +1,7 @@
+/**
+ * Accessible Disclosure component that controls visibility of a section of
+ * content. It follows the WAI-ARIA Disclosure Pattern.
+ *
+ * @see https://reakit.io/docs/disclosure/
+ */
+export { DisclosureContent } from 'reakit';

--- a/packages/components/src/disclosure/index.js
+++ b/packages/components/src/disclosure/index.js
@@ -3,5 +3,8 @@
  * content. It follows the WAI-ARIA Disclosure Pattern.
  *
  * @see https://reakit.io/docs/disclosure/
+ *
+ * The plan is to build own API that accounts for future breaking changes
+ * in Reakit (https://github.com/WordPress/gutenberg/pull/28085).
  */
 export { DisclosureContent } from 'reakit';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -35,6 +35,7 @@ export { default as ColorIndicator } from './color-indicator';
 export { default as ColorPalette } from './color-palette';
 export { default as ColorPicker } from './color-picker';
 export { default as ComboboxControl } from './combobox-control';
+export * from './composite';
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -41,6 +41,7 @@ export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';
 export { default as Disabled } from './disabled';
+export { DisclosureContent as __unstableDisclosureContent } from './disclosure';
 export { default as Draggable } from './draggable';
 export {
 	default as DropZone,

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -35,7 +35,12 @@ export { default as ColorIndicator } from './color-indicator';
 export { default as ColorPalette } from './color-palette';
 export { default as ColorPicker } from './color-picker';
 export { default as ComboboxControl } from './combobox-control';
-export * from './composite';
+export {
+	Composite as __unstableComposite,
+	CompositeGroup as __unstableCompositeGroup,
+	CompositeItem as __unstableCompositeItem,
+	useCompositeState as __unstableUseCompositeState,
+} from './composite';
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -1,15 +1,14 @@
 /**
- * External dependencies
- */
-import { DisclosureContent } from 'reakit/Disclosure';
-
-/**
  * WordPress dependencies
  */
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EntityProvider } from '@wordpress/core-data';
-import { Panel, PanelBody } from '@wordpress/components';
+import {
+	__unstableDisclosureContent,
+	Panel,
+	PanelBody,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -67,7 +66,7 @@ export default function WidgetAreaEdit( {
 				{ ( { opened } ) => (
 					// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
 					// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
-					<DisclosureContent visible={ opened }>
+					<__unstableDisclosureContent visible={ opened }>
 						<EntityProvider
 							kind="root"
 							type="postType"
@@ -75,7 +74,7 @@ export default function WidgetAreaEdit( {
 						>
 							<WidgetAreaInnerBlocks />
 						</EntityProvider>
-					</DisclosureContent>
+					</__unstableDisclosureContent>
 				) }
 			</PanelBody>
 		</Panel>

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -5,7 +5,7 @@ import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EntityProvider } from '@wordpress/core-data';
 import {
-	__unstableDisclosureContent,
+	__unstableDisclosureContent as DisclosureContent,
 	Panel,
 	PanelBody,
 } from '@wordpress/components';
@@ -66,7 +66,7 @@ export default function WidgetAreaEdit( {
 				{ ( { opened } ) => (
 					// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
 					// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
-					<__unstableDisclosureContent visible={ opened }>
+					<DisclosureContent visible={ opened }>
 						<EntityProvider
 							kind="root"
 							type="postType"
@@ -74,7 +74,7 @@ export default function WidgetAreaEdit( {
 						>
 							<WidgetAreaInnerBlocks />
 						</EntityProvider>
-					</__unstableDisclosureContent>
+					</DisclosureContent>
 				) }
 			</PanelBody>
 		</Panel>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR explores how we could stop duplicating bundled code from Reakit:
<img width="499" alt="Screen Shot 2021-01-07 at 07 56 59" src="https://user-images.githubusercontent.com/699132/103861595-f981b380-50bd-11eb-92a6-b9c319abf9c4.png">

It's based on the discussion that started with my own comment https://github.com/WordPress/gutenberg/pull/28013#issuecomment-755928763. The idea comes from @youknowriad who proposed we expose shared APIs as part of `@wordpress/components`.

## TODO

- [x] Find a compelling way to add documentation referencing Reakit
- [x] Add ESLint check that prevents using new APIs directly from Reakit – moved to https://github.com/WordPress/gutenberg/pull/28095

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
