### PR TITLE
Full Site Editing: Update theme attribute injection and removal

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -110,11 +110,10 @@ function _gutenberg_get_template_files( $template_type ) {
  * stylesheet as a theme attribute into each wp_template_part
  *
  * @param string $template_content serialized wp_template content.
- * @param string $theme the active theme's stylesheet.
  *
  * @return string Updated wp_template content.
  */
-function _inject_theme_attribute_in_content( $template_content, $theme ) {
+function _inject_theme_attribute_in_content( $template_content ) {
 	$has_updated_content = false;
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );
@@ -122,10 +121,9 @@ function _inject_theme_attribute_in_content( $template_content, $theme ) {
 	foreach ( $template_blocks as $key => $block ) {
 		if (
 			'core/template-part' === $block['blockName'] &&
-			! isset( $block['attrs']['theme'] ) &&
-			wp_get_theme()->get_stylesheet() === $theme
+			! isset( $block['attrs']['theme'] )
 		) {
-			$template_blocks[ $key ]['attrs']['theme'] = $theme;
+			$template_blocks[ $key ]['attrs']['theme'] = wp_get_theme()->get_stylesheet();
 			$has_updated_content                       = true;
 		}
 	}
@@ -155,7 +153,7 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 	$theme                  = wp_get_theme()->get_stylesheet();
 
 	if ( 'wp_template' === $template_type ) {
-		$template_content = _inject_theme_attribute_in_content( $template_content, $theme );
+		$template_content = _inject_theme_attribute_in_content( $template_content );
 	}
 
 	$template            = new WP_Block_Template();

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -136,9 +136,9 @@ function _inject_theme_attribute_in_content( $template_content, $theme ) {
 		}
 
 		return $new_content;
-	} else {
-		return $template_content;
 	}
+
+	return $template_content;
 }
 
 /**

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -56,8 +56,7 @@ function gutenberg_edit_site_export() {
 	// Load templates into the zip file.
 	$templates = gutenberg_get_block_templates();
 	foreach ( $templates as $template ) {
-		$updated_content   = _remove_theme_attribute_from_content( $template->content );
-		$template->content = $updated_content;
+		$template->content = _remove_theme_attribute_from_content( $template->content );
 
 		$zip->addFromString(
 			'theme/block-templates/' . $template->slug . '.html',

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -6,8 +6,8 @@
  */
 
 /**
- * Parses wp_template content and injects the current theme's
- * stylesheet as a theme attribute into each wp_template_part
+ * Parses wp_template content and removes the theme attribute from
+ * each wp_template_part
  *
  * @param string $template_content serialized wp_template content.
  *

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -31,9 +31,9 @@ function _remove_theme_attribute_from_content( $template_content ) {
 		}
 
 		return $new_content;
-	} else {
-		return $template_content;
 	}
+
+	return $template_content;
 }
 
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Follow up to @vindl's code review comments in https://github.com/WordPress/gutenberg/pull/28088. The functionality introduced by #28088 should not change at all. We're just refactoring the underlying source code and addressing the following comments:

- [Comment about dropping a parameter in _inject_theme_attribute_in_content](https://github.com/WordPress/gutenberg/pull/28088#discussion_r557733131)
- [Comment about no returns in else statements](https://github.com/WordPress/gutenberg/pull/28088#discussion_r557733884)
- [Comment about fixing JSDoc comment for _remove_theme_attribute_from_content](https://github.com/WordPress/gutenberg/pull/28088#discussion_r557737559)
- [Comment about intermediate variable](https://github.com/WordPress/gutenberg/pull/28088/files/52f61bf4ad4af3dcc77cbf20306edfbc32216461#r557738622)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
**Before applying this PR:**
- Open the front end and the site editor. It should load all the template parts.
- Ensure that the [theme-experiments](https://github.com/WordPress/theme-experiments/tree/e755034e596474b5481e3642cb9468bb2a54fa65) repo is downloaded locally
- Install the TT1-blocks theme in a subdirectory of `wp-content/themes`.
   1. Add the following to `.wp-env.override.json`. This creates a copy of the locally installed TT1 theme in an "test" subdirectory in the WordPress volume.
   2. ```javascript 
      // .wp-env.override.json
      // Replace ~/work/theme-experiments/tt1-blocks with the path
      // to your locally installed TT1 block theme
      {
           "mappings": {
               "wp-content/themes/test/tt1-blocks": "~/work/theme-experiments/tt1-blocks",
           }
      }```
    3. `npx wp-env start`
- Activate TT1-blocks.
- Open the front end and the site editor: it should not be loading the header and footer template parts.

**Apply this PR:**
- Navigate to your locally installed copy of the TT1 blocks theme.
- Modify the source code of block templates and remove theme attributes from all `wp_template_parts`
    - Take `tt1-blocks/block-templates/front-page.html` for example
    - Before removal: `<!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full", "tagName":"header","className":"site-header"} /-->`
    - After removal: `<!-- wp:template-part {"slug":"header", "align":"full", "tagName":"header","className":"site-header"} /-->`
- `npx wp-env start --update`
- Open the front end and the site editor: it should load all the template parts.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Code Refactor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
