### PR TITLE
substate: Add package

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1812,6 +1812,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/substate",
+		"slug": "packages-substate",
+		"markdown_source": "../packages/substate/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/token-list",
 		"slug": "packages-token-list",
 		"markdown_source": "../packages/token-list/README.md",

--- a/packages/substate/.npmrc
+++ b/packages/substate/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/substate/CHANGELOG.md
+++ b/packages/substate/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+Initial release.

--- a/packages/substate/README.md
+++ b/packages/substate/README.md
@@ -1,0 +1,10 @@
+# Substate
+
+> High performance subscription-based state management (powered by Zustand).
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/substate/package.json
+++ b/packages/substate/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@wordpress/substate",
+  "version": "1.0.0-prerelease",
+  "description": "Fork of zustand.",
+  "author": "The WordPress Contributors",
+  "license": "GPL-2.0-or-later",
+  "keywords": [ "wordpress" ],
+  "homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/substate/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WordPress/gutenberg.git",
+    "directory": "packages/substate"
+  },
+  "bugs": {
+    "url": "https://github.com/WordPress/gutenberg/issues"
+  },
+  "main": "build/index.js",
+  "module": "build-module/index.js",
+  "react-native": "src/index",
+  "types": "build-types",
+  "sideEffects": false,
+  "dependencies": {
+    "@babel/runtime": "^7.12.5",
+    "@wordpress/element": "file:../element"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/substate/src/index.js
+++ b/packages/substate/src/index.js
@@ -1,0 +1,6 @@
+export { default as createStore } from './zustand';
+export { default as shallowCompare } from './zustand/shallow';
+export { default as createBaseStore } from './zustand/vanilla';
+// eslint-disable-next-line import/no-unresolved
+export * from './zustand/types';
+export * from './use-sub-state';

--- a/packages/substate/src/use-sub-state.js
+++ b/packages/substate/src/use-sub-state.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import createStore from './zustand';
+
+/**
+ * @template {Record<string | number | symbol, unknown>} TState
+ * @param {import('./zustand/types').StateCreator<TState> | import('./zustand/types').StoreApi<TState>} createState
+ */
+export function useSubState( createState ) {
+	return useRef( createStore( createState ) ).current;
+}

--- a/packages/substate/src/zustand/README.md
+++ b/packages/substate/src/zustand/README.md
@@ -1,0 +1,10 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+-   [Zustand](#zustand)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Zustand
+
+> Forked from https://github.com/pmndrs/zustand/releases/tag/v3.3.1

--- a/packages/substate/src/zustand/index.js
+++ b/packages/substate/src/zustand/index.js
@@ -1,0 +1,151 @@
+/* eslint-disable jsdoc/no-undefined-types */
+/**
+ * WordPress dependencies
+ */
+import {
+	useEffect,
+	useLayoutEffect,
+	useReducer,
+	useRef,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import createImpl from './vanilla';
+export * from './vanilla';
+
+/**
+ * Preferred over direct usage of `useLayoutEffect` when supporting
+ * server rendered components (SSR) because currently React
+ * throws a warning when using useLayoutEffect in that environment.
+ */
+const useIsoLayoutEffect =
+	typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+/**
+ * @template {import('./types').State} TState
+ * @param {import('./types').StateCreator<TState> | import('./types').StoreApi<TState>} createState
+ *
+ * @return {import('./types').UseStore<TState>} The store.
+ */
+export default function create( createState ) {
+	/**
+	 * @type {import('./types').StoreApi<TState>}
+	 */
+	const api =
+		typeof createState === 'function'
+			? createImpl( createState )
+			: createState;
+
+	/**
+	 * @template StateSlice
+	 * @type {any}
+	 * @param {import('./types').StateSelector<TState, StateSlice>} [selector]
+	 * @param {import('./types').EqualityChecker<StateSlice>} [equalityFn]
+	 */
+	const useStore = (
+		selector = /** @type {any} */ ( api.getState ),
+		equalityFn = Object.is
+	) => {
+		const [ , forceUpdate ] = useReducer( ( c ) => c + 1, 0 );
+
+		const state = api.getState();
+		const stateRef = useRef( state );
+		const selectorRef = useRef( selector );
+		const equalityFnRef = useRef( equalityFn );
+		const erroredRef = useRef( false );
+
+		/**
+		 * @type {import('react').MutableRefObject<StateSlice | undefined>}
+		 */
+		const currentSliceRef = useRef();
+		if ( currentSliceRef.current === undefined ) {
+			currentSliceRef.current = selector( state );
+		}
+
+		/**
+		 * @type {StateSlice | undefined}
+		 */
+		let newStateSlice;
+		let hasNewStateSlice = false;
+
+		// The selector or equalityFn need to be called during the render phase if
+		// they change. We also want legitimate errors to be visible so we re-run
+		// them if they errored in the subscriber.
+		if (
+			stateRef.current !== state ||
+			selectorRef.current !== selector ||
+			equalityFnRef.current !== equalityFn ||
+			erroredRef.current
+		) {
+			// Using local variables to avoid mutations in the render phase.
+			newStateSlice = selector( state );
+			hasNewStateSlice = ! equalityFn(
+				/** @type {StateSlice} */ ( currentSliceRef.current ),
+				/** @type {StateSlice} */ ( newStateSlice )
+			);
+		}
+
+		// Syncing changes in useEffect.
+		useIsoLayoutEffect( () => {
+			if ( hasNewStateSlice ) {
+				currentSliceRef.current = /** @type {StateSlice} */ ( newStateSlice );
+			}
+			stateRef.current = state;
+			selectorRef.current = selector;
+			equalityFnRef.current = equalityFn;
+			erroredRef.current = false;
+		} );
+
+		const stateBeforeSubscriptionRef = useRef( state );
+		useIsoLayoutEffect( () => {
+			const listener = () => {
+				try {
+					const nextState = api.getState();
+					const nextStateSlice = selectorRef.current( nextState );
+					if (
+						! equalityFnRef.current(
+							/** @type {StateSlice} */ ( currentSliceRef.current ),
+							nextStateSlice
+						)
+					) {
+						stateRef.current = nextState;
+						currentSliceRef.current = nextStateSlice;
+						forceUpdate();
+					}
+				} catch ( error ) {
+					erroredRef.current = true;
+					forceUpdate();
+				}
+			};
+			const unsubscribe = api.subscribe( listener );
+			if ( api.getState() !== stateBeforeSubscriptionRef.current ) {
+				listener(); // state has changed before subscription
+			}
+			return unsubscribe;
+		}, [] );
+
+		return hasNewStateSlice
+			? /** @type {StateSlice} */ ( newStateSlice )
+			: currentSliceRef.current;
+	};
+
+	Object.assign( useStore, api );
+
+	// For backward compatibility (No TS types for this)
+	useStore[ Symbol.iterator ] = function* () {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'[useStore, api] = create() is deprecated and will be removed in v4'
+		);
+		yield useStore;
+		yield api;
+	};
+
+	return useStore;
+}
+/* eslint-enable jsdoc/no-undefined-types */

--- a/packages/substate/src/zustand/middleware.js
+++ b/packages/substate/src/zustand/middleware.js
@@ -1,0 +1,209 @@
+/* eslint-disable jsdoc/no-undefined-types */
+/**
+ * @template {import('./types').State} S
+ * @template {{ type: unknown }} A
+ * @param {(state: S, action: A) => S} reducer
+ * @param {S} initial
+ *
+ * @return {import('./types').Redux<S, A>} A thin redux implementation.
+ */
+export const redux = ( reducer, initial ) => ( set, get, api ) => {
+	api.dispatch = ( /** @type {A} */ action ) => {
+		set( ( /** @type {S} */ state ) => reducer( state, action ) );
+		if ( api.devtools ) {
+			api.devtools.send( api.devtools.prefix + action.type, get() );
+		}
+		return action;
+	};
+	return { dispatch: api.dispatch, ...initial };
+};
+
+/**
+ * @template {import('./types').State} S
+ * @param {import('./types').StateCreator<S, import('./types').NamedSet<S>>} fn
+ * @param {string} [prefix]
+ *
+ * @return {import('./types').DevTools<S>} Devtools for Redux implementation
+ */
+export const devtools = ( fn, prefix ) => ( set, get, api ) => {
+	let extension;
+	try {
+		extension =
+			/** @type {any} */ ( window ).__REDUX_DEVTOOLS_EXTENSION__ ||
+			/** @type {any} */ ( window ).top.__REDUX_DEVTOOLS_EXTENSION__;
+	} catch {}
+
+	if ( ! extension ) {
+		if (
+			// @ts-ignore
+			process.env.NODE_ENV === 'development' &&
+			typeof window !== 'undefined'
+		) {
+			// eslint-disable-next-line no-console
+			console.warn( 'Please install/enable Redux devtools extension' );
+		}
+		api.devtools = null;
+		return fn( set, get, api );
+	}
+	/**
+	 * @type {import('./types').NamedSet<S>}
+	 */
+	const namedSet = ( state, replace, name ) => {
+		set( state, replace );
+		if ( ! api.dispatch ) {
+			api.devtools.send(
+				api.devtools.prefix + ( name || 'action' ),
+				get()
+			);
+		}
+	};
+	const initialState = fn( namedSet, get, api );
+	if ( ! api.devtools ) {
+		const savedSetState = api.setState;
+		api.setState = (
+			/** @type {import('./types').PartialState<S>} */ state,
+			/** @type {boolean | undefined} */ replace
+		) => {
+			savedSetState( state, replace );
+			api.devtools.send(
+				api.devtools.prefix + 'setState',
+				api.getState()
+			);
+		};
+		api.devtools = extension.connect( { name: prefix } );
+		api.devtools.prefix = prefix ? `${ prefix } > ` : '';
+		api.devtools.subscribe( ( /** @type {any} */ message ) => {
+			if ( message.type === 'DISPATCH' && message.state ) {
+				const ignoreState =
+					message.payload.type === 'JUMP_TO_ACTION' ||
+					message.payload.type === 'JUMP_TO_STATE';
+				if ( ! api.dispatch && ! ignoreState ) {
+					api.setState( JSON.parse( message.state ) );
+				} else {
+					savedSetState( JSON.parse( message.state ) );
+				}
+			} else if (
+				message.type === 'DISPATCH' &&
+				message.payload?.type === 'COMMIT'
+			) {
+				api.devtools.init( api.getState() );
+			}
+		} );
+		api.devtools.init( initialState );
+	}
+	return initialState;
+};
+
+/**
+ * @template {import('./types').State} PrimaryState
+ * @template {import('./types').State} SecondaryState
+ * @param {PrimaryState} initialState
+ * @param {import('./types').CombineCreate<PrimaryState, SecondaryState>} create
+ *
+ * @return {import('./types').StateCreator<PrimaryState & SecondaryState>} State creator.
+ */
+export const combine = ( initialState, create ) => ( set, get, api ) =>
+	Object.assign(
+		{},
+		initialState,
+		create(
+			/** @type {import('./types').SetState<PrimaryState>} */ ( set ),
+			/** @type {import('./types').GetState<PrimaryState>} */ ( get ),
+			/** @type {import('./types').StoreApi<PrimaryState>} */ ( api )
+		)
+	);
+
+/**
+ * @template {import('./types').State} S
+ * @param {import('./types').StateCreator<S>} config
+ * @param {import('./types').PersistOptions<S>} options
+ *
+ * @return {import('./types').StateCreator<S>} Persistance middleware
+ */
+export const persist = ( config, options ) => ( set, get, api ) => {
+	const {
+		name,
+		getStorage = () => window.localStorage,
+		serialize = JSON.stringify,
+		deserialize = JSON.parse,
+		blacklist,
+		whitelist,
+		onRehydrateStorage,
+		version = 0,
+	} = options || {};
+
+	/**
+	 * @type {import('./types').StateStorage | undefined}
+	 */
+	let storage;
+
+	try {
+		storage = getStorage();
+	} catch ( e ) {
+		// prevent error if the storage is not defined (e.g. when server side rendering a page)
+	}
+
+	if ( ! storage ) return config( set, get, api );
+
+	const setItem = async () => {
+		const state = { ...get() };
+
+		if ( whitelist ) {
+			Object.keys( state ).forEach( ( key ) => {
+				// eslint-disable-next-line no-unused-expressions
+				! whitelist.includes( key ) && delete state[ key ];
+			} );
+		}
+		if ( blacklist ) {
+			blacklist.forEach( ( key ) => delete state[ key ] );
+		}
+
+		// eslint-disable-next-line no-unused-expressions
+		storage?.setItem( name, await serialize( { state, version } ) );
+	};
+
+	const savedSetState = api.setState;
+
+	api.setState = ( state, replace ) => {
+		savedSetState( state, replace );
+		setItem();
+	};
+
+	// rehydrate initial state with existing stored state
+	( async () => {
+		const postRehydrationCallback =
+			onRehydrateStorage?.( get() ) || undefined;
+
+		try {
+			const storageValue = await storage.getItem( name );
+
+			if ( storageValue ) {
+				const deserializedStorageValue = await deserialize(
+					storageValue
+				);
+
+				// if versions mismatch, clear storage by storing the new initial state
+				if ( deserializedStorageValue.version !== version ) {
+					setItem();
+				} else {
+					set( deserializedStorageValue.state );
+				}
+			}
+		} catch ( e ) {
+			throw new Error( `Unable to get to stored state in "${ name }"` );
+		} finally {
+			// eslint-disable-next-line no-unused-expressions
+			postRehydrationCallback?.( get() );
+		}
+	} )();
+
+	return config(
+		( payload ) => {
+			set( payload );
+			setItem();
+		},
+		get,
+		api
+	);
+};
+/* eslint-enable jsdoc/no-undefined-types */

--- a/packages/substate/src/zustand/shallow.js
+++ b/packages/substate/src/zustand/shallow.js
@@ -1,0 +1,43 @@
+/**
+ * @typedef {Record<string | number | symbol, unknown>} Obj
+ */
+
+/**
+ * @template {any}T
+ * @template {any}U
+ *
+ * @param {T} objA
+ * @param {U} objB
+ */
+export default function shallow( objA, objB ) {
+	if ( Object.is( objA, objB ) ) {
+		return true;
+	}
+	if (
+		typeof objA !== 'object' ||
+		objA === null ||
+		typeof objB !== 'object' ||
+		objB === null
+	) {
+		return false;
+	}
+
+	const keysA = Object.keys( /** @type {Object} */ ( objA ) );
+	if (
+		keysA.length !== Object.keys( /** @type {Object} */ ( objB ) ).length
+	) {
+		return false;
+	}
+	for ( let i = 0; i < keysA.length; i++ ) {
+		if (
+			! Object.prototype.hasOwnProperty.call( objB, keysA[ i ] ) ||
+			! Object.is(
+				/** @type {Obj} */ ( objA )[ keysA[ i ] ],
+				/** @type {Obj} */ ( objB )[ keysA[ i ] ]
+			)
+		) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/packages/substate/src/zustand/types.ts
+++ b/packages/substate/src/zustand/types.ts
@@ -1,0 +1,124 @@
+export type State = Record<string | number | symbol, unknown>;
+export type PartialState<T extends State> =
+	| Partial<T>
+	| ((state: T) => Partial<T>);
+export type StateSelector<T extends State, U> = (state: T) => U;
+export type EqualityChecker<T> = (state: T, newState: T) => boolean;
+export type StateListener<T> = (state: T, previousState: T) => void;
+export type StateSliceListener<T> = (slice: T, previousSlice: T) => void;
+export interface Subscribe<T extends State> {
+	(listener: StateListener<T>): () => void;
+	<StateSlice>(
+		listener: StateSliceListener<StateSlice>,
+		selector: StateSelector<T, StateSlice>,
+		equalityFn?: EqualityChecker<StateSlice>,
+	): () => void;
+}
+export type SetState<T extends State> = (
+	partial: PartialState<T>,
+	replace?: boolean,
+) => void;
+export type GetState<T extends State> = () => T;
+export type Destroy = () => void;
+export interface StoreApi<T extends State> {
+	setState: SetState<T>;
+	getState: GetState<T>;
+	subscribe: Subscribe<T>;
+	destroy: Destroy;
+}
+export type StateCreator<T extends State, CustomSetState = SetState<T>> = (
+	set: CustomSetState,
+	get: GetState<T>,
+	api: StoreApi<T>,
+) => T;
+
+export type Redux<S extends State, A extends { type: unknown }> = (
+	set: SetState<S>,
+	get: GetState<S>,
+	api: StoreApi<S> & {
+		dispatch?: (a: A) => A;
+		devtools?: any;
+	},
+) => S & { dispatch: (a: A) => A };
+
+export type NamedSet<S extends State> = (
+	partial: PartialState<S>,
+	replace?: boolean,
+	name?: string,
+) => void;
+
+export type DevTools<S extends State> = (
+	set: SetState<S>,
+	get: GetState<S>,
+	api: StoreApi<S> & { dispatch?: unknown; devtools?: any },
+) => S;
+
+export type CombineCreate<
+	PrimaryState extends State,
+	SecondaryState extends State
+> = (
+	set: SetState<PrimaryState>,
+	get: GetState<PrimaryState>,
+	api: StoreApi<PrimaryState>,
+) => SecondaryState;
+
+export type StateStorage = {
+	getItem: (name: string) => string | null | Promise<string | null>;
+	setItem: (name: string, value: string) => void | Promise<void>;
+};
+type StorageValue<S> = { state: S; version: number };
+
+export type PersistOptions<S> = {
+	/** Name of the storage (must be unique) */
+	name: string;
+	/**
+	 * A function returning a storage.
+	 * The storage must fit `window.localStorage`'s api (or an async version of it).
+	 * For example the storage could be `AsyncStorage` from React Native.
+	 *
+	 * @default () => localStorage
+	 */
+	getStorage?: () => StateStorage;
+	/**
+	 * Use a custom serializer.
+	 * The returned string will be stored in the storage.
+	 *
+	 * @default JSON.stringify
+	 */
+	serialize?: (state: StorageValue<S>) => string | Promise<string>;
+	/**
+	 * Use a custom deserializer.
+	 *
+	 * @param str The storage's current value.
+	 * @default JSON.parse
+	 */
+	deserialize?: (str: string) => StorageValue<S> | Promise<S>;
+	/**
+	 * Prevent some items from being stored.
+	 */
+	blacklist?: (keyof S)[];
+	/**
+	 * Only store the listed properties.
+	 */
+	whitelist?: (keyof S)[];
+	/**
+	 * A function returning another (optional) function.
+	 * The main function will be called before the storage rehydration.
+	 * The returned function will be called after the storage rehydration.
+	 */
+	onRehydrateStorage?: (state: S) => ((state: S) => void) | void;
+	/**
+	 * If the stored state's version mismatch the one specified here, the storage will not be used.
+	 * This is useful when adding a breaking change to your store.
+	 */
+	version?: number;
+};
+
+export interface UseStore<T extends State> {
+	(): T;
+	<U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U;
+	setState: SetState<T>;
+	getState: GetState<T>;
+	subscribe: Subscribe<T>;
+	destroy: Destroy;
+}

--- a/packages/substate/src/zustand/vanilla.js
+++ b/packages/substate/src/zustand/vanilla.js
@@ -1,0 +1,88 @@
+/* eslint-disable jsdoc/no-undefined-types */
+/**
+ * @template {import('./types').State}TState
+ * @param {import('./types').StateCreator<TState>} createState
+ * @return {import('./types').StoreApi<TState>} The store.
+ */
+export default function create( createState ) {
+	/** @type {TState} */
+	let state;
+	/** @type {Set<import('./types').StateListener<TState>>} */
+	const listeners = new Set();
+
+	/** @type {import('./types').SetState<TState>} */
+	const setState = ( partial, replace ) => {
+		const nextState =
+			typeof partial === 'function' ? partial( state ) : partial;
+		if ( nextState !== state ) {
+			const previousState = state;
+			state = replace
+				? /** @type {TState} */ ( nextState )
+				: Object.assign( {}, state, nextState );
+			listeners.forEach( ( listener ) =>
+				listener( state, previousState )
+			);
+		}
+	};
+
+	/** @type {import('./types').GetState<TState>} */
+	const getState = () => state;
+
+	/**
+	 * @template StateSlice
+	 * @param {import('./types').StateSliceListener<StateSlice>} listener
+	 * @param {import('./types').StateSelector<TState, StateSlice>} selector
+	 * @param {import('./types').EqualityChecker<StateSlice>} equalityFn
+	 */
+	const subscribeWithSelector = (
+		listener,
+		selector = /** @type {any} */ ( getState ),
+		equalityFn = Object.is
+	) => {
+		/** @type {StateSlice} */
+		let currentSlice = selector( state );
+		function listenerToAdd() {
+			const nextSlice = selector( state );
+			if ( ! equalityFn( currentSlice, nextSlice ) ) {
+				const previousSlice = currentSlice;
+				listener( ( currentSlice = nextSlice ), previousSlice );
+			}
+		}
+		listeners.add( listenerToAdd );
+		// Unsubscribe
+		return () => listeners.delete( listenerToAdd );
+	};
+
+	/**
+	 * @template StateSlice
+	 * @param {import('./types').StateListener<StateSlice> | import('./types').StateSliceListener<StateSlice> } listener
+	 * @param {import('./types').StateSelector<TState, StateSlice>} [selector]
+	 * @param {import('./types').EqualityChecker<StateSlice>} [equalityFn]
+	 */
+	const subscribe = ( listener, selector, equalityFn ) => {
+		if ( selector || equalityFn ) {
+			return subscribeWithSelector(
+				/** @type {import('./types').StateSliceListener<StateSlice>} */ ( listener ),
+				selector,
+				equalityFn
+			);
+		}
+		listeners.add(
+			/** @type {import('./types').StateListener<TState>} */ ( listener )
+		);
+		// Unsubscribe
+		return () =>
+			listeners.delete(
+				/** @type {import('./types').StateListener<TState>} */ ( listener )
+			);
+	};
+
+	/**
+	 * @type {import('./types').Destroy}
+	 */
+	const destroy = () => listeners.clear();
+	const api = { setState, getState, subscribe, destroy };
+	state = createState( setState, getState, api );
+	return api;
+}
+/* eslint-enable jsdoc/no-undefined-types */

--- a/packages/substate/tsconfig.json
+++ b/packages/substate/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"include": ["src/**/*"],
+	"references": [ { "path": "../element" } ]
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This package is a fork of zustand plus one `useSubState` hook that is a dependency of G2.

Question is, should this just go into `compose`? Or can it stay as it's own package?

## How has this been tested?
Unused so build just has to pass.

## Types of changes
New feature/package

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
