### PR TITLE
[RNMobile] Disable Unsupported block editor for Reusable blocks

### DIFF
--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -12,21 +12,15 @@ import {
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import { BottomSheet, Icon, Disabled } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { help } from '@wordpress/icons';
-import {
-	requestUnsupportedBlockFallback,
-	sendActionButtonPressedAction,
-	actionButtons,
-} from '@wordpress/react-native-bridge';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
-import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -42,11 +36,6 @@ export default function ReusableBlockEdit( {
 	const recordArgs = [ 'postType', 'wp_block', ref ];
 
 	const [ showHelp, setShowHelp ] = useState( false );
-	const [ sendFallbackMessage, setSendFallbackMessage ] = useState( false );
-	const [ sendButtonPressMessage, setSendButtonPressMessage ] = useState(
-		false
-	);
-	const timeoutId = useRef();
 	const infoTextStyle = usePreferredColorSchemeStyle(
 		styles.infoText,
 		styles.infoTextDark
@@ -59,23 +48,12 @@ export default function ReusableBlockEdit( {
 		styles.infoSheetIcon,
 		styles.infoSheetIconDark
 	);
-	const actionButtonStyle = usePreferredColorSchemeStyle(
-		styles.actionButton,
-		styles.actionButtonDark
-	);
 	const spinnerStyle = usePreferredColorSchemeStyle(
 		styles.spinner,
 		styles.spinnerDark
 	);
 
-	const {
-		reusableBlock,
-		hasResolved,
-		isEditing,
-		settings,
-		isUnsupportedBlockEditorSupported,
-		canEnableUnsupportedBlockEditor,
-	} = useSelect(
+	const { reusableBlock, hasResolved, isEditing, settings } = useSelect(
 		( select ) => {
 			const { getSettings } = select( 'core/block-editor' );
 
@@ -99,35 +77,16 @@ export default function ReusableBlockEdit( {
 					reusableBlocksStore
 				).__experimentalIsEditingReusableBlock( clientId ),
 				settings: getSettings(),
-				isUnsupportedBlockEditorSupported:
-					getSettings( 'capabilities' ).unsupportedBlockEditor ===
-					true,
-				canEnableUnsupportedBlockEditor:
-					getSettings( 'capabilities' )
-						.canEnableUnsupportedBlockEditor === true,
 			};
 		},
 		[ ref, clientId ]
 	);
-
-	const { invalidateResolution } = useDispatch( 'core' );
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		'wp_block',
 		{ id: ref }
 	);
-
-	useEffect( () => {
-		return () => {
-			clearTimeout( timeoutId.current );
-			/**
-			 * Invalidate entity record upon unmount to keep the reusable block updated
-			 * in case it's modified through UBE
-			 */
-			invalidateResolution( 'getEntityRecord', recordArgs );
-		};
-	}, [] );
 
 	function openSheet() {
 		setShowHelp( true );
@@ -137,19 +96,6 @@ export default function ReusableBlockEdit( {
 		setShowHelp( false );
 	}
 
-	function requestFallback() {
-		closeSheet();
-
-		if (
-			canEnableUnsupportedBlockEditor &&
-			! isUnsupportedBlockEditorSupported
-		) {
-			setSendButtonPressMessage( true );
-		} else {
-			setSendFallbackMessage( true );
-		}
-	}
-
 	function renderSheet() {
 		const infoTitle =
 			Platform.OS === 'android'
@@ -157,42 +103,12 @@ export default function ReusableBlockEdit( {
 						"Reusable blocks aren't editable on WordPress for Android"
 				  )
 				: __( "Reusable blocks aren't editable on WordPress for iOS" );
-		const reusableBlockActionButton = applyFilters(
-			'native.reusable_block_action_button',
-			__( 'Edit using web editor' )
-		);
 
 		return (
 			<BottomSheet
 				isVisible={ showHelp }
 				hideHeader
 				onClose={ closeSheet }
-				onModalHide={ () => {
-					if ( sendFallbackMessage ) {
-						// On iOS, onModalHide is called when the controller is still part of the hierarchy.
-						// A small delay will ensure that the controller has already been removed.
-						timeoutId.current = setTimeout( () => {
-							requestUnsupportedBlockFallback(
-								`<!-- wp:block {"ref":${ reusableBlock.id }} /-->`,
-								clientId,
-								reusableBlock.name,
-								reusableBlock.title
-							);
-							invalidateResolution(
-								'getEntityRecord',
-								recordArgs
-							);
-						}, 100 );
-						setSendFallbackMessage( false );
-					} else if ( sendButtonPressMessage ) {
-						timeoutId.current = setTimeout( () => {
-							sendActionButtonPressedAction(
-								actionButtons.missingBlockAlertActionButton
-							);
-						}, 100 );
-						setSendButtonPressMessage( false );
-					}
-				} }
 			>
 				<View style={ styles.infoContainer }>
 					<Icon
@@ -204,23 +120,6 @@ export default function ReusableBlockEdit( {
 						{ infoTitle }
 					</Text>
 				</View>
-				{ ( isUnsupportedBlockEditorSupported ||
-					canEnableUnsupportedBlockEditor ) && (
-					<>
-						<BottomSheet.Cell
-							label={ reusableBlockActionButton }
-							separatorType="topFullWidth"
-							onPress={ requestFallback }
-							labelStyle={ actionButtonStyle }
-						/>
-						<BottomSheet.Cell
-							label={ __( 'Dismiss' ) }
-							separatorType="topFullWidth"
-							onPress={ closeSheet }
-							labelStyle={ actionButtonStyle }
-						/>
-					</>
-				) }
 			</BottomSheet>
 		);
 	}

--- a/packages/block-library/src/block/editor.native.scss
+++ b/packages/block-library/src/block/editor.native.scss
@@ -94,14 +94,6 @@
 	color: $white;
 }
 
-.actionButton {
-	color: $blue-50;
-}
-
-.actionButtonDark {
-	color: $blue-30;
-}
-
 .spinner {
 	height: $grid-unit-60;
 	border-width: $border-width;

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -31,6 +31,9 @@ import { applyFilters } from '@wordpress/hooks';
  */
 import styles from './style.scss';
 
+// Blocks that can't be edited through the Unsupported block editor identified by their name.
+const UBE_UNSUPPORTED_BLOCKS = [ 'core/block' ];
+
 export class UnsupportedBlockEdit extends Component {
 	constructor( props ) {
 		super( props );
@@ -110,6 +113,7 @@ export class UnsupportedBlockEdit extends Component {
 			clientId,
 			isUnsupportedBlockEditorSupported,
 			canEnableUnsupportedBlockEditor,
+			isEditableInUnsupportedBlockEditor,
 		} = this.props;
 		const infoTextStyle = getStylesFromColorScheme(
 			styles.infoText,
@@ -187,27 +191,30 @@ export class UnsupportedBlockEdit extends Component {
 					<Text style={ [ infoTextStyle, infoTitleStyle ] }>
 						{ infoTitle }
 					</Text>
-					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
-						{ missingBlockDetail }
-					</Text>
+					{ isEditableInUnsupportedBlockEditor && (
+						<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
+							{ missingBlockDetail }
+						</Text>
+					) }
 				</View>
 				{ ( isUnsupportedBlockEditorSupported ||
-					canEnableUnsupportedBlockEditor ) && (
-					<>
-						<BottomSheet.Cell
-							label={ missingBlockActionButton }
-							separatorType="topFullWidth"
-							onPress={ this.requestFallback }
-							labelStyle={ actionButtonStyle }
-						/>
-						<BottomSheet.Cell
-							label={ __( 'Dismiss' ) }
-							separatorType="topFullWidth"
-							onPress={ this.toggleSheet }
-							labelStyle={ actionButtonStyle }
-						/>
-					</>
-				) }
+					canEnableUnsupportedBlockEditor ) &&
+					isEditableInUnsupportedBlockEditor && (
+						<>
+							<BottomSheet.Cell
+								label={ missingBlockActionButton }
+								separatorType="topFullWidth"
+								onPress={ this.requestFallback }
+								labelStyle={ actionButtonStyle }
+							/>
+							<BottomSheet.Cell
+								label={ __( 'Dismiss' ) }
+								separatorType="topFullWidth"
+								onPress={ this.toggleSheet }
+								labelStyle={ actionButtonStyle }
+							/>
+						</>
+					) }
 			</BottomSheet>
 		);
 	}
@@ -269,7 +276,7 @@ export class UnsupportedBlockEdit extends Component {
 }
 
 export default compose( [
-	withSelect( ( select ) => {
+	withSelect( ( select, { attributes } ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return {
 			isUnsupportedBlockEditorSupported:
@@ -277,6 +284,9 @@ export default compose( [
 			canEnableUnsupportedBlockEditor:
 				getSettings( 'capabilities' )
 					.canEnableUnsupportedBlockEditor === true,
+			isEditableInUnsupportedBlockEditor: ! UBE_UNSUPPORTED_BLOCKS.includes(
+				attributes.originalName
+			),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -32,7 +32,7 @@ import { applyFilters } from '@wordpress/hooks';
 import styles from './style.scss';
 
 // Blocks that can't be edited through the Unsupported block editor identified by their name.
-const UBE_UNSUPPORTED_BLOCKS = [ 'core/block' ];
+const UBE_INCOMPATIBLE_BLOCKS = [ 'core/block' ];
 
 export class UnsupportedBlockEdit extends Component {
 	constructor( props ) {
@@ -284,7 +284,7 @@ export default compose( [
 			canEnableUnsupportedBlockEditor:
 				getSettings( 'capabilities' )
 					.canEnableUnsupportedBlockEditor === true,
-			isEditableInUnsupportedBlockEditor: ! UBE_UNSUPPORTED_BLOCKS.includes(
+			isEditableInUnsupportedBlockEditor: ! UBE_INCOMPATIBLE_BLOCKS.includes(
 				attributes.originalName
 			),
 		};

--- a/packages/block-library/src/missing/test/edit.native.js
+++ b/packages/block-library/src/missing/test/edit.native.js
@@ -9,7 +9,9 @@ import { Text } from 'react-native';
  */
 import { BottomSheet, Icon } from '@wordpress/components';
 import { help, plugins } from '@wordpress/icons';
+import { storeConfig } from '@wordpress/block-editor';
 jest.mock( '@wordpress/blocks' );
+jest.mock( '@wordpress/block-editor/src/store/selectors' );
 
 /**
  * Internal dependencies
@@ -27,6 +29,10 @@ const getTestComponentWithContent = ( attributes = defaultAttributes ) => {
 };
 
 describe( 'Missing block', () => {
+	beforeEach( () => {
+		storeConfig.selectors.getSettings.mockReturnValue( {} );
+	} );
+
 	it( 'renders without crashing', () => {
 		const component = getTestComponentWithContent();
 		const rendered = component.toJSON();
@@ -61,6 +67,47 @@ describe( 'Missing block', () => {
 					defaultAttributes.originalName +
 					"' is not fully-supported"
 			);
+		} );
+
+		describe( 'Unsupported block editor', () => {
+			beforeEach( () => {
+				// By default we set the web editor as available
+				storeConfig.selectors.getSettings.mockReturnValue( {
+					unsupportedBlockEditor: true,
+				} );
+			} );
+
+			it( 'renders edit action if web editor is available', () => {
+				const component = getTestComponentWithContent();
+				const testInstance = component.root;
+				const bottomSheet = testInstance.findByType( BottomSheet );
+				const bottomSheetCells = bottomSheet.props.children[ 1 ];
+				expect( bottomSheetCells ).toBeTruthy();
+				expect( bottomSheetCells.props.children.length ).toBe( 2 );
+				expect( bottomSheetCells.props.children[ 0 ].props.label ).toBe(
+					'Edit using web editor'
+				);
+			} );
+
+			it( 'does not render edit action if is not available', () => {
+				storeConfig.selectors.getSettings.mockReturnValue( {
+					unsupportedBlockEditor: false,
+				} );
+
+				const component = getTestComponentWithContent();
+				const testInstance = component.root;
+				const bottomSheet = testInstance.findByType( BottomSheet );
+				expect( bottomSheet.props.children[ 1 ] ).toBeFalsy();
+			} );
+
+			it( 'does not render edit action if editing the block is not supported', () => {
+				const component = getTestComponentWithContent( {
+					originalName: 'core/block',
+				} );
+				const testInstance = component.root;
+				const bottomSheet = testInstance.findByType( BottomSheet );
+				expect( bottomSheet.props.children[ 1 ] ).toBeFalsy();
+			} );
 		} );
 	} );
 

--- a/packages/block-library/src/missing/test/edit.native.js
+++ b/packages/block-library/src/missing/test/edit.native.js
@@ -69,7 +69,7 @@ describe( 'Missing block', () => {
 			);
 		} );
 
-		describe( 'Unsupported block editor', () => {
+		describe( 'Unsupported block editor (UBE)', () => {
 			beforeEach( () => {
 				// By default we set the web editor as available
 				storeConfig.selectors.getSettings.mockReturnValue( {
@@ -77,7 +77,7 @@ describe( 'Missing block', () => {
 				} );
 			} );
 
-			it( 'renders edit action if web editor is available', () => {
+			it( 'renders edit action if UBE is available', () => {
 				const component = getTestComponentWithContent();
 				const testInstance = component.root;
 				const bottomSheet = testInstance.findByType( BottomSheet );
@@ -89,7 +89,7 @@ describe( 'Missing block', () => {
 				);
 			} );
 
-			it( 'does not render edit action if is not available', () => {
+			it( 'does not render edit action if UBE is not available', () => {
 				storeConfig.selectors.getSettings.mockReturnValue( {
 					unsupportedBlockEditor: false,
 				} );
@@ -100,7 +100,7 @@ describe( 'Missing block', () => {
 				expect( bottomSheet.props.children[ 1 ] ).toBeFalsy();
 			} );
 
-			it( 'does not render edit action if editing the block is not supported', () => {
+			it( 'does not render edit action if the block is incompatible with UBE', () => {
 				const component = getTestComponentWithContent( {
 					originalName: 'core/block',
 				} );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 * [**] Add support for setting heading anchors
+* [**] Disable Unsupported Block Editor for Reusable blocks
 
 
 #### Bug Fix


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3067

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Reusable blocks are no longer editable through UBE (Unsupported block editor) due to recent changes in the editing flow on the web version. Until we fully support editing them in the native editor, the edition through UBE should be disabled.

### `core/block` [Reusable block] _(only enabled in development mode)_
All UBE related logic has been removed, now on double tap on the block only a message is displayed.

### `missing/block` [Missing block]
A list with the unsupported blocks has been added to this block, this way we can control whether display the option for editing it using the web editor (UBE).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Since these changes are related to unsupported blocks, it requires a quick setup to be done in the **web version editor**:
1. Create a post/page.
2. Add a block that is not supported in the native editor like GIF (`jetpack/gif`).
3. Create a Reusable block and add it.
4. Save the post/page.

The following flows have been used for testing these changes:

<details><summary>Reusable block (dev mode only)</summary>

**This has to be tested in development mode.**

### Steps
1. Go to a post/page that has a Reusable block.
2. Tap on it two times.
3. Check that there's no option to edit it through the web editor.

</details>

<details><summary>Missing block - UBE supported block</summary>

### Steps
1. Go to a post/page that has a block that is not supported in the native editor.
2. Tap on it two times.
3. Check that the option of editing it through the web editor is displayed.

</details>

<details><summary>Missing block - UBE unsupported block</summary>

**This has to be tested in release mode or by disabling the Reusable block from the block list in [`block-library` package](https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/index.native.js#L228).** 

### Steps
1. Go to a post/page that has a Reusable block.
2. Tap on it two times.
3. Check that there's no option to edit it through the web editor.

</details>

## Screenshots <!-- if applicable -->

<details><summary>Reusable block (dev mode only)</summary>

<img src=https://user-images.githubusercontent.com/14905380/106141091-ef5c4d80-616f-11eb-910c-d3bd3bbae08e.png width=400>

</details>

<details><summary>Missing block (jetpack/gif) - UBE supported block</summary>

<img src=https://user-images.githubusercontent.com/14905380/106141886-10716e00-6171-11eb-9928-4181199b33b2.png width=400>

</details>

<details><summary>Missing block (core/block) - UBE unsupported block</summary>

<img src=https://user-images.githubusercontent.com/14905380/106141935-1d8e5d00-6171-11eb-9e33-2dda6ff33d09.png width=400>

</details>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
