### PR TITLE
Coding Standards: Fix PHPCS warnings

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -695,7 +695,7 @@ function gutenberg_extend_block_editor_styles_html() {
 
 	$block_registry = WP_Block_Type_Registry::get_instance();
 
-	foreach ( $block_registry->get_all_registered() as $block_name => $block_type ) {
+	foreach ( $block_registry->get_all_registered() as $block_type ) {
 		if ( ! empty( $block_type->style ) ) {
 			$handles[] = $block_type->style;
 		}

--- a/phpunit/class-wp-rest-template-controller-test.php
+++ b/phpunit/class-wp-rest-template-controller-test.php
@@ -107,7 +107,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 
 	public function test_create_item() {
 		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'POST', '/wp/v2/templates' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/templates' );
 		$request->set_body_params(
 			array(
 				'slug'        => 'my_custom_template',
@@ -144,7 +144,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 
 	public function test_update_item() {
 		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'PUT', '/wp/v2/templates/tt1-blocks//index' );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/templates/tt1-blocks//index' );
 		$request->set_body_params(
 			array(
 				'title' => 'My new Index Title',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -415,7 +415,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	function test_remove_insecure_properties_removes_invalid_contexts() {
 		$theme_json = new WP_Theme_JSON(
 			array(
-				'global' => array(
+				'global'    => array(
 					'styles' => array(
 						'color' => array(
 							'background' => 'green',
@@ -453,13 +453,13 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'global' => array(
-					'styles' => array(
+					'styles'  => array(
 						'color' => array(
 							'gradient' => 'linear-gradient(55deg,rgba(6,147,227,1) 0%,rgb(84,177,218) 54%,rgb(155,81,224) 100%)',
-							'text'       => 'var:preset|color|dark-gray',
+							'text'     => 'var:preset|color|dark-gray',
 						),
 					),
-					'invalid'   => array(
+					'invalid' => array(
 						'background' => 'green',
 					),
 				),
@@ -473,7 +473,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				'styles' => array(
 					'color' => array(
 						'gradient' => 'linear-gradient(55deg,rgba(6,147,227,1) 0%,rgb(84,177,218) 54%,rgb(155,81,224) 100%)',
-						'text'       => 'var:preset|color|dark-gray',
+						'text'     => 'var:preset|color|dark-gray',
 					),
 				),
 			),
@@ -485,13 +485,13 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'global' => array(
-					'styles' => array(
+					'styles'  => array(
 						'color' => array(
 							'gradient' => 'url(\'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxMCcgaGVpZ2h0PScxMCc+PHNjcmlwdD5hbGVydCgnb2snKTwvc2NyaXB0PjxsaW5lYXJHcmFkaWVudCBpZD0nZ3JhZGllbnQnPjxzdG9wIG9mZnNldD0nMTAlJyBzdG9wLWNvbG9yPScjRjAwJy8+PHN0b3Agb2Zmc2V0PSc5MCUnIHN0b3AtY29sb3I9JyNmY2MnLz4gPC9saW5lYXJHcmFkaWVudD48cmVjdCBmaWxsPSd1cmwoI2dyYWRpZW50KScgeD0nMCcgeT0nMCcgd2lkdGg9JzEwMCUnIGhlaWdodD0nMTAwJScvPjwvc3ZnPg==\')',
-							'text'       => 'var:preset|color|dark-gray',
+							'text'     => 'var:preset|color|dark-gray',
 						),
 					),
-					'invalid'   => array(
+					'invalid' => array(
 						'background' => 'green',
 					),
 				),
@@ -504,7 +504,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			'global' => array(
 				'styles' => array(
 					'color' => array(
-						'text'       => 'var:preset|color|dark-gray',
+						'text' => 'var:preset|color|dark-gray',
 					),
 				),
 			),
@@ -515,21 +515,21 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	function test_remove_insecure_properties_removes_properties_when_not_allowed_in_a_context() {
 		$theme_json = new WP_Theme_JSON(
 			array(
-				'global' => array(
-					'styles' => array(
-						'color' => array(
-							'text'       => 'var:preset|color|dark-gray',
+				'global'     => array(
+					'styles'  => array(
+						'color'   => array(
+							'text' => 'var:preset|color|dark-gray',
 						),
 						'spacing' => array(
 							'padding' => array(
-								'top' => '1px',
-								'right' => '1px',
+								'top'    => '1px',
+								'right'  => '1px',
 								'bottom' => '1px',
-								'left' => '1px',
+								'left'   => '1px',
 							),
 						),
 					),
-					'invalid'   => array(
+					'invalid' => array(
 						'background' => 'green',
 					),
 				),
@@ -537,10 +537,10 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					'styles' => array(
 						'spacing' => array(
 							'padding' => array(
-								'top' => '1px',
-								'right' => '1px',
+								'top'    => '1px',
+								'right'  => '1px',
 								'bottom' => '1px',
-								'left' => '1px',
+								'left'   => '1px',
 							),
 						),
 					),
@@ -551,10 +551,10 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json->remove_insecure_properties();
 		$result   = $theme_json->get_raw_data();
 		$expected = array(
-			'global' => array(
+			'global'     => array(
 				'styles' => array(
 					'color' => array(
-						'text'       => 'var:preset|color|dark-gray',
+						'text' => 'var:preset|color|dark-gray',
 					),
 				),
 			),
@@ -562,10 +562,10 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				'styles' => array(
 					'spacing' => array(
 						'padding' => array(
-							'top' => '1px',
-							'right' => '1px',
+							'top'    => '1px',
+							'right'  => '1px',
 							'bottom' => '1px',
-							'left' => '1px',
+							'left'   => '1px',
 						),
 					),
 				),
@@ -581,10 +581,10 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					'styles' => array(
 						'spacing' => array(
 							'padding' => array(
-								'top' => '1px',
-								'right' => '1px',
+								'top'    => '1px',
+								'right'  => '1px',
 								'bottom' => 'var(--unsafe-var-y)',
-								'left' => '1px',
+								'left'   => '1px',
 							),
 						),
 					),
@@ -599,9 +599,9 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				'styles' => array(
 					'spacing' => array(
 						'padding' => array(
-							'top' => '1px',
+							'top'   => '1px',
 							'right' => '1px',
-							'left' => '1px',
+							'left'  => '1px',
 						),
 					),
 				),
@@ -615,8 +615,8 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			array(
 				'global' => array(
 					'settings' => array(
-						'color' => array(
-							'custom'   => true,
+						'color'   => array(
+							'custom'  => true,
 							'palette' => array(
 								array(
 									'name'  => 'Red',
@@ -678,7 +678,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			array(
 				'global' => array(
 					'settings' => array(
-						'color' => array(
+						'color'      => array(
 							'palette' => array(
 								array(
 									'name'  => 'Red/><b>ok</ok>',
@@ -736,7 +736,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$expected = array(
 			'global' => array(
 				'settings' => array(
-					'color' => array(
+					'color'      => array(
 						'palette' => array(
 							array(
 								'name'  => 'Pink',


### PR DESCRIPTION
## Description

Ran `vendor/bin/phpcs` and got some warnings so this PR fixes them.
Most of the fixes (alignments etc) were automatic via `phpcbf`, the only manual change was in `client-assets.php` where we had an unused var in the `foreach` loop.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] ~~My code has proper inline documentation.~~ <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
