### PR TITLE
Fix site editor pins.

### DIFF
--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -107,7 +107,7 @@ body.is-navigation-sidebar-open {
 		display: none;
 
 		@include break-medium() {
-			display: block;
+			display: inline-flex;
 		}
 	}
 


### PR DESCRIPTION
Before:

<img width="297" alt="Screenshot 2021-01-28 at 10 45 07" src="https://user-images.githubusercontent.com/1204802/106119985-1c9c0200-6156-11eb-9bab-0c1dac257e6c.png">

After:

<img width="387" alt="Screenshot 2021-01-28 at 10 45 57" src="https://user-images.githubusercontent.com/1204802/106120003-202f8900-6156-11eb-97a1-6f37c8514ba0.png">

This is almost certainly my bad (#28526) — apologies. But I like how the fix is really tiny!