### PR TITLE
Try: Transparent spacer.

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -11,7 +11,7 @@
 }
 
 .block-library-spacer__resize-container.has-show-handle {
-	background: $gray-100;
+	background: rgba($black, 0.1);
 
 	.is-dark-theme & {
 		background: rgba($white, 0.15);


### PR DESCRIPTION
Mitigates #28092.

Before, light theme:

<img width="1322" alt="Screenshot 2021-01-11 at 14 37 11" src="https://user-images.githubusercontent.com/1204802/104190129-e8b5a280-541b-11eb-9c9b-5ce90c0d6fcf.png">

Before, inside a Cover block:

<img width="854" alt="Screenshot 2021-01-11 at 14 50 01" src="https://user-images.githubusercontent.com/1204802/104190386-53ff7480-541c-11eb-86c9-91cc7536cb1d.png">

Before (after also, actually), dark theme:

<img width="1319" alt="Screenshot 2021-01-11 at 14 37 32" src="https://user-images.githubusercontent.com/1204802/104190145-ef441a00-541b-11eb-9cfa-cf94b294f436.png">

After:

<img width="1355" alt="Screenshot 2021-01-11 at 14 38 28" src="https://user-images.githubusercontent.com/1204802/104190153-f2d7a100-541b-11eb-89a9-ec39a4ad22ac.png">

<img width="1202" alt="Screenshot 2021-01-11 at 14 38 45" src="https://user-images.githubusercontent.com/1204802/104190157-f408ce00-541b-11eb-9bbe-238bbf77075c.png">

<img width="857" alt="Screenshot 2021-01-11 at 14 46 35" src="https://user-images.githubusercontent.com/1204802/104190159-f539fb00-541b-11eb-9309-dd545dfa46f0.png">

<img width="828" alt="Screenshot 2021-01-11 at 14 46 50" src="https://user-images.githubusercontent.com/1204802/104190161-f66b2800-541b-11eb-9e91-4f819eff043a.png">

In https://github.com/WordPress/gutenberg/issues/28092#issuecomment-757919152 I discuss how there are some problems with transparencies and colors. This PR does not fix those fully, but the fact that the Cover block is at least aware of its background color and is therefore smart enough to set `is-dark-theme` as a classname on itself when the background is dark, it does mean that I believe this PR is good enough to ship as an interim step. Longer term we probably do need to look into better canvas color awareness.