### PR TITLE
Add margin support to Separator block

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -10,6 +10,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { forwardRef, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { getBlockType, withBlockContentContext } from '@wordpress/blocks';
+import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -28,6 +29,8 @@ import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { defaultLayout, LayoutProvider } from './layout';
+
+const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -179,11 +182,17 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			}
 		),
 		children: (
-			<InnerBlocks
-				{ ...options }
-				clientId={ clientId }
-				wrapperRef={ ref }
-			/>
+			<>
+				<InnerBlocks
+					{ ...options }
+					clientId={ clientId }
+					wrapperRef={ ref }
+				/>
+				<BoxControlVisualizer
+					values={ props.style?.spacing }
+					showValues={ props.style?.visualizers }
+				/>
+			</>
 		),
 	};
 }

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -10,13 +10,12 @@ import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import { cleanEmptyObject } from './utils';
+import { SPACING_SUPPORT_KEY } from './padding';
 import useEditorFeature from '../components/use-editor-feature';
 
-export const SPACING_SUPPORT_KEY = 'spacing';
-
-const hasPaddingSupport = ( blockName ) => {
+const hasMarginSupport = ( blockName ) => {
 	const spacingSupport = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
-	return spacingSupport && spacingSupport.padding;
+	return spacingSupport && spacingSupport.margin;
 };
 
 /**
@@ -26,19 +25,20 @@ const hasPaddingSupport = ( blockName ) => {
  *
  * @return {WPElement} Line height edit element.
  */
-export function PaddingEdit( props ) {
+export function MarginEdit( props ) {
 	const {
 		name: blockName,
 		attributes: { style },
 		setAttributes,
 	} = props;
+
 	const customUnits = useEditorFeature( 'spacing.units' );
 	const units = customUnits?.map( ( unit ) => ( {
 		value: unit,
 		label: unit,
 	} ) );
 
-	if ( ! hasPaddingSupport( blockName ) ) {
+	if ( ! hasMarginSupport( blockName ) ) {
 		return null;
 	}
 
@@ -48,7 +48,7 @@ export function PaddingEdit( props ) {
 			...style,
 			spacing: {
 				...spacing,
-				padding: next,
+				margin: next,
 			},
 		};
 
@@ -63,7 +63,7 @@ export function PaddingEdit( props ) {
 			...style,
 			visualizers: {
 				...spacing,
-				padding: next,
+				margin: next,
 			},
 		};
 
@@ -76,11 +76,11 @@ export function PaddingEdit( props ) {
 		web: (
 			<>
 				<BoxControl
-					values={ style?.spacing?.padding }
+					values={ style?.spacing?.margin }
 					onChange={ onChange }
 					onChangeShowVisualizer={ onChangeShowVisualizer }
-					label={ __( 'Padding' ) }
-					type="padding"
+					label={ __( 'Margin' ) }
+					type="margin"
 					units={ units }
 				/>
 			</>

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -20,6 +20,7 @@ import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
 import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
+import { MarginEdit } from './margin';
 import SpacingPanelControl from '../components/spacing-panel-control';
 
 const styleSupportKeys = [
@@ -167,6 +168,7 @@ export const withBlockControls = createHigherOrderComponent(
 			hasSpacingSupport && (
 				<SpacingPanelControl key="spacing">
 					<PaddingEdit { ...props } />
+					<MarginEdit { ...props } />
 				</SpacingPanelControl>
 			),
 		];

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -19,6 +19,10 @@
 	"supports": {
 		"anchor": true,
 		"reusable": false,
-		"html": false
+		"html": false,
+		"spacing": {
+			"padding": true,
+			"margin": true
+		}
 	}
 }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -27,7 +27,7 @@ import { __ } from '@wordpress/i18n';
 import { CSS_UNITS } from '../columns/utils';
 
 function ColumnEdit( {
-	attributes: { verticalAlignment, width, templateLock = false },
+	attributes: { verticalAlignment, width, style, templateLock = false },
 	setAttributes,
 	clientId,
 } ) {
@@ -63,7 +63,9 @@ function ColumnEdit( {
 	const widthWithUnit = Number.isFinite( width ) ? width + '%' : width;
 	const blockProps = useBlockProps( {
 		className: classes,
-		style: widthWithUnit ? { flexBasis: widthWithUnit } : undefined,
+		style: widthWithUnit
+			? { flexBasis: widthWithUnit, ...style }
+			: { ...style },
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		templateLock,

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -17,6 +17,10 @@
 		"color": {
 			"gradients": true,
 			"link": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true
 		}
 	},
 	"editorStyle": "wp-block-columns-editor",

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -52,7 +52,7 @@ function ColumnsEditContainer( {
 	updateColumns,
 	clientId,
 } ) {
-	const { verticalAlignment } = attributes;
+	const { verticalAlignment, style } = attributes;
 
 	const { count } = useSelect(
 		( select ) => {
@@ -69,6 +69,7 @@ function ColumnsEditContainer( {
 
 	const blockProps = useBlockProps( {
 		className: classes,
+		style,
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -55,7 +55,8 @@
 		"align": true,
 		"html": false,
 		"spacing": {
-			"padding": true
+			"padding": true,
+			"margin": true
 		}
 	},
 	"editorStyle": "wp-block-cover-editor",

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -564,8 +564,8 @@ function CoverEdit( {
 				data-url={ url }
 			>
 				<BoxControlVisualizer
-					values={ styleAttribute?.spacing?.padding }
-					showValues={ styleAttribute?.visualizers?.padding }
+					values={ styleAttribute?.spacing }
+					showValues={ styleAttribute?.visualizers }
 				/>
 				<ResizableCover
 					className="block-library-cover__resize-container"

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -23,7 +23,8 @@
 			"link": true
 		},
 		"spacing": {
-			"padding": true
+			"padding": true,
+			"margin": true
 		},
 		"__experimentalBorder": {
 			"radius": true

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -36,8 +36,8 @@ function GroupEdit( { attributes, clientId } ) {
 	return (
 		<TagName { ...blockProps }>
 			<BoxControlVisualizer
-				values={ attributes.style?.spacing?.padding }
-				showValues={ attributes.style?.visualizers?.padding }
+				values={ attributes.style?.spacing }
+				showValues={ attributes.style?.visualizers }
 			/>
 			<div { ...innerBlocksProps } />
 		</TagName>

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -12,7 +12,10 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": ["center","wide","full"]
+		"align": ["center","wide","full"],
+		"spacing": {
+			"margin": true
+		}
 	},
 	"editorStyle": "wp-block-separator-editor",
 	"style": "wp-block-separator"

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -6,17 +6,20 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { HorizontalRule } from '@wordpress/components';
+import { View } from '@wordpress/primitives';
+import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 import { withColors, useBlockProps } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
 import SeparatorSettings from './separator-settings';
 
-function SeparatorEdit( { color, setColor, className } ) {
+const { __Visualizer: BoxControlVisualizer } = BoxControl;
+
+function SeparatorEdit( { attributes, color, setColor, className } ) {
 	return (
 		<>
-			<HorizontalRule
+			<View
 				{ ...useBlockProps( {
 					className: classnames( className, {
 						'has-background': color.color,
@@ -27,7 +30,12 @@ function SeparatorEdit( { color, setColor, className } ) {
 						color: color.color,
 					},
 				} ) }
-			/>
+			>
+				<BoxControlVisualizer
+					values={ attributes.style?.spacing }
+					showValues={ attributes.style?.visualizers }
+				/>
+			</View>
 			<SeparatorSettings color={ color } setColor={ setColor } />
 		</>
 	);

--- a/packages/block-library/src/separator/edit.native.js
+++ b/packages/block-library/src/separator/edit.native.js
@@ -6,19 +6,17 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
+import { HorizontalRule } from '@wordpress/components';
 import { withColors, useBlockProps } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
 import SeparatorSettings from './separator-settings';
 
-const { __Visualizer: BoxControlVisualizer } = BoxControl;
-
-function SeparatorEdit( { attributes, color, setColor, className } ) {
+function SeparatorEdit( { color, setColor, className } ) {
 	return (
 		<>
-			<div
+			<HorizontalRule
 				{ ...useBlockProps( {
 					className: classnames( className, {
 						'has-background': color.color,
@@ -29,12 +27,7 @@ function SeparatorEdit( { attributes, color, setColor, className } ) {
 						color: color.color,
 					},
 				} ) }
-			>
-				<BoxControlVisualizer
-					values={ attributes.style?.spacing }
-					showValues={ attributes.style?.visualizers }
-				/>
-			</div>
+			/>
 			<SeparatorSettings color={ color } setColor={ setColor } />
 		</>
 	);

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -58,6 +58,11 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		support: [ 'spacing', 'padding' ],
 		properties: [ 'top', 'right', 'bottom', 'left' ],
 	},
+	margin: {
+		value: [ 'spacing', 'margin' ],
+		support: [ 'spacing', 'margin' ],
+		properties: [ 'top', 'right', 'bottom', 'left' ],
+	},
 	textDecoration: {
 		value: [ 'typography', 'textDecoration' ],
 		support: [ '__experimentalTextDecoration' ],

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import UnitControl from './unit-control';
-import { LABELS, getAllValue, isValuesMixed, isValuesDefined } from './utils';
+import { LABELS, isValuesMixed, isValuesDefined } from './utils';
 
 export default function AllInputControl( {
 	onChange = noop,
@@ -16,9 +16,11 @@ export default function AllInputControl( {
 	values,
 	...props
 } ) {
-	const allValue = getAllValue( values );
+	const allValues = Object.values( values );
+	const [ singleValue ] = allValues.slice( 0, 1 );
 	const hasValues = isValuesDefined( values );
 	const isMixed = hasValues && isValuesMixed( values );
+	const disableUnits = isMixed || singleValue?.match( /^(auto|calc)/ );
 
 	const allPlaceholder = isMixed ? LABELS.mixed : null;
 
@@ -58,9 +60,9 @@ export default function AllInputControl( {
 	return (
 		<UnitControl
 			{ ...props }
-			disableUnits={ isMixed }
+			disableUnits={ disableUnits }
 			isOnly
-			value={ allValue }
+			value={ ! isMixed && singleValue }
 			onChange={ handleOnChange }
 			onFocus={ handleOnFocus }
 			onHoverOn={ handleOnHoverOn }

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -51,6 +51,7 @@ export default function BoxControl( {
 	label = __( 'Box Control' ),
 	values: valuesProp,
 	units,
+	type,
 } ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
@@ -108,6 +109,7 @@ export default function BoxControl( {
 		isLinked,
 		units,
 		values: inputValues,
+		type,
 	};
 
 	return (

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -16,6 +16,7 @@ export default function BoxInputControls( {
 	onHoverOn = noop,
 	onHoverOff = noop,
 	values,
+	type,
 	...props
 } ) {
 	const createHandleOnFocus = ( side ) => ( event ) => {
@@ -39,7 +40,6 @@ export default function BoxInputControls( {
 	const createHandleOnChange = ( side ) => ( next, { event } ) => {
 		const { altKey } = event;
 		const nextValues = { ...values };
-
 		nextValues[ side ] = next;
 
 		/**
@@ -82,6 +82,8 @@ export default function BoxInputControls( {
 					onHoverOn={ createHandleOnHoverOn( 'top' ) }
 					onHoverOff={ createHandleOnHoverOff( 'top' ) }
 					label={ LABELS.top }
+					disableUnits={ top?.match( /^(auto|calc)/ ) }
+					type={ `${ type }Top` }
 				/>
 				<UnitControl
 					{ ...props }
@@ -91,6 +93,8 @@ export default function BoxInputControls( {
 					onHoverOn={ createHandleOnHoverOn( 'right' ) }
 					onHoverOff={ createHandleOnHoverOff( 'right' ) }
 					label={ LABELS.right }
+					disableUnits={ right?.match( /^(auto|calc)/ ) }
+					type={ `${ type }Right` }
 				/>
 				<UnitControl
 					{ ...props }
@@ -100,6 +104,8 @@ export default function BoxInputControls( {
 					onHoverOn={ createHandleOnHoverOn( 'bottom' ) }
 					onHoverOff={ createHandleOnHoverOff( 'bottom' ) }
 					label={ LABELS.bottom }
+					disableUnits={ bottom?.match( /^(auto|calc)/ ) }
+					type={ `${ type }Bottom` }
 				/>
 				<UnitControl
 					{ ...props }
@@ -110,6 +116,8 @@ export default function BoxInputControls( {
 					onHoverOn={ createHandleOnHoverOn( 'left' ) }
 					onHoverOff={ createHandleOnHoverOff( 'left' ) }
 					label={ LABELS.left }
+					disableUnits={ left?.match( /^(auto|calc)/ ) }
+					type={ `${ type }Left` }
 				/>
 			</Layout>
 		</LayoutContainer>

--- a/packages/components/src/box-control/styles/box-control-styles.js
+++ b/packages/components/src/box-control/styles/box-control-styles.js
@@ -28,7 +28,7 @@ export const HeaderControlWrapper = styled( Flex )`
 
 export const UnitControlWrapper = styled.div`
 	box-sizing: border-box;
-	max-width: 80px;
+	max-width: 100px;
 `;
 
 export const LayoutContainer = styled( Flex )`
@@ -65,7 +65,7 @@ const unitControlMarginStyles = ( { isFirst } ) => {
 };
 
 export const UnitControl = styled( BaseUnitControl )`
-	max-width: 60px;
+	max-width: 100px;
 	${ unitControlBorderRadiusStyles };
 	${ unitControlMarginStyles };
 `;

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -22,6 +22,10 @@ export const LABELS = {
 	mixed: __( 'Mixed' ),
 };
 
+export const CUSTOM_VALUES = {
+	AUTO: 'auto',
+};
+
 export const DEFAULT_VALUES = {
 	top: null,
 	right: null,
@@ -34,6 +38,11 @@ export const DEFAULT_VISUALIZER_VALUES = {
 	right: false,
 	bottom: false,
 	left: false,
+};
+
+export const DEFAULT_VISUALIZER_SPACING_VALUES = {
+	padding: DEFAULT_VISUALIZER_VALUES,
+	margin: DEFAULT_VISUALIZER_VALUES,
 };
 
 /**
@@ -82,7 +91,6 @@ export function getAllValue( values = {} ) {
 	 * simple truthy check.
 	 */
 	const allValue = isNumber( value ) ? `${ value }${ unit }` : null;
-
 	return allValue;
 }
 
@@ -93,10 +101,8 @@ export function getAllValue( values = {} ) {
  * @return {boolean} Whether values are mixed.
  */
 export function isValuesMixed( values = {} ) {
-	const allValue = getAllValue( values );
-	const isMixed = isNaN( parseFloat( allValue ) );
-
-	return isMixed;
+	const vals = Object.values( values );
+	return vals.some( ( val ) => val !== vals[ 0 ] );
 }
 
 /**
@@ -111,4 +117,41 @@ export function isValuesDefined( values ) {
 		values !== undefined &&
 		! isEmpty( Object.values( values ).filter( Boolean ) )
 	);
+}
+
+const sideStyles = {
+	margin: {
+		top: { transform: 'translateY(-100%)' },
+		right: { transform: 'translateX(100%)' },
+		bottom: { transform: 'translateY(100%)' },
+		left: { transform: 'translateX(-100%)' },
+	},
+	padding: {
+		top: null,
+		right: null,
+		bottom: null,
+		left: null,
+	},
+};
+
+/**
+ * Modifies the style properties of each side.
+ *
+ * @param {string} type of field
+ * @return {function(*, [*, *]): *} reducer function adding additional styles
+ */
+
+export function extendStyles( type ) {
+	return ( acc, [ side, value ] ) => {
+		const styles = sideStyles[ type ][ side ];
+		return {
+			...acc,
+			[ side ]: {
+				style: {
+					...styles,
+					[ side ]: value,
+				},
+			},
+		};
+	};
 }

--- a/packages/components/src/box-control/visualizer.js
+++ b/packages/components/src/box-control/visualizer.js
@@ -13,70 +13,88 @@ import {
 	BottomView,
 	LeftView,
 } from './styles/box-control-visualizer-styles';
-import { DEFAULT_VALUES, DEFAULT_VISUALIZER_VALUES } from './utils';
+import {
+	DEFAULT_VISUALIZER_VALUES,
+	DEFAULT_VISUALIZER_SPACING_VALUES,
+	DEFAULT_VALUES,
+	extendStyles,
+} from './utils';
 
 export default function BoxControlVisualizer( {
 	children,
-	showValues = DEFAULT_VISUALIZER_VALUES,
-	values: valuesProp = DEFAULT_VALUES,
+	showValues = DEFAULT_VISUALIZER_SPACING_VALUES,
+	values,
 	...props
 } ) {
 	const isPositionAbsolute = ! children;
-	return (
-		<Container
-			{ ...props }
-			isPositionAbsolute={ isPositionAbsolute }
-			aria-hidden="true"
-		>
-			<Sides showValues={ showValues } values={ valuesProp } />
-			{ children }
-		</Container>
-	);
+	const valuesProp = {
+		margin: { ...DEFAULT_VALUES, ...values?.margin },
+		padding: { ...DEFAULT_VALUES, ...values?.padding },
+	};
+
+	return Object.entries( showValues ).map( ( [ key, value ] ) => {
+		return (
+			<Container
+				{ ...props }
+				key={ key }
+				isPositionAbsolute={ isPositionAbsolute }
+				aria-hidden="true"
+			>
+				<Sides
+					showValues={ value }
+					type={ key }
+					values={ valuesProp[ key ] }
+				/>
+				{ children }
+			</Container>
+		);
+	} );
 }
 
-function Sides( { showValues = DEFAULT_VISUALIZER_VALUES, values } ) {
-	const { top, right, bottom, left } = values;
+function Sides( { showValues = DEFAULT_VISUALIZER_VALUES, ...props } ) {
+	const { top, right, bottom, left } = Object.entries( props.values ).reduce(
+		extendStyles( props.type ),
+		{}
+	);
 
 	return (
 		<>
-			<Top isVisible={ showValues.top } value={ top } />
-			<Right isVisible={ showValues.right } value={ right } />
-			<Bottom isVisible={ showValues.bottom } value={ bottom } />
-			<Left isVisible={ showValues.left } value={ left } />
+			<Top isVisible={ showValues.top } value={ top?.style } />
+			<Right isVisible={ showValues.right } value={ right?.style } />
+			<Bottom isVisible={ showValues.bottom } value={ bottom?.style } />
+			<Left isVisible={ showValues.left } value={ left?.style } />
 		</>
 	);
 }
 
 function Top( { isVisible = false, value } ) {
-	const height = value;
+	const { top: height, ...styles } = value;
 	const animationProps = useSideAnimation( height );
 	const isActive = animationProps.isActive || isVisible;
-
-	return <TopView isActive={ isActive } style={ { height } } />;
+	return <TopView isActive={ isActive } style={ { height, ...styles } } />;
 }
 
 function Right( { isVisible = false, value } ) {
-	const width = value;
+	const { right: width, ...styles } = value;
 	const animationProps = useSideAnimation( width );
 	const isActive = animationProps.isActive || isVisible;
 
-	return <RightView isActive={ isActive } style={ { width } } />;
+	return <RightView isActive={ isActive } style={ { width, ...styles } } />;
 }
 
 function Bottom( { isVisible = false, value } ) {
-	const height = value;
+	const { bottom: height, ...styles } = value;
 	const animationProps = useSideAnimation( height );
 	const isActive = animationProps.isActive || isVisible;
-
-	return <BottomView isActive={ isActive } style={ { height } } />;
+	return <BottomView isActive={ isActive } style={ { height, ...styles } } />;
 }
 
 function Left( { isVisible = false, value } ) {
-	const width = value;
+	const { left: width, ...styles } = value;
 	const animationProps = useSideAnimation( width );
 	const isActive = animationProps.isActive || isVisible;
 
-	return <LeftView isActive={ isActive } style={ { width } } />;
+	return <LeftView isActive={ isActive } style={ { width, ...styles } } />;
 }
 
 /**

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -93,9 +93,11 @@ export function NumberControl(
 				nextValue = subtract( nextValue, incrementalValue );
 			}
 
-			nextValue = roundClamp( nextValue, min, max, incrementalValue );
-
-			state.value = nextValue;
+			if ( ! isNaN( nextValue ) ) {
+				state.value = roundClamp( nextValue, min, max );
+			} else {
+				state.value = nextValue;
+			}
 		}
 
 		/**
@@ -155,7 +157,11 @@ export function NumberControl(
 			type === inputControlActionTypes.PRESS_ENTER ||
 			type === inputControlActionTypes.COMMIT
 		) {
-			state.value = roundClamp( currentValue, min, max );
+			if ( ! isNaN( currentValue ) ) {
+				state.value = roundClamp( currentValue, min, max );
+			} else {
+				state.value = currentValue;
+			}
 		}
 
 		return state;

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -133,7 +133,7 @@ describe( 'NumberControl', () => {
 			input.focus();
 			fireKeyDown( { keyCode: UP, shiftKey: true } );
 
-			expect( input.value ).toBe( '20' );
+			expect( input.value ).toBe( '15' );
 		} );
 
 		it( 'should increment by custom shiftStep on key UP + shift press', () => {
@@ -143,7 +143,7 @@ describe( 'NumberControl', () => {
 			input.focus();
 			fireKeyDown( { keyCode: UP, shiftKey: true } );
 
-			expect( input.value ).toBe( '100' );
+			expect( input.value ).toBe( '105' );
 		} );
 
 		it( 'should increment but be limited by max on shiftStep', () => {
@@ -211,7 +211,7 @@ describe( 'NumberControl', () => {
 		} );
 
 		it( 'should decrement by shiftStep on key DOWN + shift press', () => {
-			render( <StatefulNumberControl value={ 5 } /> );
+			render( <StatefulNumberControl value={ 5 } min={ 0 } /> );
 
 			const input = getInput();
 			input.focus();
@@ -227,7 +227,7 @@ describe( 'NumberControl', () => {
 			input.focus();
 			fireKeyDown( { keyCode: DOWN, shiftKey: true } );
 
-			expect( input.value ).toBe( '-100' );
+			expect( input.value ).toBe( '-95' );
 		} );
 
 		it( 'should decrement but be limited by min on shiftStep', () => {

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -45,7 +45,12 @@ function UnitControl(
 	},
 	ref
 ) {
-	const [ value, initialUnit ] = getParsedValue( valueProp, unitProp, units );
+	const [ value, initialUnit ] = getParsedValue(
+		valueProp,
+		unitProp,
+		units,
+		props.type
+	);
 	const [ unit, setUnit ] = useControlledState( unitProp, {
 		initial: initialUnit,
 	} );
@@ -65,7 +70,8 @@ function UnitControl(
 		 * Customizing the onChange callback.
 		 * This allows as to broadcast a combined value+unit to onChange.
 		 */
-		next = getValidParsedUnit( next, units, value, unit ).join( '' );
+		const { type } = props;
+		next = getValidParsedUnit( next, units, value, unit, type ).join( '' );
 
 		onChange( next, changeProps );
 	};
@@ -90,11 +96,13 @@ function UnitControl(
 			refParsedValue.current = null;
 			return;
 		}
+
 		const [ parsedValue, parsedUnit ] = getValidParsedUnit(
 			event.target.value,
 			units,
 			value,
-			unit
+			unit,
+			props.type
 		);
 
 		refParsedValue.current = parsedValue;
@@ -105,7 +113,7 @@ function UnitControl(
 			);
 			const changeProps = { event, data };
 
-			onChange( `${ parsedValue }${ parsedUnit }`, changeProps );
+			onChange( `${ parsedValue }`, changeProps );
 			onUnitChange( parsedUnit, changeProps );
 
 			setUnit( parsedUnit );
@@ -163,7 +171,7 @@ function UnitControl(
 			<ValueInput
 				aria-label={ label }
 				type={ isPressEnterToChange ? 'text' : 'number' }
-				{ ...omit( props, [ 'children' ] ) }
+				{ ...omit( props, [ 'children', 'type' ] ) }
 				autoComplete={ autoComplete }
 				className={ classes }
 				disabled={ disabled }

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -92,7 +92,7 @@ describe( 'UnitControl', () => {
 		} );
 
 		it( 'should decrement value on DOWN press', () => {
-			let state = 50;
+			let state = '50px';
 			const setState = ( nextState ) => ( state = nextState );
 
 			render( <UnitControl value={ state } onChange={ setState } /> );
@@ -104,7 +104,7 @@ describe( 'UnitControl', () => {
 		} );
 
 		it( 'should decrement value on DOWN + SHIFT press, with step', () => {
-			let state = 50;
+			let state = '50px';
 			const setState = ( nextState ) => ( state = nextState );
 
 			render( <UnitControl value={ state } onChange={ setState } /> );


### PR DESCRIPTION
Some folks would like to be able to control the height of the Separator block #25989. This PR enables that by adding support for custom margins. It depends on the changes from #25988 that introduce the margin support flag and also includes those for ease of testing.

Testing this requires a theme that enables [Spacing block support](https://developer.wordpress.org/block-editor/developers/block-api/block-supports/#spacing) so Twenty Twenty One is a good one.

This would, I think, satisfy and close #25989.

## How has this been tested?
Trying various margin settings on a Separator block and previewing on the frontend.

## Screenshots 

https://user-images.githubusercontent.com/9000376/105650779-b5d2cc00-5e69-11eb-913b-891db587e3e9.mp4

## Types of changes
feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
