### PR TITLE
Make sure toggleProps doesn't replace important props on ToolbarGroup

### DIFF
--- a/packages/components/src/toolbar-group/toolbar-group-collapsed.js
+++ b/packages/components/src/toolbar-group/toolbar-group-collapsed.js
@@ -20,7 +20,6 @@ function ToolbarGroupCollapsed( { controls = [], toggleProps, ...props } ) {
 			controls={ controls }
 			toggleProps={ {
 				...internalToggleProps,
-				...toggleProps,
 				'data-toolbar-item': true,
 			} }
 			{ ...props }
@@ -28,10 +27,12 @@ function ToolbarGroupCollapsed( { controls = [], toggleProps, ...props } ) {
 	);
 
 	if ( accessibleToolbarState ) {
-		return <ToolbarItem>{ renderDropdownMenu }</ToolbarItem>;
+		return (
+			<ToolbarItem { ...toggleProps }>{ renderDropdownMenu }</ToolbarItem>
+		);
 	}
 
-	return renderDropdownMenu();
+	return renderDropdownMenu( toggleProps );
 }
 
 export default ToolbarGroupCollapsed;


### PR DESCRIPTION
This PR is a follow-up to #26135.

When we do this:

```jsx
<ToolbarItem>{ renderDropdownMenu }</ToolbarItem>
```

`renderDropdownMenu` will receive `internalToggleProps` from `ToolbarItem` so the toggle button can work as a roving tabindex item. The way it's done today — by merging the incoming `toggleProps` with `internalToggleProps` using object spread — might result in `toggleProps` replacing important props passed by `ToolbarItem`, like event handlers etc.

Instead, we can just pass `toggleProps` to `ToolbarItem`, which will already handle those cases, by merging event handlers and other props properly.

This PR is not fixing any existing issues, but preventing them from happening in the future.

cc/ @tellthemachines Could you please check if your changes on #26135 still work with this PR?