### PR TITLE
Update useFocusReturn to fix focus loss in modal

### DIFF
--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -52,14 +52,6 @@ function useFocusReturn( onFocusReturn ) {
 
 			focusedBeforeMount.current = node.ownerDocument.activeElement;
 		} else if ( focusedBeforeMount.current ) {
-			const isFocused = ref.current.contains(
-				ref.current.ownerDocument.activeElement
-			);
-
-			if ( ! isFocused ) {
-				return;
-			}
-
 			// Defer to the component's own explicit focus return behavior, if
 			// specified. This allows for support that the `onFocusReturn`
 			// decides to allow the default behavior to occur under some


### PR DESCRIPTION
## Description
Fixes #28089  This removes an early return from useFocusReturn that was preventing it from working when a modal was called from another modal or dropdown. To be honest, I'm not entirely sure what the purpose of the early return was. Removing it doesn't seem to cause any problems in my manual testing or the automated testing but does fix the issue. Maybe @ellatrix or @youknowriad might have some more insight into why it was there in the first place.

## How has this been tested?
1. Open the Options menu
2. Navigate to Preferences and open that
3. Press escape closing Preferences
4. Observe that returns to the Options menu Preferences link

## Screenshots
![BOqd9OiQ7B](https://user-images.githubusercontent.com/6653970/105554019-83dc3100-5cd4-11eb-94bc-90b01357503e.gif)

## Types of changes
Bugfix (non-breaking change that fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
