### PR TITLE
Try: Show pattern categories as a row of horizontal buttons

### DIFF
--- a/packages/block-editor/src/components/inserter/pattern-panel.js
+++ b/packages/block-editor/src/components/inserter/pattern-panel.js
@@ -6,28 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { SelectControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { ButtonGroup, Button } from '@wordpress/components';
 
 function PatternInserterPanel( {
-	selectedCategory,
 	patternCategories,
 	onClickCategory,
 	children,
 } ) {
-	const categoryOptions = () => {
-		const options = [];
-
-		patternCategories.map( ( patternCategory ) => {
-			return options.push( {
-				value: patternCategory.name,
-				label: patternCategory.label,
-			} );
-		} );
-
-		return options;
-	};
-
 	const onChangeSelect = ( selected ) => {
 		onClickCategory(
 			patternCategories.find(
@@ -46,14 +31,20 @@ function PatternInserterPanel( {
 	return (
 		<>
 			<div className={ getPanelHeaderClassName() }>
-				<SelectControl
-					className="block-editor-inserter__panel-dropdown"
-					label={ __( 'Filter patterns' ) }
-					hideLabelFromVision
-					value={ selectedCategory.name }
-					onChange={ onChangeSelect }
-					options={ categoryOptions() }
-				/>
+				<ButtonGroup className="block-editor-inserter__panel-chips">
+					{ patternCategories.map( ( patternCategory ) => {
+						return (
+							<Button
+								key={ patternCategory.name }
+								onClick={ () => {
+									onChangeSelect( patternCategory.name );
+								} }
+							>
+								{ patternCategory.label }
+							</Button>
+						);
+					} ) }
+				</ButtonGroup>
 			</div>
 			<div className="block-editor-inserter__panel-content">
 				{ children }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -197,12 +197,15 @@ $block-inserter-tabs-height: 44px;
 	font-weight: 500;
 }
 
-.block-editor-inserter__panel-dropdown select.components-select-control__input.components-select-control__input.components-select-control__input {
-	line-height: 1.2;
-}
-
-.block-editor-inserter__panel-dropdown select {
-	border: none;
+.block-editor-inserter__panel-chips {
+	.components-button.components-button {
+		box-shadow: 0 0 0 $border-width $gray-300;
+		margin: 0 $grid-unit-10 $grid-unit-10 0;
+		border-radius: $radius-block-ui;
+		font-size: $helptext-font-size;
+		height: auto;
+		padding: 6px;
+	}
 }
 
 .block-editor-inserter__block-list {


### PR DESCRIPTION
Takes a stab at the second half of #28312. 

**Note: incomplete, work in progress.** I did not spend much time on this PR, it's mostly a proof of concept to test out the validity of the idea. And that idea is: by showing a horizontal list of categories instead of a dropdown, it's immediately more visible the breadth of content available as patterns:

<img width="644" alt="Screenshot 2021-01-20 at 12 27 36" src="https://user-images.githubusercontent.com/1204802/105169343-b1ca4580-5b1b-11eb-9131-98778fff630f.png">

The hope is that by letting you all try this PR out, we can evaluate whether to take the next step or not. And those next steps would include:

- The active filter needs to be shown
- Should we show an "All" category at the beginning?
- Is the ButtonGroup the correct compnent to use?
- What's a good visual treatment?
- Do we need to collapse multiple rows of categories onto a single row?

But it's not worth spending time on that until we decide whether this accomplishes the goal or not. So your feedback is welcome!

You can test this PR on Gutenberg.run: http://gutenberg.run/28353