### PR TITLE
Fix isRTL check by loading the ltr string explilcitely

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -95,6 +95,11 @@ function gutenberg_override_script( $scripts, $handle, $src, $deps = array(), $v
 	if ( 'wp-i18n' !== $handle && 'wp-polyfill' !== $handle ) {
 		$scripts->set_translations( $handle, 'default' );
 	}
+	if ( 'wp-i18n' === $handle ) {
+		$ltr    = _x( 'ltr', 'text direction', 'default' );
+		$output = sprintf( "wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ '%s' ] }, 'default' );", $ltr );
+		$scripts->add_inline_script( 'wp-i18n', $output, 'after' );
+	}
 }
 
 /**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -96,7 +96,7 @@ function gutenberg_override_script( $scripts, $handle, $src, $deps = array(), $v
 		$scripts->set_translations( $handle, 'default' );
 	}
 	if ( 'wp-i18n' === $handle ) {
-		$ltr    = _x( 'ltr', 'text direction', 'default' );
+		$ltr    = 'rtl' === _x( 'ltr', 'text direction', 'default' ) ? 'rtl' : 'ltr';
 		$output = sprintf( "wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ '%s' ] }, 'default' );", $ltr );
 		$scripts->add_inline_script( 'wp-i18n', $output, 'after' );
 	}


### PR DESCRIPTION
closes #28221 
closes #28252 

Due to potential infinite loop, translations for i18n script are not being loaded. This PR  makes sure we load the "ltr" string as an inline script.

The root issue is being tackled in https://core.trac.wordpress.org/ticket/46089

**Testing instructions**

 - Use an RTL language
 - Insert a paragraph
 - the ltr/rtl direction button should be visible.