### PR TITLE
Verse: Fix line-wrap rendering on front-end of site

### DIFF
--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,4 +1,5 @@
 pre.wp-block-verse {
 	font-family: inherit;
 	overflow: auto;
+	white-space: pre-wrap;
 }

--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,5 +1,4 @@
 pre.wp-block-verse {
 	font-family: inherit;
 	overflow: auto;
-	white-space: nowrap;
 }


### PR DESCRIPTION
This update fixes the front-end rendering of the text content of the Verse block.

Below is a screenshot of the correctly rendered formatted text for Verse:

<img width="627" alt="Screen Shot 2021-01-11 at 12 28 48 PM" src="https://user-images.githubusercontent.com/2322354/104216958-be0e1e80-5408-11eb-9664-0018f01c9c02.png">

Resolves: https://github.com/WordPress/gutenberg/issues/28108

## How has this been tested?

Local Gutenberg

* `npm run dev`
* Add a Verse block
* Type content, indented with space

## Types of changes

* Removed `white-space` CSS for the Verse block

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
