### PR TITLE
Account for undefined block and innerblocks in conversion to reusable block lifecycle

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -106,12 +106,12 @@ function GalleryEdit( props ) {
 	}, [] );
 
 	const innerBlockImages = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getBlock( clientId ).innerBlocks;
+		return select( 'core/block-editor' ).getBlock( clientId )?.innerBlocks;
 	} );
 
 	const images = useMemo(
 		() =>
-			innerBlockImages.map( ( block ) => ( {
+			innerBlockImages?.map( ( block ) => ( {
 				id: block.attributes.id,
 				url: block.attributes.url,
 				attributes: block.attributes,
@@ -122,6 +122,7 @@ function GalleryEdit( props ) {
 	const imageData = useSelect(
 		( select ) => {
 			if (
+				! innerBlockImages ||
 				innerBlockImages.length === 0 ||
 				some(
 					innerBlockImages,
@@ -158,6 +159,11 @@ function GalleryEdit( props ) {
 	}, [ shortCodeTransforms, shortCodeImages ] );
 
 	useEffect( () => {
+		if ( ! images ) {
+			setAttributes( { imageCount: undefined } );
+			return;
+		}
+
 		if ( images.length !== imageCount ) {
 			setAttributes( { imageCount: images.length } );
 		}
@@ -308,7 +314,7 @@ function GalleryEdit( props ) {
 		}
 	}, [ linkTo ] );
 
-	const hasImages = !! images.length;
+	const hasImages = !! images?.length;
 
 	const mediaPlaceholder = (
 		<MediaPlaceholder

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -122,8 +122,7 @@ function GalleryEdit( props ) {
 	const imageData = useSelect(
 		( select ) => {
 			if (
-				! innerBlockImages ||
-				innerBlockImages.length === 0 ||
+				! innerBlockImages?.length ||
 				some(
 					innerBlockImages,
 					( imageBlock ) => ! imageBlock.attributes.id


### PR DESCRIPTION
## Description
Adds checks for undefined block and innerblocks to prevent console errors in conversion to reusable block - only relates to the [Gallery block refactor PR](https://github.com/WordPress/gutenberg/pull/25940)

## Testing
Check out this PR
Add a new gallery block and add images
Convert the block to a reusable block and check it is successful and there are no console errors