### PR TITLE
Fix repeated backgrounds for cover srcset

### DIFF
--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -13,6 +13,7 @@ import {
 	getColorClassName,
 	InnerBlocks,
 	__experimentalGetGradientClass,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
@@ -71,6 +72,10 @@ const deprecated = [
 				type: 'string',
 				default: 'center',
 			},
+			isRepeated: {
+				type: 'boolean',
+				default: false,
+			},
 			minHeight: {
 				type: 'number',
 			},
@@ -91,6 +96,7 @@ const deprecated = [
 				dimRatio,
 				focalPoint,
 				hasParallax,
+				isRepeated,
 				overlayColor,
 				url,
 				minHeight: minHeightProp,
@@ -142,6 +148,7 @@ const deprecated = [
 				{
 					'has-background-dim': dimRatio !== 0,
 					'has-parallax': hasParallax,
+					'is-repeated': isRepeated,
 					'has-background-gradient': gradient || customGradient,
 					[ gradientClass ]: ! url && gradientClass,
 					'has-custom-content-position': ! isContentPositionCenter(
@@ -152,7 +159,7 @@ const deprecated = [
 			);
 
 			return (
-				<div className={ classes } style={ style }>
+				<div { ...useBlockProps.save( { className: classes, style } ) }>
 					{ url &&
 						( gradient || customGradient ) &&
 						dimRatio !== 0 && (

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -331,7 +331,7 @@ function CoverEdit( {
 		: minHeight;
 
 	const style = {
-		...( isImageBackground && hasParallax
+		...( isImageBackground && ( hasParallax || isRepeated )
 			? backgroundImageStyles( url )
 			: {} ),
 		backgroundColor: overlayColor.color,

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -55,7 +55,7 @@ export default function save( { attributes } ) {
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
 
 	const style = {
-		...( isImageBackground && hasParallax
+		...( isImageBackground && ( hasParallax || isRepeated )
 			? backgroundImageStyles( url )
 			: {} ),
 		backgroundColor: ! overlayColorClass ? customOverlayColor : undefined,

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
@@ -9,7 +9,8 @@
             "dimRatio": 40,
             "backgroundType": "image",
             "title": "",
-            "contentAlign": "center"
+            "contentAlign": "center",
+            "isRepeated": false
         },
         "innerBlocks": [
             {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

> Repeated backgrounds aren't working. That feature #26001 came along after this PR was made but got merged before it (#25171). I remember seeing it discussed https://github.com/WordPress/gutenberg/pull/25421#discussion_r505603111 that setting the Cover to have a fixed background is an exception to the img/srcset being used. So it would seem the repeated background option should trigger that same exception.

See https://github.com/WordPress/gutenberg/pull/25171#issuecomment-761109370. Thanks @stokesman for reporting the bug.

This just adds a check for `isRepeated` in addition to `hasParallax` for using background styles.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Use the repeated background in the cover block. See that it still works.

- Checkout cfe936aeee74ec4204962ae84ea5d6badc17a4e4 (commit before #25171). Add the old block to a post and save the post. Checkout this branch. Re-open the post. See that the deprecated block gets upgraded.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
