### PR TITLE
Run the load time indicator computation multiple times

### DIFF
--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -127,7 +127,7 @@ describe( 'Post Editor Performance', () => {
 		}, html );
 		await saveDraft();
 
-		let i = 1;
+		let i = 5;
 
 		// Measuring loading time
 		while ( i-- ) {


### PR DESCRIPTION
Related #28432 

To get a more stable "load time indicator" in our performance benchmarks, this PR loads the time 5 times and do an average instead of just doing a single attempt.