### PR TITLE
Fix invalid cover block transforms

### DIFF
--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -14,26 +14,42 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/image' ],
 			transform: ( { caption, url, align, id, anchor } ) =>
-				createBlock( 'core/cover', {
-					title: caption,
-					url,
-					align,
-					id,
-					anchor,
-				} ),
+				createBlock(
+					'core/cover',
+					{
+						url,
+						align,
+						id,
+						anchor,
+					},
+					[
+						createBlock( 'core/paragraph', {
+							content: caption,
+							fontSize: 'large',
+						} ),
+					]
+				),
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
 			transform: ( { caption, src, align, id, anchor } ) =>
-				createBlock( 'core/cover', {
-					title: caption,
-					url: src,
-					align,
-					id,
-					backgroundType: VIDEO_BACKGROUND_TYPE,
-					anchor,
-				} ),
+				createBlock(
+					'core/cover',
+					{
+						url: src,
+						align,
+						id,
+						backgroundType: VIDEO_BACKGROUND_TYPE,
+						anchor,
+					},
+					[
+						createBlock( 'core/paragraph', {
+							content: caption,
+							fontSize: 'large',
+						} ),
+					]
+				),
 		},
 	],
 	to: [


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The cover block has two 'from' transforms that are currently failing and causing a bug in the editor:
- Transforming an image to a cover. 
- Transforming a video to a cover.

In both cases, hovering over the transform item in the block switcher causes parts of the block toolbar to disappear, and the switcher menu gets partly stuck open.

The cause seems to be that the attributes weren't updated when the cover block started using inner blocks. `title` is a now deprecated attribute, and instead the transform should convert it to an inner paragraph block.

## How has this been tested?
#### Images
1. Add an image block and upload an image or choose from the media library.
2. Add a caption.
3. Click on the block switcher and hover over the 'Cover' option.
4. The block toolbar should remain the same, and the preview shows correctly with the caption text converted to a paragraph.

#### Videos
1. Add a video block and upload a video or choose from the media library.
2. Add a caption.
3. Click on the block switcher and hover over the 'Cover' option.
4. The block toolbar should remain the same, and the preview shows correctly with the caption text converted to a paragraph.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
