### PR TITLE
Update react-native-bridge to build an AAR to publish on Bintray and use in WordPress Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46493,18 +46493,18 @@
 					"dev": true
 				},
 				"mime-db": {
-					"version": "1.44.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+					"version": "1.45.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+					"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
 					"dev": true
 				},
 				"mime-types": {
-					"version": "2.1.27",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-					"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+					"version": "2.1.28",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+					"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.44.0"
+						"mime-db": "1.45.0"
 					}
 				},
 				"ms": {
@@ -46547,9 +46547,9 @@
 					}
 				},
 				"tar-stream": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-					"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+					"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
 					"dev": true,
 					"requires": {
 						"bl": "^4.0.3",
@@ -46560,9 +46560,9 @@
 					}
 				},
 				"ws": {
-					"version": "7.4.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-					"integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+					"version": "7.4.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+					"integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
 					"dev": true
 				},
 				"yauzl": {

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -143,7 +143,24 @@ repositories {
 }
 
 dependencies {
-    implementation project(':@wordpress_react-native-aztec')
+    // Embedding Aztec seems to break the build from source when running from
+    // the WordPress Android project. That shouldn't be the case. While we
+    // investigate, embed only when making a binary build.
+    //
+    // Note that this also means that we cannot run an `assemble` task for
+    // WordPress Android while building from source, because that would result
+    // in an unsupported "direct local AAR file dependency". That shouldn't be
+    // a blocker becuase CI runs `assemble` tasks and should always do so
+    // without building dependencies from source, for performance and
+    // correctness reasons (as building from source should only be used while
+    // developing changes, right?)
+    if (rootProject.ext.buildGutenbergFromSource) {
+        implementation project(':@wordpress_react-native-aztec')
+    } else {
+        // embed is a method from the fat-aar plugin that will the Aztec project
+        // dependency into the generated AAR
+        embed project(':@wordpress_react-native-aztec')
+    }
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -364,3 +364,64 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         delete nodeModulesFolders
     }
 }
+
+// Allows to override the artifact version by passing a -PbintrayVersion
+// parameter when calling Gradle
+def getBintrayVersion() {
+  return project.properties['bintrayVersion'] ?: android.defaultConfig.versionName
+}
+
+bintray {
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_KEY')
+    publications = ['GutenbergMobilePublication']
+    publish = true
+    pkg {
+        repo = 'maven'
+        name = 'react-native-gutenberg-bridge'
+        licenses = ['GPL-2.0']
+        // FIXME: Once this works properly poit to 'wordpress-mobile'
+        userOrg = 'mokagio'
+        // FIXME: Once this works properly poit to the original gutenberg (or gutenberg-mobile) repo. See also: https://github.com/oguzkocer/gutenberg/commit/0ca71b1abe3ea22b77abb3f390534e66e39161d5#diff-320e7dacc9e9a83ac8128d299319f82cf6dfa2609e0ebbc043d13de33ea92773R350-R353
+        vcsUrl = 'https://github.com/wordpress-mobile/gutenberg-mobile.git'
+        version {
+            name = getBintrayVersion()
+            released  = new Date()
+        }
+    }
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            GutenbergMobilePublication(MavenPublication) {
+                artifact bundleReleaseAar
+
+                groupId 'com.github.wordpress-mobile.gutenberg-mobile'
+                artifactId 'react-native-gutenberg-bridge'
+                version getBintrayVersion()
+
+                addDependenciesToPom(pom)
+            }
+        }
+    }
+}
+
+// This is a workaround for adding the dependencies of the library. It's brought from the
+// plugin's README file: https://github.com/bintray/gradle-bintray-plugin/blob/1.8.5/README.md
+def addDependenciesToPom(pom) {
+    pom.withXml {
+        def dependenciesNode = asNode().getAt('dependencies')[0] ?: asNode().appendNode('dependencies')
+
+        // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+        configurations.implementation.allDependencies.each {
+            // Ensure dependencies such as fileTree are not included.
+            if (it.name != 'unspecified') {
+                def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+            }
+        }
+    }
+}

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -121,6 +121,10 @@ android {
         main {
             assets.srcDirs += buildAssetsFolder
             assets.srcDirs += '../../../../src/block-support'
+            // Despite being in a folder called "resources", the files in
+            // unsupported-block-editor are accessed as assets by their
+            // consumers: the WordPressEditor library.
+            assets.srcDirs += '../../../../resources/unsupported-block-editor'
         }
     }
 }

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -120,6 +120,7 @@ android {
     sourceSets {
         main {
             assets.srcDirs += buildAssetsFolder
+            assets.srcDirs += '../../../../src/block-support'
         }
     }
 }

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -21,6 +21,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
 
         if (buildGutenbergMobileJSBundle) {
             classpath 'com.github.node-gradle:gradle-node-plugin:3.0.0-rc2'
@@ -31,6 +32,8 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish' // this enables publishing via Bintray
 
 def buildGutenbergMobileJSBundle =
         System.getenv('SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD').asBoolean()

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -22,6 +22,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        // Allows embedding other dependencies into the AAR for this one
+        classpath 'com.kezong:fat-aar:1.2.20'
 
         if (buildGutenbergMobileJSBundle) {
             classpath 'com.github.node-gradle:gradle-node-plugin:3.0.0-rc2'
@@ -34,6 +36,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish' // this enables publishing via Bintray
+apply plugin: 'com.kezong.fat-aar'
 
 def buildGutenbergMobileJSBundle =
         System.getenv('SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD').asBoolean()

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -210,8 +210,18 @@ dependencies {
         implementation "com.facebook.react:react-native:${rnVersion}"
     }
 
-    debugImplementation files(hermesPath + "hermes-debug.aar")
-    releaseImplementation files(hermesPath + "hermes-release.aar")
+    // We used to add the Hermes engine like this, but it creates problems with
+    // both direct AAR from Bintray usage and Gradle composite build.
+    //
+    // Leaving it here as a starting point for eventually embed it correctly
+    // here so that consumers don't have to do it.
+    //
+    // See:
+    // - https://github.com/wordpress-mobile/WordPress-Android/pull/13642
+    // - https://github.com/wordpress-mobile/gutenberg-mobile/issues/2973
+    //
+    // debugImplementation files(hermesPath + "hermes-debug.aar")
+    // releaseImplementation files(hermesPath + "hermes-release.aar")
 }
 
 boolean isBundleUpToDate() {

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -395,9 +395,7 @@ bintray {
         repo = 'maven'
         name = 'react-native-gutenberg-bridge'
         licenses = ['GPL-2.0']
-        // FIXME: Once this works properly poit to 'wordpress-mobile'
-        userOrg = 'mokagio'
-        // FIXME: Once this works properly poit to the original gutenberg (or gutenberg-mobile) repo. See also: https://github.com/oguzkocer/gutenberg/commit/0ca71b1abe3ea22b77abb3f390534e66e39161d5#diff-320e7dacc9e9a83ac8128d299319f82cf6dfa2609e0ebbc043d13de33ea92773R350-R353
+        userOrg = 'wordpress-mobile'
         vcsUrl = 'https://github.com/wordpress-mobile/gutenberg-mobile.git'
         version {
             name = getBintrayVersion()

--- a/packages/react-native-bridge/android/settings.gradle
+++ b/packages/react-native-bridge/android/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = '@wordpress/react-native-bridge'
+rootProject.name = '@wordpress_react-native-bridge'
 
 include ':@wordpress_react-native-aztec'
 project(':@wordpress_react-native-aztec').projectDir = new File(rootProject.projectDir, '../../react-native-aztec/android')

--- a/packages/react-native-bridge/android/src/main/res/values/colors.xml
+++ b/packages/react-native-bridge/android/src/main/res/values/colors.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <color name="status_bar_color">#006088</color>
+    <color name="white">@android:color/white</color>
 
 </resources>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This is part of the [Composite Android build for Gutenberg](https://github.com/orgs/wordpress-mobile/projects/80#card-52385844), an effort to simplify and speed up the build and workflow for developers of the WordPress Android app.

The changes in this PR are the minimum require to build an AAR that can both be published to Bintray and used by the WordPress app.

The diff includes changes to the `package-lock.json` because [CI told me so](https://github.com/WordPress/gutenberg/pull/28216/checks?check_run_id=1710376166) even though I didn't changed the `package.json` itself 🤔 .

This supersedes #27836.

## How has this been tested?

I generated and published an AAR from this changeset and verified it works in the WordPress app via [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13642). 

## Types of changes

This PR tweaks the `react-native-bridge/android` build configuration only.

## Checklist:

- [ ] ~~My code is tested.~~ There's no infrastructure to test these changes automatically. I only performed manual testing, i.e.: run the generated AAR in the WrodPress Android app and verified it works.
- [ ] ~~My code follows the WordPress code style.~~ N.A. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] ~~My code follows the accessibility standards.~~ N.A. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md --> N.A.
