### PR TITLE
Fix NaN bounds in FocalPointPicker

### DIFF
--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -60,13 +60,6 @@ URL of the image or video to be displayed
 
 Autoplays HTML5 video. This only applies to video sources (`url`).
 
-### `dimensions`
-
--   Type: `Object`
--   Required: Yes
-
-An object describing the height and width of the image. Requires two parameters: `height`, `width`.
-
 ### `value`
 
 -   Type: `Object`

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -85,7 +85,8 @@ export class FocalPointPicker extends Component {
 	calculateBounds() {
 		const bounds = INITIAL_BOUNDS;
 
-		if ( ! this.mediaRef.current ) {
+		// Returns early if the ref isn't available or has no size
+		if ( ! this.mediaRef.current?.clientWidth ) {
 			return bounds;
 		}
 


### PR DESCRIPTION
Two small changes here.

The main one is to address an issue (I've not seen reported) in which the focal point picker component causes a console error and ceases to allow adjustment in the horizontal axis. Perhaps this is an issue that may not occur on some setups but happens every time (EDIT: in Chrome) on my modestly powered laptop which is the only device I've tested on for now. 

UPDATE: I've tested in Firefox and didn't reproduce (but didn't try very hard). It is possible according to this comment https://github.com/WordPress/gutenberg/pull/28406#issuecomment-764957558. UPDATE № 2: I tested in Safari and found that I couldn't reproduce unless the console was opened 🙈 

The second change is an unrelated minor documentation update. When searching for issues with this component I saw #16056 and figured it wouldn't hurt to address that too.

## How has this been tested?
In a post with Cover or Media & Text blocks. Selecting such blocks and verifying there are no errors in the console. Using the Focal point picker and verifying that it works in both vertical and horizontal axes.

## Screenshots
Before, with error and broken x-axis:

https://user-images.githubusercontent.com/9000376/105410183-6c267f00-5be6-11eb-970c-49ae4ae0c9ea.mp4

After, resolved:

https://user-images.githubusercontent.com/9000376/105410359-ae4fc080-5be6-11eb-974a-bd8cf78745b2.mp4

## Types of changes
Bug fix #28487
Documentation fix: #16056

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
