### PR TITLE
FocalPointPicker: Fix rendering and dragging experience

### DIFF
--- a/packages/components/src/focal-point-picker/focal-point.js
+++ b/packages/components/src/focal-point-picker/focal-point.js
@@ -1,26 +1,24 @@
 /**
+ * Internal dependencies
+ */
+import {
+	FocalPointWrapper,
+	PointerIconPathFill,
+	PointerIconPathOutline,
+	PointerIconSVG,
+} from './styles/focal-point-style';
+
+/**
  * External dependencies
  */
 import classnames from 'classnames';
 
-/**
- * Internal dependencies
- */
-import {
-	PointerIconSVG,
-	PointerIconPathFill,
-	PointerIconPathOutline,
-	FocalPointWrapper,
-} from './styles/focal-point-style';
-
 export default function FocalPoint( {
 	coordinates = { left: '50%', top: '50%' },
-	isDragging = false,
 	...props
 } ) {
 	const classes = classnames(
-		'components-focal-point-picker__icon_container',
-		isDragging && 'is-dragging'
+		'components-focal-point-picker__icon_container'
 	);
 
 	const style = {

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -181,6 +181,9 @@ export class FocalPointPicker extends Component {
 
 		if ( ! isDragging ) return;
 
+		// Prevents text-selection when dragging.
+		event.preventDefault();
+
 		const { shiftKey } = event;
 		const pickerDimensions = this.pickerDimensions();
 		const cursorPosition = {

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -52,6 +52,14 @@ export class FocalPointPicker extends Component {
 	componentDidMount() {
 		document.addEventListener( 'mouseup', this.handleOnMouseUp );
 		window.addEventListener( 'resize', this.updateBounds );
+
+		/*
+		 * Set initial bound values.
+		 *
+		 * This is necessary for Safari:
+		 * https://github.com/WordPress/gutenberg/issues/25814
+		 */
+		this.updateBounds();
 	}
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.url !== this.props.url ) {
@@ -59,7 +67,7 @@ export class FocalPointPicker extends Component {
 				isDragging: false,
 			} );
 		}
-		/**
+		/*
 		 * Handles cases where the incoming value changes.
 		 * An example is the values resetting based on an UNDO action.
 		 */

--- a/packages/components/src/input-control/utils.js
+++ b/packages/components/src/input-control/utils.js
@@ -41,10 +41,8 @@ export function useDragCursor( isDragging, dragDirection ) {
 	useEffect( () => {
 		if ( isDragging ) {
 			document.documentElement.style.cursor = dragCursor;
-			document.documentElement.style.userSelect = 'none';
 		} else {
 			document.documentElement.style.cursor = null;
-			document.documentElement.style.userSelect = null;
 		}
 	}, [ isDragging ] );
 

--- a/packages/components/src/input-control/utils.js
+++ b/packages/components/src/input-control/utils.js
@@ -41,10 +41,10 @@ export function useDragCursor( isDragging, dragDirection ) {
 	useEffect( () => {
 		if ( isDragging ) {
 			document.documentElement.style.cursor = dragCursor;
-			document.documentElement.style.pointerEvents = 'none';
+			document.documentElement.style.userSelect = 'none';
 		} else {
 			document.documentElement.style.cursor = null;
-			document.documentElement.style.pointerEvents = null;
+			document.documentElement.style.userSelect = null;
 		}
 	}, [ isDragging ] );
 


### PR DESCRIPTION
## Description

![2021-01-11 07-07-35 2021-01-11 07_07_49](https://user-images.githubusercontent.com/2322354/104180802-bd12c800-53db-11eb-8e35-bcfc3b5551b1.gif)


This update improves the FocalPointPicker component to ensure that the focal point UI is visible during dragging.
The solution involved removing (an old) `.is-dragging` class that was attached to the focal point UI.
At some point, `.is-dragging` (globally) was forced to be `display: none !important`.

Also, `InputControl` drag update stability has been improved by removing the `pointer-event: none` disabling during drag.

Resolves https://github.com/WordPress/gutenberg/issues/25814

## Tasks

* [x] Fix render visibility of Focal Pointer UI when dragging
* [x] Fix interaction issues for Safari
* [x] Improve text-selection handling on dragging

## How has this been tested?

Locally in Gutenberg and Storybook

* `npm run dev`
* Add a cover blog
* Add an image background
* Adjust the position by dragging the focal point UI

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
