### PR TITLE
Image options are not visible in pop up on clicking replace button from Image block

### DIFF
--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -179,7 +179,7 @@ $arrow-size: 8px;
 	.components-popover & {
 		position: absolute;
 		height: auto;
-		overflow-y: auto;
+		overflow-y: unset;
 	}
 
 	.components-popover.is-expanded & {


### PR DESCRIPTION
## Description
Image options are not visible in pop up on clicking replace button from Image block due to the horizontal scroll.

WordPress Track ticket: https://core.trac.wordpress.org/ticket/52396

## How has this been tested?
1.Create new article.
2.Add image block.
3.Add any image inside the image block.
4.Click on replace button from the image block.

## Screenshots

![image](https://user-images.githubusercontent.com/20163248/106308147-494f3700-6286-11eb-8402-c8948746167e.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
