### PR TITLE
Autocomplete: add position property

### DIFF
--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -97,9 +97,12 @@ Whether to apply debouncing for the autocompleter. Set to true to enable debounc
 -   Type: `Boolean`
 -   Required: No
 
+
 #### position
 
-Use this string to modify the direction in which the popover should open relative to its parent node.
+Use this string to modify the direction in which the popover should open relative to its parent node. This value will be propagated to [`position` property of the the `<Popover />` component](../popover#position), where it describes...
+
+> Specify y- and x-axis as a space-separated string. Supports "top", "middle", "bottom" y axis, and "left", "center", "right" x axis.
 
 -   Type: `String`
 -   Required: No

--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -97,6 +97,14 @@ Whether to apply debouncing for the autocompleter. Set to true to enable debounc
 -   Type: `Boolean`
 -   Required: No
 
+#### popoverProps
+
+Properties of `popoverProps` object will be passed as props to the nested `Popover` component.
+Use this object to modify props available for the `Popover` component that are not already exposed in the `AutocompleterUI` component, e.g.: the direction in which the popover should open relative to its parent node set with `position` prop.
+
+-   Type: `Object`
+-   Required: No
+
 ## Usage
 
 The following is a contrived completer for fresh fruit.

--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -97,13 +97,13 @@ Whether to apply debouncing for the autocompleter. Set to true to enable debounc
 -   Type: `Boolean`
 -   Required: No
 
-#### popoverProps
+#### position
 
-Properties of `popoverProps` object will be passed as props to the nested `Popover` component.
-Use this object to modify props available for the `Popover` component that are not already exposed in the `AutocompleterUI` component, e.g.: the direction in which the popover should open relative to its parent node set with `position` prop.
+Use this string to modify the direction in which the popover should open relative to its parent node.
 
--   Type: `Object`
+-   Type: `String`
 -   Required: No
+-   Default: 'top right'
 
 ## Usage
 

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -233,6 +233,7 @@ const getAutoCompleterUI = ( autocompleter ) => {
 		onReset,
 		value,
 		contentRef,
+		popoverProps = {},
 	} ) {
 		const [ items ] = useItems( filterValue );
 		const anchorRef = useAnchorRef( { ref: contentRef, value } );
@@ -252,6 +253,7 @@ const getAutoCompleterUI = ( autocompleter ) => {
 				position="top right"
 				className="components-autocomplete__popover"
 				anchorRef={ anchorRef }
+				{ ...popoverProps }
 			>
 				<div
 					id={ listBoxId }
@@ -535,7 +537,7 @@ function Autocomplete( {
 	}, [ textContent ] );
 
 	const { key: selectedKey = '' } = filteredOptions[ selectedIndex ] || {};
-	const { className } = autocompleter || {};
+	const { className, popoverProps } = autocompleter || {};
 	const isExpanded = !! autocompleter && filteredOptions.length > 0;
 	const listBoxId = isExpanded
 		? `components-autocomplete-listbox-${ instanceId }`
@@ -563,6 +565,7 @@ function Autocomplete( {
 					onSelect={ select }
 					value={ record }
 					contentRef={ contentRef }
+					popoverProps={ popoverProps }
 				/>
 			) }
 		</>

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -233,7 +233,7 @@ const getAutoCompleterUI = ( autocompleter ) => {
 		onReset,
 		value,
 		contentRef,
-		popoverProps = {},
+		position = 'top right',
 	} ) {
 		const [ items ] = useItems( filterValue );
 		const anchorRef = useAnchorRef( { ref: contentRef, value } );
@@ -250,10 +250,9 @@ const getAutoCompleterUI = ( autocompleter ) => {
 			<Popover
 				focusOnMount={ false }
 				onClose={ onReset }
-				position="top right"
+				position={ position }
 				className="components-autocomplete__popover"
 				anchorRef={ anchorRef }
-				{ ...popoverProps }
 			>
 				<div
 					id={ listBoxId }
@@ -537,7 +536,7 @@ function Autocomplete( {
 	}, [ textContent ] );
 
 	const { key: selectedKey = '' } = filteredOptions[ selectedIndex ] || {};
-	const { className, popoverProps } = autocompleter || {};
+	const { className, position } = autocompleter || {};
 	const isExpanded = !! autocompleter && filteredOptions.length > 0;
 	const listBoxId = isExpanded
 		? `components-autocomplete-listbox-${ instanceId }`
@@ -565,7 +564,7 @@ function Autocomplete( {
 					onSelect={ select }
 					value={ record }
 					contentRef={ contentRef }
-					popoverProps={ popoverProps }
+					position={ position }
 				/>
 			) }
 		</>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
The changes suggested in this PR allow setting the position to the autocomplete Popover. 

## How has this been tested?

* It doesn't introduce any change by default.
* Create an Autocomplete and defines the position:

```es6
{
	// ...
	position: 'bottom',
	// ...
},
```

```es6
const autocompleters = [
	{
		name: 'fruit',
		// The prefix that triggers this completer
		triggerPrefix: '~',
		// The option data
		options: [
			{ visual: '🍎', name: 'Apple', id: 1 },
			{ visual: '🍊', name: 'Orange', id: 2 },
			{ visual: '🍇', name: 'Grapes', id: 3 },
		],
		// Returns a label for an option like "🍊 Orange"
		getOptionLabel: option => (
			<span>
				<span className="icon" >{ option.visual }</span>{ option.name }
			</span>
		),
		// Declares that options should be matched by their name
		getOptionKeywords: option => [ option.name ],
		// Declares that the Grapes option is disabled
		isOptionDisabled: option => option.name === 'Grapes',
		// Declares completions should be inserted as abbreviations
		getOptionCompletion: option => (
			<abbr title={ option.name }>{ option.visual }</abbr>
		),

		position: 'bottom', // <- position here
	}
];
```

You should see the autocomplete popover below to the text input component.

## Screenshots <!-- if applicable -->

canvas | React devtools
------|--------
![image](https://user-images.githubusercontent.com/77539/106340658-4863d880-6279-11eb-8f49-9ea7ccffc046.png) | <img width="829" alt="Screen Shot 2021-04-13 at 10 24 53 AM" src="https://user-images.githubusercontent.com/77539/114559955-9cf4de00-9c42-11eb-9d73-c2547add3eb4.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->