### PR TITLE
Fix regression caused by #28395

### DIFF
--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -111,7 +111,8 @@ const BUILD_TASK_BY_EXTENSION = {
 					// Editor styles should be excluded from the default CSS vars output.
 					.concat(
 						file.includes( 'common.scss' ) ||
-							! file.includes( 'block-library' )
+							( ! file.includes( 'block-library' ) &&
+								! file.includes( 'editor-styles.scss' ) )
 							? [ 'default-custom-properties' ]
 							: []
 					)


### PR DESCRIPTION
See comment on https://github.com/WordPress/gutenberg/pull/28395#issuecomment-766804476

## Description
#28395 caused a small regression. This PR fixes the focus color on selected blocks when using the non-default color-scheme.

## How has this been tested?
1. Go to your profile on the dashboard and set your user's Admin Color Scheme to `Midnight`.
2. Create a new post
3. Add a new paragraph
4. Click the paragraph to focus on it
5. The outline should be red instead of the default blue.

## Types of changes
`editor-styles` should not get the vars.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] ~~My code follows the accessibility standards.~~ <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] ~~My code has proper inline documentation.~~ <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->

cc @jasmussen