### PR TITLE
Refactor useEventHandlers to use Callback Ref.

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -3,11 +3,12 @@
  */
 import classnames from 'classnames';
 import { omit } from 'lodash';
+import mergeRefs from 'react-merge-refs';
 
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useContext } from '@wordpress/element';
+import { useRef, useEffect, useContext, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
 
@@ -92,7 +93,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 
 	useFocusFirstElement( ref, clientId );
-	useEventHandlers( ref, clientId );
+	const eventHandlersRef = useEventHandlers( ref, clientId );
 
 	// Block Reordering animation
 	useMovingAnimation(
@@ -107,10 +108,14 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const blockMovingModeClassNames = useBlockMovingModeClassNames( clientId );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
 
+	const mergedRefs = useCallback( mergeRefs( [ ref, eventHandlersRef ] ), [
+		ref,
+		eventHandlersRef,
+	] );
 	return {
 		...wrapperProps,
 		...props,
-		ref,
+		ref: mergedRefs,
 		id: `block-${ clientId }${ htmlSuffix }`,
 		tabIndex: 0,
 		role: 'group',

--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useContext } from '@wordpress/element';
+import { useContext, useCallback } from '@wordpress/element';
 import { isTextField } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -26,6 +26,7 @@ import { SelectionStart } from '../../writing-flow';
  * @param {string}    clientId Block client ID.
  */
 export function useEventHandlers( ref, clientId ) {
+	// TODO some blocks pass their own reference to `useBlockProps` - How to handle this..
 	const onSelectionStart = useContext( SelectionStart );
 	const { isSelected, rootClientId, index } = useSelect(
 		( select ) => {
@@ -47,8 +48,8 @@ export function useEventHandlers( ref, clientId ) {
 		'core/block-editor'
 	);
 
-	useEffect( () => {
-		if ( ! isSelected ) {
+	return useCallback(
+		( node ) => {
 			/**
 			 * Marks the block as selected when focused and not already
 			 * selected. This specifically handles the case where block does not
@@ -60,87 +61,90 @@ export function useEventHandlers( ref, clientId ) {
 			function onFocus( event ) {
 				// If an inner block is focussed, that block is resposible for
 				// setting the selected block.
-				if ( ! isInsideRootBlock( ref.current, event.target ) ) {
+				if ( ! isInsideRootBlock( node, event.target ) ) {
 					return;
 				}
 
 				selectBlock( clientId );
 			}
+			/**
+			 * Interprets keydown event intent to remove or insert after block if
+			 * key event occurs on wrapper node. This can occur when the block has
+			 * no text fields of its own, particularly after initial insertion, to
+			 * allow for easy deletion and continuous writing flow to add additional
+			 * content.
+			 *
+			 * @param {KeyboardEvent} event Keydown event.
+			 */
+			function onKeyDown( event ) {
+				const { keyCode, target } = event;
 
-			ref.current.addEventListener( 'focusin', onFocus );
+				if (
+					keyCode !== ENTER &&
+					keyCode !== BACKSPACE &&
+					keyCode !== DELETE
+				) {
+					return;
+				}
 
-			return () => {
+				if ( target !== node || isTextField( target ) ) {
+					return;
+				}
+
+				event.preventDefault();
+
+				if ( keyCode === ENTER ) {
+					insertDefaultBlock( {}, rootClientId, index + 1 );
+				} else {
+					removeBlock( clientId );
+				}
+			}
+
+			function onMouseLeave( { buttons } ) {
+				// The primary button must be pressed to initiate selection.
+				// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+				if ( buttons === 1 ) {
+					onSelectionStart( clientId );
+				}
+			}
+
+			/**
+			 * Prevents default dragging behavior within a block. To do: we must
+			 * handle this in the future and clean up the drag target.
+			 *
+			 * @param {DragEvent} event Drag event.
+			 */
+			function onDragStart( event ) {
+				event.preventDefault();
+			}
+
+			// Make sure to cleanup any events/references added to the last instance.
+			if ( ref.current ) {
 				ref.current.removeEventListener( 'focusin', onFocus );
-			};
-		}
-
-		/**
-		 * Interprets keydown event intent to remove or insert after block if
-		 * key event occurs on wrapper node. This can occur when the block has
-		 * no text fields of its own, particularly after initial insertion, to
-		 * allow for easy deletion and continuous writing flow to add additional
-		 * content.
-		 *
-		 * @param {KeyboardEvent} event Keydown event.
-		 */
-		function onKeyDown( event ) {
-			const { keyCode, target } = event;
-
-			if (
-				keyCode !== ENTER &&
-				keyCode !== BACKSPACE &&
-				keyCode !== DELETE
-			) {
-				return;
+				ref.current.removeEventListener( 'mouseleave', onMouseLeave );
+				ref.current.removeEventListener( 'keydown', onKeyDown );
+				ref.current.removeEventListener( 'dragstart', onDragStart );
+			}
+			if ( ! node ) return;
+			if ( ! isSelected ) {
+				node.addEventListener( 'focusin', onFocus );
 			}
 
-			if ( target !== ref.current || isTextField( target ) ) {
-				return;
-			}
+			node.addEventListener( 'keydown', onKeyDown );
+			node.addEventListener( 'mouseleave', onMouseLeave );
+			node.addEventListener( 'dragstart', onDragStart );
 
-			event.preventDefault();
-
-			if ( keyCode === ENTER ) {
-				insertDefaultBlock( {}, rootClientId, index + 1 );
-			} else {
-				removeBlock( clientId );
-			}
-		}
-
-		function onMouseLeave( { buttons } ) {
-			// The primary button must be pressed to initiate selection.
-			// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
-			if ( buttons === 1 ) {
-				onSelectionStart( clientId );
-			}
-		}
-
-		/**
-		 * Prevents default dragging behavior within a block. To do: we must
-		 * handle this in the future and clean up the drag target.
-		 *
-		 * @param {DragEvent} event Drag event.
-		 */
-		function onDragStart( event ) {
-			event.preventDefault();
-		}
-
-		ref.current.addEventListener( 'keydown', onKeyDown );
-		ref.current.addEventListener( 'mouseleave', onMouseLeave );
-		ref.current.addEventListener( 'dragstart', onDragStart );
-
-		return () => {
-			ref.current.removeEventListener( 'mouseleave', onMouseLeave );
-			ref.current.removeEventListener( 'keydown', onKeyDown );
-			ref.current.removeEventListener( 'dragstart', onDragStart );
-		};
-	}, [
-		isSelected,
-		rootClientId,
-		index,
-		onSelectionStart,
-		insertDefaultBlock,
-		removeBlock,
-		selectBlock,
-	] );
+			// Save a reference to the node to be used when unmounting.
+			ref.current = node;
+		},
+		[
+			isSelected,
+			rootClientId,
+			index,
+			onSelectionStart,
+			insertDefaultBlock,
+			removeBlock,
+			selectBlock,
+		]
+	);
 }

--- a/packages/rich-text/src/component/use-inline-warning.js
+++ b/packages/rich-text/src/component/use-inline-warning.js
@@ -6,6 +6,7 @@ import { useEffect } from '@wordpress/element';
 export function useInlineWarning( { ref } ) {
 	useEffect( () => {
 		if ( process.env.NODE_ENV === 'development' ) {
+			if ( ! ref.current ) return;
 			const target = ref.current;
 			const { defaultView } = target.ownerDocument;
 			const computedStyle = defaultView.getComputedStyle( target );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR will refactor `useEventHandlers` to use  Callback Ref.

The current code has a problematic behaviour on blocks like `Latest Posts`, that change their `ref`, based on some conditions (ex wait for a request). Inside `useBlockProps`, that is calling `useEventHandlers`, we assign a `onFocus` handler for the first ref. Later when the `ref` changes, the `onFocus` handler hasn't been attached.... 

This happens because the `ref.current` doesn't trigger a rerender when it changes.

Related issues: https://github.com/WordPress/gutenberg/issues/28417, https://github.com/WordPress/gutenberg/issues/28880

### This is not working currently as there is more work to be done

1. I have to check how to handle some blocks that pass their own `ref` in `useBlockProps`.
2. Make `RichText` component work, as it expects ref.current to be always set, but with Callback Ref it can be null on first render.



