### PR TITLE
Add panel button props

### DIFF
--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -149,6 +149,14 @@ The rendered children. If the children is a `Function`, it will be called with a
 -   Type: `React.ReactNode | Function`
 -   Required: No
 
+###### buttonProps
+
+Props that are passed to the `Button` component in the `PanelBodyTitle` within the panel body.
+
+-   Type: `Object`
+-   Required: No
+-   Default: `{}`
+
 ---
 
 #### PanelRow

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -21,6 +21,7 @@ import { useControlledState, useUpdateEffect } from '../utils';
 
 export function PanelBody(
 	{
+		buttonProps,
 		children,
 		className,
 		icon,
@@ -82,6 +83,7 @@ export function PanelBody(
 				isOpened={ isOpened }
 				onClick={ handleOnToggle }
 				title={ title }
+				{ ...buttonProps }
 			/>
 			{ typeof children === 'function'
 				? children( { opened: isOpened } )

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -21,7 +21,7 @@ import { useControlledState, useUpdateEffect } from '../utils';
 
 export function PanelBody(
 	{
-		buttonProps,
+		buttonProps = {},
 		children,
 		className,
 		icon,

--- a/packages/components/src/panel/stories/index.js
+++ b/packages/components/src/panel/stories/index.js
@@ -49,6 +49,11 @@ export const multipleBodies = () => {
 						<Placeholder />
 					</PanelRow>
 				</PanelBody>
+				<PanelBody
+					title="Disabled Settings"
+					initialOpen={ false }
+					buttonProps={ { disabled: true } }
+				/>
 			</Panel>
 		</ScrollableContainer>
 	);

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -136,5 +136,21 @@ describe( 'PanelBody', () => {
 
 			expect( panelContent ).toBeFalsy();
 		} );
+
+		it( 'should pass button props to panel title', () => {
+			const mock = jest.fn();
+
+			const { container } = render(
+				<PanelBody title="Panel" buttonProps={ { onClick: mock } }>
+					<div>Content</div>
+				</PanelBody>
+			);
+
+			const panelToggle = getPanelToggle( container );
+
+			fireEvent.click( panelToggle );
+
+			expect( mock ).toHaveBeenCalled();
+		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds `buttonProps` to `PanelBody` to allow modifying the button state/props for panel toggles.

## How has this been tested?
Verified manually via storybook and added tests for addition of props.

1. Run `npm run storybook:dev`
2. Check that the final section of Panels->Multiple bodies is disbled.
3. Make sure additional tests are passing.

## Screenshots <!-- if applicable -->
<img width="342" alt="Screen Shot 2021-01-12 at 4 04 34 PM" src="https://user-images.githubusercontent.com/10561050/104375273-1882aa00-54f1-11eb-808a-8fb613b8cf5e.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
