### PR TITLE
RN: Add width settings to button block

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -20,6 +20,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 	LinkSettingsNavigation,
+	UnitControl,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -38,6 +39,31 @@ const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUE = 50;
 const INITIAL_MAX_WIDTH = 108;
 const MIN_WIDTH = 40;
+
+function WidthPanel( { selectedWidth, setAttributes } ) {
+	function handleChange( newWidth ) {
+		// Check if we are toggling the width off
+		const width = selectedWidth === newWidth ? undefined : newWidth;
+
+		// Update attributes
+		setAttributes( { width } );
+	}
+
+	return (
+		<PanelBody title={ __( 'Width Settings' ) }>
+			<UnitControl
+				label={ __( 'Width Settings' ) }
+				min={ 1 }
+				max={ 100 }
+				onChange={ handleChange }
+				decimalNum={ 1 }
+				value={ selectedWidth }
+				unit={ '%' }
+				disabledUnits={ true }
+			/>
+		</PanelBody>
+	);
+}
 
 class ButtonEdit extends Component {
 	constructor( props ) {
@@ -293,8 +319,9 @@ class ButtonEdit extends Component {
 			onReplace,
 			mergeBlocks,
 			parentWidth,
+			setAttributes,
 		} = this.props;
-		const { placeholder, text, borderRadius, url } = attributes;
+		const { placeholder, text, borderRadius, url, width } = attributes;
 		const { maxWidth, isButtonFocused, placeholderTextWidth } = this.state;
 		const { paddingTop: spacing, borderWidth } = styles.defaultButton;
 
@@ -313,13 +340,19 @@ class ButtonEdit extends Component {
 		// To achieve proper expanding and shrinking `RichText` on iOS, there is a need to set a `minWidth`
 		// value at least on 1 when `RichText` is focused or when is not focused, but `RichText` value is
 		// different than empty string.
-		const minWidth =
+		let minWidth =
 			isButtonFocused || ( ! isButtonFocused && text && text !== '' )
 				? MIN_WIDTH
 				: placeholderTextWidth;
 		// To achieve proper expanding and shrinking `RichText` on Android, there is a need to set
 		// a `placeholder` as an empty string when `RichText` is focused,
 		// because `AztecView` is calculating a `minWidth` based on placeholder text.
+		// console.log( minWidth, maxWidth, width )
+
+		if ( width ) {
+			minWidth = Math.floor( maxWidth * ( width / 100 ) );
+		}
+
 		const placeholderText =
 			isButtonFocused || ( ! isButtonFocused && text && text !== '' )
 				? ''
@@ -408,6 +441,10 @@ class ButtonEdit extends Component {
 							onChange={ this.onChangeBorderRadius }
 						/>
 					</PanelBody>
+					<WidthPanel
+						selectedWidth={ width }
+						setAttributes={ setAttributes }
+					/>
 					<PanelBody title={ __( 'Link Settings' ) }>
 						{ this.getLinkSettings( true ) }
 					</PanelBody>

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -44,7 +44,7 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 	function handleChange( newWidth ) {
 		// Check if we are toggling the width off
 		let width = selectedWidth === newWidth ? undefined : newWidth;
-		if( newWidth === 'auto') {
+		if ( newWidth === 'auto' ) {
 			width = undefined;
 		}
 		// Update attributes
@@ -52,12 +52,12 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 	}
 
 	const options = [
-		{ value: 'auto', label: 'Auto'},
-		{ value: '25', label: '25%'},
-		{ value: '50', label: '50%'},
-		{ value: '75', label: '75%'},
-		{ value: '100', label: '100%'},
-	]
+		{ value: 'auto', label: __( 'Auto' ) },
+		{ value: '25', label: '25%' },
+		{ value: '50', label: '50%' },
+		{ value: '75', label: '75%' },
+		{ value: '100', label: '100%' },
+	];
 
 	if ( ! selectedWidth ) {
 		selectedWidth = 'auto';

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -20,7 +20,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 	LinkSettingsNavigation,
-	UnitControl,
+	SelectControl,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -43,23 +43,33 @@ const MIN_WIDTH = 40;
 function WidthPanel( { selectedWidth, setAttributes } ) {
 	function handleChange( newWidth ) {
 		// Check if we are toggling the width off
-		const width = selectedWidth === newWidth ? undefined : newWidth;
-
+		let width = selectedWidth === newWidth ? undefined : newWidth;
+		if( newWidth === 'auto') {
+			width = undefined;
+		}
 		// Update attributes
 		setAttributes( { width } );
 	}
 
+	const options = [
+		{ value: 'auto', label: 'Auto'},
+		{ value: '25', label: '25%'},
+		{ value: '50', label: '50%'},
+		{ value: '75', label: '75%'},
+		{ value: '100', label: '100%'},
+	]
+
+	if ( ! selectedWidth ) {
+		selectedWidth = 'auto';
+	}
+
 	return (
 		<PanelBody title={ __( 'Width Settings' ) }>
-			<UnitControl
-				label={ __( 'Width Settings' ) }
-				min={ 1 }
-				max={ 100 }
-				onChange={ handleChange }
-				decimalNum={ 1 }
+			<SelectControl
+				label={ __( 'Width' ) }
 				value={ selectedWidth }
-				unit={ '%' }
-				disabledUnits={ true }
+				onChange={ handleChange }
+				options={ options }
 			/>
 		</PanelBody>
 	);

--- a/packages/components/src/unit-control/index.native.js
+++ b/packages/components/src/unit-control/index.native.js
@@ -38,6 +38,7 @@ function UnitControl( {
 	unit,
 	getStylesFromColorScheme,
 	decimalNum,
+	disabledUnits,
 	...props
 } ) {
 	const pickerRef = useRef();
@@ -90,6 +91,13 @@ function UnitControl( {
 			: undefined;
 
 	const renderUnitPicker = () => {
+		if ( disabledUnits ) {
+			return (
+				<View style={ styles.unitText }>
+					<Text>{ unit }</Text>
+				</View>
+			);
+		}
 		return (
 			<View style={ styles.unitMenu } ref={ anchorNodeRef }>
 				{ renderUnitButton() }

--- a/packages/components/src/unit-control/style.native.scss
+++ b/packages/components/src/unit-control/style.native.scss
@@ -17,3 +17,9 @@
 	justify-content: center;
 	align-items: center;
 }
+
+.unitText {
+	justify-content: center;
+	align-items: center;
+	padding: 0 2px;
+}


### PR DESCRIPTION
This PR adds a width selection slider to the button block. 


## Description
It does so by using the `UnitControl` component. That is currently being used by the column width selection.


## How has this been tested?
1. Load this PR in the demo app or your flavour of mobile app.
2. Add a buttons block. 
3. Select the settings of a single button.
4. Change the width by dragging the slider. (See screenshot)
5. Notice the width change.

## Screenshots <!-- if applicable -->
Current web implementation (notice the right sidebar, button group 25%,50%,75%,100%) 
<img width="586" alt="Screen Shot 2021-01-25 at 12 13 46 PM" src="https://user-images.githubusercontent.com/115071/105760816-22e86f00-5f07-11eb-8b5f-31b1f0579f56.png">

Currently implemented. 
<img width="412" alt="Screen Shot 2021-01-25 at 12 12 00 PM" src="https://user-images.githubusercontent.com/115071/105760929-4ad7d280-5f07-11eb-9ff9-c17eb9ddd813.png">

Based on the `UnitControl` that looks like this in the column settings.
<img width="408" alt="Screen Shot 2021-01-25 at 12 12 19 PM" src="https://user-images.githubusercontent.com/115071/105760990-5f1bcf80-5f07-11eb-9112-785fc271d403.png">


## Types of changes
This PR add the ability to the mobile UnitControl component to only use a single unit. ? 
Maybe this can be simplified?

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
