### PR TITLE
Site Editor: make `postId=1&postType=page` URLs work on reload

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -19,8 +19,41 @@ function gutenberg_add_template_loader_filters() {
 		}
 		add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
 	}
+
+	// for admin.php?p=1&_wp-find-template=true requests
+	add_action( 'load-admin.php', 'gutenberg_find_template_by_id' );
 }
 add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
+
+/**
+ * This is bad and gross and it works.
+ * See https://github.com/WordPress/gutenberg/issues/28315
+ *
+ * @return void
+ */
+function gutenberg_find_template_by_id() {
+	if ( ! ( isset( $_GET['p'] ) && isset( $_GET['_wp-find-template'] ) ) ) {
+		return;
+	}
+	$post_id = absint( $_GET['p'] );
+	$post = get_post( $post_id );
+	if ( ! $post ) {
+		return wp_send_json_error( array( 'message' => __( 'No matching template found.', 'gutenberg' ) ) );;
+	}
+
+	$type = $post->post_type;
+	$slug = $post->post_name;
+	$id = $post->ID;
+
+	// this is just a hacky replication of get_page_templates()
+	$templates = array(
+		sprintf( '%s-%s.php', $type, $slug ),
+		sprintf( '%s-%d.php', $type, $id ),
+		sprintf( '%s.php', $type )
+	);
+
+	gutenberg_override_query_template( '', $type, $templates );
+}
 
 /**
  * Get the template hierarchy for a given template type.

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -20,7 +20,7 @@ function gutenberg_add_template_loader_filters() {
 		add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
 	}
 
-	// for admin.php?p=1&_wp-find-template=true requests
+	// For admin.php?p=1&_wp-find-template=true requests.
 	add_action( 'load-admin.php', 'gutenberg_find_template_by_id' );
 }
 add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
@@ -36,20 +36,20 @@ function gutenberg_find_template_by_id() {
 		return;
 	}
 	$post_id = absint( $_GET['p'] );
-	$post = get_post( $post_id );
+	$post    = get_post( $post_id );
 	if ( ! $post ) {
-		return wp_send_json_error( array( 'message' => __( 'No matching template found.', 'gutenberg' ) ) );;
+		return wp_send_json_error( array( 'message' => __( 'No matching template found.', 'gutenberg' ) ) );
 	}
 
 	$type = $post->post_type;
 	$slug = $post->post_name;
-	$id = $post->ID;
+	$id   = $post->ID;
 
-	// this is just a hacky replication of get_page_templates()
+	// this is just a hacky replication of `get_page_templates()`.
 	$templates = array(
 		sprintf( '%s-%s.php', $type, $slug ),
 		sprintf( '%s-%d.php', $type, $id ),
-		sprintf( '%s.php', $type )
+		sprintf( '%s.php', $type ),
 	);
 
 	gutenberg_override_query_template( '', $type, $templates );


### PR DESCRIPTION
## Description

When editing a page in the Site Editor, the URL structure changes to `postId=1&postType=page`. Refreshing at that URL would throw an error because loading the template happens normally by simply appending `?_wp-find_template` to the fully qualified URL of the page itself, making use of template loader filters.

But the editor doesn't know this when it loads and instead tries to simply append `?_wp-find_template` to the postID, leading to a request to `wp-admin/admin.php?p=1&_wp-find-template=true` that returned an empty response with a HTTP 200 code, leading to an error when trying to `JSON.parse( '' )`.

I made those requests work, even if they maybe aren't the requests we should be making. This was the quickest way to get this working, but we should probably migrate all of this logic to the REST API, as indicated in several code comments.

Fixes #28315 

## How has this been tested?
1. Open site editor
2. Open navigation panel
3. Navigate to "Pages"
4. Open any page you have
5. Press refresh

The same page that had been loaded before, should be loaded properly upon refresh, rather than the gray screen as shown in #28315 

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
