### PR TITLE
Add a full screen modal component

### DIFF
--- a/packages/components/src/modal/header.js
+++ b/packages/components/src/modal/header.js
@@ -40,7 +40,12 @@ const ModalHeader = ( {
 				) }
 			</div>
 			{ isDismissible && (
-				<Button onClick={ onClose } icon={ close } label={ label } />
+				<Button
+					className="components-modal-header__close"
+					onClick={ onClose }
+					icon={ close }
+					label={ label }
+				/>
 			) }
 		</div>
 	);

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Component, createPortal } from '@wordpress/element';
@@ -102,6 +107,7 @@ class Modal extends Component {
 	 */
 	render() {
 		const {
+			overlayClassName,
 			onRequestClose,
 			title,
 			icon,
@@ -109,6 +115,7 @@ class Modal extends Component {
 			children,
 			aria,
 			instanceId,
+			isFullscreen,
 			isDismissible,
 			isDismissable, //Deprecated
 			// Many of the documented props for Modal are passed straight through
@@ -134,9 +141,17 @@ class Modal extends Component {
 					labelledby: title ? headingId : null,
 					describedby: aria.describedby,
 				} }
+				overlayClassName={ classnames(
+					'components-modal__screen-overlay',
+					overlayClassName,
+					{
+						'is-dialog': ! isFullscreen,
+						'is-full-screen': isFullscreen,
+					}
+				) }
 				{ ...otherProps }
 			>
-				<div className={ 'components-modal__content' } role="document">
+				<div className="components-modal__content" role="document">
 					<ModalHeader
 						closeLabel={ closeButtonLabel }
 						headingId={ headingId }

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -36,7 +36,7 @@ class Modal extends Component {
 		openModalCount++;
 
 		if ( openModalCount === 1 ) {
-			this.openFirstModal();
+			this.openFirstModal( this.props.isFullscreen );
 		}
 	}
 
@@ -48,7 +48,7 @@ class Modal extends Component {
 		openModalCount--;
 
 		if ( openModalCount === 0 ) {
-			this.closeLastModal();
+			this.closeLastModal( this.props.isFullscreen );
 		}
 
 		this.cleanDOM();
@@ -66,6 +66,7 @@ class Modal extends Component {
 	prepareDOM() {
 		if ( ! parentElement ) {
 			parentElement = document.createElement( 'div' );
+			parentElement.className = 'components-modal__portal';
 			document.body.appendChild( parentElement );
 		}
 		this.node = document.createElement( 'div' );
@@ -85,19 +86,29 @@ class Modal extends Component {
 	 * It appends an additional div to the body for the modals to be rendered in,
 	 * it hides any other elements from screen-readers and adds an additional class
 	 * to the body to prevent scrolling while the modal is open.
+	 *
+	 * @param {boolean} isFullscreen
 	 */
-	openFirstModal() {
+	openFirstModal( isFullscreen ) {
 		ariaHelper.hideApp( parentElement );
 		document.body.classList.add( this.props.bodyOpenClassName );
+		if ( isFullscreen ) {
+			document.body.classList.add( 'is-fullscreen-modal' );
+		}
 	}
 
 	/**
 	 * Cleans up the DOM after the last modal is closed and makes the app available
 	 * for screen-readers again.
+	 *
+	 * @param {boolean} isFullscreen
 	 */
-	closeLastModal() {
+	closeLastModal( isFullscreen ) {
 		document.body.classList.remove( this.props.bodyOpenClassName );
 		ariaHelper.showApp();
+		if ( isFullscreen ) {
+			document.body.classList.remove( 'is-fullscreen-modal' );
+		}
 	}
 
 	/**

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,15 +5,49 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba($black, 0.35);
 	z-index: z-index(".components-modal__screen-overlay");
 
-	// This animates the appearance of the white background.
-	@include edit-post__fade-in-animation();
+	&.is-full-screen {
+		padding: 20px;
+		background: $white;
+		overflow: auto;
+
+		@include break-small() {
+			padding: 100px;
+		}
+
+		// These are two divs rendered by Higher-order components
+		// We need their height to be 100% for the verticalcentering
+		// of the modal.
+		& > div,
+		& > div > div {
+			height: 100%;
+		}
+	}
+
+	&.is-dialog {
+		// This animates the appearance of the background.
+		@include edit-post__fade-in-animation();
+
+		background-color: rgba($black, 0.7);
+	}
 }
 
 // The modal window element.
-.components-modal__frame {
+.components-modal__screen-overlay.is-full-screen .components-modal__frame {
+	max-width: 800px;
+	min-height: 100%;
+	margin: auto;
+	display: grid;
+	align-items: center;
+
+	// Animate the modal frame/contents appearing on the page.
+	transform-origin: top center;
+	animation: components-modal__appear-scale-animation 0.2s forwards;
+	@include reduce-motion("animation");
+}
+
+.components-modal__screen-overlay.is-dialog .components-modal__frame {
 	// On small screens the content needs to be full width because of limited
 	// space.
 	position: absolute;
@@ -38,20 +72,10 @@
 		max-width: calc(100% - #{ $grid-unit-20 } - #{ $grid-unit-20 });
 		max-height: 90%;
 		transform: translate(-50%, -50%);
-
 		// Animate the modal frame/contents appearing on the page.
-		animation: components-modal__appear-animation 0.1s ease-out;
+		animation: components-modal__appear-slide-animation 0.1s ease-out;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");
-	}
-}
-
-@keyframes components-modal__appear-animation {
-	from {
-		margin-top: $grid-unit-40;
-	}
-	to {
-		margin-top: 0;
 	}
 }
 
@@ -60,34 +84,31 @@
 // modal screen).
 .components-modal__header {
 	box-sizing: border-box;
-	border-bottom: $border-width solid $gray-300;
-	padding: 0 $grid-unit-30;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 	background: $white;
 	align-items: center;
 	height: $header-height;
-	z-index: z-index(".components-modal__header");
-	// For z-index to take effect, the element must be positioned. A "sticky"
-	// element is positioned, but since this is not supported in IE11,
-	// "relative" is used as a fallback.
-	position: relative;
-	position: sticky;
-	top: 0;
-	margin: 0 -#{$grid-unit-30} $grid-unit-30;
+	margin-bottom: 2 * $grid-unit-30;
 
-	// Rules inside this query are only run by Microsoft Edge.
-	// Edge has bugs around position: sticky;, so it needs a separate top rule.
-	// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
-	@supports (-ms-ime-align:auto) {
-		position: fixed;
-		width: 100%;
-	}
+	.components-modal__screen-overlay.is-dialog & {
+		border-bottom: $border-width solid $gray-300;
+		padding: 0 $grid-unit-30;
 
-	.components-modal__header-heading {
-		font-size: 1rem;
-		font-weight: 600;
+		position: relative;
+		position: sticky;
+		top: 0;
+		z-index: z-index(".components-modal__header");
+		margin: 0 -#{$grid-unit-30} $grid-unit-30;
+
+		// Rules inside this query are only run by Microsoft Edge.
+		// Edge has bugs around position: sticky;, so it needs a separate top rule.
+		// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
+		@supports (-ms-ime-align:auto) {
+			position: fixed;
+			width: 100%;
+		}
 	}
 
 	h1 {
@@ -99,6 +120,16 @@
 		position: relative;
 		left: $grid-unit-10;
 	}
+}
+
+.components-modal__screen-overlay.is-dialog .components-modal__header-heading {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.components-modal__screen-overlay.is-full-screen .components-modal__header-heading {
+	font-size: 2rem;
+	font-weight: 300;
 }
 
 .components-modal__header-heading-container {
@@ -122,12 +153,37 @@
 // Modal contents.
 .components-modal__content {
 	box-sizing: border-box;
-	height: 100%;
 	padding: 0 $grid-unit-30 $grid-unit-30;
 
-	// Rules inside this query are only run by Microsoft Edge.
-	// This is a companion top padding to the fixed rule in line 77.
-	@supports (-ms-ime-align:auto) {
-		padding-top: $header-height;
+	.components-modal__screen-overlay.is-dialog & {
+		height: 100%;
+
+		// Rules inside this query are only run by Microsoft Edge.
+		// This is a companion top padding to the fixed rule in line 77.
+		@supports (-ms-ime-align:auto) {
+			padding-top: $header-height;
+		}
+	}
+}
+
+.components-modal__screen-overlay.is-full-screen .components-modal-header__close svg {
+	transform: scale(1.5);
+}
+
+@keyframes components-modal__appear-scale-animation {
+	from {
+		transform: scale(0.1);
+	}
+	to {
+		transform: scale(1);
+	}
+}
+
+@keyframes components-modal__appear-slide-animation {
+	from {
+		margin-top: $grid-unit-40;
+	}
+	to {
+		margin-top: 0;
 	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -140,10 +140,6 @@ body.modal-open.is-fullscreen-modal {
 		animation: components-modal__content-scale-back 0.4s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
 	}
 
-	.interface-interface-skeleton__editor {
-		border-radius: $grid-unit-10;
-	}
-
 	// Increase full screen modal padding on medium+ screens
 	@include break-medium() {
 		.components-modal__header {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -6,48 +6,12 @@
 	bottom: 0;
 	left: 0;
 	z-index: z-index(".components-modal__screen-overlay");
-
-	&.is-full-screen {
-		padding: 20px;
-		background: $white;
-		overflow: auto;
-
-		@include break-small() {
-			padding: 100px;
-		}
-
-		// These are two divs rendered by Higher-order components
-		// We need their height to be 100% for the verticalcentering
-		// of the modal.
-		& > div,
-		& > div > div {
-			height: 100%;
-		}
-	}
-
-	&.is-dialog {
-		// This animates the appearance of the background.
-		@include edit-post__fade-in-animation();
-
-		background-color: rgba($black, 0.7);
-	}
+	background-color: rgba($black, 0.7);
+	// This animates the appearance of the background.
+	@include edit-post__fade-in-animation();
 }
 
-// The modal window element.
-.components-modal__screen-overlay.is-full-screen .components-modal__frame {
-	max-width: 800px;
-	min-height: 100%;
-	margin: auto;
-	display: grid;
-	align-items: center;
-
-	// Animate the modal frame/contents appearing on the page.
-	transform-origin: top center;
-	animation: components-modal__appear-scale-animation 0.2s forwards;
-	@include reduce-motion("animation");
-}
-
-.components-modal__screen-overlay.is-dialog .components-modal__frame {
+.components-modal__frame {
 	// On small screens the content needs to be full width because of limited
 	// space.
 	position: absolute;
@@ -60,21 +24,29 @@
 	border: $border-width solid $gray-300;
 	background: $white;
 	box-shadow: $shadow-modal;
-	overflow: auto;
 
-	// Show a centered modal on bigger screens.
-	@include break-small() {
-		top: 50%;
-		right: auto;
-		bottom: auto;
-		left: 50%;
-		min-width: $modal-min-width;
-		max-width: calc(100% - #{ $grid-unit-20 } - #{ $grid-unit-20 });
-		max-height: 90%;
-		transform: translate(-50%, -50%);
-		// Animate the modal frame/contents appearing on the page.
-		animation: components-modal__appear-slide-animation 0.1s ease-out;
-		animation-fill-mode: forwards;
+	.components-modal__screen-overlay.is-dialog & {
+		// Show a centered modal on bigger screens.
+		@include break-small() {
+			top: 50%;
+			right: auto;
+			bottom: auto;
+			left: 50%;
+			min-width: $modal-min-width;
+			max-width: calc(100% - #{ $grid-unit-20 } - #{ $grid-unit-20 });
+			max-height: 90%;
+			transform: translate(-50%, -50%);
+			// Animate the modal frame/contents appearing on the page.
+			animation: components-modal__appear-slide-animation 0.1s ease-out;
+			animation-fill-mode: forwards;
+			@include reduce-motion("animation");
+		}
+	}
+
+	.components-modal__screen-overlay.is-full-screen & {
+		top: 100%;
+		transform-origin: top center;
+		animation: components-modal__appear-slide-from-bottom 0.3s forwards;
 		@include reduce-motion("animation");
 	}
 }
@@ -92,23 +64,21 @@
 	height: $header-height;
 	margin-bottom: 2 * $grid-unit-30;
 
-	.components-modal__screen-overlay.is-dialog & {
-		border-bottom: $border-width solid $gray-300;
-		padding: 0 $grid-unit-30;
+	border-bottom: $border-width solid $gray-300;
+	padding: 0 $grid-unit-30;
 
-		position: relative;
-		position: sticky;
-		top: 0;
-		z-index: z-index(".components-modal__header");
-		margin: 0 -#{$grid-unit-30} $grid-unit-30;
+	position: relative;
+	position: sticky;
+	top: 0;
+	z-index: z-index(".components-modal__header");
+	margin: 0 -#{$grid-unit-30} $grid-unit-30;
 
-		// Rules inside this query are only run by Microsoft Edge.
-		// Edge has bugs around position: sticky;, so it needs a separate top rule.
-		// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
-		@supports (-ms-ime-align:auto) {
-			position: fixed;
-			width: 100%;
-		}
+	// Rules inside this query are only run by Microsoft Edge.
+	// Edge has bugs around position: sticky;, so it needs a separate top rule.
+	// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
+	@supports (-ms-ime-align:auto) {
+		position: fixed;
+		width: 100%;
 	}
 
 	h1 {
@@ -122,14 +92,9 @@
 	}
 }
 
-.components-modal__screen-overlay.is-dialog .components-modal__header-heading {
+.components-modal__screen-overlay .components-modal__header-heading {
 	font-size: 1rem;
 	font-weight: 600;
-}
-
-.components-modal__screen-overlay.is-full-screen .components-modal__header-heading {
-	font-size: 2rem;
-	font-weight: 300;
 }
 
 .components-modal__header-heading-container {
@@ -155,8 +120,9 @@
 	box-sizing: border-box;
 	padding: 0 $grid-unit-30 $grid-unit-30;
 
-	.components-modal__screen-overlay.is-dialog & {
+	.components-modal__screen-overlay & {
 		height: 100%;
+		overflow: auto;
 
 		// Rules inside this query are only run by Microsoft Edge.
 		// This is a companion top padding to the fixed rule in line 77.
@@ -164,18 +130,21 @@
 			padding-top: $header-height;
 		}
 	}
+
 }
 
-.components-modal__screen-overlay.is-full-screen .components-modal-header__close svg {
-	transform: scale(1.5);
+// Scale down the content of the page.
+body.modal-open.is-fullscreen-modal > *:not(.components-modal__portal) {
+	transition: transform 0.5s;
+	transform: scale(0.9);
 }
 
-@keyframes components-modal__appear-scale-animation {
+@keyframes components-modal__appear-slide-from-bottom {
 	from {
-		transform: scale(0.1);
+		top: 100%;
 	}
 	to {
-		transform: scale(1);
+		top: 100px;
 	}
 }
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -37,7 +37,7 @@
 			max-height: 90%;
 			transform: translate(-50%, -50%);
 			// Animate the modal frame/contents appearing on the page.
-			animation: components-modal__appear-slide-animation 0.1s ease-out;
+			animation: components-modal__appear-slide-animation 0.4s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
 			animation-fill-mode: forwards;
 			@include reduce-motion("animation");
 		}
@@ -46,7 +46,7 @@
 	.components-modal__screen-overlay.is-full-screen & {
 		top: 100%;
 		transform-origin: top center;
-		animation: components-modal__appear-slide-from-bottom 0.3s forwards;
+		animation: components-modal__appear-slide-from-bottom 0.4s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
 		@include reduce-motion("animation");
 	}
 }
@@ -62,7 +62,6 @@
 	background: $white;
 	align-items: center;
 	height: $header-height;
-	margin-bottom: 2 * $grid-unit-30;
 
 	border-bottom: $border-width solid $gray-300;
 	padding: 0 $grid-unit-30;
@@ -134,9 +133,38 @@
 }
 
 // Scale down the content of the page.
-body.modal-open.is-fullscreen-modal > *:not(.components-modal__portal) {
-	transition: transform 0.5s;
-	transform: scale(0.9);
+body.modal-open.is-fullscreen-modal {
+	background: $gray-900;
+
+	> *:not(.components-modal__portal) {
+		animation: components-modal__content-scale-back 0.4s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
+	}
+
+	.interface-interface-skeleton__editor {
+		border-radius: $grid-unit-10;
+	}
+
+	// Increase full screen modal padding on medium+ screens
+	@include break-medium() {
+		.components-modal__header {
+			margin: 0 -#{$grid-unit-60} $grid-unit-40 * 2;
+			padding: 0 $grid-unit-60;
+			height: $grid-unit-60 * 2;
+		}
+
+		.components-modal__content {
+			padding: 0 $grid-unit-60 $grid-unit-60;
+		}
+	}
+}
+
+@keyframes components-modal__content-scale-back {
+	from {
+		transform: scale(1);
+	}
+	to {
+		transform: scale(0.93);
+	}
 }
 
 @keyframes components-modal__appear-slide-from-bottom {
@@ -144,7 +172,7 @@ body.modal-open.is-fullscreen-modal > *:not(.components-modal__portal) {
 		top: 100%;
 	}
 	to {
-		top: 100px;
+		top: 7%;
 	}
 }
 

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
@@ -105,6 +105,7 @@ export function KeyboardShortcutHelpModal( { isModalActive, toggleModal } ) {
 			title={ __( 'Keyboard shortcuts' ) }
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ toggleModal }
+			isFullscreen
 		>
 			<ShortcutSection
 				className="edit-post-keyboard-shortcut-help-modal__main-shortcuts"

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -319,6 +319,7 @@ export default function PreferencesModal() {
 			title={ __( 'Preferences' ) }
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ closeModal }
+			isFullscreen
 		>
 			{ modalContent }
 		</Modal>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -319,7 +319,6 @@ export default function PreferencesModal() {
 			title={ __( 'Preferences' ) }
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ closeModal }
-			isFullscreen
 		>
 			{ modalContent }
 		</Modal>


### PR DESCRIPTION
This PR restores an experiment I did a long time ago to allow full screen modals.
The main use-case for this is going to be the "template switch" modal explored in #28390 
For the current PR, I applied the styles to the "Preferences" modal as well. I personally like it but it folks think it's not a good fit, we can restore the style before merging.

**Testing instructions**

 - Check different modals: Preferences, Keyboard shortcuts 
 - Make sure they look great in both mobile and web