### PR TITLE
Clear block selection in the navigation editor when clicking editor canvas

### DIFF
--- a/packages/block-editor/src/components/skip-to-selected-block/index.js
+++ b/packages/block-editor/src/components/skip-to-selected-block/index.js
@@ -19,17 +19,15 @@ const SkipToSelectedBlock = ( { selectedBlockClientId } ) => {
 		selectedBlockElement.focus();
 	};
 
-	return (
-		selectedBlockClientId && (
-			<Button
-				isSecondary
-				className="block-editor-skip-to-selected-block"
-				onClick={ onClick }
-			>
-				{ __( 'Skip to the selected block' ) }
-			</Button>
-		)
-	);
+	return selectedBlockClientId ? (
+		<Button
+			isSecondary
+			className="block-editor-skip-to-selected-block"
+			onClick={ onClick }
+		>
+			{ __( 'Skip to the selected block' ) }
+		</Button>
+	) : null;
 };
 
 export default withSelect( ( select ) => {

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -219,4 +219,38 @@ describe( 'Navigation editor', () => {
 
 		expect( await getSerializedBlocks() ).toMatchSnapshot();
 	} );
+
+	it( 'shows a submenu when a link is selected and hides it when clicking the editor to deselect it', async () => {
+		await setUpResponseMocking( [
+			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),
+			...getMenuItemMocks( { GET: menuItemsFixture } ),
+		] );
+		await visitNavigationEditor();
+
+		// Select a link block with nested links in a submenu.
+		const parentLinkXPath =
+			'//li[@aria-label="Block: Link" and contains(.,"WordPress.org")]';
+		const linkBlock = await page.waitForXPath( parentLinkXPath );
+		await linkBlock.click();
+
+		// There should be a submenu link visible.
+		//
+		// Submenus are hidden using `visibility: hidden` and shown using
+		// `visibility: visible` so the visible/hidden options must be used
+		// when selecting the elements.
+		const submenuLinkXPath = `${ parentLinkXPath }//li[@aria-label="Block: Link"]`;
+		const submenuLinkVisible = await page.waitForXPath( submenuLinkXPath, {
+			visible: true,
+		} );
+		expect( submenuLinkVisible ).toBeDefined();
+
+		// Click the editor canvas.
+		await page.click( '.edit-navigation-editor__block-view' );
+
+		// There should be a submenu in the DOM, but it should be hidden.
+		const submenuLinkHidden = await page.waitForXPath( submenuLinkXPath, {
+			hidden: true,
+		} );
+		expect( submenuLinkHidden ).toBeDefined();
+	} );
 } );

--- a/packages/edit-navigation/src/components/editor/block-view.js
+++ b/packages/edit-navigation/src/components/editor/block-view.js
@@ -1,8 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { BlockList, ObserveTyping, WritingFlow } from '@wordpress/block-editor';
+import {
+	BlockList,
+	ObserveTyping,
+	WritingFlow,
+	__unstableUseBlockSelectionClearer,
+} from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
 
 /**
  * The current navigation rendered in the form of a core Navigation block.
@@ -11,8 +17,11 @@ import { Spinner } from '@wordpress/components';
  * @param {boolean} props.isPending Whether the navigation post has loaded.
  */
 export default function BlockView( { isPending } ) {
+	const layoutRef = useRef();
+	__unstableUseBlockSelectionClearer( layoutRef );
+
 	return (
-		<div className="edit-navigation-editor__block-view">
+		<div className="edit-navigation-editor__block-view" ref={ layoutRef }>
 			{ isPending ? (
 				<Spinner />
 			) : (

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -1,5 +1,5 @@
 .edit-navigation-editor {
-	margin: $grid-unit-20;
+	flex-grow: 1;
 
 	@include break-medium() {
 		align-items: flex-start;
@@ -8,7 +8,9 @@
 }
 
 .edit-navigation-editor__block-view {
+	padding: $grid-unit-20;
 	@include break-medium() {
+		height: 100%;
 		flex-grow: 1;
 	}
 
@@ -20,16 +22,12 @@
 
 .edit-navigation-editor__list-view {
 	border-top: 1px solid $gray-300;
-	margin-top: $grid-unit-20;
-	padding-top: $grid-unit-20;
+	padding: $grid-unit-20;
 
 	@include break-medium() {
 		border-left: 1px solid $gray-300;
 		border-top: none;
-		margin-left: $grid-unit-20;
 		margin-top: 0;
-		padding-left: $grid-unit-20;
-		padding-top: 0;
 		width: 300px;
 	}
 

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -10,8 +10,8 @@
 .edit-navigation-editor__block-view {
 	padding: $grid-unit-20;
 	@include break-medium() {
-		height: 100%;
 		flex-grow: 1;
+		align-self: stretch;
 	}
 
 	.components-spinner {

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -7,3 +7,15 @@
 		padding-left: 0;
 	}
 }
+
+.edit-navigation-layout {
+	display: flex;
+	flex-direction: column;
+	// Make the navigation layout full-height, accounting for wp-admin top bar and other furniture.
+	height: calc(100vh - 146px);
+
+	// Wp admin top bar becomes less-chunky, so a smaller subtraction is needed.
+	@include break-medium() {
+		height: calc(100vh - 97px);
+	}
+}

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -6,16 +6,16 @@
 	#wpcontent {
 		padding-left: 0;
 	}
-}
 
-.edit-navigation-layout {
-	display: flex;
-	flex-direction: column;
-	// Make the navigation layout full-height, accounting for wp-admin top bar and other furniture.
-	height: calc(100vh - 146px);
-
-	// Wp admin top bar becomes less-chunky, so a smaller subtraction is needed.
-	@include break-medium() {
-		height: calc(100vh - 97px);
+	#wpwrap,
+	#wpcontent,
+	#wpbody,
+	#wpbody-content,
+	.edit-navigation,
+	.components-drop-zone__provider,
+	.edit-navigation-layout {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #22626

Implements the 'block selection clearing' feature in the Navigation Editor.

What is it? In the post and site editor, when clicking in the empty editor canvas blocks are deselected. This feature wasn't present in the Navigation Editor.

Because block selection determines whether a sub-menu is open, it was a bit hard to close sub-menus in the navigation editor, which this solves.

This has required a bit of CSS wrangling as previously the block editor part of the Navigation Editor had a lot of margin around it, and collapsed to the height of its content leaving no empty clickable area. 

## How has this been tested?
1. Open the navigation editor
2. Make a menu with submenus
3. Click on a block with a submenu to open that submenu
4. Click the editor canvas, observe the menu should close and the block become deselected.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![clear-block-selection](https://user-images.githubusercontent.com/677833/105326402-abfe5e00-5c08-11eb-880d-c3dbc4afa36b.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
