### PR TITLE
Add check for zero to the FocalPointPicker mediaRef which prevents a division by zero error

### DIFF
--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -89,10 +89,19 @@ export class FocalPointPicker extends Component {
 			return bounds;
 		}
 
+		// Prevent division by zero when updateBounds runs in componentDidMount
+		if (
+			this.mediaRef.current.clientWidth === 0 ||
+			this.mediaRef.current.clientHeight === 0
+		) {
+			return bounds;
+		}
+
 		const dimensions = {
 			width: this.mediaRef.current.clientWidth,
 			height: this.mediaRef.current.clientHeight,
 		};
+
 		const pickerDimensions = this.pickerDimensions();
 
 		const widthRatio = pickerDimensions.width / dimensions.width;


### PR DESCRIPTION
## Description
Fixes #28487. In #28096, because updateBounds was added to `componentDidMount`, it runs after the `mediaRef` exists, but before it has received the width/height or the image. This results in a division by 0 which errors out and sets the left bound of the focal point picker to be `NaN`. This caused the focal point picker to not work in the horizontal direction as well as throwing a console error.

Specifically, these lines were erroring because dimensions.width and dimensions.height were both set to 0
```
const widthRatio = pickerDimensions.width / dimensions.width;
const heightRatio = pickerDimensions.height / dimensions.height;
```

## How has this been tested?
Open a new post and insert a cover block
Select the cover block
See that the focal point picker can now be moved horizontally and there is no console error

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
