### PR TITLE
Inserter: Fix left padding on Block Pattern Inserter dropdown

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -158,7 +158,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__panel-header-patterns {
-	padding: $grid-unit-20 $grid-unit-20 0 $grid-unit-10;
+	padding: $grid-unit-20 $grid-unit-20 0;
 }
 
 .block-editor-inserter__panel-content {


### PR DESCRIPTION
## Description
This updates the left padding on the Block Inserter Patterns dropdown so that it aligns with the other elements in the Inserter. See screenshot of before/after below.


## How has this been tested?
* Tested locally, confirmed this does not affect the other Inserter tabs.

## Screenshots <!-- if applicable -->
Before/after screenshots:
<img width="662" alt="Screen Shot 2021-01-12 at 3 37 08 PM" src="https://user-images.githubusercontent.com/204742/104382824-110cd200-54ec-11eb-8f7f-6e3360badf87.png">

## Types of changes
* Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
