### PR TITLE
Improve button block appender.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -22,7 +22,8 @@
 
 // For vertical flex containers, a 100% width ensures correct alignment.
 .is-vertical .block-list-appender {
-	width: 100%;
+	width: $icon-size;
+	margin-right: auto;
 }
 
 .block-list-appender > .block-editor-inserter {

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -1,7 +1,12 @@
 // These styles are only applied to the appender when it appears inside of a block.
 // Otherwise the default appender may be improperly positioned in some themes.
 .block-editor-block-list__block .block-list-appender {
-	margin: 0;
+	margin: 0 0 0 $grid-unit-10;
+	display: inline-flex;
+	align-self: center;
+	height: $icon-size;
+	width: $icon-size;
+	padding: 0;
 
 	.block-editor-default-block-appender {
 		margin: $grid-unit-10 0;
@@ -20,7 +25,6 @@
 .block-list-appender > .block-editor-inserter {
 	display: block;
 }
-
 
 // Hide the nested appender unless parent or child is selected.
 // This selector targets unselected blocks that have only a single nesting level.

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -2,10 +2,8 @@
 // Otherwise the default appender may be improperly positioned in some themes.
 .block-editor-block-list__block .block-list-appender {
 	margin: 0 0 0 $grid-unit-10;
-	display: inline-flex;
 	align-self: center;
 	height: $icon-size;
-	width: $icon-size;
 	padding: 0;
 
 	.block-editor-default-block-appender {
@@ -20,6 +18,11 @@
 		transition: all 0.1s ease;
 		@include reduce-motion("transition");
 	}
+}
+
+// For vertical flex containers, a 100% width ensures correct alignment.
+.is-vertical .block-list-appender {
+	width: 100%;
 }
 
 .block-list-appender > .block-editor-inserter {

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -1,10 +1,17 @@
 // These styles are only applied to the appender when it appears inside of a block.
 // Otherwise the default appender may be improperly positioned in some themes.
 .block-editor-block-list__block .block-list-appender {
-	margin: 0 0 0 $grid-unit-10;
 	align-self: center;
-	height: $icon-size;
 	padding: 0;
+	list-style: none;
+
+	// Add a little left margin when used horizontally.
+	margin: 0 0 0 $grid-unit-10;
+
+	// ... unless it's the only child.
+	&:first-child {
+		margin-left: 0;
+	}
 
 	.block-editor-default-block-appender {
 		margin: $grid-unit-10 0;
@@ -24,6 +31,8 @@
 .is-vertical .block-list-appender {
 	width: $icon-size;
 	margin-right: auto;
+	margin-top: $grid-unit-15;
+	margin-left: $grid-unit-15;
 }
 
 .block-list-appender > .block-editor-inserter {

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -31,19 +31,12 @@
 	&.block-list-appender__toggle {
 		display: flex;
 		flex-direction: row;
-		color: $gray-900;
 		box-shadow: none;
 		height: $icon-size;
 		width: $icon-size;
-		padding: 0;
-		margin-left: $grid-unit-10;
-
-		&:active {
-			color: $white;
-		}
 
 		& > svg {
-			width: 24px;
+			width: $icon-size;
 			background-color: $gray-900;
 			color: $white;
 			border-radius: $radius-block-ui;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -10,18 +10,6 @@
 	margin: 0;
 }
 
-// Polish the Appender.
-.wp-block-navigation .block-list-appender {
-	display: inline-flex;
-	align-self: center;
-	width: $icon-size;
-	height: $icon-size;
-}
-
-.wp-block-navigation.is-vertical .block-list-appender {
-	margin: $grid-unit-10;
-}
-
 .wp-block-navigation__inserter-content {
 	padding: $grid-unit-20;
 }

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -68,10 +68,7 @@
 
 // Polish the Appender.
 .wp-block-social-links .block-list-appender {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	margin: 0;
+	padding: 0;
 
 	&::before {
 		content: "";
@@ -82,10 +79,6 @@
 
 	.block-editor-inserter {
 		position: absolute;
-	}
-
-	.block-editor-button-block-appender.block-list-appender__toggle {
-		margin: 0;
 	}
 }
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -79,6 +79,7 @@
 
 	.block-editor-inserter {
 		position: absolute;
+		top: 0;
 	}
 }
 


### PR DESCRIPTION
This is a followup to a previous PR that improved the focus style of the button block appender.

The button block appender is the appender used in horizontal button blocks, such as Social Links, Navigation, Buttons.

This PR does three things:

1. It refactors and cleans up the CSS, so there's less CSS that's unique to each of those.
2. It improves the focus style for the navigation appender yet again.
3. It improves the vertical positioning of the appender button inside the Buttons block.

Before:

<img width="126" alt="Screenshot 2021-01-25 at 15 05 21" src="https://user-images.githubusercontent.com/1204802/105716395-0bb57b80-5f1f-11eb-83fc-db0c8e8dbd69.png">

<img width="661" alt="Screenshot 2021-01-25 at 15 06 54" src="https://user-images.githubusercontent.com/1204802/105716401-0ce6a880-5f1f-11eb-9dc8-f726b7fccd55.png">

After:

<img width="765" alt="Screenshot 2021-01-25 at 15 03 57" src="https://user-images.githubusercontent.com/1204802/105716409-0fe19900-5f1f-11eb-9775-325aecc6bf39.png">

<img width="178" alt="Screenshot 2021-01-25 at 15 04 01" src="https://user-images.githubusercontent.com/1204802/105716416-1112c600-5f1f-11eb-8998-5402b904ff37.png">

<img width="282" alt="Screenshot 2021-01-25 at 15 04 04" src="https://user-images.githubusercontent.com/1204802/105716419-12dc8980-5f1f-11eb-90d6-538b4389bcf5.png">

<img width="96" alt="Screenshot 2021-01-25 at 15 04 10" src="https://user-images.githubusercontent.com/1204802/105716422-140db680-5f1f-11eb-9f53-05dddd5d8265.png">

<img width="288" alt="Screenshot 2021-01-25 at 15 04 13" src="https://user-images.githubusercontent.com/1204802/105716430-15d77a00-5f1f-11eb-8f1a-c645a79b41b1.png">

<img width="655" alt="Screenshot 2021-01-25 at 15 04 23" src="https://user-images.githubusercontent.com/1204802/105716439-17a13d80-5f1f-11eb-8f1d-d666721514f2.png">

<img width="695" alt="Screenshot 2021-01-25 at 15 04 19" src="https://user-images.githubusercontent.com/1204802/105716445-1a039780-5f1f-11eb-82ab-357c3b1f5a43.png">

When you test this PR, please test every appender. Things should be scoped to touching just the button block appender, but test wider than that regardless.

Also focus specifically on Buttons, Navigation and Social Links blocks. Test both setup states, and fully set up.