### PR TITLE
Fix handling of raw transforms that return multiple blocks

### DIFF
--- a/packages/blocks/src/api/raw-handling/html-to-blocks.js
+++ b/packages/blocks/src/api/raw-handling/html-to-blocks.js
@@ -19,7 +19,7 @@ export function htmlToBlocks( html ) {
 
 	doc.body.innerHTML = html;
 
-	return Array.from( doc.body.children ).map( ( node ) => {
+	return Array.from( doc.body.children ).flatMap( ( node ) => {
 		const rawTransform = findTransform(
 			getRawTransforms(),
 			( { isMatch } ) => isMatch( node )

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -87,6 +87,33 @@ describe( 'Blocks raw handling', () => {
 			},
 			save: () => null,
 		} );
+
+		registerBlockType( 'test/transform-to-multiple-blocks', {
+			title: 'Test Transform to Multiple Blocks',
+			category: 'text',
+			transforms: {
+				from: [
+					{
+						type: 'raw',
+						isMatch: ( node ) => {
+							return node.textContent
+								.split( ' ' )
+								.every( ( chunk ) => /^P\S+?/.test( chunk ) );
+						},
+						transform: ( node ) => {
+							return node.textContent
+								.split( ' ' )
+								.map( ( chunk ) =>
+									createBlock( 'core/paragraph', {
+										content: chunk.substring( 1 ),
+									} )
+								);
+						},
+					},
+				],
+			},
+			save: () => null,
+		} );
 	} );
 
 	it( 'should filter inline content', () => {
@@ -360,6 +387,18 @@ describe( 'Blocks raw handling', () => {
 				} )
 			)
 		).toBe( block );
+	} );
+
+	it( 'should handle transforms that return an array of blocks', () => {
+		const transformed = pasteHandler( {
+			HTML: '<p>P1 P2</p>',
+			plainText: 'P1 P2\n',
+		} )
+			.map( getBlockContent )
+			.join( '' );
+
+		expect( transformed ).toBe( '<p>1</p><p>2</p>' );
+		expect( console ).toHaveLogged();
 	} );
 
 	describe( 'pasteHandler', () => {


### PR DESCRIPTION
Fixes #28370

## Description

Flattens the return array in `raw-handling/html-to-blocks.js` so that we don't pass a deeply nested array to the consumer handlers (`rawHandler`, `pasteHandler`), which are only shallowly flattened.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- `test/integration/blocks-raw-handling.test.js` (not sure if the added test is necessary)
- Test cases like the one in the original issue work as expected.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
