### PR TITLE
Add a "global_styles" filter

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -31,7 +31,19 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		// is inmediately reflected.
 		$cached = get_transient( $transient_name );
 		if ( $cached ) {
-			return $cached;
+			$stylesheet = get_transient( 'global_styles' );
+			if ( $stylesheet ) {
+				/**
+				 * Filters global styles.
+				 *
+				 * @param string        $stylesheet The styles.
+				 * @param WP_Theme_JSON $tree       Input tree.
+				 * @param string        $type       Type of stylesheet we want accepts 'all', 'block_styles', and 'css_variables'.
+				 *
+				 * @return string Stylesheet.
+				 */
+				return apply_filters( 'global_styles', $stylesheet, $type, $tree );
+			}
 		}
 	}
 
@@ -43,7 +55,16 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
 	}
 
-	return $stylesheet;
+	/**
+	 * Filters global styles.
+	 *
+	 * @param string        $stylesheet The styles.
+	 * @param WP_Theme_JSON $tree       Input tree.
+	 * @param string        $type       Type of stylesheet we want accepts 'all', 'block_styles', and 'css_variables'.
+	 *
+	 * @return string Stylesheet.
+	 */
+	return apply_filters( 'global_styles', $stylesheet, $type, $tree );
 }
 
 /**

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -31,19 +31,17 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		// is inmediately reflected.
 		$cached = get_transient( $transient_name );
 		if ( $cached ) {
-			$stylesheet = get_transient( 'global_styles' );
-			if ( $stylesheet ) {
-				/**
-				 * Filters global styles.
-				 *
-				 * @param string        $stylesheet The styles.
-				 * @param WP_Theme_JSON $tree       Input tree.
-				 * @param string        $type       Type of stylesheet we want accepts 'all', 'block_styles', and 'css_variables'.
-				 *
-				 * @return string Stylesheet.
-				 */
-				return apply_filters( 'global_styles', $stylesheet, $type, $tree );
-			}
+			$stylesheet = $cached;
+			/**
+			 * Filters global styles.
+			 *
+			 * @param string        $stylesheet The styles.
+			 * @param WP_Theme_JSON $tree       Input tree.
+			 * @param string        $type       Type of stylesheet we want accepts 'all', 'block_styles', and 'css_variables'.
+			 *
+			 * @return string Stylesheet.
+			 */
+			return apply_filters( 'global_styles', $stylesheet, $type, $tree );
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

While working on an FSE theme and trying to figure out how to load webfonts, it became apparent that there is currently no way for a theme to determine if a webfont defined in the `theme.json` file is actually used. As a result, themes are forced to always load webfonts they want to use.

This PR adds a `global_styles` filter to allow 3rd-party developers (both in themes and plugins) to filter the global styles on the frontend in order to add things if needed.

Example for the webfont:
```php
add_filter( 'global_styles', function( $styles ) {
    // Check if the "Literata" webfont is used.
    if ( false !== strpos( $styles, 'var(--wp--preset--font-family--literata)' ) ) {
        // Add webfont styles.
        $styles .= my_theme_get_webfont_styles( 'literata' );
    }
    return $styles;
} );
```

## Types of changes

* Added a filter in the `gutenberg_experimental_global_styles_get_stylesheet` function's return.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
