### PR TITLE
Docs: Update list of core block categories

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -56,9 +56,9 @@ Blocks are grouped into categories to help users browse and discover them.
 
 The core provided categories are:
 
--   common
--   formatting
--   layout
+-   text
+-   media
+-   design
 -   widgets
 -   embed
 


### PR DESCRIPTION
These name changes of block categories were introduced in Gutenberg 8.3 / WordPress 5.5.
