### PR TITLE
Refactored Gallery: Add custom gutter sizing

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -52,6 +52,9 @@
 		"imageCount": {
 			"type": "number",
 			"default": 0
+		},
+		"gutterSize": {
+			"type": "number"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -66,6 +66,10 @@ const MOBILE_CONTROL_PROPS_RANGE_CONTROL = Platform.select( {
 	native: { type: 'stepper' },
 } );
 
+const DEFAULT_GUTTER_SIZE = 16;
+const MAX_GUTTER_SIZE = 100;
+const MIN_GUTTER_SIZE = 0;
+
 function GalleryEdit( props ) {
 	const {
 		setAttributes,
@@ -79,14 +83,15 @@ function GalleryEdit( props ) {
 	} = props;
 
 	const {
+		columns = defaultColumnsNumber( imageCount ),
+		gutterSize,
 		imageCount,
+		imageCrop,
+		imageUploads,
 		linkTarget,
 		linkTo,
-		columns = defaultColumnsNumber( imageCount ),
-		sizeSlug,
-		imageUploads,
 		shortCodeTransforms,
-		imageCrop,
+		sizeSlug,
 	} = attributes;
 
 	const {
@@ -338,6 +343,10 @@ function GalleryEdit( props ) {
 
 	const blockProps = useBlockProps( {
 		className: classnames( className, 'has-nested-images' ),
+		style: {
+			'--gallery-block--gutter-size':
+				gutterSize !== undefined && `${ gutterSize }px`,
+		},
 	} );
 
 	if ( ! hasImages ) {
@@ -362,6 +371,19 @@ function GalleryEdit( props ) {
 							required
 						/>
 					) }
+					<RangeControl
+						label={ __( 'Gutter size' ) }
+						value={ gutterSize }
+						onChange={ ( newGutterSize ) =>
+							setAttributes( { gutterSize: newGutterSize } )
+						}
+						initialPosition={ DEFAULT_GUTTER_SIZE }
+						min={ MIN_GUTTER_SIZE }
+						max={ MAX_GUTTER_SIZE }
+						{ ...MOBILE_CONTROL_PROPS_RANGE_CONTROL }
+						resetFallbackValue={ DEFAULT_GUTTER_SIZE }
+						allowReset
+					/>
 					<ToggleControl
 						label={ __( 'Crop images' ) }
 						checked={ !! imageCrop }

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -10,17 +10,24 @@ import { defaultColumnsNumber } from './shared';
 
 export default function save( { attributes } ) {
 	const {
-		imageCount,
-		columns = defaultColumnsNumber( imageCount ),
-		imageCrop,
 		caption,
+		columns = defaultColumnsNumber( imageCount ),
+		gutterSize,
+		imageCount,
+		imageCrop,
 	} = attributes;
+
 	const className = `blocks-gallery-grid has-nested-images columns-${ columns } ${
 		imageCrop ? 'is-cropped' : ''
 	}`;
 
+	const style = {
+		'--gallery-block--gutter-size':
+			gutterSize !== undefined && `${ gutterSize }px`,
+	};
+
 	return (
-		<figure { ...useBlockProps.save( { className } ) }>
+		<figure { ...useBlockProps.save( { className, style } ) }>
 			<InnerBlocks.Content />
 			{ ! RichText.isEmpty( caption ) && (
 				<RichText.Content

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -9,13 +9,13 @@
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
 		// Add space between thumbnails, and unset right most thumbnails later.
-		margin: 0 $grid-unit-20 $grid-unit-20 0;
+		margin: 0 var(--gallery-block--gutter-size, #{$grid-unit-20}) var(--gallery-block--gutter-size, #{$grid-unit-20}) 0;
 
 		&:last-of-type:not(#individual-image) {
 			margin-right: 0;
 		}
 
-		width: calc(50% - #{$grid-unit-20});
+		width: calc(50% - var(--gallery-block--gutter-size, #{$grid-unit-20}));
 
 		&:nth-of-type(even) {
 			margin-right: 0;
@@ -112,11 +112,11 @@
 			margin-top: auto;
 			margin-bottom: auto;
 			img {
-				margin-bottom: $grid-unit-20;
+				margin-bottom: var(--gallery-block--gutter-size, #{$grid-unit-20});
 			}
 
 			figcaption {
-				bottom: $grid-unit-20;
+				bottom: var(--gallery-block--gutter-size, #{$grid-unit-20});
 			}
 		}
 	}
@@ -155,19 +155,19 @@
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
-				margin-right: $grid-unit-20;
-				width: calc(#{100% / $i} - #{$grid-unit-20 * ( $i - 1 ) / $i});
+				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				width: calc(#{100% / $i} - calc(var(--gallery-block--gutter-size, #{$grid-unit-20}) * calc(#{$i - 1}) / #{$i}));
 			}
 
 			// Prevent collapsing margin while sibling is being dragged.
 			&.columns-#{$i} figure.wp-block-image:not(#individual-image).is-dragging ~ figure.wp-block-image:not(#individual-image) {
-				margin-right: $grid-unit-20;
+				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
 			}
 		}
 
 		// Unset the right margin on every rightmost gallery item to ensure center balance.
 		@for $column-count from 1 through 8 {
-			&.columns-#{$column-count} figure.wp-block-image:not(#individual-image):nth-of-type( #{ $column-count }n ) {
+			&.columns-#{$column-count} figure.wp-block-image:not(#individual-image):nth-of-type(#{ $column-count }n) {
 				margin-right: 0;
 			}
 		}


### PR DESCRIPTION
## Description
* Adds ability to specify custom gutter sizing for the refactored gallery.

## How has this been tested?
Manually.

#### Testing instructions
1. Checkout this PR, create a post and gallery, adding images
2. Select gallery block and adjust gutter size control in the sidebar, confirming gallery spacing adjusts accordingly
3. Change other gallery config options e.g. number of columns, cropping etc and confirm gallery behaves
4. Select images and alter their block style selections, add captions and confirm gallery appears ok
5. Save the post and check the frontend renders as expected.

## Screenshots <!-- if applicable -->

![GalleryGutters](https://user-images.githubusercontent.com/60436221/105284463-3b524400-5bfe-11eb-8eab-9ddde1aba06e.gif)

_Note: When gutter is removed or very small it doesn't give any space for drag and drop indicators. Demo of this issue below:_

![GalleryGuttersDnD](https://user-images.githubusercontent.com/60436221/105284509-558c2200-5bfe-11eb-89d5-6692646240a9.gif)

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
