### PR TITLE
[Inserter]: Add keyboard navigation in Patterns

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/README.md
+++ b/packages/block-editor/src/components/block-patterns-list/README.md
@@ -53,6 +53,19 @@ The performed event after a click on a block pattern. In most cases, the pattern
 -   Type: `Function`
 -   Required: Yes
 
+#### isDraggable
+Enables drag and drop functionality to the available block patterns.
+
+-   Type: `boolean`
+-   Required: No
+
+#### label
+The aria label for the block patterns list.
+
+-   Type: `string`
+-   Required: No
+-   Default: `Patterns`
+
 ## Related components
 
 Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/block-patterns-list/README.md
+++ b/packages/block-editor/src/components/block-patterns-list/README.md
@@ -59,12 +59,18 @@ Enables drag and drop functionality to the available block patterns.
 -   Type: `boolean`
 -   Required: No
 
+#### orientation
+The orientation value determines which arrow keys can be used to move focus. Available options are (`vertical`|`horizontal`). If not provided all arrow keys work.
+
+-   Type: `string`
+-   Required: No
+
 #### label
 The aria label for the block patterns list.
 
 -   Type: `string`
 -   Required: No
--   Default: `Patterns`
+-   Default: `Block Patterns`
 
 ## Related components
 

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -11,6 +11,7 @@ import {
 	__unstableCompositeItem as CompositeItem,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -82,6 +83,7 @@ function BlockPatternList( {
 	blockPatterns,
 	shownPatterns,
 	onClickPattern,
+	label = __( 'Patterns' ),
 } ) {
 	const composite = useCompositeState( { orientation: 'vertical' } );
 	return (
@@ -89,6 +91,7 @@ function BlockPatternList( {
 			{ ...composite }
 			role="listbox"
 			className="block-editor-block-patterns-list"
+			aria-label={ label }
 		>
 			{ blockPatterns.map( ( pattern ) => {
 				const isShown = shownPatterns.includes( pattern );

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -3,7 +3,6 @@
  */
 import { useMemo } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
-import { ENTER, SPACE } from '@wordpress/keycodes';
 import {
 	VisuallyHidden,
 	__unstableComposite as Composite,
@@ -44,14 +43,6 @@ function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 						{ ...composite }
 						className="block-editor-block-patterns-list__item"
 						onClick={ () => onClick( pattern, blocks ) }
-						onKeyDown={ ( event ) => {
-							if (
-								ENTER === event.keyCode ||
-								SPACE === event.keyCode
-							) {
-								onClick( pattern, blocks );
-							}
-						} }
 					>
 						<BlockPreview
 							blocks={ blocks }
@@ -83,9 +74,10 @@ function BlockPatternList( {
 	blockPatterns,
 	shownPatterns,
 	onClickPattern,
-	label = __( 'Patterns' ),
+	orientation,
+	label = __( 'Block Patterns' ),
 } ) {
-	const composite = useCompositeState( { orientation: 'vertical' } );
+	const composite = useCompositeState( { orientation } );
 	return (
 		<Composite
 			{ ...composite }

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -4,7 +4,12 @@
 import { useMemo } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { ENTER, SPACE } from '@wordpress/keycodes';
-import { VisuallyHidden } from '@wordpress/components';
+import {
+	VisuallyHidden,
+	__unstableComposite as Composite,
+	__unstableUseCompositeState as useCompositeState,
+	__unstableCompositeItem as CompositeItem,
+} from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -13,7 +18,7 @@ import { useInstanceId } from '@wordpress/compose';
 import BlockPreview from '../block-preview';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 
-function BlockPattern( { isDraggable, pattern, onClick } ) {
+function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 	const { content, viewportWidth } = pattern;
 	const blocks = useMemo( () => parse( content ), [ content ] );
 	const instanceId = useInstanceId( BlockPattern );
@@ -23,18 +28,7 @@ function BlockPattern( { isDraggable, pattern, onClick } ) {
 		<InserterDraggableBlocks isEnabled={ isDraggable } blocks={ blocks }>
 			{ ( { draggable, onDragStart, onDragEnd } ) => (
 				<div
-					className="block-editor-block-patterns-list__item"
-					role="button"
-					onClick={ () => onClick( pattern, blocks ) }
-					onKeyDown={ ( event ) => {
-						if (
-							ENTER === event.keyCode ||
-							SPACE === event.keyCode
-						) {
-							onClick( pattern, blocks );
-						}
-					} }
-					tabIndex={ 0 }
+					className="block-editor-block-patterns-list__list-item"
 					aria-label={ pattern.title }
 					aria-describedby={
 						pattern.description ? descriptionId : undefined
@@ -43,18 +37,34 @@ function BlockPattern( { isDraggable, pattern, onClick } ) {
 					onDragStart={ onDragStart }
 					onDragEnd={ onDragEnd }
 				>
-					<BlockPreview
-						blocks={ blocks }
-						viewportWidth={ viewportWidth }
-					/>
-					<div className="block-editor-block-patterns-list__item-title">
-						{ pattern.title }
-					</div>
-					{ !! pattern.description && (
-						<VisuallyHidden id={ descriptionId }>
-							{ pattern.description }
-						</VisuallyHidden>
-					) }
+					<CompositeItem
+						role="option"
+						as={ 'div' }
+						{ ...composite }
+						className="block-editor-block-patterns-list__item"
+						onClick={ () => onClick( pattern, blocks ) }
+						onKeyDown={ ( event ) => {
+							if (
+								ENTER === event.keyCode ||
+								SPACE === event.keyCode
+							) {
+								onClick( pattern, blocks );
+							}
+						} }
+					>
+						<BlockPreview
+							blocks={ blocks }
+							viewportWidth={ viewportWidth }
+						/>
+						<div className="block-editor-block-patterns-list__item-title">
+							{ pattern.title }
+						</div>
+						{ !! pattern.description && (
+							<VisuallyHidden id={ descriptionId }>
+								{ pattern.description }
+							</VisuallyHidden>
+						) }
+					</CompositeItem>
 				</div>
 			) }
 		</InserterDraggableBlocks>
@@ -73,19 +83,29 @@ function BlockPatternList( {
 	shownPatterns,
 	onClickPattern,
 } ) {
-	return blockPatterns.map( ( pattern ) => {
-		const isShown = shownPatterns.includes( pattern );
-		return isShown ? (
-			<BlockPattern
-				key={ pattern.name }
-				pattern={ pattern }
-				onClick={ onClickPattern }
-				isDraggable={ isDraggable }
-			/>
-		) : (
-			<BlockPatternPlaceholder key={ pattern.name } />
-		);
-	} );
+	const composite = useCompositeState( { orientation: 'vertical' } );
+	return (
+		<Composite
+			{ ...composite }
+			role="listbox"
+			className="block-editor-block-patterns-list"
+		>
+			{ blockPatterns.map( ( pattern ) => {
+				const isShown = shownPatterns.includes( pattern );
+				return isShown ? (
+					<BlockPattern
+						key={ pattern.name }
+						pattern={ pattern }
+						onClick={ onClickPattern }
+						isDraggable={ isDraggable }
+						composite={ composite }
+					/>
+				) : (
+					<BlockPatternPlaceholder key={ pattern.name } />
+				);
+			} ) }
+		</Composite>
+	);
 }
 
 export default BlockPatternList;

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -39,7 +39,7 @@ function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 				>
 					<CompositeItem
 						role="option"
-						as={ 'div' }
+						as="div"
 						{ ...composite }
 						className="block-editor-block-patterns-list__item"
 						onClick={ () => onClick( pattern, blocks ) }

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -1,5 +1,6 @@
 .block-editor-block-patterns-list__list-item {
-	// width: 100%;
+	cursor: pointer;
+	margin-top: $grid-unit-20;
 
 	&.is-placeholder {
 		min-height: 100px;
@@ -11,6 +12,7 @@
 }
 
 .block-editor-block-patterns-list__item {
+	height: 100%;
 	border-radius: $radius-block-ui;
 	transition: all 0.05s ease-in-out;
 	position: relative;

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -1,8 +1,17 @@
-.block-editor-block-patterns-list__item {
+.block-editor-block-patterns-list__list-item {
+	// width: 100%;
 
+	&.is-placeholder {
+		min-height: 100px;
+	}
+
+	&[draggable="true"] .block-editor-block-preview__container {
+		cursor: grab;
+	}
+}
+
+.block-editor-block-patterns-list__item {
 	border-radius: $radius-block-ui;
-	cursor: pointer;
-	margin-top: $grid-unit-20;
 	transition: all 0.05s ease-in-out;
 	position: relative;
 	border: $border-width solid transparent;
@@ -16,14 +25,6 @@
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
-	}
-
-	&.is-placeholder {
-		min-height: 100px;
-	}
-
-	&[draggable="true"] .block-editor-block-preview__container {
-		cursor: grab;
 	}
 }
 

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -112,6 +112,7 @@ function BlockPatternsCategory( {
 						blockPatterns={ currentCategoryPatterns }
 						onClickPattern={ onClick }
 						label={ patternCategory.label }
+						orientation="vertical"
 						isDraggable
 					/>
 				</PatternInserterPanel>

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -103,7 +103,6 @@ function BlockPatternsCategory( {
 		<>
 			{ !! currentCategoryPatterns.length && (
 				<PatternInserterPanel
-					title={ patternCategory.title }
 					selectedCategory={ patternCategory }
 					patternCategories={ populatedCategories }
 					onClickCategory={ onClickCategory }
@@ -112,6 +111,7 @@ function BlockPatternsCategory( {
 						shownPatterns={ currentShownPatterns }
 						blockPatterns={ currentCategoryPatterns }
 						onClickPattern={ onClick }
+						label={ patternCategory.label }
 						isDraggable
 					/>
 				</PatternInserterPanel>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -332,6 +332,14 @@ $block-inserter-tabs-height: 44px;
 	padding: $grid-unit-20;
 }
 
+.block-editor-inserter__quick-inserter-patterns {
+	.block-editor-block-patterns-list {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-gap: $grid-unit-10;
+	}
+}
+
 .block-editor-inserter__quick-inserter-separator {
 	border-top: $border-width solid $gray-300;
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -332,12 +332,6 @@ $block-inserter-tabs-height: 44px;
 	padding: $grid-unit-20;
 }
 
-.block-editor-inserter__quick-inserter-patterns {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-gap: $grid-unit-10;
-}
-
 .block-editor-inserter__quick-inserter-separator {
 	border-top: $border-width solid $gray-300;
 }

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -148,7 +148,7 @@ export async function insertBlock( searchTerm ) {
 export async function insertPattern( searchTerm ) {
 	await searchForPattern( searchTerm );
 	const insertButton = await page.waitForXPath(
-		`//div[@role = 'button']//div[contains(text(), '${ searchTerm }')]`
+		`//div[@role = 'option']//div[contains(text(), '${ searchTerm }')]`
 	);
 	await insertButton.click();
 	// We should wait until the inserter closes and the focus moves to the content.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/28245

This PR adds keyboard navigation to the `Patterns List` in inserter. It uses the `Composite` component from `Reakit`, which is also used for block types list.


## Testing instructions
1. Open the inserter and navigate with keyboard through `Patterns`.
2. Everything else should be identical with the current implementation (styling).
<!-- Please describe what you have changed or added -->

