### PR TITLE
Fix aborted rendering of non-nested reusable blocks

### DIFF
--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -24,7 +24,7 @@ function render_block_core_block( $attributes ) {
 		return '';
 	}
 
-	if ( in_array( $attributes['ref'], $seen_refs, true ) ) {
+	if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
 		if ( ! is_admin() ) {
 			trigger_error(
 				sprintf(
@@ -47,13 +47,15 @@ function render_block_core_block( $attributes ) {
 			'';
 	}
 
-	$seen_refs[] = $attributes['ref'];
-
 	if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
 		return '';
 	}
 
-	return do_blocks( $reusable_block->post_content );
+	$seen_refs[ $attributes['ref'] ] = true;
+
+	$result = do_blocks( $reusable_block->post_content );
+	unset( $seen_refs[ $attributes['ref'] ] );
+	return $result;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/pull/28405#issuecomment-766687251.

Since #28405, `render_block_core_block` prevents fatal rendering loops in Reusable Blocks by aborting if a given block has already been rendered. This effectively prevents loops, but also unintentionally prevented the same reusable block from being rendered twice on the same page, even if one isn't nested in the other.

This PR fixes this by explicitly forgetting a Reusable Block after it has finished rendering, [as suggested](https://github.com/WordPress/gutenberg/pull/28405#issuecomment-766741751) by @carlomanf.

## How has this been tested?

* **Ensure a reusable block can be used more than once on the same page.**
  1. Create a simple reusable block.
  2. In a new post, add more than one instance of this block.
  3. Save and preview the rendered page.
  4. Verify that all blocks are rendered.

* **Ensure that recursive reusable blocks are still forbidden.**
  1. Create a reusable block that contains itself, per instructions in #18704.
  2. Still following the original report, add that malignant block to a post, save and preview.
  3. Verify that the block was prevented from rendering and that, depending on the site's debug flags, the appropriate warnings are or aren't displayed.

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
