### PR TITLE
Polish the appender focus style.

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -33,7 +33,8 @@
 		flex-direction: row;
 		color: $gray-900;
 		box-shadow: none;
-		height: 24px;
+		height: $icon-size;
+		width: $icon-size;
 		padding: 0;
 		margin-left: $grid-unit-10;
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -15,9 +15,10 @@ $navigation-item-height: 46px;
 
 // Polish the Appender.
 .wp-block-navigation .block-list-appender {
-	margin: 0;
-	display: flex;
-	align-items: center;
+	display: inline-flex;
+	align-self: center;
+	width: $icon-size;
+	height: $icon-size;
 }
 
 .wp-block-navigation.is-vertical .block-list-appender {


### PR DESCRIPTION
Have you ever seen this weird focus style when you try to click the navigation block?

<img width="866" alt="Screenshot 2021-01-15 at 10 19 31" src="https://user-images.githubusercontent.com/1204802/104707964-67ad2280-571d-11eb-915a-2dfb565291c2.png">

That's the focus style on the container of the appender. That container can receive focus so as to support Firefox, which does things differently (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus, or line 84 in block-list-appender/index.js). 

But the shape is dumb, the focus style is bad, and the fact that it has this shape means you can't click above the plus to select the navigation parent. This PR fixes that:

<img width="458" alt="Screenshot 2021-01-15 at 10 31 10" src="https://user-images.githubusercontent.com/1204802/104708155-9b884800-571d-11eb-993c-7a6b9af094fb.png">

Now you can click outside the plus to select the navigation parent. And the shape is sane.