### PR TITLE
Root element & border radius

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -50,7 +50,7 @@ class WP_Theme_JSON {
 		'--wp--style--color--link',
 		'background',
 		'backgroundColor',
-		'border',
+		'borderRadius',
 		'color',
 		'fontFamily',
 		'fontSize',

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -50,7 +50,6 @@ class WP_Theme_JSON {
 		'--wp--style--color--link',
 		'background',
 		'backgroundColor',
-		'borderRadius',
 		'color',
 		'fontFamily',
 		'fontSize',


### PR DESCRIPTION
[Follow-up](https://github.com/WordPress/gutenberg/pull/25791/files#r560085006).

The support for the border-radius property in the root element doesn't work because it's declared as `border` while it should have been declared as `borderRadius`. The values on the `GLOBAL_SUPPORTS` array need to be the same as the property names in the `PROPERTIES_METADATA`.

There are two potential fixes here:

1. Remove the support for border-radius in the root element. These styles are attached to the `:root` selector so I'm not sure it makes much sense to have this property. There's also the issue that there's no UI control for users to tweak this property via the global styles sidebar.
2. Rename `border` to `borderRadius`.

I've opted for going with 1, but if we want to go with 2 we just need to revert the last commit https://github.com/WordPress/gutenberg/pull/28320/commits/12ea43401f9de0097127bbfe0d21087b44ab30c7