### PR TITLE
Fix Cover focal point picker.

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -6,6 +6,7 @@
 	overflow: hidden;
 	min-height: 430px;
 	width: 100%;
+	height: 100%; // This explicit height rule is necessary for the focal point picker to work.
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -3,7 +3,6 @@
 	position: relative;
 	background-size: cover;
 	background-position: center center;
-	overflow: hidden;
 	min-height: 430px;
 	width: 100%;
 	height: 100%; // This explicit height rule is necessary for the focal point picker to work.


### PR DESCRIPTION
In #28114, the explicit `height` property was removed from the cover block.

That caused a bug where content inside the cover would overflow the edges, which was fixed in #28287, which kept the height removed, but added an `overflow` property instead.

While the overflow fixed the problem with overlapping content, the height was still necessary for the focal point picker to work. 

Currently:

<img width="1232" alt="Screenshot 2021-01-20 at 11 07 44" src="https://user-images.githubusercontent.com/1204802/105160369-72e2c280-5b10-11eb-94ed-597950fb29f5.png">

After this patch:

<img width="1214" alt="Screenshot 2021-01-20 at 11 09 35" src="https://user-images.githubusercontent.com/1204802/105160376-770ee000-5b10-11eb-80cb-5d3e645a9adf.png">

I could also remove the overflow rule again, making it a full revert. But the overflow doesn't appear to be causing any issues on its own. Open to suggestions here.

While it's unfortunate we didn't catch the focal point picker issue in the last patch, I don't think fixing that is as urgent as the overflow issue. Still good to get into the next version.