### PR TITLE
Fix a typo in a link of the handbook page

### DIFF
--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -39,7 +39,7 @@ To update an existing page:
 
 ### Create a New Document
 
-To add a new documentation page requires a working JavaScript development environment to build the documentation, see the [JavaScript build setup documentation](/docs/designers-developer/developers/tutorials/javascript/js-build-setup.md):
+To add a new documentation page requires a working JavaScript development environment to build the documentation, see the [JavaScript build setup documentation](/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md):
 
 1. Create a Markdown file in the [docs](https://github.com/WordPress/gutenberg/tree/HEAD/docs) folder, use lower-case, no spaces, if needed a dash separator, and .md extension.
 2. Add content, all documents require one and only H1 tag, using markdown notation.


### PR DESCRIPTION
Fix a typo in a link in this handbook page https://github.com/WordPress/gutenberg/blob/master/docs/contributors/document.md which was redirecting to a page not found