### PR TITLE
Preformatted block: Add color controls.

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -346,7 +346,6 @@ These are the current color properties supported by blocks:
 | Post Hierarchical Terms | Yes | Yes | Yes | Yes |
 | Post Tags | Yes | Yes | Yes | Yes |
 | Post Title | Yes | Yes | - | Yes |
-| Preformatted | Yes | Yes | - | Yes |
 | Site Tagline | Yes | Yes | - | Yes |
 | Site Title | Yes | Yes | - | Yes |
 | Social Links | Yes | - | - | Yes |

--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -346,6 +346,7 @@ These are the current color properties supported by blocks:
 | Post Hierarchical Terms | Yes | Yes | Yes | Yes |
 | Post Tags | Yes | Yes | Yes | Yes |
 | Post Title | Yes | Yes | - | Yes |
+| Preformatted | Yes | Yes | - | Yes |
 | Site Tagline | Yes | Yes | - | Yes |
 | Site Title | Yes | Yes | - | Yes |
 | Social Links | Yes | - | - | Yes |

--- a/packages/block-library/src/preformatted/block.json
+++ b/packages/block-library/src/preformatted/block.json
@@ -13,6 +13,9 @@
 	},
 	"supports": {
 		"anchor": true,
+		"color": {
+			"gradients": true
+		},
 		"fontSize": true
 	},
 	"style": "wp-block-preformatted"

--- a/packages/block-library/src/preformatted/style.scss
+++ b/packages/block-library/src/preformatted/style.scss
@@ -1,3 +1,7 @@
 .wp-block-preformatted {
 	white-space: pre-wrap;
 }
+
+.wp-block-preformatted.has-background {
+	padding: $block-bg-padding--v $block-bg-padding--h;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add color controls for the preformatted block. When the block is using background, I'm adding some padding. Fixes https://github.com/WordPress/gutenberg/issues/28098

## How has this been tested?
Tested using the block and changing colors while using twentytwentyone. 

## Screenshots <!-- if applicable -->

<img src="https://cldup.com/WCvfp-Jwgd.png" />

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature (non-breaking change which adds functionality).

## Checklist:
- [ ] My code is tested.
- [ x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
