### PR TITLE
Ensure inline image width popover doesn't appear over media library modal

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -53,6 +53,9 @@ $z-layers: (
 	// Needs to be bellow media library that has a z-index of 160000.
 	"{core/video track editor popover}": 160000 - 10,
 
+	// Needs to be bellow media library that has a z-index of 160000.
+	".block-editor-format-toolbar__image-popover": 160000 - 10,
+
 	// Small screen inner blocks overlay must be displayed above drop zone,
 	// settings menu, and movers.
 	".block-editor-block-list__layout.has-overlay::after": 60,

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -47,6 +47,7 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 			position="bottom center"
 			focusOnMount={ false }
 			anchorRef={ anchorRef }
+			className="block-editor-format-toolbar__image-popover"
 		>
 			<form
 				className="block-editor-format-toolbar__image-container-content"

--- a/packages/format-library/src/image/style.scss
+++ b/packages/format-library/src/image/style.scss
@@ -1,3 +1,7 @@
+.block-editor-format-toolbar__image-popover {
+	z-index: z-index(".block-editor-format-toolbar__image-popover");
+}
+
 .block-editor-format-toolbar__image-container-content {
 	display: flex;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #27608

Add image popover z-index
