### PR TITLE
[RNMobile] Fix height of the bottom-sheet after using back button

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -4,7 +4,6 @@
 import { View, Easing } from 'react-native';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-
 /**
  * WordPress dependencies
  */
@@ -80,7 +79,7 @@ function BottomSheetNavigationContainer( { children, animate, main, theme } ) {
 	};
 
 	const setHeight = useCallback(
-		( height, layout ) => {
+		( height ) => {
 			// The screen is fullHeight or changing from fullScreen to the default mode
 			if (
 				( typeof currentHeight === 'string' &&
@@ -93,8 +92,8 @@ function BottomSheetNavigationContainer( { children, animate, main, theme } ) {
 				return;
 			}
 
-			if ( currentHeight !== height && height > 1 ) {
-				if ( animate && layout && currentHeight === 1 ) {
+			if ( height > 1 ) {
+				if ( currentHeight === 1 ) {
 					setCurrentHeight( height );
 				} else if ( animate ) {
 					performLayoutAnimation( ANIMATION_DURATION );

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -4,6 +4,7 @@
 import { View, Easing } from 'react-native';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+
 /**
  * WordPress dependencies
  */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
The height of the bottom-sheet stays incorrect in some scenarios. I also removed the `layout` argument since it is not used anymore.

To reproduce:

1. add button block
2. open settings
3. open the background color settings
4. select gradient segment
5. open "customize gradient"
6. use the back button on the top left of bottom-sheet
7. switch to solid segment
8. switch back to the gradient segment
9. the height is not correct


## How has this been tested?
1. add button block
2. open settings
3. open the background color settings
4. select gradient segment
5. open "customize gradient"
6. use the back button on the top left of bottom-sheet
7. switch to solid segment
8. switch back to the gradient segment
9. the height should be changed

## Screenshots <!-- if applicable -->
before | after
--- | ---
![notworkingbottom](https://user-images.githubusercontent.com/16336501/106466221-598c2f80-649b-11eb-956d-96b2f2ea0791.gif) | ![workingbottom](https://user-images.githubusercontent.com/16336501/106466233-5e50e380-649b-11eb-931a-edb9dbf6254b.gif)


## Types of changes
Bug-fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
