### PR TITLE
Pinned items regression followup.

### DIFF
--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -1,10 +1,14 @@
 .interface-pinned-items {
+	display: flex;
+
 	// We intentionally hide pinned items (plugins) on mobile, and unhide them at desktop breakpoints.
 	// Otherwise the list can wreak havoc on the layout.
-	display: none;
+	.components-button:not(:first-child) {
+		display: none;
 
-	@include break-small() {
-		display: flex;
+		@include break-small() {
+			display: flex;
+		}
 	}
 
 	.components-button {


### PR DESCRIPTION
Quick followup to #28521, apologies and thank you @Copons for input.

The previous fix hid all pinned items on mobile. But that as of recent changes, and possibly the original cause of the regression, that includes the settings sidebar.

This PR fixes that:

![pinning-issue](https://user-images.githubusercontent.com/1204802/106005767-d3e03c80-60b4-11eb-9cd9-d539f36c93c2.gif)

Jacopo further alerted me to the fact that [it isn't necessarily as simple as a first-child solution](https://github.com/Automattic/wp-calypso/pull/49329#issuecomment-768236907), because if you unpin a plugin, then pin it again, it shows up at as the first child. However that doesn't survive a reload:

![bugfix](https://user-images.githubusercontent.com/1204802/106005578-a4c9cb00-60b4-11eb-98c6-bd731ce38582.gif)


For that reason, I would suggest this PR is a good interim fix, because you can't even pin or unpin items on mobile at all.

But we should follow up with a separate fix that either moves the cog back out of the "pinned items" group, or makes sure it always shows up as the first child — or just that it has a child name that is easily targetted.