### PR TITLE
Try: Cover block image rules, very high specificity.

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -43,12 +43,6 @@
 	.wp-block-cover__placeholder-background-options {
 		width: 100%;
 	}
-
-	// Fix object-fit when block is full width in the editor.
-	.wp-block-cover__image-background {
-		width: inherit;
-		height: inherit;
-	}
 }
 
 [data-align="left"] > .wp-block-cover,

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -1,8 +1,4 @@
 .wp-block-cover {
-	position: relative;
-	width: 100%;
-	height: 100%; // This explicit height rule is necessary for the focal point picker to work.
-
 	// Override default cover styles
 	// because we're not ready yet to show the cover block.
 	&.is-placeholder {

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -1,5 +1,7 @@
 .wp-block-cover {
 	position: relative;
+	width: 100%;
+	height: 100%; // This explicit height rule is necessary for the focal point picker to work.
 
 	// Override default cover styles
 	// because we're not ready yet to show the cover block.

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -178,6 +178,8 @@
 		bottom: 0;
 		width: inherit;
 		height: inherit;
+		margin: 0;
+		padding: 0;
 		object-fit: cover;
 	}
 }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -4,8 +4,6 @@
 	background-size: cover;
 	background-position: center center;
 	min-height: 430px;
-	width: 100%;
-	height: 100%; // This explicit height rule is necessary for the focal point picker to work.
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -176,10 +174,10 @@
 		left: 0;
 		right: 0;
 		bottom: 0;
-		width: inherit;
-		height: inherit;
 		margin: 0;
 		padding: 0;
+		width: 100%;
+		height: 100%;
 		object-fit: cover;
 	}
 }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -172,8 +172,12 @@
 .wp-block-cover__image-background,
 .wp-block-cover__video-background {
 	position: absolute;
-	width: 100%;
-	height: 100%;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	width: inherit;
+	height: inherit;
 	object-fit: cover;
 }
 

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -4,6 +4,8 @@
 	background-size: cover;
 	background-position: center center;
 	min-height: 430px;
+	width: 100%;
+	height: 100%; // This explicit height rule is necessary for the focal point picker to work.
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -166,19 +168,25 @@
 		}
 	}
 
-	// Extra specificity for in edit mode where other styles would override it otherwise.
+	// The extra specificity here helps scope the rules.
+	// The rules have the !important suffix, to protect the behavior from theme CSS bleed.
 	img.wp-block-cover__image-background,
 	video.wp-block-cover__video-background {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		margin: 0;
-		padding: 0;
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
+		position: absolute !important;
+		top: 0 !important;
+		left: 0 !important;
+		right: 0 !important;
+		bottom: 0 !important;
+		margin: 0 !important;
+		padding: 0 !important;
+		width: 100% !important;
+		height: 100% !important;
+		max-width: none !important;
+		max-height: none !important;
+		object-fit: cover !important;
+		outline: none !important;
+		border: none !important;
+		box-shadow: none !important;
 	}
 }
 

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -167,18 +167,19 @@
 			width: auto;
 		}
 	}
-}
 
-.wp-block-cover__image-background,
-.wp-block-cover__video-background {
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	width: inherit;
-	height: inherit;
-	object-fit: cover;
+	// Extra specificity for in edit mode where other styles would override it otherwise.
+	img.wp-block-cover__image-background,
+	video.wp-block-cover__video-background {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		width: inherit;
+		height: inherit;
+		object-fit: cover;
+	}
 }
 
 .wp-block-cover__video-background {


### PR DESCRIPTION
This PR is a copy of #28404, but is separate because the changes are pretty opinionated. That lets us try a milder approach in the original branch, and this pretty heavy approach separately.

The bulk of the change is to be found in this commit: https://github.com/WordPress/gutenberg/commit/b15d1da140729ea636ec873a7b3005ebd3ecc204, which adds additional selectors and suffixes them with !important. 

The reason that inspired that change is TwentyEleven, which has this CSS:

<img src="https://user-images.githubusercontent.com/1204802/105461174-27095800-5c8d-11eb-9a0d-c89bb37fc57a.png">

It reminded me that the `img` element is almost always styled by themes in numerous creative ways. If we don't anticipate themes doing this, it's likely the cover block, which now uses the image in a purely mechanical way, will suffer all kinds of CSS bleed.

So by anticipating what might bleed in here, the _hope_ is that we make the cover and its use of image, more resilient to that same bleed.

I almost always try to avoid !importants, but this seems like the right place for it. 

Here's TwentyEleven shown in #28404: 

<img width="785" alt="Screenshot 2021-01-22 at 09 20 58" src="https://user-images.githubusercontent.com/1204802/105466603-c1b96500-5c94-11eb-9822-fee310439e1e.png">

Here it is, in this branch:

<img width="804" alt="Screenshot 2021-01-22 at 09 25 19" src="https://user-images.githubusercontent.com/1204802/105466617-c847dc80-5c94-11eb-8a9b-92def8e2e79f.png">

This branch, frontend:

<img width="1091" alt="Screenshot 2021-01-22 at 09 27 40" src="https://user-images.githubusercontent.com/1204802/105466631-cbdb6380-5c94-11eb-8def-07060d09fc8f.png">
