### PR TITLE
Add `WordPress-Extra` ruleset for `phpcs`

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,6 +8,7 @@
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress.WP.I18n"/>
+	<rule ref="WordPress-Extra"/>
 	<config name="text_domain" value="gutenberg,default"/>
 
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Coding standards: Use WordPress-Extra ruleset to prevent potential security issues. 

Fixes https://github.com/WordPress/gutenberg/issues/18502

## How has this been tested?
Added the rule and confirmed locally that there's triggering different warnings and errors.

## Types of changes
Adding the `<rule ref="WordPress-Extra"/>` rule.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
