### PR TITLE
Improve the intro page of the Block Editor Handbook 

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,6 +1,6 @@
 [
 	{
-		"title": "Project Overview",
+		"title": "Getting started",
 		"slug": "handbook",
 		"markdown_source": "../docs/readme.md",
 		"parent": null

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,10 +1,6 @@
-# Project Overview
+# Getting started
 
-The Gutenberg project is transforming the way content is created on WordPress. A block editor was the first product launched creating a new methodology for working with content.
-
-The Block Editor handbook provides documentation for designers and developers on how to extend the editor, and also how you can start contributing to the project. For authors, writers, and users of the block editor see the [block editor support documentation](https://wordpress.org/support/article/wordpress-editor/).
-
-![Gutenberg Demo](https://cldup.com/kZXGDcGPMU.gif)
+"Gutenberg" is the codename for the new WordPress editor, also known as the block editor. The Gutenberg project is transforming the way content is created on WordPress.
 
 Using a system of Blocks to compose and format content, the new block-based editor is designed to create rich, flexible layouts for websites and digital products. Content is created in the unit of blocks instead of freeform text with inserted media, embeds and Shortcodes (there's a Shortcode block though).
 
@@ -12,12 +8,21 @@ Blocks treat Paragraphs, Headings, Media, and Embeds all as components that, whe
 
 The Editor offers rich new value to users with visual, drag-and-drop creation tools and powerful developer enhancements with modern vendor packages, reusable components, rich APIs and hooks to modify and extend the editor through Custom Blocks, Custom Block Styles and Plugins.
 
-## Quick Links
+<!-- Here, we could add the different visuals representing the areas of the editor (see https://github.com/WordPress/gutenberg/issues/27400#issue-754467949). -->
 
--   Beginners: The [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md) walks through creating a block plugin using the `@wordpress/create-block` package; a quick and easy way to start creating your own block.
+## Quick links
+- [Create a block tutorial](#create-a-block-tutorial) 
+- Develop for the block editor 
+- [Contribute to the block editor](contribute-to-the-block-editor)
 
--   [Gutenberg Architecture](/docs/architecture/readme.md) covers the conceptual and tool choices going into the Gutenberg project, from repository structure to packages and tools.
+### [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md)
+Learn how to create your first block for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all what you need to know to get started with the block editor.
 
--   [Block API Reference](/docs/designers-developers/developers/block-api/README.md)
+### Develop for the block editor
+Whether you want to extend the functionality of the block editor, or create a plugin based on it, you will find here all the information about the basic concepts you need to get started, the block editor APIs and its architecture.
 
--   [Contributors Guide](/docs/contributors/readme.md) covers how **you** can help; be it code, design, documentation, language, or triage, we need you to help make Gutenberg.
+<!-- Here we will have chapters on the API, component references, etc ...
+Also, we can have as bullet points links pointing to these chapters. -->
+
+### [Contribute to the block editor](/docs/contributors/readme.md)
+Everything you need to know to start contributing to the block editor. Whether you are interested in the design, code, documentation, support or internationalization of the block editor, you will find here guides to help you.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -13,7 +13,7 @@ The Editor offers rich new value to users with visual, drag-and-drop creation to
 ## Quick links
 - [Create a block tutorial](#create-a-block-tutorial) 
 - Develop for the block editor 
-- [Contribute to the block editor](contribute-to-the-block-editor)
+- [Contribute to the block editor](#contribute-to-the-block-editor)
 
 ### [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md)
 Learn how to create your first block for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all what you need to know to get started with the block editor.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,13 +2,13 @@
 
 "Gutenberg" is the codename for the new WordPress editor, also known as the block editor. The Gutenberg project is transforming the way content is created on WordPress.
 
+![Quick view of the block editor](https://make.wordpress.org/core/files/2021/01/quick-view-gutenberg-editor.png)
+
 Using a system of Blocks to compose and format content, the new block-based editor is designed to create rich, flexible layouts for websites and digital products. Content is created in the unit of blocks instead of freeform text with inserted media, embeds and Shortcodes (there's a Shortcode block though).
 
 Blocks treat Paragraphs, Headings, Media, and Embeds all as components that, when strung together, make up the content stored in the WordPress database, replacing the traditional concept of freeform text with embedded media and shortcodes. The new editor is designed with progressive enhancement, meaning that it is back-compatible with all legacy content, and it also offers a process to try to convert and split a Classic block into equivalent blocks using client-side parsing. Finally, the blocks offer enhanced editing and format controls.
 
 The Editor offers rich new value to users with visual, drag-and-drop creation tools and powerful developer enhancements with modern vendor packages, reusable components, rich APIs and hooks to modify and extend the editor through Custom Blocks, Custom Block Styles and Plugins.
-
-<!-- Here, we could add the different visuals representing the areas of the editor (see https://github.com/WordPress/gutenberg/issues/27400#issue-754467949). -->
 
 ## Quick links
 - [Create a block tutorial](#create-a-block-tutorial) 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -15,8 +15,20 @@ The Editor offers rich new value to users with visual, drag-and-drop creation to
 ### [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md)
 Learn how to create your first block for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all what you need to know to get started with the block editor.
 
-### Develop for the block editor
+- [Dynamic Blocks](https://developer.wordpress.org/block-editor/tutorials/block-tutorial/creating-dynamic-blocks/)
+
+### [Develop for the block editor](https://developer.wordpress.org/block-editor/developers/)
 Whether you want to extend the functionality of the block editor, or create a plugin based on it, you will find here all the information about the basic concepts you need to get started, the block editor APIs and its architecture.
+
+- [Block Filters](https://developer.wordpress.org/block-editor/developers/filters/block-filters/)
+- [Editor Filters](https://developer.wordpress.org/block-editor/developers/filters/editor-filters/)
+- [Theming for the Block Editor](https://developer.wordpress.org/block-editor/developers/themes/)
+- [Parser Filters](https://developer.wordpress.org/block-editor/developers/filters/parser-filters/)
+- [Block API Reference](https://developer.wordpress.org/block-editor/developers/block-api/)
+- [Block Editor Accessibility](https://developer.wordpress.org/block-editor/developers/accessibility/)
+-[Internationalization](https://developer.wordpress.org/block-editor/developers/internationalization/)
+
+
 
 <!-- Here we will have chapters on the API, component references, etc ...
 Also, we can have as bullet points links pointing to these chapters. -->

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,6 +2,8 @@
 
 "Gutenberg" is the codename for the new WordPress editor, also known as the block editor. The Gutenberg project is transforming the way content is created on WordPress.
 
+**Gutenberg** is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. The project is right now in the first phase of a four-phase process that will touch every piece of WordPress -- Editing, Customization, Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor (which is the topic of the current documentation).
+
 ![Quick view of the block editor](https://make.wordpress.org/core/files/2021/01/quick-view-of-the-block-editor.png)
 
 **Legend :**

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -19,6 +19,9 @@ The Editor offers rich new value to users with visual, drag-and-drop creation to
 
 ## Quick links
 
+### [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md)
+Learn how to create your first block for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all what you need to know to get started with the block editor.
+
 ### [Develop for the block editor](https://developer.wordpress.org/block-editor/developers/)
 Whether you want to extend the functionality of the block editor, or create a plugin based on it, you will find here all the information about the basic concepts you need to get started, the block editor APIs and its architecture.
 
@@ -29,9 +32,6 @@ Whether you want to extend the functionality of the block editor, or create a pl
 - [Block API Reference](/docs/designers-developers/developers/block-api/readme.md)
 - [Block Editor Accessibility](/docs/designers-developers/developers/accessibility.md)
 - [Internationalization](/docs/designers-developers/developers/internationalization.md)
-
-### [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md)
-Learn how to create your first block for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all what you need to know to get started with the block editor.
 
 ### [Contribute to the block editor](/docs/contributors/readme.md)
 Everything you need to know to start contributing to the block editor. Whether you are interested in the design, code, triage, documentation, support or internationalization of the block editor, you will find here guides to help you.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -19,11 +19,6 @@ The Editor offers rich new value to users with visual, drag-and-drop creation to
 
 ## Quick links
 
-### [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md)
-Learn how to create your first block for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all what you need to know to get started with the block editor.
-
-- [Dynamic Blocks](https://developer.wordpress.org/block-editor/tutorials/block-tutorial/creating-dynamic-blocks/)
-
 ### [Develop for the block editor](https://developer.wordpress.org/block-editor/developers/)
 Whether you want to extend the functionality of the block editor, or create a plugin based on it, you will find here all the information about the basic concepts you need to get started, the block editor APIs and its architecture.
 
@@ -35,6 +30,8 @@ Whether you want to extend the functionality of the block editor, or create a pl
 - [Block Editor Accessibility](/docs/designers-developers/developers/accessibility.md)
 - [Internationalization](/docs/designers-developers/developers/internationalization.md)
 
+### [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md)
+Learn how to create your first block for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all what you need to know to get started with the block editor.
 
 ### [Contribute to the block editor](/docs/contributors/readme.md)
 Everything you need to know to start contributing to the block editor. Whether you are interested in the design, code, triage, documentation, support or internationalization of the block editor, you will find here guides to help you.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,7 +2,7 @@
 
 "Gutenberg" is the codename for the new WordPress editor, also known as the block editor. The Gutenberg project is transforming the way content is created on WordPress.
 
-**Gutenberg** is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. The project is right now in the first phase of a four-phase process that will touch every piece of WordPress -- Editing, Customization, Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor (which is the topic of the current documentation).
+**Gutenberg** is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. The project is right now in the second phase of a four-phase process that will touch every piece of WordPress -- Editing, **Customization** (which includes Full Site Editing, Block Patterns, Block Directory and Block based themes), Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor (which is the topic of the current documentation).
 
 ![Quick view of the block editor](https://make.wordpress.org/core/files/2021/01/quick-view-of-the-block-editor.png)
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,7 +2,12 @@
 
 "Gutenberg" is the codename for the new WordPress editor, also known as the block editor. The Gutenberg project is transforming the way content is created on WordPress.
 
-![Quick view of the block editor](https://make.wordpress.org/core/files/2021/01/quick-view-gutenberg-editor.png)
+![Quick view of the block editor](https://make.wordpress.org/core/files/2021/01/quick-view-of-the-block-editor.png)
+
+**Legend :**
+1. Block directory
+2. Block editor content area
+3. Block options
 
 Using a system of Blocks to compose and format content, the new block-based editor is designed to create rich, flexible layouts for websites and digital products. Content is created in the unit of blocks instead of freeform text with inserted media, embeds and Shortcodes (there's a Shortcode block though).
 
@@ -26,7 +31,7 @@ Whether you want to extend the functionality of the block editor, or create a pl
 - [Parser Filters](https://developer.wordpress.org/block-editor/developers/filters/parser-filters/)
 - [Block API Reference](https://developer.wordpress.org/block-editor/developers/block-api/)
 - [Block Editor Accessibility](https://developer.wordpress.org/block-editor/developers/accessibility/)
--[Internationalization](https://developer.wordpress.org/block-editor/developers/internationalization/)
+- [Internationalization](https://developer.wordpress.org/block-editor/developers/internationalization/)
 
 
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,7 +1,5 @@
 # Getting started
 
-"Gutenberg" is the codename for the new WordPress editor, also known as the block editor. The Gutenberg project is transforming the way content is created on WordPress.
-
 **Gutenberg** is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. The project is right now in the second phase of a four-phase process that will touch every piece of WordPress -- Editing, **Customization** (which includes Full Site Editing, Block Patterns, Block Directory and Block based themes), Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor (which is the topic of the current documentation).
 
 ![Quick view of the block editor](https://make.wordpress.org/core/files/2021/01/quick-view-of-the-block-editor.png)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -22,4 +22,4 @@ Whether you want to extend the functionality of the block editor, or create a pl
 Also, we can have as bullet points links pointing to these chapters. -->
 
 ### [Contribute to the block editor](/docs/contributors/readme.md)
-Everything you need to know to start contributing to the block editor. Whether you are interested in the design, code, documentation, support or internationalization of the block editor, you will find here guides to help you.
+Everything you need to know to start contributing to the block editor. Whether you are interested in the design, code, triage, documentation, support or internationalization of the block editor, you will find here guides to help you.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -5,9 +5,9 @@
 ![Quick view of the block editor](https://make.wordpress.org/core/files/2021/01/quick-view-of-the-block-editor.png)
 
 **Legend :**
-1. Block directory
+1. Block Inserter
 2. Block editor content area
-3. Block options
+3. Settings Sidebar
 
 Using a system of Blocks to compose and format content, the new block-based editor is designed to create rich, flexible layouts for websites and digital products. Content is created in the unit of blocks instead of freeform text with inserted media, embeds and Shortcodes (there's a Shortcode block though).
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -27,18 +27,14 @@ Learn how to create your first block for the WordPress block editor. From settin
 ### [Develop for the block editor](https://developer.wordpress.org/block-editor/developers/)
 Whether you want to extend the functionality of the block editor, or create a plugin based on it, you will find here all the information about the basic concepts you need to get started, the block editor APIs and its architecture.
 
-- [Block Filters](https://developer.wordpress.org/block-editor/developers/filters/block-filters/)
-- [Editor Filters](https://developer.wordpress.org/block-editor/developers/filters/editor-filters/)
-- [Theming for the Block Editor](https://developer.wordpress.org/block-editor/developers/themes/)
-- [Parser Filters](https://developer.wordpress.org/block-editor/developers/filters/parser-filters/)
-- [Block API Reference](https://developer.wordpress.org/block-editor/developers/block-api/)
-- [Block Editor Accessibility](https://developer.wordpress.org/block-editor/developers/accessibility/)
-- [Internationalization](https://developer.wordpress.org/block-editor/developers/internationalization/)
+- [Gutenberg Architecture](/docs/architecture/readme.md)
+- [Block Style Variations](/docs/designers-developers/developers/filters/block-filters.md#block-style-variations)
+- [Creating Block Patterns](/docs/designers-developers/developers/block-api/block-patterns.md)
+- [Theming for the Block Editor](/docs/designers-developers/developers/themes/readme.md)
+- [Block API Reference](/docs/designers-developers/developers/block-api/readme.md)
+- [Block Editor Accessibility](/docs/designers-developers/developers/accessibility.md)
+- [Internationalization](/docs/designers-developers/developers/internationalization.md)
 
-
-
-<!-- Here we will have chapters on the API, component references, etc ...
-Also, we can have as bullet points links pointing to these chapters. -->
 
 ### [Contribute to the block editor](/docs/contributors/readme.md)
 Everything you need to know to start contributing to the block editor. Whether you are interested in the design, code, triage, documentation, support or internationalization of the block editor, you will find here guides to help you.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,9 +11,6 @@ Blocks treat Paragraphs, Headings, Media, and Embeds all as components that, whe
 The Editor offers rich new value to users with visual, drag-and-drop creation tools and powerful developer enhancements with modern vendor packages, reusable components, rich APIs and hooks to modify and extend the editor through Custom Blocks, Custom Block Styles and Plugins.
 
 ## Quick links
-- [Create a block tutorial](#create-a-block-tutorial) 
-- Develop for the block editor 
-- [Contribute to the block editor](#contribute-to-the-block-editor)
 
 ### [Create a Block Tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md)
 Learn how to create your first block for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all what you need to know to get started with the block editor.


### PR DESCRIPTION
This PR is a first iteration to improve the Gutenberg handbook introduction page.
See https://github.com/WordPress/gutenberg/issues/27400.