### PR TITLE
Add "Show block breadcrumbs" preference

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/block-variations.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.js
@@ -10,12 +10,12 @@ import {
 	pressKeyWithModifier,
 	openDocumentSettingsSidebar,
 	toggleScreenOption,
+	toggleMoreMenu,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Block variations', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-block-variations' );
-		await toggleScreenOption( 'Display block breadcrumbs', true );
 	} );
 
 	beforeEach( async () => {
@@ -24,7 +24,6 @@ describe( 'Block variations', () => {
 
 	afterAll( async () => {
 		await deactivatePlugin( 'gutenberg-test-block-variations' );
-		await toggleScreenOption( 'Display block breadcrumbs', false );
 	} );
 
 	const expectInserterItem = async (
@@ -110,6 +109,16 @@ describe( 'Block variations', () => {
 	} );
 	// @see @wordpres/block-editor/src/components/use-block-display-information (`useBlockDisplayInformation` hook).
 	describe( 'testing block display information with matching variations', () => {
+		beforeEach( async () => {
+			await toggleScreenOption( 'Display block breadcrumbs', true );
+			await toggleMoreMenu();
+		} );
+
+		afterEach( async () => {
+			await toggleScreenOption( 'Display block breadcrumbs', false );
+			await toggleMoreMenu();
+		} );
+
 		const getActiveBreadcrumb = async () =>
 			page.evaluate(
 				() =>

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.js
@@ -9,11 +9,13 @@ import {
 	searchForBlock,
 	pressKeyWithModifier,
 	openDocumentSettingsSidebar,
+	toggleScreenOption,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Block variations', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-block-variations' );
+		await toggleScreenOption( 'Display block breadcrumbs', true );
 	} );
 
 	beforeEach( async () => {
@@ -22,6 +24,7 @@ describe( 'Block variations', () => {
 
 	afterAll( async () => {
 		await deactivatePlugin( 'gutenberg-test-block-variations' );
+		await toggleScreenOption( 'Display block breadcrumbs', false );
 	} );
 
 	const expectInserterItem = async (

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -135,12 +135,18 @@ function Layout( { styles } ) {
 			),
 		};
 	}, [] );
+	const shouldShowBlockBreadcrumb =
+		! hasReducedUI &&
+		showBlockBreadcrumbs &&
+		! isMobileViewport &&
+		isRichEditingEnabled &&
+		mode === 'visual';
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,
 		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 		'show-icon-labels': showIconLabels,
-		'show-block-breadcrumbs': showBlockBreadcrumbs,
+		'show-block-breadcrumbs': shouldShowBlockBreadcrumb,
 	} );
 	const openSidebarPanel = () =>
 		openGeneralSidebar(
@@ -273,11 +279,7 @@ function Layout( { styles } ) {
 					</>
 				}
 				footer={
-					! hasReducedUI &&
-					showBlockBreadcrumbs &&
-					! isMobileViewport &&
-					isRichEditingEnabled &&
-					mode === 'visual' && (
+					shouldShowBlockBreadcrumb && (
 						<div className="edit-post-layout__footer">
 							<BlockBreadcrumb />
 						</div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -135,18 +135,11 @@ function Layout( { styles } ) {
 			),
 		};
 	}, [] );
-	const shouldShowBlockBreadcrumb =
-		! hasReducedUI &&
-		showBlockBreadcrumbs &&
-		! isMobileViewport &&
-		isRichEditingEnabled &&
-		mode === 'visual';
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,
 		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 		'show-icon-labels': showIconLabels,
-		'show-block-breadcrumbs': shouldShowBlockBreadcrumb,
 	} );
 	const openSidebarPanel = () =>
 		openGeneralSidebar(
@@ -279,7 +272,11 @@ function Layout( { styles } ) {
 					</>
 				}
 				footer={
-					shouldShowBlockBreadcrumb && (
+					! hasReducedUI &&
+					showBlockBreadcrumbs &&
+					! isMobileViewport &&
+					isRichEditingEnabled &&
+					mode === 'visual' && (
 						<div className="edit-post-layout__footer">
 							<BlockBreadcrumb />
 						</div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -136,6 +136,7 @@ function Layout( { styles } ) {
 		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 		'show-icon-labels': showIconLabels,
+		'show-block-breadcrumbs': showBlockBreadcrumbs,
 	} );
 	const openSidebarPanel = () =>
 		openGeneralSidebar(

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -93,7 +93,7 @@ function Layout( { styles } ) {
 		showMostUsedBlocks,
 		isInserterOpened,
 		showIconLabels,
-		hasReducedUI,
+		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
 		return {
 			hasFixedToolbar: select( editPostStore ).isFeatureActive(
@@ -126,8 +126,8 @@ function Layout( { styles } ) {
 			showIconLabels: select( editPostStore ).isFeatureActive(
 				'showIconLabels'
 			),
-			hasReducedUI: select( editPostStore ).isFeatureActive(
-				'reducedUI'
+			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
+				'showBlockBreadcrumbs'
 			),
 		};
 	}, [] );
@@ -268,7 +268,7 @@ function Layout( { styles } ) {
 					</>
 				}
 				footer={
-					! hasReducedUI &&
+					showBlockBreadcrumbs &&
 					! isMobileViewport &&
 					isRichEditingEnabled &&
 					mode === 'visual' && (

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -93,6 +93,7 @@ function Layout( { styles } ) {
 		showMostUsedBlocks,
 		isInserterOpened,
 		showIconLabels,
+		hasReducedUI,
 		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
 		return {
@@ -125,6 +126,9 @@ function Layout( { styles } ) {
 			).getAllShortcutRawKeyCombinations( 'core/edit-post/next-region' ),
 			showIconLabels: select( editPostStore ).isFeatureActive(
 				'showIconLabels'
+			),
+			hasReducedUI: select( editPostStore ).isFeatureActive(
+				'reducedUI'
 			),
 			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
 				'showBlockBreadcrumbs'
@@ -269,6 +273,7 @@ function Layout( { styles } ) {
 					</>
 				}
 				footer={
+					! hasReducedUI &&
 					showBlockBreadcrumbs &&
 					! isMobileViewport &&
 					isRichEditingEnabled &&

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -96,7 +96,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 				<EnableFeature
 					featureName="showBlockBreadcrumbs"
 					help={ __(
-						'Shows block breadcrumbs on the bottom of the editor.'
+						'Shows block breadcrumbs at the bottom of the editor.'
 					) }
 					label={ __( 'Display block breadcrumbs' ) }
 				/>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -93,6 +93,13 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 					help={ __( 'Make the editor look like your theme.' ) }
 					label={ __( 'Use theme styles' ) }
 				/>
+				<EnableFeature
+					featureName="showBlockBreadcrumbs"
+					help={ __(
+						'Shows block breadcrumbs on the bottom of the editor.'
+					) }
+					label={ __( 'Display block breadcrumbs' ) }
+				/>
 			</Section>
 			<Section
 				title={ __( 'Document settings' ) }

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -8,8 +8,8 @@ import { get } from 'lodash';
  */
 import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch, useSelect } from '@wordpress/data';
+import { compose, useViewportMatch } from '@wordpress/compose';
 import {
 	PostTaxonomies,
 	PostExcerptCheck,
@@ -34,9 +34,26 @@ import { store as editPostStore } from '../../store';
 const MODAL_NAME = 'edit-post/preferences';
 
 export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const { mode, isRichEditingEnabled, hasReducedUI } = useSelect(
+		( select ) => {
+			return {
+				mode: select( editPostStore ).getEditorMode(),
+				isRichEditingEnabled: select(
+					'core/editor'
+				).getEditorSettings().richEditingEnabled,
+				hasReducedUI: select( editPostStore ).isFeatureActive(
+					'reducedUI'
+				),
+			};
+		},
+		[]
+	);
+
 	if ( ! isModalActive ) {
 		return null;
 	}
+
 	return (
 		<Modal
 			className="edit-post-preferences-modal"
@@ -93,13 +110,18 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 					help={ __( 'Make the editor look like your theme.' ) }
 					label={ __( 'Use theme styles' ) }
 				/>
-				<EnableFeature
-					featureName="showBlockBreadcrumbs"
-					help={ __(
-						'Shows block breadcrumbs at the bottom of the editor.'
+				{ ! hasReducedUI &&
+					! isMobileViewport &&
+					isRichEditingEnabled &&
+					mode === 'visual' && (
+						<EnableFeature
+							featureName="showBlockBreadcrumbs"
+							help={ __(
+								'Shows block breadcrumbs at the bottom of the editor.'
+							) }
+							label={ __( 'Display block breadcrumbs' ) }
+						/>
 					) }
-					label={ __( 'Display block breadcrumbs' ) }
-				/>
 			</Section>
 			<Section
 				title={ __( 'Document settings' ) }

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -53,7 +53,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="showBlockBreadcrumbs"
-      help="Shows block breadcrumbs on the bottom of the editor."
+      help="Shows block breadcrumbs at the bottom of the editor."
       label="Display block breadcrumbs"
     />
   </Section>

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -51,6 +51,11 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
       help="Make the editor look like your theme."
       label="Use theme styles"
     />
+    <WithSelect(WithDispatch(BaseOption))
+      featureName="showBlockBreadcrumbs"
+      help="Shows block breadcrumbs on the bottom of the editor."
+      label="Display block breadcrumbs"
+    />
   </Section>
   <Section
     description="Choose what displays in the panel."

--- a/packages/edit-post/src/store/defaults.js
+++ b/packages/edit-post/src/store/defaults.js
@@ -11,6 +11,7 @@ export const PREFERENCES_DEFAULTS = {
 		fullscreenMode: true,
 		showIconLabels: false,
 		themeStyles: true,
+		showBlockBreadcrumbs: true,
 	},
 	hiddenBlockTypes: [],
 	preferredStyleVariations: {},

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -72,7 +72,8 @@ function InterfaceSkeleton(
 			className={ classnames(
 				className,
 				'interface-interface-skeleton',
-				regionsClassName
+				regionsClassName,
+				!! footer && 'has-footer'
 			) }
 		>
 			{ !! drawer && (

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -63,7 +63,7 @@ html.interface-interface-skeleton__html-container {
 	overscroll-behavior-y: none;
 
 	// Footer overlap prevention
-	.show-block-breadcrumbs & {
+	.has-footer & {
 		@include break-medium() {
 			padding-bottom: $button-size-small + $border-width;
 		}

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -63,8 +63,10 @@ html.interface-interface-skeleton__html-container {
 	overscroll-behavior-y: none;
 
 	// Footer overlap prevention
-	@include break-medium() {
-		padding-bottom: $button-size-small + $border-width;
+	.show-block-breadcrumbs & {
+		@include break-medium() {
+			padding-bottom: $button-size-small + $border-width;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
Resolves https://github.com/WordPress/gutenberg/issues/27515

- Block breadcrumbs aren't removed anymore when reduced UI is enabled
- Add an option to the preferences to enable/disable block breadcrumbs
- By default, block breadcrumbs are toggled on

## How has this been tested?
1. Open post editor
2. Make sure block breadcrumbs are displayed by default
3. Open more menu
4. Click preferences
5. Disable "Display block breadcrumbs"
6. Close preferences modal
7. Make sure block breadcrumbs aren't displayed

## Screenshots <!-- if applicable -->

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
