### PR TITLE
Components: Allow extra props for RadioControl component

### DIFF
--- a/packages/components/src/radio-control/index.js
+++ b/packages/components/src/radio-control/index.js
@@ -21,6 +21,7 @@ export default function RadioControl( {
 	help,
 	onChange,
 	options = [],
+	...props
 } ) {
 	const instanceId = useInstanceId( RadioControl );
 	const id = `inspector-radio-control-${ instanceId }`;
@@ -53,6 +54,7 @@ export default function RadioControl( {
 							aria-describedby={
 								!! help ? `${ id }__help` : undefined
 							}
+							{...props}
 						/>
 						<label htmlFor={ `${ id }-${ index }` }>
 							{ option.label }

--- a/packages/components/src/radio-control/index.js
+++ b/packages/components/src/radio-control/index.js
@@ -54,7 +54,7 @@ export default function RadioControl( {
 							aria-describedby={
 								!! help ? `${ id }__help` : undefined
 							}
-							{...props}
+							{ ...props }
 						/>
 						<label htmlFor={ `${ id }-${ index }` }>
 							{ option.label }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR allows extra props for RadioControl component like `disabled` or ARIA related props.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
It's an enhancement that aligns the component's API with other components.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
