### PR TITLE
Components: Fix truncate export

### DIFF
--- a/packages/components/src/truncate/index.js
+++ b/packages/components/src/truncate/index.js
@@ -1,3 +1,3 @@
-export { default as Truncate } from './truncate';
+export { default } from './truncate';
 
 export * from './use-truncate';

--- a/packages/components/src/truncate/stories/index.js
+++ b/packages/components/src/truncate/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { Truncate } from '../index';
+import Truncate from '../index';
 
 export default {
 	component: Truncate,

--- a/packages/components/src/truncate/test/truncate.js
+++ b/packages/components/src/truncate/test/truncate.js
@@ -6,7 +6,7 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { Truncate } from '../index';
+import Truncate from '..';
 
 describe( 'props', () => {
 	test( 'should render correctly', () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes the Truncate export.

## How has this been tested?
No longer causes a warning during `npm run dev`.

## Types of changes
Bug fix, fixes #28510

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
