### PR TITLE
Fix legacy settings tests for custom spacing

### DIFF
--- a/phpunit/class-wp-theme-json-legacy-settings-test.php
+++ b/phpunit/class-wp-theme-json-legacy-settings-test.php
@@ -86,7 +86,8 @@ class Theme_JSON_Legacy_Settings_Test extends WP_UnitTestCase {
 		$input = gutenberg_get_common_block_editor_settings();
 
 		$expected = array(
-			'units' => array( array() ),
+			'units'         => array( array() ),
+			'customPadding' => false,
 		);
 
 		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );
@@ -100,7 +101,8 @@ class Theme_JSON_Legacy_Settings_Test extends WP_UnitTestCase {
 		$input = gutenberg_get_common_block_editor_settings();
 
 		$expected = array(
-			'units' => array( 'px', 'em', 'rem', 'vh', 'vw' ),
+			'units'         => array( 'px', 'em', 'rem', 'vh', 'vw' ),
+			'customPadding' => false,
 		);
 
 		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );
@@ -114,7 +116,8 @@ class Theme_JSON_Legacy_Settings_Test extends WP_UnitTestCase {
 		$input = gutenberg_get_common_block_editor_settings();
 
 		$expected = array(
-			'units' => array( 'rem', 'em' ),
+			'units'         => array( 'rem', 'em' ),
+			'customPadding' => false,
 		);
 
 		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );


### PR DESCRIPTION
The PHP tests are failing because the docker image has been updated to PHP 8 but the phpunit hasn't been updated yet.

https://github.com/WordPress/gutenberg/pull/28623 made some changes to custom spacing that made some PHP tests fail. Those failures were [masked](https://github.com/WordPress/gutenberg/runs/1790824162) by the fact that PHP test didn't run at all.

This PR fixes those tests.

## How to test

- Use https://github.com/WordPress/gutenberg/pull/28623 as a base
  - Destroy env: `npm run wp-env destroy`
  - Install & start new env: `npm run wp-env start`
  - Install composer packages: `npm run test-php`

- Cherry-pick this PR on top: `git cherry-pick <name-of-this-pr-locally>`

The expected result is that tests pass.