### PR TITLE
Template Parts: Fix loading issue

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -121,9 +121,8 @@ function _inject_theme_attribute_in_content( $template_content, $theme ) {
 
 	foreach ( $template_blocks as $key => $block ) {
 		if ( 'core/template-part' === $block['blockName'] && ! isset( $block['attrs']['theme'] ) ) {
-			// phpcs:ignore
-			$template_blocks[$key]['attrs']['theme'] = $theme;
-			$has_updated_content                     = true;
+			$template_blocks[ $key ]['attrs']['theme'] = $theme;
+			$has_updated_content                       = true;
 		}
 	}
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -120,7 +120,7 @@ function _inject_theme_attribute_in_content( $template_content, $theme ) {
 
 	$updated_blocks = array_map(
 		function( $block ) use ( $theme ) {
-			if ( 'core/template-part' === $block['blockName'] ) {
+			if ( 'core/template-part' === $block['blockName'] && ! isset( $block['attrs']['theme'] ) ) {
 				$block['attrs']['theme'] = $theme;
 			}
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -115,25 +115,27 @@ function _gutenberg_get_template_files( $template_type ) {
  * @return string Updated wp_template content.
  */
 function _inject_theme_attribute_in_content( $template_content, $theme ) {
-	$new_content = '';
-	$blocks      = parse_blocks( $template_content );
+	$has_updated_content = false;
+	$new_content         = '';
+	$template_blocks     = parse_blocks( $template_content );
 
-	$updated_blocks = array_map(
-		function( $block ) use ( $theme ) {
-			if ( 'core/template-part' === $block['blockName'] && ! isset( $block['attrs']['theme'] ) ) {
-				$block['attrs']['theme'] = $theme;
-			}
-
-			return $block;
-		},
-		$blocks
-	);
-
-	foreach ( $updated_blocks as $block ) {
-		$new_content = $new_content . serialize_block( $block );
+	foreach ( $template_blocks as $key => $block ) {
+		if ( 'core/template-part' === $block['blockName'] && ! isset( $block['attrs']['theme'] ) ) {
+			// phpcs:ignore
+			$template_blocks[$key]['attrs']['theme'] = $theme;
+			$has_updated_content                     = true;
+		}
 	}
 
-	return $new_content;
+	if ( $has_updated_content ) {
+		foreach ( $template_blocks as $block ) {
+			$new_content = $new_content . serialize_block( $block );
+		}
+
+		return $new_content;
+	} else {
+		return $template_content;
+	}
 }
 
 /**

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -105,6 +105,15 @@ function _gutenberg_get_template_files( $template_type ) {
 	return $template_files;
 }
 
+/**
+ * Parses wp_template content and injects the current theme's
+ * stylesheet as a theme attribute into each wp_template_part
+ *
+ * @param string $template_content serialized wp_template content.
+ * @param string $theme the active theme's stylesheet.
+ *
+ * @return string Updated wp_template content.
+ */
 function _inject_theme_attribute_in_content( $template_content, $theme ) {
 	$new_content = '';
 	$blocks      = parse_blocks( $template_content );

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -132,7 +132,7 @@ function _inject_theme_attribute_in_content( $template_content, $theme ) {
 
 	if ( $has_updated_content ) {
 		foreach ( $template_blocks as $block ) {
-			$new_content = $new_content . serialize_block( $block );
+			$new_content .= serialize_block( $block );
 		}
 
 		return $new_content;

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -120,7 +120,11 @@ function _inject_theme_attribute_in_content( $template_content, $theme ) {
 	$template_blocks     = parse_blocks( $template_content );
 
 	foreach ( $template_blocks as $key => $block ) {
-		if ( 'core/template-part' === $block['blockName'] && ! isset( $block['attrs']['theme'] ) ) {
+		if (
+			'core/template-part' === $block['blockName'] &&
+			! isset( $block['attrs']['theme'] ) &&
+			wp_get_theme()->get_stylesheet() === $theme
+		) {
 			$template_blocks[ $key ]['attrs']['theme'] = $theme;
 			$has_updated_content                       = true;
 		}

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -20,8 +20,7 @@ function _remove_theme_attribute_from_content( $template_content ) {
 
 	foreach ( $template_blocks as $key => $block ) {
 		if ( 'core/template-part' === $block['blockName'] && isset( $block['attrs']['theme'] ) ) {
-			// phpcs:ignore
-			unset( $template_blocks[$key]['attrs']['theme'] );
+			unset( $template_blocks[ $key ]['attrs']['theme'] );
 			$has_updated_content = true;
 		}
 	}

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -27,7 +27,7 @@ function _remove_theme_attribute_from_content( $template_content ) {
 
 	if ( $has_updated_content ) {
 		foreach ( $template_blocks as $block ) {
-			$new_content = $new_content . serialize_block( $block );
+			$new_content .= serialize_block( $block );
 		}
 
 		return $new_content;

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -88,14 +88,14 @@ class Block_Templates_Test extends WP_UnitTestCase {
 			$content_with_existing_theme_attribute,
 			$theme
 		);
-		$this->assertStringNotContainsString( $theme, $template_content );
+		$this->assertEquals( $content_with_existing_theme_attribute, $template_content );
 
 		$content_with_no_template_part = '<!-- wp:post-content /-->';
 		$template_content              = _inject_theme_attribute_in_content(
-			$content_with_existing_theme_attribute,
+			$content_with_no_template_part,
 			$theme
 		);
-		$this->assertStringNotContainsString( $theme, $template_content );
+		$this->assertEquals( $content_with_no_template_part, $template_content );
 	}
 
 	/**

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -81,8 +81,11 @@ class Block_Templates_Test extends WP_UnitTestCase {
 			$content_without_theme_attribute,
 			$theme
 		);
-		$actual                          = '<!-- wp:template-part {"slug":"header","theme":"$theme","align":"full", "tagName":"header","className":"site-header"} /-->';
-		$this->assertStringContainsString( $actual, $template_content );
+		$expected                        = sprintf(
+			'<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->',
+			get_stylesheet()
+		);
+		$this->assertEquals( $expected, $template_content );
 
 		// Does not inject theme when there is an existing theme attribute.
 		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->';

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -74,6 +74,30 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'wp_template', $template->type );
 	}
 
+	function test_inject_theme_attribute_in_content() {
+		$theme                           = get_stylesheet();
+		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->';
+		$template_content                = _inject_theme_attribute_in_content(
+			$content_without_theme_attribute,
+			$theme
+		);
+		$this->assertStringContainsString( $theme, $template_content );
+
+		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->';
+		$template_content                      = _inject_theme_attribute_in_content(
+			$content_with_existing_theme_attribute,
+			$theme
+		);
+		$this->assertStringNotContainsString( $theme, $template_content );
+
+		$content_with_no_template_part = '<!-- wp:post-content /-->';
+		$template_content              = _inject_theme_attribute_in_content(
+			$content_with_existing_theme_attribute,
+			$theme
+		);
+		$this->assertStringNotContainsString( $theme, $template_content );
+	}
+
 	/**
 	 * Should retrieve the template from the theme files.
 	 */

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -81,8 +81,10 @@ class Block_Templates_Test extends WP_UnitTestCase {
 			$content_without_theme_attribute,
 			$theme
 		);
-		$this->assertStringContainsString( $theme, $template_content );
+		$actual                          = '<!-- wp:template-part {"slug":"header","theme":"$theme","align":"full", "tagName":"header","className":"site-header"} /-->';
+		$this->assertStringContainsString( $actual, $template_content );
 
+		// Does not inject theme when there is an existing theme attribute.
 		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->';
 		$template_content                      = _inject_theme_attribute_in_content(
 			$content_with_existing_theme_attribute,
@@ -90,6 +92,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals( $content_with_existing_theme_attribute, $template_content );
 
+		// Does not inject theme when there is no template part.
 		$content_with_no_template_part = '<!-- wp:post-content /-->';
 		$template_content              = _inject_theme_attribute_in_content(
 			$content_with_no_template_part,

--- a/phpunit/class-edit-site-export-test.php
+++ b/phpunit/class-edit-site-export-test.php
@@ -6,7 +6,7 @@
  */
 
 class Edit_Site_Export_Test extends WP_UnitTestCase {
-	function test_inject_theme_attribute_in_content() {
+	function test_remove_theme_attribute_from_content() {
 		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full","tagName":"header","className":"site-header"} /-->';
 		$template_content                = _remove_theme_attribute_from_content( $content_without_theme_attribute );
 		$expected                        = '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->';

--- a/phpunit/class-edit-site-export-test.php
+++ b/phpunit/class-edit-site-export-test.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Test `gutenberg_edit_site_export` and its helper functions.
+ *
+ * @package    Gutenberg
+ */
+
+class Edit_Site_Export_Test extends WP_UnitTestCase {
+	function test_inject_theme_attribute_in_content() {
+		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full","tagName":"header","className":"site-header"} /-->';
+		$template_content                = _remove_theme_attribute_from_content( $content_without_theme_attribute );
+		$expected                        = '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->';
+		$this->assertEquals( $expected, $template_content );
+
+		// Does not modify content when there is no existing theme attribute.
+		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->';
+		$template_content                      = _remove_theme_attribute_from_content( $content_with_existing_theme_attribute );
+		$this->assertEquals( $content_with_existing_theme_attribute, $template_content );
+
+		// Does not remove theme when there is no template part.
+		$content_with_no_template_part = '<!-- wp:post-content /-->';
+		$template_content              = _remove_theme_attribute_from_content( $content_with_no_template_part );
+		$this->assertEquals( $content_with_no_template_part, $template_content );
+	}
+}
+


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
We currently query for template parts by theme in the client.

```javascript
// packages/block-library/src/template-part/edit/index.js:43
select( 'core' ).getEntityRecord(
    'postType',
    'wp_template_part',
    theme + '//' + slug
)
```

The canonical identifier for themes is the stylesheet property, which is the path of the theme directory relative to wp-content/themes. Unfortunately, the value of `theme` provided in the client side query above is, under some circumstances, **not** actually the theme stylesheet. In other words, sometimes it isn't the correct identifier. 

The mismatch happens because the `theme` value in our query is derived from block attributes in template blocks, which are defined by themes. Take, for example, the [TT1 404 template](https://github.com/WordPress/theme-experiments/blob/e755034e596474b5481e3642cb9468bb2a54fa65/tt1-blocks/block-templates/404.html#L1) in the TT1 blocks theme. A serialized template part in the template looks like this:

```<!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full", "tagName":"header","className":"site-header"} /-->```

The header template part in the 404 template has a "tt1-blocks" theme attribute. This theme attribute is what is eventually included in our client side query -- normally no big deal. If the WordPress theme exists in the root of the themes directory like so `wp-content/themes/tt1-blocks`, then the theme stylesheet is "tt1-blocks", and it will match the theme attribute in the client side query. 

If, however, the theme exists in a subdirectory, like `wp-content/themes/subdirectory/tt1-blocks`, the stylesheet then becomes "subdirectory/tt1-blocks". This no longer matches the theme attribute provided in the 404 template, and, as a result, the query is no longer correct.

### Note:
This PR will require follow-up work (which has not been implemented yet) to properly address the template parts not loading issue. We're going to have to remove _all_ theme attributes from theme provided template blocks. Going back to the [TT1 404 template](https://github.com/WordPress/theme-experiments/blob/e755034e596474b5481e3642cb9468bb2a54fa65/tt1-blocks/block-templates/404.html#L1) as an example, when the follow-up PRs are completed, serialized template parts will look like this:

```
// Before
<!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full", "tagName":"header","className":"site-header"} /-->

// After
<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->
```

When loading theme provided template parts, the changes in this PR will then [insert the correct theme stylesheet for the serialized theme attribute](https://github.com/WordPress/gutenberg/pull/28088/files#diff-6ca30c26729f0fb3398ad5c6b4e82d1a83bfe5bd920e4cb6deca5646d9e578bdR117-R138). This will allow template parts to load correctly again.

See [this comment](https://github.com/WordPress/gutenberg/pull/27910#discussion_r552037266) for more context.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Before applying this PR:
- Open the front end and the site editor. It should load all the template parts.
- Ensure that the [theme-experiments](https://github.com/WordPress/theme-experiments/tree/e755034e596474b5481e3642cb9468bb2a54fa65) repo is downloaded locally
- Install the TT1-blocks theme in a subdirectory of `wp-content/themes`.
   1. Add the following to `.wp-env.override.json`. This creates a copy of the locally installed TT1 theme in an "test" subdirectory in the WordPress volume.
   2. ```javascript 
      // .wp-env.override.json
      // Replace ~/work/theme-experiments/tt1-blocks with the path
      // to your locally installed TT1 block theme
      {
           "mappings": {
               "wp-content/themes/test/tt1-blocks": "~/work/theme-experiments/tt1-blocks",
           }
      }```
    3. `npx wp-env start`
- Activate TT1-blocks.
- Open the front end and the site editor: it should not be loading the header and footer template parts.

Apply this PR:
- Navigate to your locally installed copy of the TT1 blocks theme.
- Modify the source code of block templates and remove theme attributes from all `wp_template_parts`
    - Take `tt1-blocks/block-templates/front-page.html` for example
    - Before removal: `<!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full", "tagName":"header","className":"site-header"} /-->`
    - After removal: `<!-- wp:template-part {"slug":"header", "align":"full", "tagName":"header","className":"site-header"} /-->`
- `npx wp-env start --update`
- Open the front end and the site editor: it should load all the template parts.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug Fix for https://github.com/Automattic/wp-calypso/issues/48145

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
