### PR TITLE
Cover: improve various states.

### DIFF
--- a/packages/block-editor/src/components/block-alignment-matrix-toolbar/index.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-toolbar/index.js
@@ -19,6 +19,7 @@ export function BlockAlignmentMatrixToolbar( props ) {
 		label = __( 'Change matrix alignment' ),
 		onChange = noop,
 		value = 'center',
+		isDisabled,
 	} = props;
 
 	const icon = <AlignmentMatrixControl.Icon value={ value } />;
@@ -50,6 +51,7 @@ export function BlockAlignmentMatrixToolbar( props ) {
 							label={ label }
 							icon={ icon }
 							showTooltip
+							disabled={ isDisabled }
 						/>
 					</ToolbarGroup>
 				);

--- a/packages/block-editor/src/components/block-full-height-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-full-height-alignment-toolbar/index.js
@@ -9,6 +9,7 @@ function BlockFullHeightAlignmentToolbar( {
 	isActive,
 	label = __( 'Toggle full height' ),
 	onToggle,
+	isDisabled,
 } ) {
 	return (
 		<ToolbarGroup>
@@ -17,6 +18,7 @@ function BlockFullHeightAlignmentToolbar( {
 				icon={ fullscreen }
 				label={ label }
 				onClick={ () => onToggle( ! isActive ) }
+				disabled={ isDisabled }
 			/>
 		</ToolbarGroup>
 	);

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -355,31 +355,29 @@ function CoverEdit( {
 	const controls = (
 		<>
 			<BlockControls>
+				<BlockAlignmentMatrixToolbar
+					label={ __( 'Change content position' ) }
+					value={ contentPosition }
+					onChange={ ( nextPosition ) =>
+						setAttributes( {
+							contentPosition: nextPosition,
+						} )
+					}
+					isDisabled={ ! hasBackground }
+				/>
 				<FullHeightAlignment
 					isActive={ isMinFullHeight }
 					onToggle={ toggleMinFullHeight }
+					isDisabled={ ! hasBackground }
 				/>
-				{ hasBackground && (
-					<>
-						<BlockAlignmentMatrixToolbar
-							label={ __( 'Change content position' ) }
-							value={ contentPosition }
-							onChange={ ( nextPosition ) =>
-								setAttributes( {
-									contentPosition: nextPosition,
-								} )
-							}
-						/>
-
-						<MediaReplaceFlow
-							mediaId={ id }
-							mediaURL={ url }
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							accept="image/*,video/*"
-							onSelect={ onSelectMedia }
-						/>
-					</>
-				) }
+				<MediaReplaceFlow
+					mediaId={ id }
+					mediaURL={ url }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					accept="image/*,video/*"
+					onSelect={ onSelectMedia }
+					name={ ! url ? __( 'Add Media' ) : __( 'Replace' ) }
+				/>
 			</BlockControls>
 			<InspectorControls>
 				{ !! url && (
@@ -433,53 +431,49 @@ function CoverEdit( {
 						</PanelRow>
 					</PanelBody>
 				) }
-				{ hasBackground && (
-					<>
-						<PanelBody title={ __( 'Dimensions' ) }>
-							<CoverHeightInput
-								value={ temporaryMinHeight || minHeight }
-								unit={ minHeightUnit }
-								onChange={ ( newMinHeight ) =>
-									setAttributes( { minHeight: newMinHeight } )
-								}
-								onUnitChange={ ( nextUnit ) =>
-									setAttributes( {
-										minHeightUnit: nextUnit,
-									} )
-								}
-							/>
-						</PanelBody>
-						<PanelColorGradientSettings
-							title={ __( 'Overlay' ) }
-							initialOpen={ true }
-							settings={ [
-								{
-									colorValue: overlayColor.color,
-									gradientValue,
-									onColorChange: setOverlayColor,
-									onGradientChange: setGradient,
-									label: __( 'Color' ),
-								},
-							] }
-						>
-							{ !! url && (
-								<RangeControl
-									label={ __( 'Opacity' ) }
-									value={ dimRatio }
-									onChange={ ( newDimRation ) =>
-										setAttributes( {
-											dimRatio: newDimRation,
-										} )
-									}
-									min={ 0 }
-									max={ 100 }
-									step={ 10 }
-									required
-								/>
-							) }
-						</PanelColorGradientSettings>
-					</>
-				) }
+				<PanelBody title={ __( 'Dimensions' ) }>
+					<CoverHeightInput
+						value={ temporaryMinHeight || minHeight }
+						unit={ minHeightUnit }
+						onChange={ ( newMinHeight ) =>
+							setAttributes( { minHeight: newMinHeight } )
+						}
+						onUnitChange={ ( nextUnit ) =>
+							setAttributes( {
+								minHeightUnit: nextUnit,
+							} )
+						}
+					/>
+				</PanelBody>
+				<PanelColorGradientSettings
+					title={ __( 'Overlay' ) }
+					initialOpen={ true }
+					settings={ [
+						{
+							colorValue: overlayColor.color,
+							gradientValue,
+							onColorChange: setOverlayColor,
+							onGradientChange: setGradient,
+							label: __( 'Color' ),
+						},
+					] }
+				>
+					{ !! url && (
+						<RangeControl
+							label={ __( 'Opacity' ) }
+							value={ dimRatio }
+							onChange={ ( newDimRation ) =>
+								setAttributes( {
+									dimRatio: newDimRation,
+								} )
+							}
+							min={ 0 }
+							max={ 100 }
+							step={ 10 }
+							required
+						/>
+					) }
+				</PanelColorGradientSettings>
 			</InspectorControls>
 		</>
 	);


### PR DESCRIPTION
It's confusing that some settings appear and disappear, and it's not clear how to add an image background if a background color is already set because the toolbar says "Replace".

This PR makes the following changes:

- Move "full height" after alignment matrix based on importance.
- Show alignment matrix and full height in the block placeholder but in a disabled state.
- Display replace media flow with "Add Media" text.
- When a background color is set, show "Add Media" instead of "Replace".
- Only show "Replace" when a video or image is set already.

Placeholder state:
![image](https://user-images.githubusercontent.com/548849/105334020-aee05b00-5bd6-11eb-8853-231e92d77170.png)

With background color set:
![image](https://user-images.githubusercontent.com/548849/105334088-c586b200-5bd6-11eb-8a30-0a0f0986fac0.png)

With background media set:
![image](https://user-images.githubusercontent.com/548849/105334146-d59e9180-5bd6-11eb-8482-f42b3aa7d3e5.png)
