### PR TITLE
Fix template part border states.

### DIFF
--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -100,27 +100,7 @@
 			left: $border-width;
 			right: $border-width;
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
-		}
-	}
-
-	&.is-selected {
-		&::after {
-			// 2px outside.
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
-			}
-		}
-	}
-
-	&.has-child-selected {
-		&::after {
-			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-
-			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width $dark-theme-focus;
-			}
+			box-shadow: 0 0 0 $border-width $gray-900;
 		}
 	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -89,3 +89,21 @@
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 }
+
+// Ensures a border is present when a child block is selected.
+.block-editor-block-list__block[data-type="core/template-part"] {
+	&.has-child-selected {
+		&::after {
+			top: $border-width;
+			bottom: $border-width;
+			left: $border-width;
+			right: $border-width;
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
+
+			.is-dark-theme & {
+				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+			}
+		}
+	}
+}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -92,6 +92,7 @@
 
 // Ensures a border is present when a child block is selected.
 .block-editor-block-list__block[data-type="core/template-part"] {
+	&.is-selected,
 	&.has-child-selected {
 		&::after {
 			top: $border-width;
@@ -99,10 +100,26 @@
 			left: $border-width;
 			right: $border-width;
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+		}
+	}
+
+	&.is-selected {
+		&::after {
+			// 2px outside.
+			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+			}
+		}
+	}
+
+	&.has-child-selected {
+		&::after {
 			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+				box-shadow: 0 0 0 $border-width $dark-theme-focus;
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Similar to the CSS for the entity spotlight, Template Part border state styles were stripped in #27271.  The noted PR was to test showing block borders on hover, but removed a very important non-conflicting border state that is present for entity editing awareness - the has-child-selected state.  This state has since been asked to be re-implemented via PR https://github.com/WordPress/gutenberg/pull/27780.

This PR re-introduces the has-child-selected border state for template parts so that when a child block in a template part is selected a small outline for the template part will be visible.  This state is important for understanding what is/is not part of the template part currently being edited and works together with the entity spotlight system (being fixed here https://github.com/WordPress/gutenberg/pull/28239) to visually highlight this for the user.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Load the Site Editor
* Select a child block of the template part header.
* Verify the border exists.

![Screen Shot 2021-01-15 at 10 50 30 AM](https://user-images.githubusercontent.com/28742426/104748289-87dde100-571f-11eb-8555-3c135a566d49.png)

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
