### PR TITLE
Site Editor: Fix gray screen on refresh when editing pages and posts

### DIFF
--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -135,7 +135,11 @@ export function setHomeTemplateId( homeTemplateId ) {
  */
 export function* setPage( page ) {
 	if ( ! page.path && page.context?.postId ) {
-		page.path = `?p=${ page.context.postId }`;
+		if ( page.context?.postType === 'page' ) {
+			page.path = `/?page_id=${ page.context.postId }`;
+		} else {
+			page.path = `/?p=${ page.context.postId }`;
+		}
 	}
 	const { id: templateId, slug: templateSlug } = yield controls.resolveSelect(
 		'core',

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -3,6 +3,7 @@
  */
 import { controls } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
+import { getPathAndQueryString } from '@wordpress/url';
 
 /**
  * Returns an action object used to toggle a feature flag.
@@ -135,11 +136,15 @@ export function setHomeTemplateId( homeTemplateId ) {
  */
 export function* setPage( page ) {
 	if ( ! page.path && page.context?.postId ) {
-		if ( page.context?.postType === 'page' ) {
-			page.path = `/?page_id=${ page.context.postId }`;
-		} else {
-			page.path = `/?p=${ page.context.postId }`;
-		}
+		const entity = yield controls.resolveSelect(
+			'core',
+			'getEntityRecord',
+			'postType',
+			page.context.postType || 'post',
+			page.context.postId
+		);
+
+		page.path = getPathAndQueryString( entity.link );
 	}
 	const { id: templateId, slug: templateSlug } = yield controls.resolveSelect(
 		'core',


### PR DESCRIPTION
Fixes #28315

## Description
`setPage` action issued wrong requests when passing `postType` and `postId` only (no path specified). Let's use the right URL based on the `postType`.

Note: `path` should be absolute here to avoid issuing requests to `admin.php`.
## How has this been tested?

1. Open site editor
2. Open navigation panel
3. Navigate to "Pages"
4. Open "Sample page" (or any page you have)
5. Press refresh
6. Make sure it loads the same page
7. Repeat with a post too

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
