### PR TITLE
Fix file formatting for e2e test plugin

### DIFF
--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -1,4 +1,4 @@
-(function () {
+( function () {
 	var registerBlockType = wp.blocks.registerBlockType;
 	var createBlock = wp.blocks.createBlock;
 	var el = wp.element.createElement;
@@ -42,39 +42,39 @@
 	];
 
 	var save = function () {
-		return el(InnerBlocks.Content);
+		return el( InnerBlocks.Content );
 	};
 
-	registerBlockType('test/test-inner-blocks-no-locking', {
+	registerBlockType( 'test/test-inner-blocks-no-locking', {
 		title: 'Test Inner Blocks no locking',
 		icon: 'cart',
 		category: 'text',
 
-		edit: function (props) {
-			return el(InnerBlocks, {
+		edit: function ( props ) {
+			return el( InnerBlocks, {
 				template: TEMPLATE,
-			});
+			} );
 		},
 
 		save,
-	});
+	} );
 
-	registerBlockType('test/test-inner-blocks-locking-all', {
+	registerBlockType( 'test/test-inner-blocks-locking-all', {
 		title: 'Test InnerBlocks locking all',
 		icon: 'cart',
 		category: 'text',
 
-		edit: function (props) {
-			return el(InnerBlocks, {
+		edit: function ( props ) {
+			return el( InnerBlocks, {
 				template: TEMPLATE,
 				templateLock: 'all',
-			});
+			} );
 		},
 
 		save,
-	});
+	} );
 
-	registerBlockType('test/test-inner-blocks-update-locked-template', {
+	registerBlockType( 'test/test-inner-blocks-update-locked-template', {
 		title: 'Test Inner Blocks update locked template',
 		icon: 'cart',
 		category: 'text',
@@ -86,44 +86,45 @@
 			},
 		},
 
-		edit: function (props) {
+		edit: function ( props ) {
 			const hasUpdatedTemplated = props.attributes.hasUpdatedTemplate;
 			return el(
 				'div',
 				null,
 				[
-					el('button', {
-						onClick() {
-							props.setAttributes({ hasUpdatedTemplate: true })
-						}
-					}, 'Update template'),
-					el(InnerBlocks, {
+					el( 'button', {
+						onClick: function () {
+							props.setAttributes( { hasUpdatedTemplate: true } )
+						},
+					}, 'Update template' ),
+					el( InnerBlocks, {
 						template: hasUpdatedTemplated ? TEMPLATE_TWO_PARAGRAPHS : TEMPLATE,
 						templateLock: 'all',
-					})
+					} ),
 				]
 			);
 		},
 
 		save,
-	});
+	} );
 
-	registerBlockType('test/test-inner-blocks-paragraph-placeholder', {
+
+	registerBlockType( 'test/test-inner-blocks-paragraph-placeholder', {
 		title: 'Test Inner Blocks Paragraph Placeholder',
 		icon: 'cart',
 		category: 'text',
 
-		edit: function (props) {
-			return el(InnerBlocks, {
+		edit: function ( props ) {
+			return el( InnerBlocks, {
 				template: TEMPLATE_PARAGRAPH_PLACEHOLDER,
 				templateInsertUpdatesSelection: true,
-			});
+			} );
 		},
 
 		save,
-	});
+	} );
 
-	registerBlockType('test/test-inner-blocks-transformer-target', {
+	registerBlockType( 'test/test-inner-blocks-transformer-target', {
 		title: 'Test Inner Blocks transformer target',
 		icon: 'cart',
 		category: 'text',
@@ -138,7 +139,7 @@
 						'test/test-inner-blocks-locking-all',
 						'test/test-inner-blocks-paragraph-placeholder',
 					],
-					transform: function (attributes, innerBlocks) {
+					transform: function ( attributes, innerBlocks ) {
 						return createBlock(
 							'test/test-inner-blocks-transformer-target',
 							attributes,
@@ -150,8 +151,8 @@
 			to: [
 				{
 					type: 'block',
-					blocks: ['test/i-dont-exist'],
-					transform: function (attributes, innerBlocks) {
+					blocks: [ 'test/i-dont-exist' ],
+					transform: function ( attributes, innerBlocks ) {
 						return createBlock(
 							'test/test-inner-blocks-transformer-target',
 							attributes,
@@ -162,12 +163,12 @@
 			],
 		},
 
-		edit: function (props) {
-			return el(InnerBlocks, {
+		edit: function ( props ) {
+			return el( InnerBlocks, {
 				template: TEMPLATE,
-			});
+			} );
 		},
 
 		save,
-	});
-})();
+	} );
+} )();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Alternative to #28033.

Fixes some formatting issues to a file that my editor automatically made, and ended up being committed in #28007. As explained in #28033, these files are ignored by prettier but should at least still comply as much as posssible with WordPress coding standards.