### PR TITLE
Data: graduate the __experimentalResolveSelect function to a stable status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45794,9 +45794,9 @@
 					"dev": true
 				},
 				"bl": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
+					"integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
 					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Added new `resolveSelect` registry method to initiate and wait for selector resolution
+
 ## 4.26.0 (2020-12-17)
 
 ### New Features

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -591,6 +591,29 @@ components via a consumer.
 See <a name="#RegistryConsumer">RegistryConsumer</a> documentation for
 example.
 
+<a name="resolveSelect" href="#resolveSelect">#</a> **resolveSelect**
+
+Given the name of a registered store, returns an object containing the store's
+selectors pre-bound to state so that you only need to supply additional arguments,
+and modified so that they return promises that resolve to their eventual values,
+after any resolvers have ran.
+
+_Usage_
+
+```js
+import { resolveSelect } from '@wordpress/data';
+
+resolveSelect( 'my-shop' ).getPrice( 'hammer' ).then(console.log)
+```
+
+_Parameters_
+
+-   _storeNameOrDefinition_ `(string|WPDataStore)`: Unique namespace identifier for the store or the store definition.
+
+_Returns_
+
+-   `Object`: Object containing the store's promise-wrapped selectors.
+
 <a name="select" href="#select">#</a> **select**
 
 Given the name or definition of a registered store, returns an object of the store's selectors.

--- a/packages/data/src/controls.js
+++ b/packages/data/src/controls.js
@@ -97,7 +97,7 @@ export const builtinControls = {
 		( registry ) => ( { storeKey, selectorName, args } ) => {
 			const method = registry.select( storeKey )[ selectorName ]
 				.hasResolver
-				? '__experimentalResolveSelect'
+				? 'resolveSelect'
 				: 'select';
 			return registry[ method ]( storeKey )[ selectorName ]( ...args );
 		}

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -106,15 +106,14 @@ export const select = defaultRegistry.select;
  *
  * @example
  * ```js
- * import { __experimentalResolveSelect } from '@wordpress/data';
+ * import { resolveSelect } from '@wordpress/data';
  *
- * __experimentalResolveSelect( 'my-shop' ).getPrice( 'hammer' ).then(console.log)
+ * resolveSelect( 'my-shop' ).getPrice( 'hammer' ).then(console.log)
  * ```
  *
  * @return {Object} Object containing the store's promise-wrapped selectors.
  */
-export const __experimentalResolveSelect =
-	defaultRegistry.__experimentalResolveSelect;
+export const resolveSelect = defaultRegistry.resolveSelect;
 
 /**
  * Given the name of a registered store, returns an object of the store's action creators.

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -148,10 +148,11 @@ export default function createReduxStore( key, options ) {
 				selectors = result.selectors;
 			}
 
+			const resolveSelectors = mapResolveSelectors( selectors, store );
+
 			const getSelectors = () => selectors;
 			const getActions = () => actions;
-			const getResolveSelectors = () =>
-				mapResolveSelectors( selectors, store );
+			const getResolveSelectors = () => resolveSelectors;
 
 			// We have some modules monkey-patching the store object
 			// It's wrong to do so but until we refactor all of our effects to controls
@@ -185,7 +186,7 @@ export default function createReduxStore( key, options ) {
 				selectors,
 				resolvers,
 				getSelectors,
-				__experimentalGetResolveSelectors: getResolveSelectors,
+				getResolveSelectors,
 				getActions,
 				subscribe,
 			};

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -112,17 +112,17 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 *
 	 * @return {Object} Each key of the object matches the name of a selector.
 	 */
-	function __experimentalResolveSelect( storeNameOrDefinition ) {
+	function resolveSelect( storeNameOrDefinition ) {
 		const storeName = isObject( storeNameOrDefinition )
 			? storeNameOrDefinition.name
 			: storeNameOrDefinition;
 		__experimentalListeningStores.add( storeName );
 		const store = stores[ storeName ];
 		if ( store ) {
-			return store.__experimentalGetResolveSelectors();
+			return store.getResolveSelectors();
 		}
 
-		return parent && parent.__experimentalResolveSelect( storeName );
+		return parent && parent.resolveSelect( storeName );
 	}
 
 	/**
@@ -218,7 +218,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		namespaces: stores, // TODO: Deprecate/remove this.
 		subscribe,
 		select,
-		__experimentalResolveSelect,
+		resolveSelect,
 		dispatch,
 		use,
 		register,

--- a/packages/edit-navigation/src/store/controls.js
+++ b/packages/edit-navigation/src/store/controls.js
@@ -167,9 +167,7 @@ const controls = {
 
 	RESOLVE_MENU_ITEMS: createRegistryControl(
 		( registry ) => ( { query } ) => {
-			return registry
-				.__experimentalResolveSelect( 'core' )
-				.getMenuItems( query );
+			return registry.resolveSelect( 'core' ).getMenuItems( query );
 		}
 	),
 };

--- a/packages/edit-navigation/src/store/test/controls.js
+++ b/packages/edit-navigation/src/store/test/controls.js
@@ -271,7 +271,7 @@ describe( 'controls', () => {
 	it( 'triggers RESOLVE_MENU_ITEMS', () => {
 		const getMenuItems = jest.fn( () => [ 'menu-1', 'menu-2' ] );
 		const registry = {
-			__experimentalResolveSelect: jest.fn( () => ( {
+			resolveSelect: jest.fn( () => ( {
 				getMenuItems,
 			} ) ),
 		};
@@ -282,9 +282,7 @@ describe( 'controls', () => {
 			} )
 		).toEqual( [ 'menu-1', 'menu-2' ] );
 
-		expect( registry.__experimentalResolveSelect ).toHaveBeenCalledWith(
-			'core'
-		);
+		expect( registry.resolveSelect ).toHaveBeenCalledWith( 'core' );
 		expect( getMenuItems ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/edit-widgets/src/store/controls.js
+++ b/packages/edit-widgets/src/store/controls.js
@@ -163,14 +163,14 @@ const controls = {
 	RESOLVE_WIDGET_AREAS: createRegistryControl(
 		( registry ) => ( { query } ) => {
 			return registry
-				.__experimentalResolveSelect( 'core' )
+				.resolveSelect( 'core' )
 				.getEntityRecords( KIND, WIDGET_AREA_ENTITY_TYPE, query );
 		}
 	),
 
 	RESOLVE_WIDGETS: createRegistryControl( ( registry ) => ( { query } ) => {
 		return registry
-			.__experimentalResolveSelect( 'core' )
+			.resolveSelect( 'core' )
 			.getEntityRecords( 'root', 'widget', query );
 	} ),
 };


### PR DESCRIPTION
The `registry.resolveSelect()` function and the `resolveSelect` control are already widely used and they proved useful. They no longer need to be kept in the experimental status.

This PR removes the `__experimental` prefix from all definitions and usages.

Also addresses a little performance issue pointed out by @noisysocks in https://github.com/WordPress/gutenberg/pull/27276/commits/ffef5a7b03057994f18cb99dd73f70ba08ad48eb#r565022458: instead of mapping the selectors again and again on every call to `getResolveSelectors()`, we now map them all on store creation/registration.
