### PR TITLE
Fix block error when transforming blocks with Link Popover opened

### DIFF
--- a/packages/rich-text/src/component/use-anchor-ref.js
+++ b/packages/rich-text/src/component/use-anchor-ref.js
@@ -31,8 +31,10 @@ export function useAnchorRef( { ref, value, settings = {} } ) {
 	const activeFormat = name ? getActiveFormat( value, name ) : undefined;
 
 	return useMemo( () => {
-		const { ownerDocument } = ref.current;
-		const { defaultView } = ownerDocument;
+		if ( ! ref.current ) return;
+		const {
+			ownerDocument: { defaultView },
+		} = ref.current;
 		const selection = defaultView.getSelection();
 
 		if ( ! selection.rangeCount ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/28111

## To reproduce

1. Create a new post
2. Add a paragraph
3. Add a link inside the paragraph
4. While the URL PopOver is opened, convert the paragraph block into a heading (or viceversa).

I'm not sure if there is a better fix here, but I'd love any ideas if you have any...
The change in code come from this PR: https://github.com/WordPress/gutenberg/pull/26782
