### PR TITLE
Improve robustness of nav screen test

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -144,6 +144,7 @@ describe( 'Navigation editor', () => {
 
 	it( 'allows creation of a menu', async () => {
 		const pagesResponse = createMockPages( pagesFixture );
+
 		const menuResponse = {
 			id: 4,
 			description: '',
@@ -188,9 +189,14 @@ describe( 'Navigation editor', () => {
 		// Close the dropdown.
 		await page.keyboard.press( 'Escape' );
 
+		// A snackbar will appear when menu creation has completed.
+		await page.waitForXPath( '//div[contains(., "Menu created")]' );
+
 		// Select the navigation block and create a block from existing pages.
-		await page.waitForSelector( 'div[aria-label="Block: Navigation"]' );
-		await page.click( 'div[aria-label="Block: Navigation"]' );
+		const navigationBlock = await page.waitForSelector(
+			'div[aria-label="Block: Navigation"]'
+		);
+		await navigationBlock.click();
 
 		const [ addAllPagesButton ] = await page.$x(
 			'//button[contains(., "Add all pages")]'

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -180,8 +180,9 @@ describe( 'Navigation editor', () => {
 			'//button[contains(., "Add new")]'
 		);
 		await addNewButton.click();
+
 		await page.keyboard.type( 'Main Menu' );
-		const [ createMenuButton ] = await page.$x(
+		const createMenuButton = await page.waitForXPath(
 			'//button[contains(., "Create menu")]'
 		);
 		await createMenuButton.click();
@@ -198,7 +199,7 @@ describe( 'Navigation editor', () => {
 		);
 		await navigationBlock.click();
 
-		const [ addAllPagesButton ] = await page.$x(
+		const addAllPagesButton = await page.waitForXPath(
 			'//button[contains(., "Add all pages")]'
 		);
 		await addAllPagesButton.click();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Should make the recently introduced navigation more robust.

Adds a couple of extra `waits` in, particular waiting for a snackbar notice that indicates menu creation has happened before proceeding.

## Types of changes
Automated testing
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
