### PR TITLE
Add stale issue workflow for issues with need info requested

### DIFF
--- a/.github/workflows/stale-issue-needs-info.yml
+++ b/.github/workflows/stale-issue-needs-info.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Help us move this issue forward. It has no activity after 15 days of requesting more information. A bot is marking the issue as stale. Please add additional information or this issued will be closed in 5 days.'
+        stale-issue-message: 'Help us move this issue forward. Since it has no activity after 15 days of requesting more information, a bot is marking the issue as stale. Please add additional information as a comment or this issued will be closed in 5 days.'
         close-issue-message: 'This issue was closed because more information was requested and there was no activity. If this is a bug report and still a problem, please supply the additional information requested and reopen the issue.'
         days-before-stale: 15
         days-before-close: 5

--- a/.github/workflows/stale-issue-needs-info.yml
+++ b/.github/workflows/stale-issue-needs-info.yml
@@ -1,0 +1,18 @@
+name: "Close stale issues that requires info"
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is being marked as stale because it is marked "Needs More Info" and has been 15 days with no activity. To keep open, remove the stale label or comment on the issue, else this will be closed in 5 days.'
+        close-issue-message: 'This issue was closed because more information was requested and there was no activity. If the issue still exists, please reopen supplying the additional information requested.'
+        days-before-stale: 15
+        days-before-close: 5
+        only-labels: '[Status] Needs More Info'
+        stale-issue-label: '[Status] Stale'

--- a/.github/workflows/stale-issue-needs-info.yml
+++ b/.github/workflows/stale-issue-needs-info.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is being marked as stale because it is marked "Needs More Info" and has been 15 days with no activity. To keep open, remove the stale label or comment on the issue, else this will be closed in 5 days.'
+        stale-issue-message: 'Help us move this issue forward. It has no activity after 15 days of requesting more information. A bot is marking the issue as stale. Please add additional information or this issued will be closed in 5 days.'
         close-issue-message: 'This issue was closed because more information was requested and there was no activity. If this is a bug report and still a problem, please supply the additional information requested and reopen the issue.'
         days-before-stale: 15
         days-before-close: 5

--- a/.github/workflows/stale-issue-needs-info.yml
+++ b/.github/workflows/stale-issue-needs-info.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is being marked as stale because it is marked "Needs More Info" and has been 15 days with no activity. To keep open, remove the stale label or comment on the issue, else this will be closed in 5 days.'
-        close-issue-message: 'This issue was closed because more information was requested and there was no activity. If the issue still exists, please reopen supplying the additional information requested.'
+        close-issue-message: 'This issue was closed because more information was requested and there was no activity. If this is a bug report and still a problem, please supply the additional information requested and reopen the issue.'
         days-before-stale: 15
         days-before-close: 5
         only-labels: '[Status] Needs More Info'


### PR DESCRIPTION
## Description

Fixes #27418

Adds a new workflow using the [GitHub stale action](https://github.com/actions/stale) to check for issues with the `[Status] Needs More Info` label and no activity in the past 15 days. For issues detected the workflow will:

1. Add label `[Status] Stale` and the message 

 >  Help us move this issue forward. It has no activity after 15 days of requesting more information. A bot is marking the issue as stale. Please add additional information or this issued will be closed in 5 days.

2. After 5 days, if no activity, and the stale label is still there it will close the issue, remove the stale label and add the message:

> This issue was closed because more information was requested and there was no activity. If the issue still exists, please reopen supplying the additional information requested.

---

@annezazu Please confirm the messages are fine, I switched to 15 days per @youknowriad comment.

