### PR TITLE
E2E FSE: Fix intermittent errors in multi entity editing test

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -191,7 +191,7 @@ describe( 'Multi-entity editor states', () => {
 			);
 
 			// Our custom template shows up in the " templates > all" menu; let's use it.
-			clickTemplateItem( [ 'Templates', 'All' ], templateName );
+			await clickTemplateItem( [ 'Templates', 'All' ], templateName );
 			await page.waitForXPath(
 				`//p[contains(@class, "edit-site-document-actions__title") and contains(text(), '${ templateName }')]`
 			);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add missing `await`

## How has this been tested?
Tests should pass both on CI and locally.


## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
