### PR TITLE
Fix navigation editor error

### DIFF
--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Navigation editor allows creation of a menu 1`] = `
+"<!-- wp:navigation -->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/page/home\\"} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/page/about\\"} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/page/contact\\"} /-->
+<!-- /wp:navigation -->"
+`;
+
 exports[`Navigation editor displays the first menu from the REST response when at least one menu exists 1`] = `
 "<!-- wp:navigation -->
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"description\\":\\"\\",\\"rel\\":\\"\\",\\"url\\":\\"http://localhost:8889/\\",\\"title\\":\\"\\",\\"className\\":\\"\\"} /-->

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -144,7 +144,6 @@ describe( 'Navigation editor', () => {
 
 	it( 'allows creation of a menu', async () => {
 		const pagesResponse = createMockPages( pagesFixture );
-		// Prepare the endpoints for creating a menu.
 		const menuResponse = {
 			id: 4,
 			description: '',
@@ -154,7 +153,7 @@ describe( 'Navigation editor', () => {
 			auto_add: false,
 		};
 
-		// Initially return nothing from the API
+		// Initially return nothing from the menu and menuItem endpoints
 		await setUpResponseMocking( [
 			...getMenuMocks( { GET: [] } ),
 			...getMenuItemMocks( { GET: [] } ),
@@ -165,6 +164,7 @@ describe( 'Navigation editor', () => {
 		// Wait for the header to show that no menus are available.
 		await page.waitForXPath( '//h2[contains(., "No menus available")]' );
 
+		// Prepare the menu endpoint for creating a menu.
 		await setUpResponseMocking( [
 			...getMenuMocks( {
 				GET: [ menuResponse ],

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -189,6 +189,7 @@ describe( 'Navigation editor', () => {
 		await page.keyboard.press( 'Escape' );
 
 		// Select the navigation block and create a block from existing pages.
+		await page.waitForSelector( 'div[aria-label="Block: Navigation"]' );
 		await page.click( 'div[aria-label="Block: Navigation"]' );
 
 		const [ addAllPagesButton ] = await page.$x(

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -29,6 +29,21 @@ const menusFixture = [
 	},
 ];
 
+const pagesFixture = [
+	{
+		title: 'Home',
+		slug: 'home',
+	},
+	{
+		title: 'About',
+		slug: 'about',
+	},
+	{
+		title: 'Contact',
+		slug: 'contact',
+	},
+];
+
 // Matching against variations of the same URL encoded and non-encoded
 // produces the most reliable mocking.
 const REST_MENUS_ROUTES = [
@@ -38,6 +53,10 @@ const REST_MENUS_ROUTES = [
 const REST_MENU_ITEMS_ROUTES = [
 	'/__experimental/menu-items',
 	`rest_route=${ encodeURIComponent( '/__experimental/menu-items' ) }`,
+];
+const REST_PAGES_ROUTES = [
+	'/wp/v2/pages',
+	`rest_route=${ encodeURIComponent( '/wp/v2/pages' ) }`,
 ];
 
 /**
@@ -51,38 +70,63 @@ function matchUrlToRoute( reqUrl, routes ) {
 	return routes.some( ( route ) => reqUrl.includes( route ) );
 }
 
-/**
- * Creates mocked REST API responses for calls to menus and menu-items
- * endpoints.
- * Note: this needs to be within a single call to
- * `setUpResponseMocking` as you can only setup response mocking once per test run.
- *
- * @param {Array} menus menus to provide as mocked responses to menus entity API requests.
- * @param {Array} menuItems menu items to provide as mocked responses to menu-items entity API requests.
- */
-async function mockAllMenusResponses(
-	menus = menusFixture,
-	menuItems = menuItemsFixture
+function getEndpointMocks(
+	matchingRoutes,
+	responsesByMethod,
+	processor = ( data ) => data
 ) {
-	const mappedMenus = menus.length
-		? menus.map( ( menu, index ) => ( {
-				...menu,
-				id: index + 1,
-		  } ) )
-		: [];
+	return [ 'GET', 'POST', 'DELETE', 'PUT' ].reduce( ( mocks, restMethod ) => {
+		if ( responsesByMethod[ restMethod ] ) {
+			return [
+				...mocks,
+				{
+					match: ( request ) =>
+						matchUrlToRoute( request.url(), matchingRoutes ) &&
+						request.method() === restMethod,
+					onRequestMatch: createJSONResponse(
+						processor( responsesByMethod[ restMethod ] )
+					),
+				},
+			];
+		}
 
-	await setUpResponseMocking( [
-		{
-			match: ( request ) =>
-				matchUrlToRoute( request.url(), REST_MENUS_ROUTES ),
-			onRequestMatch: createJSONResponse( mappedMenus ),
-		},
-		{
-			match: ( request ) =>
-				matchUrlToRoute( request.url(), REST_MENU_ITEMS_ROUTES ),
-			onRequestMatch: createJSONResponse( menuItems ),
-		},
-	] );
+		return mocks;
+	}, [] );
+}
+
+function getMenuMocks( responsesByMethod ) {
+	const assignMenuIds = ( menus ) =>
+		menus.length
+			? menus.map( ( menu, index ) => ( {
+					...menu,
+					id: index + 1,
+			  } ) )
+			: [];
+
+	return getEndpointMocks(
+		REST_MENUS_ROUTES,
+		responsesByMethod,
+		assignMenuIds
+	);
+}
+
+function getMenuItemMocks( responsesByMethod ) {
+	return getEndpointMocks( REST_MENU_ITEMS_ROUTES, responsesByMethod );
+}
+
+function getPagesMocks( responsesByMethod ) {
+	const buildPages = ( pages ) =>
+		pages.map( ( { title, slug }, index ) => ( {
+			id: index + 1,
+			type: 'page',
+			link: `https://this/is/a/test/page/${ slug }`,
+			title: {
+				rendered: title,
+				raw: title,
+			},
+		} ) );
+
+	return getEndpointMocks( REST_PAGES_ROUTES, responsesByMethod, buildPages );
 }
 
 async function visitNavigationEditor() {
@@ -100,13 +144,61 @@ async function getSerializedBlocks() {
 
 describe( 'Navigation editor', () => {
 	useExperimentalFeatures( [ '#gutenberg-navigation' ] );
-
 	afterEach( async () => {
 		await setUpResponseMocking( [] );
 	} );
 
+	it( 'allows creation of a menu', async () => {
+		await setUpResponseMocking( [
+			...getMenuMocks( {
+				GET: [],
+				POST: {
+					id: 4,
+					description: '',
+					name: 'Main Menu',
+					slug: 'main-menu',
+					meta: [],
+					auto_add: false,
+				},
+			} ),
+			...getMenuItemMocks( { GET: [] } ),
+			...getPagesMocks( { GET: pagesFixture } ),
+		] );
+		await visitNavigationEditor();
+
+		// Wait for the header to show that no menus are available.
+		await page.waitForXPath( '//h2[contains(., "No menus available")]' );
+
+		// Add a new menu.
+		const [ addNewButton ] = await page.$x(
+			'//button[contains(., "Add new")]'
+		);
+		await addNewButton.click();
+		await page.keyboard.type( 'Main Menu' );
+		const [ createMenuButton ] = await page.$x(
+			'//button[contains(., "Create menu")]'
+		);
+		await createMenuButton.click();
+
+		// Close the dropdown.
+		await page.keyboard.press( 'Escape' );
+
+		// Select the navigation block and create a block from existing pages.
+		await page.click( 'div[aria-label="Block: Navigation"]' );
+
+		const [ addAllPagesButton ] = await page.$x(
+			'//button[contains(., "Add all pages")]'
+		);
+		await addAllPagesButton.click();
+
+		expect( await getSerializedBlocks() ).toMatchSnapshot();
+	} );
+
 	it( 'displays the first menu from the REST response when at least one menu exists', async () => {
-		await mockAllMenusResponses();
+		await setUpResponseMocking( [
+			...getMenuMocks( { GET: menusFixture } ),
+			...getMenuItemMocks( { GET: menuItemsFixture } ),
+		] );
 		await visitNavigationEditor();
 
 		// Wait for the header to show the menu name.

--- a/packages/edit-navigation/src/components/layout/use-navigation-block-editor.js
+++ b/packages/edit-navigation/src/components/layout/use-navigation-block-editor.js
@@ -21,11 +21,11 @@ export default function useNavigationBlockEditor( post ) {
 	);
 
 	const onChange = useCallback(
-		async ( updatedBlocks ) => {
-			await _onChange( updatedBlocks );
+		async ( ...args ) => {
+			await _onChange( ...args );
 			createMissingMenuItems( post );
 		},
-		[ blocks, _onChange ]
+		[ _onChange, post ]
 	);
 
 	return [ blocks, onInput, onChange ];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Currently when interacting with blocks on the navigation screen there's an error in the console:
```console
entity-provider.js:175 Uncaught (in promise) TypeError: Cannot read property 'selectionStart' of undefined
```

This seems to have been introduced by https://github.com/WordPress/gutenberg/pull/27954, one of the changes there is that the `onChange` function returned by the `useEntityBlockEditor` hook must be passed an object as the second argument with the selectionStart and selection End.

The navigation editor wraps `onChange` and wasn't passing this new second argument, but does now after this fix.

## How has this been tested?
Added an e2e test

1. Enable the navigation screen experiment
2. Browse to the navigation screen
3. Open your browser console
4. Try adding a menu and several blocks, the console error mentioned above shouldn't happen.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
