### PR TITLE
Update the RSS block to not use the undefined value.

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -80,7 +80,7 @@ function render_block_core_rss( $attributes ) {
 	}
 
 	$classes           = 'grid' === $attributes['blockLayout'] ? ' is-grid columns-' . $attributes['columns'] : '';
-	$list_items_markup = sprintf( "<ul class='%s'>%s</ul>", esc_attr( $class ), $list_items );
+	$list_items_markup = sprintf( "<ul class='%s'>%s</ul>", esc_attr( $classes ), $list_items );
 
 	// PHP 5.2 compatibility. See: http://simplepie.org/wiki/faq/i_m_getting_memory_leaks.
 	$rss->__destruct();
@@ -93,7 +93,8 @@ function render_block_core_rss( $attributes ) {
  * Registers the `core/rss` block on server.
  */
 function register_block_core_rss() {
-	register_block_type( 'core/rss',
+	register_block_type(
+		'core/rss',
 		array(
 			'attributes'      => array(
 				'columns'        => array(


### PR DESCRIPTION
## Description

@desrosj and I are doing some cleanup on older branches of WordPress. This was leading to an undefined error.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
