### PR TITLE
Create Block: Allow using locally installed packages with templates

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### New Features
 
 -   Add support for handling static assets with the `assetsPath` field in the external template configuration ([#28038](https://github.com/WordPress/gutenberg/pull/28038)).
+-   Allow using locally installed packages with templates ([#28105](https://github.com/WordPress/gutenberg/pull/28105)).
 
 ### Internal
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Related to: #27881.

This PR will simplify testing of the new template that @jessynd is baking in #27881. So far it was possible to use only built-in templates (`es5` and `esnext`) and 3rd party templates hosted on npm. There is a proposal to add a new template to be used with the [Create a Block Tutorial](https://github.com/WordPress/gutenberg/tree/master/docs/designers-developers/developers/tutorials/create-block). It's going to be published to npm as an official WordPress package, but as usual we want to make it testable with the latest version during development. This is where testing with locally installed packages is going to be helpful.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I did a couple of tests mostly to validate existing functionality.

### Built-in template

```bash
npx wp-create-block --template es5
```

Works as usual.

### Installed packages

Testing errors for now.

```bash
npx wp-create-block --template lodash
```
<img width="888" alt="Screen Shot 2021-01-12 at 08 19 28" src="https://user-images.githubusercontent.com/699132/104282199-f8ca9200-54ae-11eb-83cd-76df2c34f4f0.png">


```bash
npx wp-create-block --template lodash-es
```

<img width="1175" alt="Screen Shot 2021-01-12 at 08 18 05" src="https://user-images.githubusercontent.com/699132/104282055-bdc85e80-54ae-11eb-8d58-997c5297090a.png">

### External packages

```bash
npx wp-create-block --template package-does-not-exist-i-guess
```

<img width="1546" alt="Screen Shot 2021-01-12 at 08 21 04" src="https://user-images.githubusercontent.com/699132/104282351-34655c00-54af-11eb-9577-3f1b1207dc39.png">

```bash
npx wp-create-block --template vue
```

<img width="1071" alt="Screen Shot 2021-01-12 at 08 22 39" src="https://user-images.githubusercontent.com/699132/104282452-5e1e8300-54af-11eb-93f4-3a45bde3f0d9.png">

```bash
npx wp-create-block --template wp-block-directory-template
```

<img width="1182" alt="Screen Shot 2021-01-12 at 08 26 58" src="https://user-images.githubusercontent.com/699132/104282855-f452a900-54af-11eb-9dcb-5776f5599107.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
