### PR TITLE
Make default block appender appear more consistently.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -75,22 +75,22 @@ export function DefaultBlockAppender( {
 export default compose(
 	withSelect( ( select, ownProps ) => {
 		const {
+			getBlockAttributes,
 			getBlockCount,
 			getBlockName,
-			isBlockValid,
 			getSettings,
 			getTemplateLock,
 		} = select( blockEditorStore );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
-		const isLastBlockDefault =
+		const isLastBlockEmptyDefault =
 			getBlockName( ownProps.lastBlockClientId ) ===
-			getDefaultBlockName();
-		const isLastBlockValid = isBlockValid( ownProps.lastBlockClientId );
+				getDefaultBlockName() &&
+			getBlockAttributes( ownProps.lastBlockClientId )?.content === '';
 		const { bodyPlaceholder } = getSettings();
 
 		return {
-			isVisible: isEmpty || ! isLastBlockDefault || ! isLastBlockValid,
+			isVisible: isEmpty || ! isLastBlockEmptyDefault,
 			showPrompt: isEmpty,
 			isLocked: !! getTemplateLock( ownProps.rootClientId ),
 			placeholder: bodyPlaceholder,

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -465,7 +465,6 @@ describe( 'Links', () => {
 		// Confirm that submitting the input without any changes keeps the same
 		// value and moves focus back to the paragraph.
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( '.' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
## Description
Fixes #5055. Also addresses some points raised in #13571 and #26404.

This PR makes the default block appender more consistent in when it appears.

### Current behavior in `master`

The appender appears after every block _except_ a Paragraph block. However, this has often been confusing and annoying in situations such as a Column where inserting a block after the last one in the Column feels weird because you have to do one of the following:

- Use the sibling inserter and then move the block down.
- Click the Paragraph, move your cursor to the end of the text, and press <kbd>Enter</kbd>.
- Click the Paragraph, and click the <kbd>Add block</kbd> button in the top bar.

None of these are particularly obvious at first. And the fact that the appender appears for every other block just makes it more confusing. I don't think most users will understand why a Heading or List at the end of a Column or post shows an appender, but a Paragraph doesn't.

### Behavior in this PR

The appender appears after every block including the Paragraph, with the exception that empty Paragraph blocks retain the current behavior in order to avoid having multiple appenders shown simultaneously.

I believe this behavior makes a whole lot more sense, and is a lot more predictable for users. I think there's definitely more work that could be done in the future (see #13571), but for now, this PR should greatly improve the situation.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/19592990/106051345-f28f0500-60ad-11eb-8308-ca4f8b2e452f.png)
![image](https://user-images.githubusercontent.com/19592990/106052350-156de900-60af-11eb-8627-519ee9918267.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
