### PR TITLE
Try: Fix buttons faux space-between.

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -3,6 +3,7 @@
  *
  * Please use variables from this sheet to ensure consistency across the UI.
  * Don't add to this sheet unless you're pretty sure the value will be reused in many places.
+ * For example, don't add rules to this sheet that affect block visuals. It's purely for UI.
  */
 
 @import "./colors";
@@ -43,7 +44,6 @@ $grid-unit-60: 6 * $grid-unit;		// 48px
  */
 
 $icon-size: 24px;
-$button-margin: 0.5em;
 $button-size: 36px;
 $button-size-small: 24px;
 $header-height: 60px;

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -1,5 +1,8 @@
 $blocks-button__height: 3.1em;
 
+// This variable is repeated across Button, Buttons, and Buttons editor styles.
+$blocks-block__margin: 0.5em;
+
 // Prefer the link selector instead of the regular button classname
 // to support the previous markup in addition to the new one.
 .wp-block-button__link {
@@ -43,15 +46,15 @@ $blocks-button__height: 3.1em;
 	}
 
 	&.wp-block-button__width-25 {
-		width: calc(25% - #{ $button-margin });
+		width: calc(25% - #{ $blocks-block__margin });
 	}
 
 	&.wp-block-button__width-50 {
-		width: calc(50% - #{ $button-margin });
+		width: calc(50% - #{ $blocks-block__margin });
 	}
 
 	&.wp-block-button__width-75 {
-		width: calc(75% - #{ $button-margin });
+		width: calc(75% - #{ $blocks-block__margin });
 	}
 
 	&.wp-block-button__width-100 {

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -1,3 +1,6 @@
+// This variable is repeated across Button, Buttons, and Buttons editor styles.
+$blocks-block__margin: 0.5em;
+
 .wp-block > .wp-block-buttons {
 	display: flex;
 	flex-wrap: wrap;
@@ -7,7 +10,8 @@
 	> .wp-block {
 		// Override editor auto block margins.
 		margin-left: 0;
-		margin-top: $button-margin;
+		margin-top: $blocks-block__margin;
+		margin-right: $blocks-block__margin;
 	}
 	> .block-list-appender {
 		display: inline-flex;

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -1,3 +1,6 @@
+// This variable is repeated across Button, Buttons, and Buttons editor styles.
+$blocks-block__margin: 0.5em;
+
 .wp-block-buttons {
 	display: flex;
 	flex-direction: row;
@@ -18,8 +21,8 @@
 	> .wp-block-button {
 		display: inline-block;
 		/*rtl:ignore*/
-		margin-right: $button-margin;
-		margin-bottom: $button-margin;
+		margin-right: $blocks-block__margin;
+		margin-bottom: $blocks-block__margin;
 
 		&:last-child {
 			/*rtl:ignore*/
@@ -46,7 +49,7 @@
 
 		> .wp-block-button {
 			/*rtl:ignore*/
-			margin-left: $button-margin;
+			margin-left: $blocks-block__margin;
 			/*rtl:ignore*/
 			margin-right: 0;
 
@@ -69,7 +72,7 @@
 		/*rtl:ignore*/
 		margin-left: 0;
 		/*rtl:ignore*/
-		margin-right: $button-margin;
+		margin-right: $blocks-block__margin;
 
 		&:last-child {
 			/*rtl:ignore*/
@@ -80,7 +83,7 @@
 		/*rtl:ignore*/
 		margin-right: 0;
 		/*rtl:ignore*/
-		margin-left: $button-margin;
+		margin-left: $blocks-block__margin;
 
 		&:first-child {
 			/*rtl:ignore*/

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -21,6 +21,8 @@ $blocks-block__margin: 0.5em;
 	> .wp-block-button {
 		display: inline-block;
 		/*rtl:ignore*/
+		margin-left: 0;
+		/*rtl:ignore*/
 		margin-right: $blocks-block__margin;
 		margin-bottom: $blocks-block__margin;
 


### PR DESCRIPTION
Buttons in the Buttons block appear to be have "space-between" applied, even when they don't:

<img width="1151" alt="Screenshot 2021-01-26 at 10 40 34" src="https://user-images.githubusercontent.com/1204802/105828393-5f79a080-5fc3-11eb-9ee7-fa1f18b1ecbc.png">

This is because inside a flex container, if a margin is set to auto, that's the net result.

This PR fixes that. After:

<img width="1106" alt="Screenshot 2021-01-26 at 10 40 40" src="https://user-images.githubusercontent.com/1204802/105828482-79b37e80-5fc3-11eb-9825-5a8cfb309630.png">

The frontend already worked.

<img width="831" alt="Screenshot 2021-01-26 at 10 40 46" src="https://user-images.githubusercontent.com/1204802/105828488-7b7d4200-5fc3-11eb-862d-ad97c1d3e89b.png">

One larger issue is this rule from #21971:

```
// Extra specificity needed to override default element margins like lists (ul).
.block-editor-block-list__layout .wp-block {
	margin-left: auto;
	margin-right: auto;
}
```

It's going to continue to cause headaches for flex containers and themes. I wonder if there's a way we can refactor that rule away, without regressing what 21971 meant to fix. CC: @kjellr @scruffian.

Another issue was the use of the `_variables.scss` stylesheet to store a margin property that was used across the Button and Buttons blocks. It was added in #25999, but no block values should be added there, that stylesheet is purely for UI. And in adding a variable there, it also goes against the componentization / isolation of styles to each block container.

For that reason, I'd very much welcome input on how we can refactor this:

- The variable, now renamed `$blocks-block__margin` is used primarily in the Button block stylesheet. This is fine.
- It's used in the Buttons editor stylesheet only to increase specificity of the rules, due to the "auto" margins mentioned above. This one is hard to fix without refactoring away those auto margins.
- I'm unsure exactly why it's needed in the Buttons block, it seems like we could let rules here be inherited from the Button block @ntsekouras?