### PR TITLE
Full Site Editing: Overwrite theme attributes in file based templates

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -122,7 +122,6 @@ function _inject_theme_attribute_in_content( $template_content, $theme ) {
 	foreach ( $template_blocks as $key => $block ) {
 		if (
 			'core/template-part' === $block['blockName'] &&
-			! isset( $block['attrs']['theme'] ) &&
 			wp_get_theme()->get_stylesheet() === $theme
 		) {
 			$template_blocks[ $key ]['attrs']['theme'] = $theme;

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -87,14 +87,6 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals( $expected, $template_content );
 
-		// Does not inject theme when there is an existing theme attribute.
-		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->';
-		$template_content                      = _inject_theme_attribute_in_content(
-			$content_with_existing_theme_attribute,
-			$theme
-		);
-		$this->assertEquals( $content_with_existing_theme_attribute, $template_content );
-
 		// Does not inject theme when there is no template part.
 		$content_with_no_template_part = '<!-- wp:post-content /-->';
 		$template_content              = _inject_theme_attribute_in_content(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This ticket is a follow up to https://github.com/WordPress/gutenberg/pull/28088.

To simplify and constrain the scope of full site editing work, there was a prior decision made to assume that when we serve template files, they're always from the currently active theme. See the discussion [here](https://github.com/WordPress/gutenberg/pull/27910#discussion_r552063897). There were also [discussions](https://github.com/WordPress/gutenberg/pull/27910#discussion_r554203550) about removing the theme attribute from file-based template parts.

Following that logic, there were questions about just stripping the theme attribute in template files entirely, and replacing them with the currently active theme. We couldn't think of valid use cases otherwise, so this PR is a proposal to ignore theme attributes from file-based templates and to replace them with the current theme's stylesheet.

### Note:
I left a note in the PR description of #28088. We were were planning to remove the theme attribute entirely from all file-based template parts (and I'd say it's still worthwhile to do so). These changes accomplish the same goal, but do so in a programmatic and scalable way.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for https://github.com/Automattic/wp-calypso/issues/48145

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
