### PR TITLE
FSE: Parse the template before <head> gets rendered

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -154,15 +154,14 @@ function gutenberg_render_title_tag() {
 }
 
 /**
- * Renders the markup for the current template.
+ * Returns the markup for the current template.
  */
-function gutenberg_render_the_template() {
+function gutenberg_get_the_template_html() {
 	global $_wp_current_template_content;
 	global $wp_embed;
 
 	if ( ! $_wp_current_template_content ) {
-		echo '<h1>' . esc_html__( 'No matching template found', 'gutenberg' ) . '</h1>';
-		return;
+		return '<h1>' . esc_html__( 'No matching template found', 'gutenberg' ) . '</h1>';
 	}
 
 	$content = $wp_embed->run_shortcode( $_wp_current_template_content );
@@ -178,9 +177,14 @@ function gutenberg_render_the_template() {
 
 	// Wrap block template in .wp-site-blocks to allow for specific descendant styles
 	// (e.g. `.wp-site-blocks > *`).
-	echo '<div class="wp-site-blocks">';
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput
-	echo '</div>';
+	return '<div class="wp-site-blocks">' . $content . '</div>';
+}
+
+/**
+ * Renders the markup for the current template.
+ */
+function gutenberg_render_the_template() {
+	echo gutenberg_get_the_template_html(); // phpcs:ignore WordPress.Security.EscapeOutput
 }
 
 /**

--- a/lib/template-canvas.php
+++ b/lib/template-canvas.php
@@ -21,7 +21,7 @@ $template_html = gutenberg_get_the_template_html();
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 
-<?php echo $template_html; ?>
+<?php echo $template_html; // phpcs:ignore WordPress.Security.EscapeOutput ?>
 
 <?php wp_footer(); ?>
 </body>

--- a/lib/template-canvas.php
+++ b/lib/template-canvas.php
@@ -5,6 +5,11 @@
  * @package gutenberg
  */
 
+/**
+ * Get the template HTML.
+ * This needs to run before <head> so that blocks can add scripts and styles in wp_head().
+ */
+$template_html = gutenberg_get_the_template_html();
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
@@ -16,7 +21,7 @@
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 
-<?php gutenberg_render_the_template(); ?>
+<?php echo $template_html; ?>
 
 <?php wp_footer(); ?>
 </body>


### PR DESCRIPTION
## Description

Currently block assets (both scripts & styles) in FSE themes get loaded in the footer. That happens because `wp_head()` runs before we parse the template, and therefore when the `<head>` gets rendered we are not aware of what the page is or contains.
This can lead to FOUC and down the line it could get real messy since blocks have no way to enqueue anything in the `<head>`.

This PR changes that behavior by getting the template contents prior to printing the `<head>`.

## Types of changes
* Copied the `gutenberg_render_the_template` function to a new `gutenberg_get_the_template_html` function which returns the HTML instead of rendering it
* The  `gutenberg_render_the_template` function now simply echoes the result of the `gutenberg_get_the_template_html` function. I couldn't find it used anywhere, but for backwards-compatibility's sake I did not delete it.
* In the `template-canvas.php` file we now get the template contents first, and then we continue with printing the contents of the template like before.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
