### PR TITLE
Try: Show two columns of patterns.

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -10,14 +10,6 @@
 	&[draggable="true"] .block-editor-block-preview__container {
 		cursor: grab;
 	}
-}
-
-.block-editor-block-patterns-list__item {
-	height: 100%;
-	border-radius: $radius-block-ui;
-	transition: all 0.05s ease-in-out;
-	position: relative;
-	border: $border-width solid transparent;
 
 	// Show patterns in two columns, in the main inserter.
 	.edit-post-layout__inserter-panel & {
@@ -35,6 +27,14 @@
 			clear: left;
 		}
 	}
+}
+
+.block-editor-block-patterns-list__item {
+	height: 100%;
+	border-radius: $radius-block-ui;
+	transition: all 0.05s ease-in-out;
+	position: relative;
+	border: $border-width solid transparent;
 
 	&:hover {
 		border: $border-width solid var(--wp-admin-theme-color);

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -1,4 +1,5 @@
 .block-editor-block-patterns-list__list-item {
+	border-radius: $radius-block-ui;
 	cursor: pointer;
 	margin-top: $grid-unit-20;
 
@@ -18,6 +19,23 @@
 	position: relative;
 	border: $border-width solid transparent;
 
+	// Show patterns in two columns, in the main inserter.
+	.edit-post-layout__inserter-panel & {
+		width: calc(50% - #{ $grid-unit-15 / 2 });
+
+		// Every pattern comes with an adjacent div.
+		// Using nth-child, we apply rules to only every 3rd patterns, starting from 1. That targets ever 2nd visual item.
+		// Right:
+		float: right;
+		clear: right;
+
+		// Left:
+		&:nth-of-type(4n+1) {
+			float: left;
+			clear: left;
+		}
+	}
+
 	&:hover {
 		border: $border-width solid var(--wp-admin-theme-color);
 	}
@@ -32,6 +50,6 @@
 
 .block-editor-block-patterns-list__item-title {
 	padding: $grid-unit-05;
-	font-size: 12px;
+	font-size: $helptext-font-size;
 	text-align: center;
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -334,7 +334,7 @@ $block-inserter-tabs-height: 44px;
 	.block-editor-block-patterns-list {
 		display: grid;
 		grid-template-columns: 1fr 1fr;
-		grid-gap: $grid-unit-10;
+		grid-gap: $grid-unit-15;
 	}
 }
 


### PR DESCRIPTION
This takes a stab at one half of #28312, showing two columns of patterns in the main inserter, just like we do in the sibling inserter:

<img width="1234" alt="Screenshot 2021-01-19 at 12 41 38" src="https://user-images.githubusercontent.com/1204802/105031437-9ac12000-5a55-11eb-879f-dcb9bc09e451.png">
<img width="599" alt="Screenshot 2021-01-19 at 12 54 34" src="https://user-images.githubusercontent.com/1204802/105031440-9bf24d00-5a55-11eb-8bf8-07dd348f0781.png">

The purpose is to show the breadth of patterns, when there are a lot of them. Combined with the drag and drop that was recently added, to me this feels worth trying.