### PR TITLE
simple wording fix

### DIFF
--- a/lib/full-site-editing/default-template-types.php
+++ b/lib/full-site-editing/default-template-types.php
@@ -27,7 +27,7 @@ function gutenberg_get_default_template_types() {
 		),
 		'singular'       => array(
 			'title'       => _x( 'Singular', 'Template name', 'gutenberg' ),
-			'description' => __( 'Used when a single entry is queried. This template will be overridden the Single, Post, and Page templates where appropriate', 'gutenberg' ),
+			'description' => __( 'Used when a single entry is queried. This template will be overridden by the Single, Post, and Page templates where appropriate', 'gutenberg' ),
 		),
 		'single'         => array(
 			'title'       => _x( 'Single', 'Template name', 'gutenberg' ),
@@ -43,7 +43,7 @@ function gutenberg_get_default_template_types() {
 		),
 		'archive'        => array(
 			'title'       => _x( 'Archive', 'Template name', 'gutenberg' ),
-			'description' => __( 'Used when multiple entries are queried. This template will be overridden the Category, Author, and Date templates where appropriate', 'gutenberg' ),
+			'description' => __( 'Used when multiple entries are queried. This template will be overridden by the Category, Author, and Date templates where appropriate', 'gutenberg' ),
 		),
 		'author'         => array(
 			'title'       => _x( 'Author Archive', 'Template name', 'gutenberg' ),


### PR DESCRIPTION
This PR is a simple wording fix.
Changes "this template will be overriden the..." to "this template will be overriden **by** the..."

## Types of changes
Edited strings

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
