### PR TITLE
Hide writing prompt from subsequent empty paragraphs

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -132,6 +132,7 @@ function ParagraphBlock( {
 								'Empty block; start writing or type forward slash to choose a block'
 						  )
 				}
+				data-empty={ content ? false : true }
 				placeholder={
 					placeholder ||
 					__( 'Start writing or type / to choose a block' )

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -2,3 +2,21 @@
 .block-editor-block-list__block[data-type="core/paragraph"].has-drop-cap:focus {
 	min-height: auto !important;
 }
+
+// Hide multiple sequential paragraphs.
+.block-editor-block-list__block[data-empty="true"] {
+	[data-rich-text-placeholder] {
+		opacity: 1;
+		transition: opacity 0.1s linear;
+		@include reduce-motion("transition");
+	}
+}
+.block-editor-block-list__block[data-empty="true"] + .block-editor-block-list__block[data-empty="true"] {
+	[data-rich-text-placeholder] {
+		opacity: 0;
+	}
+
+	&:hover [data-rich-text-placeholder] {
+		opacity: 1;
+	}
+}

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -7,16 +7,11 @@
 .block-editor-block-list__block[data-empty="true"] {
 	[data-rich-text-placeholder] {
 		opacity: 1;
-		transition: opacity 0.1s linear;
-		@include reduce-motion("transition");
 	}
 }
+
 .block-editor-block-list__block[data-empty="true"] + .block-editor-block-list__block[data-empty="true"] {
 	[data-rich-text-placeholder] {
 		opacity: 0;
-	}
-
-	&:hover [data-rich-text-placeholder] {
-		opacity: 1;
 	}
 }


### PR DESCRIPTION
This one revisits work from https://github.com/WordPress/gutenberg/pull/27995#issuecomment-760338837.

It fixes #13599, mitigates #17366. 

_It has been edited and refactored._

What it does is, if you have 5 empty paragraphs in succession, only the first one shows a tip:

![empty](https://user-images.githubusercontent.com/1204802/110296688-e3776d00-7ff2-11eb-96bf-b0fca69ebca8.gif)