### PR TITLE
Warning component: Remove extra margin

### DIFF
--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -15,8 +15,7 @@
 		font-family: $default-font;
 		font-size: $default-font-size;
 		color: $gray-900;
-		margin: 0 0 1em;
-
+		margin: 0;
 	}
 
 	// Required extra-specifity to override paragraph block styles.
@@ -35,6 +34,7 @@
 
 	.block-editor-warning__actions {
 		display: flex;
+		margin-top: 1em;
 	}
 
 	.block-editor-warning__action {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The bottom margin is set on the warning message. This adds up as extra spacing on the bottom of the box if no actions are specified.

## How has this been tested?
Warning without actions
1. Open block editor
2. Create a new reusable block
3. Save the post
4. Delete reusable block
5. Refresh block editor
6. See the warning about deleted reusable block

Warning with actions
1. Open block editor
2. Insert a paragraph block with some text
3. Switch to the code editor
4. Change `core/paragraph` to `core/paragraph2` or any other non-existing block name
5. Exit code editor
6. See the warning about the missing block with actions

## Screenshots <!-- if applicable -->
| before | after |
| - | - |
| ![image](https://user-images.githubusercontent.com/2256104/105018454-4c0b8a00-5a45-11eb-8cc2-27ece724487a.png) | ![image](https://user-images.githubusercontent.com/2256104/105018489-5af23c80-5a45-11eb-825c-82c29926c083.png) |



## Types of changes
Styling

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
