### PR TITLE
Fixes #24895: isURL uses a bit of heuristics

### DIFF
--- a/packages/url/src/is-url.js
+++ b/packages/url/src/is-url.js
@@ -15,9 +15,29 @@
  */
 export function isURL( url ) {
 	// A URL can be considered value if the `URL` constructor is able to parse
-	// it. The constructor throws an error for an invalid URL.
+	// it. The constructor throws an error for most invalid URLs.
 	try {
-		new URL( url );
+		const parsed = new URL( url );
+
+		// Special cases
+		if ( /^\s/.test( parsed.pathname ) ) {
+			// Valid paths probably don't start with whitespace
+			return false;
+		}
+
+		// Check given protocol (parsed is lowercase)
+		const m = url.match( /^\s*([^:]+):/ );
+		if ( ! m ) {
+			// No protocol
+			return false;
+		}
+
+		if ( /[A-Z]/.test( m[ 1 ] ) && /[a-z]/.test( m[ 1 ] ) ) {
+			// Mixed case protocol could be a word like "Note:" but let
+			// it pass if it's a recognized protocol.
+			return /^(https?|s?ftp|ssh|mailto)?:$/.test( parsed.protocol );
+		}
+
 		return true;
 	} catch ( error ) {
 		return false;

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -34,10 +34,12 @@ describe( 'isURL', () => {
 		[ 'http://wordpress.org' ],
 		[ 'https://wordpress.org' ],
 		[ 'HTTPS://WORDPRESS.ORG' ],
+		[ 'HTtp://wordpress.org/mixed-case-protocol/ok-if-in-list' ],
 		[ 'https://wordpress.org/./foo' ],
 		[ 'https://wordpress.org/path?query#fragment' ],
 		[ 'https://localhost/foo#bar' ],
 		[ 'mailto:example@example.com' ],
+		[ 'Mailto:example@example.com' ],
 		[ 'ssh://user:password@127.0.0.1:8080' ],
 	] )( 'valid (true): %s', ( url ) => {
 		expect( isURL( url ) ).toBe( true );
@@ -50,6 +52,11 @@ describe( 'isURL', () => {
 		[ 'HTTP: HyperText Transfer Protocol' ],
 		[ 'URLs begin with a http:// prefix' ],
 		[ 'Go here: http://wordpress.org' ],
+		[ 'Note: Not a real scheme' ],
+
+		// Fails in node 12, but correct in node 15
+		[ 'Note:Not a mixed case scheme unless common' ],
+
 		[ 'http://' ],
 		[ '' ],
 	] )( 'invalid (false): %s', ( url ) => {


### PR DESCRIPTION
## Description

Adds heuristics to `isURL` so it now rejects a few things that the underlying `new URL()` allows. This is not meant to be exhaustive, but covers some common cases.

NOTE: I can't build the master branch, but if this looks acceptable I can cherry-pick this to be based on master.

## How has this been tested?

Node 15. `npm run test-unit` and `npm run test-unit:native`

## Types of changes

Fixes #24895. Adds some pattern testing to `isURL`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
