### PR TITLE
Improve dropcap behavior

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -14,18 +14,18 @@ import {
 	InspectorControls,
 	RichText,
 	useBlockProps,
-	getFontSize,
+	//getFontSize,
 	__experimentalUseEditorFeature as useEditorFeature,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState } from '@wordpress/element';
+/*import { useSelect } from '@wordpress/data';
+import { useEffect, useRef, useState } from '@wordpress/element';*/
 import { formatLtr } from '@wordpress/icons';
 
-function getComputedStyle( node, pseudo ) {
+/*function getComputedStyle( node, pseudo ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node, pseudo );
-}
+}*/
 
 const name = 'core/paragraph';
 
@@ -50,7 +50,7 @@ function ParagraphRTLToolbar( { direction, setDirection } ) {
 	);
 }
 
-function useDropCapMinHeight( ref, isDisabled, dependencies ) {
+/*function useDropCapMinHeight( ref, isDisabled, dependencies ) {
 	const [ minHeight, setMinHeight ] = useState();
 
 	useEffect( () => {
@@ -65,7 +65,7 @@ function useDropCapMinHeight( ref, isDisabled, dependencies ) {
 	}, [ isDisabled, ...dependencies ] );
 
 	return minHeight;
-}
+}*/
 
 function ParagraphBlock( {
 	attributes,
@@ -81,11 +81,11 @@ function ParagraphBlock( {
 		direction,
 		dropCap,
 		placeholder,
-		fontSize,
-		style,
+		//fontSize,
+		//style,
 	} = attributes;
 	const isDropCapFeatureEnabled = useEditorFeature( 'typography.dropCap' );
-	const ref = useRef();
+	/*const ref = useRef();
 	const inlineFontSize = style?.fontSize;
 	const size = useSelect(
 		( select ) => {
@@ -95,14 +95,14 @@ function ParagraphBlock( {
 		[ fontSize, inlineFontSize ]
 	);
 	const hasDropCap = isDropCapFeatureEnabled && dropCap;
-	const minHeight = useDropCapMinHeight( ref, ! hasDropCap, [ size ] );
+	const minHeight = useDropCapMinHeight( ref, ! hasDropCap, [ size ] ); */
 	const blockProps = useBlockProps( {
-		ref,
+		//ref,
 		className: classnames( {
 			'has-drop-cap': dropCap,
 			[ `has-text-align-${ align }` ]: align,
 		} ),
-		style: { direction, minHeight },
+		style: { direction },
 	} );
 
 	return (

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -14,18 +14,10 @@ import {
 	InspectorControls,
 	RichText,
 	useBlockProps,
-	//getFontSize,
 	__experimentalUseEditorFeature as useEditorFeature,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-/*import { useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState } from '@wordpress/element';*/
 import { formatLtr } from '@wordpress/icons';
-
-/*function getComputedStyle( node, pseudo ) {
-	return node.ownerDocument.defaultView.getComputedStyle( node, pseudo );
-}*/
 
 const name = 'core/paragraph';
 
@@ -50,23 +42,6 @@ function ParagraphRTLToolbar( { direction, setDirection } ) {
 	);
 }
 
-/*function useDropCapMinHeight( ref, isDisabled, dependencies ) {
-	const [ minHeight, setMinHeight ] = useState();
-
-	useEffect( () => {
-		if ( isDisabled ) {
-			setMinHeight();
-			return;
-		}
-
-		setMinHeight(
-			getComputedStyle( ref.current, 'first-letter' ).lineHeight
-		);
-	}, [ isDisabled, ...dependencies ] );
-
-	return minHeight;
-}*/
-
 function ParagraphBlock( {
 	attributes,
 	mergeBlocks,
@@ -75,29 +50,9 @@ function ParagraphBlock( {
 	setAttributes,
 	clientId,
 } ) {
-	const {
-		align,
-		content,
-		direction,
-		dropCap,
-		placeholder,
-		//fontSize,
-		//style,
-	} = attributes;
+	const { align, content, direction, dropCap, placeholder } = attributes;
 	const isDropCapFeatureEnabled = useEditorFeature( 'typography.dropCap' );
-	/*const ref = useRef();
-	const inlineFontSize = style?.fontSize;
-	const size = useSelect(
-		( select ) => {
-			const { fontSizes } = select( blockEditorStore ).getSettings();
-			return getFontSize( fontSizes, fontSize, inlineFontSize ).size;
-		},
-		[ fontSize, inlineFontSize ]
-	);
-	const hasDropCap = isDropCapFeatureEnabled && dropCap;
-	const minHeight = useDropCapMinHeight( ref, ! hasDropCap, [ size ] ); */
 	const blockProps = useBlockProps( {
-		//ref,
 		className: classnames( {
 			'has-drop-cap': dropCap,
 			[ `has-text-align-${ align }` ]: align,

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -28,6 +28,11 @@
 	font-style: normal;
 }
 
+// Prevent the dropcap from breaking out of the box when a background is applied.
+p.has-drop-cap.has-background {
+	overflow: hidden;
+}
+
 p.has-background {
 	padding: $block-bg-padding--v $block-bg-padding--h;
 }


### PR DESCRIPTION
_This PR is effectively a revert of #18409, and for that reason it needs a good review._

Fixes #10832. Here's the problem: in 18409 a min-height was applied to any paragraph that had a dropcap. This effectively means that if you have a short line of text, the next paragraph in line will not wrap around the dropcap, causing a space in the flow:

<img width="1250" alt="Screenshot 2021-02-03 at 09 53 36" src="https://user-images.githubusercontent.com/1204802/106725302-83fbfb00-6609-11eb-92a4-fd8972ce6ed2.png">

This PR fixes that by effectively removing that min-height entirely:

<img width="1127" alt="Screenshot 2021-02-03 at 10 12 03" src="https://user-images.githubusercontent.com/1204802/106725334-8b230900-6609-11eb-89bb-367245d87425.png">

In addition to that, it adds a clearing behavior to paragraphs that have a _background color_, so that this is possible:

<img width="969" alt="Screenshot 2021-02-03 at 10 15 10" src="https://user-images.githubusercontent.com/1204802/106725375-97a76180-6609-11eb-930d-bb1daa9d8fa5.png">

That last bit is a bit contentious, as you might actually _want_ to keep the float behavior, to accomplish this:

<img width="990" alt="Screenshot 2021-02-03 at 09 55 33" src="https://user-images.githubusercontent.com/1204802/106725415-a68e1400-6609-11eb-9cc6-6472dfc0cb2f.png">

That part is being discussed in https://github.com/WordPress/gutenberg/issues/10832#issuecomment-772345355.

See also https://github.com/WordPress/gutenberg/pull/28685#issuecomment-785810965 for additional examples. 