### PR TITLE
Try: zero width space in empty paragraph.

### DIFF
--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -38,5 +38,5 @@ p.has-text-color a {
 
 // Prevent an empty P tag from collapsing, so it matches the backend.
 p:empty::before {
-	content: "\a0";
+	content: "\200B";
 }


### PR DESCRIPTION
This is a followup to https://github.com/WordPress/gutenberg/pull/27995/files#r557493964. It replaces the nonbreaking space character output in empty paragraphs, with a zero width space.

Before:

<img width="212" alt="Screenshot 2021-01-18 at 08 41 17" src="https://user-images.githubusercontent.com/1204802/104886150-90295c80-5969-11eb-8f24-d30a45a8fe67.png">

After:

<img width="444" alt="Screenshot 2021-01-18 at 08 42 13" src="https://user-images.githubusercontent.com/1204802/104886156-91f32000-5969-11eb-86d0-83f63de16045.png">

The two are supposed to look identical, and I can confirm they do.

I forgot to mention this on the other PR: Mac VoiceOver reads out nothing in the empty paragraphs. 