### PR TITLE
Image: add flow for converting to cover block from toolbar.

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -24,7 +24,7 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { image as icon } from '@wordpress/icons';
+import { image as icon, textColor } from '@wordpress/icons';
 
 /* global wp */
 
@@ -284,6 +284,7 @@ export function ImageEdit( {
 			/>
 			<ToolbarGroup>
 				<ToolbarButton
+					icon={ textColor }
 					label={ __( 'Add text overlay' ) }
 					onClick={ () =>
 						replaceBlocks(
@@ -291,9 +292,7 @@ export function ImageEdit( {
 							switchToBlockType( imageBlock, 'core/cover' )
 						)
 					}
-				>
-					{ __( '[abc]' ) }
-				</ToolbarButton>
+				/>
 			</ToolbarGroup>
 		</BlockControls>
 	);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -8,13 +8,8 @@ import { get, omit, pick } from 'lodash';
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
-import { switchToBlockType } from '@wordpress/blocks';
-import {
-	ToolbarGroup,
-	ToolbarButton,
-	withNotices,
-} from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { withNotices } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import {
 	BlockAlignmentToolbar,
 	BlockControls,
@@ -24,7 +19,7 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { image as icon, textColor } from '@wordpress/icons';
+import { image as icon } from '@wordpress/icons';
 
 /* global wp */
 
@@ -85,7 +80,6 @@ export function ImageEdit( {
 	insertBlocksAfter,
 	noticeOperations,
 	onReplace,
-	clientId,
 } ) {
 	const {
 		url = '',
@@ -113,13 +107,6 @@ export function ImageEdit( {
 		const { getSettings } = select( 'core/block-editor' );
 		return getSettings().mediaUpload;
 	} );
-
-	const imageBlock = useSelect( ( select ) => {
-		const { getBlock } = select( 'core/block-editor' );
-		return getBlock( clientId );
-	} );
-
-	const { replaceBlocks } = useDispatch( 'core/block-editor' );
 
 	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();
@@ -282,18 +269,6 @@ export function ImageEdit( {
 				value={ align }
 				onChange={ updateAlignment }
 			/>
-			<ToolbarGroup>
-				<ToolbarButton
-					icon={ textColor }
-					label={ __( 'Add text overlay' ) }
-					onClick={ () =>
-						replaceBlocks(
-							clientId,
-							switchToBlockType( imageBlock, 'core/cover' )
-						)
-					}
-				/>
-			</ToolbarGroup>
 		</BlockControls>
 	);
 	const src = isExternal ? url : undefined;

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -8,8 +8,13 @@ import { get, omit, pick } from 'lodash';
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
-import { withNotices } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { switchToBlockType } from '@wordpress/blocks';
+import {
+	ToolbarGroup,
+	ToolbarButton,
+	withNotices,
+} from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	BlockAlignmentToolbar,
 	BlockControls,
@@ -80,6 +85,7 @@ export function ImageEdit( {
 	insertBlocksAfter,
 	noticeOperations,
 	onReplace,
+	clientId,
 } ) {
 	const {
 		url = '',
@@ -107,6 +113,13 @@ export function ImageEdit( {
 		const { getSettings } = select( 'core/block-editor' );
 		return getSettings().mediaUpload;
 	} );
+
+	const imageBlock = useSelect( ( select ) => {
+		const { getBlock } = select( 'core/block-editor' );
+		return getBlock( clientId );
+	} );
+
+	const { replaceBlocks } = useDispatch( 'core/block-editor' );
 
 	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();
@@ -269,6 +282,19 @@ export function ImageEdit( {
 				value={ align }
 				onChange={ updateAlignment }
 			/>
+			<ToolbarGroup>
+				<ToolbarButton
+					label={ __( 'Add text overlay' ) }
+					onClick={ () =>
+						replaceBlocks(
+							clientId,
+							switchToBlockType( imageBlock, 'core/cover' )
+						)
+					}
+				>
+					{ __( '[abc]' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
 		</BlockControls>
 	);
 	const src = isExternal ? url : undefined;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -318,7 +318,7 @@ export default function Image( {
 					<ToolbarGroup>
 						<ToolbarButton
 							icon={ textColor }
-							label={ __( 'Add text overlay' ) }
+							label={ __( 'Add text over image' ) }
 							onClick={ () =>
 								replaceBlocks(
 									currentId,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -31,8 +31,8 @@ import {
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
-import { createBlock } from '@wordpress/blocks';
-import { crop, upload } from '@wordpress/icons';
+import { createBlock, switchToBlockType } from '@wordpress/blocks';
+import { crop, textColor, upload } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -83,14 +83,19 @@ export default function Image( {
 } ) {
 	const captionRef = useRef();
 	const prevUrl = usePrevious( url );
-	const { image, multiImageSelection } = useSelect(
+	const { block, currentId, image, multiImageSelection } = useSelect(
 		( select ) => {
 			const { getMedia } = select( 'core' );
-			const { getMultiSelectedBlockClientIds, getBlockName } = select(
-				'core/block-editor'
-			);
+			const {
+				getMultiSelectedBlockClientIds,
+				getBlockName,
+				getSelectedBlock,
+				getSelectedBlockClientId,
+			} = select( 'core/block-editor' );
 			const multiSelectedClientIds = getMultiSelectedBlockClientIds();
 			return {
+				block: getSelectedBlock(),
+				currentId: getSelectedBlockClientId(),
 				image: id && isSelected ? getMedia( id ) : null,
 				multiImageSelection:
 					multiSelectedClientIds.length &&
@@ -113,7 +118,9 @@ export default function Image( {
 			] );
 		}
 	);
-	const { toggleSelection } = useDispatch( 'core/block-editor' );
+	const { replaceBlocks, toggleSelection } = useDispatch(
+		'core/block-editor'
+	);
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
 		noticesStore
 	);
@@ -299,6 +306,20 @@ export default function Image( {
 						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
 					/>
+				) }
+				{ ! multiImageSelection && (
+					<ToolbarGroup>
+						<ToolbarButton
+							icon={ textColor }
+							label={ __( 'Add text overlay' ) }
+							onClick={ () =>
+								replaceBlocks(
+									currentId,
+									switchToBlockType( block, 'core/cover' )
+								)
+							}
+						/>
+					</ToolbarGroup>
 				) }
 			</BlockControls>
 			<InspectorControls>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -31,7 +31,11 @@ import {
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
-import { createBlock, switchToBlockType } from '@wordpress/blocks';
+import {
+	createBlock,
+	getBlockType,
+	switchToBlockType,
+} from '@wordpress/blocks';
 import { crop, textColor, upload } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -138,6 +142,9 @@ export default function Image( {
 		),
 		( { name, slug } ) => ( { value: slug, label: name } )
 	);
+
+	// Check if the cover block is registered.
+	const coverBlockExists = !! getBlockType( 'core/cover' );
 
 	useEffect( () => {
 		if ( ! isSelected ) {
@@ -307,7 +314,7 @@ export default function Image( {
 						onError={ onUploadError }
 					/>
 				) }
-				{ ! multiImageSelection && (
+				{ ! multiImageSelection && coverBlockExists && (
 					<ToolbarGroup>
 						<ToolbarButton
 							icon={ textColor }


### PR DESCRIPTION
Closes #28386.

This PR adds an action to the toolbar of the image block to communicate it's possible to add overlay text.
![image](https://user-images.githubusercontent.com/548849/105470504-ec59ec80-5c99-11eb-98fb-deecd57f2721.png)

Upon clicking the button the block transforms immediately to a cover block with its placeholder paragraph.
![image](https://user-images.githubusercontent.com/548849/105470884-65594400-5c9a-11eb-9db6-78220dbf87f2.png)

To do:

- [x] Account for the case where **Cover** is not available.
- [x] Make sure this option is at the end of the toolbar, since we don't want it to take prevalence over other actions.

Later:

- Explore if it makes sense to make some other adjustments to the resulting block (like no overlay by default, for example?).
- Consider having this disabled if the image block has a link set since that wouldn't transfer to a cover block.