### PR TITLE
Enlarging navigation menu popovers to be same as sidebar width

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -71,6 +71,7 @@ $shadow-modal: 0 3px 30px rgba($black, 0.2);
  */
 
 $sidebar-width: 280px;
+$navigation-editor-toolbar-width: $sidebar-width;
 $content-width: 840px;
 $wide-content-width: 1100px;
 $widget-area-width: 700px;

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -56,6 +56,9 @@ export default function Header( {
 				</h2>
 
 				<DropdownMenu
+					contentClassName={
+						'edit-navigation-header__component-popover'
+					}
 					icon={ null }
 					toggleProps={ {
 						showTooltip: false,
@@ -84,6 +87,9 @@ export default function Header( {
 
 				<Dropdown
 					position="bottom center"
+					contentClassName={
+						'edit-navigation-header__component-popover'
+					}
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<Button
 							isTertiary
@@ -102,7 +108,7 @@ export default function Header( {
 				/>
 
 				<Dropdown
-					contentClassName="edit-navigation-header__manage-locations"
+					contentClassName="edit-navigation-header__manage-locations edit-navigation-header__component-popover"
 					position="bottom center"
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<Button

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -41,3 +41,7 @@
 	display: block;
 	margin: $grid-unit-20 auto;
 }
+
+.edit-navigation-header__component-popover .components-popover__content {
+	width: $navigation-editor-toolbar-width;
+}

--- a/packages/edit-navigation/src/components/toolbar/block-inspector-dropdown.js
+++ b/packages/edit-navigation/src/components/toolbar/block-inspector-dropdown.js
@@ -9,6 +9,7 @@ import { BlockInspector } from '@wordpress/block-editor';
 export default function BlockInspectorDropdown() {
 	return (
 		<Dropdown
+			contentClassName={ 'edit-navigation-toolbar__component-popover' }
 			position="bottom left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button

--- a/packages/edit-navigation/src/components/toolbar/style.scss
+++ b/packages/edit-navigation/src/components/toolbar/style.scss
@@ -40,3 +40,8 @@
 .edit-navigation-toolbar__save-button {
 	margin: 0 $grid-unit-10 0 auto;
 }
+
+
+.edit-navigation-toolbar__component-popover .components-popover__content {
+	width: $navigation-editor-toolbar-width;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closing https://github.com/WordPress/gutenberg/issues/28183

Popovers in the navigation menu were too narrow. The fixed-width has been added - the same as for a sidebar

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested visually

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
