### PR TITLE
Wp-env: Add MySQL port info to start logs

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -191,10 +191,10 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 	spinner.text = 'Done!'
 		.concat( '\n' )
 		.concat( `MySQL is listening on port ${ mySQLPort }` )
-		.concat( 'WordPress started' )
+		.concat( 'WordPress development site started' )
 		.concat( siteUrl ? ` at ${ siteUrl }` : '.' )
 		.concat( '\n' )
-		.concat( 'WordPress E2E testing site started' )
+		.concat( 'WordPress test site started' )
 		.concat( e2eSiteUrl ? ` at ${ e2eSiteUrl }` : '.' );
 };
 

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -188,13 +188,13 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 	);
 	const mySQLPort = mySQLAddress.stdout.split( ':' ).pop();
 
-	spinner.prefixText = `MySQL is listening on port ${ mySQLPort }`
-		.concat( 'WordPress development site started' )
+	spinner.prefixText = 'WordPress development site started'
 		.concat( siteUrl ? ` at ${ siteUrl }` : '.' )
 		.concat( '\n' )
 		.concat( 'WordPress test site started' )
 		.concat( e2eSiteUrl ? ` at ${ e2eSiteUrl }` : '.' )
 		.concat( '\n' )
+		.concat( `MySQL is listening on port ${ mySQLPort }` )
 		.concat( '\n' );
 
 	spinner.text = 'Done!';

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -65,7 +65,7 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 
 	// Check if the hash of the config has changed. If so, run configuration.
 	const configHash = md5( config );
-	const workDirectoryPath = config.workDirectoryPath;
+	const { workDirectoryPath, dockerComposeConfigPath } = config;
 	const shouldConfigureWp =
 		update ||
 		( await didCacheChange( CONFIG_CACHE_KEY, configHash, {
@@ -73,7 +73,7 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 		} ) );
 
 	const dockerComposeConfig = {
-		config: config.dockerComposeConfigPath,
+		config: dockerComposeConfigPath,
 		log: config.debug,
 	};
 
@@ -182,9 +182,16 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 	}
 
 	const siteUrl = config.env.development.config.WP_SITEURL;
-	spinner.text = 'WordPress started'.concat(
-		siteUrl ? ` at ${ siteUrl }.` : '.'
+	const mySQLAddress = await exec(
+		`docker-compose -f ${ dockerComposeConfigPath } port mysql 3306`
 	);
+	const mySQLPort = mySQLAddress.stdout.split( ':' ).pop();
+
+	spinner.text = 'Done! \n'
+		.concat( `MySQL is listening on port ${ mySQLPort }` )
+		.concat( 'WordPress started' )
+		.concat( siteUrl ? ` at ${ siteUrl }` : '.' )
+		.concat( '\n' );
 };
 
 /**

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -182,16 +182,20 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 	}
 
 	const siteUrl = config.env.development.config.WP_SITEURL;
+	const e2eSiteUrl = config.env.tests.config.WP_TESTS_DOMAIN;
 	const mySQLAddress = await exec(
 		`docker-compose -f ${ dockerComposeConfigPath } port mysql 3306`
 	);
 	const mySQLPort = mySQLAddress.stdout.split( ':' ).pop();
 
-	spinner.text = 'Done! \n'
+	spinner.text = 'Done!'
+		.concat( '\n' )
 		.concat( `MySQL is listening on port ${ mySQLPort }` )
 		.concat( 'WordPress started' )
 		.concat( siteUrl ? ` at ${ siteUrl }` : '.' )
-		.concat( '\n' );
+		.concat( '\n' )
+		.concat( 'WordPress E2E testing site started' )
+		.concat( e2eSiteUrl ? ` at ${ e2eSiteUrl }` : '.' );
 };
 
 /**

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -188,14 +188,16 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 	);
 	const mySQLPort = mySQLAddress.stdout.split( ':' ).pop();
 
-	spinner.text = 'Done!'
-		.concat( '\n' )
-		.concat( `MySQL is listening on port ${ mySQLPort }` )
+	spinner.prefixText = `MySQL is listening on port ${ mySQLPort }`
 		.concat( 'WordPress development site started' )
 		.concat( siteUrl ? ` at ${ siteUrl }` : '.' )
 		.concat( '\n' )
 		.concat( 'WordPress test site started' )
-		.concat( e2eSiteUrl ? ` at ${ e2eSiteUrl }` : '.' );
+		.concat( e2eSiteUrl ? ` at ${ e2eSiteUrl }` : '.' )
+		.concat( '\n' )
+		.concat( '\n' );
+
+	spinner.text = 'Done!';
 };
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Follow up for #21545. See this comment https://github.com/WordPress/gutenberg/pull/21545#issuecomment-614349354.

<img width="810" alt="Screen Shot 2021-01-25 at 3 57 38 PM" src="https://user-images.githubusercontent.com/5414230/105780852-4242c480-5f26-11eb-8438-c3b6394eaee0.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Apply this PR
- Run `npx wp-env start`
- Take note of the output logs. Copy the MySQL port.
- Download [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) I went through the macOS app store.
- Open the application, select "TCP/IP" connection, and input the following info:
  ```
  Name: WordPress Gutenberg
  Host: 127.0.0.1
  Database: wordpress
  Port: [PASTE_MY_SQL_PORT_HERE]
  Time Zone: Use Server Time Zone
  ``` 
- Click on connect
- Connection should be successful
- Once connected, you should see all database tables for your local WordPress instance like so:
<img width="796" alt="Screen Shot 2021-01-22 at 2 06 44 PM" src="https://user-images.githubusercontent.com/5414230/105553967-47500b80-5cbb-11eb-9b13-207d010553e6.png"> 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
