### PR TITLE
Gallery Block Refactor: Add handling of short code transforms

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -10,6 +10,13 @@
 				"type": "object"
 			}
 		},
+		"shortCodeTransforms": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "object"
+			}
+		},
 		"columns": {
 			"type": "number",
 			"minimum": 1,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -186,7 +186,6 @@ function GalleryEdit( props ) {
 		if ( existingBlock ) {
 			return existingBlock.attributes;
 		}
-
 		return {
 			...pickRelevantMediaFiles( image, sizeSlug ),
 			...getHrefAndDestination( image, linkTo ),
@@ -226,6 +225,7 @@ function GalleryEdit( props ) {
 
 				return file;
 			} );
+
 		const existingImageBlocks = replace
 			? innerBlockImages.filter( ( block ) =>
 					processedImages.find(

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, every, toString } from 'lodash';
+import { filter, every } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -59,19 +59,14 @@ const transforms = {
 		{
 			type: 'shortcode',
 			tag: 'gallery',
+
 			attributes: {
-				images: {
+				shortCodeTransforms: {
 					type: 'array',
 					shortcode: ( { named: { ids } } ) => {
 						return parseShortcodeIds( ids ).map( ( id ) => ( {
-							id: toString( id ),
+							id: parseInt( id ),
 						} ) );
-					},
-				},
-				ids: {
-					type: 'array',
-					shortcode: ( { named: { ids } } ) => {
-						return parseShortcodeIds( ids );
 					},
 				},
 				columns: {

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -13,7 +13,11 @@ import { createBlobURL } from '@wordpress/blob';
  * Internal dependencies
  */
 import { pickRelevantMediaFiles } from './shared';
-import { LINK_DESTINATION_ATTACHMENT } from './constants';
+import {
+	LINK_DESTINATION_ATTACHMENT,
+	LINK_DESTINATION_NONE,
+	LINK_DESTINATION_MEDIA,
+} from './constants';
 
 const parseShortcodeIds = ( ids ) => {
 	if ( ! ids ) {
@@ -78,9 +82,16 @@ const transforms = {
 				linkTo: {
 					type: 'string',
 					shortcode: ( {
-						named: { link = LINK_DESTINATION_ATTACHMENT },
+						named: { link = LINK_DESTINATION_NONE },
 					} ) => {
-						return link;
+						switch ( link ) {
+							case 'post':
+								return LINK_DESTINATION_ATTACHMENT;
+							case 'file':
+								return LINK_DESTINATION_MEDIA;
+							default:
+								return LINK_DESTINATION_NONE;
+						}
 					},
 				},
 			},

--- a/packages/block-library/src/gallery/use-short-code-transform.js
+++ b/packages/block-library/src/gallery/use-short-code-transform.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { every } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+export default function useShortCodeTransform(
+	shortCodeTransforms,
+	getMedia,
+	setAttributes,
+	replaceInnerBlocks,
+	clientId
+) {
+	if ( ! shortCodeTransforms || shortCodeTransforms.length === 0 ) {
+		return;
+	}
+	const newImageData = shortCodeTransforms.map( ( image ) => {
+		return getMedia( image.id );
+	} );
+	if ( every( newImageData, ( img ) => img && img.source_url ) ) {
+		const newBlocks = newImageData.map( ( image ) => {
+			return createBlock( 'core/image', {
+				inheritedAttributes: {
+					linkDestination: true,
+					linkTarget: true,
+					sizeSlug: true,
+				},
+				id: image.id,
+				url: image.source_url,
+			} );
+		} );
+		replaceInnerBlocks( clientId, newBlocks );
+		setAttributes( { shortCodeTransforms: undefined } );
+	}
+}


### PR DESCRIPTION
Adds handling of Gallery shortcode transforms to the new gallery format

### Tesing

Check out this PR
Add a new post and just add `[gallery ids="341,342"]` in editor code view - replace ids with ones that match images in your text env
Go back to editor view and choose option to convert Classic to Blocks
Should convert to new Gallery block format