### PR TITLE
Make parent block selector visible and offset the toolbar.

### DIFF
--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -12,10 +17,12 @@ import NavigableToolbar from '../navigable-toolbar';
 import { BlockToolbar } from '../';
 
 function BlockContextualToolbar( { focusOnMount, ...props } ) {
-	const { blockType } = useSelect( ( select ) => {
-		const { getBlockName, getSelectedBlockClientIds } = select(
-			'core/block-editor'
-		);
+	const { blockType, hasParents } = useSelect( ( select ) => {
+		const {
+			getBlockName,
+			getBlockParents,
+			getSelectedBlockClientIds,
+		} = select( 'core/block-editor' );
 		const { getBlockType } = select( blocksStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -23,6 +30,7 @@ function BlockContextualToolbar( { focusOnMount, ...props } ) {
 			blockType:
 				selectedBlockClientId &&
 				getBlockType( getBlockName( selectedBlockClientId ) ),
+			hasParents: getBlockParents( selectedBlockClientId ).length,
 		};
 	}, [] );
 	if ( blockType ) {
@@ -30,11 +38,16 @@ function BlockContextualToolbar( { focusOnMount, ...props } ) {
 			return null;
 		}
 	}
+
+	const classes = classnames( 'block-editor-block-contextual-toolbar', {
+		'with-offset': hasParents,
+	} );
+
 	return (
 		<div className="block-editor-block-contextual-toolbar-wrapper">
 			<NavigableToolbar
 				focusOnMount={ focusOnMount }
-				className="block-editor-block-contextual-toolbar"
+				className={ classes }
 				/* translators: accessibility text for the block toolbar */
 				aria-label={ __( 'Block tools' ) }
 				{ ...props }

--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -39,6 +39,7 @@ function BlockContextualToolbar( { focusOnMount, ...props } ) {
 		}
 	}
 
+	// Shifts the toolbar to make room for the parent block selector.
 	const classes = classnames( 'block-editor-block-contextual-toolbar', {
 		'with-offset': hasParents,
 	} );

--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -41,7 +41,7 @@ function BlockContextualToolbar( { focusOnMount, ...props } ) {
 
 	// Shifts the toolbar to make room for the parent block selector.
 	const classes = classnames( 'block-editor-block-contextual-toolbar', {
-		'with-offset': hasParents,
+		'has-parent': hasParents,
 	} );
 
 	return (

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -5,11 +5,13 @@ import { getBlockType, store as blocksStore } from '@wordpress/blocks';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
+import { useShowMoversGestures } from '../block-toolbar/utils';
 
 /**
  * Block parent selector component, displaying the hierarchy of the
@@ -18,32 +20,50 @@ import BlockIcon from '../block-icon';
  * @return {WPComponent} Parent block selector.
  */
 export default function BlockParentSelector() {
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-	const { parentBlockType, firstParentClientId, shouldHide } = useSelect(
-		( select ) => {
-			const {
-				getBlockName,
-				getBlockParents,
-				getSelectedBlockClientId,
-			} = select( 'core/block-editor' );
-			const { hasBlockSupport } = select( blocksStore );
-			const selectedBlockClientId = getSelectedBlockClientId();
-			const parents = getBlockParents( selectedBlockClientId );
-			const _firstParentClientId = parents[ parents.length - 1 ];
-			const parentBlockName = getBlockName( _firstParentClientId );
-			const _parentBlockType = getBlockType( parentBlockName );
-			return {
-				parentBlockType: _parentBlockType,
-				firstParentClientId: _firstParentClientId,
-				shouldHide: ! hasBlockSupport(
-					_parentBlockType,
-					'__experimentalParentSelector',
-					true
-				),
-			};
-		},
-		[]
+	const { selectBlock, toggleBlockHighlight } = useDispatch(
+		'core/block-editor'
 	);
+	const {
+		parentBlockType,
+		firstParentClientId,
+		shouldHide,
+		hasReducedUI,
+	} = useSelect( ( select ) => {
+		const {
+			getBlockName,
+			getBlockParents,
+			getSelectedBlockClientId,
+			getSettings,
+		} = select( 'core/block-editor' );
+		const { hasBlockSupport } = select( blocksStore );
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const parents = getBlockParents( selectedBlockClientId );
+		const _firstParentClientId = parents[ parents.length - 1 ];
+		const parentBlockName = getBlockName( _firstParentClientId );
+		const _parentBlockType = getBlockType( parentBlockName );
+		const settings = getSettings();
+		return {
+			parentBlockType: _parentBlockType,
+			firstParentClientId: _firstParentClientId,
+			shouldHide: ! hasBlockSupport(
+				_parentBlockType,
+				'__experimentalParentSelector',
+				true
+			),
+			hasReducedUI: settings.hasReducedUI,
+		};
+	}, [] );
+
+	const nodeRef = useRef();
+	const { gestures: showMoversGestures } = useShowMoversGestures( {
+		ref: nodeRef,
+		onChange( isFocused ) {
+			if ( isFocused && hasReducedUI ) {
+				return;
+			}
+			toggleBlockHighlight( firstParentClientId, isFocused );
+		},
+	} );
 
 	if ( shouldHide ) {
 		return null;
@@ -54,6 +74,8 @@ export default function BlockParentSelector() {
 			<div
 				className="block-editor-block-parent-selector"
 				key={ firstParentClientId }
+				ref={ nodeRef }
+				{ ...showMoversGestures }
 			>
 				<ToolbarButton
 					className="block-editor-block-parent-selector__button"

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -54,6 +54,8 @@ export default function BlockParentSelector() {
 		};
 	}, [] );
 
+	// Allows highlighting the parent block outline when focusing or hovering
+	// the parent block selector within the child.
 	const nodeRef = useRef();
 	const { gestures: showMoversGestures } = useShowMoversGestures( {
 		ref: nodeRef,

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -60,7 +60,7 @@ export default function BlockParentSelector() {
 					onClick={ () => selectBlock( firstParentClientId ) }
 					label={ sprintf(
 						/* translators: %s: Name of the block's parent. */
-						__( 'Select parent (%s)' ),
+						__( 'Select %s' ),
 						parentBlockType.title
 					) }
 					showTooltip

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -104,12 +104,10 @@ export default function BlockToolbar( { hideDragHandle } ) {
 
 	return (
 		<div className={ classes }>
+			{ ! isMultiToolbar && (
+				<BlockParentSelector clientIds={ blockClientIds } />
+			) }
 			<div ref={ nodeRef } { ...showMoversGestures }>
-				{ ! isMultiToolbar && (
-					<div className="block-editor-block-toolbar__block-parent-selector-wrapper">
-						<BlockParentSelector clientIds={ blockClientIds } />
-					</div>
-				) }
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
 					<ToolbarGroup className="block-editor-block-toolbar__block-controls">
 						<BlockSwitcher clientIds={ blockClientIds } />

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -104,7 +104,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 
 	return (
 		<div className={ classes }>
-			{ ! isMultiToolbar && (
+			{ ! isMultiToolbar && ! displayHeaderToolbar && (
 				<BlockParentSelector clientIds={ blockClientIds } />
 			) }
 			<div ref={ nodeRef } { ...showMoversGestures }>

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -64,9 +64,10 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		};
 	}, [] );
 
+	// Handles highlighting the current block outline on hover or focus of the
+	// block type toolbar area.
 	const { toggleBlockHighlight } = useDispatch( 'core/block-editor' );
 	const nodeRef = useRef();
-
 	const { showMovers, gestures: showMoversGestures } = useShowMoversGestures(
 		{
 			ref: nodeRef,
@@ -79,6 +80,8 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		}
 	);
 
+	// Account for the cases where the block toolbar is rendered within the
+	// header are and not contextually to the block.
 	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) || hasFixedToolbar;
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -81,7 +81,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	);
 
 	// Account for the cases where the block toolbar is rendered within the
-	// header are and not contextually to the block.
+	// header area and not contextually to the block.
 	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) || hasFixedToolbar;
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -52,11 +52,6 @@
 	position: absolute;
 	top: -$border-width;
 	left: calc(-#{$grid-unit-60} - #{$grid-unit-10} - #{$border-width});
-
-	// Top Toolbar.
-	.edit-post-header-toolbar__block-toolbar & {
-		display: none;
-	}
 }
 
 // Block controls.

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -45,13 +45,13 @@
 }
 
 .block-editor-block-contextual-toolbar.with-offset {
-	margin-left: calc(#{$grid-unit-60} + #{$grid-unit-15});
+	margin-left: calc(#{$grid-unit-60} + #{$grid-unit-10});
 }
 
 .block-editor-block-parent-selector {
 	position: absolute;
 	top: -$border-width;
-	left: calc(-#{$grid-unit-60} - #{$grid-unit-15} - #{$border-width});
+	left: calc(-#{$grid-unit-60} - #{$grid-unit-10} - #{$border-width});
 
 	// Top Toolbar.
 	.edit-post-header-toolbar__block-toolbar & {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -44,6 +44,21 @@
 	}
 }
 
+.block-editor-block-contextual-toolbar.with-offset {
+	margin-left: calc(#{$grid-unit-60} + #{$grid-unit-15});
+}
+
+.block-editor-block-parent-selector {
+	position: absolute;
+	top: -$border-width;
+	left: calc(-#{$grid-unit-60} - #{$grid-unit-15} - #{$border-width});
+
+	// Top Toolbar.
+	.edit-post-header-toolbar__block-toolbar & {
+		display: none;
+	}
+}
+
 // Block controls.
 .block-editor-block-toolbar__block-controls {
 	// The !important modifier should be removed when https://github.com/WordPress/gutenberg/issues/24898 refactors the spacing grid.
@@ -88,22 +103,6 @@
 	// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
 	@supports (position: sticky) {
 		display: inline-flex;
-	}
-}
-
-.block-editor-block-toolbar__block-parent-selector-wrapper {
-	position: absolute;
-	top: -1px;
-	left: -1px;
-	opacity: 0;
-	transition: all 60ms linear;
-	z-index: -1; // This makes it slide out from underneath the toolbar.
-
-	@include reduce-motion("transition");
-
-	.is-showing-movers & {
-		opacity: 1;
-		transform: translateY(-($block-toolbar-height + $grid-unit-15));
 	}
 }
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -44,7 +44,7 @@
 	}
 }
 
-.block-editor-block-contextual-toolbar.with-offset {
+.block-editor-block-contextual-toolbar.has-parent {
 	margin-left: calc(#{$grid-unit-60} + #{$grid-unit-10});
 }
 

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -49,7 +49,7 @@ async function testGroupKeyboardNavigation(
 	await page.keyboard.press( 'Tab' );
 	await expectLabelToHaveFocus( currentBlockLabel );
 	await pressKeyWithModifier( 'shift', 'Tab' );
-	await expectLabelToHaveFocus( 'Select parent (Group)' );
+	await expectLabelToHaveFocus( 'Select Group' );
 	await page.keyboard.press( 'ArrowRight' );
 	await expectLabelToHaveFocus( currentBlockTitle );
 }


### PR DESCRIPTION
Closes #28522.
Complements #23800.

![image](https://user-images.githubusercontent.com/548849/106329262-6f260d00-6281-11eb-86d2-3c524fdc49a1.png)


- [x] Show parent selector and offset toolbar.
- [x] Ensure toolbar keyboard navigation works properly.
- [x] Highlight parent block's outline on hover / focus.
- [x] Handle Top Toolbar.
- [x] Disable for mobile.

Parent highlighting outline:

![image](https://user-images.githubusercontent.com/548849/106329412-aac0d700-6281-11eb-8f3e-0233f2a06743.png)

Current block highlighting outline:

![image](https://user-images.githubusercontent.com/548849/106329465-c3c98800-6281-11eb-9505-0f44c84b5adb.png)
