### PR TITLE
Remove new navigation block features in the navigation editor

### DIFF
--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -43,6 +43,8 @@ function removeNavigationBlockSettingsUnsupportedFeatures( settings, name ) {
 			html: false,
 			inserter: true,
 		},
+		// Remove any block variations.
+		variations: undefined,
 	};
 }
 

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, set, flatten, omit, partialRight } from 'lodash';
+import { map, set, flatten, partialRight } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -39,13 +39,9 @@ function removeNavigationBlockSettingsUnsupportedFeatures( settings, name ) {
 	return {
 		...settings,
 		supports: {
-			...omit( settings.supports, [
-				'anchor',
-				'customClassName',
-				'color',
-				'fontSize',
-			] ),
 			customClassName: false,
+			html: false,
+			inserter: true,
 		},
 	};
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Over the last few months, a few extra features have been added to the navigation block. Typography options, and variations. Neither of these are or can be supported in the Navigation Editor, as WordPress menus don't support these options.

Previously the code `omit`ted these unsupported options, but I think there are so many now that it's better to over them.

## How has this been tested?
1 Visit the navigation screen
2. Typography and transformations should not be visible

## Screenshots <!-- if applicable -->
| Before | After |
|--------|-----|
|<img width="209" alt="Screenshot 2021-01-21 at 3 04 17 pm" src="https://user-images.githubusercontent.com/677833/105315681-a6018080-5bfa-11eb-9691-23fff11d51df.png">|<img width="181" alt="Screenshot 2021-01-21 at 3 05 20 pm" src="https://user-images.githubusercontent.com/677833/105315689-a8fc7100-5bfa-11eb-9194-73b744a8afbd.png">|

## Types of changes
(Un-)Enhancement
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
