### PR TITLE
theme.json docs: fix codetabs in use

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -52,7 +52,7 @@ To address this need, we've started to experiment with CSS Custom Properties, ak
 - **Presets**: [color palettes](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes), [font sizes](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-font-sizes), or [gradients](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-gradient-presets) declared by the theme are converted to CSS Custom Properties and enqueued both the front-end and the editors.
 
 {% codetabs %}
-{% Input: theme.json %}
+{% Input %}
 ```json
 {
   "settings": {
@@ -75,7 +75,7 @@ To address this need, we've started to experiment with CSS Custom Properties, ak
   },
 }
 ```
-{% Output: CSS %}
+{% Output %}
 ```css
 :root {
   --wp--preset--color--black: #000000;
@@ -87,7 +87,7 @@ To address this need, we've started to experiment with CSS Custom Properties, ak
 - **Custom properties**: there's also a mechanism to create your own CSS Custom Properties.
 
 {% codetabs %}
-{% Input: theme.json %}
+{% Input %}
 ```json
 {
   "settings": {
@@ -102,7 +102,7 @@ To address this need, we've started to experiment with CSS Custom Properties, ak
   },
 }
 ```
-{% Output: CSS %}
+{% Output %}
 ```css
 :root {
   --wp--custom--line-height--body: 1.7;


### PR DESCRIPTION
The block editor handbook uses `codetabs` as a mechanism to provide ESNext/ES5 code comparisons. [Example](https://developer.wordpress.org/block-editor/tutorials/block-tutorial/writing-your-first-block-type/#registering-the-block):

![Captura de ecrã de 2021-02-02 11-34-14](https://user-images.githubusercontent.com/583546/106588265-de825200-654a-11eb-8bae-fa0e1f60792d.png)

In https://github.com/WordPress/gutenberg/pull/28639/files/09aaa04982cadc90e044c27a8915be927a85e089#r568052600 I pushed a change that used it to illustrate a similar situation: input (theme.json)  / output (CSS). It didn't work that well:

![Captura de ecrã de 2021-02-02 11-34-08](https://user-images.githubusercontent.com/583546/106588431-0ffb1d80-654b-11eb-8fc9-578e65305c09.png)

![Captura de ecrã de 2021-02-02 11-33-57](https://user-images.githubusercontent.com/583546/106588446-138ea480-654b-11eb-9aa7-e082ccab74ab.png)

I haven't found any missing markup, so I thought I'd push a change that uses a single work in the tab ("Input" instead of "Input: theme.json" / "Output" instead of "Output: css"). Not sure if the colon or spaces is why the parser broke.
