### PR TITLE
Try: Fix menu item word wrap.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -3,6 +3,7 @@
 	.wp-block-navigation__container {
 		color: $gray-900;
 		background-color: $white;
+		min-width: 200px;
 	}
 }
 


### PR DESCRIPTION
Fixes #22181.

Before:

<img width="787" alt="before" src="https://user-images.githubusercontent.com/1204802/105980873-b0f26000-6095-11eb-8e6c-5cd9ab7366e6.png">

After:

<img width="554" alt="Screenshot 2021-01-27 at 11 48 14" src="https://user-images.githubusercontent.com/1204802/105980883-b2bc2380-6095-11eb-90ad-acea490b944c.png">

This PR simply adds a min-width to menu items, frontend and backend, allowing more text in menu items before the text wraps.

Another alternative is to add `white-space: nowrap;` to menu items, happy to change to that if there are strong opinions, but this felt the least intrusive.

Ultimately, this CSS is the _default menu CSS_, and themes are meant to style this further and override colors and dimensions. So we should be the least opinionated we can, about the styles.