### PR TITLE
Wrong type for variation field `keywords`

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -268,7 +268,7 @@ An object describing a variation defined for the block type can contain the foll
     -   `inserter` - Block Variation is shown on the inserter.
     -   `block` - Used by blocks to filter specific block variations. Mostly used in Placeholder patterns like `Columns` block.
     -   `transform` - Block Variation will be shown in the component for Block Variations transformations.
--   `keywords` (optional, type `string[]`) - An array of terms (which can be translated) that help users discover the variation while searching.
+-   `keywords` (optional, type `Array[]`) - An array of terms (which can be translated) that help users discover the variation while searching.
 -   `isActive` (optional, type `Function`) - A function that accepts a block's attributes and the variation's attributes and determines if a variation is active. This function doesn't try to find a match dynamically based on all block's attributes, as in many cases some attributes are irrelevant. An example would be for `embed` block where we only care about `providerNameSlug` attribute's value.
 
 It's also possible to override the default block style variation using the `className` attribute when defining block variations.


### PR DESCRIPTION
A small mistake. Keywords type is an Array, not string. 
