### PR TITLE
wp-env: Fix upload directory conflict in phpunit service

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -164,6 +164,11 @@ module.exports = function buildDockerComposeConfig( config ) {
 	// https://github.com/docker-library/wordpress/issues/256
 	const cliUser = '33:33';
 
+	// If the user mounted their own uploads folder, we should not override it in the phpunit service.
+	const isMappingTestUploads = testsMounts.some( ( mount ) =>
+		mount.endsWith( ':/var/www/html/wp-content/uploads' )
+	);
+
 	return {
 		version: '3.7',
 		services: {
@@ -214,13 +219,10 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: phpunitImage,
 				depends_on: [ 'tests-wordpress' ],
 				volumes: [
-					...testsMounts.filter(
-						( mount ) =>
-							! mount.endsWith(
-								':/var/www/html/wp-content/uploads'
-							)
-					),
-					'phpunit-uploads:/var/www/html/wp-content/uploads',
+					...testsMounts,
+					...( ! isMappingTestUploads
+						? [ 'phpunit-uploads:/var/www/html/wp-content/uploads' ]
+						: [] ),
 				],
 				environment: {
 					LOCAL_DIR: 'html',

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -214,7 +214,12 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: phpunitImage,
 				depends_on: [ 'tests-wordpress' ],
 				volumes: [
-					...testsMounts,
+					...testsMounts.filter(
+						( mount ) =>
+							! mount.endsWith(
+								':/var/www/html/wp-content/uploads'
+							)
+					),
 					'phpunit-uploads:/var/www/html/wp-content/uploads',
 				],
 				environment: {

--- a/packages/env/test/build-docker-compose-config.js
+++ b/packages/env/test/build-docker-compose-config.js
@@ -73,4 +73,46 @@ describe( 'buildDockerComposeConfig', () => {
 			expect.arrayContaining( localSources )
 		);
 	} );
+
+	it( 'should not map the default phpunit uploads directory if the user has specified their own directory', () => {
+		const envConfig = {
+			...CONFIG,
+			mappings: {
+				'wp-content/uploads': {
+					path: '/path/to/wp-uploads',
+				},
+			},
+		};
+		const dockerConfig = buildDockerComposeConfig( {
+			env: { development: envConfig, tests: envConfig },
+		} );
+		const expectedVolumes = [
+			'tests-wordpress:/var/www/html',
+			'/path/to/wp-uploads:/var/www/html/wp-content/uploads',
+		];
+		expect( dockerConfig.services.phpunit.volumes ).toEqual(
+			expectedVolumes
+		);
+	} );
+
+	it( 'should map the default phpunit uploads directory even if the user has specified their own directory only for the development instance', () => {
+		const envConfig = {
+			...CONFIG,
+			mappings: {
+				'wp-content/uploads': {
+					path: '/path/to/wp-uploads',
+				},
+			},
+		};
+		const dockerConfig = buildDockerComposeConfig( {
+			env: { development: envConfig, tests: CONFIG },
+		} );
+		const expectedVolumes = [
+			'tests-wordpress:/var/www/html',
+			'phpunit-uploads:/var/www/html/wp-content/uploads',
+		];
+		expect( dockerConfig.services.phpunit.volumes ).toEqual(
+			expectedVolumes
+		);
+	} );
 } );


### PR DESCRIPTION
Resolves #27922

If a user mounts their own `wp-content/uploads` directory, this conflicts with the upload directory in the phpunit service.

The fix is to mount the user-specified directory instead of the named docker volume if the user has indicated that they want their own upload directory used for the tests service.

If the user wishes to specify their own uploads directory for development, but just have the default internal one used for testing, they can use the environments feature of wp-env:

```json
{
  "env": {
    "development": {
      "mappings": {
        "local/upload/path": "wp-content/uploads"
      }
    }
  }
}
```

## How has this been tested?
Locally, in wp-env, and in unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
