### PR TITLE
[WIP] Border Radius Support: Allow zero, min and max border radius values

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -56,7 +56,10 @@ The settings section has the following structure and default values:
   "settings": {
     "some/context": {
       "border": {
-        "customRadius": false /* true to opt-in */
+        "customRadius": false, /* true to opt-in */
+        "defaultRadius": 0, /* Optional, used as fallback when resetting border radius control */
+        "maxRadius": 50, /* Optional, sets maximum border radius, defaults to `50` */
+        "minRadius": 0 /* Optional, sets minimum border radius, defaults to `0` */
       },
       "color": {
         "custom": true, /* false to opt-out, as in add_theme_support('disable-custom-colors') */

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -118,7 +118,10 @@ class WP_Theme_JSON {
 		),
 		'settings' => array(
 			'border'     => array(
-				'customRadius' => null,
+				'customRadius'  => null,
+				'defaultRadius' => null,
+				'maxRadius'     => null,
+				'minRadius'     => null,
 			),
 			'color'      => array(
 				'custom'         => null,

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -12,8 +12,8 @@ import useEditorFeature from '../components/use-editor-feature';
 import { BORDER_SUPPORT_KEY } from './border';
 import { cleanEmptyObject } from './utils';
 
-const MIN_BORDER_RADIUS_VALUE = 0;
-const MAX_BORDER_RADIUS_VALUE = 50;
+const DEFAULT_MIN_RADIUS = 0;
+const DEFAULT_MAX_RADIUS = 50;
 
 /**
  * Inspector control panel containing the border radius related configuration.
@@ -27,12 +27,16 @@ export function BorderRadiusEdit( props ) {
 		setAttributes,
 	} = props;
 
+	const min = useEditorFeature( 'border.minRadius' ) || DEFAULT_MIN_RADIUS;
+	const max = useEditorFeature( 'border.maxRadius' ) || DEFAULT_MAX_RADIUS;
+	const defaultRadius = useEditorFeature( 'border.defaultRadius' );
+
 	if ( useIsBorderRadiusDisabled( props ) ) {
 		return null;
 	}
 
 	const onChange = ( newRadius ) => {
-		const newStyle = {
+		let newStyle = {
 			...style,
 			border: {
 				...style?.border,
@@ -40,16 +44,21 @@ export function BorderRadiusEdit( props ) {
 			},
 		};
 
-		setAttributes( { style: cleanEmptyObject( newStyle ) } );
+		if ( newRadius === undefined ) {
+			newStyle = cleanEmptyObject( newStyle );
+		}
+
+		setAttributes( { style: newStyle } );
 	};
 
 	return (
 		<RangeControl
 			value={ style?.border?.radius }
 			label={ __( 'Border radius' ) }
-			min={ MIN_BORDER_RADIUS_VALUE }
-			max={ MAX_BORDER_RADIUS_VALUE }
-			initialPosition={ 0 }
+			min={ min }
+			max={ max }
+			initialPosition={ defaultRadius || min }
+			resetFallbackValue={ defaultRadius }
 			allowReset
 			onChange={ onChange }
 		/>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

* Fixes problem where explicitly setting a border radius of zero wasn't honoured https://github.com/WordPress/gutenberg/pull/27667#pullrequestreview-575042015
* Aims to smooth out some of the UX around the border radius control for blocks opting into that support, including allowing configurable min and max values.

#### Issues with this approach

- I couldn't find a clean way to access the current theme.json value for the block's border radius when outside the global styles sidebar. I might be missing something. 
- In the interim, to illustrate the how the control should behave when resetting it, you can add a `defaultRadius` value to the theme.json settings for the block context. Assuming that matches the style value, then the reset would appear to work correctly.

## How has this been tested?
Manually.

#### Testing instructions
1. Checkout this PR
2. Update your theme.json file to opt into the border radius support and define a border radius style for the image block context. [Example gist](https://gist.github.com/aaronrobertshaw/9c1fb0971c135e6250acaae333214a8f).
3. Create a new post and add an image block. It should display with the default radius set in your theme.json
4. Select the block and confirm that you can apply a `0` value border radius and it takes affect.
5. Ensure the border radius control honours the min/max values you set in the theme.json as well.

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/60436221/106098631-16714a00-6185-11eb-8e95-723a6324d4fb.gif" width="400" />


## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
