### PR TITLE
Wp-env: Expose mariadb port to host

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -174,7 +174,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 		services: {
 			mysql: {
 				image: 'mariadb',
-				ports: [ '3306' ],
+				ports: [ '3306:3306' ],
 				environment: {
 					MYSQL_ALLOW_EMPTY_PASSWORD: 'yes',
 				},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
When I spin up WordPress locally with `wp-env`, I also use [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) to visualize and manage my database. The app, however, needs access to the database port from the docker MariaDB instance, which requires tinkering with the `build-docker-compose-config.js` file.

This PR intends to expose the mariaDB port to the host by default. I'm curious if anyone might be opposed or know of alternative ways to handle this.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Don't apply this PR
- Spin up local Gutenberg dev environment
- Download [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) I went through the macOS app store.
- Open the application, select "TCP/IP" connection, and input the following info:
  ```
  Name: WordPress Gutenberg
  Host: 127.0.0.1
  Database: wordpress
  Port: 3306
  Time Zone: Use Server Time Zone
  ``` 
- Click on connect
- Connection should _**not**_ be successful
- Apply this PR
- Run `npx wp-env start --update` to regenerate the docker compose file
- Return to the Sequel Ace app
- Click on connect
- Connection should be successful
- Once connected, you should see all database tables for your local WordPress instance like so:
<img width="796" alt="Screen Shot 2021-01-22 at 2 06 44 PM" src="https://user-images.githubusercontent.com/5414230/105553967-47500b80-5cbb-11eb-9b13-207d010553e6.png"> 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
