### PR TITLE
Fix sidebar settings block card icon shrinking

### DIFF
--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -1,4 +1,3 @@
-
 .block-editor-block-card {
 	display: flex;
 	align-items: flex-start;

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -3,14 +3,6 @@
 	align-items: flex-start;
 }
 
-.block-editor-block-card__icon {
-	border: $border-width solid $gray-300;
-	padding: 7px;
-	margin-right: 10px;
-	height: 36px;
-	width: 36px;
-}
-
 .block-editor-block-card__content {
 	flex-grow: 1;
 }

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -19,6 +19,7 @@
 }
 
 .block-editor-block-card .block-editor-block-icon {
+	flex: 0 0 $button-size;
 	margin-left: -2px;
 	margin-right: 10px;
 	padding: 0 3px;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
* Removed unused class (`.block-editor-block-card__icon`)
* Fixed the width of the icon

## How has this been tested?
1. Open block editor
2. Open settings sidebar
3. Switch to Block tab
4. Keep clicking on different block types to see the icon growing and shrinking
5. Checkout to this branch
6. Refresh block editor
7. Keep clicking on different block types to confirm the icon's width isn't changing

## Screenshots <!-- if applicable -->
Look how the space between the blue lines and block title varies in the sidebar.

**before**

https://user-images.githubusercontent.com/2256104/106620770-2f597100-6572-11eb-89da-cd5dbbec3641.mov

**after**

https://user-images.githubusercontent.com/2256104/106620793-354f5200-6572-11eb-87e3-9b23970c98e3.mov

## Types of changes
What types of changes does your code introduce?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
