### PR TITLE
Ensure sticky tabs are in front of their panel’s descendants 

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -10,13 +10,18 @@ $z-layers: (
 	".block-editor-block-list__layout .reusable-block-indicator": 1,
 	".block-editor-block-list__block-selection-button": 22,
 	".components-form-toggle__input": 1,
-	".components-panel__header.edit-post-sidebar__panel-tabs": -1,
-	".edit-post-sidebar .components-panel": -2,
 	".edit-post-text-editor__toolbar": 1,
-	".block-editor-inserter__tabs": 1,
 	".edit-post-sidebar__panel-tab.is-active": 1,
-	".block-editor-inserter__tab.is-active": 1,
-	".components-panel__header": 1,
+
+	// These next three share a stacking context
+	".block-editor-inserter__tabs .components-tab-panel__tab-content": 0, // lower scrolling content
+	".block-editor-inserter__tabs .components-tab-panel__tabs": 1, // higher sticky element
+	".block-editor-inserter__search": 1, // higher sticky element
+
+	// These next two share a stacking context
+	".interface-complementary-area .components-panel" : 0, // lower scrolling content
+	".interface-complementary-area .components-panel__header": 1, // higher sticky element
+
 	".components-modal__header": 10,
 	".edit-post-meta-boxes-area.is-loading::before": 1,
 	".edit-post-meta-boxes-area .spinner": 5,

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -99,7 +99,7 @@ $block-inserter-tabs-height: 44px;
 	position: sticky;
 	top: 0;
 	background: $white;
-	z-index: 1;
+	z-index: z-index(".block-editor-inserter__search");
 
 	input[type="search"].block-editor-inserter__search-input {
 		@include input-control;
@@ -157,7 +157,7 @@ $block-inserter-tabs-height: 44px;
 		// Computed based off the search input height and paddings
 		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60;
 		background: $white;
-		z-index: 1;
+		z-index: z-index(".block-editor-inserter__tabs .components-tab-panel__tabs");
 		border-bottom: $border-width solid $gray-300;
 
 		.components-tab-panel__tabs-item {
@@ -172,7 +172,7 @@ $block-inserter-tabs-height: 44px;
 		flex-direction: column;
 		// Make a stacking context that keeps all descendents behind the sticky tabs
 		position: relative;
-		z-index: 0;
+		z-index: z-index(".block-editor-inserter__tabs .components-tab-panel__tab-content");
 	}
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -170,7 +170,9 @@ $block-inserter-tabs-height: 44px;
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;
+		// Make a stacking context that keeps all descendents behind the sticky tabs
 		position: relative;
+		z-index: 0;
 	}
 }
 

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -14,13 +14,13 @@
 		border: none;
 		// Make a stacking context that keeps all descendents behind the sticky header
 		position: relative;
-		z-index: -1 + z-index(".components-panel__header");
+		z-index: z-index(".interface-complementary-area .components-panel");
 	}
 
 	.components-panel__header {
 		position: sticky;
 		top: 0;
-		z-index: z-index(".components-panel__header");
+		z-index: z-index(".interface-complementary-area .components-panel__header");
 
 		&.edit-post-sidebar__panel-tabs {
 			top: $panel-header-height;

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -12,6 +12,9 @@
 
 	.components-panel {
 		border: none;
+		// Make a stacking context that keeps all descendents behind the sticky header
+		position: relative;
+		z-index: -1 + z-index(".components-panel__header");
 	}
 
 	.components-panel__header {


### PR DESCRIPTION
#28003 brought sticky tabs to the sidebar inspector 🎉  . One thing that was (understandably) overlooked was that descendants might not stack as expected:
![image](https://user-images.githubusercontent.com/9000376/106173223-8f05e580-6148-11eb-8ebb-1a4c87b6c4d4.png)

This PR adds a little style to prevent that.

UPDATE: now that #28642 has appeared, I've pushed another commit to apply the same approach to styles for the inserter tab panel content.

## How has this been tested?
Scrolling the inserter and sidebar inspector to verify no descendants appear in front of the sticker header/tabs.

## Types of changes
Bug fix #28642

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
