### PR TITLE
Avoid focusing blocks when inserting them into the canvas

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -657,6 +657,7 @@ _Returns_
 
 Returns the initial caret position for the selected block.
 This position is to used to position the caret properly when the selected block changes.
+If the current block is not a RichText, having initial position set to 0 means "focus block"
 
 _Parameters_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1309,6 +1309,7 @@ _Parameters_
 
 -   _selectionStart_ `WPBlockSelection`: The selection start.
 -   _selectionEnd_ `WPBlockSelection`: The selection end.
+-   _initialPosition_ `(||undefined)`: Initial block position.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1139,6 +1139,7 @@ _Parameters_
 -   _index_ `?number`: Index at which block should be inserted.
 -   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
 -   _updateSelection_ `?boolean`: If true block selection will be updated.  If false, block selection will not change. Defaults to true.
+-   _initialPosition_ `(||null)`: Initial focus position. Setting it to null prevent focusing the inserted block.
 -   _meta_ `?Object`: Optional Meta values to be passed to the action object.
 
 _Returns_
@@ -1272,7 +1273,7 @@ _Parameters_
 -   _clientIds_ `(string|Array<string>)`: Block client ID(s) to replace.
 -   _blocks_ `(Object|Array<Object>)`: Replacement block(s).
 -   _indexToSelect_ `number`: Index of replacement block to select.
--   _initialPosition_ `number`: Index of caret after in the selected block after the operation.
+-   _initialPosition_ `(||null)`: Index of caret after in the selected block after the operation.
 -   _meta_ `?Object`: Optional Meta values to be passed to the action object.
 
 <a name="replaceInnerBlocks" href="#replaceInnerBlocks">#</a> **replaceInnerBlocks**
@@ -1285,6 +1286,7 @@ _Parameters_
 -   _rootClientId_ `string`: Client ID of the block whose InnerBlocks will re replaced.
 -   _blocks_ `Array<Object>`: Block objects to insert as new InnerBlocks
 -   _updateSelection_ `?boolean`: If true block selection will be updated. If false, block selection will not change. Defaults to false.
+-   _initialPosition_ `(||null)`: Initial block position.
 
 _Returns_
 
@@ -1309,7 +1311,7 @@ _Parameters_
 
 -   _selectionStart_ `WPBlockSelection`: The selection start.
 -   _selectionEnd_ `WPBlockSelection`: The selection end.
--   _initialPosition_ `(||undefined)`: Initial block position.
+-   _initialPosition_ `(||null)`: Initial block position.
 
 _Returns_
 
@@ -1325,7 +1327,7 @@ reflects a reverse selection.
 _Parameters_
 
 -   _clientId_ `string`: Block client ID.
--   _initialPosition_ `?number`: Optional initial position. Pass as -1 to reflect reverse selection.
+-   _initialPosition_ `(||null)`: Optional initial position. Pass as -1 to reflect reverse selection.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -665,7 +665,7 @@ _Parameters_
 
 _Returns_
 
--   `?Object`: Selected block.
+-   `(||null)`: Initial position.
 
 <a name="getSelectionEnd" href="#getSelectionEnd">#</a> **getSelectionEnd**
 

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -373,7 +373,21 @@ _Returns_
 
 -   `Array`: Block list.
 
+<a name="getEditorSelection" href="#getEditorSelection">#</a> **getEditorSelection**
+
+Returns the current selection.
+
+_Parameters_
+
+-   _state_ `Object`: 
+
+_Returns_
+
+-   `WPBlockSelection`: The selection end.
+
 <a name="getEditorSelectionEnd" href="#getEditorSelectionEnd">#</a> **getEditorSelectionEnd**
+
+> **Deprecated** since Gutenberg 10.0.0.
 
 Returns the current selection end.
 
@@ -386,6 +400,8 @@ _Returns_
 -   `WPBlockSelection`: The selection end.
 
 <a name="getEditorSelectionStart" href="#getEditorSelectionStart">#</a> **getEditorSelectionStart**
+
+> **Deprecated** since Gutenberg 10.0.0.
 
 Returns the current selection start.
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -398,7 +398,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				}
 			}
 		},
-		onReplace( blocks, indexToSelect, initialPosition ) {
+		onReplace( blocks, indexToSelect, initialPosition = 0 ) {
 			if (
 				blocks.length &&
 				! isUnmodifiedDefaultBlock( blocks[ blocks.length - 1 ] )
@@ -409,7 +409,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				[ ownProps.clientId ],
 				blocks,
 				indexToSelect,
-				initialPosition || 0
+				initialPosition
 			);
 		},
 		toggleSelection( selectionEnabled ) {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -376,7 +376,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			const { clientId, rootClientId } = ownProps;
 			const { getBlockIndex } = select( blockEditorStore );
 			const index = getBlockIndex( clientId, rootClientId );
-			insertBlocks( blocks, index + 1, rootClientId );
+			insertBlocks( blocks, index + 1, rootClientId, 0 );
 		},
 		onMerge( forward ) {
 			const { clientId } = ownProps;
@@ -409,7 +409,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				[ ownProps.clientId ],
 				blocks,
 				indexToSelect,
-				initialPosition
+				initialPosition || 0
 			);
 		},
 		toggleSelection( selectionEnabled ) {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -376,7 +376,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			const { clientId, rootClientId } = ownProps;
 			const { getBlockIndex } = select( blockEditorStore );
 			const index = getBlockIndex( clientId, rootClientId );
-			insertBlocks( blocks, index + 1, rootClientId, 0 );
+			insertBlocks( blocks, index + 1, rootClientId );
 		},
 		onMerge( forward ) {
 			const { clientId } = ownProps;
@@ -398,7 +398,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				}
 			}
 		},
-		onReplace( blocks, indexToSelect, initialPosition = 0 ) {
+		onReplace( blocks, indexToSelect, initialPosition ) {
 			if (
 				blocks.length &&
 				! isUnmodifiedDefaultBlock( blocks[ blocks.length - 1 ] )

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -18,6 +18,7 @@ import useBlockDropZone from '../use-block-drop-zone';
 import useInsertionPoint from './insertion-point';
 import BlockPopover from './block-popover';
 import { store as blockEditorStore } from '../../store';
+import { useScrollSelectionIntoView } from '../selection-scroll-into-view';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -32,6 +33,7 @@ export default function BlockList( { className } ) {
 	const ref = useRef();
 	const [ blockNodes, setBlockNodes ] = useState( {} );
 	const insertionPoint = useInsertionPoint( ref );
+	useScrollSelectionIntoView( ref );
 
 	return (
 		<BlockNodes.Provider value={ blockNodes }>

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -62,7 +62,7 @@ export function useFocusFirstElement( ref, clientId ) {
 	const initialPosition = useInitialPosition( clientId );
 
 	useEffect( () => {
-		if ( initialPosition === undefined ) {
+		if ( initialPosition === undefined || initialPosition === null ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -45,7 +45,7 @@ function useInitialPosition( clientId ) {
 			}
 
 			// If there's no initial position, return 0 to focus the start.
-			return getSelectedBlocksInitialCaretPosition() || 0;
+			return getSelectedBlocksInitialCaretPosition();
 		},
 		[ clientId ]
 	);
@@ -53,7 +53,7 @@ function useInitialPosition( clientId ) {
 
 /**
  * Transitions focus to the block or inner tabbable when the block becomes
- * selected.
+ * selected and an initial position is set.
  *
  * @param {RefObject} ref      React ref with the block element.
  * @param {string}    clientId Block client ID.

--- a/packages/block-editor/src/components/block-navigation/appender.js
+++ b/packages/block-editor/src/components/block-navigation/appender.js
@@ -67,7 +67,6 @@ export default function BlockNavigationAppender( {
 						<Inserter
 							rootClientId={ parentBlockClientId }
 							__experimentalIsQuick
-							__experimentalSelectBlockOnInsert={ false }
 							aria-describedby={ descriptionId }
 							toggleProps={ { ref, tabIndex, onFocus } }
 						/>

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -84,7 +84,12 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const isTemplate = blocks.length === 1 && isTemplatePart( blocks[ 0 ] );
 
 	const onTransform = ( name ) =>
-		replaceBlocks( clientIds, switchToBlockType( blocks, name ) );
+		replaceBlocks(
+			clientIds,
+			switchToBlockType( blocks, name ),
+			undefined,
+			0
+		);
 	const hasPossibleBlockTransformations = !! possibleBlockTransformations.length;
 	if ( ! hasBlockStyles && ! hasPossibleBlockTransformations ) {
 		return (

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -84,12 +84,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const isTemplate = blocks.length === 1 && isTemplatePart( blocks[ 0 ] );
 
 	const onTransform = ( name ) =>
-		replaceBlocks(
-			clientIds,
-			switchToBlockType( blocks, name ),
-			undefined,
-			0
-		);
+		replaceBlocks( clientIds, switchToBlockType( blocks, name ) );
 	const hasPossibleBlockTransformations = !! possibleBlockTransformations.length;
 	if ( ! hasBlockStyles && ! hasPossibleBlockTransformations ) {
 		return (

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -17,20 +17,13 @@ import { Icon, plus } from '@wordpress/icons';
 import Inserter from '../inserter';
 
 function ButtonBlockAppender(
-	{
-		rootClientId,
-		className,
-		__experimentalSelectBlockOnInsert: selectBlockOnInsert,
-		onFocus,
-		tabIndex,
-	},
+	{ rootClientId, className, onFocus, tabIndex },
 	ref
 ) {
 	return (
 		<Inserter
 			position="bottom center"
 			rootClientId={ rootClientId }
-			__experimentalSelectBlockOnInsert={ selectBlockOnInsert }
 			__experimentalIsQuick
 			renderToggle={ ( {
 				onToggle,

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -101,10 +101,7 @@ export { default as Inserter } from './inserter';
 export { default as __experimentalLibrary } from './inserter/library';
 export { default as __experimentalSearchForm } from './inserter/search-form';
 export { default as BlockEditorKeyboardShortcuts } from './keyboard-shortcuts';
-export {
-	default as MultiSelectScrollIntoView,
-	useScrollMultiSelectionIntoView as __unstableUseScrollMultiSelectionIntoView,
-} from './multi-select-scroll-into-view';
+export { MultiSelectScrollIntoView } from './selection-scroll-into-view';
 export { default as NavigableToolbar } from './navigable-toolbar';
 export {
 	default as ObserveTyping,

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -40,8 +40,12 @@ export default function useInnerBlockTemplateSync(
 	templateLock,
 	templateInsertUpdatesSelection
 ) {
+	const getSelectedBlocksInitialCaretPosition = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSelectedBlocksInitialCaretPosition,
+		[]
+	);
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
-
 	const innerBlocks = useSelect(
 		( select ) => select( blockEditorStore ).getBlocks( clientId ),
 		[ clientId ]
@@ -69,7 +73,12 @@ export default function useInnerBlockTemplateSync(
 						nextBlocks,
 						innerBlocks.length === 0 &&
 							templateInsertUpdatesSelection &&
-							nextBlocks.length !== 0
+							nextBlocks.length !== 0,
+						// This ensures the "initialPosition" doesn't change when applying the template
+						// If we're supposed to focus the block, we'll focus the first inner block
+						// otherwise, we won't apply any auto-focus.
+						// This ensures for instance that the focus stays in the inserter when inserting the "buttons" block.
+						getSelectedBlocksInitialCaretPosition()
 					);
 				}
 			}

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -83,7 +83,7 @@ function InserterListItem( {
 						disabled={ item.isDisabled }
 						onClick={ ( event ) => {
 							event.preventDefault();
-							onSelect( item );
+							onSelect( item, event.metaKey );
 							onHover( null );
 						} }
 						onFocus={ () => {

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -23,6 +23,22 @@ import { ENTER } from '@wordpress/keycodes';
 import BlockIcon from '../block-icon';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 
+/**
+ * Return true if platform is MacOS.
+ *
+ * @param {Object} _window   window object by default; used for DI testing.
+ *
+ * @return {boolean} True if MacOS; false otherwise.
+ */
+function isAppleOS( _window = window ) {
+	const { platform } = _window.navigator;
+
+	return (
+		platform.indexOf( 'Mac' ) !== -1 ||
+		[ 'iPad', 'iPhone' ].includes( platform )
+	);
+}
+
 function InserterListItem( {
 	className,
 	composite,
@@ -84,14 +100,20 @@ function InserterListItem( {
 						disabled={ item.isDisabled }
 						onClick={ ( event ) => {
 							event.preventDefault();
-							onSelect( item, event.metaKey );
+							onSelect(
+								item,
+								isAppleOS() ? event.metaKey : event.ctrlKey
+							);
 							onHover( null );
 						} }
 						onKeyDown={ ( event ) => {
 							const { keyCode } = event;
 							if ( keyCode === ENTER ) {
 								event.preventDefault();
-								onSelect( item, event.metaKey );
+								onSelect(
+									item,
+									isAppleOS() ? event.metaKey : event.ctrlKey
+								);
 								onHover( null );
 							}
 						} }

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -15,6 +15,7 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 } from '@wordpress/blocks';
+import { ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -85,6 +86,14 @@ function InserterListItem( {
 							event.preventDefault();
 							onSelect( item, event.metaKey );
 							onHover( null );
+						} }
+						onKeyDown={ ( event ) => {
+							const { keyCode } = event;
+							if ( keyCode === ENTER ) {
+								event.preventDefault();
+								onSelect( item, event.metaKey );
+								onHover( null );
+							}
 						} }
 						onFocus={ () => {
 							if ( isDragging.current ) {

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -37,14 +37,14 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 	);
 
 	const onSelectItem = useCallback(
-		( { name, initialAttributes, innerBlocks } ) => {
+		( { name, initialAttributes, innerBlocks }, shouldFocusBlock ) => {
 			const insertedBlock = createBlock(
 				name,
 				initialAttributes,
 				createBlocksFromInnerBlocksTemplate( innerBlocks )
 			);
 
-			onInsert( insertedBlock );
+			onInsert( insertedBlock, undefined, shouldFocusBlock );
 		},
 		[ onInsert ]
 	);

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -40,13 +40,13 @@ function useInsertionPoint( {
 	onSelect,
 } ) {
 	const {
-		selectedBlock,
 		destinationRootClientId,
 		destinationIndex,
+		getSelectedBlock,
 	} = useSelect(
 		( select ) => {
 			const {
-				getSelectedBlock,
+				getSelectedBlock: _getSelectedBlock,
 				getBlockIndex,
 				getBlockOrder,
 				getBlockInsertionPoint,
@@ -84,7 +84,7 @@ function useInsertionPoint( {
 			}
 
 			return {
-				selectedBlock: getSelectedBlock(),
+				getSelectedBlock: _getSelectedBlock,
 				destinationRootClientId: _destinationRootClientId,
 				destinationIndex: _destinationIndex,
 			};
@@ -101,6 +101,8 @@ function useInsertionPoint( {
 
 	const onInsertBlocks = useCallback(
 		( blocks, meta ) => {
+			const selectedBlock = getSelectedBlock();
+
 			if (
 				! isAppender &&
 				selectedBlock &&
@@ -137,7 +139,7 @@ function useInsertionPoint( {
 		},
 		[
 			isAppender,
-			selectedBlock,
+			getSelectedBlock,
 			replaceBlocks,
 			insertBlocks,
 			destinationRootClientId,

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -1,9 +1,14 @@
 /**
+ * External dependencies
+ */
+import { castArray } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
-import { _n } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { useCallback } from '@wordpress/element';
 
@@ -125,12 +130,14 @@ function useInsertionPoint( {
 					meta
 				);
 			}
-
-			// translators: %d: the name of the block that has been added
-			const message = _n(
-				'%d block added.',
-				'%d blocks added.',
-				blocks.length
+			const message = sprintf(
+				// translators: %d: the name of the block that has been added
+				_n(
+					'%d block added.',
+					'%d blocks added.',
+					castArray( blocks ).length
+				),
+				castArray( blocks ).length
 			);
 			speak( message );
 

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -106,7 +106,7 @@ function useInsertionPoint( {
 	} = useDispatch( blockEditorStore );
 
 	const onInsertBlocks = useCallback(
-		( blocks, meta ) => {
+		( blocks, meta, shouldForceFocusBlock = false ) => {
 			const selectedBlock = getSelectedBlock();
 
 			if (
@@ -118,7 +118,7 @@ function useInsertionPoint( {
 					selectedBlock.clientId,
 					blocks,
 					null,
-					shouldFocusBlock ? 0 : undefined,
+					shouldFocusBlock || shouldForceFocusBlock ? 0 : undefined,
 					meta
 				);
 			} else {
@@ -126,7 +126,7 @@ function useInsertionPoint( {
 					blocks,
 					destinationIndex,
 					destinationRootClientId,
-					shouldFocusBlock,
+					shouldFocusBlock || shouldForceFocusBlock,
 					meta
 				);
 			}
@@ -153,6 +153,7 @@ function useInsertionPoint( {
 			destinationRootClientId,
 			destinationIndex,
 			onSelect,
+			shouldFocusBlock,
 		]
 	);
 

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -38,6 +38,7 @@ function useInsertionPoint( {
 	clientId,
 	isAppender,
 	onSelect,
+	shouldFocusBlock = true,
 } ) {
 	const {
 		destinationRootClientId,
@@ -112,7 +113,7 @@ function useInsertionPoint( {
 					selectedBlock.clientId,
 					blocks,
 					null,
-					undefined,
+					shouldFocusBlock ? 0 : undefined,
 					meta
 				);
 			} else {
@@ -120,7 +121,7 @@ function useInsertionPoint( {
 					blocks,
 					destinationIndex,
 					destinationRootClientId,
-					false,
+					shouldFocusBlock,
 					meta
 				);
 			}

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -1,14 +1,9 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
-import { _n, sprintf } from '@wordpress/i18n';
+import { _n } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { useCallback } from '@wordpress/element';
 
@@ -28,8 +23,6 @@ import { store as blockEditorStore } from '../../../store';
  *                                           block with this ID.
  * @property {boolean=}  isAppender          Whether the inserter is an appender
  *                                           or not.
- * @property {boolean=}  selectBlockOnInsert Whether the block should be
- *                                           selected on insert.
  * @property {Function=} onSelect            Called after insertion.
  */
 
@@ -44,7 +37,6 @@ function useInsertionPoint( {
 	insertionIndex,
 	clientId,
 	isAppender,
-	selectBlockOnInsert,
 	onSelect,
 } ) {
 	const {
@@ -118,7 +110,7 @@ function useInsertionPoint( {
 					selectedBlock.clientId,
 					blocks,
 					null,
-					null,
+					undefined,
 					meta
 				);
 			} else {
@@ -126,23 +118,18 @@ function useInsertionPoint( {
 					blocks,
 					destinationIndex,
 					destinationRootClientId,
-					selectBlockOnInsert,
+					false,
 					meta
 				);
 			}
 
-			if ( ! selectBlockOnInsert ) {
-				const message = sprintf(
-					// translators: %d: the name of the block that has been added
-					_n(
-						'%d block added.',
-						'%d blocks added.',
-						castArray( blocks ).length
-					),
-					castArray( blocks ).length
-				);
-				speak( message );
-			}
+			// translators: %d: the name of the block that has been added
+			const message = _n(
+				'%d block added.',
+				'%d blocks added.',
+				blocks.length
+			);
+			speak( message );
 
 			if ( onSelect ) {
 				onSelect();
@@ -155,7 +142,6 @@ function useInsertionPoint( {
 			insertBlocks,
 			destinationRootClientId,
 			destinationIndex,
-			selectBlockOnInsert,
 			onSelect,
 		]
 	);

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -118,7 +118,7 @@ function useInsertionPoint( {
 					selectedBlock.clientId,
 					blocks,
 					null,
-					shouldFocusBlock || shouldForceFocusBlock ? 0 : undefined,
+					shouldFocusBlock || shouldForceFocusBlock ? 0 : null,
 					meta
 				);
 			} else {

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -126,7 +126,8 @@ function useInsertionPoint( {
 					blocks,
 					destinationIndex,
 					destinationRootClientId,
-					shouldFocusBlock || shouldForceFocusBlock,
+					true,
+					shouldFocusBlock || shouldForceFocusBlock ? 0 : null,
 					meta
 				);
 			}

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -132,7 +132,6 @@ class Inserter extends Component {
 			clientId,
 			isAppender,
 			showInserterHelpPanel,
-			__experimentalSelectBlockOnInsert: selectBlockOnInsert,
 
 			// This prop is experimental to give some time for the quick inserter to mature
 			// Feel free to make them stable after a few releases.
@@ -148,7 +147,6 @@ class Inserter extends Component {
 					rootClientId={ rootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }
-					selectBlockOnInsert={ selectBlockOnInsert }
 				/>
 			);
 		}
@@ -162,7 +160,6 @@ class Inserter extends Component {
 				clientId={ clientId }
 				isAppender={ isAppender }
 				showInserterHelpPanel={ showInserterHelpPanel }
-				__experimentalSelectBlockOnInsert={ selectBlockOnInsert }
 			/>
 		);
 	}
@@ -239,12 +236,9 @@ export default compose( [
 					rootClientId,
 					clientId,
 					isAppender,
-					onSelectOrClose,
-				} = ownProps;
-				const {
 					hasSingleBlockType,
 					allowedBlockType,
-					__experimentalSelectBlockOnInsert: selectBlockOnInsert,
+					onSelectOrClose,
 				} = ownProps;
 
 				if ( ! hasSingleBlockType ) {
@@ -281,21 +275,19 @@ export default compose( [
 					blockToInsert,
 					getInsertionIndex(),
 					rootClientId,
-					selectBlockOnInsert
+					false
 				);
 
 				if ( onSelectOrClose ) {
 					onSelectOrClose();
 				}
 
-				if ( ! selectBlockOnInsert ) {
-					const message = sprintf(
-						// translators: %s: the name of the block that has been added
-						__( '%s block added' ),
-						allowedBlockType.title
-					);
-					speak( message );
-				}
+				const message = sprintf(
+					// translators: %s: the name of the block that has been added
+					__( '%s block added' ),
+					allowedBlockType.title
+				);
+				speak( message );
 			},
 		};
 	} ),

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -271,12 +271,7 @@ export default compose( [
 
 				const blockToInsert = createBlock( allowedBlockType.name );
 
-				insertBlock(
-					blockToInsert,
-					getInsertionIndex(),
-					rootClientId,
-					false
-				);
+				insertBlock( blockToInsert, getInsertionIndex(), rootClientId );
 
 				if ( onSelectOrClose ) {
 					onSelectOrClose();

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -20,7 +20,6 @@ function InserterLibrary( {
 	isAppender,
 	showInserterHelpPanel,
 	showMostUsedBlocks = false,
-	__experimentalSelectBlockOnInsert,
 	__experimentalInsertionIndex,
 	onSelect = noop,
 } ) {
@@ -43,9 +42,6 @@ function InserterLibrary( {
 			isAppender={ isAppender }
 			showInserterHelpPanel={ showInserterHelpPanel }
 			showMostUsedBlocks={ showMostUsedBlocks }
-			__experimentalSelectBlockOnInsert={
-				__experimentalSelectBlockOnInsert
-			}
 			__experimentalInsertionIndex={ __experimentalInsertionIndex }
 		/>
 	);

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -43,6 +43,7 @@ function InserterLibrary( {
 			showInserterHelpPanel={ showInserterHelpPanel }
 			showMostUsedBlocks={ showMostUsedBlocks }
 			__experimentalInsertionIndex={ __experimentalInsertionIndex }
+			shouldFocusBlock={ false }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -28,6 +28,7 @@ function InserterMenu( {
 	onSelect,
 	showInserterHelpPanel,
 	showMostUsedBlocks,
+	shouldFocusBlock = true,
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
@@ -44,6 +45,7 @@ function InserterMenu( {
 		clientId,
 		isAppender,
 		insertionIndex: __experimentalInsertionIndex,
+		shouldFocusBlock,
 	} );
 	const { showPatterns, hasReusableBlocks } = useSelect(
 		( select ) => {
@@ -188,6 +190,7 @@ function InserterMenu( {
 							clientId={ clientId }
 							isAppender={ isAppender }
 							showBlockDirectory
+							shouldFocusBlock={ shouldFocusBlock }
 						/>
 					) }
 					{ ! filterValue && ( showPatterns || hasReusableBlocks ) && (

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -24,7 +24,6 @@ function InserterMenu( {
 	rootClientId,
 	clientId,
 	isAppender,
-	__experimentalSelectBlockOnInsert,
 	__experimentalInsertionIndex,
 	onSelect,
 	showInserterHelpPanel,
@@ -44,7 +43,6 @@ function InserterMenu( {
 		rootClientId,
 		clientId,
 		isAppender,
-		selectBlockOnInsert: __experimentalSelectBlockOnInsert,
 		insertionIndex: __experimentalInsertionIndex,
 	} );
 	const { showPatterns, hasReusableBlocks } = useSelect(
@@ -189,9 +187,6 @@ function InserterMenu( {
 							rootClientId={ rootClientId }
 							clientId={ clientId }
 							isAppender={ isAppender }
-							selectBlockOnInsert={
-								__experimentalSelectBlockOnInsert
-							}
 							showBlockDirectory
 						/>
 					) }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -67,8 +67,8 @@ function InserterMenu( {
 	);
 
 	const onInsert = useCallback(
-		( blocks ) => {
-			onInsertBlocks( blocks );
+		( blocks, meta, shouldForceFocusBlock ) => {
+			onInsertBlocks( blocks, meta, shouldForceFocusBlock );
 			onSelect();
 		},
 		[ onInsertBlocks, onSelect ]

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -30,7 +30,6 @@ export default function QuickInserter( {
 	rootClientId,
 	clientId,
 	isAppender,
-	selectBlockOnInsert,
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
@@ -38,7 +37,6 @@ export default function QuickInserter( {
 		rootClientId,
 		clientId,
 		isAppender,
-		selectBlockOnInsert,
 	} );
 	const [ blockTypes ] = useBlockTypesState(
 		destinationRootClientId,
@@ -105,7 +103,6 @@ export default function QuickInserter( {
 					rootClientId={ rootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }
-					selectBlockOnInsert={ selectBlockOnInsert }
 					maxBlockPatterns={ showPatterns ? SHOWN_BLOCK_PATTERNS : 0 }
 					maxBlockTypes={ SHOWN_BLOCK_TYPES }
 					isDraggable={ false }

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -36,6 +36,7 @@ function InserterSearchResults( {
 	maxBlockTypes,
 	showBlockDirectory = false,
 	isDraggable = true,
+	shouldFocusBlock = true,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
@@ -44,6 +45,7 @@ function InserterSearchResults( {
 		rootClientId,
 		clientId,
 		isAppender,
+		shouldFocusBlock,
 	} );
 	const [
 		blockTypes,

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -32,7 +32,6 @@ function InserterSearchResults( {
 	rootClientId,
 	clientId,
 	isAppender,
-	selectBlockOnInsert,
 	maxBlockPatterns,
 	maxBlockTypes,
 	showBlockDirectory = false,
@@ -45,7 +44,6 @@ function InserterSearchResults( {
 		rootClientId,
 		clientId,
 		isAppender,
-		selectBlockOnInsert,
 	} );
 	const [
 		blockTypes,

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -256,7 +256,13 @@ describe( 'useBlockSync hook', () => {
 
 		expect( onInput ).toHaveBeenCalledWith(
 			[ { clientId: 'a', innerBlocks: [], attributes: { foo: 2 } } ],
-			{ selectionEnd: {}, selectionStart: {} }
+			{
+				selection: {
+					selectionEnd: {},
+					selectionStart: {},
+					initialPosition: undefined,
+				},
+			}
 		);
 		expect( onChange ).not.toHaveBeenCalled();
 	} );
@@ -292,7 +298,13 @@ describe( 'useBlockSync hook', () => {
 
 		expect( onChange ).toHaveBeenCalledWith(
 			[ { clientId: 'a', innerBlocks: [], attributes: { foo: 2 } } ],
-			{ selectionEnd: {}, selectionStart: {} }
+			{
+				selection: {
+					selectionEnd: {},
+					selectionStart: {},
+					initialPosition: undefined,
+				},
+			}
 		);
 		expect( onInput ).not.toHaveBeenCalled();
 	} );
@@ -395,7 +407,13 @@ describe( 'useBlockSync hook', () => {
 					attributes: { foo: 2 },
 				},
 			],
-			{ selectionEnd: {}, selectionStart: {} }
+			{
+				selection: {
+					selectionEnd: {},
+					selectionStart: {},
+					initialPosition: undefined,
+				},
+			}
 		);
 		expect( onInput ).not.toHaveBeenCalled();
 	} );
@@ -433,8 +451,11 @@ describe( 'useBlockSync hook', () => {
 		];
 
 		expect( onChange1 ).toHaveBeenCalledWith( updatedBlocks1, {
-			selectionEnd: {},
-			selectionStart: {},
+			selection: {
+				initialPosition: undefined,
+				selectionEnd: {},
+				selectionStart: {},
+			},
 		} );
 
 		const newBlocks = [
@@ -469,7 +490,13 @@ describe( 'useBlockSync hook', () => {
 		// The second callback should be called with the new change.
 		expect( onChange2 ).toHaveBeenCalledWith(
 			[ { clientId: 'b', innerBlocks: [], attributes: { foo: 3 } } ],
-			{ selectionEnd: {}, selectionStart: {} }
+			{
+				selection: {
+					selectionEnd: {},
+					selectionStart: {},
+					initialPosition: undefined,
+				},
+			}
 		);
 	} );
 
@@ -526,7 +553,13 @@ describe( 'useBlockSync hook', () => {
 		// Only the new callback should be called.
 		expect( onChange2 ).toHaveBeenCalledWith(
 			[ { clientId: 'b', innerBlocks: [], attributes: { foo: 3 } } ],
-			{ selectionEnd: {}, selectionStart: {} }
+			{
+				selection: {
+					selectionEnd: {},
+					selectionStart: {},
+					initialPosition: undefined,
+				},
+			}
 		);
 	} );
 } );

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -260,7 +260,7 @@ describe( 'useBlockSync hook', () => {
 				selection: {
 					selectionEnd: {},
 					selectionStart: {},
-					initialPosition: undefined,
+					initialPosition: null,
 				},
 			}
 		);
@@ -302,7 +302,7 @@ describe( 'useBlockSync hook', () => {
 				selection: {
 					selectionEnd: {},
 					selectionStart: {},
-					initialPosition: undefined,
+					initialPosition: null,
 				},
 			}
 		);
@@ -411,7 +411,7 @@ describe( 'useBlockSync hook', () => {
 				selection: {
 					selectionEnd: {},
 					selectionStart: {},
-					initialPosition: undefined,
+					initialPosition: null,
 				},
 			}
 		);
@@ -452,7 +452,7 @@ describe( 'useBlockSync hook', () => {
 
 		expect( onChange1 ).toHaveBeenCalledWith( updatedBlocks1, {
 			selection: {
-				initialPosition: undefined,
+				initialPosition: null,
 				selectionEnd: {},
 				selectionStart: {},
 			},
@@ -494,7 +494,7 @@ describe( 'useBlockSync hook', () => {
 				selection: {
 					selectionEnd: {},
 					selectionStart: {},
-					initialPosition: undefined,
+					initialPosition: null,
 				},
 			}
 		);
@@ -557,7 +557,7 @@ describe( 'useBlockSync hook', () => {
 				selection: {
 					selectionEnd: {},
 					selectionStart: {},
-					initialPosition: undefined,
+					initialPosition: null,
 				},
 			}
 		);

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -55,10 +55,7 @@ import { store as blockEditorStore } from '../../store';
  *                                is used to initalize the block-editor store
  *                                and for resetting the blocks to incoming
  *                                changes like undo.
- * @param {Object} props.selectionStart The selection start vlaue from the
- *                                controlling component.
- * @param {Object} props.selectionEnd The selection end vlaue from the
- *                                controlling component.
+ * @param {Object} props.selection The selection state responsible to restore the selection on undo/redo.
  * @param {onBlockUpdate} props.onChange Function to call when a persistent
  *                                change has been made in the block-editor blocks
  *                                for the given clientId. For example, after
@@ -72,8 +69,7 @@ import { store as blockEditorStore } from '../../store';
 export default function useBlockSync( {
 	clientId = null,
 	value: controlledBlocks,
-	selectionStart: controlledSelectionStart,
-	selectionEnd: controlledSelectionEnd,
+	selection: controlledSelection,
 	onChange = noop,
 	onInput = noop,
 } ) {
@@ -151,10 +147,11 @@ export default function useBlockSync( {
 			pendingChanges.current.outgoing = [];
 			setControlledBlocks();
 
-			if ( controlledSelectionStart && controlledSelectionEnd ) {
+			if ( controlledSelection ) {
 				resetSelection(
-					controlledSelectionStart,
-					controlledSelectionEnd
+					controlledSelection.selectionStart,
+					controlledSelection.selectionEnd,
+					controlledSelection.initialPosition
 				);
 			}
 		}
@@ -164,6 +161,7 @@ export default function useBlockSync( {
 		const {
 			getSelectionStart,
 			getSelectionEnd,
+			getSelectedBlocksInitialCaretPosition,
 			isLastBlockChangePersistent,
 			__unstableIsLastBlockChangeIgnored,
 		} = registry.select( blockEditorStore );
@@ -223,8 +221,11 @@ export default function useBlockSync( {
 					? onChangeRef.current
 					: onInputRef.current;
 				updateParent( blocks, {
-					selectionStart: getSelectionStart(),
-					selectionEnd: getSelectionEnd(),
+					selection: {
+						selectionStart: getSelectionStart(),
+						selectionEnd: getSelectionEnd(),
+						initialPosition: getSelectedBlocksInitialCaretPosition(),
+					},
 				} );
 			}
 			previousAreBlocksDifferent = areBlocksDifferent;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -345,7 +345,7 @@ function RichTextWrapper(
 
 			// If there are pasted blocks, move the caret to the end of the selected block
 			// Otherwise, retain the default value.
-			const initialPosition = hasPastedBlocks ? -1 : null;
+			const initialPosition = hasPastedBlocks ? -1 : 0;
 
 			onReplace( blocks, indexToSelect, initialPosition );
 		},

--- a/packages/block-editor/src/components/selection-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/selection-scroll-into-view/index.js
@@ -16,26 +16,11 @@ import { getScrollContainer } from '@wordpress/dom';
 import { getBlockDOMNode } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
 
-export function useScrollMultiSelectionIntoView( ref ) {
-	const selectionEnd = useSelect( ( select ) => {
-		const {
-			getBlockSelectionEnd,
-			hasMultiSelection,
-			isMultiSelecting,
-		} = select( blockEditorStore );
-
-		const blockSelectionEnd = getBlockSelectionEnd();
-
-		if (
-			! blockSelectionEnd ||
-			isMultiSelecting() ||
-			! hasMultiSelection()
-		) {
-			return;
-		}
-
-		return blockSelectionEnd;
-	}, [] );
+export function useScrollSelectionIntoView( ref ) {
+	const selectionEnd = useSelect(
+		( select ) => select( blockEditorStore ).getBlockSelectionEnd(),
+		[]
+	);
 
 	useEffect( () => {
 		if ( ! selectionEnd ) {
@@ -67,8 +52,8 @@ export function useScrollMultiSelectionIntoView( ref ) {
  * Scrolls the multi block selection end into view if not in view already. This
  * is important to do after selection by keyboard.
  */
-export default function MultiSelectScrollIntoView() {
+export function MultiSelectScrollIntoView() {
 	const ref = useRef();
-	useScrollMultiSelectionIntoView( ref );
+	useScrollSelectionIntoView( ref );
 	return <div ref={ ref } />;
 }

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -79,7 +79,13 @@ export function onBlockDrop(
 		// If the user is inserting a block
 		if ( dropType === 'inserter' ) {
 			clearSelectedBlock();
-			insertBlocks( blocks, targetBlockIndex, targetRootClientId, false );
+			insertBlocks(
+				blocks,
+				targetBlockIndex,
+				targetRootClientId,
+				true,
+				null
+			);
 		}
 
 		// If the user is moving a block

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -113,16 +113,22 @@ export function* validateBlocksToTemplate( blocks ) {
  * Returns an action object used in signalling that selection state should be
  * reset to the specified selection.
  *
- * @param {WPBlockSelection} selectionStart The selection start.
- * @param {WPBlockSelection} selectionEnd   The selection end.
+ * @param {WPBlockSelection} selectionStart  The selection start.
+ * @param {WPBlockSelection} selectionEnd    The selection end.
+ * @param {0|-1|undefined}   initialPosition Initial block position.
  *
  * @return {Object} Action object.
  */
-export function resetSelection( selectionStart, selectionEnd ) {
+export function resetSelection(
+	selectionStart,
+	selectionEnd,
+	initialPosition
+) {
 	return {
 		type: 'RESET_SELECTION',
 		selectionStart,
 		selectionEnd,
+		initialPosition,
 	};
 }
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -194,7 +194,7 @@ export function updateBlock( clientId, updates ) {
  *
  * @return {Object} Action object.
  */
-export function selectBlock( clientId, initialPosition = null ) {
+export function selectBlock( clientId, initialPosition = 0 ) {
 	return {
 		type: 'SELECT_BLOCK',
 		initialPosition,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, findKey, first, last, some } from 'lodash';
+import { castArray, findKey, first, isObject, last, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,6 +20,7 @@ import { speak } from '@wordpress/a11y';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { controls } from '@wordpress/data';
 import { create, insert, remove, toHTMLString } from '@wordpress/rich-text';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -115,7 +116,7 @@ export function* validateBlocksToTemplate( blocks ) {
  *
  * @param {WPBlockSelection} selectionStart  The selection start.
  * @param {WPBlockSelection} selectionEnd    The selection end.
- * @param {0|-1|undefined}   initialPosition Initial block position.
+ * @param {0|-1|null}        initialPosition Initial block position.
  *
  * @return {Object} Action object.
  */
@@ -188,8 +189,8 @@ export function updateBlock( clientId, updates ) {
  * value reflecting its selection directionality. An initialPosition of -1
  * reflects a reverse selection.
  *
- * @param {string}  clientId        Block client ID.
- * @param {?number} initialPosition Optional initial position. Pass as -1 to
+ * @param {string}    clientId        Block client ID.
+ * @param {0|-1|null} initialPosition Optional initial position. Pass as -1 to
  *                                  reflect reverse selection.
  *
  * @return {Object} Action object.
@@ -353,7 +354,7 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
  * @param {(string|string[])} clientIds       Block client ID(s) to replace.
  * @param {(Object|Object[])} blocks          Replacement block(s).
  * @param {number}            indexToSelect   Index of replacement block to select.
- * @param {number}            initialPosition Index of caret after in the selected block after the operation.
+ * @param {0|-1|null}         initialPosition Index of caret after in the selected block after the operation.
  * @param {?Object}           meta            Optional Meta values to be passed to the action object.
  *
  * @yield {Object} Action object.
@@ -362,7 +363,7 @@ export function* replaceBlocks(
 	clientIds,
 	blocks,
 	indexToSelect,
-	initialPosition,
+	initialPosition = 0,
 	meta
 ) {
 	clientIds = castArray( clientIds );
@@ -546,21 +547,30 @@ export function insertBlock(
  * Returns an action object used in signalling that an array of blocks should
  * be inserted, optionally at a specific index respective a root block list.
  *
- * @param {Object[]}   blocks          Block objects to insert.
- * @param {?number}    index           Index at which block should be inserted.
- * @param {?string}    rootClientId    Optional root client ID of block list on which to insert.
- * @param {?boolean}   updateSelection If true block selection will be updated.  If false, block selection will not change. Defaults to true.
- * @param {?Object}  meta             Optional Meta values to be passed to the action object.
- *
- *  @return {Object} Action object.
+ * @param {Object[]}  blocks          Block objects to insert.
+ * @param {?number}   index           Index at which block should be inserted.
+ * @param {?string}   rootClientId    Optional root client ID of block list on which to insert.
+ * @param {?boolean}  updateSelection If true block selection will be updated.  If false, block selection will not change. Defaults to true.
+ * @param {0|-1|null} initialPosition Initial focus position. Setting it to null prevent focusing the inserted block.
+ * @param {?Object}   meta            Optional Meta values to be passed to the action object.
+ * @return {Object} Action object.
  */
 export function* insertBlocks(
 	blocks,
 	index,
 	rootClientId,
 	updateSelection = true,
+	initialPosition = 0,
 	meta
 ) {
+	if ( isObject( initialPosition ) ) {
+		meta = initialPosition;
+		initialPosition = 0;
+		deprecated( "meta argument in wp.data.dispatch('core/block-editor')", {
+			hint: 'The meta argument is now the 6th argument of the function',
+		} );
+	}
+
 	blocks = getBlocksWithDefaultStylesApplied(
 		castArray( blocks ),
 		yield controls.select( blockEditorStoreName, 'getSettings' )
@@ -585,6 +595,7 @@ export function* insertBlocks(
 			rootClientId,
 			time: Date.now(),
 			updateSelection,
+			initialPosition: updateSelection ? initialPosition : undefined,
 			meta,
 		};
 	}
@@ -908,22 +919,24 @@ export function removeBlock( clientId, selectPrevious ) {
  * Returns an action object used in signalling that the inner blocks with the
  * specified client ID should be replaced.
  *
- * @param {string}   rootClientId    Client ID of the block whose InnerBlocks will re replaced.
- * @param {Object[]} blocks          Block objects to insert as new InnerBlocks
- * @param {?boolean} updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to false.
- *
+ * @param {string}    rootClientId    Client ID of the block whose InnerBlocks will re replaced.
+ * @param {Object[]}  blocks          Block objects to insert as new InnerBlocks
+ * @param {?boolean}  updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to false.
+ * @param {0|-1|null} initialPosition Initial block position.
  * @return {Object} Action object.
  */
 export function replaceInnerBlocks(
 	rootClientId,
 	blocks,
-	updateSelection = false
+	updateSelection = false,
+	initialPosition = 0
 ) {
 	return {
 		type: 'REPLACE_INNER_BLOCKS',
 		rootClientId,
 		blocks,
 		updateSelection,
+		initialPosition: updateSelection ? initialPosition : undefined,
 		time: Date.now(),
 	};
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -595,7 +595,7 @@ export function* insertBlocks(
 			rootClientId,
 			time: Date.now(),
 			updateSelection,
-			initialPosition: updateSelection ? initialPosition : undefined,
+			initialPosition: updateSelection ? initialPosition : null,
 			meta,
 		};
 	}
@@ -936,7 +936,7 @@ export function replaceInnerBlocks(
 		rootClientId,
 		blocks,
 		updateSelection,
-		initialPosition: updateSelection ? initialPosition : undefined,
+		initialPosition: updateSelection ? initialPosition : null,
 		time: Date.now(),
 	};
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1192,7 +1192,7 @@ function selectionHelper( state = {}, action ) {
 		case 'REPLACE_INNER_BLOCKS': // REPLACE_INNER_BLOCKS and INSERT_BLOCKS should follow the same logic.
 		case 'INSERT_BLOCKS': {
 			// REPLACE_INNER_BLOCKS can be called with an empty array.
-			if ( ! action.updateSelection || ! action.blocks.length ) {
+			if ( ! action.blocks.length ) {
 				return state;
 			}
 
@@ -1225,11 +1225,7 @@ function selectionHelper( state = {}, action ) {
 				return state;
 			}
 
-			const newState = { clientId: blockToSelect.clientId };
-			if ( typeof action.initialPosition === 'number' ) {
-				newState.initialPosition = action.initialPosition;
-			}
-			return newState;
+			return { clientId: blockToSelect.clientId };
 		}
 	}
 
@@ -1372,6 +1368,11 @@ export function initialPosition( state, action ) {
 		return state;
 	} else if ( action.type === 'START_TYPING' ) {
 		return state;
+	} else if (
+		action.type === 'INSERT_BLOCKS' ||
+		action.type === 'REPLACE_INNER_BLOCKS'
+	) {
+		return action.updateSelection ? 0 : undefined;
 	}
 
 	// Reset the state by default (for any action not handled).

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1357,6 +1357,13 @@ export function isSelectionEnabled( state = true, action ) {
  * @return {?number} Initial position: -1 or undefined.
  */
 export function initialPosition( state, action ) {
+	const keepStateAction = [
+		'REMOVE_BLOCKS',
+		'START_TYPING',
+		'MARK_AUTOMATIC_CHANGE',
+		'MARK_AUTOMATIC_CHANGE_FINAL',
+	];
+
 	if (
 		action.type === 'REPLACE_BLOCKS' &&
 		typeof action.initialPosition === 'number'
@@ -1364,9 +1371,7 @@ export function initialPosition( state, action ) {
 		return action.initialPosition;
 	} else if ( action.type === 'SELECT_BLOCK' ) {
 		return action.initialPosition;
-	} else if ( action.type === 'REMOVE_BLOCKS' ) {
-		return state;
-	} else if ( action.type === 'START_TYPING' ) {
+	} else if ( keepStateAction.includes( action.type ) ) {
 		return state;
 	} else if (
 		action.type === 'INSERT_BLOCKS' ||

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1189,9 +1189,14 @@ function selectionHelper( state = {}, action ) {
 			}
 
 			return { clientId: action.clientId };
-		case 'REPLACE_INNER_BLOCKS': // REPLACE_INNER_BLOCKS and INSERT_BLOCKS should follow the same logic.
+		case 'REPLACE_INNER_BLOCKS': {
+			if ( ! action.updateSelection || ! action.blocks.length ) {
+				return state;
+			}
+
+			return { clientId: action.blocks[ 0 ].clientId };
+		}
 		case 'INSERT_BLOCKS': {
-			// REPLACE_INNER_BLOCKS can be called with an empty array.
 			if ( ! action.blocks.length ) {
 				return state;
 			}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1362,6 +1362,8 @@ export function initialPosition( state, action ) {
 		'START_TYPING',
 		'MARK_AUTOMATIC_CHANGE',
 		'MARK_AUTOMATIC_CHANGE_FINAL',
+		'SHOW_INSERTION_POINT',
+		'HIDE_INSERTION_POINT',
 	];
 
 	if (

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1371,7 +1371,10 @@ export function initialPosition( state, action ) {
 		typeof action.initialPosition === 'number'
 	) {
 		return action.initialPosition;
-	} else if ( action.type === 'SELECT_BLOCK' ) {
+	} else if (
+		action.type === 'SELECT_BLOCK' ||
+		action.type === 'RESET_SELECTION'
+	) {
 		return action.initialPosition;
 	} else if ( keepStateAction.includes( action.type ) ) {
 		return state;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1353,39 +1353,26 @@ export function isSelectionEnabled( state = true, action ) {
  * @param {boolean} state  Current state.
  * @param {Object}  action Dispatched action.
  *
- * @return {?number} Initial position: -1 or undefined.
+ * @return {number|null} Initial position: 0, -1 or null.
  */
-export function initialPosition( state, action ) {
-	const keepStateAction = [
-		'REMOVE_BLOCKS',
-		'START_TYPING',
-		'MARK_AUTOMATIC_CHANGE',
-		'MARK_AUTOMATIC_CHANGE_FINAL',
-		'SHOW_INSERTION_POINT',
-		'HIDE_INSERTION_POINT',
-		'UPDATE_BLOCK_LIST_SETTINGS',
-	];
-
+export function initialPosition( state = null, action ) {
 	if (
 		action.type === 'REPLACE_BLOCKS' &&
-		typeof action.initialPosition === 'number'
+		action.initialPosition !== undefined
 	) {
 		return action.initialPosition;
 	} else if (
-		action.type === 'SELECT_BLOCK' ||
-		action.type === 'RESET_SELECTION'
-	) {
-		return action.initialPosition;
-	} else if ( keepStateAction.includes( action.type ) ) {
-		return state;
-	} else if (
-		action.type === 'INSERT_BLOCKS' ||
-		action.type === 'REPLACE_INNER_BLOCKS'
+		[
+			'SELECT_BLOCK',
+			'RESET_SELECTION',
+			'INSERT_BLOCKS',
+			'REPLACE_INNER_BLOCKS',
+		].includes( action.type )
 	) {
 		return action.initialPosition;
 	}
 
-	// Reset the state by default (for any action not handled).
+	return state;
 }
 
 export function blocksMode( state = {}, action ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1363,6 +1363,7 @@ export function initialPosition( state, action ) {
 		'MARK_AUTOMATIC_CHANGE_FINAL',
 		'SHOW_INSERTION_POINT',
 		'HIDE_INSERTION_POINT',
+		'UPDATE_BLOCK_LIST_SETTINGS',
 	];
 
 	if (

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1189,15 +1189,9 @@ function selectionHelper( state = {}, action ) {
 			}
 
 			return { clientId: action.clientId };
-		case 'REPLACE_INNER_BLOCKS': {
-			if ( ! action.updateSelection || ! action.blocks.length ) {
-				return state;
-			}
-
-			return { clientId: action.blocks[ 0 ].clientId };
-		}
+		case 'REPLACE_INNER_BLOCKS':
 		case 'INSERT_BLOCKS': {
-			if ( ! action.blocks.length ) {
+			if ( ! action.updateSelection || ! action.blocks.length ) {
 				return state;
 			}
 
@@ -1387,7 +1381,7 @@ export function initialPosition( state, action ) {
 		action.type === 'INSERT_BLOCKS' ||
 		action.type === 'REPLACE_INNER_BLOCKS'
 	) {
-		return action.updateSelection ? 0 : undefined;
+		return action.initialPosition;
 	}
 
 	// Reset the state by default (for any action not handled).

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -696,10 +696,10 @@ export function getNextBlockClientId( state, startClientId ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {?Object} Selected block.
+ * @return {0|-1|null} Initial position.
  */
 export function getSelectedBlocksInitialCaretPosition( state ) {
-	return state.initialPosition === undefined ? null : state.initialPosition;
+	return state.initialPosition;
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -699,7 +699,7 @@ export function getNextBlockClientId( state, startClientId ) {
  * @return {?Object} Selected block.
  */
 export function getSelectedBlocksInitialCaretPosition( state ) {
-	return state.initialPosition;
+	return state.initialPosition === undefined ? null : state.initialPosition;
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -692,6 +692,7 @@ export function getNextBlockClientId( state, startClientId ) {
 /**
  * Returns the initial caret position for the selected block.
  * This position is to used to position the caret properly when the selected block changes.
+ * If the current block is not a RichText, having initial position set to 0 means "focus block"
  *
  * @param {Object} state Global application state.
  *

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -200,6 +200,7 @@ describe( 'actions', () => {
 				clientIds: [ 'chicken' ],
 				blocks: [ block ],
 				time: expect.any( Number ),
+				initialPosition: 0,
 			} );
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
@@ -318,6 +319,7 @@ describe( 'actions', () => {
 				clientIds: [ 'chicken' ],
 				blocks,
 				time: expect.any( Number ),
+				initialPosition: 0,
 			} );
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
@@ -406,6 +408,7 @@ describe( 'actions', () => {
 					rootClientId: 'testclientid',
 					time: expect.any( Number ),
 					updateSelection: true,
+					initialPosition: 0,
 				},
 			} );
 		} );
@@ -493,6 +496,7 @@ describe( 'actions', () => {
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),
 					updateSelection: false,
+					initialPosition: null,
 				},
 			} );
 		} );
@@ -549,6 +553,7 @@ describe( 'actions', () => {
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),
 					updateSelection: false,
+					initialPosition: null,
 				},
 			} );
 		} );
@@ -613,6 +618,7 @@ describe( 'actions', () => {
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),
 					updateSelection: false,
+					initialPosition: null,
 				},
 			} );
 		} );
@@ -683,6 +689,7 @@ describe( 'actions', () => {
 				5,
 				'testrootid',
 				false,
+				0,
 				meta
 			);
 
@@ -725,6 +732,7 @@ describe( 'actions', () => {
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),
 					updateSelection: false,
+					initialPosition: null,
 					meta: { patternName: 'core/chicken-ribs-pattern' },
 				},
 			} );
@@ -1140,6 +1148,7 @@ describe( 'actions', () => {
 				rootClientId: 'root',
 				time: expect.any( Number ),
 				updateSelection: false,
+				initialPosition: null,
 			} );
 		} );
 
@@ -1150,6 +1159,7 @@ describe( 'actions', () => {
 				rootClientId: 'root',
 				time: expect.any( Number ),
 				updateSelection: true,
+				initialPosition: 0,
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2301,22 +2301,6 @@ describe( 'state', () => {
 			expect( state.selectionEnd ).toEqual( expected );
 		} );
 
-		it( 'should not select inserted block if updateSelection flag is false', () => {
-			const original = deepFreeze( {
-				selectionStart: { clientId: 'a' },
-				selectionEnd: { clientId: 'a' },
-			} );
-			const action = {
-				type: 'INSERT_BLOCKS',
-				blocks: [ { clientId: 'ribs' } ],
-				updateSelection: false,
-			};
-			const state = selection( original, action );
-
-			expect( state.selectionStart ).toBe( original.selectionStart );
-			expect( state.selectionEnd ).toBe( original.selectionEnd );
-		} );
-
 		it( 'should not update the state if the block moved is already selected', () => {
 			const original = deepFreeze( {
 				selectionStart: { clientId: 'ribs' },
@@ -2473,23 +2457,6 @@ describe( 'state', () => {
 
 			expect( state.selectionStart ).toEqual( expected.selectionStart );
 			expect( state.selectionEnd ).toEqual( expected.selectionEnd );
-		} );
-
-		it( 'should not update the selection on inner blocks replace if updateSelection is false', () => {
-			const original = deepFreeze( {
-				selectionStart: { clientId: 'chicken' },
-				selectionEnd: { clientId: 'chicken' },
-			} );
-			const action = {
-				type: 'REPLACE_INNER_BLOCKS',
-				blocks: [ { clientId: 'another-block' } ],
-				rootClientId: 'parent',
-				updateSelection: false,
-			};
-			const state = selection( original, action );
-
-			expect( state.selectionStart ).toEqual( original.selectionStart );
-			expect( state.selectionEnd ).toEqual( original.selectionEnd );
 		} );
 
 		it( 'should keep the same selection on RESET_BLOCKS if the selected blocks continue to exist', () => {

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -162,8 +162,7 @@ function* loadPostTypeEntities() {
 			label: postType.labels.singular_name,
 			transientEdits: {
 				blocks: true,
-				selectionStart: true,
-				selectionEnd: true,
+				selection: true,
 			},
 			mergedEdits: { meta: true },
 			getTitle: ( record ) =>

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -172,8 +172,8 @@ export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
 
 	const onChange = useCallback(
 		( newBlocks, options ) => {
-			const { selectionStart, selectionEnd } = options;
-			const edits = { blocks: newBlocks, selectionStart, selectionEnd };
+			const { selection } = options;
+			const edits = { blocks: newBlocks, selection };
 
 			const noChange = blocks === edits.blocks;
 			if ( noChange ) {
@@ -193,8 +193,8 @@ export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
 
 	const onInput = useCallback(
 		( newBlocks, options ) => {
-			const { selectionStart, selectionEnd } = options;
-			const edits = { blocks: newBlocks, selectionStart, selectionEnd };
+			const { selection } = options;
+			const edits = { blocks: newBlocks, selection };
 			editEntityRecord( kind, type, id, edits );
 		},
 		[ kind, type, id ]

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -58,10 +58,17 @@ export async function toggleGlobalBlockInserter() {
  * Moves focus to the selected block.
  */
 async function focusSelectedBlock() {
-	const selectedBlock = await page.waitForSelector(
-		'.block-editor-block-list__block.is-selected'
-	);
-	await selectedBlock.focus();
+	// Ideally there shouuld be a UI way to do this. (Focus the selected block)
+	await page.evaluate( () => {
+		wp.data
+			.dispatch( 'core/block-editor' )
+			.selectBlock(
+				wp.data
+					.select( 'core/block-editor' )
+					.getSelectedBlockClientId(),
+				0
+			);
+	} );
 }
 
 /**

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -55,6 +55,16 @@ export async function toggleGlobalBlockInserter() {
 }
 
 /**
+ * Moves focus to the selected block.
+ */
+async function focusSelectedBlock() {
+	const selectedBlock = await page.waitForSelector(
+		'.block-editor-block-list__block.is-selected'
+	);
+	await selectedBlock.focus();
+}
+
+/**
  * Retrieves the document container by css class and checks to make sure the document's active element is within it
  */
 async function waitForInserterCloseAndContentFocus() {
@@ -135,6 +145,7 @@ export async function insertBlock( searchTerm ) {
 		`//button//span[contains(text(), '${ searchTerm }')]`
 	);
 	await insertButton.click();
+	await focusSelectedBlock();
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();
 }
@@ -151,6 +162,7 @@ export async function insertPattern( searchTerm ) {
 		`//div[@role = 'button']//div[contains(text(), '${ searchTerm }')]`
 	);
 	await insertButton.click();
+	await focusSelectedBlock();
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();
 }
@@ -168,6 +180,7 @@ export async function insertReusableBlock( searchTerm ) {
 		`//button//span[contains(text(), '${ searchTerm }')]`
 	);
 	await insertButton.click();
+	await focusSelectedBlock();
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();
 	// We should wait until the block is loaded
@@ -191,6 +204,7 @@ export async function insertBlockDirectoryBlock( searchTerm ) {
 		'.block-directory-downloadable-blocks-list li:first-child button'
 	);
 	await insertButton.click();
+	await focusSelectedBlock();
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();
 }

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -211,6 +211,12 @@ export async function insertBlockDirectoryBlock( searchTerm ) {
 		'.block-directory-downloadable-blocks-list li:first-child button'
 	);
 	await insertButton.click();
+	await page.waitForFunction(
+		() =>
+			! document.body.querySelector(
+				'.block-directory-downloadable-blocks-list li:first-child button.is-busy'
+			)
+	);
 	await focusSelectedBlock();
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
@@ -75,6 +75,11 @@ describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await insertBlock( 'Image' );
 		await closeGlobalBlockInserter();
 		await page.waitForSelector( '.product[data-number-of-children="2"]' );
+		// This focus shouldn't be neessary but there's a bug in master right now
+		// Where if you open the inserter, don't do anything and click the "appender" on the canvas
+		// the appender is not opened right away.
+		// It needs to be investigated on its own.
+		await page.focus( appenderSelector );
 		await page.click( appenderSelector );
 		expect( await getAllBlockInserterItemTitles() ).toEqual( [
 			'Gallery',

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -558,6 +558,11 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.press( 'Enter' );
 		await clickBlockToolbarButton( 'Align' );
 		await clickButton( 'Wide width' );
+
+		// Focus the block.
+		await page.keyboard.press( 'Tab' );
+
+		// Select the previous block.
 		await page.keyboard.press( 'ArrowUp' );
 
 		// Confirm correct setup.

--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -6,6 +6,7 @@ import {
 	deactivatePlugin,
 	activatePlugin,
 	activateTheme,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -105,7 +106,8 @@ describe( 'Widgets screen', () => {
 		// 	firstWidgetArea
 		// );
 
-		await addParagraphBlock.click();
+		await addParagraphBlock.focus();
+		await pressKeyWithModifier( 'primary', 'Enter' );
 
 		const addedParagraphBlockInFirstWidgetArea = await firstWidgetArea.$(
 			'[data-block][data-type="core/paragraph"][aria-label^="Empty block"]'
@@ -125,7 +127,8 @@ describe( 'Widgets screen', () => {
 		await expectInsertionPointIndicatorToBeBelowLastBlock(
 			firstWidgetArea
 		);
-		await addParagraphBlock.click();
+		await addParagraphBlock.focus();
+		await pressKeyWithModifier( 'primary', 'Enter' );
 
 		await page.keyboard.type( 'Second Paragraph' );
 
@@ -311,7 +314,8 @@ describe( 'Widgets screen', () => {
 		);
 
 		const addParagraphBlock = await getParagraphBlockInGlobalInserter();
-		await addParagraphBlock.click();
+		await addParagraphBlock.focus();
+		await pressKeyWithModifier( 'primary', 'Enter' );
 
 		const firstParagraphBlock = await firstWidgetArea.$(
 			'[data-block][data-type="core/paragraph"][aria-label^="Empty block"]'

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -12,7 +12,6 @@ import {
 	__unstableUseTypewriter as useTypewriter,
 	__unstableUseClipboardHandler as useClipboardHandler,
 	__unstableUseTypingObserver as useTypingObserver,
-	__unstableUseScrollMultiSelectionIntoView as useScrollMultiSelectionIntoView,
 	__experimentalBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableUseCanvasClickRedirect as useCanvasClickRedirect,
@@ -53,7 +52,6 @@ export default function VisualEditor( { styles } ) {
 	};
 	const resizedCanvasStyles = useResizeCanvas( deviceType );
 
-	useScrollMultiSelectionIntoView( ref );
 	useBlockSelectionClearer( ref );
 	useTypewriter( ref );
 	useClipboardHandler( ref );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -33,16 +33,13 @@ function EditorProvider( {
 		}
 		return { postId: post.id, postType: post.type };
 	}, [ post.id, post.type ] );
-	const { selectionEnd, selectionStart, isReady } = useSelect( ( select ) => {
-		const {
-			getEditorSelectionStart,
-			getEditorSelectionEnd,
-			__unstableIsEditorReady,
-		} = select( editorStore );
+	const { selection, isReady } = useSelect( ( select ) => {
+		const { getEditorSelection, __unstableIsEditorReady } = select(
+			editorStore
+		);
 		return {
 			isReady: __unstableIsEditorReady(),
-			selectionStart: getEditorSelectionStart(),
-			selectionEnd: getEditorSelectionEnd(),
+			selection: getEditorSelection(),
 		};
 	}, [] );
 	const { id, type } = __unstableTemplate ?? post;
@@ -112,8 +109,7 @@ function EditorProvider( {
 						value={ blocks }
 						onChange={ onChange }
 						onInput={ onInput }
-						selectionStart={ selectionStart }
-						selectionEnd={ selectionEnd }
+						selection={ selection }
 						settings={ editorSettings }
 						useSubRegistry={ false }
 					>

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -45,8 +45,7 @@ const postTypeEntities = [
 	...postTypeEntity,
 	transientEdits: {
 		blocks: true,
-		selectionStart: true,
-		selectionEnd: true,
+		selection: true,
 	},
 	mergedEdits: {
 		meta: true,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -593,12 +593,8 @@ export function unlockPostAutosaving( lockName ) {
  * @yield {Object} Action object
  */
 export function* resetEditorBlocks( blocks, options = {} ) {
-	const {
-		__unstableShouldCreateUndoLevel,
-		selectionStart,
-		selectionEnd,
-	} = options;
-	const edits = { blocks, selectionStart, selectionEnd };
+	const { __unstableShouldCreateUndoLevel, selection } = options;
+	const edits = { blocks, selection };
 
 	if ( __unstableShouldCreateUndoLevel !== false ) {
 		const { id, type } = yield controls.select(

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1229,9 +1229,14 @@ export function getEditorBlocks( state ) {
  *
  * @param {Object} state
  * @return {WPBlockSelection} The selection start.
+ *
+ * @deprecated since Gutenberg 10.0.0.
  */
 export function getEditorSelectionStart( state ) {
-	return getEditedPostAttribute( state, 'selectionStart' );
+	deprecated( "select('core/editor').getEditorSelectionStart", {
+		alternative: "select('core/editor').getEditorSelection",
+	} );
+	return getEditedPostAttribute( state, 'selection' )?.selectionStart;
 }
 
 /**
@@ -1239,9 +1244,24 @@ export function getEditorSelectionStart( state ) {
  *
  * @param {Object} state
  * @return {WPBlockSelection} The selection end.
+ *
+ * @deprecated since Gutenberg 10.0.0.
  */
 export function getEditorSelectionEnd( state ) {
-	return getEditedPostAttribute( state, 'selectionEnd' );
+	deprecated( "select('core/editor').getEditorSelectionStart", {
+		alternative: "select('core/editor').getEditorSelection",
+	} );
+	return getEditedPostAttribute( state, 'selection' )?.selectionEnd;
+}
+
+/**
+ * Returns the current selection.
+ *
+ * @param {Object} state
+ * @return {WPBlockSelection} The selection end.
+ */
+export function getEditorSelection( state ) {
+	return getEditedPostAttribute( state, 'selection' );
 }
 
 /**


### PR DESCRIPTION
closes  #26223

Despite what the title of the PR might suggest, this is a very impactful PR that changes a lot of things on how subtle things in  the editor work.

 - The first thing is that if you insert a block using the inserter, it's not "focused" anymore, which allows the inserter to stay open. From a screen reader perspective, this is correct. Moving the focus was the thing forcing us to actually close the inserter.
- The second thing is that before this PR, selecting a block meant necessarily focusing the block (at very few exceptions), this PR breaks this tight relationship. Basically, unless you ask to focus a block when you select it (by providing the initialPosition), we assume you just want to "select" a block in the data and not select it.  This allows us to perform things like: scroll to the right position/selected block without necessarily moving the focus.
- There are also some nice and important side effects of this change: previously we had a hook that allows us to scroll to the right position when multi-selecting, this hook now works for all kind of block selection and is  "bundled" in block-editor. It was only enabled in the post editor previously.

So, it's very important to actually test the PR properly to ensure it's working as intended and that the new behavior makes sense for all kind of users.