### PR TITLE
Docs/Tools/CI: Update references from `master` to `trunk`

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
     - '**.md'
   push:
-    branches: [master]
+    branches: [trunk]
     tags:
       - 'v*'
     paths-ignore:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -7,7 +7,7 @@ on:
     - '!packages/**/test/**'
     - '!packages/**/*.md'
   push:
-    branches: [master, wp/trunk]
+    branches: [trunk, wp/trunk]
     paths:
     - 'packages/**'
     - '!packages/**/test/**'

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -6,7 +6,7 @@ on:
     - '**.md'
   push:
     branches:
-      - master
+      - trunk
       - 'wp/**'
     paths-ignore:
     - '**.md'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -38,9 +38,9 @@ jobs:
       run: |
         npm ci
 
-    - name: Compare performance with master
+    - name: Compare performance with trunk
       if: github.event_name == 'pull_request'
-      run: ./bin/plugin/cli.js perf --ci $GITHUB_SHA master --tests-branch $GITHUB_SHA
+      run: ./bin/plugin/cli.js perf --ci $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
     - name: Compare performance with current WordPress Core and previous Gutenberg versions
       if: github.event_name == 'release'

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Checkout defaults to using the branch which triggered the event, which
-    # isn't necessarily `master` (e.g. in the case of a merge).
+    # isn't necessarily `trunk` (e.g. in the case of a merge).
     - uses: actions/checkout@v2
       with:
-        ref: master
+        ref: trunk
 
     # Changing into the action's directory and running `npm install` is much
     # faster than a full project-wide `npm ci`.

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
     - '**.md'
   push:
-    branches: [master]
+    branches: [trunk]
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
     - '**.md'
   push:
-    branches: [master]
+    branches: [trunk]
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - trunk
       - 'wp/**'
 
 jobs:

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -3,7 +3,7 @@ name: Storybook GitHub Pages
 on:
   push:
     branches:
-      - master
+      - trunk
 
 jobs:
   deploy:
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        ref: master
+        ref: trunk
 
     - name: Cache node modules
       uses: actions/cache@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - trunk
       - 'wp/**'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Gutenberg
 
-[![End-to-End Tests](https://github.com/WordPress/gutenberg/workflows/End-to-End%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22End-to-End+Tests%22+branch%3Amaster)
-[![Static Analysis (Linting, License, Type checks...)](https://github.com/WordPress/gutenberg/workflows/Static%20Analysis%20(Linting,%20License,%20Type%20checks...)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Static+Analysis+%28Linting%2C+License%2C+Type+checks...%29%22+branch%3Amaster)
-[![Unit Tests](https://github.com/WordPress/gutenberg/workflows/Unit%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Unit+Tests%22+branch%3Amaster)
-[![Create Block](https://github.com/WordPress/gutenberg/workflows/Create%20Block/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Create+Block%22+branch%3Amaster)
-[![React Native E2E Tests (iOS)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(iOS)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28iOS%29%22+branch%3Amaster)
-[![React Native E2E Tests (Android)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(Android)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28Android%29%22+branch%3Amaster)
+[![End-to-End Tests](https://github.com/WordPress/gutenberg/workflows/End-to-End%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22End-to-End+Tests%22+branch%3Atrunk)
+[![Static Analysis (Linting, License, Type checks...)](https://github.com/WordPress/gutenberg/workflows/Static%20Analysis%20(Linting,%20License,%20Type%20checks...)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Static+Analysis+%28Linting%2C+License%2C+Type+checks...%29%22+branch%3Atrunk)
+[![Unit Tests](https://github.com/WordPress/gutenberg/workflows/Unit%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Unit+Tests%22+branch%3Atrunk)
+[![Create Block](https://github.com/WordPress/gutenberg/workflows/Create%20Block/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Create+Block%22+branch%3Atrunk)
+[![React Native E2E Tests (iOS)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(iOS)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28iOS%29%22+branch%3Atrunk)
+[![React Native E2E Tests (Android)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(Android)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28Android%29%22+branch%3Atrunk)
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -211,7 +211,7 @@ async function runTestSuite( testSuite, performanceTestDirectory ) {
 async function runPerformanceTests( branches, options ) {
 	// The default value doesn't work because commander provides an array.
 	if ( branches.length === 0 ) {
-		branches = [ 'master' ];
+		branches = [ 'trunk' ];
 	}
 
 	log(

--- a/bin/plugin/commands/release.js
+++ b/bin/plugin/commands/release.js
@@ -276,37 +276,37 @@ async function runPushGitChangesStep(
 }
 
 /**
- * Cherry-picks the version bump commit into master.
+ * Cherry-picks the version bump commit into trunk.
  *
  * @param {string} gitWorkingDirectoryPath Git Working Directory Path.
  * @param {string} commitHash   Commit to cherry-pick.
  * @param {string} abortMessage Abort message.
  */
-async function runCherrypickBumpCommitIntoMasterStep(
+async function runCherrypickBumpCommitIntoTrunkStep(
 	gitWorkingDirectoryPath,
 	commitHash,
 	abortMessage
 ) {
 	await runStep(
-		'Cherry-picking the bump commit into master',
+		'Cherry-picking the bump commit into trunk',
 		abortMessage,
 		async () => {
 			await askForConfirmation(
-				'The plugin is now released. Proceed with the version bump in the master branch?',
+				'The plugin is now released. Proceed with the version bump in the trunk branch?',
 				true,
 				abortMessage
 			);
 			await git.discardLocalChanges( gitWorkingDirectoryPath );
 			await git.resetLocalBranchAgainstOrigin(
 				gitWorkingDirectoryPath,
-				'master'
+				'trunk'
 			);
 			await git.cherrypickCommitIntoBranch(
 				gitWorkingDirectoryPath,
 				commitHash,
-				'master'
+				'trunk'
 			);
-			await git.pushBranchToOrigin( gitWorkingDirectoryPath, 'master' );
+			await git.pushBranchToOrigin( gitWorkingDirectoryPath, 'trunk' );
 		}
 	);
 }
@@ -462,10 +462,10 @@ async function releasePlugin( isRC = true ) {
 	abortMessage =
 		'Aborting! Make sure to manually cherry-pick the ' +
 		formats.success( commitHash ) +
-		' commit to the master branch.';
+		' commit to the trunk branch.';
 
-	// Cherry-picking the bump commit into master
-	await runCherrypickBumpCommitIntoMasterStep(
+	// Cherry-picking the bump commit into trunk
+	await runCherrypickBumpCommitIntoTrunkStep(
 		gitWorkingDirectory,
 		commitHash,
 		abortMessage

--- a/bin/plugin/lib/git.js
+++ b/bin/plugin/lib/git.js
@@ -126,7 +126,7 @@ async function resetLocalBranchAgainstOrigin(
 }
 
 /**
- * Cherry-picks a commit into master
+ * Cherry-picks a commit into trunk
  *
  * @param {string} gitWorkingDirectoryPath Local repository path.
  * @param {string} commitHash Branch Name
@@ -136,7 +136,7 @@ async function cherrypickCommitIntoBranch(
 	commitHash
 ) {
 	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
-	await simpleGit.checkout( 'master' );
+	await simpleGit.checkout( 'trunk' );
 	await simpleGit.raw( [ 'cherry-pick', commitHash ] );
 }
 

--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script validates whether `npm init @wordpress/block` works properly
-# with the latest changes applied to the `master` branch. It purposefully
+# with the latest changes applied to the `trunk` branch. It purposefully
 # avoids installing `@wordpress/scripts` package from npm when scaffolding
 # a test block and uses the local package by executing everything from the
 # root of the project.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7659,7 +7659,7 @@ Add knobs to the [ColorIndicator Story](https://github.com/WordPress/gutenberg/p
 * Fix keyboard interaction (up/down arrow keys) causing focus to transfer out of the default block’s insertion menu.
 * Fix regression causing dynamic blocks not rendering in the frontend.
 * Fix vertical alignment issue on Media & Text block.
-* Fix some linter errors in main branch.
+* Fix some linter errors in trunk branch.
 * Fix dash line in More/Next-Page blocks.
 * Fix missing Categories block label.
 * Fix embedding and demo tests.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3653,7 +3653,7 @@ Fix action GitHub action workflow YAML syntax errors. ([23844](https://github.co
 - Global styles provider. ([21637](https://github.com/WordPress/gutenberg/pull/21637))
 - Update existing templates to use new blocks. ([21857](https://github.com/WordPress/gutenberg/pull/21857))
 - Enable pullquote block. ([21930](https://github.com/WordPress/gutenberg/pull/21930))
-- Merge release branch back to master for v1.27.1. ([22234](https://github.com/WordPress/gutenberg/pull/22234))
+- Merge release branch back to trunk for v1.27.1. ([22234](https://github.com/WordPress/gutenberg/pull/22234))
 - Wrap button blocks with buttons blocks in page templates. ([21939](https://github.com/WordPress/gutenberg/pull/21939))
 - Components: Create a separate .native entry for ToolbarItem. ([22229](https://github.com/WordPress/gutenberg/pull/22229))
 
@@ -5810,7 +5810,7 @@ Add knobs to the [ColorIndicator Story](https://github.com/WordPress/gutenberg/p
 - Fix Travis instability by [waiting for MySQL availability](https://github.com/WordPress/gutenberg/pull/16461) before install the plugin.
 - Continue the [generic RichText component](https://github.com/WordPress/gutenberg/pull/16309) refactoring.
 - Remove the [usage of the editor store](https://github.com/WordPress/gutenberg/pull/16184) from the block editor module.
-- Update the [MilestoneIt Github action](https://github.com/WordPress/gutenberg/pull/16511) to read the plugin version from master.
+- Update the [MilestoneIt Github action](https://github.com/WordPress/gutenberg/pull/16511) to read the plugin version from trunk.
 - Refactor the post meta block attributes to use a generic [custom sources mechanism](https://github.com/WordPress/gutenberg/pull/16402).
 - Expose [position prop in DotTip](https://github.com/WordPress/gutenberg/pull/14972) component.
 - Avoid docker [containers automatic restart](https://github.com/WordPress/gutenberg/pull/16547).
@@ -7659,7 +7659,7 @@ Add knobs to the [ColorIndicator Story](https://github.com/WordPress/gutenberg/p
 * Fix keyboard interaction (up/down arrow keys) causing focus to transfer out of the default block’s insertion menu.
 * Fix regression causing dynamic blocks not rendering in the frontend.
 * Fix vertical alignment issue on Media & Text block.
-* Fix some linter errors in master branch.
+* Fix some linter errors in main branch.
 * Fix dash line in More/Next-Page blocks.
 * Fix missing Categories block label.
 * Fix embedding and demo tests.
@@ -9794,7 +9794,7 @@ Add knobs to the [ColorIndicator Story](https://github.com/WordPress/gutenberg/p
 * Add security reporting instructions.
 * Improve useOnce documentation.
 * Bump copyright year to 2018 in license.md.
-* Disable Travis branch builds except for master.
+* Disable Travis branch builds except for trunk.
 
 = 2.0.0 =
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -138,7 +138,7 @@ The Gutenberg repository also includes [Storybook](https://storybook.js.org/) in
 
 You can launch Storybook by running `npm run storybook:dev` locally. It will open in your browser automatically.
 
-You can also test Storybook for the current `master` branch on GitHub Pages: [https://wordpress.github.io/gutenberg/](https://wordpress.github.io/gutenberg/)
+You can also test Storybook for the current `trunk` branch on GitHub Pages: [https://wordpress.github.io/gutenberg/](https://wordpress.github.io/gutenberg/)
 
 ## Developer Tools
 

--- a/docs/contributors/git-workflow.md
+++ b/docs/contributors/git-workflow.md
@@ -95,15 +95,15 @@ When many different people are working on a project simultaneously, pull request
 
 There are two ways to do this: merging and rebasing. In Gutenberg, the recommendation is to rebase. Rebasing means rewriting your changes as if they're happening on top of the main line of development. This ensures the commit history is always clean and linear. Rebasing can be performed as many times as needed while you're working on a pull request. **Do share your work early on** by opening a pull request and keeping your history rebase as you progress.
 
-The main line of development is known as the `master` branch. If you have a pull-request branch that cannot be merged into `master` due to a conflict (this can happen for long-running pull requests), then in the course of rebasing you'll have to manually resolve any conflicts in your local copy. Learn more in [section _Perform a rebase_](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#perform-a-rebase) of _How to Rebase a Pull Request_.
+The main line of development is known as the `trunk` branch. If you have a pull-request branch that cannot be merged into `trunk` due to a conflict (this can happen for long-running pull requests), then in the course of rebasing you'll have to manually resolve any conflicts in your local copy. Learn more in [section _Perform a rebase_](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#perform-a-rebase) of _How to Rebase a Pull Request_.
 
 Once you have resolved any conflicts locally you can update the pull request with `git push --force-with-lease`. Using the `--force-with-lease` parameter is important to guarantee that you don't accidentally overwrite someone else's work.
 
-To sum it up, you need to fetch any new changes in the repository, rebase your branch on top of `master`, and push the result back to the repository. These are the corresponding commands:
+To sum it up, you need to fetch any new changes in the repository, rebase your branch on top of `trunk`, and push the result back to the repository. These are the corresponding commands:
 
 ```sh
 git fetch
-git rebase master
+git rebase trunk
 git push --force-with-lease origin your-branch-name
 ```
 
@@ -126,8 +126,8 @@ To sync your fork, you first need to fetch the upstream changes and merge them i
 
 ``` sh
 git fetch upstream
-git checkout master
-git merge upstream/master
+git checkout trunk
+git merge upstream/trunk
 ```
 
 Once your local copy is updated, push your changes to update your fork on GitHub:
@@ -136,4 +136,4 @@ Once your local copy is updated, push your changes to update your fork on GitHub
 git push
 ```
 
-The above commands will update your `master` branch from _upstream_. To update any other branch replace `master` with the respective branch name.
+The above commands will update your `trunk` branch from _upstream_. To update any other branch replace `trunk` with the respective branch name.

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -275,7 +275,7 @@ The first step is automated via `./bin/plugin/cli.js npm-latest` command. You on
     - You'll be asked for your One-Time Password (OTP) a couple of times. This is the code from the 2FA authenticator app you use. Depending on how many packages are to be released you may be asked for more than one OTP, as they tend to expire before all packages are released.
     - If the publishing process ends up incomplete (perhaps because it timed-out or an bad OTP was introduce) you can resume it via [`lerna publish from-package`](https://github.com/lerna/lerna/tree/HEAD/commands/publish#bump-from-package).
 
-Finally, now that the npm packages are ready, a patch can be created and committed into WordPress `trunk`. You should also cherry-pick the commits created by lerna ("Publish" and the CHANGELOG update) into the main branch of Gutenberg.
+Finally, now that the npm packages are ready, a patch can be created and committed into WordPress `trunk`. You should also cherry-pick the commits created by lerna ("Publish" and the CHANGELOG update) into the `trunk` branch of Gutenberg.
 
 ### Minor WordPress Releases
 

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -94,10 +94,10 @@ Compile this to a draft post on [make.wordpress.org/core](https://make.wordpress
 
 ##### Creating the Release Branch
 
-For each milestone (let's assume it's `x.x` here), a release branch is used to release all RCs and minor releases. For the first RC of the milestone, a release branch is created from master.
+For each milestone (let's assume it's `x.x` here), a release branch is used to release all RCs and minor releases. For the first RC of the milestone, a release branch is created from trunk.
 
 ```
-git checkout master
+git checkout trunk
 git checkout -b release/x.x
 git push origin release/x.x
 ```
@@ -106,7 +106,7 @@ git push origin release/x.x
 
 1. Checkout the `release/x.x` branch.
 2. Create [a commit like this](https://github.com/WordPress/gutenberg/pull/13125/commits/13fa651dadc2472abb9b95f80db9d5f23e63ae9c), bumping the version number in `gutenberg.php`, `package.json`, and `package-lock.json` to `x.x.0-rc.1`.
-3. Create a Pull Request from the release branch into `master` using the changelog as a description and ensure the tests pass properly.
+3. Create a Pull Request from the release branch into `trunk` using the changelog as a description and ensure the tests pass properly.
 4. Tag the RC version. `git tag vx.x.0-rc.1` from the release branch.
 5. Push the tag `git push --tags`.
 6. Merge the version bump pull request and avoid removing the release branch.
@@ -129,16 +129,16 @@ Here's an example [release candidate page](https://github.com/WordPress/gutenber
 
 #### Creating Release Candidate Patches (done via `git cherry-pick`)
 
-If a bug is found in a release candidate and a fix is committed to `master`, we should include that fix in a new release candidate. To do this you'll need to use `git cherry-pick` to add these changes to the milestone's release branch. This way only fixes are added to the release candidate and not all the new code that has landed on `master` since tagging:
+If a bug is found in a release candidate and a fix is committed to `trunk`, we should include that fix in a new release candidate. To do this you'll need to use `git cherry-pick` to add these changes to the milestone's release branch. This way only fixes are added to the release candidate and not all the new code that has landed on `trunk` since tagging:
 
 1. Checkout the corresponding release branch with: `git checkout release/x.x`.
 2. Cherry-pick fix commits (in chronological order) with `git cherry-pick [SHA]`.
 3. Create [a commit like this](https://github.com/WordPress/gutenberg/pull/13125/commits/13fa651dadc2472abb9b95f80db9d5f23e63ae9c), bumping the version number in `gutenberg.php`, `package.json`, and `package-lock.json` to `x.x.0-rc.2`.
-4. Create a Pull Request from the release branch into `master` using the changelog as a description and ensure the tests pass properly. Note that if there there are merge conflicts, Travis CI will not run on the PR. Run tests locally using `npm run test` and `npm run test-e2e` if this happens.
+4. Create a Pull Request from the release branch into `trunk` using the changelog as a description and ensure the tests pass properly. Note that if there there are merge conflicts, Travis CI will not run on the PR. Run tests locally using `npm run test` and `npm run test-e2e` if this happens.
 5. Tag the RC version. `git tag vx.x.0-rc.2` from the release branch.
 6. Push the tag `git push --tags`.
 7. Create a branch for bumping the version number. `git checkout -b bump/x.x`.
-8. Create a Pull Request from the `bump/x.x` branch into `master` using the
+8. Create a Pull Request from the `bump/x.x` branch into `trunk` using the
    changelog as a description.
 9. Merge the version bump pull request.
 10. Follow the steps in [build the plugin](#build-the-plugin) and [publish the release on GitHub](#publish-the-release-on-github).
@@ -168,12 +168,12 @@ Creating a release involves:
 
 1. Checkout the release branch `git checkout release/x.x`.
 
-**Note:** This branch should never be removed or rebased. When we want to merge something from it to master and conflicts exist/may exist we use a temporary branch `bump/x.x`.
+**Note:** This branch should never be removed or rebased. When we want to merge something from it to trunk and conflicts exist/may exist we use a temporary branch `bump/x.x`.
 
 2. Create [a commit like this](https://github.com/WordPress/gutenberg/commit/00d01049685f11f9bb721ad3437cb928814ab2a2#diff-b9cfc7f2cdf78a7f4b91a753d10865a2), removing the `-rc.X` from the version number in `gutenberg.php`, `package.json`, and `package-lock.json`.
 3. Create a new branch called `bump/x.x` from `release/x.x` and switch to it: `git checkout -b bump/x.x`.
-4. Create a pull request from `bump/x.x` to `master`. Verify the continuous integrations tests pass, before continuing to the next step even if conflicts exist.
-5. Rebase `bump/x.x` against `origin/master` using `git fetch origin && git rebase origin/master`.
+4. Create a pull request from `bump/x.x` to `trunk`. Verify the continuous integrations tests pass, before continuing to the next step even if conflicts exist.
+5. Rebase `bump/x.x` against `origin/trunk` using `git fetch origin && git rebase origin/trunk`.
 6. Force push the branch `bump/x.x` using `git push --force-with-lease`.
 7. Switch to the `release/x.x` branch. Tag the version from the release branch `git tag vx.x.0`.
 8. Push the tag `git push --tags`.
@@ -298,7 +298,7 @@ Now, the branch is ready to be used to publish the npm packages.
 **Note:** For WordPress `5.0` and WordPress `5.1`, a different release process was used. This means that when choosing npm package versions targeting these two releases, you won't be able to use the next `patch` version number as it may have been already used. You should use the "metadata" modifier for these. For example, if the last published package version for this WordPress branch was `5.6.1`, choose `5.6.1+patch.1` as a version.
 
 3. Update the `CHANGELOG.md` files of the published packages with the new released versions and commit to the corresponding branch (Example `wp/5.2`).
-4. Cherry-pick the CHANGELOG update commits into the `master` branch of Gutenberg.
+4. Cherry-pick the CHANGELOG update commits into the `trunk` branch of Gutenberg.
 
 Now, the npm packages should be ready and a patch can be created and committed into the corresponding WordPress SVN branch.
 
@@ -306,15 +306,15 @@ Now, the npm packages should be ready and a patch can be created and committed i
 
 The following workflow is needed when packages require bug fixes or security releases to be published to _npm_ outside of a WordPress release cycle.
 
-Note: Both the `master` and `wp/trunk` branches are restricted and can only be _pushed_ to by the Gutenberg Core team.
+Note: Both the `trunk` and `wp/trunk` branches are restricted and can only be _pushed_ to by the Gutenberg Core team.
 
-Identify the commit hashes from the pull requests that need to be ported from the repo `master` branch to `wp/trunk`
+Identify the commit hashes from the pull requests that need to be ported from the repo `trunk` branch to `wp/trunk`
 
 The `wp/trunk` branch now needs to be prepared to release and publish the packages to _npm_.
 
 Open a terminal and perform the following steps:
 
-1. `git checkout master`
+1. `git checkout trunk`
 2. `git pull`
 3. `git checkout wp/trunk`
 4. `git pull`
@@ -324,7 +324,7 @@ Before porting commits check that the `wp/trunk` branch does not have any outsta
 1. `git checkout wp/trunk`
 2. `npm run publish:check`
 
-Now _cherry-pick_ the commits from `master` to `wp/trunk`, use `-m 1 commithash` if the commit was a pull request merge commit:
+Now _cherry-pick_ the commits from `trunk` to `wp/trunk`, use `-m 1 commithash` if the commit was a pull request merge commit:
 
 1. `git cherry-pick -m 1 cb150a2`
 2. `git push`
@@ -357,7 +357,7 @@ Begin updating the _changelogs_ based on the [Maintaining Changelogs](https://gi
     > Example
     >
     > ```
-    > [master 278f524f16] Update changelogs` 278f524
+    > [trunk 278f524f16] Update changelogs` 278f524
     > ```
 6. `git push`
 
@@ -408,9 +408,9 @@ Now that the changes have been committed to the `wp/trunk` branch and the Travis
     > lerna success published 3 packages
     > ```
 
-Now that the packages have been published the _"chore(release): publish"_ and _"Update changelogs"_ commits to `wp/trunk` need to be ported to the `master` branch:
+Now that the packages have been published the _"chore(release): publish"_ and _"Update changelogs"_ commits to `wp/trunk` need to be ported to the `trunk` branch:
 
-1. `git checkout master`
+1. `git checkout trunk`
 2. `git pull`
 3. Cherry-pick the `278f524`hash you noted above from the _"Update changelogs"_ commit made to `wp/trunk`
 4. `git cherry-pick 278f524`

--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -123,11 +123,11 @@ A pull request can generally be merged once it is:
 - Vetted against all potential edge cases.
 - Changelog entries were properly added.
 - Reviewed by someone other than the original author.
-- [Rebased](/docs/contributors/git-workflow.md#keeping-your-branch-up-to-date) onto the latest version of the master branch.
+- [Rebased](/docs/contributors/git-workflow.md#keeping-your-branch-up-to-date) onto the latest version of the trunk branch.
 
 The final pull request merge decision is made by the **@wordpress/gutenberg-core** team.
 
-All members of the WordPress organization on GitHub have the ability to review and merge pull requests. If you have reviewed a PR and are confident in the code, approve the pull request and comment pinging **@wordpress/gutenberg-core** or a specific core member who has been involved in the PR. Once they confirm there are no objections, you are free to merge the PR into master.
+All members of the WordPress organization on GitHub have the ability to review and merge pull requests. If you have reviewed a PR and are confident in the code, approve the pull request and comment pinging **@wordpress/gutenberg-core** or a specific core member who has been involved in the PR. Once they confirm there are no objections, you are free to merge the PR into trunk.
 
 Most pull requests will be automatically assigned a release milestone, but please make sure your merged pull request was assigned one. Doing so creates the historical legacy of what code landed when, and makes it possible for all project contributors (even non-technical ones) to access this information.
 

--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -496,13 +496,13 @@ This gives you the result for the current branch/code on the running environment
 In addition to that, you can also compare the metrics across branches (or tags or commits) by running the following command `./bin/plugin/cli.js perf [branches]`, example:
 
 ```
-./bin/plugin/cli.js perf master v8.1.0 v8.0.0
+./bin/plugin/cli.js perf trunk v8.1.0 v8.0.0
 ```
 
 Finally, you can pass an additional `--tests-branch` argument to specify which branch's performance test files you'd like to run. This is particularly useful when modifying/extending the perf tests:
 
 ```
-./bin/plugin/cli.js perf master v8.1.0 v8.0.0 --tests-branch add/perf-tests-coverage
+./bin/plugin/cli.js perf trunk v8.1.0 v8.0.0 --tests-branch add/perf-tests-coverage
 ```
 
 **Note** This command needs may take some time to perform the benchmark. While running make sure to avoid using your computer or have a lot of background process to minimize external factors that can impact the results across branches.

--- a/packages/components/src/ui/text/utils.js
+++ b/packages/components/src/ui/text/utils.js
@@ -12,7 +12,7 @@ import { createElement } from '@wordpress/element';
 
 /**
  * Source:
- * https://github.com/bvaughn/react-highlight-words/blob/master/src/Highlighter.js
+ * https://github.com/bvaughn/react-highlight-words/blob/HEAD/src/Highlighter.js
  */
 
 /* eslint-disable jsdoc/valid-types */

--- a/packages/customize-widgets/CHANGELOG.md
+++ b/packages/customize-widgets/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
 

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -6,7 +6,7 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [ "wordpress" ],
-	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/customize-widgets/README.md",
+	"homepage": "https://github.com/WordPress/gutenberg/blob/HEAD/packages/customize-widgets/README.md",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/WordPress/gutenberg.git",

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
@@ -75,7 +75,7 @@ describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await insertBlock( 'Image' );
 		await closeGlobalBlockInserter();
 		await page.waitForSelector( '.product[data-number-of-children="2"]' );
-		// This focus shouldn't be neessary but there's a bug in master right now
+		// This focus shouldn't be neessary but there's a bug in trunk right now
 		// Where if you open the inserter, don't do anything and click the "appender" on the canvas
 		// the appender is not opened right away.
 		// It needs to be investigated on its own.

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -399,7 +399,7 @@ Several types of strings can be passed into the `core`, `plugins`, `themes`, and
 | ----------------- | ----------------------------- | -------------------------------------------------------- |
 | Relative path     | `.<path>\|~<path>`            | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
 | Absolute path     | `/<path>\|<letter>:\<path>`   | `"/a/directory"`, `"C:\\a\\directory"`                   |
-| GitHub repository | `<owner>/<repo>[#<ref>]`      | `"WordPress/WordPress"`, `"WordPress/gutenberg#master"`  |
+| GitHub repository | `<owner>/<repo>[#<ref>]`      | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`  |
 | ZIP File          | `http[s]://<host>/<path>.zip` | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 
 Remote sources will be downloaded into a temporary directory located in `~/.wp-env`.
@@ -475,7 +475,7 @@ This is useful for plugin development when upstream Core changes need to be test
 
 ```json
 {
-	"core": "WordPress/WordPress#master",
+	"core": "WordPress/WordPress#trunk",
 	"plugins": [ "." ]
 }
 ```

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -475,7 +475,7 @@ This is useful for plugin development when upstream Core changes need to be test
 
 ```json
 {
-	"core": "WordPress/WordPress#trunk",
+	"core": "WordPress/WordPress#master",
 	"plugins": [ "." ]
 }
 ```

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -121,7 +121,7 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		return {
 			type: 'git',
 			url: `https://github.com/${ gitHubFields[ 1 ] }/${ gitHubFields[ 2 ] }.git`,
-			ref: gitHubFields[ 5 ] || 'master',
+			ref: gitHubFields[ 5 ] || 'trunk',
 			path: path.resolve(
 				workDirectoryPath,
 				gitHubFields[ 2 ],

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -121,7 +121,7 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		return {
 			type: 'git',
 			url: `https://github.com/${ gitHubFields[ 1 ] }/${ gitHubFields[ 2 ] }.git`,
-			ref: gitHubFields[ 5 ] || 'trunk',
+			ref: gitHubFields[ 5 ] || 'master',
 			path: path.resolve(
 				workDirectoryPath,
 				gitHubFields[ 2 ],

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -364,7 +364,7 @@ describe( 'readConfig', () => {
 					JSON.stringify( {
 						plugins: [
 							'WordPress/gutenberg',
-							'WordPress/gutenberg#master',
+							'WordPress/gutenberg#trunk',
 							'WordPress/gutenberg#5.0',
 							'WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.3',
 						],
@@ -377,14 +377,14 @@ describe( 'readConfig', () => {
 					{
 						type: 'git',
 						url: 'https://github.com/WordPress/gutenberg.git',
-						ref: 'master',
+						ref: 'trunk',
 						path: expect.stringMatching( /^\/.*gutenberg$/ ),
 						basename: 'gutenberg',
 					},
 					{
 						type: 'git',
 						url: 'https://github.com/WordPress/gutenberg.git',
-						ref: 'master',
+						ref: 'trunk',
 						path: expect.stringMatching( /^\/.*gutenberg$/ ),
 						basename: 'gutenberg',
 					},
@@ -541,7 +541,7 @@ describe( 'readConfig', () => {
 					JSON.stringify( {
 						mappings: {
 							test: './relative',
-							test2: 'WordPress/gutenberg#master',
+							test2: 'WordPress/gutenberg#trunk',
 						},
 					} )
 				)

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -377,7 +377,7 @@ describe( 'readConfig', () => {
 					{
 						type: 'git',
 						url: 'https://github.com/WordPress/gutenberg.git',
-						ref: 'trunk',
+						ref: 'master',
 						path: expect.stringMatching( /^\/.*gutenberg$/ ),
 						basename: 'gutenberg',
 					},

--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Improvements
 
-- The "Add First Time Contributor Label" task now runs retroactively on pushes to master, due to [permission constraints](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token) of GitHub Actions.
+- The "Add First Time Contributor Label" task now runs retroactively on pushes to trunk, due to [permission constraints](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token) of GitHub Actions.
 
 ## 1.0.0 (2019-08-29)
 

--- a/packages/project-management-automation/README.md
+++ b/packages/project-management-automation/README.md
@@ -16,7 +16,7 @@ jobs:
   pull-request-automation:
     runs-on: ubuntu-latest
     steps:
-      - uses: WordPress/gutenberg/packages/project-management-automation@master
+      - uses: WordPress/gutenberg/packages/project-management-automation@trunk
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/project-management-automation/lib/tasks/add-milestone/index.js
+++ b/packages/project-management-automation/lib/tasks/add-milestone/index.js
@@ -79,8 +79,8 @@ async function getMilestoneByTitle( octokit, owner, repo, title ) {
  * @param {GitHub}             octokit Initialized Octokit REST client.
  */
 async function addMilestone( payload, octokit ) {
-	if ( payload.ref !== 'refs/heads/master' ) {
-		debug( 'add-milestone: Commit is not to `master`. Aborting' );
+	if ( payload.ref !== 'refs/heads/trunk' ) {
+		debug( 'add-milestone: Commit is not to `trunk`. Aborting' );
 		return;
 	}
 

--- a/packages/project-management-automation/lib/tasks/add-milestone/test/index.js
+++ b/packages/project-management-automation/lib/tasks/add-milestone/test/index.js
@@ -4,9 +4,9 @@
 import addMilestone from '../';
 
 describe( 'addMilestone', () => {
-	it( 'does nothing if base is not master', async () => {
+	it( 'does nothing if base is not trunk', async () => {
 		const payload = {
-			ref: 'refs/heads/not-master',
+			ref: 'refs/heads/not-trunk',
 		};
 		const octokit = {
 			paginate: {
@@ -40,7 +40,7 @@ describe( 'addMilestone', () => {
 
 	it( 'does nothing if PR already has a milestone', async () => {
 		const payload = {
-			ref: 'refs/heads/master',
+			ref: 'refs/heads/trunk',
 			commits: [ { message: '(#123)' } ],
 			repository: {
 				owner: {
@@ -85,7 +85,7 @@ describe( 'addMilestone', () => {
 
 	it( 'correctly milestones PRs when `package.json` has a `*.[1-8]` version', async () => {
 		const payload = {
-			ref: 'refs/heads/master',
+			ref: 'refs/heads/trunk',
 			commits: [ { message: '(#123)' } ],
 			repository: {
 				owner: {
@@ -178,7 +178,7 @@ describe( 'addMilestone', () => {
 
 	it( 'correctly milestones PRs when `package.json` has a `*.9` version', async () => {
 		const payload = {
-			ref: 'refs/heads/master',
+			ref: 'refs/heads/trunk',
 			commits: [ { message: '(#123)' } ],
 			repository: {
 				owner: {

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
@@ -40,9 +40,9 @@ function getPromptMessageText( author ) {
  * @param {GitHub}             octokit Initialized Octokit REST client.
  */
 async function firstTimeContributorAccountLink( payload, octokit ) {
-	if ( payload.ref !== 'refs/heads/master' ) {
+	if ( payload.ref !== 'refs/heads/trunk' ) {
 		debug(
-			'first-time-contributor-account-link: Commit is not to `master`. Aborting'
+			'first-time-contributor-account-link: Commit is not to `trunk`. Aborting'
 		);
 		return;
 	}

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/test/index.js
@@ -12,7 +12,7 @@ describe( 'firstTimeContributorAccountLink', () => {
 	} );
 
 	const payload = {
-		ref: 'refs/heads/master',
+		ref: 'refs/heads/trunk',
 		commits: [
 			{
 				id: '4c535288a6a2b75ff23ee96c75f7d9877e919241',
@@ -32,7 +32,7 @@ describe( 'firstTimeContributorAccountLink', () => {
 		},
 	};
 
-	it( 'does nothing if not a commit to master', async () => {
+	it( 'does nothing if not a commit to trunk', async () => {
 		const payloadForBranchPush = {
 			...payload,
 			ref: 'refs/heads/update/chicken-branch',
@@ -50,11 +50,11 @@ describe( 'firstTimeContributorAccountLink', () => {
 	} );
 
 	it( 'does nothing if commit pull request undeterminable', async () => {
-		const payloadDirectToMaster = {
+		const payloadDirectToTrunk = {
 			...payload,
 			commits: [
 				{
-					message: 'Add a feature direct to master',
+					message: 'Add a feature direct to trunk',
 					author: {
 						name: 'Ghost',
 						email: 'ghost@example.invalid',
@@ -70,7 +70,7 @@ describe( 'firstTimeContributorAccountLink', () => {
 			},
 		};
 
-		await firstTimeContributorAccountLink( payloadDirectToMaster, octokit );
+		await firstTimeContributorAccountLink( payloadDirectToTrunk, octokit );
 
 		expect( octokit.repos.listCommits ).not.toHaveBeenCalled();
 	} );

--- a/packages/project-management-automation/lib/test/get-associated-pull-request.js
+++ b/packages/project-management-automation/lib/test/get-associated-pull-request.js
@@ -18,7 +18,7 @@ const VALID_COMMIT = {
 
 /**
  * An example commit which cannot be associated with a pull request, e.g. when
- * someone commits directly to master.
+ * someone commits directly to trunk.
  *
  * @type {WebhookPayloadPushCommit}
  */

--- a/packages/react-native-aztec/.gitignore
+++ b/packages/react-native-aztec/.gitignore
@@ -43,7 +43,7 @@ node_modules/
 yarn-error.log
 
 ###
-### Starting at this point, the Swift .gitignore rules from https://github.com/github/gitignore/blob/master/Swift.gitignore
+### Starting at this point, the Swift .gitignore rules from https://github.com/github/gitignore/blob/HEAD/Swift.gitignore
 ###
 
 # Xcode

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -52,7 +52,7 @@ public interface GutenbergBridgeJS2Parent extends RequestExecutor {
         void onRequestFocalPointPickerTooltipShown(boolean tooltipShown);
     }
 
-    // Ref: https://github.com/facebook/react-native/blob/master/Libraries/polyfills/console.js#L376
+    // Ref: https://github.com/facebook/react-native/blob/HEAD/Libraries/polyfills/console.js#L376
     enum LogLevel {
         TRACE(0),
         INFO(1),

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -84,7 +84,7 @@ extension Gutenberg.MediaSource {
     }
 }
 
-/// Ref. https://github.com/facebook/react-native/blob/master/Libraries/polyfills/console.js#L376
+/// Ref. https://github.com/facebook/react-native/blob/HEAD/Libraries/polyfills/console.js#L376
 public enum LogLevel: Int {
     case trace
     case info

--- a/packages/url/scripts/download-wpt-data.js
+++ b/packages/url/scripts/download-wpt-data.js
@@ -17,7 +17,7 @@ const DEFAULT_OUT_FILE = path.resolve(
  * Source test data URL.
  */
 const DATA_URL =
-	'https://raw.githubusercontent.com/web-platform-tests/wpt/master/url/resources/urltestdata.json';
+	'https://raw.githubusercontent.com/web-platform-tests/wpt/HEAD/url/resources/urltestdata.json';
 
 /**
  * Items to exclude from the default test data, where the test case relies on


### PR DESCRIPTION
# Should only be merged AFTER the main branch is renamed to `trunk`

All the CI scripts are going to be broken for this PR because the `trunk` branch doesn't exist yet 😉 

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Update references from `master` to `trunk` in:
* Documentation referencing the branch (like release documentation)
* GitHub Workflows
* Various tools that reference the main branch

## How has this been tested?
TBD

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Non-breaking changes (renamed functions are all internal)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
