### PR TITLE
Fix floating date status inferred for posts where the status has been edited

### DIFF
--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -7,7 +7,6 @@ import { withSelect } from '@wordpress/data';
 
 export function PostScheduleLabel( { date, isFloating } ) {
 	const settings = __experimentalGetSettings();
-
 	return date && ! isFloating
 		? format(
 				`${ settings.formats.date } ${ settings.formats.time }`,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -758,7 +758,7 @@ export function isEditedPostDateFloating( state ) {
 	const date = getEditedPostAttribute( state, 'date' );
 	const modified = getEditedPostAttribute( state, 'modified' );
 
-	// This should be the status of the persitedd post
+	// This should be the status of the persisted post
 	// It shouldn't use the "edited" status otherwise it breaks the
 	// infered post data floating status
 	// See https://github.com/WordPress/gutenberg/issues/28083

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -757,7 +757,12 @@ export function isEditedPostBeingScheduled( state ) {
 export function isEditedPostDateFloating( state ) {
 	const date = getEditedPostAttribute( state, 'date' );
 	const modified = getEditedPostAttribute( state, 'modified' );
-	const status = getEditedPostAttribute( state, 'status' );
+
+	// This should be the status of the persitedd post
+	// It shouldn't use the "edited" status otherwise it breaks the
+	// infered post data floating status
+	// See https://github.com/WordPress/gutenberg/issues/28083
+	const status = getCurrentPost( state ).status;
 	if (
 		status === 'draft' ||
 		status === 'auto-draft' ||

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2010,6 +2010,26 @@ describe( 'selectors', () => {
 
 			expect( isEditedPostDateFloating( state ) ).toBe( true );
 		} );
+
+		it( 'should return false for private posts even if the edited status is "draft"', () => {
+			const state = {
+				currentPost: {
+					date: '2018-09-27T01:23:45.678Z',
+					modified: '2018-09-27T01:23:45.678Z',
+					status: 'private',
+				},
+				editor: {
+					present: {
+						edits: {
+							status: 'draft',
+						},
+					},
+				},
+				initialEdits: {},
+			};
+
+			expect( isEditedPostDateFloating( state ) ).toBe( false );
+		} );
 	} );
 
 	describe( 'isSavingPost', () => {


### PR DESCRIPTION
closes #28083 

The algorithm to infer the "floating" status of post dates have been introduced in #9967. It works well but it should be using the persisted post status and not the edited one. 

See #28083 for the testing instructions. 