### PR TITLE
Add note to indicate why priority queue callbacks may be undefined

### DIFF
--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -96,9 +96,11 @@ export const createQueue = () => {
 			const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get(
 				nextElement
 			) );
-			if ( callback instanceof Function ) {
+
+			if ( typeof callback === 'function' ) {
 				callback();
 			}
+
 			elementsMap.delete( nextElement );
 		} while ( hasTimeRemaining() );
 

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -96,7 +96,9 @@ export const createQueue = () => {
 			const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get(
 				nextElement
 			) );
-			callback();
+			if ( callback instanceof Function ) {
+				callback();
+			}
 			elementsMap.delete( nextElement );
 		} while ( hasTimeRemaining() );
 

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -74,6 +74,8 @@ export const createQueue = () => {
 
 	let isRunning = false;
 
+	let count = 0;
+
 	/**
 	 * Callback to process as much queue as time permits.
 	 *
@@ -93,14 +95,13 @@ export const createQueue = () => {
 			}
 
 			const nextElement = /** @type {WPPriorityQueueContext} */ ( waitingList.shift() );
+			console.log( 'looking for ' + nextElement.id );
 			const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get(
 				nextElement
 			) );
-
-			if ( typeof callback === 'function' ) {
-				callback();
-			}
-
+			console.log( 'run', nextElement.id );
+			callback();
+			console.log( 'deleting from elementMap ' + nextElement.id );
 			elementsMap.delete( nextElement );
 		} while ( hasTimeRemaining() );
 
@@ -116,10 +117,24 @@ export const createQueue = () => {
 	 * @param {WPPriorityQueueCallback} item    Callback function.
 	 */
 	const add = ( element, item ) => {
+		element.id = count;
+		count++;
+
 		if ( ! elementsMap.has( element ) ) {
+			console.log( 'adding ' + element.id + ' to waiting list' );
 			waitingList.push( element );
 		}
+
+		console.log( 'adding ' + element.id + ' to elementMap' );
 		elementsMap.set( element, item );
+		const testAdd = elementsMap.get( element );
+
+		if ( ! testAdd ) {
+			console.log( 'add failed for ' + element.id );
+		} else {
+			console.log( 'add succeeded for ' + element.id );
+		}
+
 		if ( ! isRunning ) {
 			isRunning = true;
 			requestIdleCallback( runWaitingList );
@@ -140,7 +155,7 @@ export const createQueue = () => {
 		if ( ! elementsMap.has( element ) ) {
 			return false;
 		}
-
+		console.log( 'flushing ' + element.id );
 		const index = waitingList.indexOf( element );
 		waitingList.splice( index, 1 );
 		const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get(

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -96,12 +96,11 @@ export const createQueue = () => {
 			const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get(
 				nextElement
 			) );
+			// If errors with undefined callbacks are encountered double check that all of your useSelect calls
+			// have all dependecies set correctly in second parameter. Missing dependencies can cause unexpected
+			// loops and race conditions in the queue.
 			callback();
-			// Check that element hasn't been added back to the waitList before deleting in the event of
-			// callback being slow to complete.
-			if ( waitingList.indexOf( nextElement ) === -1 ) {
-				elementsMap.delete( nextElement );
-			}
+			elementsMap.delete( nextElement );
 		} while ( hasTimeRemaining() );
 
 		requestIdleCallback( runWaitingList );

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -74,8 +74,6 @@ export const createQueue = () => {
 
 	let isRunning = false;
 
-	let count = 0;
-
 	/**
 	 * Callback to process as much queue as time permits.
 	 *
@@ -95,13 +93,10 @@ export const createQueue = () => {
 			}
 
 			const nextElement = /** @type {WPPriorityQueueContext} */ ( waitingList.shift() );
-			console.log( 'looking for ' + nextElement.id );
 			const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get(
 				nextElement
 			) );
-			console.log( 'run', nextElement.id );
 			callback();
-			console.log( 'deleting from elementMap ' + nextElement.id );
 			elementsMap.delete( nextElement );
 		} while ( hasTimeRemaining() );
 
@@ -117,23 +112,11 @@ export const createQueue = () => {
 	 * @param {WPPriorityQueueCallback} item    Callback function.
 	 */
 	const add = ( element, item ) => {
-		element.id = count;
-		count++;
-
 		if ( ! elementsMap.has( element ) ) {
-			console.log( 'adding ' + element.id + ' to waiting list' );
 			waitingList.push( element );
 		}
 
-		console.log( 'adding ' + element.id + ' to elementMap' );
 		elementsMap.set( element, item );
-		const testAdd = elementsMap.get( element );
-
-		if ( ! testAdd ) {
-			console.log( 'add failed for ' + element.id );
-		} else {
-			console.log( 'add succeeded for ' + element.id );
-		}
 
 		if ( ! isRunning ) {
 			isRunning = true;
@@ -155,7 +138,6 @@ export const createQueue = () => {
 		if ( ! elementsMap.has( element ) ) {
 			return false;
 		}
-		console.log( 'flushing ' + element.id );
 		const index = waitingList.indexOf( element );
 		waitingList.splice( index, 1 );
 		const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get(

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -97,7 +97,11 @@ export const createQueue = () => {
 				nextElement
 			) );
 			callback();
-			elementsMap.delete( nextElement );
+			// Check that element hasn't been added back to the waitList before deleting in the event of
+			// callback being slow to complete.
+			if ( waitingList.indexOf( nextElement ) === -1 ) {
+				elementsMap.delete( nextElement );
+			}
 		} while ( hasTimeRemaining() );
 
 		requestIdleCallback( runWaitingList );
@@ -115,9 +119,7 @@ export const createQueue = () => {
 		if ( ! elementsMap.has( element ) ) {
 			waitingList.push( element );
 		}
-
 		elementsMap.set( element, item );
-
 		if ( ! isRunning ) {
 			isRunning = true;
 			requestIdleCallback( runWaitingList );
@@ -138,6 +140,7 @@ export const createQueue = () => {
 		if ( ! elementsMap.has( element ) ) {
 			return false;
 		}
+
 		const index = waitingList.indexOf( element );
 		waitingList.splice( index, 1 );
 		const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get(


### PR DESCRIPTION
## Description
In the Gallery block refactor, in some instances a callback is not defined in the waitingList method, eg. when moving or deleting blocks. This currently causes an exception which kills the queue and prevents any further actions that are dependent on it. 

It turned out that this was due to a missing dependency on a useSelect call, which was not easy to track down, so this PR just adds a hint at the point of failure to help if people encounter this in the future.

## Types of changes
Just adds a comment to help people with debugging if they encounter a similar error

