### PR TITLE
Interim fix for Latest Posts focus on load

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -450,7 +450,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 	const dateFormat = __experimentalGetSettings().formats.date;
 
 	return (
-		<>
+		<div>
 			{ inspectorControls }
 			<BlockControls>
 				<ToolbarGroup controls={ layoutControls } />
@@ -576,6 +576,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					);
 				} ) }
 			</ul>
-		</>
+		</div>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/28417
Fixes: https://github.com/WordPress/gutenberg/issues/28536

The above issues' problem is that `Latest Posts` block is not selectable and block settings will not display, after the page/post's load. It still works when inserting it for the first time..

This PR is an **interim** fix for focus handling in `Latest Posts` block. The description of the root problem and the proper fix is in this PR: https://github.com/WordPress/gutenberg/pull/28658, which I don't believe it will be soon ready - anyone of course that wants to chime in there is really welcome.

I'm not sure if it's acceptable to merge this and then work on the proper `useEventsHandler` refactor later, but with this PR with have this option.. 🤔 