### PR TITLE
Fix block inserter automatic reorder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11824,7 +11824,7 @@
 				"react-resize-aware": "^3.0.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.16",
-				"reakit": "^1.3.4",
+				"reakit": "^1.3.5",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^8.3.0"
@@ -12136,7 +12136,6 @@
 				"@wordpress/url": "file:packages/url",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
-				"reakit": "^1.3.4",
 				"rememo": "^3.0.0",
 				"uuid": "^8.3.0"
 			}
@@ -48157,9 +48156,9 @@
 			}
 		},
 		"reakit": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.4.tgz",
-			"integrity": "sha512-aLR0GBOc9vELTk4PKK/zndBbIs4RSw4B7GSGY6yoMHQ/vna0iLNd5BMhjtXspD/B7hhkYERlT6di8pIyD3HSPw==",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.5.tgz",
+			"integrity": "sha512-Luv1RPBFlWhRG32Ysjd86KC+vLoz5da3X0O8rqClaNEv259nWmnw5fG6BIUSYJwTG6PPxTidPlS+9bS6nLstfA==",
 			"requires": {
 				"@popperjs/core": "^2.5.4",
 				"body-scroll-lock": "^3.1.5",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -62,7 +62,7 @@
 		"react-resize-aware": "^3.0.1",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.16",
-		"reakit": "^1.3.4",
+		"reakit": "^1.3.5",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^8.3.0"

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -48,7 +48,6 @@
 		"@wordpress/url": "file:../url",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.19",
-		"reakit": "^1.3.4",
 		"rememo": "^3.0.0",
 		"uuid": "^8.3.0"
 	},


### PR DESCRIPTION
The manual sort of items on the block inserter was removed with #28013 as Reakit was already doing that automatically. But it turns out that this automatic feature didn't work when items were inside a container with `position: fixed`.

This has been fixed on Reakit and this PR upgrades it to the latest version.

## Changelog

### [1.3.5](https://github.com/reakit/reakit/compare/reakit@1.3.4...reakit@1.3.5) (2021-01-21)


#### Bug Fixes

* Fix automatic sort of `Composite` items in fixed containers ([#828](https://github.com/reakit/reakit/issues/828)) ([c2071e5](https://github.com/reakit/reakit/commit/c2071e5c8a2eb3645a935788b1b03931927a750c)), closes [#827](https://github.com/reakit/reakit/issues/827)

## How has this been tested?

This is better seen on #28191 with the `Most used` category activated:

1. Checkout #28191: `git checkout try/separate-block-selection-from-focus`
2. Activate the `Most used` category in `Options > Preferences` (the last button on the top bar).
3. Using the keyboard, keep adding blocks from the `Most used` category until their order changes.
4. Try to navigate through the items using the keyboard and see if the focus order matches the visual order.
5. Merge this PR commit into #28191 (`git merge fix/upgrade-reakit && npm i`) and see if it's working properly.