### PR TITLE
Padding Edit: Fix handling of custom unit theme setting

### DIFF
--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -10,7 +10,7 @@ import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import { cleanEmptyObject } from './utils';
-import useEditorFeature from '../components/use-editor-feature';
+import { useCustomUnits } from '../components/unit-control';
 
 export const SPACING_SUPPORT_KEY = 'spacing';
 
@@ -20,11 +20,11 @@ const hasPaddingSupport = ( blockName ) => {
 };
 
 /**
- * Inspector control panel containing the line height related configuration
+ * Inspector control panel containing the padding related configuration
  *
  * @param {Object} props
  *
- * @return {WPElement} Line height edit element.
+ * @return {WPElement} Padding edit element.
  */
 export function PaddingEdit( props ) {
 	const {
@@ -33,11 +33,7 @@ export function PaddingEdit( props ) {
 		setAttributes,
 	} = props;
 
-	const customUnits = useEditorFeature( 'spacing.units' );
-	const units = customUnits?.map( ( unit ) => ( {
-		value: unit,
-		label: unit,
-	} ) );
+	const units = useCustomUnits();
 
 	if ( ! hasPaddingSupport( blockName ) ) {
 		return null;


### PR DESCRIPTION
This update fixes the `Padding` style controls as it relates to the `custom-units` theme setting.
The solution involved ensuring the padding controls used the `useCustomUnit` hook, which gracefully handles consolidating the theme setting for custom units.

<img width="1110" alt="Screen Shot 2021-01-29 at 11 31 15 AM" src="https://user-images.githubusercontent.com/2322354/106302561-20e42000-6227-11eb-9048-6712044c7dc3.png">

Resolves https://github.com/WordPress/gutenberg/issues/27829

## How has this been tested?
Locally in Gutenberg.

* Activate the TwentyTwentyOne theme.
* run `npm run dev`
* Add a Cover block
* Remove the `add_theme_support( 'custom-units' );` from the theme `functions.php`
* Ensure the Cover block render okay
* Add back the `add_theme_support( 'custom-units' );` from the theme `functions.php`
* Ensure the Cover block render okay


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
