### PR TITLE
Site Editor: use correct title property in snackbar after inserting Template Part

### DIFF
--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -49,7 +49,7 @@ function TemplatePartItem( {
 			sprintf(
 				/* translators: %s: template part title. */
 				__( 'Template Part "%s" inserted.' ),
-				title
+				title.rendered
 			),
 			{
 				type: 'snackbar',


### PR DESCRIPTION
Fixes #28303 

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Use the `title.rendered` property in the snackbar message (Template Part "%s" inserted)

## How has this been tested?
1. Open Site Editor
2. Add a Template Part block
3. Press "Choose Existing" button
4. Pick a template part
5. Snackbar says 'Template Part "(Name)" inserted' (where (Name) is the name)

## Screenshots <!-- if applicable -->

Before:
![image](https://user-images.githubusercontent.com/195089/104958634-00e66e00-5996-11eb-94af-4d0f21660ad5.png)

After:
<img width="341" alt="image" src="https://user-images.githubusercontent.com/195089/104963328-e74a2400-599f-11eb-9379-1b675c4d0cee.png">


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
