### PR TITLE
Replace deprecated waitFor in e2e tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,6 +110,12 @@ module.exports = {
 			{
 				selector:
 					'CallExpression[callee.object.name="page"][callee.property.name="waitFor"]',
+				message:
+					'This method is deprecated. You should use the more explicit API methods available.',
+			},
+			{
+				selector:
+					'CallExpression[callee.object.name="page"][callee.property.name="waitForTimeout"]',
 				message: 'Prefer page.waitForSelector instead.',
 			},
 			{

--- a/packages/e2e-test-utils/src/delete-theme.js
+++ b/packages/e2e-test-utils/src/delete-theme.js
@@ -41,7 +41,7 @@ export async function deleteTheme(
 
 	// Wait for the theme to be removed from the page.
 	// eslint-disable-next-line no-restricted-syntax
-	await page.waitFor(
+	await page.waitForFunction(
 		( themeSlug ) =>
 			! document.querySelector( `[data-slug="${ themeSlug }"]` ),
 		slug

--- a/packages/e2e-test-utils/src/preview.js
+++ b/packages/e2e-test-utils/src/preview.js
@@ -15,12 +15,14 @@ export async function openPreviewPage( editorPage = page ) {
 	let openTabs = await browser.pages();
 	const expectedTabsCount = openTabs.length + 1;
 	await editorPage.click( '.block-editor-post-preview__button-toggle' );
-	await editorPage.waitFor( '.edit-post-header-preview__button-external' );
+	await editorPage.waitForSelector(
+		'.edit-post-header-preview__button-external'
+	);
 	await editorPage.click( '.edit-post-header-preview__button-external' );
 
 	// Wait for the new tab to open.
 	while ( openTabs.length < expectedTabsCount ) {
-		await editorPage.waitFor( 1 );
+		await editorPage.waitForTimeout( 1 );
 		openTabs = await browser.pages();
 	}
 

--- a/packages/e2e-tests/specs/editor/plugins/custom-post-types.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/custom-post-types.test.js
@@ -63,8 +63,7 @@ describe( 'Test Custom Post Types', () => {
 		await page.waitForSelector( PARENT_PAGE_INPUT );
 		// Wait for the list of suggestions to fetch
 		// There should be a better way to do that.
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor(
+		await page.waitForFunction(
 			( [ value, inputSelector ] ) =>
 				document.querySelector( inputSelector ).value === value,
 			{},

--- a/packages/e2e-tests/specs/editor/plugins/nonce.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/nonce.test.js
@@ -24,7 +24,7 @@ describe( 'Nonce', () => {
 	it( 'should refresh when expired', async () => {
 		await page.keyboard.press( 'Enter' );
 		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 5000 );
+		await page.waitForTimeout( 5000 );
 		await page.keyboard.type( 'test' );
 		// `saveDraft` waits for saving to be successful, so this test would
 		// timeout if it's not.

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -293,7 +293,7 @@ describe( 'adding blocks', () => {
 		// We need to wait a bit after typing otherwise we might an "early" result
 		// that is going to be "detached" when trying to click on it
 		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 100 );
+		await page.waitForTimeout( 100 );
 		const coverBlock = await page.waitForSelector(
 			'.block-editor-block-types-list .editor-block-list-item-cover'
 		);

--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -34,7 +34,7 @@ async function sleep( durationInSeconds ) {
 	// `waitFor`, which isn't apt for the use case, when provided an integer,
 	// of waiting for a given amount of time.
 	// eslint-disable-next-line no-restricted-syntax
-	await page.waitFor( durationInSeconds * 1000 );
+	await page.waitForTimeout( durationInSeconds * 1000 );
 }
 
 async function clearSessionStorage() {

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -318,7 +318,7 @@ describe( 'Links', () => {
 		// Disable reason: Wait for the animation to complete, since otherwise the
 		// click attempt may occur at the wrong point.
 		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 100 );
+		await page.waitForTimeout( 100 );
 
 		// Publish the post
 		await page.click( '.editor-post-publish-button' );

--- a/packages/e2e-tests/specs/editor/various/nux.test.js
+++ b/packages/e2e-tests/specs/editor/various/nux.test.js
@@ -50,7 +50,7 @@ describe( 'New User Experience (NUX)', () => {
 		);
 		// This shouldn't be necessary
 		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 500 );
+		await page.waitForTimeout( 500 );
 
 		// Press the right arrow key for Page 3
 		await page.keyboard.press( 'ArrowRight' );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -315,7 +315,7 @@ describe( 'Reusable blocks', () => {
 
 		// Wait for async mode to dispatch the update.
 		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 1000 );
+		await page.waitForTimeout( 1000 );
 
 		// Check that the content of the second reusable block has been updated.
 		const reusableBlocks = await page.$$( '.wp-block-block' );

--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -311,6 +311,7 @@ async function saveWidgets() {
 
 	// FIXME: The snackbar above is enough for the widget areas to get saved,
 	// but not enough for the widgets to get saved.
+	// eslint-disable-next-line no-restricted-syntax
 	await page.waitForTimeout( 500 );
 }
 


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/28093

## Description
* Replaced `waitFor` with appropriate more explicit methods
* Changed message for `waitFor` rule to warn about deprecation and prevent usage of it
* Add eslint rule for `waitForTimeout`, we should prefer other methods. We shouldn't rely on timeouts.

## How has this been tested?
* Run E2E tests and make sure they are passing
* Check CI
* Make sure we don't have any logs in the console about `waitFor` deprecation

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
