### PR TITLE
Try: Hide tip from multiple paragraphs, version 2

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -167,6 +167,7 @@ function ParagraphBlock( {
 								'Empty block; start writing or type forward slash to choose a block'
 						  )
 				}
+				data-empty={ content ? false : true }
 				placeholder={
 					placeholder ||
 					__( 'Start writing or type / to choose a block' )

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -2,3 +2,33 @@
 .block-editor-block-list__block[data-type="core/paragraph"].has-drop-cap:focus {
 	min-height: auto !important;
 }
+
+// Hide multiple empty paragraphs.
+@keyframes empty-paragraph__fade-out-animation {
+	from {
+		opacity: 1;
+	}
+	to {
+		opacity: 0;
+	}
+}
+
+.block-editor-block-list__block[data-empty="true"] {
+	opacity: 1;
+
+	// Fade empty paragraphs out after a delay.
+	animation: empty-paragraph__fade-out-animation 0.4s ease 2s;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
+
+	// Except if the paragraph is the first or last in a container.
+	&:first-child,
+	&:last-of-type {
+		animation: none;
+	}
+
+	// Or if hovered.
+	&:hover {
+		animation: none;
+	}
+}


### PR DESCRIPTION
Alternative to #28275. Only one should be merged.

It fixes #13599, mitigates #17366. 

What this PR does, is fading out empty paragraphs after 2 seconds of not interacting with them, unless it's the first or last paragraphs in a container:

![v2](https://user-images.githubusercontent.com/1204802/104900919-fa97c800-597c-11eb-9a77-17ec22895a2d.gif)
