### PR TITLE
Fix sibling inserter color

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -459,7 +459,7 @@
 .block-editor-block-list__block-popover-inserter {
 	.block-editor-inserter__toggle.components-button.has-icon {
 		// Basic look
-		background: var(--wp-admin-theme-color);
+		background: $gray-900;
 		border-radius: $radius-block-ui;
 		color: $white;
 		padding: 0;
@@ -470,8 +470,15 @@
 
 		&:hover {
 			color: $white;
-			background: $gray-900;
+			background: var(--wp-admin-theme-color);
 		}
+	}
+}
+
+.block-editor-block-list__insertion-point-inserter .block-editor-inserter__toggle.components-button.has-icon {
+	background: var(--wp-admin-theme-color);
+	&:hover {
+		background: $gray-900;
 	}
 }
 


### PR DESCRIPTION
Followup to #28550. 

I accidentally made the default appender blue:

<img width="1210" alt="Screenshot 2021-01-29 at 11 40 35" src="https://user-images.githubusercontent.com/1204802/106265722-be3f5400-6227-11eb-8d25-e3800e0c08dc.png">

This PR fixes that:

<img width="1310" alt="Screenshot 2021-01-29 at 11 45 55" src="https://user-images.githubusercontent.com/1204802/106265735-c13a4480-6227-11eb-9830-11aecba994a7.png">

While keeping the sibling inserter blue:

<img width="1220" alt="Screenshot 2021-01-29 at 11 46 00" src="https://user-images.githubusercontent.com/1204802/106265756-c5666200-6227-11eb-91c6-c80a838f609d.png">
