### PR TITLE
Add disabled support in ToggleControl and FormToggle

### DIFF
--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -79,6 +79,13 @@ If no value is passed the toggle will be unchecked.
 - Type: `Boolean`
 - Required: No
 
+#### disabled
+
+If disabled is true the toggle will be wrapped in `Disabled` component and apply the appropriate styles.
+
+- Type: `Boolean`
+- Required: No
+
 #### onChange
 
 A function that receives the checked state (boolean) as input.

--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -81,7 +81,7 @@ If no value is passed the toggle will be unchecked.
 
 #### disabled
 
-If disabled is true the toggle will be wrapped in `Disabled` component and apply the appropriate styles.
+If disabled is true the toggle will be disabled and apply the appropriate styles.
 
 - Type: `Boolean`
 - Required: No

--- a/packages/components/src/form-toggle/index.js
+++ b/packages/components/src/form-toggle/index.js
@@ -3,13 +3,24 @@
  */
 import classnames from 'classnames';
 import { noop } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import Disabled from '../disabled';
 
-function FormToggle( { className, checked, id, onChange = noop, ...props } ) {
+function FormToggle( {
+	className,
+	checked,
+	id,
+	disabled,
+	onChange = noop,
+	...props
+} ) {
 	const wrapperClasses = classnames( 'components-form-toggle', className, {
 		'is-checked': checked,
 	} );
 
-	return (
+	const formToggleInput = (
 		<span className={ wrapperClasses }>
 			<input
 				className="components-form-toggle__input"
@@ -22,6 +33,12 @@ function FormToggle( { className, checked, id, onChange = noop, ...props } ) {
 			<span className="components-form-toggle__track"></span>
 			<span className="components-form-toggle__thumb"></span>
 		</span>
+	);
+
+	return disabled ? (
+		<Disabled>{ formToggleInput }</Disabled>
+	) : (
+		formToggleInput
 	);
 }
 

--- a/packages/components/src/form-toggle/index.js
+++ b/packages/components/src/form-toggle/index.js
@@ -3,10 +3,6 @@
  */
 import classnames from 'classnames';
 import { noop } from 'lodash';
-/**
- * Internal dependencies
- */
-import Disabled from '../disabled';
 
 function FormToggle( {
 	className,
@@ -18,9 +14,10 @@ function FormToggle( {
 } ) {
 	const wrapperClasses = classnames( 'components-form-toggle', className, {
 		'is-checked': checked,
+		'is-disabled': disabled,
 	} );
 
-	const formToggleInput = (
+	return (
 		<span className={ wrapperClasses }>
 			<input
 				className="components-form-toggle__input"
@@ -28,17 +25,12 @@ function FormToggle( {
 				type="checkbox"
 				checked={ checked }
 				onChange={ onChange }
+				disabled={ disabled }
 				{ ...props }
 			/>
 			<span className="components-form-toggle__track"></span>
 			<span className="components-form-toggle__thumb"></span>
 		</span>
-	);
-
-	return disabled ? (
-		<Disabled>{ formToggleInput }</Disabled>
-	) : (
-		formToggleInput
 	);
 }
 

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -60,6 +60,7 @@ $toggle-border-width: 1px;
 	}
 
 	// Disabled state:
+	&.is-disabled,
 	.components-disabled & {
 		opacity: 0.3;
 	}

--- a/packages/components/src/toggle-control/README.md
+++ b/packages/components/src/toggle-control/README.md
@@ -50,7 +50,7 @@ If no value is passed the toggle will be unchecked.
 
 ### disabled
 
-If disabled is true the toggle input will be wrapped in `Disabled` component and apply the appropriate styles.
+If disabled is true the toggle will be disabled and apply the appropriate styles.
 
 - Type: `Boolean`
 - Required: No

--- a/packages/components/src/toggle-control/README.md
+++ b/packages/components/src/toggle-control/README.md
@@ -48,6 +48,14 @@ If no value is passed the toggle will be unchecked.
 - Type: `Boolean`
 - Required: No
 
+### disabled
+
+If disabled is true the toggle input will be wrapped in `Disabled` component and apply the appropriate styles.
+
+- Type: `Boolean`
+- Required: No
+
+
 ### onChange
 
 A function that receives the checked state (boolean) as input.

--- a/packages/components/src/toggle-control/index.js
+++ b/packages/components/src/toggle-control/index.js
@@ -21,6 +21,7 @@ export default function ToggleControl( {
 	help,
 	className,
 	onChange,
+	disabled,
 } ) {
 	function onChangeToggle( event ) {
 		onChange( event.target.checked );
@@ -45,6 +46,7 @@ export default function ToggleControl( {
 				checked={ checked }
 				onChange={ onChangeToggle }
 				aria-describedby={ describedBy }
+				disabled={ disabled }
 			/>
 			<label htmlFor={ id } className="components-toggle-control__label">
 				{ label }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/16393

This PR adds `disabled` support in `FormToggle` and if is set to `true`, it disables it and applies the appropriate styles.

I added the `disabled` support to `ToggleControl` as well, as is widely used and passes that prop down to `FormToggle` which is used internally.

### Example result
<img width="283" alt="Screenshot 2021-01-15 at 1 01 43 PM" src="https://user-images.githubusercontent.com/16275880/104717382-e613bf80-5731-11eb-8bf1-db83de9f8973.png">
