### PR TITLE
Update layout icon to use g2 design language

### DIFF
--- a/packages/icons/src/library/layout.js
+++ b/packages/icons/src/library/layout.js
@@ -4,8 +4,8 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const layout = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
-		<Path d="M2 2h5v11H2V2zm6 0h5v5H8V2zm6 0h4v16h-4V2zM8 8h5v5H8V8zm-6 6h11v4H2v-4z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M18 5.5H6a.5.5 0 00-.5.5v3h13V6a.5.5 0 00-.5-.5zm.5 5H10v8h8a.5.5 0 00.5-.5v-7.5zm-10 0h-3V18a.5.5 0 00.5.5h2.5v-8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z" />
 	</SVG>
 );
 


### PR DESCRIPTION
The [layout icon](https://github.com/WordPress/gutenberg/blob/master/packages/icons/src/library/layout.js) is currently based on one of the old Dashicons and does not match what we have in [figma](https://github.com/WordPress/gutenberg/blob/master/packages/icons/src/library/layout.js):

<img width="496" alt="Screenshot 2021-02-01 at 15 56 37" src="https://user-images.githubusercontent.com/846565/106584695-6746c100-653e-11eb-8353-5af2d22a3ece.png">

This PR updates the icon to fit in with the other "g2" icons.

Before:

<img width="297" alt="Screenshot 2021-02-02 at 09 51 57" src="https://user-images.githubusercontent.com/846565/106584758-7ded1800-653e-11eb-8eb6-b40ca2199bbc.png">


After:

<img width="283" alt="Screenshot 2021-02-02 at 10 02 57" src="https://user-images.githubusercontent.com/846565/106584778-82b1cc00-653e-11eb-958e-8bb23eba0f1b.png">
