### PR TITLE
Fix repeated backgrounds with transparent images

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -330,8 +330,10 @@ function CoverEdit( {
 		? `${ minHeight }${ minHeightUnit }`
 		: minHeight;
 
+	const isImgElement = ! ( hasParallax || isRepeated );
+
 	const style = {
-		...( isImageBackground && ( hasParallax || isRepeated )
+		...( isImageBackground && ! isImgElement
 			? backgroundImageStyles( url )
 			: {} ),
 		backgroundColor: overlayColor.color,
@@ -342,7 +344,7 @@ function CoverEdit( {
 	const mediaStyle = {
 		objectPosition:
 			// prettier-ignore
-			focalPoint && ! hasParallax
+			focalPoint && isImgElement
 				? `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100) }%`
 				: undefined,
 	};
@@ -595,7 +597,7 @@ function CoverEdit( {
 						style={ { background: gradientValue } }
 					/>
 				) }
-				{ isImageBackground && ! hasParallax && (
+				{ isImageBackground && isImgElement && (
 					<img
 						ref={ isDarkElement }
 						className="wp-block-cover__image-background"

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -54,8 +54,10 @@ export default function save( { attributes } ) {
 	const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
 
+	const isImgElement = ! ( hasParallax || isRepeated );
+
 	const style = {
-		...( isImageBackground && ( hasParallax || isRepeated )
+		...( isImageBackground && ! isImgElement
 			? backgroundImageStyles( url )
 			: {} ),
 		backgroundColor: ! overlayColorClass ? customOverlayColor : undefined,
@@ -65,7 +67,7 @@ export default function save( { attributes } ) {
 
 	const objectPosition =
 		// prettier-ignore
-		focalPoint && ! hasParallax
+		focalPoint && isImgElement
 			? `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100 ) }%`
 			: undefined;
 
@@ -101,7 +103,7 @@ export default function save( { attributes } ) {
 					}
 				/>
 			) }
-			{ isImageBackground && url && ! hasParallax && (
+			{ isImageBackground && isImgElement && url && (
 				<img
 					className={ classnames(
 						'wp-block-cover__image-background',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

See https://github.com/WordPress/gutenberg/pull/28310#issuecomment-763802436

https://user-images.githubusercontent.com/9000376/105209658-ee3b7880-5afe-11eb-963f-904ec6341e2e.mp4

In re-enabling the image repeat feature, I missed removing the `<img>` element when it was enabled. This removes that `<img>` element when the repeat feature is enabled. Thanks again to @stokesman!

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Easiest to see with an image using transparency or a small image, enable the repeat feature and see that there isn't an overlapping image with the background.

## Screenshots <!-- if applicable -->

![Screen Shot 2021-01-20 at 08 11 53-fullpage](https://user-images.githubusercontent.com/5129775/105216848-3060bc00-5af7-11eb-942c-8895088f23dd.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
