### PR TITLE
Resolve issue where insertion point is in incorrect position after changing block selection

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1405,6 +1405,7 @@ function resetInsertionPoint( state, action, defaultValue ) {
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK':
 		case 'SELECT_BLOCK':
+		case 'SELECTION_CHANGE':
 		case 'REPLACE_INNER_BLOCKS':
 		case 'INSERT_BLOCKS':
 		case 'REMOVE_BLOCKS':


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes https://github.com/WordPress/gutenberg/pull/28418#issuecomment-767239724

This is very hard to reproduce and will need some testing, ideally from @kevin940726 who originally reproduced it.

Here are my observations:
- Since #26443 `insertionPoint` state has been used to keep track of where the insertion point should be displayed.
- This state needs to be cleared when a few different actions occur, for example when selecting blocks on the `SELECT_BLOCKS` action - https://github.com/WordPress/gutenberg/blob/9631e0db970c0176c7292c040e11fec4d76d999d/packages/block-editor/src/store/reducer.js#L1405-L1413
-  When switching between blocks with RichText, `SELECT_BLOCKS` isn't actually dispatched, `SELECTION_CHANGE` is, which wasn't being handled.
- The `getBlockInsertionPoint` selector uses the `insertionPoint` state as its primary value - https://github.com/WordPress/gutenberg/blob/9631e0db970c0176c7292c040e11fec4d76d999d/packages/block-editor/src/store/selectors.js#L1164-L1166
- If that insertion point is not cleared correctly it can potentially show in the wrong place due to the above

## How has this been tested?
Lots of trial and error 🤷 

As mentioned, I can't reproduce it consistently, so hard to know how to provide test instructions.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
