### PR TITLE
Change the way RTL styles get enqueued

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -164,29 +164,27 @@ function gutenberg_register_core_block_styles( $block_name ) {
 
 	$block_name = str_replace( 'core/', '', $block_name );
 
-	$style_path        = is_rtl()
-		? "build/block-library/blocks/$block_name/style-rtl.css"
-		: "build/block-library/blocks/$block_name/style.css";
-	$editor_style_path = is_rtl()
-		? "build/block-library/blocks/$block_name/style-editor-rtl.css"
-		: "build/block-library/blocks/$block_name/style-editor.css";
+	$style_path        = "build/block-library/blocks/$block_name/style.css";
+	$editor_style_path = "build/block-library/blocks/$block_name/style-editor.css";
 
 	if ( file_exists( gutenberg_dir_path() . $style_path ) ) {
 		wp_register_style(
-			'wp-block-' . $block_name,
+			"wp-block-{$block_name}",
 			gutenberg_url( $style_path ),
 			array(),
 			filemtime( gutenberg_dir_path() . $style_path )
 		);
+		wp_style_add_data( "wp-block-{$block_name}", 'rtl', 'replace' );
 	}
 
 	if ( file_exists( gutenberg_dir_path() . $editor_style_path ) ) {
 		wp_register_style(
-			'wp-block-' . $block_name . '-editor',
+			"wp-block-{$block_name}-editor",
 			gutenberg_url( $editor_style_path ),
 			array(),
 			filemtime( gutenberg_dir_path() . $editor_style_path )
 		);
+		wp_style_add_data( "wp-block-{$block_name}-editor", 'rtl', 'replace' );
 	}
 }
 


### PR DESCRIPTION
This PR changes the way RTL styles get loaded. Instead of having conditionals in PHP to determine if we need to load the RTL styles or not, it now uses [`wp_style_add_data`](https://developer.wordpress.org/reference/functions/wp_style_add_data/) as proposed in https://github.com/WordPress/gutenberg/pull/25220#pullrequestreview-556325628

## How has this been tested?
Tested using the [RTL Tester plugin](https://wordpress.org/plugins/rtl-tester/).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
