### PR TITLE
Try: Cover position fix round 2

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -13,6 +13,12 @@
 	}
 }
 
+// Supply a min-width when inside a cover block, to prevent it from collapsing.
+.wp-block-cover .wp-block-embed {
+	min-width: 320px;
+	min-height: 240px;
+}
+
 .wp-block-embed {
 	// Supply caption styles to embeds, even if the theme hasn't opted in.
 	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,


### PR DESCRIPTION
Arguably better alternative to #28650, but please see that PR as well for a larger explainer on what the fundamental issue is. 

Go there now, then come back and read the followup below. I'll wait.

...

Okay so the matrix aligner in the Cover block collapses every child block to its minimum dimensions so that it can align them to the corners. Which is problematic for responsive embeds, because they can collapse to 0x0. 

This PR fixes that by assigning a minimum width/height to embeds:

![embed](https://user-images.githubusercontent.com/1204802/106585209-5fd7e580-6547-11eb-9999-e15ca60860b6.gif)

But this opens questions:

- Should this minimum size apply outside of just the Cover block? We have intentionally avoided this in the past, because embeds come in all shapes and sizes.
- What is a good minimum width and height? The current dimensions are very much chosen according to "video dimensions", and as mentioned, these come in all shapes and sizes.
- Should we simply not allow the embed block to be aligned at all, and just try and preserve its `initial` width and heights when aligned?
- What about other blocks that can collapse into 0x0 when they have no width? 

This PR works as a baseline, but I'm not sure what the best next step. Feel free to commandeer this PR.