### PR TITLE
Polish Buttons block radius, and size.

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -1,5 +1,3 @@
-$blocks-button__height: 3.1em;
-
 // This variable is repeated across Button, Buttons, and Buttons editor styles.
 $blocks-block__margin: 0.5em;
 
@@ -8,8 +6,8 @@ $blocks-block__margin: 0.5em;
 .wp-block-button__link {
 	color: $white;
 	background-color: #32373c;
-	border: none;
-	border-radius: $blocks-button__height / 2;
+	border: 2px solid #32373c;
+	border-radius: 9999px; // 100% causes an oval, but any explicit but really high value retains the pill shape.
 	box-shadow: none;
 	cursor: pointer;
 	display: inline-block;
@@ -78,12 +76,12 @@ $blocks-block__margin: 0.5em;
 
 .is-style-outline > .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
-	border: 2px solid;
+	border: 2px solid currentColor;
 }
 
 .is-style-outline > .wp-block-button__link:not(.has-text-color),
 .wp-block-button__link.is-style-outline:not(.has-text-color) {
-	color: #32373c;
+	color: currentColor;
 }
 
 .is-style-outline > .wp-block-button__link:not(.has-background),

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -1,11 +1,9 @@
-$blocks-button__height: 3.1em;
-
 // Styles copied from button block styles.
 .wp-block-post-comments-form input[type="submit"] {
 	color: $white;
 	background-color: #32373c;
 	border: none;
-	border-radius: $blocks-button__height / 2;
+	border-radius: 9999px; // 100% causes an oval, but any explicit but really high value retains the pill shape.
 	box-shadow: none;
 	cursor: pointer;
 	display: inline-block;


### PR DESCRIPTION
Buttons do not have the correct radius, and the solid button is smaller than the outline button. This PR fixes both. Before:

<img width="928" alt="before" src="https://user-images.githubusercontent.com/1204802/105968870-e8f2a680-6087-11eb-9c67-2e1cf4e885a9.png">

_Note: the "space-between" effect is a separate bug, fixed in #28485_

After:

<img width="933" alt="Screenshot 2021-01-27 at 10 08 45" src="https://user-images.githubusercontent.com/1204802/105968932-fa3bb300-6087-11eb-914a-0417862710e6.png">

Here's what changed:

- Instead of a border-radius calculated based on the perceived height of the button, we just set a really high value. This retains the pill-shape, without the need for separate variables.
- The text color of the outline button is now currentColor, to match its border (`2px solid` is the same as `2px solid currentColor`, the latter is just easier to understand).
- There's now a border around the solid button, so the size of both buttons are the same

I would very much like to retire the specific gray color for the solid button, but this has to be a separate global styles effort.

This PR needs a great deal of sanity checking especially from theme developers, as although the changes are small, they do affect shipping code.