### PR TITLE
Site Editor: Fix inserter can't be closed

### DIFF
--- a/packages/e2e-tests/specs/experiments/site-editor-inserter.test.js
+++ b/packages/e2e-tests/specs/experiments/site-editor-inserter.test.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { trashAllPosts, activateTheme } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { siteEditor } from '../../experimental-features';
+
+describe( 'Site Editor Inserter', () => {
+	beforeAll( async () => {
+		await activateTheme( 'tt1-blocks' );
+		await trashAllPosts( 'wp_template' );
+		await trashAllPosts( 'wp_template_part' );
+	} );
+	afterAll( async () => {
+		await activateTheme( 'twentytwentyone' );
+	} );
+	beforeEach( async () => {
+		await siteEditor.visit();
+	} );
+
+	it( 'inserter toggle button should toggle global inserter', async () => {
+		await page.click( '.edit-site-header-toolbar__inserter-toggle' );
+		await page.waitForSelector( '.edit-site-editor__inserter-panel', {
+			visible: true,
+		} );
+		await page.click( '.edit-site-header-toolbar__inserter-toggle' );
+		await page.waitForSelector( '.edit-site-editor__inserter-panel', {
+			hidden: true,
+		} );
+	} );
+} );

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	BlockNavigationDropdown,
@@ -25,6 +26,7 @@ import DocumentActions from './document-actions';
 import TemplateDetails from '../template-details';
 
 export default function Header( { openEntitiesSavedStates } ) {
+	const inserterButton = useRef();
 	const {
 		deviceType,
 		entityTitle,
@@ -77,12 +79,21 @@ export default function Header( { openEntitiesSavedStates } ) {
 			<div className="edit-site-header_start">
 				<div className="edit-site-header__toolbar">
 					<Button
+						ref={ inserterButton }
 						isPrimary
 						isPressed={ isInserterOpen }
 						className="edit-site-header-toolbar__inserter-toggle"
-						onClick={ () =>
-							setIsInserterOpened( ! isInserterOpen )
-						}
+						onMouseDown={ ( event ) => {
+							event.preventDefault();
+						} }
+						onClick={ () => {
+							if ( isInserterOpen ) {
+								// Focusing the inserter button closes the inserter popover
+								inserterButton.current.focus();
+							} else {
+								setIsInserterOpened( true );
+							}
+						} }
 						icon={ plus }
 						label={ _x(
 							'Add block',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Clicking the inserter button in the header toolbar keeps reopening the inserter. Fixing it by the same technique that's used in the `edit-post`

## How has this been tested?
1. Open site editor
2. Click on inserter button
3. Inserter should open
4. Click on inserter button
5. Inserter should close

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
