### PR TITLE
Cover: Fix matrix alignment issue.

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -172,8 +172,10 @@
 .wp-block-cover__image-background,
 .wp-block-cover__video-background {
 	position: absolute;
-	width: 100%;
-	height: 100%;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	object-fit: cover;
 }
 


### PR DESCRIPTION
This one pairs well with #28350, but is separate just for cleanliness. 

When you use the matrix aligment, the separate background image shifts. This PR fixes that. Before:

<img width="1202" alt="Screenshot 2021-01-20 at 18 44 03" src="https://user-images.githubusercontent.com/1204802/105214203-fc65b500-5b4f-11eb-9a64-708b782e4128.png">

After:

<img width="1156" alt="Screenshot 2021-01-20 at 18 45 22" src="https://user-images.githubusercontent.com/1204802/105214211-fe2f7880-5b4f-11eb-82fb-af0227224300.png">

For context, position absolute, combined with width/height 100% works in most cases, but is still subject to the box model, collapsing margins, and other hard-to-predict things. By replacing those with top/right/bottom/left values of zero, we set neither widths nor heights, but accomplish the same.