### PR TITLE
Fix lint issues (proper number of spaces)

### DIFF
--- a/lib/class-wp-rest-pattern-directory-controller.php
+++ b/lib/class-wp-rest-pattern-directory-controller.php
@@ -271,9 +271,9 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		$query_params['context']['default']  = 'view';
 
 		$query_params['category'] = array(
-			'description'       => __( 'Limit results to those matching a category ID.', 'gutenberg' ),
-			'type'              => 'integer',
-			'minimum'           => 1,
+			'description' => __( 'Limit results to those matching a category ID.', 'gutenberg' ),
+			'type'        => 'integer',
+			'minimum'     => 1,
 		);
 
 		/**

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -271,15 +271,15 @@ class WP_Theme_JSON {
 			'value'   => array( 'border', 'radius' ),
 			'support' => array( '__experimentalBorder', 'radius' ),
 		),
-		'borderColor'             => array(
+		'borderColor'              => array(
 			'value'   => array( 'border', 'color' ),
 			'support' => array( '__experimentalBorder', 'color' ),
 		),
-		'borderWidth'             => array(
+		'borderWidth'              => array(
 			'value'   => array( 'border', 'width' ),
 			'support' => array( '__experimentalBorder', 'width' ),
 		),
-		'borderStyle'             => array(
+		'borderStyle'              => array(
 			'value'   => array( 'border', 'style' ),
 			'support' => array( '__experimentalBorder', 'style' ),
 		),

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -102,7 +102,7 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 			$theme_settings['settings'][ $all_blocks ]['spacing'] = array();
 		}
 		$theme_settings['settings'][ $all_blocks ]['spacing']['customPadding'] = $settings['enableCustomSpacing'];
-	} else if ( current( (array) get_theme_support( 'custom-spacing' ) ) ) {
+	} elseif ( current( (array) get_theme_support( 'custom-spacing' ) ) ) {
 		if ( ! isset( $theme_settings['settings'][ $all_blocks ]['spacing'] ) ) {
 			$theme_settings['settings'][ $all_blocks ]['spacing'] = array();
 		}


### PR DESCRIPTION
The PHP tests are failing because the docker image has been updated to PHP 8 but the phpunit hasn't been updated yet.

For some PRs that landed recently, the test and lint jobs probably didn't run properly.  This PR fixes some of the existing lint issues.

## How to test

- Use https://github.com/WordPress/gutenberg/pull/28623 as a base
  - Destroy env: `npm run wp-env destroy`
  - Install & start new env: `npm run wp-env start`
  - Install composer packages: `npm run test-php`

- Cherry-pick this PR on top: `git cherry-pick <name-of-this-pr-locally>`

The expected result is that the lint issues for bad spacing no longer happen.