### PR TITLE
E2E tests: Handle upgrade screen

### DIFF
--- a/packages/e2e-test-utils/src/visit-admin-page.js
+++ b/packages/e2e-test-utils/src/visit-admin-page.js
@@ -20,6 +20,14 @@ import { getPageError } from './get-page-error';
 export async function visitAdminPage( adminPath, query ) {
 	await page.goto( createURL( join( 'wp-admin', adminPath ), query ) );
 
+	// Handle upgrade required screen
+	if ( isCurrentURL( 'wp-admin/upgrade.php' ) ) {
+		// Click update
+		await page.click( '.button.button-large.button-primary' );
+		// Click continue
+		await page.click( '.button.button-large' );
+	}
+
 	if ( isCurrentURL( 'wp-login.php' ) ) {
 		await loginUser();
 		await visitAdminPage( adminPath, query );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
E2E tests might get stuck on the "Database Update Required" screen. This PR takes care of the screen by automatically clicking on update.

## How has this been tested?
The quickest way is to change the `db_version` option in the database.
1. Add this line 
```js
update_option('db_version', get_option('db_version') - 1);
```
at https://github.com/WordPress/gutenberg/blob/cdc34fb17eb058b56a8e55f583c17b5fe1db54d7/gutenberg.php#L17-L19 after the comment.

2. Open http://localhost:8889
3. Then open http://localhost:8889/wp-admin
4. Make sure upgrade screen pops up
5. Comment the line you just added (or remove it)
6. Now run e2e tests interactively (`npm run test-e2e -- --puppeteer-interactive`)
7. Make sure puppeteer successfully goes through the upgrade screen

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
