### PR TITLE
Changelog script: More fine-grained Changelogs for patch releases

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -60,6 +60,10 @@ program
 	.alias( 'changelog' )
 	.option( '-m, --milestone <milestone>', 'Milestone' )
 	.option( '-t, --token <token>', 'Github token' )
+	.option(
+		'-u, --unreleased',
+		"Only include PRs that haven't been included in a release yet"
+	)
 	.description( 'Generates a changelog from merged Pull Requests' )
 	.action( catchException( getReleaseChangelog ) );
 

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -476,9 +476,15 @@ async function getChangelog( settings ) {
 
 	const pullRequests = await fetchAllPullRequests( octokit, settings );
 	if ( ! pullRequests.length ) {
-		throw new Error(
-			'There are no pull requests associated with the milestone.'
-		);
+		if ( settings.unreleased ) {
+			throw new Error(
+				'There are no unreleased pull requests associated with the milestone.'
+			);
+		} else {
+			throw new Error(
+				'There are no pull requests associated with the milestone.'
+			);
+		}
 	}
 
 	let changelog = '';

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -22,21 +22,24 @@ const manifest = require( '../../../package.json' );
 /** @typedef {import('@octokit/rest')} GitHub */
 /** @typedef {import('@octokit/rest').IssuesListForRepoResponseItem} IssuesListForRepoResponseItem */
 /** @typedef {import('@octokit/rest').IssuesListMilestonesForRepoResponseItem} OktokitIssuesListMilestonesForRepoResponseItem */
+/** @typedef {import('@octokit/rest').ReposListReleasesResponseItem} ReposListReleasesResponseItem */
 
 /**
  * @typedef WPChangelogCommandOptions
  *
- * @property {string=} milestone Optional Milestone title.
- * @property {string=} token     Optional personal access token.
+ * @property {string=}  milestone   Optional Milestone title.
+ * @property {string=}  token       Optional personal access token.
+ * @property {boolean=} unreleased  Optional flag to only include issues that haven't been part of a release yet.
  */
 
 /**
  * @typedef WPChangelogSettings
  *
- * @property {string}  owner     Repository owner.
- * @property {string}  repo      Repository name.
- * @property {string=} token     Optional personal access token.
- * @property {string}  milestone Milestone title.
+ * @property {string}   owner       Repository owner.
+ * @property {string}   repo        Repository name.
+ * @property {string=}  token       Optional personal access token.
+ * @property {string}   milestone   Milestone title.
+ * @property {boolean=} unreleased  Only include issues that have been closed since the milestone's latest release.
  */
 
 /**
@@ -381,6 +384,43 @@ function getEntry( issue ) {
 }
 
 /**
+ * Returns the latest release for a given series
+ *
+ * @param {GitHub} octokit  Initialized Octokit REST client.
+ * @param {string} owner    Repository owner.
+ * @param {string} repo     Repository name.
+ * @param {string} series   Gutenberg release series (e.g. '6.7' or '9.8').
+ *
+ * @return {Promise<ReposListReleasesResponseItem|undefined>} Promise resolving to pull
+ *                                                            requests for the given
+ *                                                            milestone.
+ */
+async function getLatestReleaseInSeries( octokit, owner, repo, series ) {
+	const releaseOptions = await octokit.repos.listReleases.endpoint.merge( {
+		owner,
+		repo,
+	} );
+
+	let latestReleaseForMilestone;
+
+	/**
+	 * @type {AsyncIterableIterator<import('@octokit/rest').Response<import('@octokit/rest').ReposListReleasesResponse>>}
+	 */
+	const releases = octokit.paginate.iterator( releaseOptions );
+
+	for await ( const releasesPage of releases ) {
+		latestReleaseForMilestone = releasesPage.data.find( ( release ) =>
+			release.name.startsWith( series )
+		);
+
+		if ( latestReleaseForMilestone ) {
+			return latestReleaseForMilestone;
+		}
+	}
+	return undefined;
+}
+
+/**
  * Returns a promise resolving to an array of pull requests associated with the
  * changelog settings object.
  *
@@ -391,7 +431,7 @@ function getEntry( issue ) {
  *                                            pull requests.
  */
 async function fetchAllPullRequests( octokit, settings ) {
-	const { owner, repo, milestone: milestoneTitle } = settings;
+	const { owner, repo, milestone: milestoneTitle, unreleased } = settings;
 	const milestone = await getMilestoneByTitle(
 		octokit,
 		owner,
@@ -405,13 +445,19 @@ async function fetchAllPullRequests( octokit, settings ) {
 		);
 	}
 
+	const series = milestoneTitle.replace( 'Gutenberg ', '' );
+	const latestReleaseInSeries = unreleased
+		? await getLatestReleaseInSeries( octokit, owner, repo, series )
+		: undefined;
+
 	const { number } = milestone;
 	const issues = await getIssuesByMilestone(
 		octokit,
 		owner,
 		repo,
 		number,
-		'closed'
+		'closed',
+		latestReleaseInSeries ? latestReleaseInSeries.published_at : undefined
 	);
 	return issues.filter( ( issue ) => issue.pull_request );
 }
@@ -502,6 +548,7 @@ async function getReleaseChangelog( options ) {
 						),
 				  } )
 				: options.milestone,
+		unreleased: options.unreleased,
 	} );
 }
 

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -71,9 +71,8 @@ async function getIssuesByMilestone( octokit, owner, repo, milestone, state ) {
 	 */
 	const releases = octokit.paginate.iterator( releaseOptions );
 
-	for await ( const r of releases ) {
-		const releasesPage = r.data;
-		latestReleaseInSeries = releasesPage.find( ( release ) =>
+	for await ( const releasesPage of releases ) {
+		latestReleaseInSeries = releasesPage.data.find( ( release ) =>
 			release.name.startsWith( series )
 		);
 

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -87,7 +87,9 @@ async function getIssuesByMilestone( octokit, owner, repo, milestone, state ) {
 		repo,
 		milestone,
 		state,
-		since: latestReleaseInSeries?.published_at,
+		...( latestReleaseInSeries && {
+			since: latestReleaseInSeries.published_at,
+		} ),
 	} );
 
 	/**

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -118,6 +118,7 @@ async function getIssuesByMilestone( octokit, owner, repo, milestone, state ) {
 					new Date(
 						// The ugly `as unknown as string` cast is required because of
 						// https://github.com/octokit/plugin-rest-endpoint-methods.js/issues/64
+						// Fixed in v18.1.1, see https://github.com/WordPress/gutenberg/pull/29043
 						/** @type {string} */ (
 							/** @type {unknown} */ ( pull.closed_at )
 						)

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -96,6 +96,9 @@ async function getIssuesByMilestone( octokit, owner, repo, milestone, state ) {
 	 */
 	const responses = octokit.paginate.iterator( options );
 
+	/**
+	 * @type {import('@octokit/rest').IssuesListForRepoResponse}
+	 */
 	const pulls = [];
 
 	for await ( const response of responses ) {

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -118,7 +118,7 @@ async function getIssuesByMilestone( octokit, owner, repo, milestone, state ) {
 					new Date(
 						// The ugly `as unknown as string` cast is required because of
 						// https://github.com/octokit/plugin-rest-endpoint-methods.js/issues/64
-						// Fixed in v18.1.1, see https://github.com/WordPress/gutenberg/pull/29043
+						// Fixed in Octokit v18.1.1, see https://github.com/WordPress/gutenberg/pull/29043
 						/** @type {string} */ (
 							/** @type {unknown} */ ( pull.closed_at )
 						)

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -114,7 +114,14 @@ async function getIssuesByMilestone( octokit, owner, repo, milestone, state ) {
 		return pulls.filter(
 			( pull ) =>
 				pull.closed_at &&
-				latestReleasePublishedAtTimestamp < new Date( pull.closed_at )
+				latestReleasePublishedAtTimestamp <
+					new Date(
+						// The ugly `as unknown as string` cast is required because of
+						// https://github.com/octokit/plugin-rest-endpoint-methods.js/issues/64
+						/** @type {string} */ (
+							/** @type {unknown} */ ( pull.closed_at )
+						)
+					)
 		);
 	}
 

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -103,6 +103,18 @@ async function getIssuesByMilestone( octokit, owner, repo, milestone, state ) {
 		pulls.push( ...issues );
 	}
 
+	if ( latestReleaseInSeries?.published_at ) {
+		const latestReleasePublishedAtTimestamp = new Date(
+			latestReleaseInSeries.published_at
+		);
+
+		return pulls.filter(
+			( pull ) =>
+				pull.closed_at &&
+				latestReleasePublishedAtTimestamp < new Date( pull.closed_at )
+		);
+	}
+
 	return pulls;
 }
 

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -67,6 +67,8 @@ To override the default behavior, you can pass one or both of the following opti
     -   Example: `npm run changelog -- --milestone="Gutenberg 8.1"`
 -   `--token <token>`: Provide a [GitHub personal access token](https://github.com/settings/tokens) for authenticating requests. This should only be necessary if you run the script frequently enough to been blocked by [rate limiting](https://developer.github.com/v3/#rate-limiting).
     -   Example: `npm run changelog -- --token="..."`
+-   `--unreleased`: Only list PRs that have been closed after the latest release in the milestone's series has been published. In other words, only list PRs that haven't been part of a release yet.
+    -   Example: `npm run changelog -- --milestone="Gutenberg 9.8" --unreleased`. If the latest version in the 9.8 series is 9.8.3, only show PRs for the in the 9.8 series that were closed (merged) after 9.8.3 was published.
 
 The script will output a generated changelog, grouped by pull request label. _Note that this is intended to be a starting point for release notes_. You will still want to manually review and curate the changelog entries.
 


### PR DESCRIPTION
## Description
The Changelog generator script, `bin/plugin/commands/changelog.js`, currently doesn't support patch releases: It's only possible to generate a Changelog for a given milestone (which are per-minor-release, i.e. per-release-branch), but not on a more fine-grained basis. If the Changelog script is run for a patch release, the generated Changelog includes everything from the `.0` stable release from that series up to the patch release.

This PR adds an `--unreleased` option to the Changelog script that makes it look up the latest release in the series, and only includes issues that were modified after that release was published. This will allow us to use the script to generate the Changelog for patch releases (or at least a baseline -- see 'Discussion' for a caveat).

This will come in handy as we automate more and more parts of the build process -- especially to auto-generate a Changelog for patch releases, and to pre-populate the corresponding release notes. (Cf. #28138.)

## How has this been tested?

Apply this patch to simulate that you're creating the Changelog for v9.8.1, and that the latest release is v9.8.0:

```diff
diff --git a/bin/plugin/lib/milestone.js b/bin/plugin/lib/milestone.js
index ef246b2105..0421ab109f 100644
--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -73,7 +73,7 @@ async function getIssuesByMilestone( octokit, owner, repo, milestone, state ) {
 
        for await ( const releasesPage of releases ) {
                latestReleaseInSeries = releasesPage.data.find( ( release ) =>
-                       release.name.startsWith( series )
+                       release.name.startsWith( '9.8.0' )
                );
 
                if ( latestReleaseInSeries ) {

```

Then, run:

```
npm run changelog -- --milestone="Gutenberg 9.8"
```

## Output

### Before:

Basically like the [9.8.0 changelog](https://github.com/WordPress/gutenberg/releases/tag/v9.8.0), plus the PRs on the 9.8 milestone that have been merged since 9.8.

### After:

Only issues that have been modified since 9.8.0 was published:

```
💃Preparing changelog for milestone: "Gutenberg 9.8"

### Enhancements

- Try: Transparent spacer. ([28103](https://github.com/WordPress/gutenberg/pull/28103))

### Bug Fixes

- Fix cover matrix alignment. ([28404](https://github.com/WordPress/gutenberg/pull/28404))
- Revert "Cover: Fix matrix alignment issue.". ([28364](https://github.com/WordPress/gutenberg/pull/28364))
- Cover: Fix matrix alignment issue. ([28361](https://github.com/WordPress/gutenberg/pull/28361))
- Fix nested cover block bug. ([28114](https://github.com/WordPress/gutenberg/pull/28114))

### Experiments

- FSE: Fix iframe error in Firefox. ([28212](https://github.com/WordPress/gutenberg/pull/28212))

### Various

- Add srcset for cover image. ([25171](https://github.com/WordPress/gutenberg/pull/25171))

```

## Discussion

Note that this still includes a few erroneous entries (e.g. the `srcset` issue under the `Various` heading). The reason for these is that we use the `since` parameter to filter for issues that have been _modified_ since the previous release in the series was published. However, that doesn't just include _closed_ issues, but also issues to which a new comment was added, or that were otherwise modified.

I do think however that it's better to (manually) go through a few stray extra Changelog entries rather than getting the entire Changelog for the `.0` version of the series again.

## Possible future improvements

In a future iteration, I think we should maybe reconsider our source of truth for Changelog generation: Maybe we shouldn't query the list of issues/PRs for the milestone from the GitHub API. Instead, we have more reliable information right at our fingertips: git itself. We might just want to call `git log` with some arguments to get that exact kind of information (in a more reliable way than from GH's milestone, which just manually replicates that information). If we still want/need PR numbers etc, we can probably query those from the GH API, based on the Changelog obtained from `git`.
