### PR TITLE
Fix regression with pinned plugin items on mobile.

### DIFF
--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -1,5 +1,11 @@
 .interface-pinned-items {
-	display: flex;
+	// We intentionally hide pinned items (plugins) on mobile, and unhide them at desktop breakpoints.
+	// Otherwise the list can wreak havoc on the layout.
+	display: none;
+
+	@include break-small() {
+		display: flex;
+	}
 
 	.components-button {
 		margin-left: $grid-unit-05;


### PR DESCRIPTION
This PR fixes an issue where the behavior for pinned items (sidebar plugins, mostly) were unintentionally reverted. Before:

<img width="331" alt="Screenshot 2021-01-27 at 13 02 04" src="https://user-images.githubusercontent.com/1204802/105988735-65917f00-60a0-11eb-9ea5-11fbb8290bef.png">

After:

<img width="617" alt="after" src="https://user-images.githubusercontent.com/1204802/105988745-675b4280-60a0-11eb-9082-5095d5ca0d6f.png">

The behavior, specifically, is that pinned items are available only in the More menu on mobile breakpoints. It regressed here: https://github.com/WordPress/gutenberg/commit/34d5c6bb595241b89fe983291fdb8e3926337be5#diff-68c0defb9ce321bc5b02b65a5b2d503661cc2dedac4cc48dfc89b65825a00e49R2