### PR TITLE
Add a welcome comment to first time contributor PRs

### DIFF
--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -57,7 +57,7 @@ async function firstTimeContributorLabel( payload, octokit ) {
 		issue_number: payload.pull_request.number,
 		body: ':wave: Thanks for your first Pull Request and for helping build the future of Gutenberg and WordPress, @' +
 		author +
-		"!. In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/), +
+		"!. In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/)," +
 		'where we hold [regularly weekly meetings](https://make.wordpress.org/core/tag/core-editor-summary/) open to anyone to coordinate with each other.\n\n' +
 		'If you want to learn more about WordPress development in general, check out the [Core Handbook](https://make.wordpress.org/core/handbook/) full of helpful information.'
 	} );

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -46,6 +46,22 @@ async function firstTimeContributorLabel( payload, octokit ) {
 		issue_number: payload.pull_request.number,
 		labels: [ 'First-time Contributor' ],
 	} );
+	
+/**
+ * Adds a welcome comment to the first time PR
+ */
+	
+	await octokit.issues.createComment( {
+		owner,
+		repo,
+		issue_number: payload.pull_request.number,
+		body: ':wave: Thanks for your first Pull Request and for helping build the future of Gutenberg and WordPress, @' +
+		author +
+		"!. In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/), +
+		'where we hold [regularly weekly meetings](https://make.wordpress.org/core/tag/core-editor-summary/) open to anyone to coordinate with each other.\n\n' +
+		'If you want to learn more about WordPress development in general, check out the [Core Handbook](https://make.wordpress.org/core/handbook/) full of helpful information.'
+	} );
+}
 }
 
 module.exports = firstTimeContributorLabel;

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -46,20 +46,21 @@ async function firstTimeContributorLabel( payload, octokit ) {
 		issue_number: payload.pull_request.number,
 		labels: [ 'First-time Contributor' ],
 	} );
-	
-/**
- * Adds a welcome comment to the first time PR
- */
-	
+
+	/**
+	 * Adds a welcome comment to the first time PR
+	 */
+
 	await octokit.issues.createComment( {
 		owner,
 		repo,
 		issue_number: payload.pull_request.number,
-		body: ':wave: Thanks for your first Pull Request and for helping build the future of Gutenberg and WordPress, @' +
-		author +
-		"!. In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/)," +
-		'where we hold [regularly weekly meetings](https://make.wordpress.org/core/tag/core-editor-summary/) open to anyone to coordinate with each other.\n\n' +
-		'If you want to learn more about WordPress development in general, check out the [Core Handbook](https://make.wordpress.org/core/handbook/) full of helpful information.'
+		body:
+			':wave: Thanks for your first Pull Request and for helping build the future of Gutenberg and WordPress, @' +
+			author +
+			"!. In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/)," +
+			'where we hold [regularly weekly meetings](https://make.wordpress.org/core/tag/core-editor-summary/) open to anyone to coordinate with each other.\n\n' +
+			'If you want to learn more about WordPress development in general, check out the [Core Handbook](https://make.wordpress.org/core/handbook/) full of helpful information.',
 	} );
 }
 

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -62,6 +62,5 @@ async function firstTimeContributorLabel( payload, octokit ) {
 		'If you want to learn more about WordPress development in general, check out the [Core Handbook](https://make.wordpress.org/core/handbook/) full of helpful information.'
 	} );
 }
-}
 
 module.exports = firstTimeContributorLabel;

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
@@ -32,6 +32,7 @@ describe( 'firstTimeContributorLabel', () => {
 			},
 			issues: {
 				addLabels: jest.fn(),
+				createComment: jest.fn(),
 			},
 		};
 
@@ -43,6 +44,7 @@ describe( 'firstTimeContributorLabel', () => {
 			author: 'ghost',
 		} );
 		expect( octokit.issues.addLabels ).not.toHaveBeenCalled();
+		expect( octokit.issues.createComment ).not.toHaveBeenCalled();
 	} );
 
 	it( 'adds the First Time Contributor label if the user has no commits', async () => {
@@ -56,8 +58,15 @@ describe( 'firstTimeContributorLabel', () => {
 			},
 			issues: {
 				addLabels: jest.fn(),
+				createComment: jest.fn(),
 			},
 		};
+
+		const expectedComment =
+			':wave: Thanks for your first Pull Request and for helping build the future of Gutenberg and WordPress, @ghost' +
+			"!. In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/)," +
+			'where we hold [regularly weekly meetings](https://make.wordpress.org/core/tag/core-editor-summary/) open to anyone to coordinate with each other.\n\n' +
+			'If you want to learn more about WordPress development in general, check out the [Core Handbook](https://make.wordpress.org/core/handbook/) full of helpful information.';
 
 		await firstTimeContributorLabel( payload, octokit );
 
@@ -71,6 +80,12 @@ describe( 'firstTimeContributorLabel', () => {
 			repo: 'gutenberg',
 			issue_number: 123,
 			labels: [ 'First-time Contributor' ],
+		} );
+		expect( octokit.issues.createComment ).toHaveBeenCalledWith( {
+			owner: 'WordPress',
+			repo: 'gutenberg',
+			issue_number: 123,
+			body: expectedComment,
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description

This PR seeks to close out this project automation task by adding in a welcome message to first time contributors encouraging them to join WordPress.org slack and to review the core handbook: https://github.com/WordPress/gutenberg/issues/27423 Rather than creating a new file, decided to just latch onto our current setup for adding the first time contributor label. 

I'm no JS developer so, in a true inception moment, I'll need some "first time contributor" like guidance here to get this right 😄 and, per usual, welcome thoughts on what this message should say. [Since we already have a message](https://github.com/WordPress/gutenberg/blob/6b8bf9173b71a2bfc6679eb400cfd2776be1653d/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js#L20-L33) in place when a PR is merged to encourage folks to connect their WordPress.org profile, I'm leaving that out.


## Types of changes

This is a new feature that adds a welcome message in GitHub to new contributors. 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
