### PR TITLE
Inserter: Add description to content used in search

### DIFF
--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -6,6 +6,7 @@ import { deburr, differenceWith, find, words } from 'lodash';
 // Default search helpers
 const defaultGetName = ( item ) => item.name || '';
 const defaultGetTitle = ( item ) => item.title;
+const defaultGetDescription = ( item ) => item.description || '';
 const defaultGetKeywords = ( item ) => item.keywords || [];
 const defaultGetCategory = ( item ) => item.category;
 const defaultGetCollection = () => null;
@@ -126,6 +127,7 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 	const {
 		getName = defaultGetName,
 		getTitle = defaultGetTitle,
+		getDescription = defaultGetDescription,
 		getKeywords = defaultGetKeywords,
 		getCategory = defaultGetCategory,
 		getCollection = defaultGetCollection,
@@ -133,6 +135,7 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 
 	const name = getName( item );
 	const title = getTitle( item );
+	const description = getDescription( item );
 	const keywords = getKeywords( item );
 	const category = getCategory( item );
 	const collection = getCollection( item );
@@ -150,9 +153,14 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 	} else if ( normalizedTitle.startsWith( normalizedSearchInput ) ) {
 		rank += 20;
 	} else {
-		const terms = [ name, title, ...keywords, category, collection ].join(
-			' '
-		);
+		const terms = [
+			name,
+			title,
+			description,
+			...keywords,
+			category,
+			collection,
+		].join( ' ' );
 		const normalizedSearchTerms = words( normalizedSearchInput );
 		const unmatchedTerms = removeMatchingTerms(
 			normalizedSearchTerms,


### PR DESCRIPTION
Fixes #28253 — Search the description in addition to the name, keywords, etc, when searching for blocks. This makes the local block search work more like the block directory search. It should help users who installed blocks from the Block Directory using a given search term (ex, Maps) find those blocks again once they're installed (see #24911).

**Testing**

Locally tested by searching for "snippets"; the code block should be found.

Test the Block Directory flow by
1. Search for "Maps"
2. Install the block called "Map" by WebFactory Ltd, it should insert a map block
3. Open the inserter again, and search for "Maps" to add another map block
4. It should find the locally installed "Map" block
