### PR TITLE
Post context switching on setupEditor action.

### DIFF
--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -83,7 +83,11 @@ function Editor( {
 			} );
 			postObject = posts?.[ 0 ];
 		} else {
-			postObject = getEntityRecord( 'postType', postObject.postType, postObject.postId );
+			postObject = getEntityRecord(
+				'postType',
+				postObject.postType,
+				postObject.postId
+			);
 		}
 		const isFSETheme = getEditorSettings().isFSETheme;
 		const isViewable = getPostType( postType )?.viewable ?? false;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -68,30 +68,29 @@ function Editor( {
 		const { getBlockTypes } = select( blocksStore );
 
 		let postObject = {
-			postType: currentPostObj?.type ?? postType,
-			postId: currentPostObj?.id ?? postId,
+			type: currentPostObj?.type ?? postType,
+			id: currentPostObj?.id ?? postId,
 		};
 
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-			postObject.postType
+			postObject.type
 		);
 		// Ideally the initializeEditor function should be called using the ID of the REST endpoint.
 		// to avoid the special case.
 		if ( isTemplate ) {
-			const posts = getEntityRecords( 'postType', postObject.postType, {
-				wp_id: postObject.postId,
+			const posts = getEntityRecords( 'postType', postObject.type, {
+				wp_id: postObject.id,
 			} );
 			postObject = posts?.[ 0 ];
 		} else {
 			postObject = getEntityRecord(
 				'postType',
-				postObject.postType,
-				postObject.postId
+				postObject.type,
+				postObject.id
 			);
 		}
 		const isFSETheme = getEditorSettings().isFSETheme;
-		const isViewable =
-			getPostType( postObject.postType )?.viewable ?? false;
+		const isViewable = getPostType( postObject.type )?.viewable ?? false;
 
 		return {
 			hasFixedToolbar:

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -90,7 +90,7 @@ function Editor( {
 			);
 		}
 		const isFSETheme = getEditorSettings().isFSETheme;
-		const isViewable = getPostType( postType )?.viewable ?? false;
+		const isViewable = getPostType( postObject.postType )?.viewable ?? false;
 
 		return {
 			hasFixedToolbar:

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -64,20 +64,26 @@ function Editor( {
 			getEntityRecords,
 		} = select( 'core' );
 		const { getEditorSettings, getCurrentPost } = select( 'core/editor' );
+		const currentPostObj = getCurrentPost();
 		const { getBlockTypes } = select( blocksStore );
+
+		let postObject = {
+			postType: currentPostObj?.type ?? postType,
+			postId: currentPostObj?.id ?? postId,
+		};
+
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-			postType
+			postObject.postType
 		);
 		// Ideally the initializeEditor function should be called using the ID of the REST endpoint.
 		// to avoid the special case.
-		let postObject;
 		if ( isTemplate ) {
-			const posts = getEntityRecords( 'postType', postType, {
-				wp_id: postId,
+			const posts = getEntityRecords( 'postType', postObject.postType, {
+				wp_id: postObject.postId,
 			} );
 			postObject = posts?.[ 0 ];
 		} else {
-			postObject = getEntityRecord( 'postType', postType, postId );
+			postObject = getEntityRecord( 'postType', postObject.postType, postObject.postId );
 		}
 		const isFSETheme = getEditorSettings().isFSETheme;
 		const isViewable = getPostType( postType )?.viewable ?? false;
@@ -103,7 +109,7 @@ function Editor( {
 				isFSETheme &&
 				isViewable &&
 				postObject &&
-				getCurrentPost().status !== 'auto-draft'
+				currentPostObj.status !== 'auto-draft'
 					? __experimentalGetTemplateForLink( postObject.link )
 					: null,
 			post: postObject,

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -90,7 +90,8 @@ function Editor( {
 			);
 		}
 		const isFSETheme = getEditorSettings().isFSETheme;
-		const isViewable = getPostType( postObject.postType )?.viewable ?? false;
+		const isViewable =
+			getPostType( postObject.postType )?.viewable ?? false;
 
 		return {
 			hasFixedToolbar:

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -75,6 +75,8 @@ function Editor( {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			postObject.type
 		);
+		const isViewable = getPostType( postObject.type )?.viewable ?? false;
+
 		// Ideally the initializeEditor function should be called using the ID of the REST endpoint.
 		// to avoid the special case.
 		if ( isTemplate ) {
@@ -90,7 +92,6 @@ function Editor( {
 			);
 		}
 		const isFSETheme = getEditorSettings().isFSETheme;
-		const isViewable = getPostType( postObject.type )?.viewable ?? false;
 
 		return {
 			hasFixedToolbar:


### PR DESCRIPTION
## Description
On Gutenberge released with WordPress 5.6 using the `setupEditor()`action from the `core/editor` store with another post/page entity resulted in the visual editor being reloaded with the new post content. I noticed that in recent released that behavior ceased to function (the content was being replaced in the code editor but not in the visual editor). This PR attempts to solve that by always having the `<Editor />` component use the current post from the Redux store.

## How has this been tested?
Tested against tag wp/5.6 and comparing against latest Gutenberg from the master branch (9.8.1 as of this PR).

## Screenshots

https://user-images.githubusercontent.com/1933681/105751910-a5c3f680-5f14-11eb-83c2-5603c540b615.mp4

## Types of changes
Modifying the Editor to always use the current post Id and post Type not just the one that was loaded on page initialization. This makes it behave the way Gutenberg tag wp/5.6 was behaving.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
