### PR TITLE
[RNMobile/iOS] Correct autoscroll to be enabled when the keyboard is going to appear

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.native.js
+++ b/packages/edit-post/src/components/visual-editor/index.native.js
@@ -20,7 +20,7 @@ export default class VisualEditor extends Component {
 		this.keyboardDidHide = this.keyboardDidHide.bind( this );
 
 		this.state = {
-			shouldEnableAutoScroll: true,
+			isAutoScrollEnabled: true,
 		};
 	}
 
@@ -41,11 +41,11 @@ export default class VisualEditor extends Component {
 	}
 
 	keyboardDidShow() {
-		this.setState( { shouldEnableAutoScroll: false } );
+		this.setState( { isAutoScrollEnabled: false } );
 	}
 
 	keyboardDidHide() {
-		this.setState( { shouldEnableAutoScroll: true } );
+		this.setState( { isAutoScrollEnabled: true } );
 	}
 
 	renderHeader() {
@@ -55,13 +55,13 @@ export default class VisualEditor extends Component {
 
 	render() {
 		const { safeAreaBottomInset } = this.props;
-		const { shouldEnableAutoScroll } = this.state;
+		const { isAutoScrollEnabled } = this.state;
 
 		return (
 			<BlockList
 				header={ this.renderHeader }
 				safeAreaBottomInset={ safeAreaBottomInset }
-				autoScroll={ shouldEnableAutoScroll }
+				autoScroll={ isAutoScrollEnabled }
 			/>
 		);
 	}

--- a/packages/edit-post/src/components/visual-editor/index.native.js
+++ b/packages/edit-post/src/components/visual-editor/index.native.js
@@ -16,50 +16,52 @@ export default class VisualEditor extends Component {
 	constructor( props ) {
 		super( props );
 		this.renderHeader = this.renderHeader.bind( this );
-		this.keyboardWillShow = this.keyboardWillShow.bind( this );
-		this.keyboardWillHide = this.keyboardWillHide.bind( this );
+		this.keyboardDidShow = this.keyboardDidShow.bind( this );
+		this.keyboardDidHide = this.keyboardDidHide.bind( this );
 
 		this.state = {
-			isKeyboardOpen: false,
+			shouldEnableAutoScroll: true,
 		};
 	}
 
 	componentWillMount() {
-		this.keyboardWillShowListener = Keyboard.addListener(
-			'keyboardWillShow',
-			this.keyboardWillShow
+		this.keyboardDidShow = Keyboard.addListener(
+			'keyboardDidShow',
+			this.keyboardDidShow
 		);
-		this.keyboardWillHideListener = Keyboard.addListener(
-			'keyboardWillHide',
-			this.keyboardWillHide
+		this.keyboardDidHideListener = Keyboard.addListener(
+			'keyboardDidHide',
+			this.keyboardDidHide
 		);
 	}
 
 	componentWillUnmount() {
-		this.keyboardWillShowListener.remove();
-		this.keyboardWillHideListener.remove();
+		this.keyboardDidShow.remove();
+		this.keyboardDidHideListener.remove();
 	}
 
-	keyboardWillShow() {
-		this.setState( { isKeyboardOpen: true } );
+	keyboardDidShow() {
+		this.setState( { shouldEnableAutoScroll: false } );
 	}
 
-	keyboardWillHide() {
-		this.setState( { isKeyboardOpen: false } );
+	keyboardDidHide() {
+		this.setState( { shouldEnableAutoScroll: true } );
 	}
+
 	renderHeader() {
 		const { setTitleRef } = this.props;
 		return <Header setTitleRef={ setTitleRef } />;
 	}
+
 	render() {
 		const { safeAreaBottomInset } = this.props;
-		const { isKeyboardOpen } = this.state;
+		const { shouldEnableAutoScroll } = this.state;
 
 		return (
 			<BlockList
 				header={ this.renderHeader }
 				safeAreaBottomInset={ safeAreaBottomInset }
-				autoScroll={ isKeyboardOpen }
+				autoScroll={ shouldEnableAutoScroll }
 			/>
 		);
 	}

--- a/packages/edit-post/src/components/visual-editor/index.native.js
+++ b/packages/edit-post/src/components/visual-editor/index.native.js
@@ -3,7 +3,10 @@
  */
 import { Component } from '@wordpress/element';
 import { BlockList } from '@wordpress/block-editor';
-
+/**
+ * External dependencies
+ */
+import { Keyboard } from 'react-native';
 /**
  * Internal dependencies
  */
@@ -13,6 +16,36 @@ export default class VisualEditor extends Component {
 	constructor( props ) {
 		super( props );
 		this.renderHeader = this.renderHeader.bind( this );
+		this.keyboardWillShow = this.keyboardWillShow.bind( this );
+		this.keyboardWillHide = this.keyboardWillHide.bind( this );
+
+		this.state = {
+			isKeyboardOpen: false,
+		};
+	}
+
+	componentWillMount() {
+		this.keyboardWillShowListener = Keyboard.addListener(
+			'keyboardWillShow',
+			this.keyboardWillShow
+		);
+		this.keyboardWillHideListener = Keyboard.addListener(
+			'keyboardWillHide',
+			this.keyboardWillHide
+		);
+	}
+
+	componentWillUnmount() {
+		this.keyboardWillShowListener.remove();
+		this.keyboardWillHideListener.remove();
+	}
+
+	keyboardWillShow() {
+		this.setState( { isKeyboardOpen: true } );
+	}
+
+	keyboardWillHide() {
+		this.setState( { isKeyboardOpen: false } );
 	}
 	renderHeader() {
 		const { setTitleRef } = this.props;
@@ -24,7 +57,7 @@ export default class VisualEditor extends Component {
 			<BlockList
 				header={ this.renderHeader }
 				safeAreaBottomInset={ safeAreaBottomInset }
-				autoScroll={ true }
+				autoScroll={ this.state.isKeyboardOpen }
 			/>
 		);
 	}

--- a/packages/edit-post/src/components/visual-editor/index.native.js
+++ b/packages/edit-post/src/components/visual-editor/index.native.js
@@ -53,11 +53,13 @@ export default class VisualEditor extends Component {
 	}
 	render() {
 		const { safeAreaBottomInset } = this.props;
+		const { isKeyboardOpen } = this.state;
+
 		return (
 			<BlockList
 				header={ this.renderHeader }
 				safeAreaBottomInset={ safeAreaBottomInset }
-				autoScroll={ this.state.isKeyboardOpen }
+				autoScroll={ isKeyboardOpen }
 			/>
 		);
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3024

<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1.Open a post/page for editing
2.Focus on a heading block that is near the bottom of the screen
3.Notice that the heading block scrolls up to become visible above the keyboard
4.Press the alignement button
5.Notice that the heading block scrolls back behind the alignment **actionsheet**

## Screenshots <!-- if applicable -->

![ios-scroll](https://user-images.githubusercontent.com/22746080/105169983-96136f00-5b1c-11eb-8a34-d3b465ec5d05.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
