### PR TITLE
Block Validation: Allow unitless zero CSS lengths

### DIFF
--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -171,6 +171,14 @@ describe( 'validation', () => {
 				'url(https://wordpress.org/img.png)'
 			);
 		} );
+
+		it( 'omits length units from zero values', () => {
+			const normalizedValue = getNormalizedStyleValue(
+				'44% 0% 18em 0em'
+			);
+
+			expect( normalizedValue ).toBe( '44% 0 18em 0' );
+		} );
 	} );
 
 	describe( 'getStyleProperties()', () => {

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -8,6 +8,7 @@ import {
 	getTextWithCollapsedWhitespace,
 	getMeaningfulAttributePairs,
 	isEquivalentTextTokens,
+	getNormalizedLength,
 	getNormalizedStyleValue,
 	getStyleProperties,
 	isEqualAttributesOfName,
@@ -158,6 +159,32 @@ describe( 'validation', () => {
 			);
 
 			expect( isEqual ).toBe( true );
+		} );
+	} );
+
+	describe( 'getNormalizedLength()', () => {
+		it( 'omits unit from zero px length', () => {
+			const normalizedLength = getNormalizedLength( '0px' );
+
+			expect( normalizedLength ).toBe( '0' );
+		} );
+
+		it( 'retains unit in non-zero px length', () => {
+			const normalizedLength = getNormalizedLength( '50px' );
+
+			expect( normalizedLength ).toBe( '50px' );
+		} );
+
+		it( 'omits unit from zero percentage', () => {
+			const normalizedLength = getNormalizedLength( '0%' );
+
+			expect( normalizedLength ).toBe( '0' );
+		} );
+
+		it( 'retains unit in non-zero percentage', () => {
+			const normalizedLength = getNormalizedLength( '50%' );
+
+			expect( normalizedLength ).toBe( '50%' );
 		} );
 	} );
 

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -206,6 +206,14 @@ describe( 'validation', () => {
 
 			expect( normalizedValue ).toBe( '44% 0 18em 0' );
 		} );
+
+		it( 'leaves zero values in calc() expressions alone', () => {
+			const normalizedValue = getNormalizedStyleValue(
+				'calc(0em + 5px)'
+			);
+
+			expect( normalizedValue ).toBe( 'calc(0em + 5px)' );
+		} );
 	} );
 
 	describe( 'getStyleProperties()', () => {

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -17,13 +17,6 @@ import { getSaveContent } from '../serializer';
 import { normalizeBlockType } from '../utils';
 
 /**
- * CSS length units
- *
- * @type {Array}
- */
-const CSS_UNITS = [ '%', 'px', 'em', 'rem', 'vw', 'vh' ];
-
-/**
  * Globally matches any consecutive whitespace
  *
  * @type {RegExp}
@@ -341,10 +334,7 @@ export function isEquivalentTextTokens(
  * @return {string} Normalized CSS length value.
  */
 export function getNormalizedLength( value ) {
-	if ( CSS_UNITS.some( ( unit ) => value === '0' + unit ) ) {
-		return '0';
-	}
-	return value;
+	return 0 === parseFloat( value ) ? '0' : value;
 }
 
 /**

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -326,6 +326,22 @@ export function isEquivalentTextTokens(
 }
 
 /**
+ * Given a CSS length value, returns a normalized CSS length value for strict equality
+ * comparison.
+ *
+ * @param {string} value CSS length value.
+ *
+ * @return {string} Normalized CSS length value.
+ */
+export function getNormalizedLength( value ) {
+	const cssUnits = [ '%', 'px', 'em', 'rem', 'vw', 'vh' ];
+	if ( cssUnits.some( ( unit ) => value === '0' + unit ) ) {
+		return '0';
+	}
+	return value;
+}
+
+/**
  * Given a style value, returns a normalized style value for strict equality
  * comparison.
  *
@@ -334,8 +350,12 @@ export function isEquivalentTextTokens(
  * @return {string} Normalized style value.
  */
 export function getNormalizedStyleValue( value ) {
+	const textPieces = getTextPiecesSplitOnWhitespace( value );
+	const normalizedPieces = textPieces.map( getNormalizedLength );
+	const result = normalizedPieces.join( ' ' );
+
 	return (
-		value
+		result
 			// Normalize URL type to omit whitespace or quotes
 			.replace( REGEXP_STYLE_URL_TYPE, 'url($1)' )
 	);

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -17,6 +17,13 @@ import { getSaveContent } from '../serializer';
 import { normalizeBlockType } from '../utils';
 
 /**
+ * CSS length units
+ *
+ * @type {Array}
+ */
+const CSS_UNITS = [ '%', 'px', 'em', 'rem', 'vw', 'vh' ];
+
+/**
  * Globally matches any consecutive whitespace
  *
  * @type {RegExp}
@@ -334,8 +341,7 @@ export function isEquivalentTextTokens(
  * @return {string} Normalized CSS length value.
  */
 export function getNormalizedLength( value ) {
-	const cssUnits = [ '%', 'px', 'em', 'rem', 'vw', 'vh' ];
-	if ( cssUnits.some( ( unit ) => value === '0' + unit ) ) {
+	if ( CSS_UNITS.some( ( unit ) => value === '0' + unit ) ) {
 		return '0';
 	}
 	return value;


### PR DESCRIPTION
## Description
Fixes #28497. Quoting that issue:

> The Cover block with a focal point will generate some HTML like the following:
> 
> ```
> <img class="wp-block-cover__image-background wp-image-703" alt="" src="https://example.com/image.jpeg" style="object-position:0% 44%" data-object-fit="cover" data-object-position="0% 44%"/>
> ```
> 
> When a simple CSS optimization plugin runs on post save (for example, applying [this](https://packagist.org/packages/cerdic/css-tidy) to style attributes), it removes the redundant `%` from `0%`. The following post content is stored to the database:
> 
> ```
> <img class="wp-block-cover__image-background wp-image-703" alt="" src="https://example.com/image.jpeg" style="object-position:0 44%;" data-object-fit="cover" data-object-position="0% 44%" />
> ```
> 
> When the editor is refreshed, the post content is invalid. The CSS is semantically the same, but the missing redundant `%` causes block invalidation to occur. The block should be resilient to this change as the style is semantically identical.
> 
> Note that #28487 makes this issue much more likely to be encountered as a `0` value must be picked in the focal point picker.

This PR changes `style` attribute normalization (which is part of block validation) accordingly.

## How has this been tested?

```
npm run test-unit packages/blocks/src/api/test/validation.js
```

Furthermore, verify that #28497 is fixed (see that issue's instructions to reproduce).
