### PR TITLE
Edit Site: Fix templates export

### DIFF
--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -56,7 +56,7 @@ function gutenberg_edit_site_export() {
 	// Load templates into the zip file.
 	$templates = gutenberg_get_block_templates();
 	foreach ( $templates as $template ) {
-		$updated_content   = _remove_theme_attribute_from_content( $template['content'] );
+		$updated_content   = _remove_theme_attribute_from_content( $template->content );
 		$template->content = $updated_content;
 
 		$zip->addFromString(

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -56,7 +56,7 @@ function gutenberg_edit_site_export() {
 	// Load templates into the zip file.
 	$templates = gutenberg_get_block_templates();
 	foreach ( $templates as $template ) {
-		$updated_content   = _remove_theme_attribute_from_content( $template['content'] );
+		$updated_content   = _remove_theme_attribute_from_content( $template->content );
 		$template->content = $updated_content;
 
 		$zip->addFromString(
@@ -94,7 +94,7 @@ add_action(
 				'methods'             => 'GET',
 				'callback'            => 'gutenberg_edit_site_export',
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return true;return current_user_can( 'edit_theme_options' );
 				},
 			)
 		);

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -56,7 +56,7 @@ function gutenberg_edit_site_export() {
 	// Load templates into the zip file.
 	$templates = gutenberg_get_block_templates();
 	foreach ( $templates as $template ) {
-		$updated_content   = _remove_theme_attribute_from_content( $template->content );
+		$updated_content   = _remove_theme_attribute_from_content( $template['content'] );
 		$template->content = $updated_content;
 
 		$zip->addFromString(
@@ -94,7 +94,7 @@ add_action(
 				'methods'             => 'GET',
 				'callback'            => 'gutenberg_edit_site_export',
 				'permission_callback' => function () {
-					return true;return current_user_can( 'edit_theme_options' );
+					return current_user_can( 'edit_theme_options' );
 				},
 			)
 		);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
Fixes https://github.com/WordPress/gutenberg/issues/28270

## Description
We are trying to use an object as an array, this causes the export endpoint to fail.

## How has this been tested?
1. Open site editor
2. Export
3. Make sure a zip file is downloaded

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
