### PR TITLE
Scripts: Prevent mangle of translation functions

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -121,6 +121,9 @@ const config = {
 					compress: {
 						passes: 2,
 					},
+					mangle: {
+						//reserved: [ '__', '_n', '_nx', '_x' ],
+					},
 				},
 				extractComments: false,
 			} ),

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -122,7 +122,7 @@ const config = {
 						passes: 2,
 					},
 					mangle: {
-						//reserved: [ '__', '_n', '_nx', '_x' ],
+						reserved: [ '__', '_n', '_nx', '_x' ],
 					},
 				},
 				extractComments: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,6 +81,9 @@ module.exports = {
 					compress: {
 						passes: 2,
 					},
+					mangle: {
+						reserved: [ '__', '_n', '_nx', '_x' ],
+					},
 				},
 				extractComments: false,
 			} ),


### PR DESCRIPTION
## Description
In https://github.com/WordPress/gutenberg/issues/28221 we discovered that a string in the `i18n` package was not translated and not correctly extracted. It's believed this is related to function name mangling in the build optimization.

Translation function names should remain unmangled so that they can be properly extracted and processed for translation by Core tooling.

## How has this been tested?

Compare the `isRTL` function declaration in the i18n build asset from this branch with the [current release](https://plugins.svn.wordpress.org/gutenberg/tags/9.7.2/build/i18n/index.js).

Current release:

```js
function(){return"rtl"===i("ltr","text direction")}              },
```

Build from this branch:

```js
function(){return"rtl"===_x("ltr","text direction")}
```

The mangled name `i` is not extracted for translation, but the `_x` name should be 👍 

Fixes: #28221
## Types of changes
Bug fix: Translation function names should not be mangled.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
