### PR TITLE
Block List: Add drop indicator for last position when appender hidden

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -106,6 +106,18 @@ function Items( {
 
 	const isAppenderDropTarget = dropTargetIndex === blockClientIds.length;
 
+	// Filter non-selected blocks as potential last drop targets.
+	const nonSelectedIds = blockClientIds.filter(
+		( id ) =>
+			! multiSelectedBlockClientIds.includes( id ) &&
+			id !== selectedBlockClientId
+	);
+
+	// Find index in list for last possible drop target.
+	const lastBlockIndex = nonSelectedIds.length
+		? blockClientIds.indexOf( nonSelectedIds[ nonSelectedIds.length - 1 ] )
+		: undefined;
+
 	return (
 		<>
 			{ blockClientIds.map( ( clientId, index ) => {
@@ -113,7 +125,16 @@ function Items( {
 					? multiSelectedBlockClientIds.includes( clientId )
 					: selectedBlockClientId === clientId;
 
-				const isDropTarget = dropTargetIndex === index;
+				// Allows display of horizontal drop indicator at the end
+				// position of a list when the appender is hidden.
+				const isLastDropTarget =
+					! renderAppender &&
+					dropTargetIndex > index &&
+					orientation === 'horizontal' &&
+					index === lastBlockIndex;
+
+				const isDropTarget =
+					dropTargetIndex === index || isLastDropTarget;
 
 				return (
 					<AsyncModeProvider
@@ -133,6 +154,7 @@ function Items( {
 								'is-dropping-horizontally':
 									isDropTarget &&
 									orientation === 'horizontal',
+								'is-last-drop-target': isLastDropTarget,
 								'has-active-entity': activeEntityBlockId,
 							} ) }
 							activeEntityBlockId={ activeEntityBlockId }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -128,7 +128,7 @@ function Items( {
 				// Allows display of horizontal drop indicator at the end
 				// position of a list when the appender is hidden.
 				const isLastDropTarget =
-					! renderAppender &&
+					renderAppender === false &&
 					dropTargetIndex > index &&
 					orientation === 'horizontal' &&
 					index === lastBlockIndex;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -33,6 +33,16 @@
 		border-top: none;
 		border-left: 4px solid var(--wp-admin-theme-color);
 	}
+
+	// Displays horizontal drop indicator after last block in list if appender is hidden
+	&.is-drop-target.is-dropping-horizontally.is-last-drop-target::before {
+		top: 0;
+		bottom: 0;
+		left: auto;
+		right: -6px;
+		border-top: none;
+		border-left: 4px solid var(--wp-admin-theme-color);
+	}
 }
 
 /**


### PR DESCRIPTION
## Description
In the course of refactoring the Gallery block to use nested image blocks, we came across the need to prevent the appender being rendered. The downside of this is that the appender’s element is actually used to display a drop indicator for the last position within the block list. 

Without the appender there is no visual cue that a block can be dropped there. This PR will add a new class to the last block so the drop indicator can be shown via it. That is, if the appender is being hidden and the block list orientation is horizontal. 

A PR trialling this approach within the context of the refactored gallery can be found at https://github.com/WordPress/gutenberg/pull/28161

## How has this been tested?
The easiest means to test this would be to tweak the buttons block by adding `renderAppender: false,` to the `innerBlocksProps` of the buttons block in  `packages/block-library/src/buttons/edit.js`

```
	const innerBlocksProps = useInnerBlocksProps( blockProps, {
		allowedBlocks: ALLOWED_BLOCKS,
		template: BUTTONS_TEMPLATE,
		orientation,
		renderAppender: false,
		__experimentalLayout: {
			type: 'default',
			alignments: [],
		},
		templateInsertUpdatesSelection: true,
	} );
```

#### Testing Instructions
1. Update  `packages/block-library/src/buttons/edit.js` to include `renderAppender: false,` in the `innerBlocksProps` .
2. Create new post, add buttons block and three buttons inside it then save.
3. Attempt to drag an individual button to the last position within the buttons block. Notice the lack of the blue drop indicator for the final position.
4. Select multiple buttons and try reordering again, confirming no drop indicator
5. Checkout this PR and reload the editor
6. Repeat steps 3 & 4 confirming this time there is a drop indicator present

## Screenshots <!-- if applicable -->

#### Buttons
| Before | After | 
|-------|-------|
| ![EndDropIndicator](https://user-images.githubusercontent.com/60436221/104558735-00e12800-568f-11eb-9bea-72796e832cd7.gif) | ![EndDropIndicator2](https://user-images.githubusercontent.com/60436221/104558738-02aaeb80-568f-11eb-8091-1f1d55289121.gif) |

#### Gallery via https://github.com/WordPress/gutenberg/pull/28161

| Before | After | After - Multiple Images |
|-------|-------|------------------------|
| ![DropIndicator](https://user-images.githubusercontent.com/60436221/104433617-07f82f80-55d6-11eb-92d9-a50b733803bd.gif) | ![DropIndicator2](https://user-images.githubusercontent.com/60436221/104433633-0c244d00-55d6-11eb-917a-c9c4e949d7c3.gif) | ![DropIndicator3](https://user-images.githubusercontent.com/60436221/104433756-2eb66600-55d6-11eb-8629-9fe5337f46c2.gif) |


## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
