### PR TITLE
Fixed Social Icons shape, and horizontal and vertical alignments (fixes #28340)

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -11,8 +11,10 @@
 	transform: none;
 }
 
+// Align social links vertically to Page-Links text when using vertical Navigation block.
 .editor-styles-wrapper .wp-block-social-links {
 	padding: 0;
+	padding-left: 0.5em;
 }
 
 // Placeholder/setup state.

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -11,10 +11,8 @@
 	transform: none;
 }
 
-// Align social links vertically to Page-Links text when using vertical Navigation block.
 .editor-styles-wrapper .wp-block-social-links {
 	padding: 0;
-	padding-left: 0.5em;
 }
 
 // Placeholder/setup state.

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -2,7 +2,6 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-start;
-	align-items: center;
 	padding-left: 0;
 	padding-right: 0;
 	// Some themes set text-indent on all <ul>
@@ -22,7 +21,7 @@
 	.wp-social-link {
 		// This needs specificity to override some themes.
 		&.wp-social-link.wp-social-link {
-			margin: 4px 8px 4px 0;
+			margin: auto 8px auto 0;
 		}
 
 		// By setting the font size, we can scale icons and paddings consistently based on that.
@@ -91,8 +90,7 @@
 	@include reduce-motion("transition");
 
 	// Dimensions.
-	// Height value has to be fit-content otherwise the social icons will be oblong instead of circle when selecting Small or Normal Size in the Block Editor.
-	height: fit-content;
+	height: auto;
 
 	a {
 		display: block;

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-start;
+	align-items: center;
 	padding-left: 0;
 	padding-right: 0;
 	// Some themes set text-indent on all <ul>
@@ -90,7 +91,8 @@
 	@include reduce-motion("transition");
 
 	// Dimensions.
-	height: auto;
+	// Height value has to be fit-content otherwise the social icons will be oblong instead of circle when selecting Small or Normal Size in the Block Editor.
+	height: fit-content;
 
 	a {
 		display: block;


### PR DESCRIPTION
Fixes #28340

Original issue was that when adding Social Icons to a Navigation block, the icons would be oblong instead of circle. The icons only misshapened when size Small or Normal was selected.

I also noticed that when a horizontal Nav block was added, the social icons wouldn't align horizontally, and in a vertical Nav block, the social icons wouldn't align vertically.