### PR TITLE
Site Editor: Add unit test for site templates export

### DIFF
--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -36,17 +36,18 @@ function _remove_theme_attribute_from_content( $template_content ) {
 	}
 }
 
-
 /**
- * Output a ZIP file with an export of the current templates
- * and template parts from the site editor, and close the connection.
+ * Creates an export of the current templates and
+ * template parts from the site editor at the
+ * specified path in a ZIP file.
+ *
+ * @param string $filename path of the ZIP file.
  */
-function gutenberg_edit_site_export() {
-	// Create ZIP file and directories.
-	$filename = tempnam( get_temp_dir(), 'edit-site-export' );
+function gutenberg_edit_site_export_create_zip( $filename ) {
 	if ( ! class_exists( 'ZipArchive' ) ) {
 		return new WP_Error( 'Zip Export not supported.' );
 	}
+
 	$zip = new ZipArchive();
 	$zip->open( $filename, ZipArchive::OVERWRITE );
 	$zip->addEmptyDir( 'theme' );
@@ -74,8 +75,19 @@ function gutenberg_edit_site_export() {
 		);
 	}
 
-	// Send back the ZIP file.
+	// Save changes to the zip file.
 	$zip->close();
+}
+
+/**
+ * Output a ZIP file with an export of the current templates
+ * and template parts from the site editor, and close the connection.
+ */
+function gutenberg_edit_site_export() {
+	// Create ZIP file in the temporary directory.
+	$filename = tempnam( get_temp_dir(), 'edit-site-export' );
+	gutenberg_edit_site_export_create_zip( $filename );
+
 	header( 'Content-Type: application/zip' );
 	header( 'Content-Disposition: attachment; filename=edit-site-export.zip' );
 	header( 'Content-Length: ' . filesize( $filename ) );

--- a/phpunit/class-edit-site-export-test.php
+++ b/phpunit/class-edit-site-export-test.php
@@ -22,5 +22,33 @@ class Edit_Site_Export_Test extends WP_UnitTestCase {
 		$template_content              = _remove_theme_attribute_from_content( $content_with_no_template_part );
 		$this->assertEquals( $content_with_no_template_part, $template_content );
 	}
+
+	function test_gutenberg_edit_site_export() {
+		$filename = tempnam( get_temp_dir(), 'edit-site-export' );
+		gutenberg_edit_site_export_create_zip( $filename );
+		$this->assertTrue( file_exists( $filename ), 'zip file is created at the specified path' );
+		$this->assertTrue( filesize( $filename ) > 0, 'zip file is larger than 0 bytes' );
+
+		// Open ZIP file and make sure the directories exist.
+		$zip = new ZipArchive();
+		$zip->open( $filename, ZipArchive::RDONLY );
+		$hasThemeDir              = $zip->locateName( 'theme/' ) !== false;
+		$hasBlockTemplatesDir     = $zip->locateName( 'theme/block-templates/' ) !== false;
+		$hasBlockTemplatePartsDir = $zip->locateName( 'theme/block-template-parts/' ) !== false;
+		$this->assertTrue( $hasThemeDir, 'theme directory exists' );
+		$this->assertTrue( $hasBlockTemplatesDir, 'theme/block-templates directory exists' );
+		$this->assertTrue( $hasBlockTemplatePartsDir, 'theme/block-template-parts directory exists' );
+
+		// ZIP file contains at least one HTML file.
+		$hasHtmlFiles = false;
+		for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+			$filename = $zip->getNameIndex( $i );
+			if ( substr( $filename, -5 ) === '.html' ) {
+				$hasHtmlFiles = true;
+				break;
+			}
+		}
+		$this->assertTrue( $hasHtmlFiles, 'contains at least one html file' );
+	}
 }
 

--- a/phpunit/class-edit-site-export-test.php
+++ b/phpunit/class-edit-site-export-test.php
@@ -32,23 +32,24 @@ class Edit_Site_Export_Test extends WP_UnitTestCase {
 		// Open ZIP file and make sure the directories exist.
 		$zip = new ZipArchive();
 		$zip->open( $filename, ZipArchive::RDONLY );
-		$hasThemeDir              = $zip->locateName( 'theme/' ) !== false;
-		$hasBlockTemplatesDir     = $zip->locateName( 'theme/block-templates/' ) !== false;
-		$hasBlockTemplatePartsDir = $zip->locateName( 'theme/block-template-parts/' ) !== false;
-		$this->assertTrue( $hasThemeDir, 'theme directory exists' );
-		$this->assertTrue( $hasBlockTemplatesDir, 'theme/block-templates directory exists' );
-		$this->assertTrue( $hasBlockTemplatePartsDir, 'theme/block-template-parts directory exists' );
+		$has_theme_dir                = $zip->locateName( 'theme/' ) !== false;
+		$has_block_templates_dir      = $zip->locateName( 'theme/block-templates/' ) !== false;
+		$has_block_template_parts_dir = $zip->locateName( 'theme/block-template-parts/' ) !== false;
+		$this->assertTrue( $has_theme_dir, 'theme directory exists' );
+		$this->assertTrue( $has_block_templates_dir, 'theme/block-templates directory exists' );
+		$this->assertTrue( $has_block_template_parts_dir, 'theme/block-template-parts directory exists' );
 
 		// ZIP file contains at least one HTML file.
-		$hasHtmlFiles = false;
-		for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+		$has_html_files = false;
+		$num_files      = $zip->count();
+		for ( $i = 0; $i < $num_files; $i++ ) {
 			$filename = $zip->getNameIndex( $i );
-			if ( substr( $filename, -5 ) === '.html' ) {
-				$hasHtmlFiles = true;
+			if ( '.html' === substr( $filename, -5 ) ) {
+				$has_html_files = true;
 				break;
 			}
 		}
-		$this->assertTrue( $hasHtmlFiles, 'contains at least one html file' );
+		$this->assertTrue( $has_html_files, 'contains at least one html file' );
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add a simple unit test to make sure the export function works.

## How has this been tested?
**Make sure export still works**
1. Open site editor
2. Click 3 dots menu in the top right corner
3. Click Export
4. Make sure a zip file is downloaded

**Make sure tests are passing**
1. Run `npm run test-unit-php`
2. Or check CI


## Types of changes
Code Quality

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
