### PR TITLE
Chore: Add changelog for 28231

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bug Fix
 
 -   Ensure that `check-engines` uses the same default version of Node.js and npm as this package ([#28143](https://github.com/WordPress/gutenberg/pull/28143)).
+-   Prevent translation function names from being mangled to ensure stings are extracted ([#28231](https://github.com/WordPress/gutenberg/pull/28231)).
 
 ### Internal
 


### PR DESCRIPTION

## Description
This includes a changelog entry describing https://github.com/WordPress/gutenberg/pull/28231.

I've avoided pushing it there to prevent re-triggering the tests and slowing the process. It can be easily merged if desired.