### PR TITLE
Annotations: Replace store name string with exposed store definition

### DIFF
--- a/packages/annotations/src/block/index.js
+++ b/packages/annotations/src/block/index.js
@@ -5,6 +5,10 @@ import { addFilter } from '@wordpress/hooks';
 import { withSelect } from '@wordpress/data';
 
 /**
+ * Internal dependencies
+ */
+import { STORE_NAME } from '../store/constants';
+/**
  * Adds annotation className to the block-list-block component.
  *
  * @param {Object} OriginalComponent The original BlockListBlock component.
@@ -13,7 +17,7 @@ import { withSelect } from '@wordpress/data';
 const addAnnotationClassName = ( OriginalComponent ) => {
 	return withSelect( ( select, { clientId, className } ) => {
 		const annotations = select(
-			'core/annotations'
+			STORE_NAME
 		).__experimentalGetAnnotationsForBlock( clientId );
 
 		return {
@@ -28,8 +32,4 @@ const addAnnotationClassName = ( OriginalComponent ) => {
 	} )( OriginalComponent );
 };
 
-addFilter(
-	'editor.BlockListBlock',
-	'core/annotations',
-	addAnnotationClassName
-);
+addFilter( 'editor.BlockListBlock', STORE_NAME, addAnnotationClassName );

--- a/packages/annotations/src/block/index.js
+++ b/packages/annotations/src/block/index.js
@@ -32,4 +32,8 @@ const addAnnotationClassName = ( OriginalComponent ) => {
 	} )( OriginalComponent );
 };
 
-addFilter( 'editor.BlockListBlock', STORE_NAME, addAnnotationClassName );
+addFilter(
+	'editor.BlockListBlock',
+	'core/annotations',
+	addAnnotationClassName
+);

--- a/packages/annotations/src/format/annotation.js
+++ b/packages/annotations/src/format/annotation.js
@@ -7,7 +7,10 @@ import { applyFormat, removeFormat } from '@wordpress/rich-text';
 const FORMAT_NAME = 'core/annotation';
 
 const ANNOTATION_ATTRIBUTE_PREFIX = 'annotation-text-';
-const STORE_NAME = 'core/annotations';
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from '../store/constants';
 
 /**
  * Applies given annotations to the given record.

--- a/packages/annotations/src/store/constants.js
+++ b/packages/annotations/src/store/constants.js
@@ -1,0 +1,6 @@
+/**
+ * The identifier for the data store.
+ *
+ * @type {string}
+ */
+export const STORE_NAME = 'core/annotations';

--- a/packages/annotations/src/store/index.js
+++ b/packages/annotations/src/store/index.js
@@ -13,7 +13,7 @@ import * as actions from './actions';
 /**
  * Module Constants
  */
-const STORE_NAME = 'core/annotations';
+import { STORE_NAME } from './constants';
 
 /**
  * Store definition for the annotations namespace.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addresses #27088. Replaces the store names (hardcoded strings) with the exposed `store` definitions. 
There's still (only) one hardcoded reference to the store name left: [`e2e-tests/plugins/plugins-api/annotations-sidebar.js`](https://github.com/WordPress/gutenberg/blob/a8e96920032ab4f9ccb38c29de34f90c296ed7a7/packages/e2e-tests/plugins/plugins-api/annotations-sidebar.js), but since it's a E2E test file, it's best to leave it there, as explained in https://github.com/WordPress/gutenberg/pull/27414#issuecomment-737991500.
## How has this been tested?
`npm run test`.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Code refactoring, non-breaking change.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->