### PR TITLE
Contact info inner blocks disappearing

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -153,11 +153,12 @@ export class BlockList extends Component {
 		const { isRootList, maxWidth } = this.props;
 
 		const layoutWidth = Math.floor( layout.width );
-
 		if ( isRootList && blockWidth !== layoutWidth ) {
 			this.setState( {
 				blockWidth: Math.min( layoutWidth, maxWidth ),
 			} );
+		} else if ( ! isRootList && ! blockWidth ) {
+			this.setState( { blockWidth: Math.min( layoutWidth, maxWidth ) } );
 		}
 	}
 


### PR DESCRIPTION
Fixes [#3064](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3064).
`gutenberg-mobile`: [#3071](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3071)

## Description
Contact Info inner blocks were disappearing because `blockWidth` wasn't set and `render` in `BlockListItem` now returns `null` if `blockWidth` is `undefined` or `0`.

## How has this been tested?
1. Open app and insert contact info block.
2. Verify that contact info block has email/address/phone inner blocks by default.

## Screenshots <!-- if applicable -->
![Simulator Screen Shot - iPhone 11 - 2021-01-28 at 16 28 54](https://user-images.githubusercontent.com/13263478/106206571-ed04ee00-6185-11eb-8033-ace5ef3bf1a3.png)

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
