### PR TITLE
Components: Set a default for the ComboboxControl onFilterValueChange

### DIFF
--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -46,7 +46,7 @@ function ComboboxControl( {
 	label,
 	options,
 	onChange,
-	onFilterValueChange,
+	onFilterValueChange = () => {},
 	hideLabelFromVision,
 	help,
 	allowReset = true,

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { deburr } from 'lodash';
+import { noop, deburr } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -46,7 +46,7 @@ function ComboboxControl( {
 	label,
 	options,
 	onChange,
-	onFilterValueChange = () => {},
+	onFilterValueChange = noop,
 	hideLabelFromVision,
 	help,
 	allowReset = true,

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -259,14 +259,14 @@ export default {
 	component: ComboboxControl,
 };
 
-function ComboboxControlWithState() {
-	const mapCountryOption = ( country ) => ( {
-		value: country.code,
-		label: country.name,
-	} );
-	const [ filteredOptions, setFilteredOptions ] = useState(
-		countries.map( mapCountryOption )
-	);
+const mapCountryOption = ( country ) => ( {
+	value: country.code,
+	label: country.name,
+} );
+
+const countryOptions = countries.map( mapCountryOption );
+
+function CountryCodeComboboxControl() {
 	const [ value, setValue ] = useState( null );
 
 	return (
@@ -275,13 +275,10 @@ function ComboboxControlWithState() {
 				value={ value }
 				onChange={ setValue }
 				label="Select a country"
-				options={ filteredOptions }
-				onFilterValueChange={ () =>
-					setFilteredOptions( countries.map( mapCountryOption ) )
-				}
+				options={ countryOptions }
 			/>
 			<p>Value: { value }</p>
 		</>
 	);
 }
-export const _default = () => <ComboboxControlWithState />;
+export const _default = () => <CountryCodeComboboxControl />;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
While using the the `ComboboxControl` I noticed that there were errors stating that `onFilterValueChange` was undefined. Looking at the example in Storybook, it seems that this was probably required in the past, and was a way for the logic of how the suggestions are filtered, to be handled outside of the combobox. 

This can safely be set to a no-op function and the control works as expected. This PR sets that as the default and updates the Storybook example so that it shows the simplified usage.

## How has this been tested?
This has been manually tested, in the block I'm developing and using Storybook. The frontend functionality remains unchanged.

## Types of changes
This should probably be categorised as a bug fix. The `onFilterValueChange` prop can be optional, but would cause an error if omitted.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
