### PR TITLE
Abstract Justification Toolbar to it's own block-editor component

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `JustifyToolbar` component abstracted out of the Navigation block so can be used elsewhere.
+
 ## 5.2.0 (2020-12-17)
 
 ### New Feature

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -402,6 +402,10 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-controls/README.md>
 
+<a name="JustifyToolbar" href="#JustifyToolbar">#</a> **JustifyToolbar**
+
+Undocumented declaration.
+
 <a name="LineHeightControl" href="#LineHeightControl">#</a> **LineHeightControl**
 
 Undocumented declaration.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -404,9 +404,7 @@ _Related_
 
 <a name="JustifyToolbar" href="#JustifyToolbar">#</a> **JustifyToolbar**
 
-_Related_
-
--   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/justify-toolbar/README.md>
+Undocumented declaration.
 
 <a name="LineHeightControl" href="#LineHeightControl">#</a> **LineHeightControl**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -404,7 +404,9 @@ _Related_
 
 <a name="JustifyToolbar" href="#JustifyToolbar">#</a> **JustifyToolbar**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/justify-toolbar/README.md>
 
 <a name="LineHeightControl" href="#LineHeightControl">#</a> **LineHeightControl**
 

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -42,6 +42,7 @@ export {
 } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
+export { default as JustifyToolbar } from './justify-toolbar';
 export { default as __experimentalLinkControl } from './link-control';
 export { default as __experimentalLinkControlSearchInput } from './link-control/search-input';
 export { default as __experimentalLinkControlSearchResults } from './link-control/search-results';

--- a/packages/block-editor/src/components/justify-toolbar/README.md
+++ b/packages/block-editor/src/components/justify-toolbar/README.md
@@ -28,12 +28,10 @@ _Note:_ In this example that we render `JustifyToolbar` as a child of the `Block
 
 ### Props
 
-#### `value`
-* **Type:** `String`
-* **Default:** `undefined`
-* **Options:**: `left`, `center`, `right`, `space-between`
+#### `isCollapsed`
+* **Type:** `boolean`
 
-The current value of the alignment setting. You may only choose from the `Options` listed above.
+Whether to display toolbar options in the dropdown menu.
 
 #### `onChange`
 * **Type:** `Function`
@@ -49,6 +47,12 @@ Properties of `popoverProps` object will be passed as props to the nested `Popov
 
 Use this object to modify props available for the `Popover` component that are not already exposed in the `DropdownMenu` component, e.g.: the direction in which the popover should open relative to its parent node set with `position` prop.
 
+#### `value`
+* **Type:** `String`
+* **Default:** `undefined`
+* **Options:**: `left`, `center`, `right`, `space-between`
+
+The current value of the alignment setting. You may only choose from the `Options` listed above.
 
 ## Related components
 

--- a/packages/block-editor/src/components/justify-toolbar/README.md
+++ b/packages/block-editor/src/components/justify-toolbar/README.md
@@ -2,7 +2,9 @@
 
 The `JustifyToolbar` component renders a toolbar that displays justify options for the selected block.
 
-This component is used in the Navigation block to set the flex justification for the elements, allowing for justify `left`, `center`, `right`, and `space-between`.
+This component is used to set the flex justification for the elements in the block, allowing to justify `left`, `center`, `right`, and `space-between`. In comparison, the alignment options are for the block itself.
+
+See the Navigation block for an example usage.
 
 ## Development guidelines
 
@@ -13,18 +15,28 @@ Renders an justification toolbar with options.
 ```jsx
 import { JustifyToolbar } from '@wordpress/block-editor';
 
-const MyJustifyToolbar = () => (
+const MyJustifyToolbar = ( { attributes, setAttributes } ) => (
 	<BlockControls>
 		<JustifyToolbar
-			value={ textAlign }
-			onChange={ ( nextAlign ) => {
-				setAttributes( { textAlign: nextAlign } );
+			value={ attributes.justification }
+			onChange={ ( next ) => {
+				setAttributes( { justfication: next } );
 			} }
 		/>
 	</BlockControls>
 );
 ```
+
+**NOTE:** The justfify toolbar does not add any classes to your component, you must do this using the `setAttributes` function. The toolbar does define the following classnames you should use:
+
+	items-justified-left
+	items-justified-center
+	items-justified-right
+	items-justified-space-between
+
+
 _Note:_ In this example that we render `JustifyToolbar` as a child of the `BlockControls` component.
+
 
 ### Props
 

--- a/packages/block-editor/src/components/justify-toolbar/README.md
+++ b/packages/block-editor/src/components/justify-toolbar/README.md
@@ -28,10 +28,19 @@ _Note:_ In this example that we render `JustifyToolbar` as a child of the `Block
 
 ### Props
 
+#### `allowedControls`
+* **Type:** `string[]`
+* **Default:** `[ 'left', 'center', 'right', 'space-between' ]`
+
+An array of strings for what controls to show, by default it shows all.
+
+
 #### `isCollapsed`
 * **Type:** `boolean`
+* **Default:** `true`
 
 Whether to display toolbar options in the dropdown menu.
+
 
 #### `onChange`
 * **Type:** `Function`

--- a/packages/block-editor/src/components/justify-toolbar/README.md
+++ b/packages/block-editor/src/components/justify-toolbar/README.md
@@ -1,3 +1,56 @@
 ## Justify Toolbar
 
 The `JustifyToolbar` component renders a toolbar that displays justify options for the selected block.
+
+This component is used in the Navigation block to set the flex justification for the elements, allowing for justify `left`, `center`, `right`, and `space-between`.
+
+## Development guidelines
+
+### Usage
+
+Renders an justification toolbar with options.
+
+```jsx
+import { JustifyToolbar } from '@wordpress/block-editor';
+
+const MyJustifyToolbar = () => (
+	<BlockControls>
+		<JustifyToolbar
+			value={ textAlign }
+			onChange={ ( nextAlign ) => {
+				setAttributes( { textAlign: nextAlign } );
+			} }
+		/>
+	</BlockControls>
+);
+```
+_Note:_ In this example that we render `JustifyToolbar` as a child of the `BlockControls` component.
+
+### Props
+
+#### `value`
+* **Type:** `String`
+* **Default:** `undefined`
+* **Options:**: `left`, `center`, `right`, `space-between`
+
+The current value of the alignment setting. You may only choose from the `Options` listed above.
+
+#### `onChange`
+* **Type:** `Function`
+
+A callback function invoked when the toolbar's justification value is changed via an interaction with any of the toolbar's buttons. Called with the new alignment value (ie: `left`, `center`, `right`, `space-between`, `undefined`) as the only argument.
+
+
+#### `popoverProps`
+* **Type:** `Object`
+* **Required:** No
+
+Properties of `popoverProps` object will be passed as props to the nested `Popover` component.
+
+Use this object to modify props available for the `Popover` component that are not already exposed in the `DropdownMenu` component, e.g.: the direction in which the popover should open relative to its parent node set with `position` prop.
+
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.
+

--- a/packages/block-editor/src/components/justify-toolbar/README.md
+++ b/packages/block-editor/src/components/justify-toolbar/README.md
@@ -1,0 +1,3 @@
+## Justify Toolbar
+
+The `JustifyToolbar` component renders a toolbar that displays justify options for the selected block.

--- a/packages/block-editor/src/components/justify-toolbar/README.md
+++ b/packages/block-editor/src/components/justify-toolbar/README.md
@@ -56,6 +56,7 @@ Whether to display toolbar options in the dropdown menu.
 
 #### `onChange`
 * **Type:** `Function`
+* **Required:** Yes
 
 A callback function invoked when the toolbar's justification value is changed via an interaction with any of the toolbar's buttons. Called with the new alignment value (ie: `left`, `center`, `right`, `space-between`, `undefined`) as the only argument.
 

--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -14,7 +14,7 @@ import {
 } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
-const navIcons = {
+const icons = {
 	left: justifyLeft,
 	center: justifyCenter,
 	right: justifyRight,
@@ -22,7 +22,7 @@ const navIcons = {
 };
 
 export function JustifyToolbar( { onChange, value, popoverProps } ) {
-	const icon = value ? navIcons[ value ] : navIcons.left;
+	const icon = value ? icons[ value ] : icons.left;
 
 	return (
 		<ToolbarGroup

--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -21,14 +21,8 @@ const navIcons = {
 	'space-between': justifySpaceBetween,
 };
 
-export function JustifyToolbar( {
-	handleItemsAlignment,
-	itemsJustification,
-	popoverProps,
-} ) {
-	const icon = itemsJustification
-		? navIcons[ itemsJustification ]
-		: navIcons.left;
+export function JustifyToolbar( { onChange, value, popoverProps } ) {
+	const icon = value ? navIcons[ value ] : navIcons.left;
 
 	return (
 		<ToolbarGroup
@@ -40,26 +34,26 @@ export function JustifyToolbar( {
 				{
 					icon: justifyLeft,
 					title: __( 'Justify items left' ),
-					isActive: 'left' === itemsJustification,
-					onClick: handleItemsAlignment( 'left' ),
+					isActive: 'left' === value,
+					onClick: onChange( 'left' ),
 				},
 				{
 					icon: justifyCenter,
 					title: __( 'Justify items center' ),
-					isActive: 'center' === itemsJustification,
-					onClick: handleItemsAlignment( 'center' ),
+					isActive: 'center' === value,
+					onClick: onChange( 'center' ),
 				},
 				{
 					icon: justifyRight,
 					title: __( 'Justify items right' ),
-					isActive: 'right' === itemsJustification,
-					onClick: handleItemsAlignment( 'right' ),
+					isActive: 'right' === value,
+					onClick: onChange( 'right' ),
 				},
 				{
 					icon: justifySpaceBetween,
 					title: __( 'Space between items' ),
-					isActive: 'space-between' === itemsJustification,
-					onClick: handleItemsAlignment( 'space-between' ),
+					isActive: 'space-between' === value,
+					onClick: onChange( 'space-between' ),
 				},
 			] }
 		/>

--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -21,7 +21,12 @@ const icons = {
 	'space-between': justifySpaceBetween,
 };
 
-export function JustifyToolbar( { onChange, value, popoverProps } ) {
+export function JustifyToolbar( {
+	isCollapsed,
+	onChange,
+	value,
+	popoverProps,
+} ) {
 	const icon = value ? icons[ value ] : icons.left;
 
 	return (
@@ -29,7 +34,7 @@ export function JustifyToolbar( { onChange, value, popoverProps } ) {
 			icon={ icon }
 			popoverProps={ popoverProps }
 			label={ __( 'Change items justification' ) }
-			isCollapsed
+			isCollapsed={ isCollapsed }
 			controls={ [
 				{
 					icon: justifyLeft,

--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { ToolbarGroup } from '@wordpress/components';
+import {
+	justifyLeft,
+	justifyCenter,
+	justifyRight,
+	justifySpaceBetween,
+} from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+const navIcons = {
+	left: justifyLeft,
+	center: justifyCenter,
+	right: justifyRight,
+	'space-between': justifySpaceBetween,
+};
+
+export function JustifyToolbar( {
+	handleItemsAlignment,
+	itemsJustification,
+	popoverProps,
+} ) {
+	const icon = itemsJustification
+		? navIcons[ itemsJustification ]
+		: navIcons.left;
+
+	return (
+		<ToolbarGroup
+			icon={ icon }
+			popoverProps={ popoverProps }
+			label={ __( 'Change items justification' ) }
+			isCollapsed
+			controls={ [
+				{
+					icon: justifyLeft,
+					title: __( 'Justify items left' ),
+					isActive: 'left' === itemsJustification,
+					onClick: handleItemsAlignment( 'left' ),
+				},
+				{
+					icon: justifyCenter,
+					title: __( 'Justify items center' ),
+					isActive: 'center' === itemsJustification,
+					onClick: handleItemsAlignment( 'center' ),
+				},
+				{
+					icon: justifyRight,
+					title: __( 'Justify items right' ),
+					isActive: 'right' === itemsJustification,
+					onClick: handleItemsAlignment( 'right' ),
+				},
+				{
+					icon: justifySpaceBetween,
+					title: __( 'Space between items' ),
+					isActive: 'space-between' === itemsJustification,
+					onClick: handleItemsAlignment( 'space-between' ),
+				},
+			] }
+		/>
+	);
+}
+
+export default JustifyToolbar;

--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -21,13 +21,46 @@ const icons = {
 	'space-between': justifySpaceBetween,
 };
 
-export function JustifyToolbar( {
-	isCollapsed,
-	onChange,
-	value,
-	popoverProps,
-} ) {
+export function JustifyToolbar( props ) {
+	const {
+		allowedControls = [ 'left', 'center', 'right', 'space-between' ],
+		isCollapsed = true,
+		onChange,
+		value,
+		popoverProps,
+	} = props;
+
 	const icon = value ? icons[ value ] : icons.left;
+	const allControls = [
+		{
+			name: 'left',
+			icon: justifyLeft,
+			title: __( 'Justify items left' ),
+			isActive: 'left' === value,
+			onClick: onChange( 'left' ),
+		},
+		{
+			name: 'center',
+			icon: justifyCenter,
+			title: __( 'Justify items center' ),
+			isActive: 'center' === value,
+			onClick: onChange( 'center' ),
+		},
+		{
+			name: 'right',
+			icon: justifyRight,
+			title: __( 'Justify items right' ),
+			isActive: 'right' === value,
+			onClick: onChange( 'right' ),
+		},
+		{
+			name: 'space-between',
+			icon: justifySpaceBetween,
+			title: __( 'Space between items' ),
+			isActive: 'space-between' === value,
+			onClick: onChange( 'space-between' ),
+		},
+	];
 
 	return (
 		<ToolbarGroup
@@ -35,32 +68,9 @@ export function JustifyToolbar( {
 			popoverProps={ popoverProps }
 			label={ __( 'Change items justification' ) }
 			isCollapsed={ isCollapsed }
-			controls={ [
-				{
-					icon: justifyLeft,
-					title: __( 'Justify items left' ),
-					isActive: 'left' === value,
-					onClick: onChange( 'left' ),
-				},
-				{
-					icon: justifyCenter,
-					title: __( 'Justify items center' ),
-					isActive: 'center' === value,
-					onClick: onChange( 'center' ),
-				},
-				{
-					icon: justifyRight,
-					title: __( 'Justify items right' ),
-					isActive: 'right' === value,
-					onClick: onChange( 'right' ),
-				},
-				{
-					icon: justifySpaceBetween,
-					title: __( 'Space between items' ),
-					isActive: 'space-between' === value,
-					onClick: onChange( 'space-between' ),
-				},
-			] }
+			controls={ allControls.filter( ( elem ) =>
+				allowedControls.includes( elem.name )
+			) }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -21,15 +21,13 @@ const icons = {
 	'space-between': justifySpaceBetween,
 };
 
-export function JustifyToolbar( props ) {
-	const {
-		allowedControls = [ 'left', 'center', 'right', 'space-between' ],
-		isCollapsed = true,
-		onChange,
-		value,
-		popoverProps,
-	} = props;
-
+export function JustifyToolbar( {
+	allowedControls = [ 'left', 'center', 'right', 'space-between' ],
+	isCollapsed = true,
+	onChange,
+	value,
+	popoverProps,
+} ) {
 	const icon = value ? icons[ value ] : icons.left;
 	const allControls = [
 		{

--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-
-/**
  * WordPress dependencies
  */
 import { ToolbarGroup } from '@wordpress/components';

--- a/packages/block-editor/src/components/justify-toolbar/style.scss
+++ b/packages/block-editor/src/components/justify-toolbar/style.scss
@@ -1,16 +1,16 @@
 // Justification.
-.items-justified-left > ul {
+.items-justified-left {
 	justify-content: flex-start;
 }
 
-.items-justified-center > ul {
+.items-justified-center {
 	justify-content: center;
 }
 
-.items-justified-right > ul {
+.items-justified-right {
 	justify-content: flex-end;
 }
 
-.items-justified-space-between > ul {
+.items-justified-space-between {
 	justify-content: space-between;
 }

--- a/packages/block-editor/src/components/justify-toolbar/style.scss
+++ b/packages/block-editor/src/components/justify-toolbar/style.scss
@@ -1,0 +1,16 @@
+// Justification.
+.items-justified-left > ul {
+	justify-content: flex-start;
+}
+
+.items-justified-center > ul {
+	justify-content: center;
+}
+
+.items-justified-right > ul {
+	justify-content: flex-end;
+}
+
+.items-justified-space-between > ul {
+	justify-content: space-between;
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -32,6 +32,7 @@
 @import "./components/contrast-checker/style.scss";
 @import "./components/default-block-appender/style.scss";
 @import "./components/font-appearance-control/style.scss";
+@import "./components/justify-toolbar/style.scss";
 @import "./components/link-control/style.scss";
 @import "./components/line-height-control/style.scss";
 @import "./components/image-size-control/style.scss";

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -121,8 +121,8 @@ function Navigation( {
 			<BlockControls>
 				{ hasItemJustificationControls && (
 					<JustifyToolbar
-						itemsJustification={ attributes.itemsJustification }
-						handleItemsAlignment={ handleItemsAlignment }
+						value={ attributes.itemsJustification }
+						onChange={ handleItemsAlignment }
 						popoverProps={ {
 							position: 'bottom right',
 							isAlternate: true,

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -11,6 +11,7 @@ import {
 	InnerBlocks,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	InspectorControls,
+	JustifyToolbar,
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
@@ -23,12 +24,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useBlockNavigator from './use-block-navigator';
-import {
-	justifyLeft,
-	justifyCenter,
-	justifyRight,
-	justifySpaceBetween,
-} from '@wordpress/icons';
+
 import NavigationPlaceholder from './placeholder';
 import PlaceholderPreview from './placeholder-preview';
 
@@ -46,13 +42,6 @@ function Navigation( {
 	hasItemJustificationControls = attributes.orientation === 'horizontal',
 	hasListViewModal = true,
 } ) {
-	const navIcons = {
-		left: justifyLeft,
-		center: justifyCenter,
-		right: justifyRight,
-		'space-between': justifySpaceBetween,
-	};
-
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
 	);
@@ -127,57 +116,17 @@ function Navigation( {
 		};
 	}
 
-	const POPOVER_PROPS = {
-		position: 'bottom right',
-		isAlternate: true,
-	};
-
 	return (
 		<>
 			<BlockControls>
 				{ hasItemJustificationControls && (
-					<ToolbarGroup
-						icon={
-							attributes.itemsJustification
-								? navIcons[ attributes.itemsJustification ]
-								: navIcons.left
-						}
-						popoverProps={ POPOVER_PROPS }
-						label={ __( 'Change items justification' ) }
-						isCollapsed
-						controls={ [
-							{
-								icon: justifyLeft,
-								title: __( 'Justify items left' ),
-								isActive:
-									'left' === attributes.itemsJustification,
-								onClick: handleItemsAlignment( 'left' ),
-							},
-							{
-								icon: justifyCenter,
-								title: __( 'Justify items center' ),
-								isActive:
-									'center' === attributes.itemsJustification,
-								onClick: handleItemsAlignment( 'center' ),
-							},
-							{
-								icon: justifyRight,
-								title: __( 'Justify items right' ),
-								isActive:
-									'right' === attributes.itemsJustification,
-								onClick: handleItemsAlignment( 'right' ),
-							},
-							{
-								icon: justifySpaceBetween,
-								title: __( 'Space between items' ),
-								isActive:
-									'space-between' ===
-									attributes.itemsJustification,
-								onClick: handleItemsAlignment(
-									'space-between'
-								),
-							},
-						] }
+					<JustifyToolbar
+						itemsJustification={ attributes.itemsJustification }
+						handleItemsAlignment={ handleItemsAlignment }
+						popoverProps={ {
+							position: 'bottom right',
+							isAlternate: true,
+						} }
 					/>
 				) }
 				{ hasListViewModal && (

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -6,3 +6,15 @@
 		min-width: 200px;
 	}
 }
+
+.items-justified-center > ul {
+	justify-content: center;
+}
+
+.items-justified-right > ul {
+	justify-content: flex-end;
+}
+
+.items-justified-space-between > ul {
+	justify-content: space-between;
+}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -6,20 +6,3 @@
 		min-width: 200px;
 	}
 }
-
-// Justification.
-.items-justified-left > ul {
-	justify-content: flex-start;
-}
-
-.items-justified-center > ul {
-	justify-content: center;
-}
-
-.items-justified-right > ul {
-	justify-content: flex-end;
-}
-
-.items-justified-space-between > ul {
-	justify-content: space-between;
-}


### PR DESCRIPTION

## Description

Move the toolbar created for the Navigation block to add justification controls, mainly space-between, to it's own component within the block-editor components. We want to add these controls additional to the Social Links block, but first need this PR to abstract it out and then can use in both spots without duplicating work.

## How has this been tested?

1. Create a Navigation block using the justify controls
2. Apply the PR and confirm the block still works
3. Confirm the justify controls still work
4. You can modify the style.scss in the justify-toolbar component and confirm that is where the CSS comes from.

## Types of changes

No functional changes, just code organization and clean up making the component reusable.


