### PR TITLE
Site Editor: Add template part missing state

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -38,14 +38,6 @@ export default function TemplatePartEdit( {
 	// new edits to trigger this.
 	const { isResolved, innerBlocks, isMissing } = useSelect(
 		( select ) => {
-			if ( ! templatePartId ) {
-				return {
-					isResolved: false,
-					innerBlocks: [],
-					isMissing: false,
-				};
-			}
-
 			const { getEntityRecord, hasFinishedResolution } = select( 'core' );
 			const { getBlocks } = select( 'core/block-editor' );
 
@@ -54,11 +46,12 @@ export default function TemplatePartEdit( {
 				'wp_template_part',
 				templatePartId,
 			];
-			const entityRecord = getEntityRecord( ...getEntityArgs );
-			const hasResolvedEntity = hasFinishedResolution(
-				'getEntityRecord',
-				getEntityArgs
-			);
+			const entityRecord = templatePartId
+				? getEntityRecord( ...getEntityArgs )
+				: null;
+			const hasResolvedEntity = templatePartId
+				? hasFinishedResolution( 'getEntityRecord', getEntityArgs )
+				: false;
 
 			return {
 				innerBlocks: getBlocks( clientId ),

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -73,6 +73,18 @@ export default function TemplatePartEdit( {
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing;
 
+	if ( ! isPlaceholder && isMissing ) {
+		return (
+			<TagName { ...blockProps }>
+				<Warning>
+					{ __(
+						'Template part has been deleted or is unavailable.'
+					) }
+				</Warning>
+			</TagName>
+		);
+	}
+
 	const inspectorAdvancedControls = (
 		<InspectorAdvancedControls>
 			<SelectControl
@@ -140,13 +152,6 @@ export default function TemplatePartEdit( {
 					/>
 				) }
 				{ ! isPlaceholder && ! isResolved && <Spinner /> }
-				{ ! isPlaceholder && isMissing && (
-					<Warning>
-						{ __(
-							'Template part has been deleted or is unavailable.'
-						) }
-					</Warning>
-				) }
 			</TagName>
 		</>
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
If a template part has been deleted or unavailable for some reason, we had a spinner loading infinitely. Added a `missing` state to the block to be more user friendly.

NOTE: We have a [regression](https://github.com/WordPress/gutenberg/issues/28153) that doesn't show the spinner. So if you test on master right now, then you will only see an empty template part block with no spinner. If you checkout to this branch you will see the warning.

## How has this been tested?
1. Open site editor
2. Add Template Part block, create a new template
3. Add some content
4. Save
5. Go to WP Admin -> Appearance -> Template parts
6. Delete your new template part
7. Go back to site editor
8. Make sure you see the warning instead of an empty template part block (or infinitely loading spinner)

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/104905166-4600a500-5982-11eb-9a1b-b1f93d9449d2.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
