### PR TITLE
Fix margins and width of 100%-width buttons

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -55,7 +55,9 @@ $blocks-button__height: 3.1em;
 	}
 
 	&.wp-block-button__width-100 {
-		width: calc(100% - #{ $button-margin });
+		margin-left: 0;
+		margin-right: 0;
+		width: 100%;
 	}
 }
 

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -55,7 +55,6 @@ $blocks-button__height: 3.1em;
 	}
 
 	&.wp-block-button__width-100 {
-		margin-left: 0;
 		margin-right: 0;
 		width: 100%;
 	}


### PR DESCRIPTION
Currently, if a button is set to 100% width, it isn't quite 100% width. It also incorporates space for a right margin:

![Screen Shot 2021-01-25 at 11 52 03 AM](https://user-images.githubusercontent.com/1202812/105737457-f848e700-5f03-11eb-9f9a-fe250b9be850.png)

This gets especially weird when the buttons in there are justified to the center, and he right margin on the last item is automatically removed: 

![Screen Shot 2021-01-25 at 11 52 50 AM](https://user-images.githubusercontent.com/1202812/105737463-faab4100-5f03-11eb-9830-fe2327a76410.png)

Since 100%-width buttons won't ever have anything to the right of them, I think it's fine for them to lose that margin all the time and actually be 100% width. This PR makes that change: 

![Screen Shot 2021-01-25 at 11 47 38 AM](https://user-images.githubusercontent.com/1202812/105737506-0860c680-5f04-11eb-83e0-98658b4ef6e7.png)
