### PR TITLE
Show an error message when a reusable block has gone missing.

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -136,6 +136,9 @@ export function* getEntityRecord( kind, name, key = '', query ) {
 
 		const record = yield apiFetch( { path } );
 		yield receiveEntityRecords( kind, name, record, query );
+	} catch ( error ) {
+		// We need a way to handle and access REST API errors in state
+		// Until then, catching the error ensures the resolver is marked as resolved.
 	} finally {
 		yield* __unstableReleaseStoreLock( lock );
 	}

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -274,6 +274,24 @@ describe( 'Reusable blocks', () => {
 		expect( console ).not.toHaveErrored();
 	} );
 
+	it( 'Should show a proper message when the reusable block is missing', async () => {
+		// Insert a non-existant reusable block
+		await page.evaluate( () => {
+			const { createBlock } = window.wp.blocks;
+			const { dispatch } = window.wp.data;
+			dispatch( 'core/block-editor' ).resetBlocks( [
+				createBlock( 'core/block', { ref: 123456 } ),
+			] );
+		} );
+
+		await page.waitForXPath(
+			'//*[contains(@class, "block-editor-warning")]/*[text()="Block has been deleted or is unavailable."]'
+		);
+
+		// This happens when the 404 is returned.
+		expect( console ).toHaveErrored();
+	} );
+
 	it( 'should be able to insert a reusable block twice', async () => {
 		await createReusableBlock(
 			'Awesome Paragraph',


### PR DESCRIPTION
closes #28082 

**Testing instructions**

 - Add a reusable block
 - save the post
 - go to the "manage reusable blocks" and remove the reusable block
 - Reload the post in the editor
 - Notice the "missing block" message.