### PR TITLE
Fix backwards compatibility issue with Inline Image format

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -35,7 +35,7 @@ export const image = {
 
 function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 	const { style } = activeObjectAttributes;
-	const [ width, setWidth ] = useState( style.replace( /\D/g, '' ) );
+	const [ width, setWidth ] = useState( style?.replace( /\D/g, '' ) );
 	const anchorRef = useAnchorRef( {
 		ref: contentRef,
 		value,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28218

This seems to have been caused by a recent refactor of the code for the inline image UI - https://github.com/WordPress/gutenberg/pull/26779.

## How has this been tested?
1. Install the Yoast plugin
2. Add a Yoast FAQ block
3. Use the add image button in the block to add an image
4. Deselect the block and then reselect it
5. An error shouldn't be thrown.

I also tested reverting the change from #26779 to make sure the behavior in this change is the same as it was before the refactor that caused the issue.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
