### PR TITLE
Calculate frecency for block variations properly

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -22,7 +22,7 @@ import {
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
-import { isReusableBlock, getBlockVariations } from '@wordpress/blocks';
+import { getBlockVariations } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -1520,7 +1520,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					? `${ blockName }/${ match.name }`
 					: blockName;
 				const insert = { name: id };
-				if ( isReusableBlock( block ) ) {
+				if ( blockName === 'core/block' ) {
 					insert.ref = attributes.ref;
 					id += '/' + attributes.ref;
 				}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1517,7 +1517,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 				// If a block variation match is found change the name to be the same with the
 				// one that is used for block variations in the Inserter (`getItemFromVariation`).
 				let id = match?.name
-					? `${ blockName }-${ match.name }`
+					? `${ blockName }/${ match.name }`
 					: blockName;
 				const insert = { name: id };
 				if ( isReusableBlock( block ) ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -22,7 +22,7 @@ import {
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
-import { isReusableBlock } from '@wordpress/blocks';
+import { isReusableBlock, getBlockVariations } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -1509,11 +1509,20 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 		case 'INSERT_BLOCKS':
 		case 'REPLACE_BLOCKS':
 			return action.blocks.reduce( ( prevState, block ) => {
-				let id = block.name;
-				const insert = { name: block.name };
+				const { attributes, name: blockName } = block;
+				const variations = getBlockVariations( blockName );
+				const match = variations?.find( ( variation ) =>
+					variation.isActive?.( attributes, variation.attributes )
+				);
+				// If a block variation match is found change the name to be the same with the
+				// one that is used for block variations in the Inserter (`getItemFromVariation`).
+				let id = match?.name
+					? `${ blockName }-${ match.name }`
+					: blockName;
+				const insert = { name: id };
 				if ( isReusableBlock( block ) ) {
-					insert.ref = block.attributes.ref;
-					id += '/' + block.attributes.ref;
+					insert.ref = attributes.ref;
+					id += '/' + attributes.ref;
 				}
 
 				return {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1398,7 +1398,7 @@ const canIncludeBlockTypeInInserter = ( state, blockType, rootClientId ) => {
  * @return {Function} Function to transform a block variation to inserter item
  */
 const getItemFromVariation = ( state, item ) => ( variation ) => {
-	const variationId = `${ item.id }-${ variation.name }`;
+	const variationId = `${ item.id }/${ variation.name }`;
 	const { time, count = 0 } = getInsertUsage( state, variationId ) || {};
 	return {
 		...item,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1393,27 +1393,33 @@ const canIncludeBlockTypeInInserter = ( state, blockType, rootClientId ) => {
 /**
  * Return a function to be used to tranform a block variation to an inserter item
  *
+ * @param {Object} state Global State
  * @param {Object} item Denormalized inserter item
  * @return {Function} Function to transform a block variation to inserter item
  */
-const getItemFromVariation = ( item ) => ( variation ) => ( {
-	...item,
-	id: `${ item.id }-${ variation.name }`,
-	icon: variation.icon || item.icon,
-	title: variation.title || item.title,
-	description: variation.description || item.description,
-	category: variation.category || item.category,
-	// If `example` is explicitly undefined for the variation, the preview will not be shown.
-	example: variation.hasOwnProperty( 'example' )
-		? variation.example
-		: item.example,
-	initialAttributes: {
-		...item.initialAttributes,
-		...variation.attributes,
-	},
-	innerBlocks: variation.innerBlocks,
-	keywords: variation.keywords || item.keywords,
-} );
+const getItemFromVariation = ( state, item ) => ( variation ) => {
+	const variationId = `${ item.id }-${ variation.name }`;
+	const { time, count = 0 } = getInsertUsage( state, variationId ) || {};
+	return {
+		...item,
+		id: variationId,
+		icon: variation.icon || item.icon,
+		title: variation.title || item.title,
+		description: variation.description || item.description,
+		category: variation.category || item.category,
+		// If `example` is explicitly undefined for the variation, the preview will not be shown.
+		example: variation.hasOwnProperty( 'example' )
+			? variation.example
+			: item.example,
+		initialAttributes: {
+			...item.initialAttributes,
+			...variation.attributes,
+		},
+		innerBlocks: variation.innerBlocks,
+		keywords: variation.keywords || item.keywords,
+		frecency: calculateFrecency( time, count ),
+	};
+};
 
 /**
  * Returns the calculated frecency.
@@ -1588,7 +1594,7 @@ export const getInserterItems = createSelector(
 		for ( const item of blockTypeInserterItems ) {
 			const { variations = [] } = item;
 			if ( variations.length ) {
-				const variationMapper = getItemFromVariation( item );
+				const variationMapper = getItemFromVariation( state, item );
 				blockVariations.push( ...variations.map( variationMapper ) );
 			}
 		}

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2622,6 +2622,80 @@ describe( 'state', () => {
 				},
 			} );
 		} );
+		describe( 'block variations handling', () => {
+			const blockWithVariations = 'core/test-block-with-variations';
+			beforeAll( () => {
+				const variations = [
+					{
+						name: 'apple',
+						attributes: { fruit: 'apple' },
+					},
+					{ name: 'orange', attributes: { fruit: 'orange' } },
+				].map( ( variation ) => ( {
+					...variation,
+					isActive: ( blockAttributes, variationAttributes ) =>
+						blockAttributes?.fruit === variationAttributes.fruit,
+				} ) );
+				registerBlockType( blockWithVariations, {
+					save: noop,
+					edit: noop,
+					title: 'Fruit with variations',
+					variations,
+				} );
+			} );
+			afterAll( () => {
+				unregisterBlockType( blockWithVariations );
+			} );
+			it( 'should return proper results with both found or not found block variation matches', () => {
+				const state = preferences( deepFreeze( { insertUsage: {} } ), {
+					type: 'INSERT_BLOCKS',
+					blocks: [
+						{
+							clientId: 'no match',
+							name: blockWithVariations,
+						},
+						{
+							clientId: 'not a variation match',
+							name: blockWithVariations,
+							attributes: { fruit: 'not in a variation' },
+						},
+						{
+							clientId: 'orange',
+							name: blockWithVariations,
+							attributes: { fruit: 'orange' },
+						},
+						{
+							clientId: 'apple',
+							name: blockWithVariations,
+							attributes: { fruit: 'apple' },
+						},
+					],
+					time: 123456,
+				} );
+
+				const orangeVariationName = `${ blockWithVariations }-orange`;
+				const appleVariationName = `${ blockWithVariations }-apple`;
+				expect( state ).toEqual( {
+					insertUsage: expect.objectContaining( {
+						[ orangeVariationName ]: {
+							time: 123456,
+							count: 1,
+							insert: { name: orangeVariationName },
+						},
+						[ appleVariationName ]: {
+							time: 123456,
+							count: 1,
+							insert: { name: appleVariationName },
+						},
+						[ blockWithVariations ]: {
+							time: 123456,
+							count: 2,
+							insert: { name: blockWithVariations },
+						},
+					} ),
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'blocksMode', () => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2673,8 +2673,8 @@ describe( 'state', () => {
 					time: 123456,
 				} );
 
-				const orangeVariationName = `${ blockWithVariations }-orange`;
-				const appleVariationName = `${ blockWithVariations }-apple`;
+				const orangeVariationName = `${ blockWithVariations }/orange`;
+				const appleVariationName = `${ blockWithVariations }/apple`;
 				expect( state ).toEqual( {
 					insertUsage: expect.objectContaining( {
 						[ orangeVariationName ]: {

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
@@ -26,30 +26,19 @@ describe( 'Block variations', () => {
 		await deactivatePlugin( 'gutenberg-test-block-variations' );
 	} );
 
-	const expectInserterItem = async (
-		blockName,
-		blockTitle,
-		variationName = null
-	) => {
-		const inserterItemSelector = [
-			'.editor-block-list-item',
-			blockName.replace( 'core/', '' ),
-			variationName,
-		]
-			.filter( Boolean )
-			.join( '-' );
-		const inserterItem = await page.$( inserterItemSelector );
+	const expectInserterItem = async ( blockTitle ) => {
+		const inserterItem = await page.$x(
+			`//button[contains(@class, 'block-editor-block-types-list__item')]//span[text()="${ blockTitle }"]`
+		);
 		expect( inserterItem ).toBeDefined();
-		expect(
-			await inserterItem.$x( `//span[text()="${ blockTitle }"]` )
-		).toHaveLength( 1 );
+		expect( inserterItem ).toHaveLength( 1 );
 	};
 
 	test( 'Search for the overridden default Quote block', async () => {
 		await searchForBlock( 'Quote' );
 
 		expect( await page.$( '.editor-block-list-item-quote' ) ).toBeNull();
-		expectInserterItem( 'quote', 'Large Quote', 'large' );
+		expectInserterItem( 'Large Quote' );
 	} );
 
 	test( 'Insert the overridden default Quote block variation', async () => {
@@ -78,9 +67,9 @@ describe( 'Block variations', () => {
 	test( 'Search for the Paragraph block with 2 additional variations', async () => {
 		await searchForBlock( 'Paragraph' );
 
-		expectInserterItem( 'core/paragraph', 'Paragraph' );
-		expectInserterItem( 'core/paragraph', 'Success Message', 'success' );
-		expectInserterItem( 'core/paragraph', 'Warning Message', 'warning' );
+		expectInserterItem( 'Paragraph' );
+		expectInserterItem( 'Success Message' );
+		expectInserterItem( 'Warning Message' );
 	} );
 
 	test( 'Insert the Success Message block variation', async () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/28573

When we use the Inserter, we use 'frecency' for fetching and ordering the most used blocks. 'frecency' is a heuristic that combines block usage frequency and recency.
reference: https://en.wikipedia.org/wiki/Frecency

The problem is that if we use a block variation the frecency is calculated for the main block, making the results wrong.

This PR fixes the above issue.

## Testing instructions
1. Add an `embed` block variation in a page/post
2. Open the inserter and observe that only the inserted block variations are shown, ordered by `frecency`

** note about `embed`
If you paste a link that can be converted to an `embed` block variation, like a `youtube` link, first an `embed` base block is created and afterwards it's converted (a new one is created) with its respective variation. So in that case you will also see the `embed` block in the `Most used blocks`. This is about how `embed` block works.

## Notes
1. There is still problematic behaviour on `Most used blocks` as they reset on every load. This will be fixed here: https://github.com/WordPress/gutenberg/pull/28694
2. In order for this to work properly for any block, the block developer should set `isActive` property in block variations (reference: https://developer.wordpress.org/block-editor/developers/block-api/block-registration/#variations-optional).
<!-- Please describe what you have changed or added -->

### Before
![before](https://user-images.githubusercontent.com/16275880/106609240-0cc55900-656e-11eb-84ec-2416046793c1.gif)


### After
![after](https://user-images.githubusercontent.com/16275880/106609253-0f27b300-656e-11eb-87e0-9ab24663b6c9.gif)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
