### PR TITLE
Global Styles: Add border radius controls to global styles sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar/border-panel.js
+++ b/packages/edit-site/src/components/sidebar/border-panel.js
@@ -35,20 +35,25 @@ export default function BorderPanel( {
 	setStyle,
 } ) {
 	const hasBorderRadius = useHasBorderRadiusControl( { supports, name } );
+	const borderRadiusValue = parseInt(
+		getStyle( name, 'borderRadius' ) || 0,
+		10
+	);
 
 	return (
 		<PanelBody title={ __( 'Border' ) } initialOpen={ true }>
 			{ hasBorderRadius && (
 				<RangeControl
-					value={ getStyle( name, 'borderRadius' ) }
+					value={ borderRadiusValue }
 					label={ __( 'Border radius' ) }
 					min={ MIN_BORDER_RADIUS_VALUE }
 					max={ MAX_BORDER_RADIUS_VALUE }
-					initialPosition={ getStyle( name, 'borderRadius' ) || 0 }
+					initialPosition={ borderRadiusValue }
 					allowReset
-					onChange={ ( value ) =>
-						setStyle( name, 'borderRadius', value )
-					}
+					onChange={ ( value ) => {
+						const radiusStyle = value ? `${ value }px` : undefined;
+						setStyle( name, 'borderRadius', radiusStyle );
+					} }
 				/>
 			) }
 		</PanelBody>

--- a/packages/edit-site/src/components/sidebar/border-panel.js
+++ b/packages/edit-site/src/components/sidebar/border-panel.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useEditorFeature } from '../editor/utils';
+
+const MIN_BORDER_RADIUS_VALUE = 0;
+const MAX_BORDER_RADIUS_VALUE = 50;
+
+export function useHasBorderPanel( { supports, name } ) {
+	// This function will allow for easy addition of future border properties
+	// e.g. Border width.
+	// return (
+	// 	useHasBorderRadiusControl( { supports, name } ) ||
+	// 	useHasBorderWidthControl( { supports, name } )
+	// )
+	return useHasBorderRadiusControl( { supports, name } );
+}
+
+function useHasBorderRadiusControl( { supports, name } ) {
+	return (
+		useEditorFeature( 'border.customRadius', name ) &&
+		supports.includes( 'borderRadius' )
+	);
+}
+
+export default function BorderPanel( {
+	context: { supports, name },
+	getStyle,
+	setStyle,
+} ) {
+	const hasBorderRadius = useHasBorderRadiusControl( { supports, name } );
+
+	return (
+		<PanelBody title={ __( 'Border' ) } initialOpen={ true }>
+			{ hasBorderRadius && (
+				<RangeControl
+					value={ getStyle( name, 'borderRadius' ) }
+					label={ __( 'Border radius' ) }
+					min={ MIN_BORDER_RADIUS_VALUE }
+					max={ MAX_BORDER_RADIUS_VALUE }
+					initialPosition={ getStyle( name, 'borderRadius' ) || 0 }
+					allowReset
+					onChange={ ( value ) =>
+						setStyle( name, 'borderRadius', value )
+					}
+				/>
+			) }
+		</PanelBody>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -24,6 +24,7 @@ import {
 	default as TypographyPanel,
 	useHasTypographyPanel,
 } from './typography-panel';
+import { default as BorderPanel, useHasBorderPanel } from './border-panel';
 import { default as ColorPanel, useHasColorPanel } from './color-panel';
 import { default as SpacingPanel, useHasSpacingPanel } from './spacing-panel';
 
@@ -38,6 +39,7 @@ function GlobalStylesPanel( {
 	const hasColorPanel = useHasColorPanel( context );
 	const hasTypographyPanel = useHasTypographyPanel( context );
 	const hasSpacingPanel = useHasSpacingPanel( context );
+	const hasBorderPanel = useHasBorderPanel( context );
 
 	if ( ! hasColorPanel && ! hasTypographyPanel && ! hasSpacingPanel ) {
 		return null;
@@ -63,6 +65,13 @@ function GlobalStylesPanel( {
 			) }
 			{ hasSpacingPanel && (
 				<SpacingPanel
+					context={ context }
+					getStyle={ getStyle }
+					setStyle={ setStyle }
+				/>
+			) }
+			{ hasBorderPanel && (
+				<BorderPanel
 					context={ context }
 					getStyle={ getStyle }
 					setStyle={ setStyle }


### PR DESCRIPTION
## Description
Adds border radius controls to the global styles sidebar.

_Note: Border radius support is turned off by default._

## How has this been tested?
Manually.

#### Testing Instructions
1. Checkout this PR, open the Site Editor and Global Styles sidebar.
2. Confirm there are no border controls under the Global tab or the "By Block Type" tab and Group panel.
3. Opt in to border radius support via `global.settings.border.customRadius` in `experimental-default-theme.json`
  ```
			"border": {
				"customRadius": true
			}
  ```
4. Reload the editor, open the global styles sidebar again and confirm no border controls under global tab.
5. Switch to "By Block Type" tab, expand the Group panel and confirm border controls now show here.
6. Edit your theme.json file (or `experimental-default-theme.json` and copy into your active theme) adding a border radius style for `core/group` block context.
  ```
	"core/group": {
		"styles": {
			"border": {
				"radius": 20
			}
		}
	}
  ```
7. Reload the editor, navigate back to the Group panel and confirm the border controls now default to the value supplied in the previous step.

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/60436221/105142859-ccfe7a80-5b46-11eb-938e-cd5ae1d8d39e.gif" width="600" />

## Types of changes
New Feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
