### PR TITLE
Create Block: Add optional support for wp-env

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Add support for handling static assets with the `assetsPath` field in the external template configuration ([#28038](https://github.com/WordPress/gutenberg/pull/28038)).
 -   Allow using locally installed packages with templates ([#28105](https://github.com/WordPress/gutenberg/pull/28105)).
+-   Add new CLI option `--wp-env` that lets users override the setting that template defines for integration with `@wordpress/env` package ([#28234](https://github.com/WordPress/gutenberg/pull/28234)).
 
 ### Internal
 

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -47,6 +47,7 @@ Options:
 --category <name>            category name for the block
 --wp-scripts                 enable integration with `@wordpress/scripts` package
 --no-wp-scripts              disable integration with `@wordpress/scripts` package
+--wp-env                     enable integration with `@wordpress/env` package
 -h, --help                   output usage information
 ```
 
@@ -182,6 +183,7 @@ The following configurable variables are used with the template files. Template 
 -   `licenseURI` (default: `'https://www.gnu.org/licenses/gpl-2.0.html'`)
 -   `version` (default: `'0.1.0'`)
 -   `wpScripts` (default: `true`)
+-   `wpEnv` (default: `false`)
 -   `npmDependencies` (default: `[]`) – the list of remote npm packages to be installed in the project with [`npm install`](https://docs.npmjs.com/cli/v6/commands/npm-install).
 -   `editorScript` (default: `'file:./build/index.js'`)
 -   `editorStyle` (default: `'file:./build/index.css'`)

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -50,6 +50,7 @@ program
 		'--no-wp-scripts',
 		'disable integration with `@wordpress/scripts` package'
 	)
+	.option( '--wp-env', 'enable integration with `@wordpress/env` package' )
 	.action(
 		async (
 			slug,
@@ -60,6 +61,7 @@ program
 				template: templateName,
 				title,
 				wpScripts,
+				wpEnv,
 			}
 		) => {
 			await checkSystemRequirements( engines );
@@ -73,6 +75,7 @@ program
 						namespace,
 						title,
 						wpScripts,
+						wpEnv,
 					},
 					( value ) => value !== undefined
 				);

--- a/packages/create-block/lib/init-wp-env.js
+++ b/packages/create-block/lib/init-wp-env.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+const { command } = require( 'execa' );
+const { join } = require( 'path' );
+const { writeFile } = require( 'fs' ).promises;
+
+/**
+ * Internal dependencies
+ */
+const { info } = require( './log' );
+
+module.exports = async ( { slug } ) => {
+	const cwd = join( process.cwd(), slug );
+
+	info( '' );
+	info(
+		'Installing `@wordpress/env` package. It might take a couple of minutes...'
+	);
+	await command( 'npm install @wordpress/env --save-dev', {
+		cwd,
+	} );
+
+	info( '' );
+	info( 'Configuring `@wordpress/env`...' );
+	await writeFile(
+		join( cwd, '.wp-env.json' ),
+		JSON.stringify(
+			{
+				core: 'WordPress/WordPress',
+				plugins: [ '.' ],
+			},
+			null,
+			'\t'
+		)
+	);
+};

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -13,6 +13,7 @@ const { dirname, join } = require( 'path' );
 const initBlockJSON = require( './init-block-json' );
 const initPackageJSON = require( './init-package-json' );
 const initWPScripts = require( './init-wp-scripts' );
+const initWPEnv = require( './init-wp-env' );
 const { code, info, success } = require( './log' );
 
 module.exports = async (
@@ -30,6 +31,7 @@ module.exports = async (
 		licenseURI,
 		version,
 		wpScripts,
+		wpEnv,
 		npmDependencies,
 		editorScript,
 		editorStyle,
@@ -94,6 +96,10 @@ module.exports = async (
 		await initWPScripts( view );
 	}
 
+	if ( wpEnv ) {
+		await initWPEnv( view );
+	}
+
 	info( '' );
 	success(
 		`Done: block "${ title }" bootstrapped in the "${ slug }" folder.`
@@ -119,11 +125,22 @@ module.exports = async (
 		info( '' );
 		code( '  $ npm run packages-update' );
 		info( '    Updates WordPress packages to the latest version.' );
+	}
+	info( '' );
+	info( 'To enter the folder type:' );
+	info( '' );
+	code( `  $ cd ${ slug }` );
+	if ( wpScripts ) {
 		info( '' );
-		info( 'You can start by typing:' );
+		info( 'You can start development with:' );
 		info( '' );
-		code( `  $ cd ${ slug }` );
-		code( `  $ npm start` );
+		code( '  $ npm start' );
+	}
+	if ( wpEnv ) {
+		info( '' );
+		info( 'You can start WordPress with:' );
+		info( '' );
+		code( '  $ npx wp-env start' );
 	}
 	info( '' );
 	info( 'Code is Poetry' );

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -183,6 +183,7 @@ const getDefaultValues = ( blockTemplate ) => {
 		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
 		version: '0.1.0',
 		wpScripts: true,
+		wpEnv: false,
 		npmDependencies: [],
 		editorScript: 'file:./build/index.js',
 		editorStyle: 'file:./build/index.css',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR adds a new CLI option `--wp-env` that lets users override the setting that the template defines for integration with [`@wordpress/env`](https://www.npmjs.com/package/@wordpress/env) package. This makes it possible to test the scaffolded block in the WordPress instance created by `@wordpress/env`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

To create a block
```bash
npx wp-create-block my-block --wp-env
```

Then:
```bash
cd my-block
npx wp-env start
```

Go to the browser and visit:

https://localhost:8888/wp-admin/

Insert a new post and enjoy the possibility to enter newly scaffolded block 🎉 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality).
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
