### PR TITLE
Declunkify focal point picker dragging

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -235,15 +235,19 @@ function useCoverIsDark( url, dimRatio = 50, overlayColor, elementRef ) {
 	return isDark;
 }
 
+function mediaPosition( { x, y } ) {
+	return `${ Math.round( x * 100 ) }% ${ Math.round( y * 100 ) }%`;
+}
+
 function CoverEdit( {
 	attributes,
-	setAttributes,
 	isSelected,
 	noticeUI,
+	noticeOperations,
 	overlayColor,
+	setAttributes,
 	setOverlayColor,
 	toggleSelection,
-	noticeOperations,
 } ) {
 	const {
 		contentPosition,
@@ -344,9 +348,8 @@ function CoverEdit( {
 
 	const mediaStyle = {
 		objectPosition:
-			// prettier-ignore
 			focalPoint && isImgElement
-				? `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100) }%`
+				? mediaPosition( focalPoint )
 				: undefined,
 	};
 
@@ -354,6 +357,13 @@ function CoverEdit( {
 	const showFocalPointPicker =
 		isVideoBackground ||
 		( isImageBackground && ( ! hasParallax || isRepeated ) );
+
+	const imperativeFocalPointPreview = ( value ) => {
+		const [ styleOfRef, property ] = isDarkElement.current
+			? [ isDarkElement.current.style, 'objectPosition' ]
+			: [ blockProps.ref.current.style, 'backgroundPosition' ];
+		styleOfRef[ property ] = mediaPosition( value );
+	};
 
 	const controls = (
 		<>
@@ -405,6 +415,9 @@ function CoverEdit( {
 								label={ __( 'Focal point picker' ) }
 								url={ url }
 								value={ focalPoint }
+								onDrag={ ( event, value ) => {
+									imperativeFocalPointPreview( value );
+								} }
 								onChange={ ( newFocalPoint ) =>
 									setAttributes( {
 										focalPoint: newFocalPoint,

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -415,9 +415,8 @@ function CoverEdit( {
 								label={ __( 'Focal point picker' ) }
 								url={ url }
 								value={ focalPoint }
-								onDrag={ ( event, value ) => {
-									imperativeFocalPointPreview( value );
-								} }
+								onDragStart={ imperativeFocalPointPreview }
+								onDrag={ imperativeFocalPointPreview }
 								onChange={ ( newFocalPoint ) =>
 									setAttributes( {
 										focalPoint: newFocalPoint,

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -257,9 +257,8 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					onChange={ ( value ) =>
 						setAttributes( { focalPoint: value } )
 					}
-					onDrag={ ( event, value ) =>
-						imperativeFocalPointPreview( value )
-					}
+					onDragStart={ imperativeFocalPointPreview }
+					onDrag={ imperativeFocalPointPreview }
 				/>
 			) }
 			{ mediaType === 'image' && (

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -9,7 +9,7 @@ import { map, filter } from 'lodash';
  */
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
@@ -142,6 +142,13 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		[ isSelected, mediaId ]
 	);
 
+	const refMediaContainer = useRef();
+	const imperativeFocalPointPreview = ( value ) => {
+		const { style } = refMediaContainer.current.resizable;
+		const { x, y } = value;
+		style.backgroundPosition = `${ x * 100 }% ${ y * 100 }%`;
+	};
+
 	const [ temporaryMediaWidth, setTemporaryMediaWidth ] = useState( null );
 
 	const onSelectMedia = attributesFromMedia( { attributes, setAttributes } );
@@ -250,6 +257,9 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					onChange={ ( value ) =>
 						setAttributes( { focalPoint: value } )
 					}
+					onDrag={ ( event, value ) =>
+						imperativeFocalPointPreview( value )
+					}
 				/>
 			) }
 			{ mediaType === 'image' && (
@@ -321,6 +331,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					onSelectMedia={ onSelectMedia }
 					onWidthChange={ onWidthChange }
 					commitWidthChange={ commitWidthChange }
+					ref={ refMediaContainer }
 					{ ...{
 						focalPoint,
 						imageFill,

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -17,6 +17,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -39,15 +40,20 @@ export function imageFillStyles( url, focalPoint ) {
 		: {};
 }
 
-function ResizableBoxContainer( { isSelected, isStackedOnMobile, ...props } ) {
-	const isMobile = useViewportMatch( 'small', '<' );
-	return (
-		<ResizableBox
-			showHandle={ isSelected && ( ! isMobile || ! isStackedOnMobile ) }
-			{ ...props }
-		/>
-	);
-}
+const ResizableBoxContainer = forwardRef(
+	( { isSelected, isStackedOnMobile, ...props }, ref ) => {
+		const isMobile = useViewportMatch( 'small', '<' );
+		return (
+			<ResizableBox
+				ref={ ref }
+				showHandle={
+					isSelected && ( ! isMobile || ! isStackedOnMobile )
+				}
+				{ ...props }
+			/>
+		);
+	}
+);
 
 function ToolbarEditButton( { mediaId, mediaUrl, onSelectMedia } ) {
 	return (
@@ -90,7 +96,7 @@ function PlaceholderContainer( {
 	);
 }
 
-function MediaContainer( props ) {
+function MediaContainer( props, ref ) {
 	const {
 		className,
 		commitWidthChange,
@@ -154,6 +160,7 @@ function MediaContainer( props ) {
 				axis="x"
 				isSelected={ isSelected }
 				isStackedOnMobile={ isStackedOnMobile }
+				ref={ ref }
 			>
 				<ToolbarEditButton
 					onSelectMedia={ onSelectMedia }
@@ -168,4 +175,4 @@ function MediaContainer( props ) {
 	return <PlaceholderContainer { ...props } />;
 }
 
-export default withNotices( MediaContainer );
+export default withNotices( forwardRef( MediaContainer ) );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking Change
+- `onChange` prop of `FocalPointPicker` is called at the end of drag operations. Previously, it was called repetitively while dragging.
+
+### New Feature
+- Supports ref forwarding in `withNotices` and `ResizableBox`.
+- Adds `onDrag` prop of `FocalPointPicker`.
+
+### Bug Fix
+- Allows focus of the `FocalPointPicker` draggable area and adjustment with arrow keys. This was added in [#22531](https://github.com/WordPress/gutenberg/pull/22264) but was no longer working.
+
 ## 12.0.0 (2020-12-17)
 
 ### Enhancements

--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -60,13 +60,6 @@ URL of the image or video to be displayed
 
 Autoplays HTML5 video. This only applies to video sources (`url`).
 
-### `dimensions`
-
--   Type: `Object`
--   Required: Yes
-
-An object describing the height and width of the image. Requires two parameters: `height`, `width`.
-
 ### `value`
 
 -   Type: `Object`
@@ -80,3 +73,24 @@ The focal point. Should be an object containing `x` and `y` params.
 -   Required: Yes
 
 Callback which is called when the focal point changes.
+
+### `onDrag`
+
+-   Type: `Function`
+-   Required: No
+
+Callback which is called repetitively during drag operations.
+
+### `onDragEnd`
+
+-   Type: `Function`
+-   Required: No
+
+Callback which is called at the end of drag operations.
+
+### `onDragStart`
+
+-   Type: `Function`
+-   Required: No
+
+Callback which is called at the start of drag operations.

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -8,13 +8,12 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { withInstanceId } from '@wordpress/compose';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
-import withFocusOutside from '../higher-order/with-focus-outside';
 import BaseControl from '../base-control';
 import Controls from './controls';
 import FocalPoint from './focal-point';
@@ -40,18 +39,26 @@ export class FocalPointPicker extends Component {
 		this.containerRef = createRef();
 		this.mediaRef = createRef();
 
-		this.handleOnClick = this.handleOnClick.bind( this );
-		this.handleOnMouseUp = this.handleOnMouseUp.bind( this );
-		this.handleOnKeyDown = this.handleOnKeyDown.bind( this );
-		this.onMouseMove = this.onMouseMove.bind( this );
+		this.onMouseDown = this.startDrag.bind( this );
+		this.onMouseUp = this.stopDrag.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
+		this.onMouseMove = this.doDrag.bind( this );
+		this.ifDraggingStop = () => {
+			if ( this.state.isDragging ) {
+				this.stopDrag();
+			}
+		};
+		this.onChangeAtControls = ( value ) => {
+			this.updateValue( value );
+			this.props.onChange( value );
+		};
 
 		this.updateBounds = this.updateBounds.bind( this );
 		this.updateValue = this.updateValue.bind( this );
 	}
 	componentDidMount() {
-		const ownerDoc = this.containerRef.current.ownerDocument;
-		ownerDoc.addEventListener( 'mouseup', this.handleOnMouseUp );
-		ownerDoc.defaultView.addEventListener( 'resize', this.updateBounds );
+		const { defaultView } = this.containerRef.current.ownerDocument;
+		defaultView.addEventListener( 'resize', this.updateBounds );
 
 		/*
 		 * Set initial bound values.
@@ -63,26 +70,25 @@ export class FocalPointPicker extends Component {
 	}
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.url !== this.props.url ) {
-			this.setState( {
-				isDragging: false,
-			} );
+			this.ifDraggingStop();
 		}
-		if ( this.state.isDragging ) return;
 		/*
 		 * Handles cases where the incoming value changes.
 		 * An example is the values resetting based on an UNDO action.
 		 */
-		if (
-			this.props.value.x !== this.state.percentages.x ||
-			this.props.value.y !== this.state.percentages.y
-		) {
+		const {
+			isDragging,
+			percentages: { x, y },
+		} = this.state;
+		const { value } = this.props;
+		if ( ! isDragging && ( value.x !== x || value.y !== y ) ) {
 			this.setState( { percentages: this.props.value } );
 		}
 	}
 	componentWillUnmount() {
-		const ownerDoc = this.containerRef.current.ownerDocument;
-		ownerDoc.removeEventListener( 'mouseup', this.handleOnMouseUp );
-		ownerDoc.defaultView.removeEventListener( 'resize', this.updateBounds );
+		const { defaultView } = this.containerRef.current.ownerDocument;
+		defaultView.removeEventListener( 'resize', this.updateBounds );
+		this.ifDraggingStop();
 	}
 	calculateBounds() {
 		const bounds = INITIAL_BOUNDS;
@@ -137,22 +143,30 @@ export class FocalPointPicker extends Component {
 			bounds: this.calculateBounds(),
 		} );
 	}
-	handleOnClick( event ) {
+	startDrag( event ) {
 		event.persist();
 		this.containerRef.current.focus();
-		this.props.onDragStart?.( event );
-		this.setState( { isDragging: true }, () => {
-			this.onMouseMove( event );
-		} );
+		this.setState( { isDragging: true } );
+		const { ownerDocument } = this.containerRef.current;
+		ownerDocument.addEventListener( 'mouseup', this.onMouseUp );
+		ownerDocument.addEventListener( 'mousemove', this.onMouseMove );
+		const value = this.getValueFromPoint(
+			{ x: event.pageX, y: event.pageY },
+			event.shiftKey
+		);
+		this.updateValue( value );
+		this.props.onDragStart?.( value, event );
 	}
-	handleOnMouseUp( event ) {
-		event.persist?.();
-		this.props.onDragEnd?.( event );
+	stopDrag( event ) {
+		const { ownerDocument } = this.containerRef.current;
+		ownerDocument.removeEventListener( 'mouseup', this.onMouseUp );
+		ownerDocument.removeEventListener( 'mousemove', this.onMouseMove );
 		this.setState( { isDragging: false }, () => {
 			this.props.onChange( this.state.percentages );
 		} );
+		this.props.onDragEnd?.( event );
 	}
-	handleOnKeyDown( event ) {
+	onKeyDown( event ) {
 		const { keyCode, shiftKey } = event;
 		if ( ! [ UP, DOWN, LEFT, RIGHT ].includes( keyCode ) ) return;
 
@@ -169,28 +183,32 @@ export class FocalPointPicker extends Component {
 		this.updateValue( next );
 		this.props.onChange( next );
 	}
-	onMouseMove( event ) {
-		const { isDragging, bounds } = this.state;
-
-		if ( ! isDragging ) return;
-
+	doDrag( event ) {
 		// Prevents text-selection when dragging.
 		event.preventDefault();
+		const value = this.getValueFromPoint(
+			{ x: event.pageX, y: event.pageY },
+			event.shiftKey
+		);
+		this.updateValue( value );
+		this.props.onDrag?.( value, event );
+	}
+	getValueFromPoint( point, byTenths ) {
+		const { bounds } = this.state;
 
-		const { shiftKey } = event;
 		const pickerDimensions = this.pickerDimensions();
-		const cursorPosition = {
-			left: event.pageX - pickerDimensions.left,
-			top: event.pageY - pickerDimensions.top,
+		const relativePoint = {
+			left: point.x - pickerDimensions.left,
+			top: point.y - pickerDimensions.top,
 		};
 
 		const left = Math.max(
 			bounds.left,
-			Math.min( cursorPosition.left, bounds.right )
+			Math.min( relativePoint.left, bounds.right )
 		);
 		const top = Math.max(
 			bounds.top,
-			Math.min( cursorPosition.top, bounds.bottom )
+			Math.min( relativePoint.top, bounds.bottom )
 		);
 
 		let nextX =
@@ -200,18 +218,12 @@ export class FocalPointPicker extends Component {
 			( top - bounds.top ) / ( pickerDimensions.height - bounds.top * 2 );
 
 		// Enables holding shift to jump values by 10%
-		const step = shiftKey ? 0.1 : 0.01;
+		const step = byTenths ? 0.1 : 0.01;
 
 		nextX = roundClamp( nextX, 0, 1, step );
 		nextY = roundClamp( nextY, 0, 1, step );
 
-		const nextPercentage = {
-			x: nextX,
-			y: nextY,
-		};
-
-		this.updateValue( nextPercentage );
-		this.props.onDrag?.( event, nextPercentage );
+		return { x: nextX, y: nextY };
 	}
 	pickerDimensions() {
 		const containerNode = this.containerRef.current;
@@ -237,8 +249,8 @@ export class FocalPointPicker extends Component {
 	}
 	iconCoordinates() {
 		const {
-			percentages: { x, y },
 			bounds,
+			percentages: { x, y },
 		} = this.state;
 
 		if ( bounds.left === undefined || bounds.top === undefined ) {
@@ -253,12 +265,6 @@ export class FocalPointPicker extends Component {
 			left: x * ( width - bounds.left * 2 ) + bounds.left,
 			top: y * ( height - bounds.top * 2 ) + bounds.top,
 		};
-	}
-	// Callback method for the withFocusOutside higher-order component
-	handleFocusOutside() {
-		this.setState( {
-			isDragging: false,
-		} );
 	}
 	render() {
 		const {
@@ -289,10 +295,9 @@ export class FocalPointPicker extends Component {
 				<MediaWrapper className="components-focal-point-picker-wrapper">
 					<MediaContainer
 						className="components-focal-point-picker"
-						onKeyDown={ this.handleOnKeyDown }
-						onMouseDown={ this.handleOnClick }
-						onMouseMove={ this.onMouseMove }
-						onMouseUp={ this.handleOnMouseUp }
+						onKeyDown={ this.onKeyDown }
+						onMouseDown={ this.onMouseDown }
+						onBlur={ this.ifDraggingStop }
 						ref={ this.containerRef }
 						role="button"
 						tabIndex="-1"
@@ -316,10 +321,7 @@ export class FocalPointPicker extends Component {
 				</MediaWrapper>
 				<Controls
 					percentages={ percentages }
-					onChange={ ( value ) => {
-						this.updateValue( value );
-						this.props.onChange( value );
-					} }
+					onChange={ this.onChangeAtControls }
 				/>
 			</BaseControl>
 		);
@@ -335,6 +337,4 @@ FocalPointPicker.defaultProps = {
 	url: null,
 };
 
-export default compose( [ withInstanceId, withFocusOutside ] )(
-	FocalPointPicker
-);
+export default withInstanceId( FocalPointPicker );

--- a/packages/components/src/focal-point-picker/styles/focal-point-style.js
+++ b/packages/components/src/focal-point-picker/styles/focal-point-style.js
@@ -26,9 +26,7 @@ export const FocalPointWrapper = styled.div`
 	will-change: transform;
 	z-index: 10000;
 
-	&.is-dragging {
-		cursor: grabbing;
-	}
+	${ ( { isDragging } ) => isDragging && 'cursor: grabbing;' }
 `;
 
 export const PointerIconSVG = styled( SVG )`

--- a/packages/components/src/focal-point-picker/test/index.js
+++ b/packages/components/src/focal-point-picker/test/index.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { act, fireEvent, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Picker from '../index.js';
+
+describe( 'FocalPointPicker', () => {
+	describe( 'focus and blur', () => {
+		let firedDragEnd;
+		let firedDrag;
+		const { getByRole, unmount } = render(
+			<Picker
+				onChange={ () => {} }
+				onDragEnd={ () => ( firedDragEnd = true ) }
+				onDrag={ () => ( firedDrag = true ) }
+			/>
+		);
+		const dragArea = getByRole( 'button' );
+		fireEvent.mouseDown( dragArea );
+		const gainedFocus = dragArea.ownerDocument.activeElement === dragArea;
+
+		fireEvent.blur( dragArea );
+		fireEvent.mouseMove( dragArea );
+
+		// cleans up as it's not automated for renders outside of test blocks
+		unmount();
+
+		it( 'should focus the draggable area', () => {
+			expect( gainedFocus ).toBe( true );
+		} );
+
+		it( 'should stop a drag operation when focus is lost', () => {
+			expect( firedDragEnd && ! firedDrag ).toBe( true );
+		} );
+	} );
+
+	describe( 'drag gestures', () => {
+		it( 'should call onDragStart, onDrag, onDragEnd and onChange in that order', () => {
+			const logs = [];
+			const eventLogger = ( name, args ) => logs.push( { name, args } );
+			const events = [ 'onDragStart', 'onDrag', 'onDragEnd', 'onChange' ];
+			const handlers = {};
+			events.forEach( ( name ) => {
+				handlers[ name ] = ( ...all ) => eventLogger( name, all );
+			} );
+			const { getByRole } = render( <Picker { ...handlers } /> );
+			const dragArea = getByRole( 'button' );
+			act( () => {
+				fireEvent.mouseDown( dragArea );
+				fireEvent.mouseMove( dragArea );
+				fireEvent.mouseUp( dragArea );
+			} );
+			expect(
+				events.reduce( ( last, eventName, index ) => {
+					return last && logs[ index ].name === eventName;
+				}, true )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'controllability', () => {
+		it( 'should update value from props', () => {
+			const { rerender, getByRole } = render(
+				<Picker value={ { x: 0.25, y: 0.5 } } />
+			);
+			const xInput = getByRole( 'spinbutton', { name: 'Left' } );
+			rerender( <Picker value={ { x: 0.93, y: 0.5 } } /> );
+			expect( xInput.value ).toBe( '93' );
+		} );
+	} );
+} );

--- a/packages/components/src/higher-order/with-notices/index.js
+++ b/packages/components/src/higher-order/with-notices/index.js
@@ -24,8 +24,8 @@ import NoticeList from '../../notice/list';
 export default createHigherOrderComponent( ( OriginalComponent ) => {
 	let isForwardRef;
 	const { render } = OriginalComponent;
-	// Returns a forwardRef if OriginalComponent is a forwardRef
-	if ( typeof render === 'function' && render.length === 2 ) {
+	// Returns a forwardRef if OriginalComponent appears to be a forwardRef
+	if ( typeof render === 'function' ) {
 		isForwardRef = true;
 		return forwardRef( Component );
 	}

--- a/packages/components/src/higher-order/with-notices/index.js
+++ b/packages/components/src/higher-order/with-notices/index.js
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { forwardRef, useState } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -22,87 +22,79 @@ import NoticeList from '../../notice/list';
  * @return {WPComponent} Wrapped component.
  */
 export default createHigherOrderComponent( ( OriginalComponent ) => {
-	return class WrappedBlockEdit extends Component {
-		constructor() {
-			super( ...arguments );
+	let isForwardRef;
+	const { render } = OriginalComponent;
+	// Returns a forwardRef if OriginalComponent is a forwardRef
+	if ( typeof render === 'function' && render.length === 2 ) {
+		isForwardRef = true;
+		return forwardRef( Component );
+	}
+	return Component;
 
-			this.createNotice = this.createNotice.bind( this );
-			this.createErrorNotice = this.createErrorNotice.bind( this );
-			this.removeNotice = this.removeNotice.bind( this );
-			this.removeAllNotices = this.removeAllNotices.bind( this );
+	function Component( props, ref ) {
+		const [ noticeList, setNoticeList ] = useState( [] );
 
-			this.state = {
-				noticeList: [],
-			};
+		const noticeOperations = {
+			/**
+			 * Function passed down as a prop that adds a new notice.
+			 *
+			 * @param {Object} notice  Notice to add.
+			 */
+			createNotice: ( notice ) => {
+				const noticeToAdd = notice.id
+					? notice
+					: { ...notice, id: uuid() };
+				setNoticeList( ( current ) => [ ...current, noticeToAdd ] );
+			},
 
-			this.noticeOperations = {
-				createNotice: this.createNotice,
-				createErrorNotice: this.createErrorNotice,
-				removeAllNotices: this.removeAllNotices,
-				removeNotice: this.removeNotice,
-			};
-		}
+			/**
+			 * Function passed as a prop that adds a new error notice.
+			 *
+			 * @param {string} msg  Error message of the notice.
+			 */
+			createErrorNotice: ( msg ) => {
+				this.createNotice(
+					{ status: 'error', content: msg },
+					setNoticeList
+				);
+			},
 
-		/**
-		 * Function passed down as a prop that adds a new notice.
-		 *
-		 * @param {Object} notice  Notice to add.
-		 */
-		createNotice( notice ) {
-			const noticeToAdd = notice.id ? notice : { ...notice, id: uuid() };
-			this.setState( ( state ) => ( {
-				noticeList: [ ...state.noticeList, noticeToAdd ],
-			} ) );
-		}
+			/**
+			 * Removes a notice by id.
+			 *
+			 * @param {string} id  Id of the notice to remove.
+			 */
+			removeNotice: ( id ) => {
+				setNoticeList( ( current ) =>
+					current.filter( ( notice ) => notice.id !== id )
+				);
+			},
 
-		/**
-		 * Function passed as a prop that adds a new error notice.
-		 *
-		 * @param {string} msg  Error message of the notice.
-		 */
-		createErrorNotice( msg ) {
-			this.createNotice( { status: 'error', content: msg } );
-		}
+			/**
+			 * Removes all notices
+			 */
+			removeAllNotices: () => {
+				setNoticeList( [] );
+			},
+		};
 
-		/**
-		 * Removes a notice by id.
-		 *
-		 * @param {string} id  Id of the notice to remove.
-		 */
-		removeNotice( id ) {
-			this.setState( ( state ) => ( {
-				noticeList: state.noticeList.filter(
-					( notice ) => notice.id !== id
-				),
-			} ) );
-		}
-
-		/**
-		 * Removes all notices
-		 */
-		removeAllNotices() {
-			this.setState( {
-				noticeList: [],
-			} );
-		}
-
-		render() {
-			return (
-				<OriginalComponent
-					noticeList={ this.state.noticeList }
-					noticeOperations={ this.noticeOperations }
-					noticeUI={
-						this.state.noticeList.length > 0 && (
-							<NoticeList
-								className="components-with-notices-ui"
-								notices={ this.state.noticeList }
-								onRemove={ this.removeNotice }
-							/>
-						)
-					}
-					{ ...this.props }
+		const propsOut = {
+			...props,
+			noticeList,
+			noticeOperations,
+			noticeUI: noticeList.length > 0 && (
+				<NoticeList
+					className="components-with-notices-ui"
+					notices={ noticeList }
+					onRemove={ noticeOperations.removeNotice }
 				/>
-			);
-		}
-	};
+			),
+		};
+
+		return isForwardRef ? (
+			<OriginalComponent { ...propsOut } ref={ ref } />
+		) : (
+			<OriginalComponent { ...propsOut } />
+		);
+	}
 } );

--- a/packages/components/src/higher-order/with-notices/index.js
+++ b/packages/components/src/higher-order/with-notices/index.js
@@ -53,10 +53,10 @@ export default createHigherOrderComponent( ( OriginalComponent ) => {
 			 * @param {string} msg  Error message of the notice.
 			 */
 			createErrorNotice: ( msg ) => {
-				this.createNotice(
-					{ status: 'error', content: msg },
-					setNoticeList
-				);
+				noticeOperations.createNotice( {
+					status: 'error',
+					content: msg,
+				} );
 			},
 
 			/**

--- a/packages/components/src/higher-order/with-notices/test/index.js
+++ b/packages/components/src/higher-order/with-notices/test/index.js
@@ -1,0 +1,166 @@
+/**
+ * External dependencies
+ */
+import {
+	act,
+	render,
+	fireEvent,
+	waitForElementToBeRemoved,
+	within,
+} from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	forwardRef,
+	useEffect,
+	useImperativeHandle,
+	useRef,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import withNotices from '..';
+
+// Implementation detail of Notice component used to query the dismissal button
+const stockDismissText = 'Dismiss this notice';
+
+function noticesFrom( list ) {
+	return list.map( ( item ) => ( { id: item, content: item } ) );
+}
+
+function isComponentLike( object ) {
+	return typeof object === 'function';
+}
+
+function isForwardRefLike( { render: renderMethod } ) {
+	return typeof renderMethod === 'function';
+}
+
+const content = 'Base content';
+
+const BaseComponent = ( { noticeOperations, noticeUI, notifications } ) => {
+	useEffect( () => {
+		if ( notifications ) {
+			notifications.forEach( ( item ) =>
+				noticeOperations.createNotice( item )
+			);
+		}
+	}, [] );
+	return (
+		<div>
+			{ noticeUI }
+			{ content }
+		</div>
+	);
+};
+
+const TestComponent = withNotices( BaseComponent );
+
+const TestNoticeOperations = withNotices(
+	forwardRef( ( props, ref ) => {
+		useImperativeHandle( ref, () => ( { ...props.noticeOperations } ) );
+		return <BaseComponent { ...props } />;
+	} )
+);
+
+describe( 'withNotices return type', () => {
+	it( 'should be a component given a component', () => {
+		expect( isComponentLike( TestComponent ) ).toBe( true );
+	} );
+
+	it( 'should be a forwardRef given a forwardRef', () => {
+		expect( isForwardRefLike( TestNoticeOperations ) ).toBe( true );
+	} );
+} );
+
+describe( 'withNotices operations', () => {
+	let handle;
+	const Handle = ( props ) => {
+		handle = useRef();
+		return <TestNoticeOperations { ...props } ref={ handle } />;
+	};
+
+	it( 'should create notices with createNotice', () => {
+		const message = 'Aló!';
+		const { container } = render( <Handle /> );
+		const { getByText } = within( container );
+		act( () => {
+			handle.current.createNotice( { content: message } );
+		} );
+		expect( getByText( message ) ).not.toBeNull();
+	} );
+
+	it( 'should create notices of error status with createErrorNotice', () => {
+		const message = 'can’t touch this';
+		const { container } = render( <Handle /> );
+		const { getByText } = within( container );
+		act( () => {
+			handle.current.createErrorNotice( message );
+		} );
+		expect( getByText( message )?.closest( '.is-error' ) ).not.toBeNull();
+	} );
+
+	it( 'should remove a notice with removeNotice', async () => {
+		const notice = { id: 'so real', content: 'so why can’t I touch it?' };
+		const { container } = render( <Handle /> );
+		const { getByText } = within( container );
+		act( () => {
+			handle.current.createNotice( notice );
+		} );
+		expect(
+			await waitForElementToBeRemoved( () => {
+				const target = getByText( notice.content );
+				act( () => handle.current.removeNotice( notice.id ) );
+				return target;
+			} ).then( () => true )
+		).toBe( true );
+	} );
+
+	it( 'should remove all notices with removeAllNotices', async () => {
+		const messages = [ 'Aló!', 'hu dis?', 'Otis' ];
+		const notices = noticesFrom( messages );
+		const { container } = render( <Handle notifications={ notices } /> );
+		const { getByText } = within( container );
+		expect(
+			await waitForElementToBeRemoved( () => {
+				const targets = notices.map( ( notice ) =>
+					getByText( notice.content )
+				);
+				act( () => handle.current.removeAllNotices() );
+				return targets;
+			} ).then( () => true )
+		).toBe( true );
+	} );
+} );
+
+describe( 'withNotices rendering', () => {
+	it( 'should display the original component given no notices', () => {
+		const { container } = render( <TestComponent /> );
+		expect( container.innerHTML ).toBe( `<div>${ content }</div>` );
+	} );
+
+	it( 'should display notices with functioning dismissal triggers', async () => {
+		const messages = [ 'Aló!', 'hu dis?', 'Otis' ];
+		const notices = noticesFrom( messages );
+		const { container, getAllByLabelText } = render(
+			<TestComponent notifications={ notices } />
+		);
+		const [ buttonRemoveFirst ] = getAllByLabelText( stockDismissText );
+		const getRemovalTarget = () =>
+			within( container ).getByText(
+				// the last item corresponds to the first notice in the DOM
+				messages[ messages.length - 1 ]
+			);
+		expect(
+			await waitForElementToBeRemoved( () => {
+				const target = getRemovalTarget();
+				// Removes the first notice in the DOM
+				fireEvent.click( buttonRemoveFirst );
+				return target;
+			} ).then( () => true )
+		).toBe( true );
+	} );
+} );

--- a/packages/components/src/resizable-box/index.js
+++ b/packages/components/src/resizable-box/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
  * External dependencies
  */
 import classnames from 'classnames';
@@ -9,14 +14,17 @@ import { Resizable } from 're-resizable';
  */
 import ResizeTooltip from './resize-tooltip';
 
-function ResizableBox( {
-	className,
-	children,
-	showHandle = true,
-	__experimentalShowTooltip: showTooltip = false,
-	__experimentalTooltipProps: tooltipProps = {},
-	...props
-} ) {
+function ResizableBox(
+	{
+		className,
+		children,
+		showHandle = true,
+		__experimentalShowTooltip: showTooltip = false,
+		__experimentalTooltipProps: tooltipProps = {},
+		...props
+	},
+	ref
+) {
 	// Removes the inline styles in the drag handles.
 	const handleStylesOverrides = {
 		width: null,
@@ -94,6 +102,7 @@ function ResizableBox( {
 				bottomRight: handleStylesOverrides,
 				bottomLeft: handleStylesOverrides,
 			} }
+			ref={ ref }
 			{ ...props }
 		>
 			{ children }
@@ -102,4 +111,4 @@ function ResizableBox( {
 	);
 }
 
-export default ResizableBox;
+export default forwardRef( ResizableBox );


### PR DESCRIPTION
This PR stemmed from realizing that maybe it wasn't just me and my modest computer experiencing clunky dragging in the focal point picker.
https://github.com/WordPress/gutenberg/issues/28487#issuecomment-768343307

Setting out to improve that, it didn't take much tinkering to figure out that the bulk of the poor performance comes from setting block attributes during the drag operation. It's super intensive because it's driven by `onMouseMove` and causes quite the render cascade.

While I'd hoped to find the solution with changes only to `FocalPointPicker`, the consuming blocks need some changes as well. The Cover and Media & Text blocks have been updated to set their attributes only at the end of a drag operation and to preview the focal point with an imperative (render-free) approach while dragging.

A complication ensued in updating the Media & Text block. To create an imperative routine for focal point preview, a ref to a `ResizableBox` was needed, and being that it was also wrapped by `withNotices`, both components needed updates to support ref forwarding. To support that in `withNotices` it seemed best to refactor it to a function component. Touching that component looks fraught with peril since I see no unit tests for it, but I'm hoping there may be some E2E coverage.

UPDATE:  Unit tests have been added for `withNotices`. A few new unit tests have also been added for `FocalPointPicker`.

## How has this been tested?
Making posts with Cover and Media & Text blocks and dragging their focal points like mad.

## Screen recordings (as specific to my machine as they may be)
**Before:**

https://user-images.githubusercontent.com/9000376/106662181-ed6f0180-6556-11eb-8361-eeef1630d399.mp4

**After**

https://user-images.githubusercontent.com/9000376/106662341-1ee7cd00-6557-11eb-9144-4308d91960cb.mp4

## Types of changes
* Enhancement
* Breaking change: `FocalPointPicker` calls `onChange` only at the end of a drag operation, whereas before it was called for each `mousemove` event. So it still works, just not as rapidly as it used to. (I wasn't totally sure it qualifies as breaking but it's how I've classified it in the changelog).
* New feature: `onDrag` added as an event for `FocalPointPicker`. This is now what's called each `mousemove`
* Fix: Focus of the `FocalPointPicker` draggable area and adjustment with arrow keys. (This was added #22531 but was no longer working) 
* Fix: `FocalPointPicker` fires `onDragStart` and `onDragEnd` (they were in the code already but did not actually fire).
* New feature:`ResizeableBox` is now a `forwardRef`*
* New feature: `withNotices` returns a `forwardRef` if passed a `forwardRef`*

*React docs suggest to treat changing a component to a `forwardRef` as breaking, but I believe that's for a context of changing a class component with an ad-hoc prop to support ref forwarding. In the cases of `ResizableBox` and `withNotices` they had no support for ref forwarding before this otherwise have no changes. So it seems only an unbreaking added feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
