### PR TITLE
Try: Show reusable block parent border when child selected.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -312,6 +312,11 @@
 		}
 	}
 
+	// Reusable blocks parent borer.
+	&.is-reusable.has-child-selected::after {
+		box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+	}
+
 	// Select tool/navigation mode shows the default cursor until an additional click edits.
 	.is-navigate-mode & {
 		cursor: default;


### PR DESCRIPTION
Reusable blocks are now just like groups. That's awesome. The change makes it harder to know when a reusable block starts and ends. This PR tries to address that by showing a parent container border when a child is selected.

Before:

<img width="1010" alt="before" src="https://user-images.githubusercontent.com/1204802/104915854-87e51780-5991-11eb-9e6a-1289a4c15c0a.png">

After:

<img width="1000" alt="after" src="https://user-images.githubusercontent.com/1204802/104915800-7439b100-5991-11eb-8358-4dc0a18c5bca.png">

If this works well, we could explore expanding what this applies to. But in the case of reusable blocks, it feels extra necessary. 