### PR TITLE
Block Directory: Silently avoid re-installing local blocks

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -8,7 +8,6 @@ import { noop } from 'lodash';
  */
 import { getBlockType } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
-import { store as editPostStore } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
@@ -18,7 +17,6 @@ import { store as blockDirectoryStore } from '../../store';
 
 function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
 	const { installBlockType } = useDispatch( blockDirectoryStore );
-	const { setIsInserterOpened } = useDispatch( editPostStore );
 
 	if ( ! items.length ) {
 		return null;
@@ -45,7 +43,6 @@ function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
 								installBlockType( item ).then( ( success ) => {
 									if ( success ) {
 										onSelect( item );
-										setIsInserterOpened( false );
 									}
 								} );
 							}

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -36,6 +36,9 @@ function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
 					<DownloadableBlockListItem
 						key={ item.id }
 						onClick={ () => {
+							// Check if the block is registered (`getBlockType`
+							// will return an object). If so, insert the block.
+							// This prevents installing existing plugins.
 							if ( getBlockType( item.name ) ) {
 								onSelect( item );
 							} else {

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -6,6 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { getBlockType } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';
 
@@ -35,12 +36,16 @@ function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
 					<DownloadableBlockListItem
 						key={ item.id }
 						onClick={ () => {
-							installBlockType( item ).then( ( success ) => {
-								if ( success ) {
-									onSelect( item );
-									setIsInserterOpened( false );
-								}
-							} );
+							if ( getBlockType( item.name ) ) {
+								onSelect( item );
+							} else {
+								installBlockType( item ).then( ( success ) => {
+									if ( success ) {
+										onSelect( item );
+										setIsInserterOpened( false );
+									}
+								} );
+							}
 							onHover( null );
 						} }
 						item={ item }


### PR DESCRIPTION
See #24911, Fixes #24560 — it's possible to get block directory results for locally installed blocks if you use slightly different keywords (ex `maps` in place of `map`). If this happens, you can try to "Add Block", but the install process will trigger an error. Instead of trying to re-install an existing block, this PR silently switches to the regular insert block flow, so the block is added to the page.

In combination with #28301, this should fix the unreliability described in #24911.

**Testing**

1. Install the [Star Rating block](https://wordpress.org/plugins/star-rating-block/)
2. In the inserter, search for "rating"
3. Star Rating is found, and can be inserted as normal
4. In the inserter, search for "review"
5. The local block "Star Rating" is not found, but it is a result in the Block Directory- since review is in the description. See #28301 
6. Click "Add Block" next to Star Rating, it should bypass the install process and add the block to the page

## Screenshots

![Screen Shot 2021-01-18 at 3 00 18 PM](https://user-images.githubusercontent.com/541093/104958373-e7e1bb00-599d-11eb-9d61-1c7538a3552f.png)
