### PR TITLE
Try: Cover positioning fix take 1.

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -163,7 +163,8 @@
 	&.has-custom-content-position.has-custom-content-position {
 		.wp-block-cover__inner-container {
 			margin: 0;
-			width: auto;
+			width: 100%;
+			height: 100%;
 		}
 	}
 


### PR DESCRIPTION
This hopes to fix #28640.

When you use an embed block inside a cover block, and use the matrix alignment tool, the embed disappears.

This is due to these two lines of code: https://github.com/WordPress/gutenberg/pull/21091/files#diff-9e449d4b8bd69c9771de8e20c9a1d78798a6934f99e3bfc432df6ceb23def7f4R156

What happens is that when the matrix alignment tool is used, all content inside is "collapsed" to the smallest size of the content. Which in the case of an embed block is 0x0.

As soon as you add something else, just a single paragraph of text, the embed will be as wide as that embed:

![embed](https://user-images.githubusercontent.com/1204802/106583517-7b41f100-6545-11eb-92e6-59471d423e9d.gif)

This PR changes that CSS so it doesn't collapse. **But this is probably not the solution.**

So why was that CSS introduced in the first place? Because without it, the matrix alignment doesn't appear to work. Observe the master branch:

![paragraph, master](https://user-images.githubusercontent.com/1204802/106583829-cd831200-6545-11eb-9489-7a9cf9dde342.gif)

That paragraph is centered, and full width, yet it is able to align to all corners. Because its margin was zeroed out, and its width set to auto. The text alignment of the paragraph isn't actually changed, it's still centered — it's just centered inside a container as wide as its text.

Here's how that breaks with this branch:

![after](https://user-images.githubusercontent.com/1204802/106584102-18048e80-6546-11eb-8f9a-9eef3059d1c8.gif)

Observe how the text remains centered, because it _is_ centered inside a full width paragraph, and it doesn't reach its corners because the margin remains.

So while this PR technically fixes the issue — the embed doesn't collapse — it breaks the spirit of the matrix alignment in the process. 

<img width="1060" alt="after" src="https://user-images.githubusercontent.com/1204802/106584221-3c606b00-6546-11eb-8458-72a018fd330e.png">

I'm going to open a separate PR with an alternate take, but figured this PR would be a good test case and explainer for the issue.