### PR TITLE
Fix cover regression

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -3,6 +3,7 @@
 	position: relative;
 	background-size: cover;
 	background-position: center center;
+	overflow: hidden;
 	min-height: 430px;
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
In fixing another issue, https://github.com/WordPress/gutenberg/pull/28114 introduced a small regression in the Cover block, it appears. 

Fixes #28242 (I think)

Before:

<img width="1239" alt="Screenshot 2021-01-18 at 13 41 47" src="https://user-images.githubusercontent.com/1204802/104917456-b82db580-5993-11eb-975e-0ce7a9dde785.png">

After:

<img width="1340" alt="Screenshot 2021-01-18 at 13 45 55" src="https://user-images.githubusercontent.com/1204802/104917466-b9f77900-5993-11eb-878a-ac13addbf0d2.png">

It appears the `height: 100%;` property that was removed, acted as a sort of `overflow: hidden;`. So this one just adds the overflow instead.