### PR TITLE
 Hide query block toolbar settings if query is inherited 

### DIFF
--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -55,7 +55,9 @@ export default function QueryToolbar( {
 										min={ 1 }
 										max={ 100 }
 										onChange={ ( value ) =>
-											setQuery( { perPage: +value ?? -1 } )
+											setQuery( {
+												perPage: +value ?? -1,
+											} )
 										}
 										step="1"
 										value={ query.perPage }

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -34,63 +34,65 @@ export default function QueryToolbar( {
 	];
 	return (
 		<>
-			<ToolbarGroup>
-				<Dropdown
-					contentClassName="block-library-query-toolbar__popover"
-					renderToggle={ ( { onToggle } ) => (
-						<ToolbarButton
-							icon={ settings }
-							label={ __( 'Display settings' ) }
-							onClick={ onToggle }
-						/>
-					) }
-					renderContent={ () => (
-						<>
-							<BaseControl>
-								<NumberControl
-									__unstableInputWidth="60px"
-									label={ __( 'Items per Page' ) }
-									labelPosition="edge"
-									min={ 1 }
-									max={ 100 }
-									onChange={ ( value ) =>
-										setQuery( { perPage: +value ?? -1 } )
-									}
-									step="1"
-									value={ query.perPage }
-									isDragEnabled={ false }
-								/>
-							</BaseControl>
-							<BaseControl>
-								<NumberControl
-									__unstableInputWidth="60px"
-									label={ __( 'Offset' ) }
-									labelPosition="edge"
-									min={ 0 }
-									max={ 100 }
-									onChange={ ( value ) =>
-										setQuery( { offset: +value } )
-									}
-									step="1"
-									value={ query.offset }
-									isDragEnabled={ false }
-								/>
-							</BaseControl>
-							<BaseControl>
-								<RangeControl
-									label={ __( 'Number of Pages' ) }
-									min={ 1 }
-									allowReset
-									value={ query.pages }
-									onChange={ ( value ) =>
-										setQuery( { pages: value ?? -1 } )
-									}
-								/>
-							</BaseControl>
-						</>
-					) }
-				/>
-			</ToolbarGroup>
+			{ ! query.inherit && (
+				<ToolbarGroup>
+					<Dropdown
+						contentClassName="block-library-query-toolbar__popover"
+						renderToggle={ ( { onToggle } ) => (
+							<ToolbarButton
+								icon={ settings }
+								label={ __( 'Display settings' ) }
+								onClick={ onToggle }
+							/>
+						) }
+						renderContent={ () => (
+							<>
+								<BaseControl>
+									<NumberControl
+										__unstableInputWidth="60px"
+										label={ __( 'Items per Page' ) }
+										labelPosition="edge"
+										min={ 1 }
+										max={ 100 }
+										onChange={ ( value ) =>
+											setQuery( { perPage: +value ?? -1 } )
+										}
+										step="1"
+										value={ query.perPage }
+										isDragEnabled={ false }
+									/>
+								</BaseControl>
+								<BaseControl>
+									<NumberControl
+										__unstableInputWidth="60px"
+										label={ __( 'Offset' ) }
+										labelPosition="edge"
+										min={ 0 }
+										max={ 100 }
+										onChange={ ( value ) =>
+											setQuery( { offset: +value } )
+										}
+										step="1"
+										value={ query.offset }
+										isDragEnabled={ false }
+									/>
+								</BaseControl>
+								<BaseControl>
+									<RangeControl
+										label={ __( 'Number of Pages' ) }
+										min={ 1 }
+										allowReset
+										value={ query.pages }
+										onChange={ ( value ) =>
+											setQuery( { pages: value ?? -1 } )
+										}
+									/>
+								</BaseControl>
+							</>
+						) }
+					/>
+				</ToolbarGroup>
+			) }
 			<ToolbarGroup controls={ layoutControls } />
 		</>
 	);


### PR DESCRIPTION
When the query block inherits the global query we use the query's arguments for per-page etc. The toolbar settings in that case don't work and it gives the impression that the block is broken. This PR hides the toolbar for paging arguments when the block is set to inherit the global query.

## Screenshots <!-- if applicable -->
![Peek 2021-01-18 15-29](https://user-images.githubusercontent.com/588688/104921536-21b4c080-59a2-11eb-8be8-ff89dd191f02.gif)

## Types of changes

Wrapped the toolbar in a condition.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
