### PR TITLE
Fix URL cutoff.

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -151,7 +151,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 	.block-editor-link-control__search-item-header {
 		display: block;
-		margin-right: $grid-unit-30;
+		margin-right: $grid-unit-10;
 		overflow: hidden;
 		white-space: nowrap;
 	}
@@ -163,8 +163,15 @@ $block-editor-link-control-number-of-actions: 1;
 
 	.block-editor-link-control__search-item-info,
 	.block-editor-link-control__search-item-title {
-		max-width: 230px;
 		overflow: hidden;
+		text-overflow: ellipsis;
+		padding-right: $grid-unit-30;
+
+		.components-external-link__icon {
+			position: absolute;
+			right: 0;
+			margin-top: 0;
+		}
 	}
 
 	.block-editor-link-control__search-item-title {


### PR DESCRIPTION
Fixes #22298.

The original issue that @annezazu reported I can no longer reproduce. It seems likely that the issue experienced was related to CSS bleed from the theme itself, an issue that has potentially been fixed by the URL popover moving outside the editing canvas. I tested in all the twenties and could not reproduce the initial issue.

However there were improvements to be made, still. The 230px max-width doesn't appear necessary, as the container is a flex container and should size the input field 

Before:

<img width="822" alt="Screenshot 2021-01-27 at 10 49 30" src="https://user-images.githubusercontent.com/1204802/105974048-c2376e80-608d-11eb-8154-fe1884f8c09a.png">

After:

<img width="587" alt="Screenshot 2021-01-27 at 11 37 37" src="https://user-images.githubusercontent.com/1204802/105979625-2d843f00-6094-11eb-9a9f-41427b708a38.png">

<img width="652" alt="Screenshot 2021-01-27 at 11 37 46" src="https://user-images.githubusercontent.com/1204802/105979634-2eb56c00-6094-11eb-9abd-1b04f82ba28c.png">

