### PR TITLE
Fix the nav menu justify controls menu style.

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -121,6 +121,11 @@ function Navigation( {
 		};
 	}
 
+	const POPOVER_PROPS = {
+		position: 'bottom right',
+		isAlternate: true,
+	};
+
 	return (
 		<>
 			<BlockControls>
@@ -131,6 +136,7 @@ function Navigation( {
 								? navIcons[ attributes.itemsJustification ]
 								: navIcons.left
 						}
+						popoverProps={ POPOVER_PROPS }
 						label={ __( 'Change items justification' ) }
 						isCollapsed
 						controls={ [


### PR DESCRIPTION
Dropdown menus that open from block toolbars should be made of "block toolbar material". We have a popover prop for that. This PR adds it. 

Before:

<img width="675" alt="Screenshot 2021-01-15 at 10 41 15" src="https://user-images.githubusercontent.com/1204802/104708929-97105f00-571e-11eb-827b-471a4d9e61d5.png">

After:

<img width="526" alt="Screenshot 2021-01-15 at 10 41 48" src="https://user-images.githubusercontent.com/1204802/104708936-98da2280-571e-11eb-995a-cacd1b6f7f1a.png">
