### PR TITLE
Normalized reference to parsed block properites

### DIFF
--- a/packages/block-serialization-spec-parser/grammar.pegjs
+++ b/packages/block-serialization-spec-parser/grammar.pegjs
@@ -50,15 +50,15 @@
 // The `maybeJSON` function is not needed in PHP because its return semantics
 // are the same as `json_decode`
 
-if ( ! function_exists( 'peg_empty_attrs' ) ) {
-     function peg_empty_attrs() {
-         static $empty_attrs = null;
+if ( ! function_exists( 'peg_empty_attributes' ) ) {
+     function peg_empty_attributes() {
+         static $empty_attributes = null;
 
-         if ( null === $empty_attrs ) {
-             $empty_attrs = json_decode( '{}', true );
+         if ( null === $empty_attributes ) {
+             $empty_attributes = json_decode( '{}', true );
          }
 
-         return $empty_attrs;
+         return $empty_attributes;
      }
 }
 
@@ -89,8 +89,8 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
         if ( ! empty( $pre ) ) {
             $blocks[] = array(
-                'blockName' => null,
-                'attrs' => peg_empty_attrs(),
+                'name' => null,
+                'attributes' => peg_empty_attributes(),
                 'innerBlocks' => array(),
                 'innerHTML' => $pre,
                 'innerContent' => array( $pre ),
@@ -104,8 +104,8 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
             if ( ! empty( $html ) ) {
                 $blocks[] = array(
-                    'blockName' => null,
-                    'attrs' => peg_empty_attrs(),
+                    'name' => null,
+                    'attributes' => peg_empty_attributes(),
                     'innerBlocks' => array(),
                     'innerHTML' => $html,
                     'innerContent' => array( $html ),
@@ -115,8 +115,8 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
         if ( ! empty( $post ) ) {
             $blocks[] = array(
-                'blockName' => null,
-                'attrs' => peg_empty_attrs(),
+                'name' => null,
+                'attributes' => peg_empty_attributes(),
                 'innerBlocks' => array(),
                 'innerHTML' => $post,
                 'innerContent' => array( $post ),
@@ -131,8 +131,8 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
 function freeform( s ) {
     return s.length && {
-        blockName: null,
-        attrs: {},
+        name: null,
+        attributes: {},
         innerBlocks: [],
         innerHTML: s,
         innerContent: [ s ],
@@ -216,15 +216,15 @@ Block
   / Block_Balanced
 
 Block_Void
-  = "<!--" __ "wp:" blockName:Block_Name __ attrs:(a:Block_Attributes __ {
+  = "<!--" __ "wp:" name:Block_Name __ attributes:(a:Block_Attributes __ {
     /** <?php return $a; ?> **/
     return a;
   })? "/-->"
   {
     /** <?php
     return array(
-      'blockName'    => $blockName,
-      'attrs'        => empty( $attrs ) ? peg_empty_attrs() : $attrs,
+      'name'    => $name,
+      'attributes'        => empty( $attributes ) ? peg_empty_attributes() : $attributes,
       'innerBlocks'  => array(),
       'innerHTML'    => '',
       'innerContent' => array(),
@@ -232,8 +232,8 @@ Block_Void
     ?> **/
 
     return {
-      blockName: blockName,
-      attrs: attrs || {},
+      name: name,
+      attributes: attributes || {},
       innerBlocks: [],
       innerHTML: '',
       innerContent: []
@@ -247,8 +247,8 @@ Block_Balanced
     list( $innerHTML, $innerBlocks, $innerContent ) = peg_process_inner_content( $children );
 
     return array(
-      'blockName'    => $s['blockName'],
-      'attrs'        => empty( $s['attrs'] ) ? peg_empty_attrs() : $s['attrs'],
+      'name'    => $s['name'],
+      'attributes'        => empty( $s['attributes'] ) ? peg_empty_attributes() : $s['attributes'],
       'innerBlocks'  => $innerBlocks,
       'innerHTML'    => $innerHTML,
       'innerContent' => $innerContent,
@@ -261,8 +261,8 @@ Block_Balanced
     var innerContent = innerParts[ 2 ];
 
     return {
-      blockName: s.blockName,
-      attrs: s.attrs,
+      name: s.name,
+      attributes: s.attributes,
       innerBlocks: innerBlocks,
       innerHTML: innerHTML,
       innerContent: innerContent,
@@ -270,35 +270,35 @@ Block_Balanced
   }
 
 Block_Start
-  = "<!--" __ "wp:" blockName:Block_Name __ attrs:(a:Block_Attributes __ {
+  = "<!--" __ "wp:" name:Block_Name __ attributes:(a:Block_Attributes __ {
     /** <?php return $a; ?> **/
     return a;
   })? "-->"
   {
     /** <?php
     return array(
-      'blockName' => $blockName,
-      'attrs'     => isset( $attrs ) ? $attrs : array(),
+      'name' => $name,
+      'attributes'     => isset( $attributes ) ? $attributes : array(),
     );
     ?> **/
 
     return {
-      blockName: blockName,
-      attrs: attrs || {}
+      name: name,
+      attributes: attributes || {}
     };
   }
 
 Block_End
-  = "<!--" __ "/wp:" blockName:Block_Name __ "-->"
+  = "<!--" __ "/wp:" name:Block_Name __ "-->"
   {
     /** <?php
     return array(
-      'blockName' => $blockName,
+      'name' => $name,
     );
     ?> **/
 
     return {
-      blockName: blockName
+      name: name
     };
   }
 
@@ -321,10 +321,10 @@ Block_Name_Part
 
 Block_Attributes
   "JSON-encoded attributes embedded in a block's opening comment"
-  = attrs:$("{" (!("}" __ """/"? "-->") .)* "}")
+  = attributes:$("{" (!("}" __ """/"? "-->") .)* "}")
   {
-    /** <?php return json_decode( $attrs, true ); ?> **/
-    return maybeJSON( attrs );
+    /** <?php return json_decode( $attributes, true ); ?> **/
+    return maybeJSON( attributes );
   }
 
 __

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -55,7 +55,7 @@ export {
 // attributes needed to operate with the block later on.
 export {
 	default as serialize,
-	getBlockContent,
+	getBlockInnerHTML as getBlockContent,
 	getBlockDefaultClassName,
 	getBlockMenuDefaultClassName,
 	getSaveElement,

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -20,7 +20,7 @@ import {
 } from './registration';
 import { createBlock } from './factory';
 import { getBlockContentValidationResult } from './validation';
-import { getCommentDelimitedContent, getSaveContent } from './serializer';
+import { getCommentDelimitedBlockInnerHTML, getSaveContent } from './serializer';
 import { attr, html, text, query, node, children, prop } from './matchers';
 import { normalizeBlockType } from './utils';
 import { DEPRECATED_ENTRY_KEYS } from './constants';
@@ -650,7 +650,7 @@ export function serializeBlockNode( blockNode, options = {} ) {
 		.trim();
 
 	return isCommentDelimited
-		? getCommentDelimitedContent( blockName, attrs, content )
+		? getCommentDelimitedBlockInnerHTML( blockName, attrs, content )
 		: content;
 }
 

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -13,7 +13,7 @@ import { getPhrasingContentSchema, removeInvalidHTML } from '@wordpress/dom';
  */
 import { htmlToBlocks } from './html-to-blocks';
 import { hasBlockSupport } from '../registration';
-import { getBlockContent } from '../serializer';
+import { getBlockInnerHTML } from '../serializer';
 import { parseWithGrammar } from '../parser';
 import normaliseBlocks from './normalise-blocks';
 import specialCommentConverter from './special-comment-converter';
@@ -226,7 +226,7 @@ export function pasteHandler( {
 			trimmedPlainText.indexOf( '\n' ) === -1
 		) {
 			return removeInvalidHTML(
-				getBlockContent( blocks[ 0 ] ),
+				getBlockInnerHTML( blocks[ 0 ] ),
 				phrasingContentSchema
 			);
 		}

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -241,6 +241,7 @@ export function getCommentAttributes( blockType, attributes ) {
  *
  * @return {string} Serialized attributes.
  */
+
 export function serializeAttributes( attributes ) {
 	return (
 		JSON.stringify( attributes )
@@ -267,7 +268,7 @@ export function serializeAttributes( attributes ) {
  *
  * @return {string} HTML.
  */
-export function getBlockContent( block ) {
+export function getBlockInnerHTML( block ) {
 	// @todo why not getBlockInnerHtml?
 
 	// If block was parsed as invalid or encounters an error while generating
@@ -298,7 +299,7 @@ export function getBlockContent( block ) {
  *
  * @return {string} Comment-delimited block content.
  */
-export function getCommentDelimitedContent(
+export function getCommentDelimitedBlockInnerHTML(
 	rawBlockName,
 	attributes,
 	content
@@ -336,7 +337,7 @@ export function getCommentDelimitedContent(
  */
 export function serializeBlock( block, { isInnerBlocks = false } = {} ) {
 	const blockName = block.name;
-	const saveContent = getBlockContent( block );
+	const saveContent = getBlockInnerHTML( block );
 
 	if (
 		blockName === getUnregisteredTypeHandlerName() ||
@@ -347,7 +348,7 @@ export function serializeBlock( block, { isInnerBlocks = false } = {} ) {
 
 	const blockType = getBlockType( blockName );
 	const saveAttributes = getCommentAttributes( blockType, block.attributes );
-	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
+	return getCommentDelimitedBlockInnerHTML( blockName, saveAttributes, saveContent );
 }
 
 export function __unstableSerializeAndClean( blocks ) {


### PR DESCRIPTION
Fixed #5449

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
 
 [x] ```getBlockContent```, ```getCommentDelimitedContent```
  -   Recommendations:   
       - Rename ```getBlockContent``` to ```getBlockInnerHTML```
       - Rename ```getCommentDelimitedContent``` to ```getCommentDelimitedBlockInnerHTML```
       
[ ] serializeAttributes
  -   Recommendation:
     - Rename attrs argument to attributes
      - Add a JSDoc block for the function
  - *Section was already completed*

[x] Post grammar
   - Recommendations:
        - Rename ```attrs``` to ```attributes```
        - Rename ```blockName``` to ```name```

## How has this been tested?
```npm test```
```npm run test-unit```
ESLint 

## Screenshots <!-- if applicable -->

## Types of changes
Feature: Block API
Features: Parsing

## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
