### PR TITLE
Add `ref` dependency on useEventHandlers hook

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -142,5 +142,6 @@ export function useEventHandlers( ref, clientId ) {
 		insertDefaultBlock,
 		removeBlock,
 		selectBlock,
+		ref.current,
 	] );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/28417

Currently if you have inserted a `Latest Posts` block in a page/post and reload or just enter that page, if you wait for the posts to load, you cannot select it by clicking it.

**You have to wait to load the posts, because by clicking the `Placeholder` the `focus` handler is attached.

This happens because while waiting for the posts to load, we show a placeholder:
```
if ( ! hasPosts ) {
	return (
		<div { ...blockProps }>......
```
This means that inside `useBlockProps`, that is calling `useEventHandlers`, we assign a `onFocus` handler for the `div` ref.
Later the requested posts have been fetched and `Latest Posts` block render something like this:
```
<>
	<ul { ...blockProps }>....
```
So the `ref` has been changed to the `ul`, but the `onFocus` hasn't been attached.

This should apply to other blocks that render different elements like `Latest Posts`.

So my fix was to update the dependencies of the `useEventHandlers` effect to take into account a `ref` change.

I could use a sanity check and thoughts whether I'm fixing a symptom and not the root problem. 
--cc @ellatrix @youknowriad 

