### PR TITLE
Block Mover wording: 'Move block position' to 'Change block position' 

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -117,7 +117,7 @@ export const BlockMover = ( {
 				ref={ pickerRef }
 				options={ blockPageMoverOptions }
 				onChange={ onPickerSelect }
-				title={ __( 'Move block position' ) }
+				title={ __( 'Change block position' ) }
 				leftAlign={ true }
 				hideCancelButton={ Platform.OS !== 'ios' }
 			/>

--- a/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
@@ -45,7 +45,7 @@ exports[`Block Mover Picker should match snapshot 1`] = `
     leftAlign={true}
     onChange={[Function]}
     options={Array []}
-    title="Move block position"
+    title="Change block position"
   />
 </Fragment>
 `;


### PR DESCRIPTION
## Description
Changing 'Move block position' to 'Change block position' for block mover as per Slack chat with Wordpress.org folks, cc: @hypest, @iamthomasbishop.

## How has this been tested?
1. Insert paragraph block and type text.
2. Insert heading block.
3. Long press up block mover.
4. Confirm that title on popped up action sheet says 'Change block position'.

## Screenshots <!-- if applicable -->
| iOS | Android |
| - | - |
| <img src="https://user-images.githubusercontent.com/13263478/105681822-4257ab80-5eb7-11eb-9b8d-0a6481124041.png" width="100%"/> | <img src="https://user-images.githubusercontent.com/13263478/105681826-42f04200-5eb7-11eb-901d-e4717d1f6293.png" width="78%"/> |

## Types of changes
Grammatical bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
