### PR TITLE
Fix nested cover block bug

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -4,7 +4,6 @@
 	background-size: cover;
 	background-position: center center;
 	min-height: 430px;
-	height: 100%;
 	width: 100%;
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
This PR removes `height: 100%` from the default styles of the cover block. 

I'm not certain, but I think this line causes more issues than the uses cases that make it worth keeping. In particular it causes a bug when a cover block appears inside of a flex container (like a columns block), causing the height the cover to take up 100% of a container which may contain other blocks — pushing those blocks outside of the document flow:

Master | This PR
------- | ------
<img width="690" alt="Screen Shot 2021-01-11 at 3 09 10 PM" src="https://user-images.githubusercontent.com/5375500/104232969-16501b00-541f-11eb-889a-9f6b9de9fdce.png"> | <img width="701" alt="Screen Shot 2021-01-11 at 3 09 44 PM" src="https://user-images.githubusercontent.com/5375500/104232981-194b0b80-541f-11eb-895e-dfdcf272bdc9.png">

Another example of this bug: https://github.com/Automattic/themes/issues/2976#issuecomment-755797562

**How to test**
- GB master using the Twenty Twenty-One theme
- Add a columns block and a cover inside it (you can use this [block markup](https://pastebin.com/iRD71xqh))
- Verify the issue occers
- Check out this PR and verify the issue is resolved

