### PR TITLE
Testing: Prevent a direct usage of Reakit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,28 @@ module.exports = {
 			},
 		],
 		'@wordpress/no-unsafe-wp-apis': 'off',
+		'no-restricted-imports': [
+			'error',
+			{
+				paths: [
+					{
+						name: 'lodash',
+						importNames: [ 'memoize' ],
+						message: 'Please use `memize` instead.',
+					},
+					{
+						name: 'reakit',
+						message: 'Please use `@wordpress/components` instead.',
+					},
+					{
+						name: 'redux',
+						importNames: [ 'combineReducers' ],
+						message:
+							'Please use `combineReducers` from `@wordpress/data` instead.',
+					},
+				],
+			},
+		],
 		'no-restricted-syntax': [
 			'error',
 			// NOTE: We can't include the forward slash in our regex or
@@ -78,16 +100,6 @@ module.exports = {
 					'/]',
 				message:
 					'Deprecated functions must be removed before releasing this version.',
-			},
-			{
-				selector:
-					'ImportDeclaration[source.value="redux"] Identifier.imported[name="combineReducers"]',
-				message: 'Use `combineReducers` from `@wordpress/data`',
-			},
-			{
-				selector:
-					'ImportDeclaration[source.value="lodash"] Identifier.imported[name="memoize"]',
-				message: 'Use memize instead of Lodash’s memoize',
 			},
 			{
 				selector:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,7 +65,8 @@ module.exports = {
 					},
 					{
 						name: 'reakit',
-						message: 'Please use `@wordpress/components` instead.',
+						message:
+							'Please use Reakit API through `@wordpress/components` instead.',
 					},
 					{
 						name: 'redux',

--- a/packages/components/src/composite/index.js
+++ b/packages/components/src/composite/index.js
@@ -10,6 +10,7 @@
  * The plan is to build own API that accounts for future breaking changes
  * in Reakit (https://github.com/WordPress/gutenberg/pull/28085).
  */
+/* eslint-disable-next-line no-restricted-imports */
 export {
 	Composite,
 	CompositeGroup,

--- a/packages/components/src/disclosure/index.js
+++ b/packages/components/src/disclosure/index.js
@@ -7,4 +7,5 @@
  * The plan is to build own API that accounts for future breaking changes
  * in Reakit (https://github.com/WordPress/gutenberg/pull/28085).
  */
+/* eslint-disable-next-line no-restricted-imports */
 export { DisclosureContent } from 'reakit';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This is a follow-up for #28085.

This PR ensures that `reakit` imports won't be possible unless explicitly allowed inside `@wordpress/components. It should help prevent bundled code duplication as observed in #28085 that reduces the build size by 20 kb for a few API methods used.

## How has this been tested?
`npm run lint-js -- -quiet`

At the moment it reports 4 errors. They should get resolved once #28085 is merged.

```
/Users/gziolo/Projects/gutenberg/packages/block-editor/src/components/block-types-list/index.js
  4:1  error  'reakit' import is restricted from being used. Please use `@wordpress/components` instead  no-restricted-imports

/Users/gziolo/Projects/gutenberg/packages/block-editor/src/components/inserter-list-item/index.js
  5:1  error  'reakit' import is restricted from being used. Please use `@wordpress/components` instead  no-restricted-imports

/Users/gziolo/Projects/gutenberg/packages/block-library/src/template-part/edit/selection/template-part-previews.js
  18:1  error  'reakit' import is restricted from being used. Please use `@wordpress/components` instead  no-restricted-imports

/Users/gziolo/Projects/gutenberg/packages/components/src/alignment-matrix-control/index.js
  6:1  error  'reakit' import is restricted from being used. Please use `@wordpress/components` instead  no-restricted-imports

✖ 4 problems (4 errors, 0 warnings)
```