### PR TITLE
NavigationMenu component: Add isSearchDebouncing prop

### DIFF
--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -123,6 +123,13 @@ The unique identifier of the menu. The root menu can omit this, and it will defa
 
 When `hasSearch` is active, this function handles the search input's `onChange` event, making it controlled from the outside. It requires setting the `search` prop as well.
 
+### isSearchDebouncing
+
+-   Type: `boolean`
+-   Required: No
+
+Indicates whether the search is debouncing or not. In case of `true` the "No results found." text is omitted. Used to prevent showing "No results found." text between debounced searches.
+
 ### `parentMenu`
 
 -   Type: `string`

--- a/packages/components/src/navigation/menu/index.js
+++ b/packages/components/src/navigation/menu/index.js
@@ -32,6 +32,7 @@ export default function NavigationMenu( props ) {
 		onSearch: setControlledSearch,
 		parentMenu,
 		search: controlledSearch,
+		isSearchDebouncing,
 		title,
 		titleAction,
 	} = props;
@@ -84,7 +85,7 @@ export default function NavigationMenu( props ) {
 				<NavigableMenu>
 					<ul aria-labelledby={ menuTitleId }>
 						{ children }
-						{ search && (
+						{ search && ! isSearchDebouncing && (
 							<NavigationSearchNoResultsFound search={ search } />
 						) }
 					</ul>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Complementary PR for https://github.com/WordPress/gutenberg/pull/27280

Allows us to hide "No results found." text when we are doing debounced searches. This change was originally created by @jeyip but we decided to move on a different path. 

## How has this been tested?
Passing `isSearchDebouncing={true}` to `NavigationMenu` should hide the "No results found." when searching.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
