### PR TITLE
[RNMobile] Performance improvements in LatestPosts related controls

### DIFF
--- a/packages/block-library/src/latest-posts/edit.native.js
+++ b/packages/block-library/src/latest-posts/edit.native.js
@@ -219,7 +219,7 @@ class LatestPostsEdit extends Component {
 				onPress={ openGeneralSidebar }
 			>
 				<View style={ blockStyle }>
-					{ this.getInspectorControls() }
+					{ isSelected && this.getInspectorControls() }
 					<Icon icon={ icon } { ...iconStyle } />
 					<Text style={ titleStyle }>
 						{ blockType.settings.title }

--- a/packages/components/src/mobile/picker/index.android.js
+++ b/packages/components/src/mobile/picker/index.android.js
@@ -10,7 +10,7 @@ import { View } from 'react-native';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, TextControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -52,8 +52,27 @@ export default class Picker extends Component {
 		this.onClose();
 	}
 
+	getOptions() {
+		const { options, leftAlign } = this.props;
+
+		return options.map( ( option ) => (
+			<View key={ `${ option.label }-${ option.value }` }>
+				{ options.length > 1 && option.separated && <Separator /> }
+				<BottomSheet.Cell
+					icon={ option.icon }
+					leftAlign={ leftAlign }
+					label={ option.label }
+					separatorType={ 'none' }
+					onPress={ () => this.onCellPress( option.value ) }
+					disabled={ option.disabled }
+					style={ option.disabled && styles.disabled }
+				/>
+			</View>
+		) );
+	}
+
 	render() {
-		const { options, leftAlign, hideCancelButton, title } = this.props;
+		const { hideCancelButton, title } = this.props;
 		const { isVisible } = this.state;
 
 		return (
@@ -64,26 +83,9 @@ export default class Picker extends Component {
 				hideHeader
 			>
 				<PanelBody title={ title } style={ styles.panelBody }>
-					{ options.map( ( option ) => (
-						<View key={ `${ option.label }-${ option.value }` }>
-							{ options.length > 1 && option.separated && (
-								<Separator />
-							) }
-							<BottomSheet.Cell
-								icon={ option.icon }
-								leftAlign={ leftAlign }
-								label={ option.label }
-								separatorType={ 'none' }
-								onPress={ () =>
-									this.onCellPress( option.value )
-								}
-								disabled={ option.disabled }
-								style={ option.disabled && styles.disabled }
-							/>
-						</View>
-					) ) }
+					{ this.getOptions() }
 					{ ! hideCancelButton && (
-						<BottomSheet.Cell
+						<TextControl
 							label={ __( 'Cancel' ) }
 							onPress={ this.onClose }
 							separatorType={ 'none' }

--- a/packages/components/src/query-controls/category-select.js
+++ b/packages/components/src/query-controls/category-select.js
@@ -3,6 +3,10 @@
  */
 import { buildTermsTree } from './terms';
 import TreeSelect from '../tree-select';
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
 
 export default function CategorySelect( {
 	label,
@@ -12,7 +16,10 @@ export default function CategorySelect( {
 	onChange,
 	...props
 } ) {
-	const termsTree = buildTermsTree( categoriesList );
+	const termsTree = useMemo( () => {
+		return buildTermsTree( categoriesList );
+	}, [ categoriesList ] );
+
 	return (
 		<TreeSelect
 			{ ...{ label, noOptionLabel, onChange } }

--- a/packages/components/src/query-controls/index.native.js
+++ b/packages/components/src/query-controls/index.native.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import React from 'react';
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,73 +17,84 @@ import CategorySelect from './category-select';
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 100;
 
-export default function QueryControls( {
-	categoriesList,
-	selectedCategoryId,
-	numberOfItems,
-	order,
-	orderBy,
-	maxItems = DEFAULT_MAX_ITEMS,
-	minItems = DEFAULT_MIN_ITEMS,
-	onCategoryChange,
-	onNumberOfItemsChange,
-	onOrderChange,
-	onOrderByChange,
-} ) {
-	return [
-		onOrderChange && onOrderByChange && (
-			<SelectControl
-				label={ __( 'Order by' ) }
-				value={ `${ orderBy }/${ order }` }
-				options={ [
-					{
-						label: __( 'Newest to oldest' ),
-						value: 'date/desc',
-					},
-					{
-						label: __( 'Oldest to newest' ),
-						value: 'date/asc',
-					},
-					{
-						/* translators: label for ordering posts by title in ascending order */
-						label: __( 'A → Z' ),
-						value: 'title/asc',
-					},
-					{
-						/* translators: label for ordering posts by title in descending order */
-						label: __( 'Z → A' ),
-						value: 'title/desc',
-					},
-				] }
-				onChange={ ( value ) => {
-					const [ newOrderBy, newOrder ] = value.split( '/' );
-					if ( newOrder !== order ) {
-						onOrderChange( newOrder );
-					}
-					if ( newOrderBy !== orderBy ) {
-						onOrderByChange( newOrderBy );
-					}
-				} }
-			/>
-		),
-		onCategoryChange && (
-			<CategorySelect
-				categoriesList={ categoriesList }
-				label={ __( 'Category' ) }
-				noOptionLabel={ __( 'All' ) }
-				selectedCategoryId={ selectedCategoryId }
-				onChange={ onCategoryChange }
-			/>
-		),
-		onNumberOfItemsChange && (
-			<RangeControl
-				label={ __( 'Number of items' ) }
-				value={ numberOfItems }
-				onChange={ onNumberOfItemsChange }
-				min={ minItems }
-				max={ maxItems }
-				required
-			/>
-		),
-	];
-}
+const options = [
+	{
+		label: __( 'Newest to oldest' ),
+		value: 'date/desc',
+	},
+	{
+		label: __( 'Oldest to newest' ),
+		value: 'date/asc',
+	},
+	{
+		/* translators: label for ordering posts by title in ascending order */
+		label: __( 'A → Z' ),
+		value: 'title/asc',
+	},
+	{
+		/* translators: label for ordering posts by title in descending order */
+		label: __( 'Z → A' ),
+		value: 'title/desc',
+	},
+];
+
+const QueryControls = React.memo(
+	( {
+		categoriesList,
+		selectedCategoryId,
+		numberOfItems,
+		order,
+		orderBy,
+		maxItems = DEFAULT_MAX_ITEMS,
+		minItems = DEFAULT_MIN_ITEMS,
+		onCategoryChange,
+		onNumberOfItemsChange,
+		onOrderChange,
+		onOrderByChange,
+	} ) => {
+		const onChange = useCallback(
+			( value ) => {
+				const [ newOrderBy, newOrder ] = value.split( '/' );
+				if ( newOrder !== order ) {
+					onOrderChange( newOrder );
+				}
+				if ( newOrderBy !== orderBy ) {
+					onOrderByChange( newOrderBy );
+				}
+			},
+			[ order, orderBy, onOrderByChange, onOrderChange ]
+		);
+
+		return [
+			onOrderChange && onOrderByChange && (
+				<SelectControl
+					label={ __( 'Order by' ) }
+					value={ `${ orderBy }/${ order }` }
+					options={ options }
+					onChange={ onChange }
+				/>
+			),
+			onCategoryChange && (
+				<CategorySelect
+					categoriesList={ categoriesList }
+					label={ __( 'Category' ) }
+					noOptionLabel={ __( 'All' ) }
+					selectedCategoryId={ selectedCategoryId }
+					onChange={ onCategoryChange }
+				/>
+			),
+			onNumberOfItemsChange && (
+				<RangeControl
+					label={ __( 'Number of items' ) }
+					value={ numberOfItems }
+					onChange={ onNumberOfItemsChange }
+					min={ minItems }
+					max={ maxItems }
+					required
+				/>
+			),
+		];
+	}
+);
+
+export default QueryControls;

--- a/packages/components/src/query-controls/index.native.js
+++ b/packages/components/src/query-controls/index.native.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import React from 'react';
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
+import { useCallback, memo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -38,7 +34,7 @@ const options = [
 	},
 ];
 
-const QueryControls = React.memo(
+const QueryControls = memo(
 	( {
 		categoriesList,
 		selectedCategoryId,

--- a/packages/components/src/range-control/index.native.js
+++ b/packages/components/src/range-control/index.native.js
@@ -1,14 +1,14 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import React from 'react';
+import { memo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import RangeCell from '../mobile/bottom-sheet/range-cell';
 import StepperCell from '../mobile/bottom-sheet/stepper-cell';
 
-const RangeControl = React.memo(
+const RangeControl = memo(
 	( {
 		className,
 		currentInput,

--- a/packages/components/src/range-control/index.native.js
+++ b/packages/components/src/range-control/index.native.js
@@ -1,64 +1,70 @@
 /**
+ * External dependencies
+ */
+import React from 'react';
+/**
  * Internal dependencies
  */
 import RangeCell from '../mobile/bottom-sheet/range-cell';
 import StepperCell from '../mobile/bottom-sheet/stepper-cell';
 
-function RangeControl( {
-	className,
-	currentInput,
-	label,
-	value,
-	instanceId,
-	onChange,
-	beforeIcon,
-	afterIcon,
-	help,
-	allowReset,
-	initialPosition,
-	min,
-	max,
-	type,
-	separatorType,
-	...props
-} ) {
-	if ( type === 'stepper' ) {
+const RangeControl = React.memo(
+	( {
+		className,
+		currentInput,
+		label,
+		value,
+		instanceId,
+		onChange,
+		beforeIcon,
+		afterIcon,
+		help,
+		allowReset,
+		initialPosition,
+		min,
+		max,
+		type,
+		separatorType,
+		...props
+	} ) => {
+		if ( type === 'stepper' ) {
+			return (
+				<StepperCell
+					label={ label }
+					max={ max }
+					min={ min }
+					onChange={ onChange }
+					separatorType={ separatorType }
+					value={ value }
+				/>
+			);
+		}
+		const id = `inspector-range-control-${ instanceId }`;
+		const currentInputValue = currentInput === null ? value : currentInput;
+		const initialSliderValue = isFinite( currentInputValue )
+			? currentInputValue
+			: initialPosition;
+
 		return (
-			<StepperCell
+			<RangeCell
 				label={ label }
-				max={ max }
-				min={ min }
+				id={ id }
+				help={ help }
+				className={ className }
 				onChange={ onChange }
-				separatorType={ separatorType }
+				aria-describedby={ !! help ? `${ id }__help` : undefined }
+				minimumValue={ min }
+				maximumValue={ max }
 				value={ value }
+				beforeIcon={ beforeIcon }
+				afterIcon={ afterIcon }
+				allowReset={ allowReset }
+				defaultValue={ initialSliderValue }
+				separatorType={ separatorType }
+				{ ...props }
 			/>
 		);
 	}
-	const id = `inspector-range-control-${ instanceId }`;
-	const currentInputValue = currentInput === null ? value : currentInput;
-	const initialSliderValue = isFinite( currentInputValue )
-		? currentInputValue
-		: initialPosition;
-
-	return (
-		<RangeCell
-			label={ label }
-			id={ id }
-			help={ help }
-			className={ className }
-			onChange={ onChange }
-			aria-describedby={ !! help ? `${ id }__help` : undefined }
-			minimumValue={ min }
-			maximumValue={ max }
-			value={ value }
-			beforeIcon={ beforeIcon }
-			afterIcon={ afterIcon }
-			allowReset={ allowReset }
-			defaultValue={ initialSliderValue }
-			separatorType={ separatorType }
-			{ ...props }
-		/>
-	);
-}
+);
 
 export default RangeControl;

--- a/packages/components/src/select-control/index.native.js
+++ b/packages/components/src/select-control/index.native.js
@@ -1,13 +1,13 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import React from 'react';
+import { memo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import PickerCell from '../mobile/bottom-sheet/picker-cell';
 
-const SelectControl = React.memo(
+const SelectControl = memo(
 	( {
 		help,
 		instanceId,

--- a/packages/components/src/select-control/index.native.js
+++ b/packages/components/src/select-control/index.native.js
@@ -1,35 +1,41 @@
 /**
+ * External dependencies
+ */
+import React from 'react';
+/**
  * Internal dependencies
  */
 import PickerCell from '../mobile/bottom-sheet/picker-cell';
 
-function SelectControl( {
-	help,
-	instanceId,
-	label,
-	multiple = false,
-	onChange,
-	options = [],
-	className,
-	hideLabelFromVision,
-	...props
-} ) {
-	const id = `inspector-select-control-${ instanceId }`;
+const SelectControl = React.memo(
+	( {
+		help,
+		instanceId,
+		label,
+		multiple = false,
+		onChange,
+		options = [],
+		className,
+		hideLabelFromVision,
+		...props
+	} ) => {
+		const id = `inspector-select-control-${ instanceId }`;
 
-	return (
-		<PickerCell
-			label={ label }
-			hideLabelFromVision={ hideLabelFromVision }
-			id={ id }
-			help={ help }
-			className={ className }
-			onChangeValue={ onChange }
-			aria-describedby={ !! help ? `${ id }__help` : undefined }
-			multiple={ multiple }
-			options={ options }
-			{ ...props }
-		/>
-	);
-}
+		return (
+			<PickerCell
+				label={ label }
+				hideLabelFromVision={ hideLabelFromVision }
+				id={ id }
+				help={ help }
+				className={ className }
+				onChangeValue={ onChange }
+				aria-describedby={ !! help ? `${ id }__help` : undefined }
+				multiple={ multiple }
+				options={ options }
+				{ ...props }
+			/>
+		);
+	}
+);
 
 export default SelectControl;

--- a/packages/components/src/toggle-control/index.native.js
+++ b/packages/components/src/toggle-control/index.native.js
@@ -1,13 +1,13 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import React from 'react';
+import { memo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import SwitchCell from '../mobile/bottom-sheet/switch-cell';
 
-const ToggleControl = React.memo(
+const ToggleControl = memo(
 	( { label, checked, help, instanceId, className, onChange, ...props } ) => {
 		const id = `inspector-toggle-control-${ instanceId }`;
 

--- a/packages/components/src/toggle-control/index.native.js
+++ b/packages/components/src/toggle-control/index.native.js
@@ -1,31 +1,29 @@
 /**
+ * External dependencies
+ */
+import React from 'react';
+/**
  * Internal dependencies
  */
 import SwitchCell from '../mobile/bottom-sheet/switch-cell';
 
-function ToggleControl( {
-	label,
-	checked,
-	help,
-	instanceId,
-	className,
-	onChange,
-	...props
-} ) {
-	const id = `inspector-toggle-control-${ instanceId }`;
+const ToggleControl = React.memo(
+	( { label, checked, help, instanceId, className, onChange, ...props } ) => {
+		const id = `inspector-toggle-control-${ instanceId }`;
 
-	return (
-		<SwitchCell
-			label={ label }
-			id={ id }
-			help={ help }
-			className={ className }
-			value={ checked }
-			onValueChange={ onChange }
-			aria-describedby={ !! help ? id + '__help' : undefined }
-			{ ...props }
-		/>
-	);
-}
+		return (
+			<SwitchCell
+				label={ label }
+				id={ id }
+				help={ help }
+				className={ className }
+				value={ checked }
+				onValueChange={ onChange }
+				aria-describedby={ !! help ? id + '__help' : undefined }
+				{ ...props }
+			/>
+		);
+	}
+);
 
 export default ToggleControl;

--- a/packages/components/src/tree-select/index.js
+++ b/packages/components/src/tree-select/index.js
@@ -4,6 +4,10 @@
 import { unescape as unescapeString, repeat, flatMap, compact } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+/**
  * Internal dependencies
  */
 import { SelectControl } from '../';
@@ -27,10 +31,13 @@ export default function TreeSelect( {
 	tree,
 	...props
 } ) {
-	const options = compact( [
-		noOptionLabel && { value: '', label: noOptionLabel },
-		...getSelectOptions( tree ),
-	] );
+	const options = useMemo( () => {
+		return compact( [
+			noOptionLabel && { value: '', label: noOptionLabel },
+			...getSelectOptions( tree ),
+		] );
+	}, [ noOptionLabel, tree ] );
+
 	return (
 		<SelectControl
 			{ ...{ label, options, onChange } }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

Part of: https://github.com/WordPress/gutenberg/pull/28196

Contains changes only related to the `Latest Posts` block and controls available within block settings.

| BLOCK			| KIND OF SETTING		| CONTROL COMPONENT	| NESTED CONTROL COMPONENT	|
| :---			| :---: 				|  :---: 			| :---:  					|
| LatestPosts   | Post Content Settings	| `ToggleControl`   | 	 						|
|   			|      					| `ToggleControl`   | 							|	
|   			|      					| `RangeControl`    | 							|
|  				| Post Meta Settings    | `ToggleControl`   |  							|
|   			| Sorting and filtering | `QueryControls`   | `SelectControl`			|
|   			|  						| 					| `CategoryControl`			|
|   			|  						| 					| `RangeControl`			|


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Test manually `LatestPost` block on mobile and web.

1. Open the app
2. Add `LatestPosts` block
3. Open block settings
4. Play with settings and confirm that all of them works
5. Keep all the options enabled
6. Save the post and open it on web

**Expect all the enabled options are displayed properly**

## Screenshots <!-- if applicable -->

### RESULTS

**1. toggling show post content**

- updating and mounting time reduced from **16.54ms** to **6.68ms**
- avoid redundant updates in other controls eg `QueryControl`

before | after
--- | ---
<img width="1137" alt="toggle_show_post_before" src="https://user-images.githubusercontent.com/22746080/104640854-532f4280-56a9-11eb-88e9-01b3a5206cca.png"> | <img width="1137" alt="toggle_show_post" src="https://user-images.githubusercontent.com/22746080/104640846-4f9bbb80-56a9-11eb-8b3b-dbdba60e5f15.png">

**2. Toggling post date when post content is presented**

- updating time reduce from **18.79ms** to **2.61ms**
- avoid redundant updates in other controls

before | after
--- | ---
<img width="1137" alt="toggle_display_post_date_before" src="https://user-images.githubusercontent.com/22746080/104641816-8e7e4100-56aa-11eb-9cc0-a1e04690437b.png"> | <img width="1137" alt="toggle_display_post_date" src="https://user-images.githubusercontent.com/22746080/104641824-90e09b00-56aa-11eb-9d78-e0acf0c8ee83.png">

**3. Change number of items**

- updating time reduce from **12.83ms** to **3.66ms**
- avoid redundant updates in other controls

before | after
--- | ---
<img width="1137" alt="trigger_num_of_items_before" src="https://user-images.githubusercontent.com/22746080/104642744-9c809180-56ab-11eb-9893-7784c4586b15.png"> | <img width="1137" alt="trigger_num_of_items" src="https://user-images.githubusercontent.com/22746080/104642757-a0141880-56ab-11eb-9d08-86aabb5e5534.png">




## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Performance improvements

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
