### PR TITLE
Try more muted sibling inserter.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -406,23 +406,24 @@
 	position: absolute;
 	background: var(--wp-admin-theme-color);
 
-	animation: block-editor-inserter__toggle__fade-in-animation 0.3s ease;
+	// Provide a muted animation that isn't too noisy.
+	animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.3s ease;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 
 	.block-editor-block-list__insertion-point.is-vertical > & {
-		top: calc(50% - #{ $border-width });
-		height: var(--wp-admin-border-width-focus);
-		left: 0;
+		top: 50%;
 		right: 0;
+		left: 0;
+		height: $border-width;
 	}
 
 	.block-editor-block-list__insertion-point.is-horizontal > & {
 		top: 0;
-		height: 100%;
-		left: calc(50% - #{ $border-width });
 		right: 0;
-		width: var(--wp-admin-border-width-focus);
+		left: 50%;
+		height: 100%;
+		width: $border-width;
 	}
 }
 
@@ -458,7 +459,7 @@
 .block-editor-block-list__block-popover-inserter {
 	.block-editor-inserter__toggle.components-button.has-icon {
 		// Basic look
-		background: $gray-900;
+		background: var(--wp-admin-theme-color);
 		border-radius: $radius-block-ui;
 		color: $white;
 		padding: 0;
@@ -469,6 +470,7 @@
 
 		&:hover {
 			color: $white;
+			background: $gray-900;
 		}
 	}
 }
@@ -488,7 +490,7 @@
 	0% {
 		opacity: 0;
 	}
-	80% {
+	60% {
 		opacity: 0;
 	}
 	100% {
@@ -499,11 +501,9 @@
 @keyframes block-editor-inserter__toggle__fade-in-animation {
 	from {
 		opacity: 0;
-		transform: scale(0);
 	}
 	to {
 		opacity: 1;
-		transform: scale(1);
 	}
 }
 


### PR DESCRIPTION
The sibling inserter recently received an animated blue border extending from the center, to indicate orientation of the block being inserted. This is beautiful and useful, but also slightly noisy and prominent in consideration of the writing flow. It also removed the slight delay that showed the inserter only after a little pause:

![before](https://user-images.githubusercontent.com/1204802/106136515-b620df00-6169-11eb-8e4d-6bfe1aeaea57.gif)

This PR pulls it back a little:

- Introduces a delay again, but a shorter one
- Makes the horizontal line 1px thick
- Makes the plus blue same as the top inserter, making it feel like 1 element instead of 2 (it's black on hover)
- Removes the animation in favor of just the fade

On the whole, I feel like that grounds the sibling inserter to strike a better balance, remain useful, while being less noisy. What do you think?

![after](https://user-images.githubusercontent.com/1204802/106136698-ee282200-6169-11eb-9878-1a92a2ca5183.gif)
