### PR TITLE
Navigation Component: Increase color and padding specificity

### DIFF
--- a/packages/components/src/navigation/stories/default.js
+++ b/packages/components/src/navigation/stories/default.js
@@ -26,6 +26,14 @@ export function DefaultStory() {
 					onClick={ () => setActiveItem( 'item-2' ) }
 					title="Item 2"
 				/>
+				<NavigationItem>
+					<a
+						className="components-button"
+						href="http://www.example.com"
+					>
+						External Link
+					</a>
+				</NavigationItem>
 				<NavigationItem
 					item="item-sub-menu"
 					navigateToMenu="sub-menu"

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -192,6 +192,7 @@ export const ItemUI = styled.div`
 	height: auto;
 	min-height: 32px;
 	margin: 0;
+	padding: ${ space( 0.75 ) } ${ space( 2 ) };
 	font-weight: 400;
 	line-height: 20px;
 	width: 100%;

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -158,8 +158,11 @@ export const ItemBaseUI = styled.li`
 	margin-bottom: 0;
 
 	button,
+	a.components-button,
 	a {
 		width: 100%;
+		color: ${ G2.lightGray.ui };
+		padding: ${ space( 0.75 ) } ${ space( 2 ) };
 
 		&:hover,
 		&:focus:not( [aria-disabled='true'] ):active,
@@ -189,7 +192,6 @@ export const ItemUI = styled.div`
 	height: auto;
 	min-height: 32px;
 	margin: 0;
-	padding: ${ space( 0.75 ) } ${ space( 2 ) };
 	font-weight: 400;
 	line-height: 20px;
 	width: 100%;


### PR DESCRIPTION
## Description

Navigation item colors weren't being applied to `a.components-button` but only `button.components-button` elements. This PR increases specificity such that `components-button` class margin and color are overridden.

## Before
<img width="239" alt="Screen Shot 2021-01-13 at 9 08 40 AM" src="https://user-images.githubusercontent.com/1922453/104367080-2ed74700-557f-11eb-88a0-9d9f3f0ee443.png">

<img width="226" alt="Screen Shot 2021-02-01 at 6 10 32 PM" src="https://user-images.githubusercontent.com/1922453/106417744-9f57f080-64b9-11eb-9b08-8eeda60d7455.png">

## After

<img width="235" alt="Screen Shot 2021-02-01 at 6 20 24 PM" src="https://user-images.githubusercontent.com/1922453/106418009-2f963580-64ba-11eb-944d-56ab926881d9.png">

## Testing Instructions

The scenario is replicated in Storybook for ease of testing by adding an external link for comparison.

1. `npm run storybook:dev`
2. Visit Components > Navigation > Default
3. See all links have similar colors and padding

<img width="326" alt="Screen Shot 2021-02-01 at 6 28 36 PM" src="https://user-images.githubusercontent.com/1922453/106418607-a41da400-64bb-11eb-853d-2631ec30728c.png">

## Types of changes

This is a bug fix and a non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
