### PR TITLE
Add widget id to blocks in the widgets screen

### DIFF
--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
  * External dependencies
  */
 import { create, act } from 'react-test-renderer';
@@ -19,6 +24,15 @@ const TestWrapper = withRegistryProvider( ( props ) => {
 } );
 
 describe( 'useBlockSync hook', () => {
+	beforeAll( () => {
+		registerBlockType( 'test/test-block', {
+			title: 'Test block',
+			attributes: {
+				foo: { type: 'number' },
+			},
+		} );
+	} );
+
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );
@@ -101,7 +115,12 @@ describe( 'useBlockSync hook', () => {
 		);
 
 		const testBlocks = [
-			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
+			{
+				name: 'test/test-block',
+				clientId: 'a',
+				innerBlocks: [],
+				attributes: { foo: 1 },
+			},
 		];
 		await act( async () => {
 			root.update(
@@ -131,7 +150,12 @@ describe( 'useBlockSync hook', () => {
 		const onInput = jest.fn();
 
 		const value1 = [
-			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
+			{
+				name: 'test/test-block',
+				clientId: 'a',
+				innerBlocks: [],
+				attributes: { foo: 1 },
+			},
 		];
 		let root;
 		let registry;
@@ -282,7 +306,12 @@ describe( 'useBlockSync hook', () => {
 		const onInput = jest.fn();
 
 		const value1 = [
-			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
+			{
+				name: 'test/test-block',
+				clientId: 'a',
+				innerBlocks: [],
+				attributes: { foo: 1 },
+			},
 		];
 
 		await act( async () => {
@@ -325,7 +354,12 @@ describe( 'useBlockSync hook', () => {
 		const onInput = jest.fn();
 
 		const value1 = [
-			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
+			{
+				name: 'test/test-block',
+				clientId: 'a',
+				innerBlocks: [],
+				attributes: { foo: 1 },
+			},
 		];
 
 		let registry;
@@ -352,7 +386,14 @@ describe( 'useBlockSync hook', () => {
 
 		expect( replaceInnerBlocks ).not.toHaveBeenCalled();
 		expect( onChange ).toHaveBeenCalledWith(
-			[ { clientId: 'a', innerBlocks: [], attributes: { foo: 2 } } ],
+			[
+				{
+					name: 'test/test-block',
+					clientId: 'a',
+					innerBlocks: [],
+					attributes: { foo: 2 },
+				},
+			],
 			{ selectionEnd: {}, selectionStart: {} }
 		);
 		expect( onInput ).not.toHaveBeenCalled();

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -63,8 +63,6 @@ import { cloneBlock } from '@wordpress/blocks';
  *                                change has been made in the block-editor blocks
  *                                for the given clientId. When this is called,
  *                                controlling sources do not become dirty.
- * @param {boolean} props.__unstableCloneValue Whether or not to clone each of
- *                                the blocks provided in the value prop.
  */
 export default function useBlockSync( {
 	clientId = null,
@@ -73,7 +71,6 @@ export default function useBlockSync( {
 	selectionEnd: controlledSelectionEnd,
 	onChange = noop,
 	onInput = noop,
-	__unstableCloneValue = true,
 } ) {
 	const registry = useRegistry();
 
@@ -101,12 +98,9 @@ export default function useBlockSync( {
 		if ( clientId ) {
 			setHasControlledInnerBlocks( clientId, true );
 			__unstableMarkNextChangeAsNotPersistent();
-			let storeBlocks = controlledBlocks;
-			if ( __unstableCloneValue ) {
-				storeBlocks = controlledBlocks.map( ( block ) =>
-					cloneBlock( block )
-				);
-			}
+			const storeBlocks = controlledBlocks.map( ( block ) =>
+				cloneBlock( block )
+			);
 			if ( subscribed.current ) {
 				pendingChanges.current.incoming = storeBlocks;
 			}

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   `cloneBlock` now sanitizes the attributes to match the same logic `createBlock` has. [#28379](https://github.com/WordPress/gutenberg/pull/28379)
+
 ## 6.25.0 (2020-12-17)
 
 ### New Feature

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -16,6 +16,7 @@ import {
 	isFunction,
 	isEmpty,
 	map,
+	pick,
 } from 'lodash';
 
 /**
@@ -134,11 +135,17 @@ export function createBlocksFromInnerBlocksTemplate(
 export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 	const clientId = uuid();
 
+	const blockType = getBlockType( block.name );
+	const attributes = pick(
+		block.attributes,
+		Object.keys( blockType.attributes )
+	);
+
 	return {
 		...block,
 		clientId,
 		attributes: {
-			...block.attributes,
+			...attributes,
 			...mergeAttributes,
 		},
 		innerBlocks:

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -136,10 +136,10 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 	const clientId = uuid();
 
 	const blockType = getBlockType( block.name );
-	const attributes = pick(
-		block.attributes,
-		Object.keys( blockType.attributes )
-	);
+	let attributes = block.attributes;
+	if ( blockType ) {
+		attributes = pick( attributes, Object.keys( blockType.attributes ) );
+	}
 
 	return {
 		...block,

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -4,7 +4,6 @@
 import { v4 as uuid } from 'uuid';
 import {
 	every,
-	reduce,
 	castArray,
 	findIndex,
 	isObjectLike,
@@ -16,7 +15,6 @@ import {
 	isFunction,
 	isEmpty,
 	map,
-	pick,
 } from 'lodash';
 
 /**
@@ -32,7 +30,7 @@ import {
 	getBlockTypes,
 	getGroupingBlockName,
 } from './registration';
-import { normalizeBlockType } from './utils';
+import { normalizeBlockType, sanitizeBlockAttributes } from './utils';
 
 /**
  * Returns a block object given its type and attributes.
@@ -44,40 +42,7 @@ import { normalizeBlockType } from './utils';
  * @return {Object} Block object.
  */
 export function createBlock( name, attributes = {}, innerBlocks = [] ) {
-	// Get the type definition associated with a registered block.
-	const blockType = getBlockType( name );
-
-	if ( undefined === blockType ) {
-		throw new Error( `Block type '${ name }' is not registered.` );
-	}
-
-	// Ensure attributes contains only values defined by block type, and merge
-	// default values for missing attributes.
-	const sanitizedAttributes = reduce(
-		blockType.attributes,
-		( accumulator, schema, key ) => {
-			const value = attributes[ key ];
-
-			if ( undefined !== value ) {
-				accumulator[ key ] = value;
-			} else if ( schema.hasOwnProperty( 'default' ) ) {
-				accumulator[ key ] = schema.default;
-			}
-
-			if ( [ 'node', 'children' ].indexOf( schema.source ) !== -1 ) {
-				// Ensure value passed is always an array, which we're expecting in
-				// the RichText component to handle the deprecated value.
-				if ( typeof accumulator[ key ] === 'string' ) {
-					accumulator[ key ] = [ accumulator[ key ] ];
-				} else if ( ! Array.isArray( accumulator[ key ] ) ) {
-					accumulator[ key ] = [];
-				}
-			}
-
-			return accumulator;
-		},
-		{}
-	);
+	const sanitizedAttributes = sanitizeBlockAttributes( name, attributes );
 
 	const clientId = uuid();
 
@@ -135,19 +100,15 @@ export function createBlocksFromInnerBlocksTemplate(
 export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 	const clientId = uuid();
 
-	const blockType = getBlockType( block.name );
-	let attributes = block.attributes;
-	if ( blockType ) {
-		attributes = pick( attributes, Object.keys( blockType.attributes ) );
-	}
+	const sanitizedAttributes = sanitizeBlockAttributes( block.name, {
+		...block.attributes,
+		...mergeAttributes,
+	} );
 
 	return {
 		...block,
 		clientId,
-		attributes: {
-			...attributes,
-			...mergeAttributes,
-		},
+		attributes: sanitizedAttributes,
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) => cloneBlock( innerBlock ) ),

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -159,6 +159,23 @@ describe( 'block factory', () => {
 				content: 'test',
 			} );
 		} );
+
+		it( 'should sanitize attributes not defined in the block type', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					align: {
+						type: 'string',
+					},
+				},
+			} );
+
+			const block = createBlock( 'core/test-block', {
+				notDefined: 'not-defined',
+			} );
+
+			expect( block.attributes ).toEqual( {} );
+		} );
 	} );
 
 	describe( 'createBlocksFromInnerBlocksTemplate', () => {
@@ -274,6 +291,31 @@ describe( 'block factory', () => {
 						type: 'boolean',
 						default: false,
 					},
+					includesDefault: {
+						type: 'boolean',
+						default: true,
+					},
+					includesFalseyDefault: {
+						type: 'number',
+						default: 0,
+					},
+					content: {
+						type: 'array',
+						source: 'children',
+					},
+					defaultContent: {
+						type: 'array',
+						source: 'children',
+						default: 'test',
+					},
+					unknownDefaultContent: {
+						type: 'array',
+						source: 'children',
+						default: 1,
+					},
+					htmlContent: {
+						source: 'html',
+					},
 				},
 				save: noop,
 				category: 'text',
@@ -287,12 +329,19 @@ describe( 'block factory', () => {
 
 			const clonedBlock = cloneBlock( block, {
 				isDifferent: true,
+				htmlContent: 'test',
 			} );
 
 			expect( clonedBlock.name ).toEqual( block.name );
 			expect( clonedBlock.attributes ).toEqual( {
+				includesDefault: true,
+				includesFalseyDefault: 0,
 				align: 'left',
 				isDifferent: true,
+				content: [],
+				defaultContent: [ 'test' ],
+				unknownDefaultContent: [],
+				htmlContent: 'test',
 			} );
 			expect( clonedBlock.innerBlocks ).toHaveLength( 1 );
 			expect( typeof clonedBlock.clientId ).toBe( 'string' );
@@ -374,6 +423,27 @@ describe( 'block factory', () => {
 			expect( clonedBlock.innerBlocks[ 1 ].attributes ).toEqual(
 				block.innerBlocks[ 1 ].attributes
 			);
+		} );
+
+		it( 'should sanitize attributes not defined in the block type', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					align: {
+						type: 'string',
+					},
+				},
+			} );
+
+			const block = createBlock( 'core/test-block', {
+				notDefined: 'not-defined',
+			} );
+
+			const clonedBlock = cloneBlock( block, {
+				notDefined2: 'not-defined-2',
+			} );
+
+			expect( clonedBlock.attributes ).toEqual( {} );
 		} );
 	} );
 

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -17,6 +17,7 @@ import {
 	isUnmodifiedDefaultBlock,
 	getAccessibleBlockLabel,
 	getBlockLabel,
+	sanitizeBlockAttributes,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -210,5 +211,90 @@ describe( 'getAccessibleBlockLabel', () => {
 		expect( getAccessibleBlockLabel( blockType, attributes, 3 ) ).toBe(
 			'Recipe Block. Row 3'
 		);
+	} );
+} );
+
+describe( 'sanitizeBlockAttributes', () => {
+	afterEach( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'sanitize block attributes not defined in the block type', () => {
+		registerBlockType( 'core/test-block', {
+			attributes: {
+				defined: {
+					type: 'string',
+				},
+			},
+			title: 'Test block',
+		} );
+
+		const attributes = sanitizeBlockAttributes( 'core/test-block', {
+			defined: 'defined-attribute',
+			notDefined: 'not-defined-attribute',
+		} );
+
+		expect( attributes ).toEqual( {
+			defined: 'defined-attribute',
+		} );
+	} );
+
+	it( 'throws error if the block is not registered', () => {
+		expect( () => {
+			sanitizeBlockAttributes( 'core/not-registered-test-block', {} );
+		} ).toThrowErrorMatchingInlineSnapshot(
+			`"Block type 'core/not-registered-test-block' is not registered."`
+		);
+	} );
+
+	it( 'handles undefined values and default values', () => {
+		registerBlockType( 'core/test-block', {
+			attributes: {
+				hasDefaultValue: {
+					type: 'string',
+					default: 'default-value',
+				},
+				noDefaultValue: {
+					type: 'string',
+				},
+			},
+			title: 'Test block',
+		} );
+
+		const attributes = sanitizeBlockAttributes( 'core/test-block', {} );
+
+		expect( attributes ).toEqual( {
+			hasDefaultValue: 'default-value',
+		} );
+	} );
+
+	it( 'handles node and children sources as arrays', () => {
+		registerBlockType( 'core/test-block', {
+			attributes: {
+				nodeContent: {
+					source: 'node',
+				},
+				childrenContent: {
+					source: 'children',
+				},
+				withDefault: {
+					source: 'children',
+					default: 'test',
+				},
+			},
+			title: 'Test block',
+		} );
+
+		const attributes = sanitizeBlockAttributes( 'core/test-block', {
+			nodeContent: [ 'test-1', 'test-2' ],
+		} );
+
+		expect( attributes ).toEqual( {
+			nodeContent: [ 'test-1', 'test-2' ],
+			childrenContent: [],
+			withDefault: [ 'test' ],
+		} );
 	} );
 } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, has, isFunction, isString, startCase } from 'lodash';
+import { every, has, isFunction, isString, startCase, reduce } from 'lodash';
 import { default as tinycolor, mostReadable } from 'tinycolor2';
 
 /**
@@ -244,5 +244,48 @@ export function getAccessibleBlockLabel(
 		/* translators: accessibility text. %s: The block title. */
 		__( '%s Block' ),
 		title
+	);
+}
+
+/**
+ * Ensure attributes contains only values defined by block type, and merge
+ * default values for missing attributes.
+ *
+ * @param {string} name       The block's name.
+ * @param {Object} attributes The block's attributes.
+ * @return {Object} The sanitized attributes.
+ */
+export function sanitizeBlockAttributes( name, attributes ) {
+	// Get the type definition associated with a registered block.
+	const blockType = getBlockType( name );
+
+	if ( undefined === blockType ) {
+		throw new Error( `Block type '${ name }' is not registered.` );
+	}
+
+	return reduce(
+		blockType.attributes,
+		( accumulator, schema, key ) => {
+			const value = attributes[ key ];
+
+			if ( undefined !== value ) {
+				accumulator[ key ] = value;
+			} else if ( schema.hasOwnProperty( 'default' ) ) {
+				accumulator[ key ] = schema.default;
+			}
+
+			if ( [ 'node', 'children' ].indexOf( schema.source ) !== -1 ) {
+				// Ensure value passed is always an array, which we're expecting in
+				// the RichText component to handle the deprecated value.
+				if ( typeof accumulator[ key ] === 'string' ) {
+					accumulator[ key ] = [ accumulator[ key ] ];
+				} else if ( ! Array.isArray( accumulator[ key ] ) ) {
+					accumulator[ key ] = [];
+				}
+			}
+
+			return accumulator;
+		},
+		{}
 	);
 }

--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -306,6 +306,86 @@ describe( 'Widgets screen', () => {
 		}
 	` );
 	} );
+
+	it( 'Should duplicate the widgets', async () => {
+		const firstWidgetArea = await page.$(
+			'[aria-label="Block: Widget Area"][role="group"]'
+		);
+
+		const addParagraphBlock = await getParagraphBlockInGlobalInserter();
+		await addParagraphBlock.click();
+
+		const firstParagraphBlock = await firstWidgetArea.$(
+			'[data-block][data-type="core/paragraph"][aria-label^="Empty block"]'
+		);
+		await page.keyboard.type( 'First Paragraph' );
+
+		// Trigger the toolbar to appear.
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.up( 'Shift' );
+
+		const blockToolbar = await page.waitForSelector(
+			'[role="toolbar"][aria-label="Block tools"]'
+		);
+		const moreOptionsButton = await blockToolbar.$(
+			'button[aria-label="Options"]'
+		);
+		await moreOptionsButton.click();
+
+		const optionsMenu = await page.waitForSelector(
+			'[role="menu"][aria-label="Options"]'
+		);
+		const [ duplicateButton ] = await optionsMenu.$x(
+			'//*[@role="menuitem"][*[text()="Duplicate"]]'
+		);
+		await duplicateButton.click();
+
+		await page.waitForFunction(
+			( paragraph ) =>
+				paragraph.nextSibling &&
+				paragraph.nextSibling.matches( '[data-block]' ),
+			{},
+			firstParagraphBlock
+		);
+		const duplicatedParagraphBlock = await firstParagraphBlock.evaluateHandle(
+			( paragraph ) => paragraph.nextSibling
+		);
+
+		const firstParagraphBlockClientId = await firstParagraphBlock.evaluate(
+			( node ) => node.dataset.block
+		);
+		const duplicatedParagraphBlockClientId = await duplicatedParagraphBlock.evaluate(
+			( node ) => node.dataset.block
+		);
+
+		expect( firstParagraphBlockClientId ).not.toBe(
+			duplicatedParagraphBlockClientId
+		);
+		expect(
+			await duplicatedParagraphBlock.evaluate(
+				( node ) => node.textContent
+			)
+		).toBe( 'First Paragraph' );
+		expect(
+			await duplicatedParagraphBlock.evaluate(
+				( node ) => node === document.activeElement
+			)
+		).toBe( true );
+
+		await saveWidgets();
+		const serializedWidgetAreas = await getSerializedWidgetAreas();
+		expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
+		Object {
+		  "sidebar-1": "<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		<p>First Paragraph</p>
+		</div></div>
+		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		<p>First Paragraph</p>
+		</div></div>",
+		}
+	` );
+	} );
 } );
 
 async function saveWidgets() {

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -192,12 +192,10 @@ function LegacyWidgetEdit( {
 
 export default withSelect( ( select, { clientId, attributes } ) => {
 	const { widgetClass, referenceWidgetName } = attributes;
-	let widgetId = select( editWidgetsStore ).getWidgetIdForClientId(
-		clientId
-	);
+	let widgetId = attributes.__internal_widget_id;
 	const widget = select( editWidgetsStore ).getWidget( widgetId );
-	const widgetArea = select( editWidgetsStore ).getWidgetAreaForClientId(
-		clientId
+	const widgetArea = select( editWidgetsStore ).getWidgetAreaForWidgetId(
+		widgetId
 	);
 	const editorSettings = select( 'core/block-editor' ).getSettings();
 	const { availableLegacyWidgets } = editorSettings;

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -192,7 +192,7 @@ function LegacyWidgetEdit( {
 
 export default withSelect( ( select, { clientId, attributes } ) => {
 	const { widgetClass, referenceWidgetName } = attributes;
-	let widgetId = attributes.__internal_widget_id;
+	let widgetId = attributes.__internalWidgetId;
 	const widget = select( editWidgetsStore ).getWidget( widgetId );
 	const widgetArea = select( editWidgetsStore ).getWidgetAreaForWidgetId(
 		widgetId

--- a/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
@@ -16,11 +16,6 @@ export default function WidgetAreaInnerBlocks() {
 			onChange={ onChange }
 			templateLock={ false }
 			renderAppender={ InnerBlocks.DefaultBlockAppender }
-			// HACK: The widget editor relies on a mapping of block client IDs
-			// to widget IDs. We therefore instruct `useBlockSync` to not clone
-			// the blocks it receives which would change the block client IDs`.
-			// See https://github.com/WordPress/gutenberg/issues/27173.
-			__unstableCloneValue={ false }
 		/>
 	);
 }

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -11,6 +11,7 @@ import {
 	__experimentalGetCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -21,6 +22,18 @@ import { create as createLegacyWidget } from './blocks/legacy-widget';
 import * as widgetArea from './blocks/widget-area';
 import Layout from './components/layout';
 
+function __experimentalAddWidgetIdAttribute( settings ) {
+	return {
+		...settings,
+		attributes: {
+			...( settings.attributes || {} ),
+			__internal_widget_id: {
+				type: 'string',
+			},
+		},
+	};
+}
+
 /**
  * Initializes the block editor in the widgets screen.
  *
@@ -28,6 +41,12 @@ import Layout from './components/layout';
  * @param {Object} settings Block editor settings.
  */
 export function initialize( id, settings ) {
+	addFilter(
+		'blocks.registerBlockType',
+		'gutenberg/edit-widgets/add-widget-id',
+		__experimentalAddWidgetIdAttribute
+	);
+
 	const coreBlocks = __experimentalGetCoreBlocks().filter(
 		( block ) => ! [ 'core/more' ].includes( block.name )
 	);

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -11,7 +11,6 @@ import {
 	__experimentalGetCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
-import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -22,18 +21,6 @@ import { create as createLegacyWidget } from './blocks/legacy-widget';
 import * as widgetArea from './blocks/widget-area';
 import Layout from './components/layout';
 
-function __experimentalAddWidgetIdAttribute( settings ) {
-	return {
-		...settings,
-		attributes: {
-			...( settings.attributes || {} ),
-			__internal_widget_id: {
-				type: 'string',
-			},
-		},
-	};
-}
-
 /**
  * Initializes the block editor in the widgets screen.
  *
@@ -41,12 +28,6 @@ function __experimentalAddWidgetIdAttribute( settings ) {
  * @param {Object} settings Block editor settings.
  */
 export function initialize( id, settings ) {
-	addFilter(
-		'blocks.registerBlockType',
-		'gutenberg/edit-widgets/add-widget-id',
-		__experimentalAddWidgetIdAttribute
-	);
-
 	const coreBlocks = __experimentalGetCoreBlocks().filter(
 		( block ) => ! [ 'core/more' ].includes( block.name )
 	);

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { invert } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -14,7 +9,7 @@ import { store as interfaceStore } from '@wordpress/interface';
  * Internal dependencies
  */
 import { STATE_SUCCESS } from './batch-processing/constants';
-import { dispatch, select, getWidgetToClientIdMapping } from './controls';
+import { dispatch, select } from './controls';
 import { transformBlockToWidget } from './transformers';
 import {
 	buildWidgetAreaPostId,
@@ -99,8 +94,6 @@ export function* saveWidgetAreas( widgetAreas ) {
 
 export function* saveWidgetArea( widgetAreaId ) {
 	const widgets = yield select( editWidgetsStoreName, 'getWidgets' );
-	const widgetIdToClientId = yield getWidgetToClientIdMapping();
-	const clientIdToWidgetId = invert( widgetIdToClientId );
 
 	const post = yield select(
 		'core',
@@ -128,7 +121,7 @@ export function* saveWidgetArea( widgetAreaId ) {
 	const sidebarWidgetsIds = [];
 	for ( let i = 0; i < widgetsBlocks.length; i++ ) {
 		const block = widgetsBlocks[ i ];
-		const widgetId = clientIdToWidgetId[ block.clientId ];
+		const widgetId = block.attributes.__internal_widget_id;
 		const oldWidget = widgets[ widgetId ];
 		const widget = transformBlockToWidget( block, oldWidget );
 		// We'll replace the null widgetId after save, but we track it here
@@ -222,12 +215,9 @@ export function* saveWidgetArea( widgetAreaId ) {
 	for ( let i = 0; i < batch.sortedItemIds.length; i++ ) {
 		const itemId = batch.sortedItemIds[ i ];
 		const widget = batch.results[ itemId ];
-		const { clientId, position } = batchMeta[ i ];
+		const { position } = batchMeta[ i ];
 		if ( ! sidebarWidgetsIds[ position ] ) {
 			sidebarWidgetsIds[ position ] = widget.id;
-		}
-		if ( clientId !== widgetIdToClientId[ widget.id ] ) {
-			yield setWidgetIdForClientId( clientId, widget.id );
 		}
 	}
 

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -121,7 +121,7 @@ export function* saveWidgetArea( widgetAreaId ) {
 	const sidebarWidgetsIds = [];
 	for ( let i = 0; i < widgetsBlocks.length; i++ ) {
 		const block = widgetsBlocks[ i ];
-		const widgetId = block.attributes.__internal_widget_id;
+		const widgetId = block.attributes.__internalWidgetId;
 		const oldWidget = widgets[ widgetId ];
 		const widget = transformBlockToWidget( block, oldWidget );
 		// We'll replace the null widgetId after save, but we track it here

--- a/packages/edit-widgets/src/store/controls.js
+++ b/packages/edit-widgets/src/store/controls.js
@@ -55,17 +55,6 @@ export function isProcessingPost( postId ) {
 }
 
 /**
- * Selects widgetId -> clientId mapping (necessary for saving widgets).
- *
- * @return {Object} Action.
- */
-export function getWidgetToClientIdMapping() {
-	return {
-		type: 'GET_WIDGET_TO_CLIENT_ID_MAPPING',
-	};
-}
-
-/**
  * Resolves navigation post for given menuId.
  *
  * @see selectors.js
@@ -162,12 +151,6 @@ const controls = {
 	IS_PROCESSING_POST: createRegistryControl(
 		( registry ) => ( { postId } ) => {
 			return getState( registry ).processingQueue[ postId ]?.inProgress;
-		}
-	),
-
-	GET_WIDGET_TO_CLIENT_ID_MAPPING: createRegistryControl(
-		( registry ) => () => {
-			return getState( registry ).mapping || {};
 		}
 	),
 

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -4,31 +4,6 @@
 import { combineReducers } from '@wordpress/data';
 
 /**
- * Internal to edit-widgets package.
- *
- * Stores widgetId -> clientId mapping which is necessary for saving the navigation.
- *
- * @param {Object} state Redux state
- * @param {Object} action Redux action
- * @return {Object} Updated state
- */
-export function mapping( state, action ) {
-	const { type, ...rest } = action;
-	if ( type === 'SET_WIDGET_TO_CLIENT_ID_MAPPING' ) {
-		return rest.mapping;
-	}
-	if ( type === 'SET_WIDGET_ID_FOR_CLIENT_ID' ) {
-		const newMapping = {
-			...state,
-		};
-		newMapping[ action.widgetId ] = action.clientId;
-		return newMapping;
-	}
-
-	return state || {};
-}
-
-/**
  * Controls the open state of the widget areas.
  *
  * @param {Object} state   Redux state
@@ -69,7 +44,6 @@ function isInserterOpened( state = false, action ) {
 }
 
 export default combineReducers( {
-	mapping,
 	isInserterOpened,
 	widgetAreasOpenState,
 } );

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { invert, keyBy } from 'lodash';
+import { keyBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -53,32 +53,16 @@ export const getWidgetAreas = createRegistrySelector( ( select ) => () => {
 	);
 } );
 
-export const getWidgetIdForClientId = ( state, clientId ) => {
-	const widgetIdToClientId = state.mapping;
-	const clientIdToWidgetId = invert( widgetIdToClientId );
-	return clientIdToWidgetId[ clientId ];
-};
-
 /**
- * Returns widgetArea containing a block identify by given clientId
+ * Returns widgetArea containing a block identify by given widgetId
  *
- * @param {string} clientId The ID of the block.
+ * @param {string} widgetId The ID of the widget.
  * @return {Object} Containing widget area.
  */
-export const getWidgetAreaForClientId = createRegistrySelector(
-	( select ) => ( state, clientId ) => {
+export const getWidgetAreaForWidgetId = createRegistrySelector(
+	( select ) => ( state, widgetId ) => {
 		const widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();
-		for ( const widgetArea of widgetAreas ) {
-			const post = select( 'core' ).getEditedEntityRecord(
-				KIND,
-				POST_TYPE,
-				buildWidgetAreaPostId( widgetArea.id )
-			);
-			const clientIds = post.blocks.map( ( block ) => block.clientId );
-			if ( clientIds.includes( clientId ) ) {
-				return widgetArea;
-			}
-		}
+		return widgetAreas.find( ( widgetArea ) => widgetArea.id === widgetId );
 	}
 );
 

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -62,7 +62,17 @@ export const getWidgetAreas = createRegistrySelector( ( select ) => () => {
 export const getWidgetAreaForWidgetId = createRegistrySelector(
 	( select ) => ( state, widgetId ) => {
 		const widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();
-		return widgetAreas.find( ( widgetArea ) => widgetArea.id === widgetId );
+		return widgetAreas.find( ( widgetArea ) => {
+			const post = select( 'core' ).getEditedEntityRecord(
+				KIND,
+				POST_TYPE,
+				buildWidgetAreaPostId( widgetArea.id )
+			);
+			const blockWidgetIds = post.blocks.map(
+				( block ) => block.attributes.__internalWidgetId
+			);
+			return blockWidgetIds.includes( widgetId );
+		} );
 	}
 );
 

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -3,13 +3,26 @@
  */
 import { createBlock, parse, serialize } from '@wordpress/blocks';
 
+function __experimentalAddWidgetIdToBlock( block, widgetId ) {
+	return {
+		...block,
+		attributes: {
+			...( block.attributes || {} ),
+			__internal_widget_id: widgetId,
+		},
+	};
+}
+
 export function transformWidgetToBlock( widget ) {
 	if ( widget.widget_class === 'WP_Widget_Block' ) {
 		const parsedBlocks = parse( widget.settings.content );
 		if ( ! parsedBlocks.length ) {
-			return createBlock( 'core/paragraph', {}, [] );
+			return __experimentalAddWidgetIdToBlock(
+				createBlock( 'core/paragraph', {}, [] ),
+				widget.id
+			);
 		}
-		return parsedBlocks[ 0 ];
+		return __experimentalAddWidgetIdToBlock( parsedBlocks[ 0 ], widget.id );
 	}
 
 	const attributes = {
@@ -27,7 +40,10 @@ export function transformWidgetToBlock( widget ) {
 		attributes.widgetClass = widget.widget_class;
 	}
 
-	return createBlock( 'core/legacy-widget', attributes, [] );
+	return __experimentalAddWidgetIdToBlock(
+		createBlock( 'core/legacy-widget', attributes, [] ),
+		widget.id
+	);
 }
 
 export function transformBlockToWidget( block, relatedWidget = {} ) {

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -8,7 +8,7 @@ function __experimentalAddWidgetIdToBlock( block, widgetId ) {
 		...block,
 		attributes: {
 			...( block.attributes || {} ),
-			__internal_widget_id: widgetId,
+			__internalWidgetId: widgetId,
 		},
 	};
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Mentioned in this [Slack thread](https://wordpress.slack.com/archives/C01D71823PB/p1611122124032500). Basically, this PR tries to fix a saving issue in the widgets screen after merging https://github.com/WordPress/gutenberg/pull/27885#issuecomment-755895566. The recap was well documented in a [Slack thread comment](https://wordpress.slack.com/archives/C01D71823PB/p1611122605034100?thread_ts=1611122124.032500&cid=C01D71823PB).

The solution is to inject `__internalWidgetId` to all blocks in the widgets screen but not in their block types attributes, and modify the `cloneBlock` function to only clone attributes specified inside the block types (following the same logic in `createBlock`).

This PR also partially reverts #28078, specifically the `__unstableCloneValue` hack.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
```sh
npm run test-e2e -- packages/e2e-tests/specs/widgets/adding-widgets.test.js
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
