### PR TITLE
Fix issues causing the cover block to black out with a fixed background

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -335,9 +335,10 @@ function CoverEdit( {
 	const style = {
 		...( isImageBackground && ! isImgElement
 			? backgroundImageStyles( url )
-			: {} ),
+			: {
+					backgroundImage: gradientValue ? gradientValue : undefined,
+			  } ),
 		backgroundColor: overlayColor.color,
-		background: gradientValue && ! url ? gradientValue : undefined,
 		minHeight: temporaryMinHeight || minHeightWithUnit || undefined,
 	};
 
@@ -588,7 +589,7 @@ function CoverEdit( {
 							'wp-block-cover__gradient-background',
 							gradientClass
 						) }
-						style={ { background: gradientValue } }
+						style={ { backgroundImage: gradientValue } }
 					/>
 				) }
 				{ isImageBackground && isImgElement && (


### PR DESCRIPTION
## Description
Fixes #28557. There were actually two things that were happening to cause the problem:

### First Issue
The CoverEdit component was setting a background using both `background: ` and `backgroundImage:` This was causing a console error(See below), and is [know to cause inconsistent styling](https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-conflicting-style-rules).
```
react_devtools_backend.js:2430 Warning: Removing a style property during rerender (backgroundImage) when a conflicting property is set (background) can lead to styling bugs. To avoid this, don't mix shorthand and non-shorthand properties for the same value; instead, replace the shorthand with separate values.
    in div (created by CoverEdit)
    in CoverEdit (created by WithInstanceId(CoverEdit))
```

### Second Issue
Ironically, once I fixed that, ANY background image with the "fixed background" option was hidden. This is because when setting the styles, after the line setting the backgroundImage for the background, there was a line possibly setting a backgroundImage for a gradient. This was correctly checking for an image background to prevent a gradient from getting set, but was incorrectly setting backgroundImage to undefined if the condition failed - overwriting the existing backgroundImage with `undefined`.

## How has this been tested?
Add a Cover block with an image background
Observe you can toggle a fixed position, change the block alignement, and the background image still displays
Also, observe there are no longer warning in the console

## Screenshots
![jPFTq3qKWu](https://user-images.githubusercontent.com/6653970/106189077-cf2f8d00-6175-11eb-987f-3d70b4b17608.gif)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
