### PR TITLE
Contact Info Enabled in Production

### DIFF
--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -3,6 +3,7 @@ package org.wordpress.mobile.WPAndroidGlue
 import android.os.Bundle
 
 data class GutenbergProps @JvmOverloads constructor(
+    val enableContactInfoBlock: Boolean,
     val enableMediaFilesCollectionBlocks: Boolean,
     val enableMentions: Boolean,
     val enableXPosts: Boolean,
@@ -39,6 +40,7 @@ data class GutenbergProps @JvmOverloads constructor(
     fun getUpdatedCapabilitiesProps() = Bundle().apply {
         putBoolean(PROP_CAPABILITIES_MENTIONS, enableMentions)
         putBoolean(PROP_CAPABILITIES_XPOSTS, enableXPosts)
+        putBoolean(PROP_CAPABILITIES_CONTACT_INFO_BLOCK, enableContactInfoBlock)
         putBoolean(PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK, enableMediaFilesCollectionBlocks)
         putBoolean(PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, enableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
@@ -66,6 +68,7 @@ data class GutenbergProps @JvmOverloads constructor(
         private const val PROP_EDITOR_MODE_EDITOR = "editor"
 
         const val PROP_CAPABILITIES = "capabilities"
+        const val PROP_CAPABILITIES_CONTACT_INFO_BLOCK = "contactInfoBlock"
         const val PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK = "mediaFilesCollectionBlock"
         const val PROP_CAPABILITIES_MENTIONS = "mentions"
         const val PROP_CAPABILITIES_XPOSTS = "xposts"

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -16,6 +16,7 @@ public struct MediaInfo: Encodable {
 
 /// Definition of capabilities to enable in the Block Editor
 public enum Capabilities: String {
+	case contactInfoBlock
     case mediaFilesCollectionBlock
     case mentions
     case xposts

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -40,12 +40,12 @@ class GutenbergViewController: UIViewController {
     @objc func saveButtonPressed(sender: UIBarButtonItem) {
         gutenberg.requestHTML()
     }
-    
+
     func registerLongPressGestureRecognizer() {
         longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress))
         view.addGestureRecognizer(longPressGesture)
     }
-    
+
     @objc func handleLongPress() {
         NotificationCenter.default.post(Notification(name: MediaUploadCoordinator.failUpload ))
     }
@@ -209,7 +209,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         print("Gutenberg requested media editor for " + mediaUrl.absoluteString)
         callback([MediaInfo(id: 1, url: "https://cldup.com/Fz-ASbo2s3.jpg", type: "image")])
     }
-    
+
     func gutenbergDidLogUserEvent(_ event: GutenbergUserEvent) {
         print("Gutenberg loged user event")
     }
@@ -278,15 +278,15 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     func gutenbergLocale() -> String? {
         return Locale.preferredLanguages.first ?? "en"
     }
-    
+
     func gutenbergTranslations() -> [String : [String]]? {
         return nil
     }
-    
+
     func gutenbergInitialContent() -> String? {
         return nil
     }
-    
+
     func gutenbergInitialTitle() -> String? {
         return nil
     }
@@ -298,6 +298,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
             .unsupportedBlockEditor: unsupportedBlockEnabled,
             .canEnableUnsupportedBlockEditor: unsupportedBlockCanBeActivated,
             .mediaFilesCollectionBlock: true,
+            .contactInfoBlock: true,
         ]
     }
 
@@ -360,7 +361,7 @@ extension GutenbergViewController {
 
         present(alert, animated: true)
     }
-    
+
     var toggleHTMLModeAction: UIAlertAction {
         return UIAlertAction(
             title: htmlMode ? "Switch To Visual" : "Switch to HTML",
@@ -369,7 +370,7 @@ extension GutenbergViewController {
                 self.toggleHTMLMode(action)
         })
     }
-    
+
     var updateHtmlAction: UIAlertAction {
         return UIAlertAction(
             title: "Update HTML",
@@ -398,7 +399,7 @@ extension GutenbergViewController {
                 self.gutenberg.updateCapabilities()
         })
     }
-    
+
     func alertWithTextInput(using handler: ((String?) -> Void)?) -> UIAlertController {
         let alert = UIAlertController(title: "Enter HTML", message: nil, preferredStyle: .alert)
         alert.addTextField()
@@ -409,7 +410,7 @@ extension GutenbergViewController {
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         return alert
     }
-    
+
     func toggleHTMLMode(_ action: UIAlertAction) {
         htmlMode = !htmlMode
         gutenberg.toggleHTMLMode()


### PR DESCRIPTION
## Description
Added native bridge capabilities for iOS and Android in order to determine whether contact info should be shown or not.

See further descriptions in linked PRs:
* `gutenberg-mobile`: [#3001](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3001)
* `WPiOS`: [#15634](https://github.com/wordpress-mobile/WordPress-iOS/pull/15634)
* `WPAndroid`: [#13758](https://github.com/wordpress-mobile/WordPress-Android/pull/13758)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
