### PR TITLE
Fix allowedFormats in RichText component

### DIFF
--- a/packages/rich-text/src/component/use-format-types.js
+++ b/packages/rich-text/src/component/use-format-types.js
@@ -50,7 +50,7 @@ export function useFormatTypes( {
 	const allFormatTypes = useSelect( formatTypesSelector, [] );
 	const formatTypes = useMemo( () => {
 		return allFormatTypes.filter( ( { name, tagName } ) => {
-			if ( allowedFormats && allowedFormats.includes( name ) ) {
+			if ( allowedFormats && ! allowedFormats.includes( name ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR fixes a regression on `allowedFormats` in `RichText` component, which was introduced here: https://github.com/WordPress/gutenberg/pull/28130/files#diff-9802fef795fe1842bbf3d92e42af39478c5d760630f2e751fdcb80e1d7e40641L42
<!-- Please describe what you have changed or added -->

## Testing instructions

1. add `allowedFormats={ [ 'core/bold' ] }` to any `RichText` component
2. observe that it shows everything else beside the provided formats in master and that shows only `bold` in this PR.
