### PR TITLE
Create Block: Extract the package name from the template value

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Extract the package name from the value passed as an external template ([#28383](https://github.com/WordPress/gutenberg/pull/28383)).
+
 ## 2.0.0 (2021-01-21)
 
 ### Breaking Changes

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -5,6 +5,7 @@ const { command } = require( 'execa' );
 const glob = require( 'fast-glob' );
 const { mkdtemp, readFile } = require( 'fs' ).promises;
 const { fromPairs, isObject } = require( 'lodash' );
+const npmPackageArg = require( 'npm-package-arg' );
 const { tmpdir } = require( 'os' );
 const { join } = require( 'path' );
 const rimraf = require( 'rimraf' ).sync;
@@ -153,8 +154,9 @@ const getBlockTemplate = async ( templateName ) => {
 			cwd: tempCwd,
 		} );
 
+		const { name } = npmPackageArg( templateName );
 		return await configToTemplate(
-			require( require.resolve( templateName, {
+			require( require.resolve( name, {
 				paths: [ tempCwd ],
 			} ) )
 		);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

I tried to create a block using a new template using it's development version (`next` dist tag):

```bash
npx @wordpress/create-block --template @wordpress/create-block-tutorial-template@next
```

It wasn't erroring because it wasn't able to resolve the package using `@wordpress/create-block-tutorial-template@next`. This PR parses the string passed and extracts the name of the package.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

npx wp-create-block --template @wordpress/create-block-tutorial-template@next

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
