### PR TITLE
Modal: Fix sticky header when rendering Modal with overflow content

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -122,7 +122,7 @@
 // Modal contents.
 .components-modal__content {
 	box-sizing: border-box;
-	height: 100%;
+	min-height: 100%;
 	padding: 0 $grid-unit-30 $grid-unit-30;
 
 	// Rules inside this query are only run by Microsoft Edge.


### PR DESCRIPTION
This update fixes the "stickiness" of the Modal header when rendering very tall content within the Modal body.
This issue was recently discovered in the [Preferences Modal PR](https://github.com/WordPress/gutenberg/pull/28329#issuecomment-763798698)

The solution involved swapping the CSS rule `height: 100%` to `min-height: 100%`.
This achieves the requirement of forcing the content height of the Modal frame.
However, it also allows for the content height to "grow", providing more space for the "sticky" header.

GIF demo of solution:

![Screen Capture on 2021-01-21 at 08-22-59](https://user-images.githubusercontent.com/2322354/105358219-e396e700-5bc3-11eb-940a-112c2ef8fd46.gif)


## How has this been tested?

Locally on Gutenberg

* npm run dev
* Open the Keyboard Shortcuts modal
* Ensure it still works

Bonus:

Adjust one of the contents of that modal to have a height of `200vh`, making it very tall.

<img width="563" alt="Screen Shot 2021-01-21 at 8 32 07 AM" src="https://user-images.githubusercontent.com/2322354/105358150-c7934580-5bc3-11eb-9d37-dba1c6658988.png">

Ensure the sticky header still works.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
