### PR TITLE
Packages: Use canary flag for npm releases with next dist tag

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -274,23 +274,33 @@ async function publishPackagesToNpm(
 		cwd: gitWorkingDirectoryPath,
 	} );
 
-	log(
-		'>> Bumping version of public packages changed since the last release.'
-	);
-	const version = isPrerelease
-		? 'prerelease --preid next'
-		: minimumVersionBump;
-	await command( `npx lerna version ${ version } --no-private`, {
-		cwd: gitWorkingDirectoryPath,
-		stdio: 'inherit',
-	} );
+	if ( isPrerelease ) {
+		log( '>> Publishing modified packages to npm.' );
+		await command(
+			`npx lerna publish --canary ${ minimumVersionBump } --preid next`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			}
+		);
+	} else {
+		log(
+			'>> Bumping version of public packages changed since the last release.'
+		);
+		await command(
+			`npx lerna version ${ minimumVersionBump } --no-private`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			}
+		);
 
-	log( '>> Publishing packages to npm.' );
-	const distTag = isPrerelease ? ' --dist-tag next' : '';
-	await command( `npx lerna publish from-package${ distTag }`, {
-		cwd: gitWorkingDirectoryPath,
-		stdio: 'inherit',
-	} );
+		log( '>> Publishing modified packages to npm.' );
+		await command( `npx lerna publish from-package`, {
+			cwd: gitWorkingDirectoryPath,
+			stdio: 'inherit',
+		} );
+	}
 }
 
 /**

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -210,7 +210,9 @@ async function updatePackages(
 				);
 
 				log(
-					`   - ${ packageName }: ${ version } -> ${ nextVersion }`
+					`   - ${ packageName }: ${ version } -> ${
+						isPrerelease ? nextVersion + '-next.0' : nextVersion
+					}`
 				);
 			}
 		)


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

An improvement suggested by @sirreal in https://github.com/WordPress/gutenberg/commit/06cc5ed935fe33c0e5aafafc201345de51256eea#r46151872.

Let's try using `lerna publish` with `--canary` flag for prereleases (`next` dist tag).