### PR TITLE
Add an 'area' term for Template Parts.

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -104,6 +104,7 @@ class WP_Theme_JSON {
 	 */
 	const SCHEMA = array(
 		'customTemplates' => null,
+		'templateParts'   => null,
 		'styles'          => array(
 			'border'     => array(
 				'radius' => null,
@@ -1062,6 +1063,18 @@ class WP_Theme_JSON {
 		} else {
 			return $this->theme_json['customTemplates'];
 		}
+	}
+
+	/**
+	 * Returns the template part data of current theme.
+	 *
+	 * @return array
+	 */
+	public function get_template_part_data() {
+		if ( ! isset( $this->theme_json['templateParts'] ) ) {
+			return array();
+		}
+		return $this->theme_json['templateParts'];
 	}
 
 	/**

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1070,7 +1070,7 @@ class WP_Theme_JSON {
 	 *
 	 * @return array
 	 */
-	public function get_template_part_data() {
+	public function get_template_parts() {
 		if ( ! isset( $this->theme_json['templateParts'] ) ) {
 			return array();
 		}

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -177,8 +177,8 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 			$theme_json,
 			true
 		);
-		if ( isset( $data['template-parts'][ $template_file['slug'] ]['type'] ) ) {
-			$template->template_part_type = $data['template-parts'][ $template_file['slug'] ]['type'];
+		if ( isset( $data['template-parts'][ $template_file['slug'] ]['section'] ) ) {
+			$template->section = $data['template-parts'][ $template_file['slug'] ]['section'];
 		}
 	}
 
@@ -218,9 +218,9 @@ function _gutenberg_build_template_result_from_post( $post ) {
 	$template->status      = $post->post_status;
 
 	if ( 'wp_template_part' === $post->post_type ) {
-		$type_terms                   = get_the_terms( $post, 'template_part_type' );
-		$template_part_type           = $type_terms[0]->name;
-		$template->template_part_type = $template_part_type;
+		$type_terms        = get_the_terms( $post, 'section' );
+		$section           = $type_terms[0]->name;
+		$template->section = $section;
 	}
 
 	return $template;

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -125,7 +125,8 @@ function _gutenberg_add_template_part_section_info( $template_info ) {
 			$theme_json,
 			true
 		);
-		if ( isset( $data['template-parts'][ $template_info['slug'] ]['section'] ) ) {
+		if ( isset( $data['template-parts'][ $template_info['slug'] ]['section'] ) && in_array( $data['template-parts'][ $template_info['slug'] ]['section'], gutenberg_get_allowed_template_part_section_types(), true ) ) {
+
 			$template_info['section'] = $data['template-parts'][ $template_info['slug'] ]['section'];
 		}
 	}

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -140,9 +140,8 @@ function _gutenberg_get_template_files( $template_type ) {
  * @return array Template part data from theme.json or empty array if not found.
  */
 function _gutenberg_get_template_part_info_from_theme_json() {
-	if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
-		$resolver           = new WP_Theme_JSON_Resolver();
-		$template_part_data = $resolver->get_theme_origin()->get_template_part_data();
+	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+		$template_part_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_part_data();
 		return $template_part_data;
 	}
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -47,10 +47,6 @@ function _gutenberg_get_template_file( $template_type, $slug ) {
 		get_template()   => get_template_directory(),
 	);
 
-	if ( 'wp_template_part' === $template_type ) {
-		$template_part_data = _gutenberg_get_template_part_info_from_theme_json();
-	}
-
 	foreach ( $themes as $theme_slug => $theme_dir ) {
 		$file_path = $theme_dir . '/' . $template_base_paths[ $template_type ] . '/' . $slug . '.html';
 		if ( file_exists( $file_path ) ) {
@@ -63,10 +59,7 @@ function _gutenberg_get_template_file( $template_type, $slug ) {
 			);
 
 			if ( 'wp_template_part' === $template_type ) {
-				return _gutenberg_add_template_part_section_info(
-					$new_template_item,
-					$template_part_data
-				);
+				return _gutenberg_add_template_part_section_info( $new_template_item );
 			}
 			return $new_template_item;
 		}
@@ -97,10 +90,6 @@ function _gutenberg_get_template_files( $template_type ) {
 
 	$template_files = array();
 
-	if ( 'wp_template_part' === $template_type ) {
-		$template_part_data = _gutenberg_get_template_part_info_from_theme_json();
-	}
-
 	foreach ( $themes as $theme_slug => $theme_dir ) {
 		$theme_template_files = _gutenberg_get_template_paths( $theme_dir . '/' . $template_base_paths[ $template_type ] );
 		foreach ( $theme_template_files as $template_file ) {
@@ -121,10 +110,7 @@ function _gutenberg_get_template_files( $template_type ) {
 			);
 
 			if ( 'wp_template_part' === $template_type ) {
-				$template_files[] = _gutenberg_add_template_part_section_info(
-					$new_template_item,
-					$template_part_data
-				);
+				$template_files[] = _gutenberg_add_template_part_section_info( $new_template_item );
 			} else {
 				$template_files[] = $new_template_item;
 			}
@@ -135,30 +121,21 @@ function _gutenberg_get_template_files( $template_type ) {
 }
 
 /**
- * Attempts to get template parts data from theme.json.
- *
- * @return array Template part data from theme.json or empty array if not found.
- */
-function _gutenberg_get_template_part_info_from_theme_json() {
-	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
-		$template_part_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_part_data();
-		return $template_part_data;
-	}
-
-	return array();
-}
-
-/**
  * Attempts to add the template part's section information to the input template.
  *
  * @param array $template_info Template to add information to (requires 'type' and 'slug' fields).
- * @param array $theme_data Template part information from theme.json.
  *
  * @return array Template.
  */
-function _gutenberg_add_template_part_section_info( $template_info, $theme_data ) {
+function _gutenberg_add_template_part_section_info( $template_info ) {
+	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+		$theme_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_part_data();
+	}
+
 	if ( isset( $theme_data[ $template_info['slug'] ]['section'] ) ) {
 		$template_info['section'] = gutenberg_filter_template_part_section_type( $theme_data[ $template_info['slug'] ]['section'] );
+	} else {
+		$template_info['section'] = WP_TEMPLATE_SECTION_UNCATEGORIZED;
 	}
 
 	return $template_info;

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -135,22 +135,16 @@ function _gutenberg_get_template_files( $template_type ) {
 }
 
 /**
- * Attempts to read the theme.json and return the 'template-parts' field.
+ * Attempts to get template parts data from theme.json.
  *
  * @return array Template part data from theme.json or empty array if not found.
  */
 function _gutenberg_get_template_part_info_from_theme_json() {
-	if ( is_readable( locate_template( 'experimental-theme.json' ) ) ) {
-		$theme_json = file_get_contents( locate_template( 'experimental-theme.json' ) );
-		$data       = json_decode(
-			$theme_json,
-			true
-		);
+	if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
+		$resolver           = new WP_Theme_JSON_Resolver();
+		$template_part_data = $resolver->get_theme_origin()->get_template_part_data();
+		return $template_part_data;
 	}
-	if ( isset( $data['template-parts'] ) ) {
-		return $data['template-parts'];
-	}
-
 	return array();
 }
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -145,6 +145,7 @@ function _gutenberg_get_template_part_info_from_theme_json() {
 		$template_part_data = $resolver->get_theme_origin()->get_template_part_data();
 		return $template_part_data;
 	}
+
 	return array();
 }
 
@@ -160,6 +161,7 @@ function _gutenberg_add_template_part_section_info( $template_info, $theme_data 
 	if ( isset( $theme_data[ $template_info['slug'] ]['section'] ) ) {
 		$template_info['section'] = gutenberg_filter_template_part_section_type( $theme_data[ $template_info['slug'] ]['section'] );
 	}
+
 	return $template_info;
 }
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -171,6 +171,17 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 		$template->title       = $default_template_types[ $template_file['slug'] ]['title'];
 	}
 
+	if ( 'wp_template_part' === $template_type && is_readable( locate_template( 'experimental-theme.json' ) ) ) {
+		$theme_json = file_get_contents( locate_template( 'experimental-theme.json' ) );
+		$data       = json_decode(
+			$theme_json,
+			true
+		);
+		if ( isset( $data['template-parts'][ $template_file['slug'] ]['type'] ) ) {
+			$template->template_part_type = $data['template-parts'][ $template_file['slug'] ]['type'];
+		}
+	}
+
 	return $template;
 }
 
@@ -182,7 +193,8 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
  * @return WP_Block_Template|WP_Error Template.
  */
 function _gutenberg_build_template_result_from_post( $post ) {
-	$terms = get_the_terms( $post, 'wp_theme' );
+	$terms      = get_the_terms( $post, 'wp_theme' );
+	$type_terms = get_the_terms( $post, 'template_part_type' );
 
 	if ( is_wp_error( $terms ) ) {
 		return $terms;
@@ -192,19 +204,21 @@ function _gutenberg_build_template_result_from_post( $post ) {
 		return new WP_Error( 'template_missing_theme', __( 'No theme is defined for this template.', 'gutenberg' ) );
 	}
 
-	$theme = $terms[0]->name;
+	$theme              = $terms[0]->name;
+	$template_part_type = $type_terms[0]->name;
 
-	$template              = new WP_Block_Template();
-	$template->wp_id       = $post->ID;
-	$template->id          = $theme . '//' . $post->post_name;
-	$template->theme       = $theme;
-	$template->content     = $post->post_content;
-	$template->slug        = $post->post_name;
-	$template->is_custom   = true;
-	$template->type        = $post->post_type;
-	$template->description = $post->post_excerpt;
-	$template->title       = $post->post_title;
-	$template->status      = $post->post_status;
+	$template                     = new WP_Block_Template();
+	$template->wp_id              = $post->ID;
+	$template->id                 = $theme . '//' . $post->post_name;
+	$template->theme              = $theme;
+	$template->content            = $post->post_content;
+	$template->slug               = $post->post_name;
+	$template->is_custom          = true;
+	$template->type               = $post->post_type;
+	$template->description        = $post->post_excerpt;
+	$template->title              = $post->post_title;
+	$template->status             = $post->post_status;
+	$template->template_part_type = $template_part_type;
 
 	return $template;
 }

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -124,8 +124,8 @@ function _gutenberg_add_template_part_section_info( $template_info ) {
 			$theme_json,
 			true
 		);
-		if ( isset( $data['template-parts'][ $template_info['slug'] ]['section'] ) && in_array( $data['template-parts'][ $template_info['slug'] ]['section'], gutenberg_get_allowed_template_part_section_types(), true ) ) {
-			$template_info['section'] = $data['template-parts'][ $template_info['slug'] ]['section'];
+		if ( isset( $data['template-parts'][ $template_info['slug'] ]['section'] ) ) {
+			$template_info['section'] = gutenberg_filter_template_part_section_type( $data['template-parts'][ $template_info['slug'] ]['section'] );
 		}
 	}
 	return $template_info;

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -95,7 +95,6 @@ function _gutenberg_get_template_files( $template_type ) {
 				// Subtract ending '.html'.
 				-5
 			);
-
 			$template_files[] = _gutenberg_add_template_part_section_info(
 				array(
 					'slug'  => $template_slug,
@@ -126,7 +125,6 @@ function _gutenberg_add_template_part_section_info( $template_info ) {
 			true
 		);
 		if ( isset( $data['template-parts'][ $template_info['slug'] ]['section'] ) && in_array( $data['template-parts'][ $template_info['slug'] ]['section'], gutenberg_get_allowed_template_part_section_types(), true ) ) {
-
 			$template_info['section'] = $data['template-parts'][ $template_info['slug'] ]['section'];
 		}
 	}

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -49,7 +49,7 @@ function _gutenberg_get_template_file( $template_type, $slug ) {
 	foreach ( $themes as $theme_slug => $theme_dir ) {
 		$file_path = $theme_dir . '/' . $template_base_paths[ $template_type ] . '/' . $slug . '.html';
 		if ( file_exists( $file_path ) ) {
-			return _gutenberg_add_template_part_section_info(
+			return _gutenberg_conditionally_add_template_part_section_info(
 				array(
 					'slug'  => $slug,
 					'path'  => $file_path,
@@ -95,7 +95,7 @@ function _gutenberg_get_template_files( $template_type ) {
 				// Subtract ending '.html'.
 				-5
 			);
-			$template_files[] = _gutenberg_add_template_part_section_info(
+			$template_files[] = _gutenberg_conditionally_add_template_part_section_info(
 				array(
 					'slug'  => $template_slug,
 					'path'  => $template_file,
@@ -117,7 +117,7 @@ function _gutenberg_get_template_files( $template_type ) {
  *
  * @return array Template.
  */
-function _gutenberg_add_template_part_section_info( $template_info ) {
+function _gutenberg_conditionally_add_template_part_section_info( $template_info ) {
 	if ( 'wp_template_part' === $template_info['type'] && is_readable( locate_template( 'experimental-theme.json' ) ) ) {
 		$theme_json = file_get_contents( locate_template( 'experimental-theme.json' ) );
 		$data       = json_decode(

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -46,11 +46,9 @@ function _gutenberg_get_template_file( $template_type, $slug ) {
 		get_stylesheet() => get_stylesheet_directory(),
 		get_template()   => get_template_directory(),
 	);
-
 	foreach ( $themes as $theme_slug => $theme_dir ) {
 		$file_path = $theme_dir . '/' . $template_base_paths[ $template_type ] . '/' . $slug . '.html';
 		if ( file_exists( $file_path ) ) {
-
 			$new_template_item = array(
 				'slug'  => $slug,
 				'path'  => $file_path,
@@ -89,7 +87,6 @@ function _gutenberg_get_template_files( $template_type ) {
 	);
 
 	$template_files = array();
-
 	foreach ( $themes as $theme_slug => $theme_dir ) {
 		$theme_template_files = _gutenberg_get_template_paths( $theme_dir . '/' . $template_base_paths[ $template_type ] );
 		foreach ( $theme_template_files as $template_file ) {
@@ -101,7 +98,6 @@ function _gutenberg_get_template_files( $template_type ) {
 				// Subtract ending '.html'.
 				-5
 			);
-
 			$new_template_item = array(
 				'slug'  => $template_slug,
 				'path'  => $template_file,

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -123,7 +123,8 @@ function _gutenberg_get_template_files( $template_type ) {
 
 			if ( 'wp_template_part' === $template_type ) {
 				$template_files[] = _gutenberg_conditionally_add_template_part_section_info(
-					$new_template_item, $template_part_data
+					$new_template_item,
+					$template_part_data
 				);
 			} else {
 				$template_files[] = $new_template_item;
@@ -140,9 +141,9 @@ function _gutenberg_get_template_files( $template_type ) {
  * @return array Template part data from theme.json or empty array if not found.
  */
 function _gutenberg_get_template_part_info_from_theme_json() {
-	if( is_readable( locate_template( 'experimental-theme.json' ) ) ){
+	if ( is_readable( locate_template( 'experimental-theme.json' ) ) ) {
 		$theme_json = file_get_contents( locate_template( 'experimental-theme.json' ) );
-		$data = json_decode(
+		$data       = json_decode(
 			$theme_json,
 			true
 		);
@@ -274,7 +275,7 @@ function _gutenberg_build_template_result_from_post( $post ) {
 	$template->status      = $post->post_status;
 
 	if ( 'wp_template_part' === $post->post_type ) {
-		$type_terms        = get_the_terms( $post, 'section' );
+		$type_terms        = get_the_terms( $post, 'wp_template_section' );
 		$section           = $type_terms[0]->name;
 		$template->section = $section;
 	}
@@ -312,7 +313,7 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 
 	if ( 'wp_template_part' === $template_type && isset( $query['section'] ) ) {
 		$wp_query_args['tax_query'][]           = array(
-			'taxonomy' => 'section',
+			'taxonomy' => 'wp_template_section',
 			'field'    => 'name',
 			'terms'    => $query['section'],
 		);

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -343,15 +343,16 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 	if ( ! isset( $query['wp_id'] ) ) {
 		$template_files = _gutenberg_get_template_files( $template_type );
 		foreach ( $template_files as $template_file ) {
-			$is_custom      = array_search(
+			$is_not_custom      = false === array_search(
 				wp_get_theme()->get_stylesheet() . '//' . $template_file['slug'],
 				array_column( $query_result, 'id' ),
 				true
 			);
-			$should_include = false === $is_custom && (
-				! isset( $query['slug__in'] ) || in_array( $template_file['slug'], $query['slug__in'], true ) ) && (
-					! isset( $query['section'] ) || $template_file['section'] === $query['section']
-				);
+			$fits_slug_query    =
+				! isset( $query['slug__in'] ) || in_array( $template_file['slug'], $query['slug__in'], true );
+			$fits_section_query =
+				! isset( $query['section'] ) || $template_file['section'] === $query['section'];
+			$should_include     = $is_not_custom && $fits_slug_query && $fits_section_query;
 			if ( $should_include ) {
 				$query_result[] = _gutenberg_build_template_result_from_file( $template_file, $template_type );
 			}

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -193,8 +193,7 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
  * @return WP_Block_Template|WP_Error Template.
  */
 function _gutenberg_build_template_result_from_post( $post ) {
-	$terms      = get_the_terms( $post, 'wp_theme' );
-	$type_terms = get_the_terms( $post, 'template_part_type' );
+	$terms = get_the_terms( $post, 'wp_theme' );
 
 	if ( is_wp_error( $terms ) ) {
 		return $terms;
@@ -204,21 +203,25 @@ function _gutenberg_build_template_result_from_post( $post ) {
 		return new WP_Error( 'template_missing_theme', __( 'No theme is defined for this template.', 'gutenberg' ) );
 	}
 
-	$theme              = $terms[0]->name;
-	$template_part_type = $type_terms[0]->name;
+	$theme = $terms[0]->name;
 
-	$template                     = new WP_Block_Template();
-	$template->wp_id              = $post->ID;
-	$template->id                 = $theme . '//' . $post->post_name;
-	$template->theme              = $theme;
-	$template->content            = $post->post_content;
-	$template->slug               = $post->post_name;
-	$template->is_custom          = true;
-	$template->type               = $post->post_type;
-	$template->description        = $post->post_excerpt;
-	$template->title              = $post->post_title;
-	$template->status             = $post->post_status;
-	$template->template_part_type = $template_part_type;
+	$template              = new WP_Block_Template();
+	$template->wp_id       = $post->ID;
+	$template->id          = $theme . '//' . $post->post_name;
+	$template->theme       = $theme;
+	$template->content     = $post->post_content;
+	$template->slug        = $post->post_name;
+	$template->is_custom   = true;
+	$template->type        = $post->post_type;
+	$template->description = $post->post_excerpt;
+	$template->title       = $post->post_title;
+	$template->status      = $post->post_status;
+
+	if ( 'wp_template_part' === $post->post_type ) {
+		$type_terms                   = get_the_terms( $post, 'template_part_type' );
+		$template_part_type           = $type_terms[0]->name;
+		$template->template_part_type = $template_part_type;
+	}
 
 	return $template;
 }

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -67,9 +67,8 @@ function _gutenberg_get_template_file( $template_type, $slug ) {
 					$new_template_item,
 					$template_part_data
 				);
-			} else {
-				return $new_template_item;
 			}
+			return $new_template_item;
 		}
 	}
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -63,7 +63,7 @@ function _gutenberg_get_template_file( $template_type, $slug ) {
 			);
 
 			if ( 'wp_template_part' === $template_type ) {
-				return _gutenberg_conditionally_add_template_part_section_info(
+				return _gutenberg_add_template_part_section_info(
 					$new_template_item,
 					$template_part_data
 				);
@@ -121,7 +121,7 @@ function _gutenberg_get_template_files( $template_type ) {
 			);
 
 			if ( 'wp_template_part' === $template_type ) {
-				$template_files[] = _gutenberg_conditionally_add_template_part_section_info(
+				$template_files[] = _gutenberg_add_template_part_section_info(
 					$new_template_item,
 					$template_part_data
 				);
@@ -150,6 +150,7 @@ function _gutenberg_get_template_part_info_from_theme_json() {
 	if ( isset( $data['template-parts'] ) ) {
 		return $data['template-parts'];
 	}
+
 	return array();
 }
 
@@ -161,7 +162,7 @@ function _gutenberg_get_template_part_info_from_theme_json() {
  *
  * @return array Template.
  */
-function _gutenberg_conditionally_add_template_part_section_info( $template_info, $theme_data ) {
+function _gutenberg_add_template_part_section_info( $template_info, $theme_data ) {
 	if ( isset( $theme_data[ $template_info['slug'] ]['section'] ) ) {
 		$template_info['section'] = gutenberg_filter_template_part_section_type( $theme_data[ $template_info['slug'] ]['section'] );
 	}
@@ -274,9 +275,10 @@ function _gutenberg_build_template_result_from_post( $post ) {
 	$template->status      = $post->post_status;
 
 	if ( 'wp_template_part' === $post->post_type ) {
-		$type_terms        = get_the_terms( $post, 'wp_template_section' );
-		$section           = $type_terms[0]->name;
-		$template->section = $section;
+		$type_terms = get_the_terms( $post, 'wp_template_section' );
+		if ( ! is_wp_error( $type_terms ) && false !== $type_terms ) {
+			$template->section = $type_terms[0]->name;
+		}
 	}
 
 	return $template;

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -57,7 +57,7 @@ function _gutenberg_get_template_file( $template_type, $slug ) {
 			);
 
 			if ( 'wp_template_part' === $template_type ) {
-				return _gutenberg_add_template_part_section_info( $new_template_item );
+				return _gutenberg_add_template_part_area_info( $new_template_item );
 			}
 			return $new_template_item;
 		}
@@ -106,7 +106,7 @@ function _gutenberg_get_template_files( $template_type ) {
 			);
 
 			if ( 'wp_template_part' === $template_type ) {
-				$template_files[] = _gutenberg_add_template_part_section_info( $new_template_item );
+				$template_files[] = _gutenberg_add_template_part_area_info( $new_template_item );
 			} else {
 				$template_files[] = $new_template_item;
 			}
@@ -117,21 +117,21 @@ function _gutenberg_get_template_files( $template_type ) {
 }
 
 /**
- * Attempts to add the template part's section information to the input template.
+ * Attempts to add the template part's area information to the input template.
  *
  * @param array $template_info Template to add information to (requires 'type' and 'slug' fields).
  *
  * @return array Template.
  */
-function _gutenberg_add_template_part_section_info( $template_info ) {
+function _gutenberg_add_template_part_area_info( $template_info ) {
 	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
 		$theme_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_parts();
 	}
 
-	if ( isset( $theme_data[ $template_info['slug'] ]['section'] ) ) {
-		$template_info['section'] = gutenberg_filter_template_part_section_type( $theme_data[ $template_info['slug'] ]['section'] );
+	if ( isset( $theme_data[ $template_info['slug'] ]['area'] ) ) {
+		$template_info['area'] = gutenberg_filter_template_part_area_type( $theme_data[ $template_info['slug'] ]['area'] );
 	} else {
-		$template_info['section'] = WP_TEMPLATE_SECTION_UNCATEGORIZED;
+		$template_info['area'] = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 	}
 
 	return $template_info;
@@ -203,8 +203,8 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 		$template->title       = $default_template_types[ $template_file['slug'] ]['title'];
 	}
 
-	if ( 'wp_template_part' === $template_type && isset( $template_file['section'] ) ) {
-		$template->section = $template_file['section'];
+	if ( 'wp_template_part' === $template_type && isset( $template_file['area'] ) ) {
+		$template->area = $template_file['area'];
 	}
 
 	return $template;
@@ -243,9 +243,9 @@ function _gutenberg_build_template_result_from_post( $post ) {
 	$template->status      = $post->post_status;
 
 	if ( 'wp_template_part' === $post->post_type ) {
-		$type_terms = get_the_terms( $post, 'wp_template_section' );
+		$type_terms = get_the_terms( $post, 'wp_template_part_area' );
 		if ( ! is_wp_error( $type_terms ) && false !== $type_terms ) {
-			$template->section = $type_terms[0]->name;
+			$template->area = $type_terms[0]->name;
 		}
 	}
 
@@ -280,11 +280,11 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 		),
 	);
 
-	if ( 'wp_template_part' === $template_type && isset( $query['section'] ) ) {
+	if ( 'wp_template_part' === $template_type && isset( $query['area'] ) ) {
 		$wp_query_args['tax_query'][]           = array(
-			'taxonomy' => 'wp_template_section',
+			'taxonomy' => 'wp_template_part_area',
 			'field'    => 'name',
-			'terms'    => $query['section'],
+			'terms'    => $query['area'],
 		);
 		$wp_query_args['tax_query']['relation'] = 'AND';
 	}
@@ -313,16 +313,16 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 	if ( ! isset( $query['wp_id'] ) ) {
 		$template_files = _gutenberg_get_template_files( $template_type );
 		foreach ( $template_files as $template_file ) {
-			$is_not_custom      = false === array_search(
+			$is_not_custom   = false === array_search(
 				wp_get_theme()->get_stylesheet() . '//' . $template_file['slug'],
 				array_column( $query_result, 'id' ),
 				true
 			);
-			$fits_slug_query    =
+			$fits_slug_query =
 				! isset( $query['slug__in'] ) || in_array( $template_file['slug'], $query['slug__in'], true );
-			$fits_section_query =
-				! isset( $query['section'] ) || $template_file['section'] === $query['section'];
-			$should_include     = $is_not_custom && $fits_slug_query && $fits_section_query;
+			$fits_area_query =
+				! isset( $query['area'] ) || $template_file['area'] === $query['area'];
+			$should_include  = $is_not_custom && $fits_slug_query && $fits_area_query;
 			if ( $should_include ) {
 				$query_result[] = _gutenberg_build_template_result_from_file( $template_file, $template_type );
 			}

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -125,7 +125,7 @@ function _gutenberg_get_template_files( $template_type ) {
  */
 function _gutenberg_add_template_part_section_info( $template_info ) {
 	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
-		$theme_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_part_data();
+		$theme_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_parts();
 	}
 
 	if ( isset( $theme_data[ $template_info['slug'] ]['section'] ) ) {

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -138,6 +138,9 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		if ( isset( $request['wp_id'] ) ) {
 			$query['wp_id'] = $request['wp_id'];
 		}
+		if ( isset( $request['section'] ) ) {
+			$query['section'] = $request['section'];
+		}
 		$templates = array();
 		foreach ( gutenberg_get_block_templates( $query, $this->post_type ) as $template ) {
 			$data        = $this->prepare_item_for_response( $template, $request );

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -336,7 +336,8 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_type   = $this->post_type;
 			$changes->post_status = 'publish';
 			$changes->tax_input   = array(
-				'wp_theme' => $template->theme,
+				'wp_theme'           => $template->theme,
+				'template_part_type' => $template->template_part_type,
 			);
 		} else {
 			$changes->ID          = $template->wp_id;
@@ -356,6 +357,16 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_excerpt = $request['description'];
 		} elseif ( null !== $template && ! $template->is_custom ) {
 			$changes->post_excerpt = $template->description;
+		}
+
+		if ( isset( $request['template_part_type'] ) ) {
+			if ( is_array( $changes->tax_input ) ) {
+				$changes->tax_input['template_part_type'] = $request['template_part_type'];
+			} else {
+				$changes->tax_input = array(
+					'template_part_type' => $request['template_part_type'],
+				);
+			}
 		}
 
 		return $changes;
@@ -385,6 +396,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			'status'      => $template->status,
 			'wp_id'       => $template->wp_id,
 		);
+
+		if ( 'wp_template_part' === $template->type ) {
+			$result['template_part_type'] = $template->template_part_type;
+		}
 
 		$result = $this->add_additional_fields_to_object( $result, $request );
 
@@ -535,6 +550,14 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				),
 			),
 		);
+
+		if ( 'wp_template_part' === $this->post_type ) {
+			$schema['properties']['template_part_type'] = array(
+				'description' => __( 'Type of template part (header, footer, etc.)', 'gutenberg' ),
+				'type'        => 'string',
+				'context'     => array( 'embed', 'view', 'edit' ),
+			);
+		}
 
 		$this->schema = $schema;
 

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -336,8 +336,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_type   = $this->post_type;
 			$changes->post_status = 'publish';
 			$changes->tax_input   = array(
-				'wp_theme'           => $template->theme,
-				'template_part_type' => $template->template_part_type,
+				'wp_theme' => $template->theme,
 			);
 		} else {
 			$changes->ID          = $template->wp_id;
@@ -359,13 +358,23 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_excerpt = $template->description;
 		}
 
-		if ( isset( $request['template_part_type'] ) ) {
-			if ( is_array( $changes->tax_input ) ) {
-				$changes->tax_input['template_part_type'] = $request['template_part_type'];
-			} else {
-				$changes->tax_input = array(
-					'template_part_type' => $request['template_part_type'],
-				);
+		if ( 'wp_template_part' === $this->post_type ) {
+			$template_part_type = null;
+
+			if ( isset( $request['template_part_type'] ) ) {
+				$template_part_type = $request['template_part_type'];
+			} elseif ( null !== $template && ! $template->is_custom ) {
+				$template_part_type = $template->template_part_type;
+			}
+
+			if ( $template_part_type ) {
+				if ( is_array( $changes->tax_input ) ) {
+					$changes->tax_input['template_part_type'] = $template_part_type;
+				} else {
+					$changes->tax_input = array(
+						'template_part_type' => $template_part_type,
+					);
+				}
 			}
 		}
 

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -363,9 +363,9 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 
 		if ( 'wp_template_part' === $this->post_type ) {
 			if ( isset( $request['section'] ) ) {
-				$changes->tax_input['section'] = gutenberg_filter_template_part_section_type( $request['section'] );
+				$changes->tax_input['wp_template_section'] = gutenberg_filter_template_part_section_type( $request['section'] );
 			} elseif ( null !== $template && ! $template->is_custom && $template->section ) {
-				$changes->tax_input['section'] = gutenberg_filter_template_part_section_type( $template->section );
+				$changes->tax_input['wp_template_section'] = gutenberg_filter_template_part_section_type( $template->section );
 			}
 		}
 

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -362,10 +362,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		if ( 'wp_template_part' === $this->post_type ) {
-			if ( isset( $request['section'] ) && in_array( $request['section'], gutenberg_get_allowed_template_part_section_types(), true ) ) {
-				$changes->tax_input['section'] = $request['section'];
-			} elseif ( null !== $template && ! $template->is_custom ) {
-				$changes->tax_input['section'] = $template->section;
+			if ( isset( $request['section'] ) ) {
+				$changes->tax_input['section'] = gutenberg_filter_template_part_section_type( $request['section'] );
+			} elseif ( null !== $template && ! $template->is_custom && $template->section ) {
+				$changes->tax_input['section'] = gutenberg_filter_template_part_section_type( $template->section );
 			}
 		}
 

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -366,6 +366,8 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				$changes->tax_input['wp_template_section'] = gutenberg_filter_template_part_section_type( $request['section'] );
 			} elseif ( null !== $template && ! $template->is_custom && $template->section ) {
 				$changes->tax_input['wp_template_section'] = gutenberg_filter_template_part_section_type( $template->section );
+			} elseif ( ! $template->section ) {
+				$changes->tax_input['wp_template_section'] = WP_TEMPLATE_SECTION_UNCATEGORIZED;
 			}
 		}
 

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -362,7 +362,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		if ( 'wp_template_part' === $this->post_type ) {
-			if ( isset( $request['section'] ) ) {
+			if ( isset( $request['section'] ) && in_array( $request['section'], gutenberg_get_allowed_template_part_section_types(), true ) ) {
 				$changes->tax_input['section'] = $request['section'];
 			} elseif ( null !== $template && ! $template->is_custom ) {
 				$changes->tax_input['section'] = $template->section;

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -359,22 +359,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		if ( 'wp_template_part' === $this->post_type ) {
-			$template_part_type = null;
-
-			if ( isset( $request['template_part_type'] ) ) {
-				$template_part_type = $request['template_part_type'];
+			if ( isset( $request['section'] ) ) {
+				$changes->tax_input['section'] = $request['section'];
 			} elseif ( null !== $template && ! $template->is_custom ) {
-				$template_part_type = $template->template_part_type;
-			}
-
-			if ( $template_part_type ) {
-				if ( is_array( $changes->tax_input ) ) {
-					$changes->tax_input['template_part_type'] = $template_part_type;
-				} else {
-					$changes->tax_input = array(
-						'template_part_type' => $template_part_type,
-					);
-				}
+				$changes->tax_input['section'] = $template->section;
 			}
 		}
 
@@ -407,7 +395,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		);
 
 		if ( 'wp_template_part' === $template->type ) {
-			$result['template_part_type'] = $template->template_part_type;
+			$result['section'] = $template->section;
 		}
 
 		$result = $this->add_additional_fields_to_object( $result, $request );
@@ -561,8 +549,8 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		);
 
 		if ( 'wp_template_part' === $this->post_type ) {
-			$schema['properties']['template_part_type'] = array(
-				'description' => __( 'Type of template part (header, footer, etc.)', 'gutenberg' ),
+			$schema['properties']['section'] = array(
+				'description' => __( 'Where the template part is intended for use (header, footer, etc.)', 'gutenberg' ),
 				'type'        => 'string',
 				'context'     => array( 'embed', 'view', 'edit' ),
 			);

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -367,7 +367,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			} elseif ( null !== $template && ! $template->is_custom && $template->area ) {
 				$changes->tax_input['wp_template_part_area'] = gutenberg_filter_template_part_area_type( $template->area );
 			} elseif ( ! $template->area ) {
-				$changes->tax_input['wp_template_part_area'] = WP_TEMPLAT_PART_AREA_UNCATEGORIZED;
+				$changes->tax_input['wp_template_part_area'] = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 			}
 		}
 

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -138,8 +138,8 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		if ( isset( $request['wp_id'] ) ) {
 			$query['wp_id'] = $request['wp_id'];
 		}
-		if ( isset( $request['section'] ) ) {
-			$query['section'] = $request['section'];
+		if ( isset( $request['area'] ) ) {
+			$query['area'] = $request['area'];
 		}
 		$templates = array();
 		foreach ( gutenberg_get_block_templates( $query, $this->post_type ) as $template ) {
@@ -362,12 +362,12 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		if ( 'wp_template_part' === $this->post_type ) {
-			if ( isset( $request['section'] ) ) {
-				$changes->tax_input['wp_template_section'] = gutenberg_filter_template_part_section_type( $request['section'] );
-			} elseif ( null !== $template && ! $template->is_custom && $template->section ) {
-				$changes->tax_input['wp_template_section'] = gutenberg_filter_template_part_section_type( $template->section );
-			} elseif ( ! $template->section ) {
-				$changes->tax_input['wp_template_section'] = WP_TEMPLATE_SECTION_UNCATEGORIZED;
+			if ( isset( $request['area'] ) ) {
+				$changes->tax_input['wp_template_part_area'] = gutenberg_filter_template_part_area_type( $request['area'] );
+			} elseif ( null !== $template && ! $template->is_custom && $template->area ) {
+				$changes->tax_input['wp_template_part_area'] = gutenberg_filter_template_part_area_type( $template->area );
+			} elseif ( ! $template->area ) {
+				$changes->tax_input['wp_template_part_area'] = WP_TEMPLAT_PART_AREA_UNCATEGORIZED;
 			}
 		}
 
@@ -400,7 +400,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		);
 
 		if ( 'wp_template_part' === $template->type ) {
-			$result['section'] = $template->section;
+			$result['area'] = $template->area;
 		}
 
 		$result = $this->add_additional_fields_to_object( $result, $request );
@@ -554,7 +554,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		);
 
 		if ( 'wp_template_part' === $this->post_type ) {
-			$schema['properties']['section'] = array(
+			$schema['properties']['area'] = array(
 				'description' => __( 'Where the template part is intended for use (header, footer, etc.)', 'gutenberg' ),
 				'type'        => 'string',
 				'context'     => array( 'embed', 'view', 'edit' ),

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -75,8 +75,8 @@ function gutenberg_register_wp_template_section_taxonomy() {
 			'public'            => false,
 			'hierarchical'      => false,
 			'labels'            => array(
-				'name'          => __( 'Sections', 'gutenberg' ),
-				'singular_name' => __( 'Section', 'gutenberg' ),
+				'name'          => __( 'Template Sections', 'gutenberg' ),
+				'singular_name' => __( 'Template Section', 'gutenberg' ),
 			),
 			'query_var'         => false,
 			'rewrite'           => false,
@@ -99,8 +99,8 @@ if ( ! defined( 'WP_TEMPLATE_SECTION_FOOTER' ) ) {
 if ( ! defined( 'WP_TEMPLATE_SECTION_SIDEBAR' ) ) {
 	define( 'WP_TEMPLATE_SECTION_SIDEBAR', 'sidebar' );
 }
-if ( ! defined( 'WP_TEMPLATE_SECTION_OTHER' ) ) {
-	define( 'WP_TEMPLATE_SECTION_OTHER', 'other' );
+if ( ! defined( 'WP_TEMPLATE_SECTION_UNCATEGORIZED' ) ) {
+	define( 'WP_TEMPLATE_SECTION_UNCATEGORIZED', 'uncategorized' );
 }
 
 /**
@@ -172,7 +172,7 @@ function gutenberg_get_allowed_template_part_section_types() {
 		WP_TEMPLATE_SECTION_HEADER,
 		WP_TEMPLATE_SECTION_FOOTER,
 		WP_TEMPLATE_SECTION_SIDEBAR,
-		WP_TEMPLATE_SECTION_OTHER,
+		WP_TEMPLATE_SECTION_UNCATEGORIZED,
 	);
 
 	/**
@@ -197,7 +197,7 @@ function gutenberg_filter_template_part_section_type( $type ) {
 	}
 	$warning_message  = '"' . $type . '"';
 	$warning_message .= __( ' is not a supported wp_template_section type and has been added as ', 'gutenberg' );
-	$warning_message .= '"' . WP_TEMPLATE_SECTION_OTHER . '".';
+	$warning_message .= '"' . WP_TEMPLATE_SECTION_UNCATEGORIZED . '".';
 	trigger_error( $warning_message, E_USER_NOTICE );
-	return WP_TEMPLATE_SECTION_OTHER;
+	return WP_TEMPLATE_SECTION_UNCATEGORIZED;
 }

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -172,7 +172,7 @@ function gutenberg_get_allowed_template_part_section_types() {
  * Checks whether the input 'type' is a supported section type.
  * Returns the input if supported, otherwise returns the 'other' type.
  *
- * @param string $type Template part section name
+ * @param string $type Template part section name.
  *
  * @return string Input if supported, else 'other'.
  */

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -195,5 +195,9 @@ function gutenberg_filter_template_part_section_type( $type ) {
 	if ( in_array( $type, gutenberg_get_allowed_template_part_section_types(), true ) ) {
 		return $type;
 	}
+	$warning_message  = '"' . $type . '"';
+	$warning_message .= __( ' is not a supported wp_template_section type and has been added as ', 'gutenberg' );
+	$warning_message .= '"' . WP_TEMPLATE_SECTION_OTHER . '".';
+	trigger_error( $warning_message, E_USER_NOTICE );
 	return WP_TEMPLATE_SECTION_OTHER;
 }

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -63,7 +63,7 @@ add_action( 'init', 'gutenberg_register_template_part_post_type' );
 /**
  * Registers the 'template_part_type' taxonomy.
  */
-function gutenberg_register_template_part_type_taxonomy(){
+function gutenberg_register_template_part_type_taxonomy() {
 	if ( ! gutenberg_is_fse_theme() ) {
 		return;
 	}

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -63,20 +63,20 @@ add_action( 'init', 'gutenberg_register_template_part_post_type' );
 /**
  * Registers the 'template_part_type' taxonomy.
  */
-function gutenberg_register_template_part_type_taxonomy() {
+function gutenberg_register_template_part_section_taxonomy() {
 	if ( ! gutenberg_is_fse_theme() ) {
 		return;
 	}
 
 	register_taxonomy(
-		'template_part_type',
+		'section',
 		array( 'wp_template_part' ),
 		array(
 			'public'            => false,
 			'hierarchical'      => false,
 			'labels'            => array(
-				'name'          => __( 'Types', 'gutenberg' ),
-				'singular_name' => __( 'Type', 'gutenberg' ),
+				'name'          => __( 'Sections', 'gutenberg' ),
+				'singular_name' => __( 'Section', 'gutenberg' ),
 			),
 			'query_var'         => false,
 			'rewrite'           => false,
@@ -87,7 +87,7 @@ function gutenberg_register_template_part_type_taxonomy() {
 		)
 	);
 }
-add_action( 'init', 'gutenberg_register_template_part_type_taxonomy' );
+add_action( 'init', 'gutenberg_register_template_part_section_taxonomy' );
 
 /**
  * Fixes the label of the 'wp_template_part' admin menu entry.

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -61,9 +61,9 @@ function gutenberg_register_template_part_post_type() {
 add_action( 'init', 'gutenberg_register_template_part_post_type' );
 
 /**
- * Registers the 'template_part_type' taxonomy.
+ * Registers the 'wp_template_section' taxonomy.
  */
-function gutenberg_register_template_part_section_taxonomy() {
+function gutenberg_register_wp_template_section_taxonomy() {
 	if ( ! gutenberg_is_fse_theme() ) {
 		return;
 	}
@@ -87,7 +87,7 @@ function gutenberg_register_template_part_section_taxonomy() {
 		)
 	);
 }
-add_action( 'init', 'gutenberg_register_template_part_section_taxonomy' );
+add_action( 'init', 'gutenberg_register_wp_template_section_taxonomy' );
 
 /**
  * Fixes the label of the 'wp_template_part' admin menu entry.

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -147,3 +147,22 @@ function set_unique_slug_on_create_template_part( $post_id ) {
 	}
 }
 add_action( 'save_post_wp_template_part', 'set_unique_slug_on_create_template_part' );
+
+/**
+ * Returns a filtered list of allowed section types for template parts.
+ *
+ * @return array The supported template part section types.
+ */
+function gutenberg_get_allowed_template_part_section_types() {
+	$default_section_types = array(
+		'header',
+		'footer',
+	);
+
+	/**
+	 * Filters the list of allowed template part section types.
+	 *
+	 * @param array $default_section_types An array of supported section types.
+	 */
+	return apply_filters( 'default_template_part_section_types', $default_section_types );
+}

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -89,6 +89,20 @@ function gutenberg_register_wp_template_section_taxonomy() {
 }
 add_action( 'init', 'gutenberg_register_wp_template_section_taxonomy' );
 
+// Definte constants for supported WP_TEMPLATE_SECTION taxonomy.
+if ( ! defined( 'WP_TEMPLATE_SECTION_HEADER' ) ) {
+	define( 'WP_TEMPLATE_SECTION_HEADER', 'header' );
+}
+if ( ! defined( 'WP_TEMPLATE_SECTION_FOOTER' ) ) {
+	define( 'WP_TEMPLATE_SECTION_FOOTER', 'footer' );
+}
+if ( ! defined( 'WP_TEMPLATE_SECTION_SIDEBAR' ) ) {
+	define( 'WP_TEMPLATE_SECTION_SIDEBAR', 'sidebar' );
+}
+if ( ! defined( 'WP_TEMPLATE_SECTION_OTHER' ) ) {
+	define( 'WP_TEMPLATE_SECTION_OTHER', 'other' );
+}
+
 /**
  * Fixes the label of the 'wp_template_part' admin menu entry.
  */
@@ -155,9 +169,10 @@ add_action( 'save_post_wp_template_part', 'set_unique_slug_on_create_template_pa
  */
 function gutenberg_get_allowed_template_part_section_types() {
 	$default_section_types = array(
-		'header',
-		'footer',
-		'other',
+		WP_TEMPLATE_SECTION_HEADER,
+		WP_TEMPLATE_SECTION_FOOTER,
+		WP_TEMPLATE_SECTION_SIDEBAR,
+		WP_TEMPLATE_SECTION_OTHER,
 	);
 
 	/**
@@ -165,7 +180,7 @@ function gutenberg_get_allowed_template_part_section_types() {
 	 *
 	 * @param array $default_section_types An array of supported section types.
 	 */
-	return apply_filters( 'default_template_part_section_types', $default_section_types );
+	return apply_filters( 'default_wp_template_section_types', $default_section_types );
 }
 
 /**
@@ -180,5 +195,5 @@ function gutenberg_filter_template_part_section_type( $type ) {
 	if ( in_array( $type, gutenberg_get_allowed_template_part_section_types(), true ) ) {
 		return $type;
 	}
-	return 'other';
+	return WP_TEMPLATE_SECTION_OTHER;
 }

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -69,7 +69,7 @@ function gutenberg_register_template_part_section_taxonomy() {
 	}
 
 	register_taxonomy(
-		'section',
+		'wp_template_section',
 		array( 'wp_template_part' ),
 		array(
 			'public'            => false,

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -157,6 +157,7 @@ function gutenberg_get_allowed_template_part_section_types() {
 	$default_section_types = array(
 		'header',
 		'footer',
+		'other',
 	);
 
 	/**
@@ -165,4 +166,19 @@ function gutenberg_get_allowed_template_part_section_types() {
 	 * @param array $default_section_types An array of supported section types.
 	 */
 	return apply_filters( 'default_template_part_section_types', $default_section_types );
+}
+
+/**
+ * Checks whether the input 'type' is a supported section type.
+ * Returns the input if supported, otherwise returns the 'other' type.
+ *
+ * @param string $type Template part section name
+ *
+ * @return string Input if supported, else 'other'.
+ */
+function gutenberg_filter_template_part_section_type( $type ) {
+	if ( in_array( $type, gutenberg_get_allowed_template_part_section_types(), true ) ) {
+		return $type;
+	}
+	return 'other';
 }

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -61,6 +61,35 @@ function gutenberg_register_template_part_post_type() {
 add_action( 'init', 'gutenberg_register_template_part_post_type' );
 
 /**
+ * Registers the 'template_part_type' taxonomy.
+ */
+function gutenberg_register_template_part_type_taxonomy(){
+	if ( ! gutenberg_is_fse_theme() ) {
+		return;
+	}
+
+	register_taxonomy(
+		'template_part_type',
+		array( 'wp_template_part' ),
+		array(
+			'public'            => false,
+			'hierarchical'      => false,
+			'labels'            => array(
+				'name'          => __( 'Types', 'gutenberg' ),
+				'singular_name' => __( 'Type', 'gutenberg' ),
+			),
+			'query_var'         => false,
+			'rewrite'           => false,
+			'show_ui'           => false,
+			'_builtin'          => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest'      => false,
+		)
+	);
+}
+add_action( 'init', 'gutenberg_register_template_part_type_taxonomy' );
+
+/**
  * Fixes the label of the 'wp_template_part' admin menu entry.
  */
 function gutenberg_fix_template_part_admin_menu_entry() {

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -61,22 +61,22 @@ function gutenberg_register_template_part_post_type() {
 add_action( 'init', 'gutenberg_register_template_part_post_type' );
 
 /**
- * Registers the 'wp_template_section' taxonomy.
+ * Registers the 'wp_template_part_area' taxonomy.
  */
-function gutenberg_register_wp_template_section_taxonomy() {
+function gutenberg_register_wp_template_part_area_taxonomy() {
 	if ( ! gutenberg_is_fse_theme() ) {
 		return;
 	}
 
 	register_taxonomy(
-		'wp_template_section',
+		'wp_template_part_area',
 		array( 'wp_template_part' ),
 		array(
 			'public'            => false,
 			'hierarchical'      => false,
 			'labels'            => array(
-				'name'          => __( 'Template Sections', 'gutenberg' ),
-				'singular_name' => __( 'Template Section', 'gutenberg' ),
+				'name'          => __( 'Template Part Areas', 'gutenberg' ),
+				'singular_name' => __( 'Template Part Area', 'gutenberg' ),
 			),
 			'query_var'         => false,
 			'rewrite'           => false,
@@ -87,20 +87,20 @@ function gutenberg_register_wp_template_section_taxonomy() {
 		)
 	);
 }
-add_action( 'init', 'gutenberg_register_wp_template_section_taxonomy' );
+add_action( 'init', 'gutenberg_register_wp_template_part_area_taxonomy' );
 
-// Definte constants for supported WP_TEMPLATE_SECTION taxonomy.
-if ( ! defined( 'WP_TEMPLATE_SECTION_HEADER' ) ) {
-	define( 'WP_TEMPLATE_SECTION_HEADER', 'header' );
+// Definte constants for supported wp_template_part_area taxonomy.
+if ( ! defined( 'WP_TEMPLATE_PART_AREA_HEADER' ) ) {
+	define( 'WP_TEMPLATE_PART_AREA_HEADER', 'header' );
 }
-if ( ! defined( 'WP_TEMPLATE_SECTION_FOOTER' ) ) {
-	define( 'WP_TEMPLATE_SECTION_FOOTER', 'footer' );
+if ( ! defined( 'WP_TEMPLATE_PART_AREA_FOOTER' ) ) {
+	define( 'WP_TEMPLATE_PART_AREA_FOOTER', 'footer' );
 }
-if ( ! defined( 'WP_TEMPLATE_SECTION_SIDEBAR' ) ) {
-	define( 'WP_TEMPLATE_SECTION_SIDEBAR', 'sidebar' );
+if ( ! defined( 'WP_TEMPLATE_PART_AREA_SIDEBAR' ) ) {
+	define( 'WP_TEMPLATE_PART_AREA_SIDEBAR', 'sidebar' );
 }
-if ( ! defined( 'WP_TEMPLATE_SECTION_UNCATEGORIZED' ) ) {
-	define( 'WP_TEMPLATE_SECTION_UNCATEGORIZED', 'uncategorized' );
+if ( ! defined( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED' ) ) {
+	define( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED', 'uncategorized' );
 }
 
 /**
@@ -163,41 +163,41 @@ function set_unique_slug_on_create_template_part( $post_id ) {
 add_action( 'save_post_wp_template_part', 'set_unique_slug_on_create_template_part' );
 
 /**
- * Returns a filtered list of allowed section types for template parts.
+ * Returns a filtered list of allowed area types for template parts.
  *
- * @return array The supported template part section types.
+ * @return array The supported template part area types.
  */
-function gutenberg_get_allowed_template_part_section_types() {
-	$default_section_types = array(
-		WP_TEMPLATE_SECTION_HEADER,
-		WP_TEMPLATE_SECTION_FOOTER,
-		WP_TEMPLATE_SECTION_SIDEBAR,
-		WP_TEMPLATE_SECTION_UNCATEGORIZED,
+function gutenberg_get_allowed_template_part_area_types() {
+	$default_area_types = array(
+		WP_TEMPLATE_PART_AREA_HEADER,
+		WP_TEMPLATE_PART_AREA_FOOTER,
+		WP_TEMPLATE_PART_AREA_SIDEBAR,
+		WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
 	);
 
 	/**
-	 * Filters the list of allowed template part section types.
+	 * Filters the list of allowed template part area types.
 	 *
-	 * @param array $default_section_types An array of supported section types.
+	 * @param array $default_area_types An array of supported area types.
 	 */
-	return apply_filters( 'default_wp_template_section_types', $default_section_types );
+	return apply_filters( 'default_wp_template_part_area_types', $default_area_types );
 }
 
 /**
- * Checks whether the input 'type' is a supported section type.
+ * Checks whether the input 'type' is a supported area type.
  * Returns the input if supported, otherwise returns the 'other' type.
  *
- * @param string $type Template part section name.
+ * @param string $type Template part area name.
  *
  * @return string Input if supported, else 'other'.
  */
-function gutenberg_filter_template_part_section_type( $type ) {
-	if ( in_array( $type, gutenberg_get_allowed_template_part_section_types(), true ) ) {
+function gutenberg_filter_template_part_area_type( $type ) {
+	if ( in_array( $type, gutenberg_get_allowed_template_part_area_types(), true ) ) {
 		return $type;
 	}
 	$warning_message  = '"' . $type . '"';
-	$warning_message .= __( ' is not a supported wp_template_section type and has been added as ', 'gutenberg' );
-	$warning_message .= '"' . WP_TEMPLATE_SECTION_UNCATEGORIZED . '".';
+	$warning_message .= __( ' is not a supported wp_template_part_area type and has been added as ', 'gutenberg' );
+	$warning_message .= '"' . WP_TEMPLATE_PART_AREA_UNCATEGORIZED . '".';
 	trigger_error( $warning_message, E_USER_NOTICE );
-	return WP_TEMPLATE_SECTION_UNCATEGORIZED;
+	return WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 }

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -18,7 +18,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		gutenberg_register_template_post_type();
 		gutenberg_register_template_part_post_type();
 		gutenberg_register_wp_theme_taxonomy();
-		gutenberg_register_template_part_section_taxonomy();
+		gutenberg_register_wp_template_section_taxonomy();
 
 		// Set up template post.
 		$args       = array(

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -37,23 +37,23 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		wp_set_post_terms( self::$post->ID, get_stylesheet(), 'wp_theme' );
 
 		// Set up template part post.
-		$template_part_args = array(
+		$template_part_args       = array(
 			'post_type'    => 'wp_template_part',
 			'post_name'    => 'my_template_part',
 			'post_title'   => 'My Template Part',
 			'post_content' => 'Content',
 			'post_excerpt' => 'Description of my template part',
 			'tax_input'    => array(
-				'wp_theme' => array(
+				'wp_theme'            => array(
 					get_stylesheet(),
 				),
-				'section' => array(
-					'header'
-				)
+				'wp_template_section' => array(
+					'header',
+				),
 			),
 		);
 		self::$template_part_post = self::factory()->post->create_and_get( $template_part_args );
-		wp_set_post_terms( self::$template_part_post->ID, 'header', 'section' );
+		wp_set_post_terms( self::$template_part_post->ID, 'header', 'wp_template_section' );
 		wp_set_post_terms( self::$template_part_post->ID, get_stylesheet(), 'wp_theme' );
 	}
 
@@ -78,8 +78,6 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Single', $template->title );
 		$this->assertEquals( 'Used when a single entry that is not a Page is queried', $template->description );
 		$this->assertEquals( 'wp_template', $template->type );
-
-		// Test template part.
 	}
 
 	function test_gutenberg_build_template_result_from_post() {

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -78,6 +78,25 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Single', $template->title );
 		$this->assertEquals( 'Used when a single entry that is not a Page is queried', $template->description );
 		$this->assertEquals( 'wp_template', $template->type );
+
+		// Test template parts.
+		$template_part = _gutenberg_build_template_result_from_file(
+			array(
+				'slug' => 'header',
+				'path' => __DIR__ . '/fixtures/template.html',
+			),
+			'wp_template_part'
+		);
+		$this->assertEquals( get_stylesheet() . '//header', $template_part->id );
+		$this->assertEquals( get_stylesheet(), $template_part->theme );
+		$this->assertEquals( 'header', $template_part->slug );
+		$this->assertEquals( 'publish', $template_part->status );
+		$this->assertEquals( false, $template_part->is_custom );
+		$this->assertEquals( 'header', $template_part->title );
+		$this->assertEquals( '', $template_part->description );
+		$this->assertEquals( 'wp_template_part', $template_part->type );
+		// TODO - update null to 'header' once tt1-blocks theme.json updated for template part section info.
+		$this->assertEquals( null, $template_part->section );
 	}
 
 	function test_gutenberg_build_template_result_from_post() {
@@ -96,7 +115,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Description of my template', $template->description );
 		$this->assertEquals( 'wp_template', $template->type );
 
-		// Test template part.
+		// Test template parts.
 		$template_part = _gutenberg_build_template_result_from_post(
 			self::$template_part_post,
 			'wp_template_part'
@@ -155,6 +174,18 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $template->status );
 		$this->assertEquals( false, $template->is_custom );
 		$this->assertEquals( 'wp_template', $template->type );
+
+		// Test template parts.
+		$id       = get_stylesheet() . '//' . 'header';
+		$template = gutenberg_get_block_template( $id, 'wp_template_part' );
+		$this->assertEquals( $id, $template->id );
+		$this->assertEquals( get_stylesheet(), $template->theme );
+		$this->assertEquals( 'header', $template->slug );
+		$this->assertEquals( 'publish', $template->status );
+		$this->assertEquals( false, $template->is_custom );
+		$this->assertEquals( 'wp_template_part', $template->type );
+		// TODO - update null to 'header' once tt1-blocks theme.json updated for template part section info.
+		$this->assertEquals( null, $template->section );
 	}
 
 	/**
@@ -169,6 +200,17 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $template->status );
 		$this->assertEquals( true, $template->is_custom );
 		$this->assertEquals( 'wp_template', $template->type );
+
+		// Test template parts.
+		$id       = get_stylesheet() . '//' . 'my_template_part';
+		$template = gutenberg_get_block_template( $id, 'wp_template_part' );
+		$this->assertEquals( $id, $template->id );
+		$this->assertEquals( get_stylesheet(), $template->theme );
+		$this->assertEquals( 'my_template_part', $template->slug );
+		$this->assertEquals( 'publish', $template->status );
+		$this->assertEquals( true, $template->is_custom );
+		$this->assertEquals( 'wp_template_part', $template->type );
+		$this->assertEquals( 'header', $template->section );
 	}
 
 	/**
@@ -201,5 +243,11 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$templates    = gutenberg_get_block_templates( array( 'wp_id' => self::$post->ID ), 'wp_template' );
 		$template_ids = get_template_ids( $templates );
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template' ), $template_ids );
+
+		// Filter template part by section.
+		$templates    = gutenberg_get_block_templates( array( 'section' => 'header' ), 'wp_template_part' );
+		$template_ids = get_template_ids( $templates );
+		// TODO - update following array result once tt1-blocks theme.json is updated for section info.
+		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template_part' ), $template_ids );
 	}
 }

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -48,12 +48,12 @@ class Block_Templates_Test extends WP_UnitTestCase {
 					get_stylesheet(),
 				),
 				'wp_template_section' => array(
-					'header',
+					WP_TEMPLATE_SECTION_SIDEBAR,
 				),
 			),
 		);
 		self::$template_part_post = self::factory()->post->create_and_get( $template_part_args );
-		wp_set_post_terms( self::$template_part_post->ID, 'header', 'wp_template_section' );
+		wp_set_post_terms( self::$template_part_post->ID, WP_TEMPLATE_SECTION_SIDEBAR, 'wp_template_section' );
 		wp_set_post_terms( self::$template_part_post->ID, get_stylesheet(), 'wp_theme' );
 	}
 
@@ -82,8 +82,9 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		// Test template parts.
 		$template_part = _gutenberg_build_template_result_from_file(
 			array(
-				'slug' => 'header',
-				'path' => __DIR__ . '/fixtures/template.html',
+				'slug'    => 'header',
+				'path'    => __DIR__ . '/fixtures/template.html',
+				'section' => WP_TEMPLATE_SECTION_HEADER,
 			),
 			'wp_template_part'
 		);
@@ -95,8 +96,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'header', $template_part->title );
 		$this->assertEquals( '', $template_part->description );
 		$this->assertEquals( 'wp_template_part', $template_part->type );
-		// TODO - update null to 'header' once tt1-blocks theme.json updated for template part section info.
-		$this->assertEquals( null, $template_part->section );
+		$this->assertEquals( WP_TEMPLATE_SECTION_HEADER, $template_part->section );
 	}
 
 	function test_gutenberg_build_template_result_from_post() {
@@ -129,7 +129,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'My Template Part', $template_part->title );
 		$this->assertEquals( 'Description of my template part', $template_part->description );
 		$this->assertEquals( 'wp_template_part', $template_part->type );
-		$this->assertEquals( 'header', $template_part->section );
+		$this->assertEquals( WP_TEMPLATE_SECTION_SIDEBAR, $template_part->section );
 	}
 
 	function test_inject_theme_attribute_in_content() {
@@ -184,8 +184,8 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $template->status );
 		$this->assertEquals( false, $template->is_custom );
 		$this->assertEquals( 'wp_template_part', $template->type );
-		// TODO - update null to 'header' once tt1-blocks theme.json updated for template part section info.
-		$this->assertEquals( null, $template->section );
+		// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part section info.
+		$this->assertEquals( WP_TEMPLATE_SECTION_UNCATEGORIZED, $template->section );
 	}
 
 	/**
@@ -210,7 +210,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $template->status );
 		$this->assertEquals( true, $template->is_custom );
 		$this->assertEquals( 'wp_template_part', $template->type );
-		$this->assertEquals( 'header', $template->section );
+		$this->assertEquals( WP_TEMPLATE_SECTION_SIDEBAR, $template->section );
 	}
 
 	/**
@@ -245,7 +245,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template' ), $template_ids );
 
 		// Filter template part by section.
-		$templates    = gutenberg_get_block_templates( array( 'section' => 'header' ), 'wp_template_part' );
+		$templates    = gutenberg_get_block_templates( array( 'section' => WP_TEMPLATE_SECTION_SIDEBAR ), 'wp_template_part' );
 		$template_ids = get_template_ids( $templates );
 		// TODO - update following array result once tt1-blocks theme.json is updated for section info.
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template_part' ), $template_ids );

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -18,7 +18,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		gutenberg_register_template_post_type();
 		gutenberg_register_template_part_post_type();
 		gutenberg_register_wp_theme_taxonomy();
-		gutenberg_register_wp_template_section_taxonomy();
+		gutenberg_register_wp_template_part_area_taxonomy();
 
 		// Set up template post.
 		$args       = array(
@@ -44,16 +44,16 @@ class Block_Templates_Test extends WP_UnitTestCase {
 			'post_content' => 'Content',
 			'post_excerpt' => 'Description of my template part',
 			'tax_input'    => array(
-				'wp_theme'            => array(
+				'wp_theme'              => array(
 					get_stylesheet(),
 				),
-				'wp_template_section' => array(
-					WP_TEMPLATE_SECTION_SIDEBAR,
+				'wp_template_part_area' => array(
+					WP_TEMPLATE_PART_AREA_SIDEBAR,
 				),
 			),
 		);
 		self::$template_part_post = self::factory()->post->create_and_get( $template_part_args );
-		wp_set_post_terms( self::$template_part_post->ID, WP_TEMPLATE_SECTION_SIDEBAR, 'wp_template_section' );
+		wp_set_post_terms( self::$template_part_post->ID, WP_TEMPLATE_PART_AREA_SIDEBAR, 'wp_template_part_area' );
 		wp_set_post_terms( self::$template_part_post->ID, get_stylesheet(), 'wp_theme' );
 	}
 
@@ -82,9 +82,9 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		// Test template parts.
 		$template_part = _gutenberg_build_template_result_from_file(
 			array(
-				'slug'    => 'header',
-				'path'    => __DIR__ . '/fixtures/template.html',
-				'section' => WP_TEMPLATE_SECTION_HEADER,
+				'slug' => 'header',
+				'path' => __DIR__ . '/fixtures/template.html',
+				'area' => WP_TEMPLATE_PART_AREA_HEADER,
 			),
 			'wp_template_part'
 		);
@@ -96,7 +96,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'header', $template_part->title );
 		$this->assertEquals( '', $template_part->description );
 		$this->assertEquals( 'wp_template_part', $template_part->type );
-		$this->assertEquals( WP_TEMPLATE_SECTION_HEADER, $template_part->section );
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
 	}
 
 	function test_gutenberg_build_template_result_from_post() {
@@ -129,7 +129,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'My Template Part', $template_part->title );
 		$this->assertEquals( 'Description of my template part', $template_part->description );
 		$this->assertEquals( 'wp_template_part', $template_part->type );
-		$this->assertEquals( WP_TEMPLATE_SECTION_SIDEBAR, $template_part->section );
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_SIDEBAR, $template_part->area );
 	}
 
 	function test_inject_theme_attribute_in_content() {
@@ -184,8 +184,8 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $template->status );
 		$this->assertEquals( false, $template->is_custom );
 		$this->assertEquals( 'wp_template_part', $template->type );
-		// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part section info.
-		$this->assertEquals( WP_TEMPLATE_SECTION_UNCATEGORIZED, $template->section );
+		// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part area info.
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_UNCATEGORIZED, $template->area );
 	}
 
 	/**
@@ -210,7 +210,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $template->status );
 		$this->assertEquals( true, $template->is_custom );
 		$this->assertEquals( 'wp_template_part', $template->type );
-		$this->assertEquals( WP_TEMPLATE_SECTION_SIDEBAR, $template->section );
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_SIDEBAR, $template->area );
 	}
 
 	/**
@@ -244,10 +244,10 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$template_ids = get_template_ids( $templates );
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template' ), $template_ids );
 
-		// Filter template part by section.
-		$templates    = gutenberg_get_block_templates( array( 'section' => WP_TEMPLATE_SECTION_SIDEBAR ), 'wp_template_part' );
+		// Filter template part by area.
+		$templates    = gutenberg_get_block_templates( array( 'area' => WP_TEMPLATE_PART_AREA_SIDEBAR ), 'wp_template_part' );
 		$template_ids = get_template_ids( $templates );
-		// TODO - update following array result once tt1-blocks theme.json is updated for section info.
+		// TODO - update following array result once tt1-blocks theme.json is updated for area info.
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template_part' ), $template_ids );
 	}
 }

--- a/phpunit/class-wp-rest-template-controller-test.php
+++ b/phpunit/class-wp-rest-template-controller-test.php
@@ -76,6 +76,30 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//index' )
 		);
+
+		// Test template parts.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/template-parts' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals(
+			array(
+				'id'          => 'tt1-blocks//header',
+				'theme'       => 'tt1-blocks',
+				'slug'        => 'header',
+				'title'       => array(
+					'raw'      => 'header',
+					'rendered' => 'header',
+				),
+				'description' => '',
+				'status'      => 'publish',
+				'is_custom'   => false,
+				'type'        => 'wp_template_part',
+				'wp_id'       => null,
+				'section'     => null,
+			),
+			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
+		);
 	}
 
 	public function test_get_item() {
@@ -100,6 +124,31 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'is_custom'   => false,
 				'type'        => 'wp_template',
 				'wp_id'       => null,
+			),
+			$data
+		);
+
+		// Test template parts.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/template-parts/tt1-blocks//header' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		unset( $data['content'] );
+		unset( $data['_links'] );
+		$this->assertEquals(
+			array(
+				'id'          => 'tt1-blocks//header',
+				'theme'       => 'tt1-blocks',
+				'slug'        => 'header',
+				'title'       => array(
+					'raw'      => 'header',
+					'rendered' => 'header',
+				),
+				'description' => '',
+				'status'      => 'publish',
+				'is_custom'   => false,
+				'type'        => 'wp_template_part',
+				'wp_id'       => null,
+				'section'     => null,
 			),
 			$data
 		);
@@ -140,6 +189,43 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 			),
 			$data
 		);
+
+		// Test template parts.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/template-parts' );
+		$request->set_body_params(
+			array(
+				'slug'        => 'my_custom_template_part',
+				'title'       => 'My Template Part',
+				'description' => 'Just a description of a template part',
+				'content'     => 'Content',
+				'section'     => 'header',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		unset( $data['_links'] );
+		unset( $data['wp_id'] );
+
+		$this->assertEquals(
+			array(
+				'id'          => 'tt1-blocks//my_custom_template_part',
+				'theme'       => 'tt1-blocks',
+				'slug'        => 'my_custom_template_part',
+				'title'       => array(
+					'raw'      => 'My Template Part',
+					'rendered' => 'My Template Part',
+				),
+				'description' => 'Just a description of a template part',
+				'status'      => 'publish',
+				'is_custom'   => true,
+				'type'        => 'wp_template_part',
+				'content'     => array(
+					'raw' => 'Content',
+				),
+				'section'     => 'header',
+			),
+			$data
+		);
 	}
 
 	public function test_update_item() {
@@ -153,6 +239,18 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals( 'My new Index Title', $data['title']['raw'] );
+		$this->assertEquals( true, $data['is_custom'] );
+
+		// Test template parts.
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/template-parts/tt1-blocks//header' );
+		$request->set_body_params(
+			array(
+				'section' => 'something unsupported',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals( 'other', $data['section'] );
 		$this->assertEquals( true, $data['is_custom'] );
 	}
 

--- a/phpunit/class-wp-rest-template-controller-test.php
+++ b/phpunit/class-wp-rest-template-controller-test.php
@@ -16,6 +16,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 		gutenberg_register_template_post_type();
 		gutenberg_register_template_part_post_type();
 		gutenberg_register_wp_theme_taxonomy();
+		gutenberg_register_wp_template_section_taxonomy();
 		self::$admin_id = $factory->user->create(
 			array(
 				'role' => 'administrator',

--- a/phpunit/class-wp-rest-template-controller-test.php
+++ b/phpunit/class-wp-rest-template-controller-test.php
@@ -96,6 +96,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'is_custom'   => false,
 				'type'        => 'wp_template_part',
 				'wp_id'       => null,
+				// TODO - update null to 'header' once tt1-blocks theme.json updated for template part section info.
 				'section'     => null,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
@@ -148,6 +149,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'is_custom'   => false,
 				'type'        => 'wp_template_part',
 				'wp_id'       => null,
+				// TODO - update null to 'header' once tt1-blocks theme.json updated for template part section info.
 				'section'     => null,
 			),
 			$data

--- a/phpunit/class-wp-rest-template-controller-test.php
+++ b/phpunit/class-wp-rest-template-controller-test.php
@@ -97,8 +97,8 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'is_custom'   => false,
 				'type'        => 'wp_template_part',
 				'wp_id'       => null,
-				// TODO - update null to 'header' once tt1-blocks theme.json updated for template part section info.
-				'section'     => null,
+				// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part section info.
+				'section'     => WP_TEMPLATE_SECTION_UNCATEGORIZED,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
 		);
@@ -150,8 +150,8 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'is_custom'   => false,
 				'type'        => 'wp_template_part',
 				'wp_id'       => null,
-				// TODO - update null to 'header' once tt1-blocks theme.json updated for template part section info.
-				'section'     => null,
+				// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part section info.
+				'section'     => WP_TEMPLATE_SECTION_UNCATEGORIZED,
 			),
 			$data
 		);
@@ -253,7 +253,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals( 'other', $data['section'] );
+		$this->assertEquals( WP_TEMPLATE_SECTION_UNCATEGORIZED, $data['section'] );
 		$this->assertEquals( true, $data['is_custom'] );
 	}
 

--- a/phpunit/class-wp-rest-template-controller-test.php
+++ b/phpunit/class-wp-rest-template-controller-test.php
@@ -16,7 +16,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 		gutenberg_register_template_post_type();
 		gutenberg_register_template_part_post_type();
 		gutenberg_register_wp_theme_taxonomy();
-		gutenberg_register_wp_template_section_taxonomy();
+		gutenberg_register_wp_template_part_area_taxonomy();
 		self::$admin_id = $factory->user->create(
 			array(
 				'role' => 'administrator',
@@ -97,8 +97,8 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'is_custom'   => false,
 				'type'        => 'wp_template_part',
 				'wp_id'       => null,
-				// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part section info.
-				'section'     => WP_TEMPLATE_SECTION_UNCATEGORIZED,
+				// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part area info.
+				'area'        => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
 		);
@@ -150,8 +150,8 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'is_custom'   => false,
 				'type'        => 'wp_template_part',
 				'wp_id'       => null,
-				// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part section info.
-				'section'     => WP_TEMPLATE_SECTION_UNCATEGORIZED,
+				// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part area info.
+				'area'        => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
 			),
 			$data
 		);
@@ -201,7 +201,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'title'       => 'My Template Part',
 				'description' => 'Just a description of a template part',
 				'content'     => 'Content',
-				'section'     => 'header',
+				'area'        => 'header',
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -225,7 +225,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'content'     => array(
 					'raw' => 'Content',
 				),
-				'section'     => 'header',
+				'area'        => 'header',
 			),
 			$data
 		);
@@ -248,12 +248,12 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/template-parts/tt1-blocks//header' );
 		$request->set_body_params(
 			array(
-				'section' => 'something unsupported',
+				'area' => 'something unsupported',
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals( WP_TEMPLATE_SECTION_UNCATEGORIZED, $data['section'] );
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_UNCATEGORIZED, $data['area'] );
 		$this->assertEquals( true, $data['is_custom'] );
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -761,7 +761,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_get_template_part_data() {
+	function test_get_template_parts {
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'templateParts' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -761,7 +761,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_get_template_parts {
+	function test_get_template_parts() {
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'templateParts' => array(
@@ -772,7 +772,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$template_parts = $theme_json->get_template_part_data();
+		$template_parts = $theme_json->get_template_parts();
 
 		$this->assertEqualSetsWithIndex(
 			$template_parts,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -247,7 +247,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						),
 						'misc'       => 'value',
 					),
-					'core/group' => array(
+					'core/group'     => array(
 						'custom' => array(
 							'base-font'   => 16,
 							'line-height' => array(
@@ -766,7 +766,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			array(
 				'templateParts' => array(
 					'header' => array(
-						'section' => 'Some section',
+						'area' => 'Some area',
 					),
 				),
 			)
@@ -778,7 +778,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			$template_parts,
 			array(
 				'header' => array(
-					'section' => 'Some section',
+					'area' => 'Some area',
 				),
 			)
 		);

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -760,4 +760,27 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 	}
+
+	function test_get_template_part_data() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'templateParts' => array(
+					'header' => array(
+						'section' => 'Some section',
+					),
+				),
+			)
+		);
+
+		$template_parts = $theme_json->get_template_part_data();
+
+		$this->assertEqualSetsWithIndex(
+			$template_parts,
+			array(
+				'header' => array(
+					'section' => 'Some section',
+				),
+			)
+		);
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR explores adding an 'area' (im open to better naming suggestions) term to aid in being able to classify and request all template parts corresponding to a specific type ('header', 'footer', etc.) - something like this will be necessary to enable items discussed in #27337

Current state of this PR:
* Registers the new tax term as `wp_template_part_area`.
* Allows themes to set the default value for this term in the 'experimental-theme.json' file.  The current schema used to determine this value is of the format `templateParts[ $slug ][ 'area' ]`.  For example, to define the 'area' of a template part whose file is named "file-name.html" the json would look like:
```
"templateParts": {
		"file-name": {
			"area": "header"
		}
	}
```
* Adds this term to the response for file based and custom template parts.
* Updates the rest controller to save this term in standard CRUD operations.
* Enables querying by this term.
* Restricts this term to a list of supported types.

## How has this been tested?

Many of the following steps are covered in the added php unit tests.  To test manually:

* Run this PR
### 1 - Verify the term is added on singular requests and persists across saving.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Add this json code to the experimental-themes.json file of a block based theme:
```
"templateParts": {
		"header": {
			"area": "header"
		}
	}
```
* Load the editor with a 'fresh' theme install (no customized theme templates or template parts).
* Log the response for the single template part request (such as `entityRecord` [here](https://github.com/WordPress/gutenberg/blob/a0c91bcdfd8f86846a33227ba9851d84476e6bff/packages/block-library/src/template-part/edit/index.js#L49)) and verify the header's "area" key is present and has the expected value "header".
* Similarly, verify the footer (which you did not add any json for) is listed as "uncategorized".
* Make changes to the template part and save.
* Log the response again for the now custom template part (is_custom should now be `true`), and verify the term key/value is still present as expected.  

### 2 - Verify querying by the term works for both non-custom and custom template parts.
* Clean/delete the customized theme template parts from the testing step above.
* The theme's JSON file will still need the addition mentioned above.
* Request template parts querying `area: "header"` and log the result.  One way to do this is to add a query to [this request](https://github.com/WordPress/gutenberg/blob/69027a01c609627e68e663e521ee397dc584c2d3/packages/block-library/src/template-part/edit/selection/template-part-previews.js#L209-L213) and log the result.  This request can be triggered by pressing the "down" chevron in a template part block's toolbar (to the right of the renaming input).
```
	select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
		area: 'header',
	} ) 
```
* Load the editor, trigger and log the request and verify only the header template part is returned in result.
* Edit the header template part and save.
* Again, trigger and log the response for the now custom template part  (is_custom should now be `true`) and verify it is the only result.

### 3 - Verify this does not work for unsupported types.
* In the theme's JSON file, change the area from type `header` to type `foobar`.
* Clean/delete custom theme template parts.
* Verify this unsupported area type is not added to the template part and shows up as `uncategorized`.

### 4 - Smoke test the normal template part flows.
* Undo any changes to Gutenberg made in the testing steps above (queries/logs).
* Verify the nav sidebar and template part selection show both header and footer as expected.
* Verify template part flows work as expected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
