### PR TITLE
Try: Cover height fix round 2.

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -1,6 +1,4 @@
 .wp-block-cover {
-	height: 100%; // This explicit height rule is necessary for the focal point picker to work.
-
 	// Override default cover styles
 	// because we're not ready yet to show the cover block.
 	&.is-placeholder {


### PR DESCRIPTION
Alternative to #28114. Maybe fixes #17921, #17919.

The problem: The Cover block has some compounding rules around height, that make it rather ill-mannered when inside a flex container. Specifically, the `height: 100%;` makes the height _incorrect_ when inside a flex container, taking up the full height regardless of what you specifically set it to using the input field in the sidebar. That effectively pushes content off the bottom of the flex container, making it overlap adjacent content.

Before:

![Screenshot 2021-01-25 at 10 30 45](https://user-images.githubusercontent.com/1204802/105687167-6ab3ca00-5ef8-11eb-8738-87036bf977e3.png)

After:

<img width="1030" alt="Screenshot 2021-01-25 at 10 25 27" src="https://user-images.githubusercontent.com/1204802/105687190-71424180-5ef8-11eb-906e-07e755df563b.png">

<img width="1442" alt="Screenshot 2021-01-25 at 10 25 34" src="https://user-images.githubusercontent.com/1204802/105687200-730c0500-5ef8-11eb-82c2-23209acd7392.png">

In previous attempts, a few things broke because of this:

- The matrix alignment (9 dot button in the toolbar) would shift the image inside off the edges
- The focal point picker broke with a JS error
- The image inside the cover would break out of the boundaries of the cover

All three _appear_ to work just fine, with removing the height now:

<img width="1197" alt="Screenshot 2021-01-25 at 10 27 59" src="https://user-images.githubusercontent.com/1204802/105687405-b23a5600-5ef8-11eb-94ae-797392e9ebc7.png">

So, what's different from last time we tried the exact same PR?

@ockham and @ajlende have tirelessly been refactoring the adjacent code to be more resilient. Specifically the new rules added around how the image is positioned inside the cover block, appear to have solved this. In other words, the `height: 100%;` has been removed from the cover block itself, to the `img` inside it.

**How to reproduce the before and after:**

Paste the following into your code editor:

```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:cover {"url":"https://cldup.com/mjSTeGK_KQ.jpg","id":178,"overlayColor":"dark-gray","focalPoint":{"x":"0.38","y":"0.12"},"minHeight":225,"minHeightUnit":"px","contentPosition":"bottom right"} -->
<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-bottom-right" style="min-height:225px"><img class="wp-block-cover__image-background wp-image-178" alt="" src="https://cldup.com/mjSTeGK_KQ.jpg" style="object-position:38% 12%" data-object-fit="cover" data-object-position="38% 12%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Cover block within a column</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2>This is a heading</h2>
<!-- /wp:heading --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:paragraph -->
<p>Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “and what is the use of a book,” thought Alice “without pictures or conversations?”</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>So she was considering in her own mind (as well as she could, for the hot day made her feel very sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>There was nothing so very remarkable in that; nor did Alice think it so very much out of the way to hear the Rabbit say to itself, “Oh dear! Oh dear! I shall be late!” (when she thought it over afterwards, it occurred to her that she ought to have wondered at this, but at the time it all seemed quite natural); but when the Rabbit actually took a watch out of its waistcoat-pocket, and looked at it, and then hurried on, Alice started to her feet, for it flashed across her mind that she had never before seen a rabbit with either a waistcoat-pocket, or a watch to take out of it, and burning with curiosity, she ran across the field after it, and fortunately was just in time to see it pop down a large rabbit-hole under the hedge.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>In another moment down went Alice after it, never once considering how in the world she was to get out again.</p>
<!-- /wp:paragraph -->
```

Initially my instinct was that this was a bug with the _columns_ block, because after all, ideally it should be able to contain any block you throw inside it, right? But my realization was that no matter how resilient you make a container block, the CSS of a child block can make it explode if you try. In this case, the height property truly was causing issues.

**To test:**

Let's take it slow with this one. It's a good fix to land, but it doesn't have to happen quickly. Let's test it thoroughly, and if it passes the checks, merge it early in a cycle.

It would be good to test this branch on:

- Then Twenty themes
- Mobile, tablet and desktop breakpoints
- Test both editor and frontend
- Test using the matrix alignment tool
- Test using the focal point picker
- Test various heights of the cover block, including an "unset"/default height
- Test both portrait and landscape pictures

Things to look for:

- Matrix alignment breaking or shifting images outside the container
- Focal point picker not working
- The thing working in the editor, but not the frontend
- The image breaking outside the boundaries of the container

As far as I can tell, this one is solid. But let's be sure!

CC: @jffng and @stokesman because you worked on an adjacent focal point picker issue.