### PR TITLE
E2E Tests: Try running in Firefox (in addition to Chrome)

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -11,13 +11,14 @@ on:
 
 jobs:
   admin:
-    name: Admin - ${{ matrix.part }}
+    name: Admin - ${{ matrix.part }} in ${{ matrix.browser }}
 
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
+        browser: ['chrome', 'firefox']
         part: [1, 2, 3, 4]
 
 
@@ -47,6 +48,10 @@ jobs:
         npm ci
         FORCE_REDUCED_MOTION=true npm run build
 
+    - name: "Install Puppeteer with ${{ matrix.browser }}"
+      if: matrix.browser != 'chrome'
+      run: PUPPETEER_PRODUCT=${{ matrix.browser }} npm install puppeteer
+
     - name: Install WordPress
       run: |
         chmod -R 767 ./ # TODO: Possibly integrate in wp-env
@@ -55,7 +60,7 @@ jobs:
     - name: Running the tests
       run: |
         $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == ${{ matrix.part }} - 1' < ~/.jest-e2e-tests )
+        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == ${{ matrix.part }} - 1' < ~/.jest-e2e-tests ) -- --puppeteer-product=${{ matrix.browser }}
 
     - name: Archive debug artifacts (screenshots, HTML snapshots)
       uses: actions/upload-artifact@v2

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Npm install and build
       run: |
-        PUPPETEER_PRODUCT=${{ matrix.browser }} npm install
+        npm ci
         FORCE_REDUCED_MOTION=true npm run build
 
     - name: Install WordPress

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Running the tests
       run: |
         $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
-        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == ${{ matrix.part }} - 1' < ~/.jest-e2e-tests ) -- --puppeteer-product=${{ matrix.browser }}
+        $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == ${{ matrix.part }} - 1' < ~/.jest-e2e-tests ) --puppeteer-product=${{ matrix.browser }}
 
     - name: Archive debug artifacts (screenshots, HTML snapshots)
       uses: actions/upload-artifact@v2

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -45,12 +45,8 @@ jobs:
 
     - name: Npm install and build
       run: |
-        npm ci
+        PUPPETEER_PRODUCT=${{ matrix.browser }} npm install
         FORCE_REDUCED_MOTION=true npm run build
-
-    - name: "Install Puppeteer with ${{ matrix.browser }}"
-      if: matrix.browser != 'chrome'
-      run: PUPPETEER_PRODUCT=${{ matrix.browser }} npm install puppeteer
 
     - name: Install WordPress
       run: |

--- a/packages/scripts/config/puppeteer.config.js
+++ b/packages/scripts/config/puppeteer.config.js
@@ -2,6 +2,7 @@ module.exports = {
 	launch: {
 		devtools: process.env.PUPPETEER_DEVTOOLS === 'true',
 		headless: process.env.PUPPETEER_HEADLESS !== 'false',
+		product: process.env.PUPPETEER_PRODUCT || 'chrome',
 		slowMo: parseInt( process.env.PUPPETEER_SLOWMO, 10 ) || 0,
 	},
 };

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -65,6 +65,10 @@ if ( hasArgInCLI( '--puppeteer-devtools' ) ) {
 	process.env.PUPPETEER_DEVTOOLS = 'true';
 }
 
+if ( hasArgInCLI( '--puppeteer-product' ) ) {
+	process.env.PUPPETEER_PRODUCT = getArgFromCLI( '--puppeteer-product' );
+}
+
 const configsMapping = {
 	WP_BASE_URL: '--wordpress-base-url',
 	WP_USERNAME: '--wordpress-username',

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -28,6 +28,11 @@ const {
 	hasProjectFile,
 } = require( '../utils' );
 
+// Need to set before running `puppeteer/install`.
+if ( hasArgInCLI( '--puppeteer-product' ) ) {
+	process.env.PUPPETEER_PRODUCT = getArgFromCLI( '--puppeteer-product' );
+}
+
 const result = spawn( 'node', [ require.resolve( 'puppeteer/install' ) ], {
 	stdio: 'inherit',
 } );
@@ -63,10 +68,6 @@ if ( hasArgInCLI( '--puppeteer-interactive' ) ) {
 if ( hasArgInCLI( '--puppeteer-devtools' ) ) {
 	process.env.PUPPETEER_HEADLESS = 'false';
 	process.env.PUPPETEER_DEVTOOLS = 'true';
-}
-
-if ( hasArgInCLI( '--puppeteer-product' ) ) {
-	process.env.PUPPETEER_PRODUCT = getArgFromCLI( '--puppeteer-product' );
 }
 
 const configsMapping = {


### PR DESCRIPTION
## Description
First stab at running e2e tests in Firefox, when run in CI.

Sometimes we see errors that only manifest in Firefox, such as the issue that was fixed by https://github.com/WordPress/gutenberg/pull/28212. In order to catch those earlier, it makes sense to add Firefox coverage to our automated tests.

Inspired by https://github.com/Automattic/jetpack/pull/17893 (which I haven't gotten to work yet :grimacing:)

## How has this been tested?
See if the e2e tests GH Actions pass :crossed_fingers: 

To run locally (with tests visible):

```
npm run test-e2e -- --puppeteer-interactive --puppeteer-product=firefox
```
