### PR TITLE
Remove code no longer necessary

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -325,7 +325,7 @@ class WP_Theme_JSON_Resolver {
 				$config = $decoded_data;
 			}
 		}
-		self::$user = new WP_Theme_JSON( $config, true );
+		self::$user = new WP_Theme_JSON( $config );
 
 		return self::$user;
 	}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -294,9 +294,8 @@ class WP_Theme_JSON {
 	 * Constructor.
 	 *
 	 * @param array   $contexts A structure that follows the theme.json schema.
-	 * @param boolean $should_escape_styles Whether the incoming styles should be escaped.
 	 */
-	public function __construct( $contexts = array(), $should_escape_styles = false ) {
+	public function __construct( $contexts = array() ) {
 		$this->contexts = array();
 
 		if ( ! is_array( $contexts ) ) {
@@ -317,10 +316,10 @@ class WP_Theme_JSON {
 			// Process styles subtree.
 			$this->process_key( 'styles', $context, self::SCHEMA );
 			if ( isset( $context['styles'] ) ) {
-				$this->process_key( 'border', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
-				$this->process_key( 'color', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
-				$this->process_key( 'spacing', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
-				$this->process_key( 'typography', $context['styles'], self::SCHEMA['styles'], $should_escape_styles );
+				$this->process_key( 'border', $context['styles'], self::SCHEMA['styles'] );
+				$this->process_key( 'color', $context['styles'], self::SCHEMA['styles'] );
+				$this->process_key( 'spacing', $context['styles'], self::SCHEMA['styles'] );
+				$this->process_key( 'typography', $context['styles'], self::SCHEMA['styles'] );
 
 				if ( empty( $context['styles'] ) ) {
 					unset( $context['styles'] );
@@ -526,9 +525,8 @@ class WP_Theme_JSON {
 	 * @param string  $key Key of the subtree to normalize.
 	 * @param array   $input Whole tree to normalize.
 	 * @param array   $schema Schema to use for normalization.
-	 * @param boolean $should_escape Whether the subproperties should be escaped.
 	 */
-	private static function process_key( $key, &$input, $schema, $should_escape = false ) {
+	private static function process_key( $key, &$input, $schema ) {
 		if ( ! isset( $input[ $key ] ) ) {
 			return;
 		}
@@ -547,36 +545,6 @@ class WP_Theme_JSON {
 			$input[ $key ],
 			$schema[ $key ]
 		);
-
-		if ( $should_escape ) {
-			$subtree = $input[ $key ];
-			foreach ( $subtree as $property => $value ) {
-				$name = 'background-color';
-				if ( 'gradient' === $property ) {
-					$name = 'background';
-				}
-
-				if ( is_array( $value ) ) {
-					$result = array();
-					foreach ( $value as $subproperty => $subvalue ) {
-						$result_subproperty = safecss_filter_attr( "$name: $subvalue" );
-						if ( '' !== $result_subproperty ) {
-							$result[ $subproperty ] = $result_subproperty;
-						}
-					}
-
-					if ( empty( $result ) ) {
-						unset( $input[ $key ][ $property ] );
-					}
-				} else {
-					$result = safecss_filter_attr( "$name: $value" );
-
-					if ( '' === $result ) {
-						unset( $input[ $key ][ $property ] );
-					}
-				}
-			}
-		}
 
 		if ( 0 === count( $input[ $key ] ) ) {
 			unset( $input[ $key ] );

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -293,7 +293,7 @@ class WP_Theme_JSON {
 	/**
 	 * Constructor.
 	 *
-	 * @param array   $contexts A structure that follows the theme.json schema.
+	 * @param array $contexts A structure that follows the theme.json schema.
 	 */
 	public function __construct( $contexts = array() ) {
 		$this->contexts = array();
@@ -522,9 +522,9 @@ class WP_Theme_JSON {
 	 * This function modifies the given input by removing
 	 * the nodes that aren't valid per the schema.
 	 *
-	 * @param string  $key Key of the subtree to normalize.
-	 * @param array   $input Whole tree to normalize.
-	 * @param array   $schema Schema to use for normalization.
+	 * @param string $key Key of the subtree to normalize.
+	 * @param array  $input Whole tree to normalize.
+	 * @param array  $schema Schema to use for normalization.
 	 */
 	private static function process_key( $key, &$input, $schema ) {
 		if ( ! isset( $input[ $key ] ) ) {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -8,39 +8,6 @@
 
 class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
-	function test_user_data_is_escaped() {
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'global' => array(
-					'styles' => array(
-						'color' => array(
-							'background' => 'green',
-							'gradient'   => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
-							'link'       => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
-							'text'       => 'var:preset|color|dark-gray',
-						),
-					),
-				),
-			),
-			true
-		);
-		$result     = $theme_json->get_raw_data();
-
-		$expected = array(
-			'global' => array(
-				'styles' => array(
-					'color' => array(
-						'background' => 'green',
-						'gradient'   => 'linear-gradient(10deg,rgba(6,147,227,1) 0%,rgb(61,132,163) 37%,rgb(155,81,224) 100%)',
-						'text'       => 'var:preset|color|dark-gray',
-					),
-				),
-			),
-		);
-
-		$this->assertEqualSetsWithIndex( $expected, $result );
-	}
-
 	function test_contexts_not_valid_are_skipped() {
 		$theme_json = new WP_Theme_JSON(
 			array(


### PR DESCRIPTION
With the introduction of https://github.com/WordPress/gutenberg/pull/28061 we no longer need this code.
