### PR TITLE
Try: Alternate cover fix.

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -172,6 +172,8 @@
 .wp-block-cover__image-background,
 .wp-block-cover__video-background {
 	position: absolute;
+	top: 0;
+	left: 0;
 	width: 100%;
 	height: 100%;
 	object-fit: cover;


### PR DESCRIPTION
Alternative to #28350, possibly followup to #28364. It still needs a good sanity check and testing, but I believe that the fundamental issue with the shifting background image is related to collapsing margins for the paragraph being positioned by the matrix. By applying some left/top positioning coordinates, it should address the fundamental issue. It works well for me:

<img width="1487" alt="Screenshot 2021-01-20 at 20 58 52" src="https://user-images.githubusercontent.com/1204802/105228374-cf6ecd80-5b62-11eb-84ae-d806aa625327.png">

<img width="1276" alt="Screenshot 2021-01-20 at 20 59 44" src="https://user-images.githubusercontent.com/1204802/105228378-d1389100-5b62-11eb-88f1-163bebfe8e10.png">

<img width="1453" alt="Screenshot 2021-01-20 at 21 00 10" src="https://user-images.githubusercontent.com/1204802/105228383-d3025480-5b62-11eb-85b9-252b35697cab.png">

<img width="1638" alt="Screenshot 2021-01-20 at 21 00 16" src="https://user-images.githubusercontent.com/1204802/105228386-d4338180-5b62-11eb-8a5d-05a45c14788f.png">

Be sure to test this in a few themes with frontend and editor both.