### PR TITLE
[RNMobile] Audio Block shallow rendering tests

### DIFF
--- a/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
@@ -1,0 +1,376 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Audio block renders audio block error state without crashing 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View
+    pointerEvents="box-none"
+    style={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          undefined,
+          undefined,
+          undefined,
+        ]
+      }
+    />
+    Modal
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "height": 44,
+        }
+      }
+    >
+      <View>
+        Svg
+      </View>
+      <View
+        style={Object {}}
+      >
+        <Text>
+          59IrU0WJtq
+        </Text>
+        <View>
+          Svg
+          <Text
+            style={Object {}}
+          >
+            Failed to insert audio file. Please tap for options.
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "height": 44,
+        },
+        false,
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="Audio caption. Empty"
+      accessibilityRole="button"
+      accessible={true}
+      style={
+        Object {
+          "display": "none",
+          "flex": 1,
+        }
+      }
+    >
+      <View>
+        <RCTAztecView
+          accessible={true}
+          activeFormats={Array []}
+          blockType={
+            Object {
+              "tag": "p",
+            }
+          }
+          deleteEnter={true}
+          disableEditingMenu={false}
+          focusable={true}
+          fontFamily="serif"
+          fontSize={14}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
+          onStartShouldSetResponder={[Function]}
+          placeholder="Write caption…"
+          placeholderTextColor="gray"
+          style={
+            Object {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
+            }
+          }
+          text={
+            Object {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "text": "",
+            }
+          }
+          textAlign="center"
+          triggerKeyCodes={Array []}
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Audio block renders audio file without crashing 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View
+    pointerEvents="box-none"
+    style={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          undefined,
+          undefined,
+          undefined,
+        ]
+      }
+    />
+    Modal
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "height": 44,
+        }
+      }
+    >
+      <View>
+        Svg
+      </View>
+      <View
+        style={Object {}}
+      >
+        <Text>
+          59IrU0WJtq
+        </Text>
+        <View>
+          <Text
+            style={Object {}}
+          >
+            MP3 audio file
+          </Text>
+        </View>
+      </View>
+      <View
+        accessibilityHint="Double tap to listen the audio file"
+        accessibilityLabel="Audio Player"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+      >
+        <Text
+          style={
+            Object {
+              "color": "white",
+            }
+          }
+        >
+          OPEN
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "height": 44,
+        },
+        false,
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="Audio caption. Empty"
+      accessibilityRole="button"
+      accessible={true}
+      style={
+        Object {
+          "display": "none",
+          "flex": 1,
+        }
+      }
+    >
+      <View>
+        <RCTAztecView
+          accessible={true}
+          activeFormats={Array []}
+          blockType={
+            Object {
+              "tag": "p",
+            }
+          }
+          deleteEnter={true}
+          disableEditingMenu={false}
+          focusable={true}
+          fontFamily="serif"
+          fontSize={14}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
+          onStartShouldSetResponder={[Function]}
+          placeholder="Write caption…"
+          placeholderTextColor="gray"
+          style={
+            Object {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
+            }
+          }
+          text={
+            Object {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "text": "",
+            }
+          }
+          textAlign="center"
+          triggerKeyCodes={Array []}
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Audio block renders placeholder without crashing 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      accessibilityHint="Double tap to select an audio file"
+      accessibilityLabel="Audio block. Empty"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Array [
+            undefined,
+            undefined,
+            undefined,
+          ],
+          undefined,
+        ]
+      }
+    >
+      Modal
+      <View
+        style={
+          Object {
+            "fill": "gray",
+          }
+        }
+      >
+        <View
+          style={Object {}}
+        >
+          Svg
+        </View>
+      </View>
+      <Text>
+        Audio
+      </Text>
+      <Text>
+        ADD AUDIO
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/packages/block-library/src/audio/test/edit.native.js
+++ b/packages/block-library/src/audio/test/edit.native.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+
+/**
+ * WordPress dependencies
+ */
+import { MediaUploadProgress } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import AudioEdit from '../edit.native.js';
+
+const getTestComponentWithContent = ( attributes = {} ) => {
+	return renderer.create(
+		<AudioEdit attributes={ attributes } setAttributes={ jest.fn() } />
+	);
+};
+
+describe( 'Audio block', () => {
+	it( 'renders placeholder without crashing', () => {
+		const component = getTestComponentWithContent();
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+
+	it( 'renders audio file without crashing', () => {
+		const component = getTestComponentWithContent( {
+			src: 'https://cldup.com/59IrU0WJtq.mp3',
+			id: '1',
+		} );
+
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+
+	it( 'renders audio block error state without crashing', () => {
+		const component = getTestComponentWithContent( {
+			src: 'https://cldup.com/59IrU0WJtq.mp3',
+			id: '1',
+		} );
+
+		const mediaUpload = component.root.findByType( MediaUploadProgress );
+		mediaUpload.instance.finishMediaUploadWithFailure( { mediaId: -1 } );
+
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR introduces shallow rendering tests for the native version of the Audio Block that are powered by `react-test-renderer`

1. The first test ensures that the Audio Block's placeholder is rendered without crashing. 
2. The second test ensures that the Audio Block is rendered once an audio file is attached. This is done by supplying the attributes of the Audio Block utilizing the `getTestComponentWithContent` that supplies the rendered Audio Block with it's attributes. 
3. The third test simulates a media upload error via `finishMediaUploadWithFailure` of the `MediaUploadProgress` component so that the Audio Block's error state can be rendered. 

## How has this been tested?
- Run `npm run test-unit:native -- packages/block-library/src/audio/test/edit.native.js`

## Types of changes
- Added a new test directory to the `audio` block path to host the test. 
- Generated a snapshot to represent the various states being tested. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
