### PR TITLE
Show the spacer block background on hover.

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -10,6 +10,7 @@
 	}
 }
 
+.wp-block-spacer.is-hovered .block-library-spacer__resize-container,
 .block-library-spacer__resize-container.has-show-handle {
 	background: rgba($black, 0.1);
 


### PR DESCRIPTION
The spacer block is useful. But when you're in the site editor and hovering blocks, it doesn't appear visually as a spacer. This issue is inspired by this video: https://wordpress.slack.com/archives/C015GUFFC00/p1610073841174300, thank you to @brentjett @cdils. 

This PR changes it so that the spacer background color is visible not just when you select the block, but when you hover it too.

Before:

<img width="1372" alt="Screenshot 2021-01-12 at 11 39 39" src="https://user-images.githubusercontent.com/1204802/104303858-e65e5180-54ca-11eb-9ca0-faa544eb7f94.png">

After:

<img width="1339" alt="Screenshot 2021-01-12 at 11 39 50" src="https://user-images.githubusercontent.com/1204802/104303864-e8281500-54ca-11eb-91e2-5a8c2b98df68.png">

This is just one small step, and I would like to see global styles expanding the range of capabilities with regards to margins and paddings, so spacers can be used less. But in the mean time, this might improve things slightly.

_Edit: the GIF recording tool did not capture the hover style at all, the compression was too high, so I replaced with screenshots._