### PR TITLE
Unit tests workflow: Run always, but bail early if only docs have changed

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,15 +6,32 @@ on:
     branches: [master, wp-trunk]
 
 jobs:
+  diff-files-list:
+    name: Make a list of files that were changed
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.make-files-list.outputs.files }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: make-files-list
+        name: Make list of files that changed
+        run: |
+          echo ::set-output name=files::$(git diff --name-only $(git merge-base master $(git rev-parse --abbrev-ref HEAD)))
+
   unit-js:
     name: JavaScript
     runs-on: ubuntu-latest
+    needs: diff-files-list
     strategy:
       fail-fast: false
       matrix:
         node: [12, 14]
 
     steps:
+    - name: Skip if only doc files have been changed
+      run: for file in ${{ needs.diff-files-list.outputs.files }}; do if [[ $file != *".md" ]]; then exit 0; fi done
+
     - uses: actions/checkout@v2
 
     - name: Cache node modules
@@ -51,10 +68,13 @@ jobs:
 
   unit-php:
     name: PHP
-
     runs-on: ubuntu-latest
+    needs: diff-files-list
 
     steps:
+    - name: Skip if only doc files have been changed
+      run: for file in ${{ needs.diff-files-list.outputs.files }}; do if [[ $file != *".md" ]]; then exit 0; fi done
+
     - uses: actions/checkout@v2
 
     - name: Cache node modules
@@ -99,10 +119,13 @@ jobs:
 
   mobile-unit-js:
     name: Mobile
-
     runs-on: ubuntu-latest
+    needs: diff-files-list
 
     steps:
+    - name: Skip if only doc files have been changed
+      run: for file in ${{ needs.diff-files-list.outputs.files }}; do if [[ $file != *".md" ]]; then exit 0; fi done
+
     - uses: actions/checkout@v2
 
     - name: Cache node modules

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,20 +8,22 @@ on:
 jobs:
   diff-files-list:
     name: Make a list of files that were changed
+    if: github.event.pull_request
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.make-files-list.outputs.files }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: master
-
-      - uses: actions/checkout@v2
 
       - id: make-files-list
         name: Make list of files that changed
         run: |
-          echo ::set-output name=files::$(git diff --name-only $(git merge-base master $(git rev-parse --abbrev-ref HEAD)))
+          curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -o diff-files.json \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
+          echo ::set-output name=files::$(jq --raw-output '.[] .filename' diff-files.json)
+          rm diff-files.json
 
   unit-js:
     name: JavaScript

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,8 +13,6 @@ jobs:
     outputs:
       files: ${{ steps.make-files-list.outputs.files }}
     steps:
-      - uses: actions/checkout@v2
-
       - id: make-files-list
         name: Make list of files that changed
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,10 +13,10 @@ jobs:
       files: ${{ steps.make-files-list.outputs.files }}
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/checkout@v2
         with:
           ref: master
+
+      - uses: actions/checkout@v2
 
       - id: make-files-list
         name: Make list of files that changed

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,12 +2,8 @@ name: Unit Tests
 
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
   push:
     branches: [master, wp-trunk]
-    paths-ignore:
-    - '**.md'
 
 jobs:
   unit-js:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+
       - id: make-files-list
         name: Make list of files that changed
         run: |


### PR DESCRIPTION
## Description
I've recently made the PHP and JS unit tests required -- meaning they _have_ to pass before a PR can be merged.
(This is in the wake of a recent issue that left PHP unit tests in a broken state -- also for subsequent PRs.)

@nosolosw then discovered that this affected documentation-only PRs (such as #28639): Since the unit test workflow had a [condition](https://github.com/WordPress/gutenberg/blob/d8d208927e964bf4f928a9e6b378902ed5fc421e/.github/workflows/unit-test.yml#L3-L10) that exempted it from running on such PRs, it never passed -- and the 'required' check criterion was never fulfilled.

This PR removes that condition from the workflow (so that the unit tests workflow always runs). Instead, it adds new steps to each unit test job that will cause them to bail early, if it the changed files are really only documentation files. (This could later be refined to e.g. only run the PHP unit tests if PHP files have been modified.)

This is based on [this answer](https://github.community/t/force-succeed-required-workflow-when-skipped/124055/3) (with a small modification to use `git diff` locally -- rather than the GH REST API -- in order to get the list of files that have been changed by the PR).

## How has this been tested?
Check the unit test GH workflows at the bottom of this PR. We'll also need a documentation-only PR to verify that it skips those -- TBD :thinking: 