### PR TITLE
Post Title block: Add placeholder state

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -73,11 +73,10 @@ export default function PostTitleEdit( {
 	);
 
 	if ( ! postType || ! postId ) {
-		const Tag = level === 0 ? 'p' : `h${ level }`;
 		titleElement = (
-			<Tag { ...( isLink ? {} : blockProps ) }>
+			<TagName { ...( isLink ? {} : blockProps ) }>
 				{ __( 'Placeholder for post title' ) }
-			</Tag>
+			</TagName>
 		);
 	}
 

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -72,6 +72,15 @@ export default function PostTitleEdit( {
 		/>
 	);
 
+	if ( ! postType || ! postId ) {
+		const Tag = level === 0 ? 'p' : `h${ level }`;
+		titleElement = (
+			<Tag { ...( isLink ? {} : blockProps ) }>
+				{ __( 'Placeholder for post title' ) }
+			</Tag>
+		);
+	}
+
 	if ( isLink ) {
 		titleElement = (
 			<a

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -58,25 +58,25 @@ export default function PostTitleEdit( {
 	const { title, link } = post;
 
 	let titleElement = (
-		<PlainText
-			tagName={ TagName }
-			placeholder={ __( 'No Title' ) }
-			value={ title }
-			onChange={ ( value ) =>
-				editEntityRecord( 'postType', postType, postId, {
-					title: value,
-				} )
-			}
-			__experimentalVersion={ 2 }
-			{ ...( isLink ? {} : blockProps ) }
-		/>
+		<TagName { ...( isLink ? {} : blockProps ) }>
+			{ __( 'Placeholder for post title' ) }
+		</TagName>
 	);
 
-	if ( ! postType || ! postId ) {
+	if ( postType && postId ) {
 		titleElement = (
-			<TagName { ...( isLink ? {} : blockProps ) }>
-				{ __( 'Placeholder for post title' ) }
-			</TagName>
+			<PlainText
+				tagName={ TagName }
+				placeholder={ __( 'No Title' ) }
+				value={ title }
+				onChange={ ( value ) =>
+					editEntityRecord( 'postType', postType, postId, {
+						title: value,
+					} )
+				}
+				__experimentalVersion={ 2 }
+				{ ...( isLink ? {} : blockProps ) }
+			/>
 		);
 	}
 

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -59,7 +59,7 @@ export default function PostTitleEdit( {
 
 	let titleElement = (
 		<TagName { ...( isLink ? {} : blockProps ) }>
-			{ __( 'Placeholder for post title' ) }
+			{ __( 'An example title' ) }
 		</TagName>
 	);
 

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -15,7 +15,9 @@ export { metadata, name };
 
 export const settings = {
 	title: _x( 'Post Title', 'block title' ),
-	description: __( 'Add the title of your post.' ),
+	description: __(
+		'Displays the title of a post, page, or any other content-type.'
+	),
 	icon,
 	edit,
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds a "placeholder state" for Post Title block. This state is shown when Post Title block is outside of Query block or any other context that could provide an entity for the block.

Fixes https://github.com/WordPress/gutenberg/issues/27029
Related https://github.com/WordPress/gutenberg/issues/19256

## How has this been tested?
1. Open site editor
2. Open Front Page template
3. Add Post Title block
4. Make sure you see "Placeholder for post title" text
5. Make sure all the formatting options are still working (alignment, heading level, text align)
6. Make sure Post Title is not editable
7. Make sure Post Title block works just as before in the Post Editor

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/104599833-8d342080-5678-11eb-845e-1eb1b5a92228.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
