### PR TITLE
Enable alignments/width for all blocks by default

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -27,7 +27,7 @@ import { BlockListItems } from '../block-list';
 import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
-import { defaultLayout, LayoutProvider } from './layout';
+import { defaultLayout, flexHorizontalLayout, LayoutProvider } from './layout';
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -50,8 +50,16 @@ function UncontrolledInnerBlocks( props ) {
 		renderAppender,
 		orientation,
 		placeholder,
-		__experimentalLayout: layout = defaultLayout,
+		__experimentalLayout,
 	} = props;
+
+	let layout = __experimentalLayout;
+	if ( ! layout && orientation === 'horizontal' ) {
+		layout = flexHorizontalLayout;
+	}
+	if ( ! layout && orientation !== 'horizontal' ) {
+		layout = defaultLayout;
+	}
 
 	useNestedSettingsUpdate(
 		clientId,

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -20,7 +20,7 @@ import BlockList from '../block-list';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { BlockContextProvider } from '../block-context';
-import { defaultLayout, LayoutProvider } from './layout';
+import { defaultLayout, flexHorizontalLayout, LayoutProvider } from './layout';
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -51,8 +51,16 @@ function UncontrolledInnerBlocks( props ) {
 		horizontalAlignment,
 		filterInnerBlocks,
 		blockWidth,
-		__experimentalLayout: layout = defaultLayout,
+		__experimentalLayout,
 	} = props;
+
+	let layout = __experimentalLayout;
+	if ( ! layout && orientation === 'horizontal' ) {
+		layout = flexHorizontalLayout;
+	}
+	if ( ! layout && orientation !== 'horizontal' ) {
+		layout = defaultLayout;
+	}
 
 	const block = useSelect(
 		( select ) => select( 'core/block-editor' ).getBlock( clientId ),

--- a/packages/block-editor/src/components/inner-blocks/layout.js
+++ b/packages/block-editor/src/components/inner-blocks/layout.js
@@ -4,6 +4,7 @@
 import { createContext, useContext } from '@wordpress/element';
 
 export const defaultLayout = { type: 'default' };
+export const flexHorizontalLayout = { type: 'flex-horizontal' };
 
 const Layout = createContext( defaultLayout );
 

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -89,7 +89,7 @@ export function addAttribute( settings ) {
 	if ( has( settings.attributes, [ 'align', 'type' ] ) ) {
 		return settings;
 	}
-	if ( hasBlockSupport( settings, 'align' ) ) {
+	if ( hasBlockSupport( settings, 'align', true ) ) {
 		// Gracefully handle if settings.attributes is undefined.
 		settings.attributes = {
 			...settings.attributes,
@@ -120,7 +120,7 @@ export const withToolbarControls = createHigherOrderComponent(
 		// and without checking the layout for availble alignments.
 		// BlockAlignmentToolbar takes both of these into account.
 		const validAlignments = getValidAlignments(
-			getBlockSupport( blockName, 'align' ),
+			getBlockSupport( blockName, 'align', true ),
 			hasBlockSupport( blockName, 'alignWide', true )
 		);
 
@@ -174,7 +174,7 @@ export const withDataAlign = createHigherOrderComponent(
 		}
 
 		const validAlignments = getValidAlignments(
-			getBlockSupport( name, 'align' ),
+			getBlockSupport( name, 'align', true ),
 			hasBlockSupport( name, 'alignWide', true ),
 			hasWideEnabled
 		);
@@ -199,7 +199,7 @@ export const withDataAlign = createHigherOrderComponent(
  */
 export function addAssignedAlign( props, blockType, attributes ) {
 	const { align } = attributes;
-	const blockAlign = getBlockSupport( blockType, 'align' );
+	const blockAlign = getBlockSupport( blockType, 'align', true );
 	const hasWideBlockSupport = hasBlockSupport( blockType, 'alignWide', true );
 
 	// Compute valid alignments without taking into account if

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -8,6 +8,7 @@
 		}
 	},
 	"supports": {
+		"align": false,
 		"customClassName": false,
 		"html": false,
 		"inserter": false

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -2,9 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/column",
 	"category": "text",
-	"parent": [
-		"core/columns"
-	],
+	"parent": [ "core/columns" ],
 	"attributes": {
 		"verticalAlignment": {
 			"type": "string"

--- a/packages/block-library/src/freeform/block.json
+++ b/packages/block-library/src/freeform/block.json
@@ -11,7 +11,8 @@
 	"supports": {
 		"className": false,
 		"customClassName": false,
-		"reusable": false
+		"reusable": false,
+		"align": false
 	},
 	"editorStyle": "wp-block-freeform-editor"
 }

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -11,7 +11,8 @@
 	"supports": {
 		"customClassName": false,
 		"className": false,
-		"html": false
+		"html": false,
+		"align": false
 	},
 	"editorStyle": "wp-block-html-editor"
 }

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -71,6 +71,7 @@
 		}
 	},
 	"supports": {
+		"align": false,
 		"anchor": true
 	},
 	"editorStyle": "wp-block-image-editor",

--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -15,7 +15,8 @@
 		"customClassName": false,
 		"className": false,
 		"html": false,
-		"multiple": false
+		"multiple": false,
+		"align": false
 	},
 	"editorStyle": "wp-block-more-editor"
 }

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -6,7 +6,8 @@
 	"supports": {
 		"customClassName": false,
 		"className": false,
-		"html": false
+		"html": false,
+		"align": false
 	},
 	"editorStyle": "wp-block-nextpage-editor"
 }

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -21,10 +21,7 @@
 		},
 		"direction": {
 			"type": "string",
-			"enum": [
-				"ltr",
-				"rtl"
-			]
+			"enum": [ "ltr", "rtl" ]
 		}
 	},
 	"supports": {
@@ -36,7 +33,8 @@
 		"fontSize": true,
 		"lineHeight": true,
 		"__experimentalSelector": "p",
-		"__unstablePasteTextInline": true
+		"__unstablePasteTextInline": true,
+		"align": false
 	},
 	"editorStyle": "wp-block-paragraph-editor",
 	"style": "wp-block-paragraph"

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -21,7 +21,8 @@
 		}
 	},
 	"supports": {
-		"anchor": true
+		"anchor": true,
+		"align": false
 	},
 	"editorStyle": "wp-block-quote-editor",
 	"style": "wp-block-quote"

--- a/packages/block-library/src/shortcode/block.json
+++ b/packages/block-library/src/shortcode/block.json
@@ -11,7 +11,8 @@
 	"supports": {
 		"className": false,
 		"customClassName": false,
-		"html": false
+		"html": false,
+		"align": false
 	},
 	"editorStyle": "wp-block-shortcode-editor"
 }


### PR DESCRIPTION
Related discussion #25973

We have right now some arbitrary decisions about which blocks do or do not support alignments. This PR tries to address this by:

 - Enable the "align" support flag by default for all blocks
 - Explicitly disable it for blocks without wrappers (html, classic, more, next-page, reusable block)
 - Automatically disable it for blocks in a container that is not using the default "layout" strategy. For example: columns block has orientation="horizontal" which means the layout is "flex-horizontal" which disables the alignments for its children.

This is just a POC for now just to get a sense of what really needs to be done and figure out the backward compatibility story.