### PR TITLE
Fix issue where gallery block requests all attachments when empty

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -376,9 +376,18 @@ class MediaUpload extends Component {
 
 	onOpen() {
 		this.updateCollection();
-		if ( ! this.props.value ) {
+
+		// For a media uploader that selects only a single item (e.g. the image
+		// block ), `this.props.value` is a number that represents the `id` of
+		// the media. For galleries, the value is an array of ids. This early
+		// return statement should handle both when no media is present.
+		if (
+			! this.props.value ||
+			( this.props.gallery && this.props.value?.length )
+		) {
 			return;
 		}
+
 		if ( ! this.props.gallery ) {
 			const selection = this.frame.state().get( 'selection' );
 			castArray( this.props.value ).forEach( ( id ) => {

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -377,14 +377,13 @@ class MediaUpload extends Component {
 	onOpen() {
 		this.updateCollection();
 
-		// For a media uploader that selects only a single item (e.g. the image
-		// block ), `this.props.value` is a number that represents the `id` of
-		// the media. For galleries, the value is an array of ids. This early
-		// return statement should handle both when no media is present.
-		if (
-			! this.props.value ||
-			( this.props.gallery && this.props.value?.length )
-		) {
+		// Handle both this.props.value being either (number[]) multiple ids
+		// (for galleries) or a (number) singular id (e.g. image block).
+		const hasMedia = Array.isArray( this.props.value )
+			? !! this.props.value?.length
+			: !! this.props.value;
+
+		if ( ! hasMedia ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28563.

When opening the media modal from a gallery block that's empty (for example when the block is first added) an HTTP request for all user media was previously and erroneously made.

This request is used to retrieve details of images already added to a gallery, but when a gallery is empty, the lack of a `post__in` property in the request has the side effect of retrieving all users images. The user in #28563 describes this having a massive server performance impact on their site that has lots of images.

For the image block, this request was already being skipped, so this PR does the same for the gallery block by improving the already present early return statement.

## How has this been tested?
### Empty Gallery Block
1. Open browser dev tools to the network tab
2. Add a gallery block.
3. Open the media library
4. Inspect network requests. There should be no `admin-ajax` requests with the following params: <img width="200" alt="Screenshot 2021-02-01 at 2 51 53 pm" src="https://user-images.githubusercontent.com/677833/106424409-18951a80-649d-11eb-9c0e-e08e050adf88.png">

### Gallery with images
1. Repeat the steps above for an empty gallery
2. Add some images to the gallery
3. Open the media library again
4. Inspect network requests. This time you should see a request made for `query-attachments`, but limited to the selected image ids using the `post__in` property in the query.,

### Empty Image Block
1. Open browser dev tools to the network tab
2. Add an image block.
3. Open the media library
4. Inspect network requests. There should be no `admin-ajax` requests with the following params: <img width="200" alt="Screenshot 2021-02-01 at 2 51 53 pm" src="https://user-images.githubusercontent.com/677833/106424409-18951a80-649d-11eb-9c0e-e08e050adf88.png">

### Image block with image
1. Repeat the steps above for an empty image block
2. Add an image to the image block
3. Open the media library again
4. Inspect network requests. This time you should see a request made for `query-attachments`, but limited to the selected image id using the `post__in` property in the query.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
