### PR TITLE
Fixes 24895: isURL uses a bit of heuristics

### DIFF
--- a/packages/url/src/is-url.js
+++ b/packages/url/src/is-url.js
@@ -15,11 +15,31 @@
  */
 export function isURL( url ) {
 	// A URL can be considered value if the `URL` constructor is able to parse
-	// it. The constructor throws an error for an invalid URL.
+	// it. The constructor throws an error for most invalid URLs.
 	try {
-		new URL( url );
+		const parsed = new URL( url );
+
+		// Special cases
+		if ( /^\s/.test( parsed.pathname ) ) {
+			// Valid paths probably don't start with whitespace
+			return false;
+		}
+
+		// Check given protocol (parsed is lowercase)
+		const m = url.match( /^\s*([^:]+):/ );
+		if ( ! m ) {
+			// No protocol
+			return false;
+		}
+
+		if ( /[A-Z]/.test( m[ 1 ] ) && /[a-z]/.test( m[ 1 ] ) ) {
+			// Mixed case protocol could be a word like "Note:" but let
+			// it pass if it's a recognized protocol.
+			return /^(https?|s?ftp|ssh|mailto)?:$/.test( parsed.protocol );
+		}
+
 		return true;
-	} catch {
+	} catch ( error ) {
 		return false;
 	}
 }

--- a/packages/url/src/test/fixtures/bug-24895-data.json
+++ b/packages/url/src/test/fixtures/bug-24895-data.json
@@ -1,0 +1,6 @@
+[
+	{ "input": "HTTP: HyperText Transfer Protocol", "failure": true },
+	{ "input": "URLs begin with a http:// prefix", "failure": true },
+	{ "input": "Note: Not a real scheme", "failure": true },
+	{ "input": "Note:Not a real scheme", "failure": true }
+]

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -31,6 +31,7 @@ import {
 	getQueryArgs,
 } from '../';
 import wptData from './fixtures/wpt-data';
+import bug24895Data from './fixtures/bug-24895-data';
 
 describe( 'isURL', () => {
 	it.each( wptData.map( ( { input, failure } ) => [ input, !! failure ] ) )(
@@ -39,6 +40,12 @@ describe( 'isURL', () => {
 			expect( isURL( input ) ).toBe( ! isFailure );
 		}
 	);
+
+	it.each(
+		bug24895Data.map( ( { input, failure } ) => [ input, !! failure ] )
+	)( '%s', ( input, isFailure ) => {
+		expect( isURL( input ) ).toBe( ! isFailure );
+	} );
 } );
 
 describe( 'isEmail', () => {


### PR DESCRIPTION
## Description

Adds heuristics to `isURL` so it now rejects a few things that the underlying `new URL()` allows. This is not meant to be exhaustive, but covers some common cases.

NOTE: I can't install the master branch (I tested this on 7.7.0).

## How has this been tested?

Node 15 on branch 7.7.0. `npm run test-unit` and `npm run test-unit:native`, adapted to master branch.

## Types of changes

Fixes #24895. Adds some pattern testing to `isURL`.

## Checklist:
- [ ] My code is tested. On the 7.7.0 branch since my master branch would not install.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
