### PR TITLE
Template Part: Prevent infinite recursion

### DIFF
--- a/packages/block-editor/src/components/use-no-recursive-renders/index.js
+++ b/packages/block-editor/src/components/use-no-recursive-renders/index.js
@@ -8,18 +8,37 @@ import {
 	useMemo,
 } from '@wordpress/element';
 
-const RenderedRefsContext = createContext( new Set() );
+/**
+ * Internal dependencies
+ */
+import { useBlockEditContext } from '../block-edit/context';
 
-// Immutably add to a Set
-function add( set, element ) {
-	const result = new Set( set );
-	result.add( element );
+const RenderedRefsContext = createContext( {} );
+
+/**
+ * Immutably adds an unique identifier to a set scoped for a given block type.
+ *
+ * @param {Object} renderedBlocks Rendered blocks grouped by block name
+ * @param {string} blockName      Name of the block.
+ * @param {*} uniqueId            Any value that acts as a unique identifier for a block instance.
+ *
+ * @return {Object} The list of rendered blocks grouped by block name.
+ */
+function addToBlockType( renderedBlocks, blockName, uniqueId ) {
+	const result = { ...renderedBlocks };
+	if ( result[ blockName ] ) {
+		result[ blockName ].add( uniqueId );
+	} else {
+		const value = new Set();
+		value.add( uniqueId );
+		result[ blockName ] = value;
+	}
 	return result;
 }
 
 /**
  * A React hook for keeping track of blocks previously rendered up in the block
- * tree. Blocks susceptible to recursiion can use this hook in their `Edit`
+ * tree. Blocks susceptible to recursion can use this hook in their `Edit`
  * function to prevent said recursion.
  *
  * @param {*} uniqueId Any value that acts as a unique identifier for a block instance.
@@ -32,10 +51,13 @@ function add( set, element ) {
  */
 export default function useNoRecursiveRenders( uniqueId ) {
 	const previouslyRenderedBlocks = useContext( RenderedRefsContext );
-	const hasAlreadyRendered = previouslyRenderedBlocks.has( uniqueId );
+	const { name: blockName } = useBlockEditContext();
+	const hasAlreadyRendered = previouslyRenderedBlocks[ blockName ]?.has(
+		uniqueId
+	);
 	const newRenderedBlocks = useMemo(
-		() => add( previouslyRenderedBlocks, uniqueId ),
-		[ uniqueId, previouslyRenderedBlocks ]
+		() => addToBlockType( previouslyRenderedBlocks, blockName, uniqueId ),
+		[ previouslyRenderedBlocks, blockName, uniqueId ]
 	);
 	const Provider = useCallback(
 		( { children } ) => (

--- a/packages/block-editor/src/components/use-no-recursive-renders/index.js
+++ b/packages/block-editor/src/components/use-no-recursive-renders/index.js
@@ -25,14 +25,14 @@ const RenderedRefsContext = createContext( {} );
  * @return {Object} The list of rendered blocks grouped by block name.
  */
 function addToBlockType( renderedBlocks, blockName, uniqueId ) {
-	const result = { ...renderedBlocks };
-	if ( result[ blockName ] ) {
-		result[ blockName ].add( uniqueId );
-	} else {
-		const value = new Set();
-		value.add( uniqueId );
-		result[ blockName ] = value;
-	}
+	const result = {
+		...renderedBlocks,
+		[ blockName ]: renderedBlocks[ blockName ]
+			? new Set( renderedBlocks[ blockName ] )
+			: new Set(),
+	};
+	result[ blockName ].add( uniqueId );
+
 	return result;
 }
 
@@ -52,8 +52,8 @@ function addToBlockType( renderedBlocks, blockName, uniqueId ) {
 export default function useNoRecursiveRenders( uniqueId ) {
 	const previouslyRenderedBlocks = useContext( RenderedRefsContext );
 	const { name: blockName } = useBlockEditContext();
-	const hasAlreadyRendered = previouslyRenderedBlocks[ blockName ]?.has(
-		uniqueId
+	const hasAlreadyRendered = Boolean(
+		previouslyRenderedBlocks[ blockName ]?.has( uniqueId )
 	);
 	const newRenderedBlocks = useMemo(
 		() => addToBlockType( previouslyRenderedBlocks, blockName, uniqueId ),

--- a/packages/block-editor/src/components/use-no-recursive-renders/test/use-no-recursive-renders.js
+++ b/packages/block-editor/src/components/use-no-recursive-renders/test/use-no-recursive-renders.js
@@ -4,28 +4,39 @@
 import { render } from '@testing-library/react';
 
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import { Fragment } from '@wordpress/element';
-import { __experimentalUseNoRecursiveRenders as useNoRecursiveRenders } from '@wordpress/block-editor';
+import useNoRecursiveRenders from '../';
+import {
+	BlockEditContextProvider,
+	useBlockEditContext,
+} from '../../block-edit/context';
 
 // Mimics a block's Edit component, such as ReusableBlockEdit, which is capable
 // of calling itself depending on its `ref` attribute.
 function Edit( { attributes: { ref } } ) {
+	const { name } = useBlockEditContext();
 	const [ hasAlreadyRendered, RecursionProvider ] = useNoRecursiveRenders(
 		ref
 	);
 
 	if ( hasAlreadyRendered ) {
-		return <div className="wp-block__reusable-block--halted">Halt</div>;
+		return <div className={ `wp-block__${ name }--halted` }>Halt</div>;
 	}
 
 	return (
 		<RecursionProvider>
-			<div className="wp-block__reusable-block">
+			<div className={ `wp-block__${ name }` }>
 				{ ref === 'SIMPLE' && <p>Done</p> }
 				{ ref === 'SINGLY-RECURSIVE' && (
 					<Edit attributes={ { ref } } />
+				) }
+				{ ref === 'ANOTHER-BLOCK-SAME-REF' && (
+					<BlockEditContextProvider
+						value={ { name: 'another-block' } }
+					>
+						<Edit attributes={ { ref } } />
+					</BlockEditContextProvider>
 				) }
 				{ ref === 'MUTUALLY-RECURSIVE-1' && (
 					<Edit attributes={ { ref: 'MUTUALLY-RECURSIVE-2' } } />
@@ -39,9 +50,13 @@ function Edit( { attributes: { ref } } ) {
 }
 
 describe( 'useNoRecursiveRenders', () => {
+	const context = { name: 'reusable-block' };
+
 	it( 'allows a single block to render', () => {
 		const { container } = render(
-			<Edit attributes={ { ref: 'SIMPLE' } } />
+			<BlockEditContextProvider value={ context }>
+				<Edit attributes={ { ref: 'SIMPLE' } } />
+			</BlockEditContextProvider>
 		);
 		expect(
 			container.querySelectorAll( '.wp-block__reusable-block' )
@@ -53,10 +68,10 @@ describe( 'useNoRecursiveRenders', () => {
 
 	it( 'allows equal but sibling blocks to render', () => {
 		const { container } = render(
-			<Fragment>
+			<BlockEditContextProvider value={ context }>
 				<Edit attributes={ { ref: 'SIMPLE' } } />
 				<Edit attributes={ { ref: 'SIMPLE' } } />
-			</Fragment>
+			</BlockEditContextProvider>
 		);
 		expect(
 			container.querySelectorAll( '.wp-block__reusable-block' )
@@ -68,9 +83,9 @@ describe( 'useNoRecursiveRenders', () => {
 
 	it( 'prevents a block from rendering itself', () => {
 		const { container } = render(
-			<Fragment>
+			<BlockEditContextProvider value={ context }>
 				<Edit attributes={ { ref: 'SINGLY-RECURSIVE' } } />
-			</Fragment>
+			</BlockEditContextProvider>
 		);
 		expect(
 			container.querySelectorAll( '.wp-block__reusable-block' )
@@ -80,11 +95,28 @@ describe( 'useNoRecursiveRenders', () => {
 		).toHaveLength( 1 );
 	} );
 
+	it( 'prevents a block from rendering itself only when the same block type', () => {
+		const { container } = render(
+			<BlockEditContextProvider value={ context }>
+				<Edit attributes={ { ref: 'ANOTHER-BLOCK-SAME-REF' } } />
+			</BlockEditContextProvider>
+		);
+		expect(
+			container.querySelectorAll( '.wp-block__reusable-block' )
+		).toHaveLength( 1 );
+		expect(
+			container.querySelectorAll( '.wp-block__another-block' )
+		).toHaveLength( 1 );
+		expect(
+			container.querySelectorAll( '.wp-block__another-block--halted' )
+		).toHaveLength( 1 );
+	} );
+
 	it( 'prevents mutual recursion between two blocks', () => {
 		const { container } = render(
-			<Fragment>
+			<BlockEditContextProvider value={ context }>
 				<Edit attributes={ { ref: 'MUTUALLY-RECURSIVE-1' } } />
-			</Fragment>
+			</BlockEditContextProvider>
 		);
 		expect(
 			container.querySelectorAll( '.wp-block__reusable-block' )

--- a/packages/block-editor/src/components/use-no-recursive-renders/test/use-no-recursive-renders.js
+++ b/packages/block-editor/src/components/use-no-recursive-renders/test/use-no-recursive-renders.js
@@ -13,11 +13,11 @@ import {
 } from '../../block-edit/context';
 
 // Mimics a block's Edit component, such as ReusableBlockEdit, which is capable
-// of calling itself depending on its `ref` attribute.
-function Edit( { attributes: { ref } } ) {
+// of calling itself depending on its `uniqueId` attribute.
+function Edit( { attributes: { uniqueId } } ) {
 	const { name } = useBlockEditContext();
 	const [ hasAlreadyRendered, RecursionProvider ] = useNoRecursiveRenders(
-		ref
+		uniqueId
 	);
 
 	if ( hasAlreadyRendered ) {
@@ -27,22 +27,22 @@ function Edit( { attributes: { ref } } ) {
 	return (
 		<RecursionProvider>
 			<div className={ `wp-block__${ name }` }>
-				{ ref === 'SIMPLE' && <p>Done</p> }
-				{ ref === 'SINGLY-RECURSIVE' && (
-					<Edit attributes={ { ref } } />
+				{ uniqueId === 'SIMPLE' && <p>Done</p> }
+				{ uniqueId === 'SINGLY-RECURSIVE' && (
+					<Edit attributes={ { uniqueId } } />
 				) }
-				{ ref === 'ANOTHER-BLOCK-SAME-REF' && (
+				{ uniqueId === 'ANOTHER-BLOCK-SAME-ID' && (
 					<BlockEditContextProvider
 						value={ { name: 'another-block' } }
 					>
-						<Edit attributes={ { ref } } />
+						<Edit attributes={ { uniqueId } } />
 					</BlockEditContextProvider>
 				) }
-				{ ref === 'MUTUALLY-RECURSIVE-1' && (
-					<Edit attributes={ { ref: 'MUTUALLY-RECURSIVE-2' } } />
+				{ uniqueId === 'MUTUALLY-RECURSIVE-1' && (
+					<Edit attributes={ { uniqueId: 'MUTUALLY-RECURSIVE-2' } } />
 				) }
-				{ ref === 'MUTUALLY-RECURSIVE-2' && (
-					<Edit attributes={ { ref: 'MUTUALLY-RECURSIVE-1' } } />
+				{ uniqueId === 'MUTUALLY-RECURSIVE-2' && (
+					<Edit attributes={ { uniqueId: 'MUTUALLY-RECURSIVE-1' } } />
 				) }
 			</div>
 		</RecursionProvider>
@@ -55,7 +55,7 @@ describe( 'useNoRecursiveRenders', () => {
 	it( 'allows a single block to render', () => {
 		const { container } = render(
 			<BlockEditContextProvider value={ context }>
-				<Edit attributes={ { ref: 'SIMPLE' } } />
+				<Edit attributes={ { uniqueId: 'SIMPLE' } } />
 			</BlockEditContextProvider>
 		);
 		expect(
@@ -69,8 +69,8 @@ describe( 'useNoRecursiveRenders', () => {
 	it( 'allows equal but sibling blocks to render', () => {
 		const { container } = render(
 			<BlockEditContextProvider value={ context }>
-				<Edit attributes={ { ref: 'SIMPLE' } } />
-				<Edit attributes={ { ref: 'SIMPLE' } } />
+				<Edit attributes={ { uniqueId: 'SIMPLE' } } />
+				<Edit attributes={ { uniqueId: 'SIMPLE' } } />
 			</BlockEditContextProvider>
 		);
 		expect(
@@ -84,7 +84,7 @@ describe( 'useNoRecursiveRenders', () => {
 	it( 'prevents a block from rendering itself', () => {
 		const { container } = render(
 			<BlockEditContextProvider value={ context }>
-				<Edit attributes={ { ref: 'SINGLY-RECURSIVE' } } />
+				<Edit attributes={ { uniqueId: 'SINGLY-RECURSIVE' } } />
 			</BlockEditContextProvider>
 		);
 		expect(
@@ -98,7 +98,7 @@ describe( 'useNoRecursiveRenders', () => {
 	it( 'prevents a block from rendering itself only when the same block type', () => {
 		const { container } = render(
 			<BlockEditContextProvider value={ context }>
-				<Edit attributes={ { ref: 'ANOTHER-BLOCK-SAME-REF' } } />
+				<Edit attributes={ { uniqueId: 'ANOTHER-BLOCK-SAME-ID' } } />
 			</BlockEditContextProvider>
 		);
 		expect(
@@ -115,7 +115,7 @@ describe( 'useNoRecursiveRenders', () => {
 	it( 'prevents mutual recursion between two blocks', () => {
 		const { container } = render(
 			<BlockEditContextProvider value={ context }>
-				<Edit attributes={ { ref: 'MUTUALLY-RECURSIVE-1' } } />
+				<Edit attributes={ { uniqueId: 'MUTUALLY-RECURSIVE-1' } } />
 			</BlockEditContextProvider>
 		);
 		expect(

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -29,7 +29,7 @@ function render_block_core_block( $attributes ) {
 			trigger_error(
 				sprintf(
 					// translators: %s is the user-provided title of the reusable block.
-					__( 'Could not render Reusable Block <strong>%s</strong>: blocks cannot be rendered inside themselves.' ),
+					__( 'Could not render Reusable Block <strong>%s</strong>. Block cannot be rendered inside itself.' ),
 					$reusable_block->post_title
 				),
 				E_USER_WARNING

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -95,7 +95,7 @@ export default function TemplatePartEdit( {
 		);
 	}
 
-	if ( hasAlreadyRendered ) {
+	if ( isEntityAvailable && hasAlreadyRendered ) {
 		return (
 			<TagName { ...blockProps }>
 				<Warning>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -74,7 +74,8 @@ export default function TemplatePartEdit( {
 	);
 
 	const blockProps = useBlockProps();
-	const isEntityAvailable = slug && ! isMissing;
+	const isPlaceholder = ! slug;
+	const isEntityAvailable = ! isPlaceholder && ! isMissing;
 	const TagName = tagName || getTagBasedOnArea( area );
 
 	// We don't want to render a missing state if we have any inner blocks.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -16,8 +16,8 @@ function render_block_core_template_part( $attributes ) {
 	static $seen_ids = array();
 
 	$template_part_id = null;
-	$content = null;
-	$area    = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
+	$content          = null;
+	$area             = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 
 	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
 		$template_part_id = $attributes['postId'];
@@ -29,7 +29,7 @@ function render_block_core_template_part( $attributes ) {
 		isset( $attributes['theme'] ) &&
 		wp_get_theme()->get_stylesheet() === $attributes['theme']
 	) {
-		$template_part_id = $attributes['theme'] + '//' + $attributes['slug'];
+		$template_part_id    = $attributes['theme'] + '//' + $attributes['slug'];
 		$template_part_query = new WP_Query(
 			array(
 				'post_type'      => 'wp_template_part',
@@ -73,27 +73,27 @@ function render_block_core_template_part( $attributes ) {
 		if ( ! is_admin() ) {
 			trigger_error(
 				sprintf(
-				   // translators: %s are the block attributes.
-				   __( 'Could not render Template Part block with the attributes <code>%s</code>: blocks cannot be rendered inside themselves.' ),
-				   wp_json_encode( $attributes )
-			   ),
-			   E_USER_WARNING
-		   );
-	   }
+					// translators: %s are the block attributes.
+					__( 'Could not render Template Part block with the attributes <code>%s</code>: blocks cannot be rendered inside themselves.' ),
+					wp_json_encode( $attributes )
+				),
+				E_USER_WARNING
+			);
+		}
 
-	   // WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
-	   // is set in `wp_debug_mode()`.
-	   $is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
-		   defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
-	   return $is_debug ?
-		   // translators: Visible only in the front end, this warning takes the place of a faulty block.
-		   __( '[block rendering halted]' ) :
+		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
+		// is set in `wp_debug_mode()`.
+		$is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
+			defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
+		return $is_debug ?
+			// translators: Visible only in the front end, this warning takes the place of a faulty block.
+			__( '[block rendering halted]' ) :
 			'';
 	}
 
 	// Run through the actions that are typically taken on the_content.
 	$seen_ids[ $template_part_id ] = true;
-	$content = do_blocks( $content );
+	$content                       = do_blocks( $content );
 	unset( $seen_ids[ $template_part_id ] );
 	$content = wptexturize( $content );
 	$content = convert_smilies( $content );

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -29,7 +29,7 @@ function render_block_core_template_part( $attributes ) {
 		isset( $attributes['theme'] ) &&
 		wp_get_theme()->get_stylesheet() === $attributes['theme']
 	) {
-		$template_part_id    = $attributes['theme'] + '//' + $attributes['slug'];
+		$template_part_id    = $attributes['theme'] . '//' . $attributes['slug'];
 		$template_part_query = new WP_Query(
 			array(
 				'post_type'      => 'wp_template_part',
@@ -74,7 +74,7 @@ function render_block_core_template_part( $attributes ) {
 			trigger_error(
 				sprintf(
 					// translators: %s are the block attributes.
-					__( 'Could not render Template Part block with the attributes <code>%s</code>: blocks cannot be rendered inside themselves.' ),
+					__( 'Could not render Template Part block with the attributes: <code>%s</code>. Block cannot be rendered inside itself.' ),
 					wp_json_encode( $attributes )
 				),
 				E_USER_WARNING

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -13,16 +13,23 @@
  * @return string The render.
  */
 function render_block_core_template_part( $attributes ) {
-	static $seen_content = array();
+	static $seen_ids = array();
 
+	$template_part_id = null;
 	$content = null;
 	$area    = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 
 	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
+		$template_part_id = $attributes['postId'];
 		// If we have a post ID and the post exists, which means this template part
 		// is user-customized, render the corresponding post content.
 		$content = get_post( $attributes['postId'] )->post_content;
-	} elseif ( isset( $attributes['theme'] ) && wp_get_theme()->get_stylesheet() === $attributes['theme'] ) {
+	} elseif (
+		isset( $attributes['slug'] ) &&
+		isset( $attributes['theme'] ) &&
+		wp_get_theme()->get_stylesheet() === $attributes['theme']
+	) {
+		$template_part_id = $attributes['theme'] + '//' + $attributes['slug'];
 		$template_part_query = new WP_Query(
 			array(
 				'post_type'      => 'wp_template_part',
@@ -58,37 +65,36 @@ function render_block_core_template_part( $attributes ) {
 		}
 	}
 
-	if ( is_null( $content ) ) {
-		return 'Template Part Not Found';
+	if ( ! $template_part_id || is_null( $content ) ) {
+		return __( 'Template Part not found.' );
 	}
 
-	if ( in_array( $content, $seen_content, true ) ) {
+	if ( isset( $seen_ids[ $template_part_id ] ) ) {
 		if ( ! is_admin() ) {
 			trigger_error(
 				sprintf(
-					// translators: %s is the user-provided title of the reusable block.
-					__( 'Could not render Template Part with the slug <strong>%s</strong>: blocks cannot be rendered inside themselves.' ),
-					$attributes['slug']
-				),
-				E_USER_WARNING
-			);
-		}
+				   // translators: %s are the block attributes.
+				   __( 'Could not render Template Part block with the attributes <code>%s</code>: blocks cannot be rendered inside themselves.' ),
+				   wp_json_encode( $attributes )
+			   ),
+			   E_USER_WARNING
+		   );
+	   }
 
-		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
-		// is set in `wp_debug_mode()`.
-		$is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
-			defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
-
-		return $is_debug ?
-			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			__( '[block rendering halted]' ) :
+	   // WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
+	   // is set in `wp_debug_mode()`.
+	   $is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
+		   defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
+	   return $is_debug ?
+		   // translators: Visible only in the front end, this warning takes the place of a faulty block.
+		   __( '[block rendering halted]' ) :
 			'';
 	}
 
-	$seen_content[] = $content;
-
 	// Run through the actions that are typically taken on the_content.
+	$seen_ids[ $template_part_id ] = true;
 	$content = do_blocks( $content );
+	unset( $seen_ids[ $template_part_id ] );
 	$content = wptexturize( $content );
 	$content = convert_smilies( $content );
 	$content = wpautop( $content );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #27612.

<!-- Please describe what you have changed or added -->
Based on #28405 from @mcsf.

Tries to apply the same technique used for Reusable block to prevent infinite recursion when the same block is inserted into itself at any level of nesting.

## Technical details

`useNoRecursiveRenders` required some improvements as there was the probability that the same unique id would be used for different block types. In theory, we could mitigate that by using the block name in the id but it would be up to the block author to ensure it. Instead, it uses the solution proposed by @mcsf to use the block edit context inside `useNoRecursiveRenders` to resolve ambiguity on the framework level.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Activate the FSE theme.
2. Open the Site Editor.
3. Insert the same Template Part block twice next to each other and ensure they render correctly.
4. Insert the same Template Part inside itself and observe it prevents infinite recursion.
5. Save the post and open the page that uses the modified template. Ensure the infinite recursion is prevented on the front-end and a warning is printed when `WP_DEBUG` and `WP_DEBUG_DISPLAY` config flags are enabled.
6. There are different combinations that might need to be tested like:
  a. Template Part A inside Template Part B that contains Template Part A.
  b. Template Part A inside Template Part B  that contains Template Part B. 

## Screenshots <!-- if applicable -->

<img width="1213" alt="Screen Shot 2021-03-03 at 11 54 22" src="https://user-images.githubusercontent.com/699132/109804115-2ec00300-7c22-11eb-8eea-ded662904700.png">
<img width="1210" alt="Screen Shot 2021-03-03 at 11 54 09" src="https://user-images.githubusercontent.com/699132/109804104-2cf63f80-7c22-11eb-887b-48425018ea91.png">


<img width="1215" alt="Screen Shot 2021-03-03 at 14 06 50" src="https://user-images.githubusercontent.com/699132/109810357-bc532100-7c29-11eb-82ad-8e63f0e06502.png">

<img width="1213" alt="Screen Shot 2021-03-03 at 14 09 04" src="https://user-images.githubusercontent.com/699132/109810623-0cca7e80-7c2a-11eb-9018-98a5c4cf7f41.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
