### PR TITLE
BlockSwitcher: Fix crash due to null reference

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -155,9 +155,13 @@ export const BlockSwitcher = ( { clientIds } ) => {
 		[ clientIds ]
 	);
 
-	return !! blocks?.length ? (
+	if ( ! blocks.length || blocks.some( ( block ) => ! block ) ) {
+		return null;
+	}
+
+	return (
 		<BlockSwitcherDropdownMenu clientIds={ clientIds } blocks={ blocks } />
-	) : null;
+	);
 };
 
 export default BlockSwitcher;

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -25,6 +25,16 @@ describe( 'BlockSwitcher', () => {
 		const wrapper = shallow( <BlockSwitcher /> );
 		expect( wrapper.html() ).toBeNull();
 	} );
+
+	test( 'should not render block switcher with null blocks', () => {
+		useSelect.mockImplementation( () => ( { blocks: [ null ] } ) );
+		const wrapper = shallow(
+			<BlockSwitcher
+				clientIds={ [ 'a1303fd6-3e60-4fff-a770-0e0ea656c5b9' ] }
+			/>
+		);
+		expect( wrapper.html() ).toBeNull();
+	} );
 } );
 describe( 'BlockSwitcherDropdownMenu', () => {
 	const headingBlock1 = {


### PR DESCRIPTION
## The bug 🐛

Fixes https://github.com/WordPress/gutenberg/issues/27833.

Fixes a null reference exception which occurs in `BlockSwitcher` when one selects a block, resizes the viewport from desktop to mobile, and then deletes that block.

This happens because of the execution order of `mapSelect` (the callback passed to `useSelect`).

First, note that all of the `mapSelect` callbacks in the block editor are called in the order that the component which defines the callback is mounted. This is because `subscribe` is called in a `useIsomorphicLayoutEffect` and then each listener is invoked in order of first added to last added.

https://github.com/WordPress/gutenberg/blob/4dace92fa0134c8e2f33f9ac251d50ed1e41e37e/packages/data/src/components/use-select/index.js#L180
https://github.com/WordPress/gutenberg/blob/4dace92fa0134c8e2f33f9ac251d50ed1e41e37e/packages/data/src/registry.js#L59

Now, let's go through three scenarios. This will illustrate why the crash happens after the viewport is resized but not in other cases.

**1) Deleting block on mobile**

1. User opens the editor. `BlockToolbar` is mounted as it is as the top of the block editor.
2. User selects a block. `BlockSwitcher` is mounted.
3. The block is deleted. The `mapSelect` in `BlockToolbar` is called (as `BlockToolbar` was mounted first). `getSelectedBlockClientIds()` returns an empty array which unmounts `BlockSwitcher`. All good. No crash.

**2) Deleting block on desktop**

1. User opens the editor.
2. User selects a block. `BlockSwitcher` and then `BlockToolbar` are both mounted at the same time in this order.
3. The block is deleted. `BlockToolbar` is unmounted by `BlockList`. `useSelect` does not call either one of the `mapSelect` callbacks because the component is unmounted. All good. No crash.

**3) Deleting block after resizing from desktop to mobile (the bug)**

1. User opens the editor.
2. User selects a block. `BlockSwitcher` and then `BlockToolbar` are both mounted at the same time in this order.
3. User resizes to a mobile viewport. `BlockToolbar` is moved to the top of the block editor.
4. The block is deleted. `BlockToolbar` is not unmounted as it is still visible. The `mapSelect` in `BlockSwitcher` is called (as `BlockSwitcher` was mounted first). `getBlocks()` returns `null` for one of the client IDs because it was deleted. Uh oh. Crash.

## The fix 🔧

I went with the simple fix which is to strengthen the guard in `BlockSwitcher` to check for `null` in the `blocks` array instead of merely checking `!! blocks?.length`. This aligns better with the signature of `getBlocksByClientId` which is guaranteed to return a (possible empty or sparse) array.

An alternative fix I considered is changing the semantics of `useSelect` / `subscribe` works so that callbacks are executed in order of last added to first ordered. I'm not sure if this will have other repercussions, though. It definitely doesn't fix the _general_ problem here which is that `mapSelect` is not called by `useSelect` in a top-down fashion. Let me know what you think.

## How to test this 🧪

Follow the reproduction steps in https://github.com/WordPress/gutenberg/issues/27833 and confirm that there is no crash.