### PR TITLE
Site Editor: Hide resize handle.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -24,9 +24,11 @@
 		outline: $border-width solid transparent;
 		transition: 0.2s outline;
 		@include reduce-motion("transition");
-		resize: none;
 		margin-top: $default-block-margin;
 		margin-bottom: $default-block-margin;
+
+		// This needs high specificity as it's output as an inline style by the library.
+		resize: none !important;
 
 		// Emulate the dimensions of a paragraph block.
 		// On mobile and in nested contexts, the plus to add blocks shows up on the right.


### PR DESCRIPTION
There's a small resize handle in the default block editor appender:

<img width="1491" alt="Screenshot 2021-01-18 at 10 04 01" src="https://user-images.githubusercontent.com/1204802/104894572-29aa3b80-5975-11eb-892b-5f297d6710c1.png">

This resize handle is added as an inline style, presumably by the React AutoSize library:

```
<textarea role="button" aria-label="Add block" class="block-editor-default-block-appender__content" readonly="" rows="1" style="overflow: hidden; overflow-wrap: break-word; resize: horizontal; height: 38px;"></textarea>
```

An `!important` was the only way to hide it:

<img width="1415" alt="Screenshot 2021-01-18 at 10 07 56" src="https://user-images.githubusercontent.com/1204802/104894750-5f4f2480-5975-11eb-81dd-0fd1573f9974.png">
