### PR TITLE
[Navigation Link]: Add block variation matcher to display information from a found match

### DIFF
--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -2,13 +2,7 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import {
-	category as categoryIcon,
-	mapMarker as linkIcon,
-	page as pageIcon,
-	postTitle as postIcon,
-	tag as tagIcon,
-} from '@wordpress/icons';
+import { mapMarker as linkIcon } from '@wordpress/icons';
 import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
@@ -17,6 +11,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -29,43 +24,7 @@ export const settings = {
 
 	description: __( 'Add a page, link, or another item to your navigation.' ),
 
-	variations: [
-		{
-			name: 'link',
-			isDefault: true,
-			title: __( 'Link' ),
-			description: __( 'A link to a URL.' ),
-			attributes: {},
-		},
-		{
-			name: 'post',
-			icon: postIcon,
-			title: __( 'Post Link' ),
-			description: __( 'A link to a post.' ),
-			attributes: { type: 'post' },
-		},
-		{
-			name: 'page',
-			icon: pageIcon,
-			title: __( 'Page Link' ),
-			description: __( 'A link to a page.' ),
-			attributes: { type: 'page' },
-		},
-		{
-			name: 'category',
-			icon: categoryIcon,
-			title: __( 'Category Link' ),
-			description: __( 'A link to a category.' ),
-			attributes: { type: 'category' },
-		},
-		{
-			name: 'tag',
-			icon: tagIcon,
-			title: __( 'Tag Link' ),
-			description: __( 'A link to a tag.' ),
-			attributes: { type: 'tag' },
-		},
-	],
+	variations,
 
 	__experimentalLabel: ( { label } ) => label,
 

--- a/packages/block-library/src/navigation-link/variations.js
+++ b/packages/block-library/src/navigation-link/variations.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	category as categoryIcon,
+	page as pageIcon,
+	postTitle as postIcon,
+	tag as tagIcon,
+} from '@wordpress/icons';
+const variations = [
+	{
+		name: 'link',
+		isDefault: true,
+		title: __( 'Link' ),
+		description: __( 'A link to a URL.' ),
+		attributes: {},
+	},
+	{
+		name: 'post',
+		icon: postIcon,
+		title: __( 'Post Link' ),
+		description: __( 'A link to a post.' ),
+		attributes: { type: 'post' },
+	},
+	{
+		name: 'page',
+		icon: pageIcon,
+		title: __( 'Page Link' ),
+		description: __( 'A link to a page.' ),
+		attributes: { type: 'page' },
+	},
+	{
+		name: 'category',
+		icon: categoryIcon,
+		title: __( 'Category Link' ),
+		description: __( 'A link to a category.' ),
+		attributes: { type: 'category' },
+	},
+	{
+		name: 'tag',
+		icon: tagIcon,
+		title: __( 'Tag Link' ),
+		description: __( 'A link to a tag.' ),
+		attributes: { type: 'tag' },
+	},
+];
+
+/**
+ * Add `isActive` function to all `navigation link` variations, if not defined.
+ * `isActive` function is used to find a variation match from a created
+ *  Block by providing its attributes.
+ */
+variations.forEach( ( variation ) => {
+	if ( variation.isActive ) return;
+	variation.isActive = ( blockAttributes, variationAttributes ) =>
+		blockAttributes.type === variationAttributes.type;
+} );
+
+export default variations;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/28578

This PR adds `isActive` matcher function to `Navigation Link` block variations. This results in showing the matching variation information, if found, in several places like the `BlockSwitcher` icon, Navigation List and Block Card.

Testing instructions are in the issue.
