### PR TITLE
Try: Polish block menu and show only fills when available.

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -37,7 +37,7 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 	return (
 		<Slot fillProps={ { ...fillProps, selectedBlocks } }>
 			{ ( fills ) => {
-				if ( fills.length > 0 ) {
+				if ( fills?.length > 0 ) {
 					return (
 						<MenuGroup>
 							{ fills }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -37,12 +37,16 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 	return (
 		<Slot fillProps={ { ...fillProps, selectedBlocks } }>
 			{ ( fills ) => {
-				return (
-					<MenuGroup>
-						{ fills }
-						<ConvertToGroupButton onClose={ fillProps?.onClose } />
-					</MenuGroup>
-				);
+				if ( fills.length > 0 ) {
+					return (
+						<MenuGroup>
+							{ fills }
+							<ConvertToGroupButton
+								onClose={ fillProps?.onClose }
+							/>
+						</MenuGroup>
+					);
+				}
 			} }
 		</Slot>
 	);

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -12,7 +12,11 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import ConvertToGroupButton from '../convert-to-group-buttons';
+import {
+	useConvertToGroupButtonProps,
+	ConvertToGroupButton,
+} from '../convert-to-group-buttons';
+import { store as blockEditorStore } from '../../store';
 
 const { Fill: BlockSettingsMenuControls, Slot } = createSlotFill(
 	'BlockSettingsMenuControls'
@@ -22,7 +26,7 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 	const selectedBlocks = useSelect(
 		( select ) => {
 			const { getBlocksByClientId, getSelectedBlockClientIds } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 			const ids =
 				clientIds !== null ? clientIds : getSelectedBlockClientIds();
@@ -34,14 +38,20 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		[ clientIds ]
 	);
 
+	// Check if current selection of blocks is Groupable or Ungroupable
+	// and pass this props down to ConvertToGroupButton.
+	const convertToGroupButtonProps = useConvertToGroupButtonProps();
+	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
+	const showConvertToGroupButton = isGroupable || isUngroupable;
 	return (
 		<Slot fillProps={ { ...fillProps, selectedBlocks } }>
 			{ ( fills ) => {
-				if ( fills?.length > 0 ) {
+				if ( fills?.length > 0 || showConvertToGroupButton ) {
 					return (
 						<MenuGroup>
 							{ fills }
 							<ConvertToGroupButton
+								{ ...convertToGroupButtonProps }
 								onClose={ fillProps?.onClose }
 							/>
 						</MenuGroup>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -141,7 +141,7 @@ export function BlockSettingsDropdown( {
 											) }
 											shortcut={ shortcuts.insertBefore }
 										>
-											{ __( 'Insert Before' ) }
+											{ __( 'Insert before' ) }
 										</MenuItem>
 										<MenuItem
 											onClick={ flow(
@@ -150,7 +150,7 @@ export function BlockSettingsDropdown( {
 											) }
 											shortcut={ shortcuts.insertAfter }
 										>
-											{ __( 'Insert After' ) }
+											{ __( 'Insert after' ) }
 										</MenuItem>
 									</>
 								) }
@@ -158,7 +158,7 @@ export function BlockSettingsDropdown( {
 									<MenuItem
 										onClick={ flow( onClose, onMoveTo ) }
 									>
-										{ __( 'Move To' ) }
+										{ __( 'Move to' ) }
 									</MenuItem>
 								) }
 								{ count === 1 && (

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -3,72 +3,24 @@
  */
 import { MenuItem } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
-import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { switchToBlockType } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import useConvertToGroupButtonProps from './use-convert-to-group-button-props';
 
-export default function ConvertToGroupButton( { onClose = () => {} } ) {
+function ConvertToGroupButton( {
+	clientIds,
+	isGroupable,
+	isUngroupable,
+	blocksSelection,
+	groupingBlockName,
+	onClose = () => {},
+} ) {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
-	const {
-		clientIds,
-		isGroupable,
-		isUngroupable,
-		blocksSelection,
-		groupingBlockName,
-	} = useSelect( ( select ) => {
-		const {
-			getBlockRootClientId,
-			getBlocksByClientId,
-			canInsertBlockType,
-			getSelectedBlockClientIds,
-		} = select( blockEditorStore );
-		const { getGroupingBlockName } = select( blocksStore );
-
-		const _clientIds = getSelectedBlockClientIds();
-		const _groupingBlockName = getGroupingBlockName();
-
-		const rootClientId = !! _clientIds?.length
-			? getBlockRootClientId( _clientIds[ 0 ] )
-			: undefined;
-
-		const groupingBlockAvailable = canInsertBlockType(
-			_groupingBlockName,
-			rootClientId
-		);
-
-		const _blocksSelection = getBlocksByClientId( _clientIds );
-
-		const isSingleGroupingBlock =
-			_blocksSelection.length === 1 &&
-			_blocksSelection[ 0 ]?.name === _groupingBlockName;
-
-		// Do we have
-		// 1. Grouping block available to be inserted?
-		// 2. One or more blocks selected
-		// (we allow single Blocks to become groups unless
-		// they are a soltiary group block themselves)
-		const _isGroupable =
-			groupingBlockAvailable &&
-			_blocksSelection.length &&
-			! isSingleGroupingBlock;
-
-		// Do we have a single Group Block selected and does that group have inner blocks?
-		const _isUngroupable =
-			isSingleGroupingBlock &&
-			!! _blocksSelection[ 0 ].innerBlocks.length;
-		return {
-			clientIds: _clientIds,
-			isGroupable: _isGroupable,
-			isUngroupable: _isUngroupable,
-			blocksSelection: _blocksSelection,
-			groupingBlockName: _groupingBlockName,
-		};
-	}, [] );
-
 	const onConvertToGroup = () => {
 		// Activate the `transform` on the Grouping Block which does the conversion
 		const newBlocks = switchToBlockType(
@@ -120,3 +72,5 @@ export default function ConvertToGroupButton( { onClose = () => {} } ) {
 		</>
 	);
 }
+
+export { useConvertToGroupButtonProps, ConvertToGroupButton };

--- a/packages/block-editor/src/components/convert-to-group-buttons/use-convert-to-group-button-props.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/use-convert-to-group-button-props.js
@@ -1,0 +1,93 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blocksStore } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
+ * Contains the properties `ConvertToGroupButton` component needs.
+ *
+ * @typedef {Object} ConvertToGroupButtonProps
+ * @property {string[]} clientIds  An array of the selected client ids.
+ * @property {boolean} isGroupable Indicates if the selected blocks can be grouped.
+ * @property {boolean} isUngroupable Indicates if the selected blocks can be ungrouped.
+ * @property {WPBlock[]} blocksSelection An array of the selected blocks.
+ * @property {string} groupingBlockName The name of block used for handling grouping interactions.
+ */
+
+/**
+ * Returns the properties `ConvertToGroupButton` component needs to work properly.
+ * It is used in `BlockSettingsMenuControls` to know if `ConvertToGroupButton`
+ * should be rendered, to avoid ending up with an empty MenuGroup.
+ *
+ * @return {ConvertToGroupButtonProps} Returns the properties needed by `ConvertToGroupButton`.
+ */
+export default function useConvertToGroupButtonProps() {
+	const {
+		clientIds,
+		isGroupable,
+		isUngroupable,
+		blocksSelection,
+		groupingBlockName,
+	} = useSelect( ( select ) => {
+		const {
+			getBlockRootClientId,
+			getBlocksByClientId,
+			canInsertBlockType,
+			getSelectedBlockClientIds,
+		} = select( blockEditorStore );
+		const { getGroupingBlockName } = select( blocksStore );
+
+		const _clientIds = getSelectedBlockClientIds();
+		const _groupingBlockName = getGroupingBlockName();
+
+		const rootClientId = !! _clientIds?.length
+			? getBlockRootClientId( _clientIds[ 0 ] )
+			: undefined;
+
+		const groupingBlockAvailable = canInsertBlockType(
+			_groupingBlockName,
+			rootClientId
+		);
+
+		const _blocksSelection = getBlocksByClientId( _clientIds );
+
+		const isSingleGroupingBlock =
+			_blocksSelection.length === 1 &&
+			_blocksSelection[ 0 ]?.name === _groupingBlockName;
+
+		// Do we have
+		// 1. Grouping block available to be inserted?
+		// 2. One or more blocks selected
+		// (we allow single Blocks to become groups unless
+		// they are a soltiary group block themselves)
+		const _isGroupable =
+			groupingBlockAvailable &&
+			_blocksSelection.length &&
+			! isSingleGroupingBlock;
+
+		// Do we have a single Group Block selected and does that group have inner blocks?
+		const _isUngroupable =
+			isSingleGroupingBlock &&
+			!! _blocksSelection[ 0 ].innerBlocks.length;
+		return {
+			clientIds: _clientIds,
+			isGroupable: _isGroupable,
+			isUngroupable: _isUngroupable,
+			blocksSelection: _blocksSelection,
+			groupingBlockName: _groupingBlockName,
+		};
+	}, [] );
+	return {
+		clientIds,
+		isGroupable,
+		isUngroupable,
+		blocksSelection,
+		groupingBlockName,
+	};
+}

--- a/packages/edit-post/src/components/visual-editor/block-inspector-button.js
+++ b/packages/edit-post/src/components/visual-editor/block-inspector-button.js
@@ -46,8 +46,8 @@ export function BlockInspectorButton( { onClick = noop, small = false } ) {
 	};
 
 	const label = areAdvancedSettingsOpened
-		? __( 'Hide More Settings' )
-		: __( 'Show More Settings' );
+		? __( 'Hide more settings' )
+		: __( 'Show more settings' );
 
 	return (
 		<MenuItem


### PR DESCRIPTION
This draft PR does two things:

1. It changes the letter casing of menu items to be sentence case, as in the other menu items (like in the top toolbar's more menu)
2. It adds a condition to only output the reusable blocks and grouping tools when they are available.

Number 2 needs a serious sanity check, while it works fine in this PR, I believe there's something about the logic that's off. 

Before:

<img width="348" alt="Screenshot 2021-01-26 at 10 52 29" src="https://user-images.githubusercontent.com/1204802/105831651-44a92b00-5fc7-11eb-8889-4944be817508.png">

After:

<img width="380" alt="Screenshot 2021-01-26 at 11 08 45" src="https://user-images.githubusercontent.com/1204802/105831657-470b8500-5fc7-11eb-9ea8-7ce222c4da0c.png">
