### PR TITLE
Dependencies: Upgrade TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53988,9 +53988,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-			"integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		},
 		"ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 		"sprintf-js": "1.1.1",
 		"style-loader": "1.0.0",
 		"terser-webpack-plugin": "3.0.3",
-		"typescript": "4.0.3",
+		"typescript": "4.1.3",
 		"uuid": "8.3.0",
 		"wd": "1.12.1",
 		"webpack": "4.42.0",

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -13,12 +13,10 @@ const firstTimeContributorLabel = require( './tasks/first-time-contributor-label
 const addMilestone = require( './tasks/add-milestone' );
 const debug = require( './debug' );
 
-/** @typedef {import('@actions/github').GitHub} GitHub */
-
 /**
  * Automation task function.
  *
- * @typedef {(payload:any,octokit:GitHub)=>void} WPAutomationTask
+ * @typedef {( payload: any, octokit: GitHub ) => void} WPAutomationTask
  */
 
 /**


### PR DESCRIPTION
## Description

Upgrade TypeScript dependency to lastes version (4.1.3). See [version 4.1 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#template-literal-types).


## How has this been tested?
Lint, tests, and type build should all pass.

## Types of changes

Internal: Upgrade TypeScript dependency


