### PR TITLE
Revert "Cover: Fix matrix alignment issue."

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -172,10 +172,8 @@
 .wp-block-cover__image-background,
 .wp-block-cover__video-background {
 	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
+	width: 100%;
+	height: 100%;
 	object-fit: cover;
 }
 


### PR DESCRIPTION
Reverts WordPress/gutenberg#28361

Reason: Visually broken on the frontend :crying_cat_face: 

See https://github.com/WordPress/gutenberg/pull/28361#issuecomment-763888663 for screenshots.