### PR TITLE
Deprecate Dashicon component and usage

### DIFF
--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * @typedef OwnProps
  *
  * @property {string} icon        Icon name
@@ -11,6 +16,10 @@
  * @return {JSX.Element} Element
  */
 function Dashicon( { icon, className, ...extraProps } ) {
+	deprecated( '`Dashicon component`', {
+		alternative: '`Icon component` from `@wordpress/icon` package',
+	} );
+
 	const iconClass = [
 		'dashicon',
 		'dashicons',

--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -17,7 +17,8 @@ import deprecated from '@wordpress/deprecated';
  */
 function Dashicon( { icon, className, ...extraProps } ) {
 	deprecated( '`Dashicon component`', {
-		alternative: '`Icon component` from `@wordpress/icon` package',
+		alternative:
+			'`Icon component` from `@wordpress/icon` package along with `@wordpress/icons` SVG icons or custom SVG icons',
 	} );
 
 	const iconClass = [

--- a/packages/components/src/icon/index.js
+++ b/packages/components/src/icon/index.js
@@ -8,6 +8,7 @@ import {
 	isValidElement,
 } from '@wordpress/element';
 import { SVG } from '@wordpress/primitives';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -16,10 +17,19 @@ import Dashicon from '../dashicon';
 
 function Icon( { icon = null, size, ...additionalProps } ) {
 	if ( 'string' === typeof icon ) {
+		deprecated( '`string` type for `icon` property in `Icon component`', {
+			alternative: '`@wordpress/icons` SVG icons or custom SVG icons',
+		} );
 		return <Dashicon icon={ icon } { ...additionalProps } />;
 	}
 
 	if ( icon && Dashicon === icon.type ) {
+		deprecated(
+			'passing `Dashicon component` for `icon` property in `Icon component`',
+			{
+				alternative: '`@wordpress/icons` SVG icons or custom SVG icons',
+			}
+		);
 		return cloneElement( icon, {
 			...additionalProps,
 		} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
[Dashicons are retired](https://make.wordpress.org/design/2020/04/20/next-steps-for-dashicons/). To encourage third-party developers to use the new `Icon` component, I'm proposing a few deprecation warnings here.

## How has this been tested?
1. Search for `icon={ formatStrikethrough }` (only one occurrence) and replace with `icon="editor-strikethrough"`
2. Load block editor
3. Add paragraph
4. Click the dropdown in the toolbar
5. Check the console for deprecation warnings

## Types of changes
Deprecation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
