### PR TITLE
[RNMobile] Added contactInfoBlock enabling capabilities flag to mobile gutenberg bridge

### DIFF
--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -3,6 +3,7 @@ package org.wordpress.mobile.WPAndroidGlue
 import android.os.Bundle
 
 data class GutenbergProps @JvmOverloads constructor(
+    val enableContactInfoBlock: Boolean,
     val enableMediaFilesCollectionBlocks: Boolean,
     val enableMentions: Boolean,
     val enableXPosts: Boolean,
@@ -39,6 +40,7 @@ data class GutenbergProps @JvmOverloads constructor(
     fun getUpdatedCapabilitiesProps() = Bundle().apply {
         putBoolean(PROP_CAPABILITIES_MENTIONS, enableMentions)
         putBoolean(PROP_CAPABILITIES_XPOSTS, enableXPosts)
+        putBoolean(PROP_CAPABILITIES_CONTACT_INFO_BLOCK, enableContactInfoBlock)
         putBoolean(PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK, enableMediaFilesCollectionBlocks)
         putBoolean(PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, enableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
@@ -66,6 +68,7 @@ data class GutenbergProps @JvmOverloads constructor(
         private const val PROP_EDITOR_MODE_EDITOR = "editor"
 
         const val PROP_CAPABILITIES = "capabilities"
+        const val PROP_CAPABILITIES_CONTACT_INFO_BLOCK = "contactInfoBlock"
         const val PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK = "mediaFilesCollectionBlock"
         const val PROP_CAPABILITIES_MENTIONS = "mentions"
         const val PROP_CAPABILITIES_XPOSTS = "xposts"

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -16,6 +16,7 @@ public struct MediaInfo: Encodable {
 
 /// Definition of capabilities to enable in the Block Editor
 public enum Capabilities: String {
+    case contactInfoBlock
     case mediaFilesCollectionBlock
     case mentions
     case xposts


### PR DESCRIPTION
## Description
Added native bridge capabilities for iOS and Android in order to determine whether contact info should be shown or not.

Replaces https://github.com/WordPress/gutenberg/pull/28168

See further descriptions in linked PRs:
* `gutenberg-mobile`: [#3001](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3001) and https://github.com/wordpress-mobile/gutenberg-mobile/pull/3015
* `WPiOS`: [#15634](https://github.com/wordpress-mobile/WordPress-iOS/pull/15634)
* `WPAndroid`: [#13758](https://github.com/wordpress-mobile/WordPress-Android/pull/13758) and https://github.com/wordpress-mobile/WordPress-Android/pull/13804

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
