### PR TITLE
Scripts: Enable React Fast Refresh for block development

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -208,7 +208,8 @@ function gutenberg_register_vendor_scripts( $scripts ) {
 		$scripts,
 		'react',
 		'https://unpkg.com/react@17.0.1/umd/react' . $react_suffix . '.js',
-		array( 'wp-polyfill' )
+		// See https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#externalising-react.
+		SCRIPT_DEBUG ? array( 'wp-react-refresh-entry', 'wp-polyfill' ) : array( 'wp-polyfill' )
 	);
 	gutenberg_register_vendor_script(
 		$scripts,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -485,24 +485,6 @@ function gutenberg_register_packages_styles( $styles ) {
 add_action( 'wp_default_styles', 'gutenberg_register_packages_styles' );
 
 /**
- * Registers common scripts and styles to be used as dependencies of the editor
- * and plugins.
- *
- * @since 0.1.0
- */
-function gutenberg_enqueue_block_editor_assets() {
-	if ( defined( 'GUTENBERG_LIVE_RELOAD' ) && GUTENBERG_LIVE_RELOAD ) {
-		$live_reload_url = ( GUTENBERG_LIVE_RELOAD === true ) ? 'http://localhost:35729/livereload.js' : GUTENBERG_LIVE_RELOAD;
-
-		wp_enqueue_script(
-			'gutenberg-live-reload',
-			$live_reload_url
-		);
-	}
-}
-add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_block_editor_assets' );
-
-/**
  * Retrieves a unique and reasonably short and human-friendly filename for a
  * vendor script based on a URL and the script handle.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,9 +1544,9 @@
 			}
 		},
 		"@discoveryjs/json-ext": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
-			"integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
+			"integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
 			"dev": true
 		},
 		"@egjs/hammerjs": {
@@ -7063,23 +7063,26 @@
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
-			"integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.1.tgz",
+			"integrity": "sha512-ccap6o7+y5L8cnvkZ9h8UXCGyy2DqtwCD+/N3Yru6lxMvcdkPKtdx13qd7sAC9s5qZktOmWf9lfUjsGOvSdYhg==",
 			"dev": true,
 			"requires": {
-				"ansi-html": "^0.0.7",
+				"ansi-html-community": "^0.0.8",
+				"common-path-prefix": "^3.0.0",
+				"core-js-pure": "^3.8.1",
 				"error-stack-parser": "^2.0.6",
-				"html-entities": "^1.2.1",
-				"native-url": "^0.2.6",
-				"schema-utils": "^2.6.5",
+				"find-up": "^5.0.0",
+				"html-entities": "^2.1.0",
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^3.0.0",
 				"source-map": "^0.7.3"
 			},
 			"dependencies": {
 				"@types/json-schema": {
-					"version": "7.0.7",
-					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-					"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+					"version": "7.0.9",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+					"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
 					"dev": true
 				},
 				"ajv": {
@@ -7100,20 +7103,75 @@
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
 					"dev": true
 				},
+				"ansi-html-community": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+					"integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
+					"dev": true
+				},
 				"fast-deep-equal": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 					"dev": true
 				},
-				"schema-utils": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-					"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 					"dev": true,
 					"requires": {
-						"@types/json-schema": "^7.0.5",
-						"ajv": "^6.12.4",
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"html-entities": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+					"integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.8",
+						"ajv": "^6.12.5",
 						"ajv-keywords": "^3.5.2"
 					}
 				},
@@ -7154,71 +7212,6 @@
 			"integrity": "sha512-GtDBhpX2pQcjl4VopOC8FktrVufrEfYRwVeMQ2WWckqKIv2BdwvlvWvj88L1WmEdBr9UNcm3rtgz+d+YXkmirA==",
 			"requires": {
 				"prop-types": "^15.5.10"
-			}
-		},
-		"@react-native-community/cli-debugger-ui": {
-			"version": "5.0.1-alpha.1",
-			"resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-5.0.1-alpha.1.tgz",
-			"integrity": "sha512-o6msDywXU7q0dPKhCTo8IrpmJ+7o+kVghyHlrAndnb30p6vnm4pID5Yi7lHXGfs6bQXorKUWX8oD5xYwWkN8qw==",
-			"requires": {
-				"serve-static": "^1.13.1"
-			}
-		},
-		"@react-native-community/cli-hermes": {
-			"version": "5.0.1-alpha.1",
-			"resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-5.0.1-alpha.1.tgz",
-			"integrity": "sha512-7FNhqeZCbON4vhzZpV8nx4gB3COJy2KGbVku376CnIAjMncxJhupqORWdMukP8jNuuvUZ1R0vj0L0+W/M5rY1w==",
-			"requires": {
-				"@react-native-community/cli-platform-android": "^5.0.1-alpha.1",
-				"@react-native-community/cli-tools": "^5.0.1-alpha.1",
-				"chalk": "^3.0.0",
-				"hermes-profile-transformer": "^0.0.6",
-				"ip": "^1.1.5"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"@react-native-community/cli-platform-android": {
@@ -7421,33 +7414,6 @@
 				}
 			}
 		},
-		"@react-native-community/cli-server-api": {
-			"version": "5.0.1-alpha.2",
-			"resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-5.0.1-alpha.2.tgz",
-			"integrity": "sha512-qzjoLF51GmvUHQrcJZE+wD3bTmgnTNOnGBU6z4terKmPdt/EBBSUkdXc6ScWWRF6oWP+xpxLZ//tKic2v2f+ag==",
-			"requires": {
-				"@react-native-community/cli-debugger-ui": "^5.0.1-alpha.1",
-				"@react-native-community/cli-tools": "^5.0.1-alpha.1",
-				"compression": "^1.7.1",
-				"connect": "^3.6.5",
-				"errorhandler": "^1.5.0",
-				"nocache": "^2.1.0",
-				"pretty-format": "^26.6.2",
-				"serve-static": "^1.13.1",
-				"ws": "^1.1.0"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-					"integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-					"requires": {
-						"options": ">=0.0.5",
-						"ultron": "1.0.x"
-					}
-				}
-			}
-		},
 		"@react-native-community/cli-tools": {
 			"version": "5.0.1-alpha.1",
 			"resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-5.0.1-alpha.1.tgz",
@@ -7502,52 +7468,6 @@
 					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"@react-native-community/cli-types": {
-			"version": "5.0.1-alpha.1",
-			"resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-5.0.1-alpha.1.tgz",
-			"integrity": "sha512-RdsLU0Jf3HodFnAY+oxCJt3VlhaN4MxGhfISvjGzqdjq3kpzmxex3+7fi6QvS97Kd6G2cheOJAdgP5wcwxp3Ng==",
-			"requires": {
-				"ora": "^3.4.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"ora": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
-					"integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
-					"requires": {
-						"chalk": "^2.4.2",
-						"cli-cursor": "^2.1.0",
-						"cli-spinners": "^2.0.0",
-						"log-symbols": "^2.2.0",
-						"strip-ansi": "^5.2.0",
-						"wcwidth": "^1.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"requires": {
-						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -15527,6 +15447,57 @@
 				"webpack": "4"
 			},
 			"dependencies": {
+				"@pmmmwh/react-refresh-webpack-plugin": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
+					"integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
+					"dev": true,
+					"requires": {
+						"ansi-html": "^0.0.7",
+						"error-stack-parser": "^2.0.6",
+						"html-entities": "^1.2.1",
+						"native-url": "^0.2.6",
+						"schema-utils": "^2.6.5",
+						"source-map": "^0.7.3"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "6.12.6",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+							"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"fast-json-stable-stringify": "^2.0.0",
+								"json-schema-traverse": "^0.4.1",
+								"uri-js": "^4.2.2"
+							}
+						},
+						"ajv-keywords": {
+							"version": "3.5.2",
+							"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+							"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+							"dev": true
+						},
+						"schema-utils": {
+							"version": "2.7.1",
+							"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+							"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+							"dev": true,
+							"requires": {
+								"@types/json-schema": "^7.0.5",
+								"ajv": "^6.12.4",
+								"ajv-keywords": "^3.5.2"
+							}
+						},
+						"source-map": {
+							"version": "0.7.3",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+							"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+							"dev": true
+						}
+					}
+				},
 				"@storybook/semver": {
 					"version": "7.3.2",
 					"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
@@ -15536,6 +15507,12 @@
 						"core-js": "^3.6.5",
 						"find-up": "^4.1.0"
 					}
+				},
+				"@types/json-schema": {
+					"version": "7.0.9",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+					"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+					"dev": true
 				},
 				"big.js": {
 					"version": "5.2.2",
@@ -15547,6 +15524,12 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 					"dev": true
 				},
 				"find-up": {
@@ -17183,6 +17166,15 @@
 			"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
 			"dev": true
 		},
+		"@types/http-proxy": {
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
+			"integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/is-function": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.0.tgz",
@@ -17445,6 +17437,12 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/retry": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+			"integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+			"dev": true
 		},
 		"@types/semver": {
 			"version": "7.3.8",
@@ -18566,15 +18564,15 @@
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-			"integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
 			"dev": true
 		},
 		"@webpack-cli/info": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-			"integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
 			"dev": true,
 			"requires": {
 				"envinfo": "^7.7.3"
@@ -18589,24 +18587,24 @@
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.1.tgz",
-			"integrity": "sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
 			"dev": true
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.6.1.tgz",
-			"integrity": "sha512-xgPfzLVpN0epIHeZofahwr5qwpukEDNAbrufgeDWN6vZPtfblGCC+OZG5TlfK+A6ePVy8sBkD8S2X4tO17JKjg==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.6.3.tgz",
+			"integrity": "sha512-Kp1ZJxtHkKEnUksaWrcMABNTOgL4wOt8VI6k2xOek2aH9PtZcWRXJNUEgnKrdJrqg5UqIjRslbVF9uUqwQJtFg==",
 			"dev": true,
 			"requires": {
-				"@wojtekmaj/enzyme-adapter-utils": "^0.1.0",
+				"@wojtekmaj/enzyme-adapter-utils": "^0.1.1",
 				"enzyme-shallow-equal": "^1.0.0",
 				"has": "^1.0.0",
 				"object.assign": "^4.1.0",
 				"object.values": "^1.1.0",
 				"prop-types": "^15.7.0",
-				"react-is": "^17.0.0",
+				"react-is": "^17.0.2",
 				"react-test-renderer": "^17.0.0"
 			},
 			"dependencies": {
@@ -18619,9 +18617,9 @@
 			}
 		},
 		"@wojtekmaj/enzyme-adapter-utils": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.1.0.tgz",
-			"integrity": "sha512-EYK/Vy0Y1ap0jH2UNQjOKtR/7HWkbEq8N+cwC5+yDf+Mwp5uu7j4Qg70RmWuzsA35DGGwgkop6m4pQsGwNOF2A==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.1.1.tgz",
+			"integrity": "sha512-bNPWtN/d8huKOkC6j1E3EkSamnRrHHT7YuR6f9JppAQqtoAm3v4/vERe4J14jQKmHLCyEBHXrlgb7H6l817hVg==",
 			"dev": true,
 			"requires": {
 				"function.prototype.name": "^1.1.0",
@@ -19729,6 +19727,7 @@
 			"version": "file:packages/scripts",
 			"dev": true,
 			"requires": {
+				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
 				"@svgr/webpack": "^5.5.0",
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",
@@ -19769,6 +19768,7 @@
 				"postcss-loader": "^6.1.1",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"puppeteer-core": "^11.0.0",
+				"react-refresh": "^0.10.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
 				"sass": "^1.35.2",
@@ -19779,8 +19779,8 @@
 				"url-loader": "^4.1.1",
 				"webpack": "^5.47.1",
 				"webpack-bundle-analyzer": "^4.4.2",
-				"webpack-cli": "^4.7.2",
-				"webpack-livereload-plugin": "^3.0.1"
+				"webpack-cli": "^4.9.1",
+				"webpack-dev-server": "^4.4.0"
 			}
 		},
 		"@wordpress/server-side-render": {
@@ -28015,6 +28015,14 @@
 			"dev": true,
 			"requires": {
 				"follow-redirects": "^1.14.0"
+			},
+			"dependencies": {
+				"follow-redirects": {
+					"version": "1.14.5",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+					"integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+					"dev": true
+				}
 			}
 		},
 		"axobject-query": {
@@ -28628,6 +28636,12 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
 			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
 		},
+		"batch": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+			"dev": true
+		},
 		"batch-processor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
@@ -28791,42 +28805,6 @@
 			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
 			"dev": true
 		},
-		"body": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
-			"integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
-			"dev": true,
-			"requires": {
-				"continuable-cache": "^0.3.1",
-				"error": "^7.0.0",
-				"raw-body": "~1.1.0",
-				"safe-json-parse": "~1.0.1"
-			},
-			"dependencies": {
-				"bytes": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-					"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
-					"dev": true
-				},
-				"raw-body": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-					"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-					"dev": true,
-					"requires": {
-						"bytes": "1",
-						"string_decoder": "0.10"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
 		"body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -28900,6 +28878,28 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
 			"integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
+		},
+		"bonjour": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+			"dev": true,
+			"requires": {
+				"array-flatten": "^2.1.0",
+				"deep-equal": "^1.0.1",
+				"dns-equal": "^1.0.0",
+				"dns-txt": "^2.0.2",
+				"multicast-dns": "^6.0.1",
+				"multicast-dns-service-types": "^1.1.0"
+			},
+			"dependencies": {
+				"array-flatten": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+					"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+					"dev": true
+				}
+			}
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -29254,6 +29254,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
 			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+		},
+		"buffer-indexof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+			"dev": true
 		},
 		"buffer-indexof-polyfill": {
 			"version": "1.0.2",
@@ -30658,6 +30664,12 @@
 			"integrity": "sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==",
 			"dev": true
 		},
+		"common-path-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+			"dev": true
+		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -30912,6 +30924,12 @@
 				}
 			}
 		},
+		"connect-history-api-fallback": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+			"dev": true
+		},
 		"console-browserify": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -30948,12 +30966,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
-		},
-		"continuable-cache": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
-			"integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
 			"dev": true
 		},
 		"conventional-changelog-angular": {
@@ -32473,6 +32485,28 @@
 			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 			"dev": true
 		},
+		"deep-equal": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+			"dev": true,
+			"requires": {
+				"is-arguments": "^1.0.4",
+				"is-date-object": "^1.0.1",
+				"is-regex": "^1.0.4",
+				"object-is": "^1.0.1",
+				"object-keys": "^1.1.1",
+				"regexp.prototype.flags": "^1.2.0"
+			},
+			"dependencies": {
+				"object-keys": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+					"dev": true
+				}
+			}
+		},
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -32503,6 +32537,123 @@
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
+		"default-gateway": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+			"integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+			"dev": true,
+			"requires": {
+				"execa": "^5.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+					"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.3",
+						"get-stream": "^6.0.0",
+						"human-signals": "^2.1.0",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.1",
+						"onetime": "^5.1.2",
+						"signal-exit": "^3.0.3",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+					"dev": true
+				},
+				"human-signals": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+					"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+					"dev": true
+				},
+				"is-stream": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+					"dev": true
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"onetime": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.5",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+					"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -32515,6 +32666,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
 			"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+			"dev": true
+		},
+		"define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
 			"dev": true
 		},
 		"define-properties": {
@@ -32789,26 +32946,11 @@
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
-		"detect-port-alt": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-			"integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
-			"dev": true,
-			"requires": {
-				"address": "^1.0.1",
-				"debug": "^2.6.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
+		"detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+			"dev": true
 		},
 		"devtools-protocol": {
 			"version": "0.0.901419",
@@ -32883,6 +33025,31 @@
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
 			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
 			"dev": true
+		},
+		"dns-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+			"dev": true
+		},
+		"dns-packet": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+			"integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+			"dev": true,
+			"requires": {
+				"ip": "^1.1.0",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"dns-txt": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+			"dev": true,
+			"requires": {
+				"buffer-indexof": "^1.0.0"
+			}
 		},
 		"docker-compose": {
 			"version": "0.22.2",
@@ -33711,15 +33878,6 @@
 			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
-			}
-		},
-		"error": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
-			"integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
-			"dev": true,
-			"requires": {
-				"string-template": "~0.2.1"
 			}
 		},
 		"error-ex": {
@@ -36288,9 +36446,9 @@
 			}
 		},
 		"faye-websocket": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+			"integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
 			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
@@ -36799,9 +36957,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.14.3",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-			"integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
+			"version": "1.14.5",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+			"integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
 			"dev": true
 		},
 		"for-in": {
@@ -38174,6 +38332,12 @@
 				}
 			}
 		},
+		"handle-thing": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+			"dev": true
+		},
 		"handlebars": {
 			"version": "4.7.6",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
@@ -38670,6 +38834,18 @@
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
 		},
+		"hpack.js": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"obuf": "^1.0.0",
+				"readable-stream": "^2.0.1",
+				"wbuf": "^1.1.0"
+			}
+		},
 		"hpq": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
@@ -38843,6 +39019,12 @@
 			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
 			"dev": true
 		},
+		"http-deceiver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+			"dev": true
+		},
 		"http-errors": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -38868,6 +39050,25 @@
 			"integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
 			"dev": true
 		},
+		"http-proxy": {
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "^4.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			},
+			"dependencies": {
+				"eventemitter3": {
+					"version": "4.0.7",
+					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+					"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+					"dev": true
+				}
+			}
+		},
 		"http-proxy-agent": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
@@ -38876,6 +39077,85 @@
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
+			}
+		},
+		"http-proxy-middleware": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
+			"integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
+			"dev": true,
+			"requires": {
+				"@types/http-proxy": "^1.17.5",
+				"http-proxy": "^1.18.1",
+				"is-glob": "^4.0.1",
+				"is-plain-obj": "^3.0.0",
+				"micromatch": "^4.0.2"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"is-glob": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-plain-obj": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+					"integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.2.3"
+					}
+				},
+				"picomatch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
 			}
 		},
 		"http-signature": {
@@ -39413,6 +39693,38 @@
 				}
 			}
 		},
+		"internal-ip": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+			"integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+			"dev": true,
+			"requires": {
+				"default-gateway": "^6.0.0",
+				"ipaddr.js": "^1.9.1",
+				"is-ip": "^3.1.0",
+				"p-event": "^4.2.0"
+			},
+			"dependencies": {
+				"p-event": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+					"integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+					"dev": true,
+					"requires": {
+						"p-timeout": "^3.1.0"
+					}
+				},
+				"p-timeout": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+					"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+					"dev": true,
+					"requires": {
+						"p-finally": "^1.0.0"
+					}
+				}
+			}
+		},
 		"internal-slot": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
@@ -39815,6 +40127,23 @@
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
 			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
 			"dev": true
+		},
+		"is-ip": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"dev": true,
+			"requires": {
+				"ip-regex": "^4.0.0"
+			},
+			"dependencies": {
+				"ip-regex": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+					"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+					"dev": true
+				}
+			}
 		},
 		"is-map": {
 			"version": "2.0.2",
@@ -45713,12 +46042,6 @@
 				}
 			}
 		},
-		"livereload-js": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
-			"integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
-			"dev": true
-		},
 		"load-json-file": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -47296,6 +47619,90 @@
 						"p-locate": "^4.1.0"
 					}
 				},
+				"metro-babel-transformer": {
+					"version": "0.64.0",
+					"resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.64.0.tgz",
+					"integrity": "sha512-itZaxKTgmKGEZWxNzbSZBc22NngrMZzoUNuU92aHSTGkYi2WH4XlvzEHsstmIKHMsRVKl75cA+mNmgk4gBFJKw==",
+					"requires": {
+						"@babel/core": "^7.0.0",
+						"metro-source-map": "0.64.0",
+						"nullthrows": "^1.1.1"
+					}
+				},
+				"metro-react-native-babel-preset": {
+					"version": "0.64.0",
+					"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.64.0.tgz",
+					"integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
+					"requires": {
+						"@babel/core": "^7.0.0",
+						"@babel/plugin-proposal-class-properties": "^7.0.0",
+						"@babel/plugin-proposal-export-default-from": "^7.0.0",
+						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+						"@babel/plugin-proposal-optional-chaining": "^7.0.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.0.0",
+						"@babel/plugin-syntax-export-default-from": "^7.0.0",
+						"@babel/plugin-syntax-flow": "^7.2.0",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
+						"@babel/plugin-syntax-optional-chaining": "^7.0.0",
+						"@babel/plugin-transform-arrow-functions": "^7.0.0",
+						"@babel/plugin-transform-block-scoping": "^7.0.0",
+						"@babel/plugin-transform-classes": "^7.0.0",
+						"@babel/plugin-transform-computed-properties": "^7.0.0",
+						"@babel/plugin-transform-destructuring": "^7.0.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+						"@babel/plugin-transform-for-of": "^7.0.0",
+						"@babel/plugin-transform-function-name": "^7.0.0",
+						"@babel/plugin-transform-literals": "^7.0.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+						"@babel/plugin-transform-object-assign": "^7.0.0",
+						"@babel/plugin-transform-parameters": "^7.0.0",
+						"@babel/plugin-transform-react-display-name": "^7.0.0",
+						"@babel/plugin-transform-react-jsx": "^7.0.0",
+						"@babel/plugin-transform-react-jsx-self": "^7.0.0",
+						"@babel/plugin-transform-react-jsx-source": "^7.0.0",
+						"@babel/plugin-transform-regenerator": "^7.0.0",
+						"@babel/plugin-transform-runtime": "^7.0.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+						"@babel/plugin-transform-spread": "^7.0.0",
+						"@babel/plugin-transform-sticky-regex": "^7.0.0",
+						"@babel/plugin-transform-template-literals": "^7.0.0",
+						"@babel/plugin-transform-typescript": "^7.5.0",
+						"@babel/plugin-transform-unicode-regex": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"react-refresh": "^0.4.0"
+					}
+				},
+				"metro-source-map": {
+					"version": "0.64.0",
+					"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.64.0.tgz",
+					"integrity": "sha512-OCG2rtcp5cLEGYvAbfkl6mEc0J2FPRP4/UCEly+juBk7hawS9bCBMBfhJm/HIsvY1frk6nT2Vsl1O8YBbwyx2g==",
+					"requires": {
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0",
+						"invariant": "^2.2.4",
+						"metro-symbolicate": "0.64.0",
+						"nullthrows": "^1.1.1",
+						"ob1": "0.64.0",
+						"source-map": "^0.5.6",
+						"vlq": "^1.0.0"
+					}
+				},
+				"metro-symbolicate": {
+					"version": "0.64.0",
+					"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.64.0.tgz",
+					"integrity": "sha512-qIi+YRrDWnLVmydj6gwidYLPaBsakZRibGWSspuXgHAxOI3UuLwlo4dpQ73Et0gyHjI7ZvRMRY8JPiOntf9AQQ==",
+					"requires": {
+						"invariant": "^2.2.4",
+						"metro-source-map": "0.64.0",
+						"nullthrows": "^1.1.1",
+						"source-map": "^0.5.6",
+						"through2": "^2.0.1",
+						"vlq": "^1.0.0"
+					}
+				},
 				"mime-db": {
 					"version": "1.47.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
@@ -47335,6 +47742,11 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
+				"react-refresh": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
+					"integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -47360,6 +47772,11 @@
 					"requires": {
 						"ansi-regex": "^5.0.0"
 					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"ws": {
 					"version": "1.1.5",
@@ -47714,6 +48131,7 @@
 			"version": "0.64.0",
 			"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.64.0.tgz",
 			"integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
+			"dev": true,
 			"requires": {
 				"@babel/core": "^7.0.0",
 				"@babel/plugin-proposal-class-properties": "^7.0.0",
@@ -47754,6 +48172,14 @@
 				"@babel/plugin-transform-unicode-regex": "^7.0.0",
 				"@babel/template": "^7.0.0",
 				"react-refresh": "^0.4.0"
+			},
+			"dependencies": {
+				"react-refresh": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
+					"integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==",
+					"dev": true
+				}
 			}
 		},
 		"metro-react-native-babel-transformer": {
@@ -47767,6 +48193,84 @@
 				"metro-react-native-babel-preset": "0.64.0",
 				"metro-source-map": "0.64.0",
 				"nullthrows": "^1.1.1"
+			},
+			"dependencies": {
+				"metro-babel-transformer": {
+					"version": "0.64.0",
+					"resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.64.0.tgz",
+					"integrity": "sha512-itZaxKTgmKGEZWxNzbSZBc22NngrMZzoUNuU92aHSTGkYi2WH4XlvzEHsstmIKHMsRVKl75cA+mNmgk4gBFJKw==",
+					"requires": {
+						"@babel/core": "^7.0.0",
+						"metro-source-map": "0.64.0",
+						"nullthrows": "^1.1.1"
+					}
+				},
+				"metro-react-native-babel-preset": {
+					"version": "0.64.0",
+					"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.64.0.tgz",
+					"integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
+					"requires": {
+						"@babel/core": "^7.0.0",
+						"@babel/plugin-proposal-class-properties": "^7.0.0",
+						"@babel/plugin-proposal-export-default-from": "^7.0.0",
+						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+						"@babel/plugin-proposal-optional-chaining": "^7.0.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.0.0",
+						"@babel/plugin-syntax-export-default-from": "^7.0.0",
+						"@babel/plugin-syntax-flow": "^7.2.0",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
+						"@babel/plugin-syntax-optional-chaining": "^7.0.0",
+						"@babel/plugin-transform-arrow-functions": "^7.0.0",
+						"@babel/plugin-transform-block-scoping": "^7.0.0",
+						"@babel/plugin-transform-classes": "^7.0.0",
+						"@babel/plugin-transform-computed-properties": "^7.0.0",
+						"@babel/plugin-transform-destructuring": "^7.0.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+						"@babel/plugin-transform-for-of": "^7.0.0",
+						"@babel/plugin-transform-function-name": "^7.0.0",
+						"@babel/plugin-transform-literals": "^7.0.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+						"@babel/plugin-transform-object-assign": "^7.0.0",
+						"@babel/plugin-transform-parameters": "^7.0.0",
+						"@babel/plugin-transform-react-display-name": "^7.0.0",
+						"@babel/plugin-transform-react-jsx": "^7.0.0",
+						"@babel/plugin-transform-react-jsx-self": "^7.0.0",
+						"@babel/plugin-transform-react-jsx-source": "^7.0.0",
+						"@babel/plugin-transform-regenerator": "^7.0.0",
+						"@babel/plugin-transform-runtime": "^7.0.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+						"@babel/plugin-transform-spread": "^7.0.0",
+						"@babel/plugin-transform-sticky-regex": "^7.0.0",
+						"@babel/plugin-transform-template-literals": "^7.0.0",
+						"@babel/plugin-transform-typescript": "^7.5.0",
+						"@babel/plugin-transform-unicode-regex": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"react-refresh": "^0.4.0"
+					}
+				},
+				"metro-source-map": {
+					"version": "0.64.0",
+					"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.64.0.tgz",
+					"integrity": "sha512-OCG2rtcp5cLEGYvAbfkl6mEc0J2FPRP4/UCEly+juBk7hawS9bCBMBfhJm/HIsvY1frk6nT2Vsl1O8YBbwyx2g==",
+					"requires": {
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0",
+						"invariant": "^2.2.4",
+						"metro-symbolicate": "0.64.0",
+						"nullthrows": "^1.1.1",
+						"ob1": "0.64.0",
+						"source-map": "^0.5.6",
+						"vlq": "^1.0.0"
+					}
+				},
+				"react-refresh": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
+					"integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
+				}
 			}
 		},
 		"metro-resolver": {
@@ -48341,6 +48845,22 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
+		"multicast-dns": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+			"dev": true,
+			"requires": {
+				"dns-packet": "^1.3.1",
+				"thunky": "^1.0.2"
+			}
+		},
+		"multicast-dns-service-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+			"dev": true
+		},
 		"multimatch": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-3.0.0.tgz",
@@ -48530,6 +49050,12 @@
 				"json-parse-better-errors": "^1.0.0",
 				"safe-buffer": "^5.1.1"
 			}
+		},
+		"node-forge": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+			"dev": true
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -49420,6 +49946,37 @@
 			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 			"dev": true
 		},
+		"object-is": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"define-properties": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+					"dev": true,
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				}
+			}
+		},
 		"object-keys": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -49947,6 +50504,12 @@
 			"integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
 			"dev": true
 		},
+		"obuf": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+			"dev": true
+		},
 		"octokit-pagination-methods": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
@@ -50266,6 +50829,24 @@
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
 			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
 			"dev": true
+		},
+		"p-retry": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+			"integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+			"dev": true,
+			"requires": {
+				"@types/retry": "^0.12.0",
+				"retry": "^0.13.1"
+			},
+			"dependencies": {
+				"retry": {
+					"version": "0.13.1",
+					"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+					"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+					"dev": true
+				}
+			}
 		},
 		"p-timeout": {
 			"version": "2.0.1",
@@ -53225,6 +53806,25 @@
 						"which": "^2.0.1"
 					}
 				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"detect-port-alt": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
+					"integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
+					"dev": true,
+					"requires": {
+						"address": "^1.0.1",
+						"debug": "^2.6.0"
+					}
+				},
 				"emojis-list": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -53696,15 +54296,15 @@
 			},
 			"dependencies": {
 				"@react-native-community/cli": {
-					"version": "5.0.1-alpha.2",
-					"resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-5.0.1-alpha.2.tgz",
-					"integrity": "sha512-PP22TVV2VyELXhAX4PcBisasssastSEx23XDklfPoCPIXD2QgGC7y39n/b5I9tOzKi2qYswCEAcDpwXYwevGOg==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-5.0.1.tgz",
+					"integrity": "sha512-9VzSYUYSEqxEH5Ib2UNSdn2eyPiYZ4T7Y79o9DKtRBuSaUIwbCUdZtIm+UUjBpLS1XYBkW26FqL8/UdZDmQvXw==",
 					"requires": {
-						"@react-native-community/cli-debugger-ui": "^5.0.1-alpha.1",
-						"@react-native-community/cli-hermes": "^5.0.1-alpha.1",
-						"@react-native-community/cli-server-api": "^5.0.1-alpha.2",
-						"@react-native-community/cli-tools": "^5.0.1-alpha.1",
-						"@react-native-community/cli-types": "^5.0.1-alpha.1",
+						"@react-native-community/cli-debugger-ui": "^5.0.1",
+						"@react-native-community/cli-hermes": "^5.0.1",
+						"@react-native-community/cli-server-api": "^5.0.1",
+						"@react-native-community/cli-tools": "^5.0.1",
+						"@react-native-community/cli-types": "^5.0.1",
 						"appdirsjs": "^1.2.4",
 						"chalk": "^3.0.0",
 						"command-exists": "^1.2.8",
@@ -53737,6 +54337,93 @@
 						"strip-ansi": "^5.2.0",
 						"sudo-prompt": "^9.0.0",
 						"wcwidth": "^1.0.1"
+					}
+				},
+				"@react-native-community/cli-debugger-ui": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-5.0.1.tgz",
+					"integrity": "sha512-5gGKaaXYOVE423BUqxIfvfAVSj5Cg1cU/TpGbeg/iqpy2CfqyWqJB3tTuVUbOOiOvR5wbU8tti6pIi1pchJ+oA==",
+					"requires": {
+						"serve-static": "^1.13.1"
+					}
+				},
+				"@react-native-community/cli-hermes": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-5.0.1.tgz",
+					"integrity": "sha512-nD+ZOFvu5MfjLB18eDJ01MNiFrzj8SDtENjGpf0ZRFndOWASDAmU54/UlU/wj8OzTToK1+S1KY7j2P2M1gleww==",
+					"requires": {
+						"@react-native-community/cli-platform-android": "^5.0.1",
+						"@react-native-community/cli-tools": "^5.0.1",
+						"chalk": "^3.0.0",
+						"hermes-profile-transformer": "^0.0.6",
+						"ip": "^1.1.5"
+					},
+					"dependencies": {
+						"@react-native-community/cli-platform-android": {
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-5.0.1.tgz",
+							"integrity": "sha512-qv9GJX6BJ+Y4qvV34vgxKwwN1cnveXUdP6y2YmTW7XoAYs5YUzKqHajpY58EyucAL2y++6+573t5y4U/9IIoww==",
+							"requires": {
+								"@react-native-community/cli-tools": "^5.0.1",
+								"chalk": "^3.0.0",
+								"execa": "^1.0.0",
+								"fs-extra": "^8.1.0",
+								"glob": "^7.1.3",
+								"jetifier": "^1.6.2",
+								"lodash": "^4.17.15",
+								"logkitty": "^0.7.1",
+								"slash": "^3.0.0",
+								"xmldoc": "^1.1.2"
+							}
+						}
+					}
+				},
+				"@react-native-community/cli-server-api": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-5.0.1.tgz",
+					"integrity": "sha512-OOxL+y9AOZayQzmSW+h5T54wQe+QBc/f67Y9QlWzzJhkKJdYx+S4VOooHoD5PFJzGbYaxhu2YF17p517pcEIIA==",
+					"requires": {
+						"@react-native-community/cli-debugger-ui": "^5.0.1",
+						"@react-native-community/cli-tools": "^5.0.1",
+						"compression": "^1.7.1",
+						"connect": "^3.6.5",
+						"errorhandler": "^1.5.0",
+						"nocache": "^2.1.0",
+						"pretty-format": "^26.6.2",
+						"serve-static": "^1.13.1",
+						"ws": "^1.1.0"
+					},
+					"dependencies": {
+						"ws": {
+							"version": "1.1.5",
+							"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+							"integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+							"requires": {
+								"options": ">=0.0.5",
+								"ultron": "1.0.x"
+							}
+						}
+					}
+				},
+				"@react-native-community/cli-tools": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-5.0.1.tgz",
+					"integrity": "sha512-XOX5w98oSE8+KnkMZZPMRT7I5TaP8fLbDl0tCu40S7Epz+Zz924n80fmdu6nUDIfPT1nV6yH1hmHmWAWTDOR+Q==",
+					"requires": {
+						"chalk": "^3.0.0",
+						"lodash": "^4.17.15",
+						"mime": "^2.4.1",
+						"node-fetch": "^2.6.0",
+						"open": "^6.2.0",
+						"shell-quote": "1.6.1"
+					}
+				},
+				"@react-native-community/cli-types": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-5.0.1.tgz",
+					"integrity": "sha512-BesXnuFFlU/d1F3+sHhvKt8fUxbQlAbZ3hhMEImp9A6sopl8TEtryUGJ1dbazGjRXcADutxvjwT/i3LJVTIQug==",
+					"requires": {
+						"ora": "^3.4.0"
 					}
 				},
 				"ansi-regex": {
@@ -54005,6 +54692,11 @@
 						"once": "^1.3.1"
 					}
 				},
+				"react-refresh": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
+					"integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -54031,15 +54723,10 @@
 						"has-flag": "^4.0.0"
 					}
 				},
-				"whatwg-fetch": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-					"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-				},
 				"ws": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+					"integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
 					"requires": {
 						"async-limiter": "~1.0.0"
 					}
@@ -54313,9 +55000,10 @@
 			}
 		},
 		"react-refresh": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
-			"integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
+			"integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
+			"dev": true
 		},
 		"react-resize-aware": {
 			"version": "3.1.0",
@@ -55656,6 +56344,12 @@
 			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
 			"dev": true
 		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -55937,12 +56631,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
-		"safe-json-parse": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
-			"integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
-			"dev": true
-		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -56213,6 +56901,21 @@
 			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
 			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
 		},
+		"select-hose": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+			"dev": true
+		},
+		"selfsigned": {
+			"version": "1.10.11",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
+			"integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+			"dev": true,
+			"requires": {
+				"node-forge": "^0.10.0"
+			}
+		},
 		"semver": {
 			"version": "7.3.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -56309,6 +57012,50 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+					"dev": true
+				}
+			}
+		},
+		"serve-index": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.4",
+				"batch": "0.6.1",
+				"debug": "2.6.9",
+				"escape-html": "~1.0.3",
+				"http-errors": "~1.6.2",
+				"mime-types": "~2.1.17",
+				"parseurl": "~1.3.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"dev": true,
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
 					"dev": true
 				}
 			}
@@ -56787,8 +57534,7 @@
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
 		},
 		"slice-ansi": {
 			"version": "0.0.4",
@@ -56996,6 +57742,25 @@
 				}
 			}
 		},
+		"sockjs": {
+			"version": "0.3.21",
+			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+			"integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
+			"dev": true,
+			"requires": {
+				"faye-websocket": "^0.11.3",
+				"uuid": "^3.4.0",
+				"websocket-driver": "^0.7.4"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				}
+			}
+		},
 		"socks": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
@@ -57177,6 +57942,78 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
+		},
+		"spdy": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+			"integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"handle-thing": "^2.0.0",
+				"http-deceiver": "^1.2.7",
+				"select-hose": "^2.0.0",
+				"spdy-transport": "^3.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"spdy-transport": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+			"integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"detect-node": "^2.0.4",
+				"hpack.js": "^2.1.6",
+				"obuf": "^1.1.2",
+				"readable-stream": "^3.0.6",
+				"wbuf": "^1.7.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"specificity": {
 			"version": "0.4.1",
@@ -57412,12 +58249,6 @@
 					}
 				}
 			}
-		},
-		"string-template": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
-			"dev": true
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -59796,6 +60627,12 @@
 				"xtend": "~4.0.1"
 			}
 		},
+		"thunky": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+			"dev": true
+		},
 		"timers-browserify": {
 			"version": "2.0.12",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -59815,20 +60652,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
-		},
-		"tiny-lr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
-			"integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
-			"dev": true,
-			"requires": {
-				"body": "^5.1.0",
-				"debug": "^3.1.0",
-				"faye-websocket": "~0.10.0",
-				"livereload-js": "^2.3.0",
-				"object-assign": "^4.1.0",
-				"qs": "^6.4.0"
-			}
 		},
 		"tinycolor2": {
 			"version": "1.4.2",
@@ -61152,6 +61975,15 @@
 				}
 			}
 		},
+		"wbuf": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+			"dev": true,
+			"requires": {
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -61530,26 +62362,31 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.2.tgz",
-			"integrity": "sha512-mEoLmnmOIZQNiRl0ebnjzQ74Hk0iKS5SiEEnpq3dRezoyR3yPaeQZCMCe+db4524pj1Pd5ghZXjT41KLzIhSLw==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.4",
-				"@webpack-cli/info": "^1.3.0",
-				"@webpack-cli/serve": "^1.5.1",
-				"colorette": "^1.2.1",
+				"@webpack-cli/configtest": "^1.1.0",
+				"@webpack-cli/info": "^1.4.0",
+				"@webpack-cli/serve": "^1.6.0",
+				"colorette": "^2.0.14",
 				"commander": "^7.0.0",
 				"execa": "^5.0.0",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
 				"interpret": "^2.2.0",
 				"rechoir": "^0.7.0",
-				"v8-compile-cache": "^2.2.0",
 				"webpack-merge": "^5.7.3"
 			},
 			"dependencies": {
+				"colorette": {
+					"version": "2.0.16",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+					"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+					"dev": true
+				},
 				"commander": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -61607,9 +62444,9 @@
 					"dev": true
 				},
 				"import-local": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
+					"integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
 					"dev": true,
 					"requires": {
 						"pkg-dir": "^4.2.0",
@@ -61756,9 +62593,9 @@
 					"dev": true
 				},
 				"signal-exit": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+					"version": "3.0.5",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+					"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
 					"dev": true
 				},
 				"which": {
@@ -61783,6 +62620,338 @@
 				"mkdirp": "^0.5.1",
 				"range-parser": "^1.2.1",
 				"webpack-log": "^2.0.0"
+			},
+			"dependencies": {
+				"range-parser": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+					"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+					"dev": true
+				}
+			}
+		},
+		"webpack-dev-server": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.4.0.tgz",
+			"integrity": "sha512-+S0XRIbsopVjPFjCO8I07FXYBWYqkFmuP56ucGMTs2hA/gV4q2M9xTmNo5Tg4o8ffRR+Nm3AsXnQXxKRyYovrA==",
+			"dev": true,
+			"requires": {
+				"ansi-html-community": "^0.0.8",
+				"bonjour": "^3.5.0",
+				"chokidar": "^3.5.2",
+				"colorette": "^2.0.10",
+				"compression": "^1.7.4",
+				"connect-history-api-fallback": "^1.6.0",
+				"del": "^6.0.0",
+				"express": "^4.17.1",
+				"graceful-fs": "^4.2.6",
+				"html-entities": "^2.3.2",
+				"http-proxy-middleware": "^2.0.0",
+				"internal-ip": "^6.2.0",
+				"ipaddr.js": "^2.0.1",
+				"open": "^8.0.9",
+				"p-retry": "^4.5.0",
+				"portfinder": "^1.0.28",
+				"schema-utils": "^3.1.0",
+				"selfsigned": "^1.10.11",
+				"serve-index": "^1.9.1",
+				"sockjs": "^0.3.21",
+				"spdy": "^4.0.2",
+				"strip-ansi": "^7.0.0",
+				"url": "^0.11.0",
+				"webpack-dev-middleware": "^5.2.1",
+				"ws": "^8.1.0"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+					"dev": true
+				},
+				"@types/json-schema": {
+					"version": "7.0.9",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+					"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+					"dev": true
+				},
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ajv-keywords": {
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+					"dev": true
+				},
+				"ansi-html-community": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+					"integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"colorette": {
+					"version": "2.0.16",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+					"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+					"dev": true
+				},
+				"del": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+					"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+					"dev": true,
+					"requires": {
+						"globby": "^11.0.1",
+						"graceful-fs": "^4.2.4",
+						"is-glob": "^4.0.1",
+						"is-path-cwd": "^2.2.0",
+						"is-path-inside": "^3.0.2",
+						"p-map": "^4.0.0",
+						"rimraf": "^3.0.2",
+						"slash": "^3.0.0"
+					}
+				},
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+					"dev": true
+				},
+				"fast-glob": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+					"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.2",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.4"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+					"dev": true
+				},
+				"html-entities": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+					"integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
+					"dev": true
+				},
+				"ipaddr.js": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+					"integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+					"dev": true
+				},
+				"is-docker": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+					"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-path-inside": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+					"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+					"dev": true
+				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
+				"merge2": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.2.3"
+					}
+				},
+				"mime-db": {
+					"version": "1.51.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+					"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.34",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+					"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+					"dev": true,
+					"requires": {
+						"mime-db": "1.51.0"
+					}
+				},
+				"open": {
+					"version": "8.4.0",
+					"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+					"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+					"dev": true,
+					"requires": {
+						"define-lazy-prop": "^2.0.0",
+						"is-docker": "^2.1.1",
+						"is-wsl": "^2.2.0"
+					}
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"picomatch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.8",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+					"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^6.0.1"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"webpack-dev-middleware": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.2.1.tgz",
+					"integrity": "sha512-Kx1X+36Rn9JaZcQMrJ7qN3PMAuKmEDD9ZISjUj3Cgq4A6PtwYsC4mpaKotSRYH3iOF6HsUa8viHKS59FlyVifQ==",
+					"dev": true,
+					"requires": {
+						"colorette": "^2.0.10",
+						"memfs": "^3.2.2",
+						"mime-types": "^2.1.31",
+						"range-parser": "^1.2.1",
+						"schema-utils": "^3.1.0"
+					}
+				},
+				"ws": {
+					"version": "8.2.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+					"dev": true
+				}
 			}
 		},
 		"webpack-filter-warnings-plugin": {
@@ -61816,77 +62985,6 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
-		},
-		"webpack-livereload-plugin": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-3.0.1.tgz",
-			"integrity": "sha512-HFjUFH9kY8P5l8jYqiKsa9keE/DN1riOWH5l6VV27c9j/5rlqWLK0PPbErgqRyP1FON5GuKOgvOJo+0Ep0mYyQ==",
-			"dev": true,
-			"requires": {
-				"anymatch": "^3.1.1",
-				"portfinder": "^1.0.17",
-				"schema-utils": ">1.0.0",
-				"tiny-lr": "^1.1.1"
-			},
-			"dependencies": {
-				"@types/json-schema": {
-					"version": "7.0.8",
-					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
-					"integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
-					"dev": true
-				},
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-					"dev": true
-				},
-				"anymatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-					"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-					"dev": true,
-					"requires": {
-						"normalize-path": "^3.0.0",
-						"picomatch": "^2.0.4"
-					}
-				},
-				"fast-deep-equal": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-					"dev": true
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
-				"schema-utils": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.8",
-						"ajv": "^6.12.5",
-						"ajv-keywords": "^3.5.2"
 					}
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7063,9 +7063,9 @@
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.1.tgz",
-			"integrity": "sha512-ccap6o7+y5L8cnvkZ9h8UXCGyy2DqtwCD+/N3Yru6lxMvcdkPKtdx13qd7sAC9s5qZktOmWf9lfUjsGOvSdYhg==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.2.tgz",
+			"integrity": "sha512-BWOG6opI9+L5HjQIj6znFLwVXkjDS98PKfRDlbPFvinTz4wQ7ZSXxV0lLOfRW12HXcqk4DEzrphjRMJFXuihNg==",
 			"dev": true,
 			"requires": {
 				"ansi-html-community": "^0.0.8",
@@ -7107,12 +7107,6 @@
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
 					"integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
-					"dev": true
-				},
-				"fast-deep-equal": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 					"dev": true
 				},
 				"find-up": {
@@ -19727,7 +19721,7 @@
 			"version": "file:packages/scripts",
 			"dev": true,
 			"requires": {
-				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
+				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
 				"@svgr/webpack": "^5.5.0",
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
 		"@emotion/native": "^11.0.0",
 		"@octokit/rest": "16.26.0",
 		"@octokit/webhooks": "7.1.0",
+		"@pmmmwh/react-refresh-webpack-plugin": "0.5.2",
 		"@storybook/addon-a11y": "6.3.2",
 		"@storybook/addon-controls": "6.3.12",
 		"@storybook/addon-docs": "6.3.2",

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -34,6 +34,10 @@ function defaultRequestToExternal( request ) {
 			return 'ReactDOM';
 	}
 
+	if ( request.includes( 'react-refresh/runtime' ) ) {
+		return 'ReactRefreshRuntime';
+	}
+
 	if ( BUNDLED_PACKAGES.includes( request ) ) {
 		return undefined;
 	}
@@ -64,6 +68,10 @@ function defaultRequestToHandle( request ) {
 
 		case 'lodash-es':
 			return 'lodash';
+	}
+
+	if ( request.includes( 'react-refresh/runtime' ) ) {
+		return 'wp-react-refresh-runtime';
 	}
 
 	if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 -   The bundled `eslint` dependency has been updated from requiring `^7.17.0` to requiring `^8.3.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 -   The `puppeteer-core` dependency has been updated from requiring `^10.1.0` to requiring `^11.0.0` (see [Breaking Changes](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0), [#36040](https://github.com/WordPress/gutenberg/pull/36040)).
+-   Removed support for live reload in the `start` command ([#28273](https://github.com/WordPress/gutenberg/pull/28273)).
+-   The bundled `webpack-cli` dependency has been updated to the next major version `^4.9.1` ([#28273](https://github.com/WordPress/gutenberg/pull/28273)).
+
+### New Features
+
+-   Added optional support for React Fast Refresh in the `start` command. It can be activated with `--hot` CLI argument ([#28273](https://github.com/WordPress/gutenberg/pull/28273)).
 
 ### Bug Fixes
 
@@ -20,7 +26,7 @@
 ### Enhancements
 
 -   The bundled `browserslist` dependency has been updated from requiring `^4.16.6` to requiring `^4.17.6` ([#36244](https://github.com/WordPress/gutenberg/pull/36244)).
--   Updated the default ESLint config to work correctly with the latest version of `@wordpress/eslint-plugin` ([#36244](https://github.com/WordPress/gutenberg/pull/36244)).
+-   # Updated the default ESLint config to work correctly with the latest version of `@wordpress/eslint-plugin` ([#36244](https://github.com/WordPress/gutenberg/pull/36244)).
 
 ## 19.1.0 (2021-11-07)
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -26,7 +26,7 @@
 ### Enhancements
 
 -   The bundled `browserslist` dependency has been updated from requiring `^4.16.6` to requiring `^4.17.6` ([#36244](https://github.com/WordPress/gutenberg/pull/36244)).
--   # Updated the default ESLint config to work correctly with the latest version of `@wordpress/eslint-plugin` ([#36244](https://github.com/WordPress/gutenberg/pull/36244)).
+-   Updated the default ESLint config to work correctly with the latest version of `@wordpress/eslint-plugin` ([#36244](https://github.com/WordPress/gutenberg/pull/36244)).
 
 ## 19.1.0 (2021-11-07)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -313,6 +313,7 @@ _Example:_
 {
 	"scripts": {
 		"start": "wp-scripts start",
+		"start:hot": "wp-scripts start --hot",
 		"start:custom": "wp-scripts start entry-one.js entry-two.js --output-path=custom"
 	}
 }
@@ -321,10 +322,12 @@ _Example:_
 This is how you execute the script with presented setup:
 
 -   `npm start` - starts the build for development.
+-   `npm start:hot` - starts the build for development with "Fast Refresh". The page will automatically reload if you make changes to the code.
 -   `npm run start:custom` - starts the build for development which contains two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
 
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 
+-   `--hot` – enables "Fast Refresh". The page will automatically reload if you make changes to the code.
 -   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
 -   `--webpack--devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,7 +32,7 @@
 		"wp-scripts": "./bin/wp-scripts.js"
 	},
 	"dependencies": {
-		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
+		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
 		"@svgr/webpack": "^5.5.0",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
 		"@wordpress/browserslist-config": "file:../browserslist-config",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,6 +32,7 @@
 		"wp-scripts": "./bin/wp-scripts.js"
 	},
 	"dependencies": {
+		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
 		"@svgr/webpack": "^5.5.0",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
@@ -72,6 +73,7 @@
 		"postcss-loader": "^6.1.1",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"puppeteer-core": "^11.0.0",
+		"react-refresh": "^0.10.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",
 		"sass": "^1.35.2",
@@ -82,8 +84,8 @@
 		"url-loader": "^4.1.1",
 		"webpack": "^5.47.1",
 		"webpack-bundle-analyzer": "^4.4.2",
-		"webpack-cli": "^4.7.2",
-		"webpack-livereload-plugin": "^3.0.1"
+		"webpack-cli": "^4.9.1",
+		"webpack-dev-server": "^4.4.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/scripts/scripts/start.js
+++ b/packages/scripts/scripts/start.js
@@ -23,7 +23,7 @@ if ( hasArgInCLI( '--webpack--devtool' ) ) {
 
 const { status } = spawn(
 	resolveBin( 'webpack' ),
-	[ ...getWebpackArgs(), '--watch' ],
+	[ hasArgInCLI( '--hot' ) ? 'serve' : 'watch', ...getWebpackArgs() ],
 	{
 		stdio: 'inherit',
 	}

--- a/tools/webpack/development.js
+++ b/tools/webpack/development.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+const { join } = require( 'path' );
+
+/**
+ * WordPress dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+const sharedConfig = {
+	mode: 'development',
+	target: 'browserslist',
+	output: {
+		filename: '[name]/index.min.js',
+		path: join( __dirname, '..', '..', 'build' ),
+	},
+};
+
+// See https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#externalising-react.
+module.exports = [
+	{
+		...sharedConfig,
+		name: 'react-refresh-entry',
+		entry: {
+			'react-refresh-entry':
+				'@pmmmwh/react-refresh-webpack-plugin/client/ReactRefreshEntry.js',
+		},
+		plugins: [ new DependencyExtractionWebpackPlugin() ],
+	},
+	{
+		...sharedConfig,
+		name: 'react-refresh-runtime',
+		entry: {
+			'react-refresh-runtime': {
+				import: 'react-refresh/runtime.js',
+				library: {
+					name: 'ReactRefreshRuntime',
+					type: 'window',
+				},
+			},
+		},
+		plugins: [
+			new DependencyExtractionWebpackPlugin( {
+				useDefaults: false,
+			} ),
+		],
+	},
+];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 const blocksConfig = require( './tools/webpack/blocks' );
+const developmentConfigs = require( './tools/webpack/development' );
 const packagesConfig = require( './tools/webpack/packages' );
 
-module.exports = [ blocksConfig, packagesConfig ];
+module.exports = [ blocksConfig, packagesConfig, ...developmentConfigs ];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Part of #21008 targeting `@wordpress/scripts`.

I followed instructions at https://github.com/pmmmwh/react-refresh-webpack-plugin and it fully works as expected for Chrome and Safari. It should work with both React Developer Tools enabled but also without them.

I was testing with `SCRIPT_DEBUG` set to `true` for WordPress to ensure that development versions of `react` and `react-dom` were served. In general, the challenge is that we are using externals for both libraries, while in the examples shared they are all bundled together. 


At the moment React Refresh needs to be activated with the `--hot` flag when executing the `start` command from `@wordpress/scripts`:

```bash
wp-scripts start --hot
```

If the flag is not provided then the `start` command should work as before.

## Resolved Blockers

- [x] Hot module replacement for CSS isn't working out of the box with webpack 4 and `MiniCSSExtractPlugin` but it should with webpack 5, see https://webpack.js.org/plugins/mini-css-extract-plugin/#hot-module-reloading-hmr.
- [x] Hot module replacement doesn't work with `MiniCSSExtractPlugin` and `splitChunks` config for the `style.scss` files
- ~Add `react/jsx-runtime` entry for the new automatic JSX transform from React 17 #34221~
- [x] Ensure that React Refresh entry and runtime get externalized and initialized before React loads (https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#externalising-react).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

The way I test it:

```bash
npx wp-create-block my-block --no-wp-scripts
cd my-block
../node_modules/.bin/wp-scripts start --hot
```

This is to ensure that we are using the latest `@wordpress/scripts` from the branch and with the default webpack config from `@wordpress/scripts`.

Ensure your WordPress instance has `SCRIPT_DEBUG` set to `true`.

## Screenshots

https://user-images.githubusercontent.com/699132/143570765-0e1f0f25-21c8-4ded-8223-1756103b7895.mov

https://user-images.githubusercontent.com/699132/143570743-1c6a57d3-69e3-44d7-a073-051fc6d0c744.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality).
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
