### PR TITLE
Code Quality: Restrict usage of direct React imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,6 +64,11 @@ module.exports = {
 						message: 'Please use `memize` instead.',
 					},
 					{
+						name: 'react',
+						message:
+							'Please use React API through `@wordpress/element` instead.',
+					},
+					{
 						name: 'reakit',
 						message:
 							'Please use Reakit API through `@wordpress/components` instead.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12470,6 +12470,7 @@
 		"@wordpress/react-native-aztec": {
 			"version": "file:packages/react-native-aztec",
 			"requires": {
+				"@wordpress/element": "file:packages/element",
 				"@wordpress/keycodes": "file:packages/keycodes"
 			}
 		},

--- a/packages/block-editor/src/components/block-media-update-progress/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/index.native.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { View } from 'react-native';
 
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
@@ -31,7 +31,7 @@ export const MEDIA_SAVE_STATE_RESET = 8;
 export const MEDIA_SAVE_FINAL_STATE_RESULT = 9;
 export const MEDIA_SAVE_MEDIAID_CHANGED = 10;
 
-export class BlockMediaUpdateProgress extends React.Component {
+export class BlockMediaUpdateProgress extends Component {
 	constructor( props ) {
 		super( props );
 

--- a/packages/block-editor/src/components/inspector-controls/index.native.js
+++ b/packages/block-editor/src/components/inspector-controls/index.native.js
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { View } from 'react-native';
+
 /**
  * WordPress dependencies
  */
+import { Children } from '@wordpress/element';
 import { createSlotFill, BottomSheetConsumer } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
@@ -30,7 +32,7 @@ const FillWithSettingsButton = ( { children, ...props } ) => {
 					</BottomSheetConsumer>
 				}
 			</Fill>
-			{ React.Children.count( children ) > 0 && <BlockSettingsButton /> }
+			{ Children.count( children ) > 0 && <BlockSettingsButton /> }
 		</>
 	);
 };

--- a/packages/block-editor/src/components/media-upload-progress/index.native.js
+++ b/packages/block-editor/src/components/media-upload-progress/index.native.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { View } from 'react-native';
 
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { subscribeMediaUpload } from '@wordpress/react-native-bridge';
@@ -21,7 +21,7 @@ export const MEDIA_UPLOAD_STATE_SUCCEEDED = 2;
 export const MEDIA_UPLOAD_STATE_FAILED = 3;
 export const MEDIA_UPLOAD_STATE_RESET = 4;
 
-export class MediaUploadProgress extends React.Component {
+export class MediaUploadProgress extends Component {
 	constructor( props ) {
 		super( props );
 

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import React from 'react';
-
-/**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Picker } from '@wordpress/components';
 import {
@@ -29,7 +25,7 @@ export const OPTION_TAKE_VIDEO = __( 'Take a Video' );
 export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
 export const OPTION_TAKE_PHOTO_OR_VIDEO = __( 'Take a Photo or Video' );
 
-export class MediaUpload extends React.Component {
+export class MediaUpload extends Component {
 	constructor( props ) {
 		super( props );
 		this.onPickerPresent = this.onPickerPresent.bind( this );

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { View, Clipboard, TouchableWithoutFeedback, Text } from 'react-native';
-import React from 'react';
 
 /**
  * WordPress dependencies

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { View, TouchableWithoutFeedback } from 'react-native';
 import { isEmpty, get, find, map } from 'lodash';
 
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import {
 	requestMediaImport,
 	mediaUploadSync,
@@ -61,7 +61,7 @@ const getUrlForSlug = ( image, { sizeSlug } ) => {
 	return get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] );
 };
 
-export class ImageEdit extends React.Component {
+export class ImageEdit extends Component {
 	constructor( props ) {
 		super( props );
 

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { View, TouchableWithoutFeedback, Text } from 'react-native';
 import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import {
 	mediaUploadSync,
 	requestImageFailedRetryDialog,
@@ -49,7 +49,7 @@ const ICON_TYPE = {
 	UPLOAD: 'upload',
 };
 
-class VideoEdit extends React.Component {
+class VideoEdit extends Component {
 	constructor( props ) {
 		super( props );
 

--- a/packages/components/src/color-picker/index.native.js
+++ b/packages/components/src/color-picker/index.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { View, Text, TouchableWithoutFeedback, Platform } from 'react-native';
-import React from 'react';
 import HsvColorPicker from 'react-native-hsv-color-picker';
 import tinycolor from 'tinycolor2';
 /**

--- a/packages/components/src/mobile/bottom-sheet/keyboard-avoiding-view.native.js
+++ b/packages/components/src/mobile/bottom-sheet/keyboard-avoiding-view.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import {
 	Keyboard,
 	LayoutAnimation,
@@ -12,13 +11,18 @@ import {
 } from 'react-native';
 
 /**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
  * This is a simplified version of Facebook's KeyboardAvoidingView.
  * It's meant to work specifically with BottomSheets.
  * This fixes an issue in the bottom padding calculation, when the
  * BottomSheet was presented on Landscape, with the keyboard already present,
  * and a TextField on Autofocus (situation present on Links UI)
  */
-class KeyboardAvoidingView extends React.Component {
+class KeyboardAvoidingView extends Component {
 	constructor() {
 		super( ...arguments );
 

--- a/packages/components/src/mobile/color-settings/index.native.js
+++ b/packages/components/src/mobile/color-settings/index.native.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { useRoute } from '@react-navigation/native';
 
 /**
  * WordPress dependencies
  */
-import { useEffect, useContext } from '@wordpress/element';
+import { memo, useEffect, useContext } from '@wordpress/element';
 import { BottomSheetContext, BottomSheet } from '@wordpress/components';
-import { useRoute } from '@react-navigation/native';
 
 /**
  * Internal dependencies
@@ -19,7 +18,7 @@ import PaletteScreen from './palette.screen';
 
 import { colorsUtils } from './utils';
 
-const ColorSettingsMemo = React.memo(
+const ColorSettingsMemo = memo(
 	( {
 		defaultSettings,
 		onHandleClosingBottomSheet,

--- a/packages/components/src/mobile/color-settings/picker-screen.native.js
+++ b/packages/components/src/mobile/color-settings/picker-screen.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useRoute, useNavigation } from '@react-navigation/native';
-import React from 'react';
 
 /**
  * WordPress dependencies

--- a/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
@@ -1,15 +1,16 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { FlatList } from 'react-native';
 import { isEqual } from 'lodash';
+
 /**
  * WordPress dependencies
  */
+import { memo } from '@wordpress/element';
 
-const List = React.memo( FlatList, isEqual );
+const List = memo( FlatList, isEqual );
 
 export const KeyboardAwareFlatList = ( {
 	extraScrollHeight,

--- a/packages/components/src/mobile/link-picker/index.native.js
+++ b/packages/components/src/mobile/link-picker/index.native.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { useState } from 'react';
 import { SafeAreaView, TouchableOpacity, View } from 'react-native';
 import { lowerCase, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { BottomSheet, Icon } from '@wordpress/components';
 import { getProtocol, prependHTTP } from '@wordpress/url';

--- a/packages/components/src/mobile/link-picker/link-picker-screen.native.js
+++ b/packages/components/src/mobile/link-picker/link-picker-screen.native.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { useNavigation, useRoute } from '@react-navigation/native';
+
 /**
  * WordPress dependencies
  */

--- a/packages/components/src/mobile/link-settings/link-settings-screen.native.js
+++ b/packages/components/src/mobile/link-settings/link-settings-screen.native.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { useNavigation, useRoute } from '@react-navigation/native';
+
 /**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */

--- a/packages/components/src/mobile/media-edit/index.native.js
+++ b/packages/components/src/mobile/media-edit/index.native.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { compact } from 'lodash';
 
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Picker } from '@wordpress/components';
 import {
@@ -32,7 +32,7 @@ const replaceOption = {
 	types: [ MEDIA_TYPE_IMAGE ],
 };
 
-export class MediaEdit extends React.Component {
+export class MediaEdit extends Component {
 	constructor( props ) {
 		super( props );
 		this.onPickerPresent = this.onPickerPresent.bind( this );

--- a/packages/components/src/mobile/picker/index.android.js
+++ b/packages/components/src/mobile/picker/index.android.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { View } from 'react-native';
 
 /**

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { useRef } from 'react';
 import { ScrollView, View } from 'react-native';
 
 /**
  * WordPress dependencies
  */
+import { useRef } from '@wordpress/element';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';

--- a/packages/edit-post/src/components/visual-editor/header.native.js
+++ b/packages/edit-post/src/components/visual-editor/header.native.js
@@ -1,10 +1,7 @@
 /**
- * External dependencies
- */
-import React from 'react';
-/**
  * WordPress dependencies
  */
+import { memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
@@ -16,7 +13,7 @@ import { ReadableContentView } from '@wordpress/components';
  */
 import styles from './style.scss';
 
-const Header = React.memo(
+const Header = memo(
 	function EditorHeader( {
 		editTitle,
 		setTitleRef,

--- a/packages/element/src/create-interpolate-element.js
+++ b/packages/element/src/create-interpolate-element.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createElement, cloneElement, Fragment, isValidElement } from 'react';
+import { createElement, cloneElement, Fragment, isValidElement } from './react';
 
 /** @typedef {import('./react').WPElement} WPElement */
 

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line no-restricted-imports
 import {
 	Children,
 	cloneElement,

--- a/packages/format-library/src/link/modal-screens/link-picker-screen.native.js
+++ b/packages/format-library/src/link/modal-screens/link-picker-screen.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { Platform, Keyboard } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { delay } from 'lodash';

--- a/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
+++ b/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { useNavigation, useRoute } from '@react-navigation/native';
 /**
  * WordPress dependencies

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import React from 'react';
-/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,42 +1,43 @@
 {
-  "name": "@wordpress/react-native-aztec",
-  "version": "1.44.1",
-  "description": "Aztec view for react-native.",
-  "private": true,
-  "author": "The WordPress Contributors",
-  "license": "GPL-2.0-or-later",
-  "keywords": [
-    "wordpress",
-    "react-native"
-  ],
-  "homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/react-native-aztec/README.md",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/WordPress/gutenberg.git",
-    "directory": "packages/react-native-aztec"
-  },
-  "bugs": {
-    "url": "https://github.com/WordPress/gutenberg/issues"
-  },
-  "dependencies": {
-    "@wordpress/keycodes": "file:../keycodes"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "install-aztec-ios": "cd ./ios && carthage bootstrap --platform iOS --cache-builds",
-    "update-aztec-ios": "cd ./ios && carthage update --platform iOS --cache-builds",
-    "clean": "npm run clean-watchman; npm run clean-node; npm run clean-react; npm run clean-metro; npm run clean-jest;",
-    "clean-jest": "rm -rf $TMPDIR/jest_*;",
-    "clean-metro": "rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/metro-bundler-cache-*;",
-    "clean-node": "rm -rf node_modules/;",
-    "clean-react": "rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/react-native-packager-cache-*;",
-    "clean-watchman": "command -v watchman >/dev/null 2>&1 && watchman watch-del-all;",
-    "clean:install": "npm run clean && npm install"
-  }
+	"name": "@wordpress/react-native-aztec",
+	"version": "1.44.1",
+	"description": "Aztec view for react-native.",
+	"private": true,
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"react-native"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/react-native-aztec/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/react-native-aztec"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"dependencies": {
+		"@wordpress/element": "file:../element",
+		"@wordpress/keycodes": "file:../keycodes"
+	},
+	"peerDependencies": {
+		"react": "*",
+		"react-native": "*"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"install-aztec-ios": "cd ./ios && carthage bootstrap --platform iOS --cache-builds",
+		"update-aztec-ios": "cd ./ios && carthage update --platform iOS --cache-builds",
+		"clean": "npm run clean-watchman; npm run clean-node; npm run clean-react; npm run clean-metro; npm run clean-jest;",
+		"clean-jest": "rm -rf $TMPDIR/jest_*;",
+		"clean-metro": "rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/metro-bundler-cache-*;",
+		"clean-node": "rm -rf node_modules/;",
+		"clean-react": "rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/react-native-packager-cache-*;",
+		"clean-watchman": "command -v watchman >/dev/null 2>&1 && watchman watch-del-all;",
+		"clean:install": "npm run clean && npm install"
+	}
 }

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import ReactNative, {
 	requireNativeComponent,
 	UIManager,
@@ -12,11 +11,12 @@ import TextInputState from 'react-native/Libraries/Components/TextInput/TextInpu
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { ENTER, BACKSPACE } from '@wordpress/keycodes';
 
 const AztecManager = UIManager.getViewManagerConfig( 'RCTAztecView' );
 
-class AztecView extends React.Component {
+class AztecView extends Component {
 	constructor() {
 		super( ...arguments );
 		this._onContentSizeChange = this._onContentSizeChange.bind( this );

--- a/test/native/__mocks__/react-native-aztec/index.js
+++ b/test/native/__mocks__/react-native-aztec/index.js
@@ -1,9 +1,9 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import React from 'react';
+import { Component } from '@wordpress/element';
 
-class AztecView extends React.Component {
+class AztecView extends Component {
 	blur = () => {};
 
 	focus = () => {};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR enables ESLint rule that will restrict the direct usage of React imports. Instead, it recommends using React API through `@wordpress/element` instead. It also ensures that we don't import React just for the sake of usage of JSX since it's handled by Babel.

As part of this changeset, I also fixed all existing violations in the codebase that is part of the mobile app. It's mostly cosmetical change.

It will also help to catch some future work like observed in #28176.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run lint-js` doesn't report any errors with this PR. You can try to import something from React and observer an error.

## Screenshots <!-- if applicable -->

<img width="1426" alt="Screen Shot 2021-01-18 at 12 08 32" src="https://user-images.githubusercontent.com/699132/104907783-e6a49400-5985-11eb-9197-e210d7208d71.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
