### PR TITLE
FSE Navigation sidebar: Show single post template in posts templates

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
@@ -7,7 +7,7 @@ export const TEMPLATES_GENERAL = [
 	'404',
 ];
 
-export const TEMPLATES_POSTS = [ 'home', 'single' ];
+export const TEMPLATES_POSTS = [ 'home', 'single', 'single-post' ];
 
 export const TEMPLATES_NEW_OPTIONS = [
 	'front-page',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Show `single-post` template in the posts menu.

## How has this been tested?
1. Open Site Editor
2. Open Navigation sidebar
3. Click Templates
4. Click + button to add a new template, choose Post
5. Navigate to Posts submenu
6. Make sure Post is displayed

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/104718485-389dad80-572b-11eb-8d84-fa00d2a96a65.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
