### PR TITLE
Make custom spacing work with core

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -378,7 +378,7 @@ add_theme_support( 'responsive-embeds' );
 
 ## Spacing control
 
-Using the Gutenberg plugin (version 8.3 or later), some blocks can provide padding controls in the editor for users. This is off by default, and requires the theme to opt in by declaring support:
+Some blocks can have padding controls. This is off by default, and requires the theme to opt in by declaring support:
 
 ```php
 add_theme_support('custom-spacing');

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -45,6 +45,7 @@ function gutenberg_get_common_block_editor_settings() {
 		'disableCustomGradients'                => get_theme_support( 'disable-custom-gradients' ),
 		'enableCustomLineHeight'                => get_theme_support( 'custom-line-height' ),
 		'enableCustomUnits'                     => get_theme_support( 'custom-units' ),
+		'enableCustomSpacing'                   => get_theme_support( 'custom-spacing' ),
 		'imageSizes'                            => $available_image_sizes,
 		'isRTL'                                 => is_rtl(),
 		'maxUploadFileSize'                     => $max_upload_size,

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -65,13 +65,6 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 			$settings['enableCustomUnits'];
 	}
 
-	if ( isset( $settings['enableCustomSpacing'] ) ) {
-		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['spacing'] ) ) {
-			$theme_settings['settings'][ $all_blocks ]['spacing'] = array();
-		}
-		$theme_settings['settings'][ $all_blocks ]['spacing']['customPadding'] = $settings['enableCustomSpacing'];
-	}
-
 	if ( isset( $settings['colors'] ) ) {
 		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['color'] ) ) {
 			$theme_settings['settings'][ $all_blocks ]['color'] = array();
@@ -98,6 +91,22 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 			$theme_settings['settings'][ $all_blocks ]['typography'] = array();
 		}
 		$theme_settings['settings'][ $all_blocks ]['typography']['fontSizes'] = $font_sizes;
+	}
+
+	// This allows to make the plugin work with WordPress 5.7 beta
+	// as well as lower versions. The second check can be removed
+	// as soon as the minimum WordPress version for the plugin
+	// is bumped to 5.7.
+	if ( isset( $settings['enableCustomSpacing'] ) ) {
+		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['spacing'] ) ) {
+			$theme_settings['settings'][ $all_blocks ]['spacing'] = array();
+		}
+		$theme_settings['settings'][ $all_blocks ]['spacing']['customPadding'] = $settings['enableCustomSpacing'];
+	} else if ( current( (array) get_theme_support( 'custom-spacing' ) ) ) {
+		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['spacing'] ) ) {
+			$theme_settings['settings'][ $all_blocks ]['spacing'] = array();
+		}
+		$theme_settings['settings'][ $all_blocks ]['spacing']['customPadding'] = true;
 	}
 
 	// Things that didn't land in core yet, so didn't have a setting assigned.

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -101,13 +101,6 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 	}
 
 	// Things that didn't land in core yet, so didn't have a setting assigned.
-	if ( current( (array) get_theme_support( 'custom-spacing' ) ) ) {
-		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['spacing'] ) ) {
-			$theme_settings['settings'][ $all_blocks ]['spacing'] = array();
-		}
-		$theme_settings['settings'][ $all_blocks ]['spacing']['customPadding'] = true;
-	}
-
 	if ( current( (array) get_theme_support( 'experimental-link-color' ) ) ) {
 		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['color'] ) ) {
 			$theme_settings['settings'][ $all_blocks ]['color'] = array();

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -65,6 +65,13 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 			$settings['enableCustomUnits'];
 	}
 
+	if ( isset( $settings['enableCustomSpacing'] ) ) {
+		if ( ! isset( $theme_settings['settings']['global']['spacing'] ) ) {
+			$theme_settings['settings']['global']['spacing'] = array();
+		}
+		$theme_settings['settings']['global']['spacing']['customPadding'] = $settings['enableCustomSpacing'];
+	}
+
 	if ( isset( $settings['colors'] ) ) {
 		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['color'] ) ) {
 			$theme_settings['settings'][ $all_blocks ]['color'] = array();
@@ -197,6 +204,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	unset( $settings['disableCustomGradients'] );
 	unset( $settings['enableCustomLineHeight'] );
 	unset( $settings['enableCustomUnits'] );
+	unset( $settings['enableCustomSpacing'] );
 	unset( $settings['fontSizes'] );
 	unset( $settings['gradients'] );
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -66,10 +66,10 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 	}
 
 	if ( isset( $settings['enableCustomSpacing'] ) ) {
-		if ( ! isset( $theme_settings['settings']['global']['spacing'] ) ) {
-			$theme_settings['settings']['global']['spacing'] = array();
+		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['spacing'] ) ) {
+			$theme_settings['settings'][ $all_blocks ]['spacing'] = array();
 		}
-		$theme_settings['settings']['global']['spacing']['customPadding'] = $settings['enableCustomSpacing'];
+		$theme_settings['settings'][ $all_blocks ]['spacing']['customPadding'] = $settings['enableCustomSpacing'];
 	}
 
 	if ( isset( $settings['colors'] ) ) {

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -46,7 +46,7 @@ const deprecatedFlags = {
 
 		return settings.enableCustomUnits;
 	},
-	'spacing.customSpacing': ( settings ) => settings.enableCustomSpacing,
+	'spacing.customPadding': ( settings ) => settings.enableCustomSpacing,
 };
 
 function blockAttributesMatch( blockAttributes, attributes ) {

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -46,6 +46,7 @@ const deprecatedFlags = {
 
 		return settings.enableCustomUnits;
 	},
+	'spacing.customSpacing': ( settings ) => settings.enableCustomSpacing,
 };
 
 function blockAttributesMatch( blockAttributes, attributes ) {


### PR DESCRIPTION
WordPress 5.7 will come with support for `custom-spacing`, so this PR makes the necessary changes in Gutenberg to work well with that. See https://github.com/WordPress/wordpress-develop/pull/951

In https://github.com/WordPress/gutenberg/pull/25788 we marked custom spacing as stable but it looks like it missed the WordPress 5.6 cut ([conversation](https://github.com/WordPress/gutenberg/pull/26859#discussion_r521917845)).

## Testing instructions

With WordPress 5.7:

- Create a WordPress environment using the main branch of wordpress-develop (make sure you have the latest changes at https://github.com/WordPress/wordpress-develop/commit/8d7e7d03ff8ad036678851f959792f76d9759025).
- Install and enable the Gutenberg plugin.
- Go to the post editor and add a group block.
- Verify that there's a spacing panel and that it works as expected:

![Captura de ecrã de 2021-01-28 11-50-07](https://user-images.githubusercontent.com/583546/106127642-00e92980-615f-11eb-9648-3d91544c6451.png)

With WordPress < 5.7:

- Using WordPress 5.6 do the same tests as above. It should work the same.
