### PR TITLE
Site Editor: Fix _wp_file_based term deletion in migration

### DIFF
--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -59,4 +59,7 @@ function _gutenberg_migrate_remove_fse_drafts() {
 	delete_option( 'gutenberg_last_synchronize_theme_template-part_checks' );
 }
 
-add_action( 'plugins_loaded', '_gutenberg_migrate_database' );
+// Deletion of the `_wp_file_based` term (in _gutenberg_migrate_remove_fse_drafts) must happen
+// after its taxonomy (`wp_theme`) is registered. This happens in `gutenberg_register_wp_theme_taxonomy`,
+// which is hooked into `init` (default priority, i.e. 10).
+add_action( 'init', '_gutenberg_migrate_database', 20 );

--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -49,9 +49,9 @@ function _gutenberg_migrate_remove_fse_drafts() {
 	}
 
 	// Delete _wp_file_based term.
-	$term = get_term_by( 'name', '_wp_file_based', 'wp-theme' );
+	$term = get_term_by( 'name', '_wp_file_based', 'wp_theme' );
 	if ( $term ) {
-		wp_delete_term( $term->term_id, 'wp-theme' );
+		wp_delete_term( $term->term_id, 'wp_theme' );
 	}
 
 	// Delete useless options.

--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -18,14 +18,14 @@ if ( ! defined( '_GUTENBERG_VERSION_MIGRATION' ) ) {
  */
 function _gutenberg_migrate_database() {
 	// The default value used here is the first version before migrations were added.
-	$gutenberg_installed_version = get_option( '_GUTENBERG_VERSION_MIGRATION', '9.7.0' );
+	$gutenberg_installed_version = get_option( 'gutenberg_version_migration', '9.7.0' );
 
 	if ( _GUTENBERG_VERSION_MIGRATION !== $gutenberg_installed_version ) {
 		if ( version_compare( $gutenberg_installed_version, '9.8.0', '<' ) ) {
 			_gutenberg_migrate_remove_fse_drafts();
 		}
 
-		update_option( '_GUTENBERG_VERSION_MIGRATION', _GUTENBERG_VERSION_MIGRATION );
+		update_option( 'gutenberg_version_migration', _GUTENBERG_VERSION_MIGRATION );
 	}
 }
 


### PR DESCRIPTION
## Description
Purports to fix #28155 :crossed_fingers: 

> The database migration introduced in #27910 did not erase all of the data it was designed to erase.
> * Auto-drafts are correctly erased but their term relationships didn't get erased. In other words, you end up with "orphan" entries in the term relationships table.
> * The `_wp_file_based` term didn't get erased.

The reason for this is twofold:

1. Execution order: The deletion was attempted from the migration, which was hooked into [`plugins_loaded`](https://developer.wordpress.org/reference/hooks/plugins_loaded/). However, the `wp_theme` taxonomy was only registered upon `init` (see https://github.com/WordPress/gutenberg/issues/28155#issuecomment-762440743).
2. A simple typo: The database migration was looking for the `wp-theme` (dash) rather than the `wp_theme` (underscore) taxonomy (see https://github.com/WordPress/gutenberg/issues/28155#issuecomment-762401534).

## How has this been tested?

Make sure you have a `_wp_file_based` term (in the `wp_theme` taxonomy) lying around from a run of the Site Editor prior to GB 9.8. To verify that you do have one, run

```
npm run wp-env run cli "wp term get wp_theme _wp_file_based --by=slug"
```

(If this comes back empty, downgrade your version of Gutenberg to 9.7 (e.g. `git checkout release/9.7 && npm run build`), install and activate an FSE-enabled theme, and load the Site Editor. Run the above WP CLI command again to verify that it worked.)

Assuming that that object is present:

- Check out this PR's branch, and build it.
- Make sure to delete the `_GUTENBERG_VERSION_MIGRATION` option in order to have the migration triggered: `npm run wp-env run cli "wp option delete _GUTENBERG_VERSION_MIGRATION"`
- Run your local WP install, and access any given page. (This will trigger the `init` hook, and thus, the migration.)
- Verify that the `_wp_file_based` term is gone by once again running:

```
npm run wp-env run cli "wp term get wp_theme _wp_file_based --by=slug"
```

## Types of changes
Bug fix

cc/ @carlomanf for review :slightly_smiling_face: 