### PR TITLE
[WIP] Separator: Trial custom separator height with independent top/bottom margins

### DIFF
--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -9,12 +9,8 @@
 		"customColor": {
 			"type": "string"
 		},
-		"height": {
-			"type": "number"
-		},
-		"heightUnit": {
-			"type": "string",
-			"default": "px"
+		"style": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -98,6 +98,7 @@ function SeparatorEdit( props ) {
 
 	const height =
 		parseFloat( marginTop || 0 ) + parseFloat( marginBottom || 0 );
+	const minCSSHeight = `${ marginConstraints.px.min * 2 }${ marginUnit }`;
 	const cssHeight = `${ height }${ marginUnit }`;
 	const blockProps = useBlockProps();
 	const wrapperClasses = blockProps.className?.replace(
@@ -115,7 +116,7 @@ function SeparatorEdit( props ) {
 			<View
 				{ ...blockProps }
 				className={ wrapperClasses }
-				style={ { height: height ? cssHeight : undefined } }
+				style={ { height: height ? cssHeight : minCSSHeight } }
 			>
 				<HorizontalRule
 					className={ classnames( blockProps.className, {

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -62,7 +62,7 @@ function SeparatorEdit( props ) {
 	}, [ hasDotsStyle ] ); // Only restricting on dots style as min/max enforced on change otherwise.
 
 	// ResizableBox callback to set height and force pixel units.
-	const onResizeStop = ( _event, _direction, elt ) => {
+	const onResize = ( _event, _direction, elt ) => {
 		const { min, max } = marginConstraints.px;
 		const newHeight = clamp( parseInt( elt.clientHeight, 10 ) );
 
@@ -93,6 +93,10 @@ function SeparatorEdit( props ) {
 				},
 			},
 		} );
+	};
+
+	const onResizeStop = ( ...args ) => {
+		onResize( ...args );
 		setIsResizing( false );
 	};
 
@@ -153,6 +157,7 @@ function SeparatorEdit( props ) {
 					} }
 					minHeight={ marginConstraints.px.min * 2 } // Height will account for top and bottom margin.
 					onResizeStart={ () => setIsResizing( true ) }
+					onResize={ onResize }
 					onResizeStop={ onResizeStop }
 					showHandle={ isSelected }
 					__experimentalShowTooltip={ true }

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -39,8 +39,9 @@ function SeparatorEdit( props ) {
 	// enforced against existing top and bottom margins.
 	useEffect( () => {
 		if (
-			marginTopValue < currentMinMargin ||
-			marginBottomValue < currentMinMargin
+			( marginTopValue || marginBottomValue ) &&
+			( marginTopValue < currentMinMargin ||
+				marginBottomValue < currentMinMargin )
 		) {
 			const topValue = Math.max( marginTopValue, currentMinMargin );
 			const bottomValue = Math.max( marginBottomValue, currentMinMargin );

--- a/packages/block-library/src/separator/edit.native.js
+++ b/packages/block-library/src/separator/edit.native.js
@@ -1,89 +1,67 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-import { clamp } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import {
-	HorizontalRule,
-	ResizableBox,
-	useConvertUnitToMobile,
-} from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { HorizontalRule, useConvertUnitToMobile } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 import { withColors, useBlockProps } from '@wordpress/block-editor';
-import { View } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
  */
 import SeparatorSettings from './separator-settings';
-import { getHeightConstraints } from './shared';
+import { getMarginConstraints, parseUnit } from './shared';
 
 function SeparatorEdit( props ) {
-	const { attributes, setAttributes, color, setColor, isSelected } = props;
-	const { height, heightUnit } = attributes;
-	const [ isResizing, setIsResizing ] = useState( false );
+	const { attributes, setAttributes, color, setColor } = props;
+	const { className, style } = attributes;
 
-	const hasDotsStyle = attributes.className?.indexOf( 'is-style-dots' ) >= 0;
-	const minimumHeightScale = hasDotsStyle ? 1.5 : 1;
-	const heightConstraints = getHeightConstraints( minimumHeightScale );
-	const currentMinHeight = heightConstraints[ heightUnit ].min;
-	const currentMaxHeight = heightConstraints[ heightUnit ].max;
+	const { top: marginTop, bottom: marginBottom } =
+		style?.spacing?.margin || {};
+	const marginUnit = parseUnit( marginTop || marginBottom );
+	const marginTopValue = parseFloat( marginTop || 0 );
+	const marginBottomValue = parseFloat( marginBottom || 0 );
 
+	// Given different display method, dots block style has larger min height requirement.
+	const hasDotsStyle = className?.indexOf( 'is-style-dots' ) >= 0;
+	const minimumMarginScale = hasDotsStyle ? 1.5 : 1;
+	const marginConstraints = getMarginConstraints( minimumMarginScale );
+	const currentMinMargin = marginConstraints[ marginUnit ].min;
+
+	// Ensure when changing block style that any change in minimum height is
+	// enforced against existing top and bottom margins.
 	useEffect( () => {
-		if ( height < currentMinHeight ) {
-			setAttributes( { height: currentMinHeight } );
+		if (
+			marginTopValue < currentMinMargin ||
+			marginBottomValue < currentMinMargin
+		) {
+			const topValue = Math.max( marginTopValue, currentMinMargin );
+			const bottomValue = Math.max( marginBottomValue, currentMinMargin );
+
+			setAttributes( {
+				style: {
+					...style,
+					spacing: {
+						...style?.spacing,
+						margin: {
+							top: `${ topValue }${ marginUnit }`,
+							bottom: `${ bottomValue }${ marginUnit }`,
+						},
+					},
+				},
+			} );
 		}
-	}, [ hasDotsStyle, heightConstraints ] );
-
-	const onResizeStart = () => {
-		setIsResizing( true );
-	};
-
-	// Change handler for sidebar height control only.
-	const updateHeight = ( value ) => {
-		setAttributes( {
-			height: clamp(
-				parseFloat( value ), // Rounding or parsing as integer here isn't ideal for em and rem units.
-				currentMinHeight,
-				currentMaxHeight
-			),
-			heightUnit,
-		} );
-	};
-
-	const updateHeightUnit = ( value ) => {
-		setAttributes( {
-			height: heightConstraints[ value ].default,
-			heightUnit: value,
-		} );
-	};
-
-	// ResizableBox callback to set height and force pixel units.
-	const onResizeStop = ( _event, _direction, elt ) => {
-		setAttributes( {
-			height: clamp(
-				parseInt( elt.clientHeight, 10 ),
-				heightConstraints.px.min,
-				heightConstraints.px.max
-			),
-			heightUnit: 'px',
-		} );
-		setIsResizing( false );
-	};
+	}, [ hasDotsStyle ] ); // Only restricting on dots style as min/max enforced on change otherwise.
 
 	const blockProps = useBlockProps();
-	const wrapperClasses = blockProps.className?.replace(
-		'wp-block-separator',
-		'wp-block-separator__wrapper'
+
+	const convertedMarginTop = useConvertUnitToMobile(
+		marginTopValue || currentMinMargin,
+		marginUnit
 	);
 
-	const convertedHeightValue = useConvertUnitToMobile(
-		height || currentMinHeight,
-		heightUnit
+	const convertedMarginBottom = useConvertUnitToMobile(
+		marginBottomValue || currentMinMargin,
+		marginUnit
 	);
 
 	// The block's className and styles are moved to the inner <hr> to retain
@@ -93,62 +71,22 @@ function SeparatorEdit( props ) {
 	// block selection.
 	return (
 		<>
-			<View
+			<HorizontalRule
 				{ ...blockProps }
-				className={ wrapperClasses }
-				style={ { height: convertedHeightValue } }
-			>
-				<HorizontalRule
-					className={ classnames( blockProps.className, {
-						'has-background': color.color,
-						[ color.class ]: color.class,
-					} ) }
-					style={ {
-						backgroundColor: color.color,
-						color: color.color,
-					} }
-				/>
-				<ResizableBox
-					className={ classnames(
-						'block-library-separator__resize-container',
-						{
-							'is-selected': isSelected,
-						}
-					) }
-					size={ {
-						height: heightUnit === 'px' && height ? height : '100%',
-					} }
-					enable={ {
-						top: false,
-						right: false,
-						bottom: true, // Only enable bottom handle.
-						left: false,
-						topRight: false,
-						bottomRight: false,
-						bottomLeft: false,
-						topLeft: false,
-					} }
-					minHeight={ heightConstraints.px.min }
-					onResizeStart={ onResizeStart }
-					onResizeStop={ onResizeStop }
-					showHandle={ isSelected }
-					__experimentalShowTooltip={ true }
-					__experimentalTooltipProps={ {
-						axis: 'y',
-						position: 'bottom',
-						isVisible: isResizing,
-					} }
-				/>
-			</View>
+				style={ {
+					backgroundColor: color.color,
+					color: color.color,
+					marginTop: convertedMarginTop,
+					marginBottom: convertedMarginBottom,
+				} }
+			/>
 			<SeparatorSettings
 				color={ color }
 				setColor={ setColor }
-				minHeight={ currentMinHeight }
-				maxHeight={ currentMaxHeight }
-				height={ height }
-				heightUnit={ heightUnit }
-				updateHeight={ updateHeight }
-				updateHeightUnit={ updateHeightUnit }
+				marginConstraints={ marginConstraints }
+				marginUnit={ marginUnit }
+				separatorStyles={ style }
+				setAttributes={ setAttributes }
 			/>
 		</>
 	);

--- a/packages/block-library/src/separator/edit.native.js
+++ b/packages/block-library/src/separator/edit.native.js
@@ -2,65 +2,33 @@
  * WordPress dependencies
  */
 import { HorizontalRule, useConvertUnitToMobile } from '@wordpress/components';
-import { useEffect } from '@wordpress/element';
 import { withColors, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import SeparatorSettings from './separator-settings';
-import { getMarginConstraints, parseUnit } from './shared';
+import { MARGIN_CONSTRAINTS, parseUnit } from './shared';
 
 function SeparatorEdit( props ) {
-	const { attributes, setAttributes, color, setColor } = props;
-	const { className, style } = attributes;
+	const {
+		attributes: { style },
+		setAttributes,
+		color,
+		setColor,
+	} = props;
 
-	const { top: marginTop, bottom: marginBottom } =
-		style?.spacing?.margin || {};
-	const marginUnit = parseUnit( marginTop || marginBottom );
-	const marginTopValue = parseFloat( marginTop || 0 );
-	const marginBottomValue = parseFloat( marginBottom || 0 );
-
-	// Given different display method, dots block style has larger min height requirement.
-	const hasDotsStyle = className?.indexOf( 'is-style-dots' ) >= 0;
-	const minimumMarginScale = hasDotsStyle ? 1.5 : 1;
-	const marginConstraints = getMarginConstraints( minimumMarginScale );
-	const currentMinMargin = marginConstraints[ marginUnit ].min;
-
-	// Ensure when changing block style that any change in minimum height is
-	// enforced against existing top and bottom margins.
-	useEffect( () => {
-		if (
-			marginTopValue < currentMinMargin ||
-			marginBottomValue < currentMinMargin
-		) {
-			const topValue = Math.max( marginTopValue, currentMinMargin );
-			const bottomValue = Math.max( marginBottomValue, currentMinMargin );
-
-			setAttributes( {
-				style: {
-					...style,
-					spacing: {
-						...style?.spacing,
-						margin: {
-							top: `${ topValue }${ marginUnit }`,
-							bottom: `${ bottomValue }${ marginUnit }`,
-						},
-					},
-				},
-			} );
-		}
-	}, [ hasDotsStyle ] ); // Only restricting on dots style as min/max enforced on change otherwise.
-
-	const blockProps = useBlockProps();
+	const { top, bottom } = style?.spacing?.margin || {};
+	const marginUnit = parseUnit( top || bottom );
+	const currentMinMargin = MARGIN_CONSTRAINTS[ marginUnit ].min;
 
 	const convertedMarginTop = useConvertUnitToMobile(
-		marginTopValue || currentMinMargin,
+		parseFloat( top || 0 ) || currentMinMargin,
 		marginUnit
 	);
 
 	const convertedMarginBottom = useConvertUnitToMobile(
-		marginBottomValue || currentMinMargin,
+		parseFloat( bottom || 0 ) || currentMinMargin,
 		marginUnit
 	);
 
@@ -72,7 +40,7 @@ function SeparatorEdit( props ) {
 	return (
 		<>
 			<HorizontalRule
-				{ ...blockProps }
+				{ ...useBlockProps() }
 				style={ {
 					backgroundColor: color.color,
 					color: color.color,
@@ -83,7 +51,6 @@ function SeparatorEdit( props ) {
 			<SeparatorSettings
 				color={ color }
 				setColor={ setColor }
-				marginConstraints={ marginConstraints }
 				marginUnit={ marginUnit }
 				separatorStyles={ style }
 				setAttributes={ setAttributes }

--- a/packages/block-library/src/separator/editor.scss
+++ b/packages/block-library/src/separator/editor.scss
@@ -16,15 +16,16 @@
 
 // Duplicate selector to overcome theme specificity.
 .editor-styles-wrapper .wp-block .wp-block-separator.wp-block-separator {
-	// Remove default margins and center within ResizableBox control.
-	left: 50%;
 	margin: 0;
 	position: absolute;
-	top: 50%;
 	width: 100%;
-	transform: translate(-50%, -50%);
 
 	&.is-style-dots {
 		border-top: none;
 	}
+}
+
+// Counter the added height of the dots style's pseudo after element
+.wp-block-separator__wrapper.is-style-dots .is-style-dots {
+	transform: translateY(-0.75em);
 }

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -9,8 +9,7 @@ import classnames from 'classnames';
 import { getColorClassName, useBlockProps } from '@wordpress/block-editor';
 
 export default function separatorSave( { attributes } ) {
-	const { color, customColor, height, heightUnit } = attributes;
-	const margin = height ? `${ height / 2 }${ heightUnit }` : undefined;
+	const { color, customColor } = attributes;
 
 	// the hr support changing color using border-color, since border-color
 	// is not yet supported in the color palette, we use background-color
@@ -28,8 +27,8 @@ export default function separatorSave( { attributes } ) {
 	const style = {
 		backgroundColor: backgroundClass ? undefined : customColor,
 		color: colorClass ? undefined : customColor,
-		marginBottom: margin,
-		marginTop: margin,
+		marginBottom: attributes.style?.spacing?.margin?.bottom,
+		marginTop: attributes.style?.spacing?.margin?.top,
 	};
 
 	return <hr { ...useBlockProps.save( { className, style } ) } />;

--- a/packages/block-library/src/separator/separator-settings.js
+++ b/packages/block-library/src/separator/separator-settings.js
@@ -61,7 +61,7 @@ const SeparatorSettings = ( props ) => {
 					min={ marginConstraints[ topUnit ].min }
 					max={ marginConstraints[ topUnit ].max }
 					onChange={ createHandleMarginChange( 'top' ) }
-					value={ style?.spacing?.margin?.top }
+					value={ top }
 					unit={ marginUnit } // Needed to force unit selection to update after box resizing.
 					units={ CSS_UNITS }
 					onUnitChange={ onUnitChange }
@@ -73,7 +73,7 @@ const SeparatorSettings = ( props ) => {
 					min={ marginConstraints[ bottomUnit ].min }
 					max={ marginConstraints[ bottomUnit ].max }
 					onChange={ createHandleMarginChange( 'bottom' ) }
-					value={ style?.spacing?.margin?.bottom }
+					value={ bottom }
 					unit={ marginUnit } // Needed to force unit selection to update after box resizing.
 					units={ CSS_UNITS }
 					onUnitChange={ onUnitChange }

--- a/packages/block-library/src/separator/separator-settings.js
+++ b/packages/block-library/src/separator/separator-settings.js
@@ -11,13 +11,12 @@ import {
 /**
  * Internal dependencies
  */
-import { CSS_UNITS, parseUnit } from './shared';
+import { CSS_UNITS, MARGIN_CONSTRAINTS, parseUnit } from './shared';
 
 const SeparatorSettings = ( props ) => {
 	const {
 		color,
 		setColor,
-		marginConstraints,
 		marginUnit,
 		separatorStyles: style,
 		setAttributes,
@@ -46,7 +45,7 @@ const SeparatorSettings = ( props ) => {
 	};
 
 	const onUnitChange = ( unit ) => {
-		const defaultValue = marginConstraints[ unit ].default;
+		const defaultValue = MARGIN_CONSTRAINTS[ unit ].default;
 		updateMargins( {
 			top: defaultValue,
 			bottom: defaultValue,
@@ -58,8 +57,8 @@ const SeparatorSettings = ( props ) => {
 			<PanelBody title={ __( 'Separator settings' ) }>
 				<UnitControl
 					label={ __( 'Top margin' ) }
-					min={ marginConstraints[ topUnit ].min }
-					max={ marginConstraints[ topUnit ].max }
+					min={ MARGIN_CONSTRAINTS[ topUnit ].min }
+					max={ MARGIN_CONSTRAINTS[ topUnit ].max }
 					onChange={ createHandleMarginChange( 'top' ) }
 					value={ top }
 					unit={ marginUnit } // Needed to force unit selection to update after box resizing.
@@ -70,8 +69,8 @@ const SeparatorSettings = ( props ) => {
 				/>
 				<UnitControl
 					label={ __( 'Bottom margin' ) }
-					min={ marginConstraints[ bottomUnit ].min }
-					max={ marginConstraints[ bottomUnit ].max }
+					min={ MARGIN_CONSTRAINTS[ bottomUnit ].min }
+					max={ MARGIN_CONSTRAINTS[ bottomUnit ].max }
 					onChange={ createHandleMarginChange( 'bottom' ) }
 					value={ bottom }
 					unit={ marginUnit } // Needed to force unit selection to update after box resizing.

--- a/packages/block-library/src/separator/separator-settings.js
+++ b/packages/block-library/src/separator/separator-settings.js
@@ -11,33 +11,73 @@ import {
 /**
  * Internal dependencies
  */
-import { HEIGHT_CSS_UNITS } from './shared';
+import { CSS_UNITS, parseUnit } from './shared';
 
 const SeparatorSettings = ( props ) => {
 	const {
 		color,
 		setColor,
-		height,
-		heightUnit,
-		minHeight,
-		maxHeight,
-		updateHeight,
-		updateHeightUnit,
+		marginConstraints,
+		marginUnit,
+		separatorStyles: style,
+		setAttributes,
 	} = props;
+	const { top, bottom } = style?.spacing?.margin || {};
+	const topUnit = parseUnit( top );
+	const bottomUnit = parseUnit( bottom );
+
+	const updateMargins = ( margins ) => {
+		setAttributes( {
+			style: {
+				...style,
+				spacing: {
+					...style?.spacing,
+					margin: margins,
+				},
+			},
+		} );
+	};
+
+	const createHandleMarginChange = ( side ) => ( value ) => {
+		updateMargins( {
+			...style?.spacing?.margin,
+			[ side ]: value,
+		} );
+	};
+
+	const onUnitChange = ( unit ) => {
+		const defaultValue = marginConstraints[ unit ].default;
+		updateMargins( {
+			top: defaultValue,
+			bottom: defaultValue,
+		} );
+	};
 
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Separator settings' ) }>
 				<UnitControl
-					label={ __( 'Height' ) }
-					min={ minHeight }
-					max={ maxHeight }
-					onChange={ updateHeight }
-					onUnitChange={ updateHeightUnit }
-					value={ `${ height }${ heightUnit }` }
-					unit={ heightUnit }
-					units={ HEIGHT_CSS_UNITS }
-					step={ heightUnit === 'px' ? '1' : '0.25' }
+					label={ __( 'Top margin' ) }
+					min={ marginConstraints[ topUnit ].min }
+					max={ marginConstraints[ topUnit ].max }
+					onChange={ createHandleMarginChange( 'top' ) }
+					value={ style?.spacing?.margin?.top }
+					unit={ marginUnit } // Needed to force unit selection to update after box resizing.
+					units={ CSS_UNITS }
+					onUnitChange={ onUnitChange }
+					step={ topUnit === 'px' ? '1' : '0.25' }
+					style={ { marginBottom: '8px' } }
+				/>
+				<UnitControl
+					label={ __( 'Bottom margin' ) }
+					min={ marginConstraints[ bottomUnit ].min }
+					max={ marginConstraints[ bottomUnit ].max }
+					onChange={ createHandleMarginChange( 'bottom' ) }
+					value={ style?.spacing?.margin?.bottom }
+					unit={ marginUnit } // Needed to force unit selection to update after box resizing.
+					units={ CSS_UNITS }
+					onUnitChange={ onUnitChange }
+					step={ bottomUnit === 'px' ? '1' : '0.25' }
 				/>
 			</PanelBody>
 			<PanelColorSettings

--- a/packages/block-library/src/separator/separator-settings.native.js
+++ b/packages/block-library/src/separator/separator-settings.native.js
@@ -45,12 +45,9 @@ const SeparatorSettings = ( props ) => {
 	};
 
 	const onUnitChange = ( unit ) => {
-		const defaultValue = MARGIN_CONSTRAINTS[ unit ].default;
-
-		// Updating the margins doesn't update the UnitControl field's input immediately :(
 		updateMargins( {
-			top: defaultValue,
-			bottom: defaultValue,
+			top: MARGIN_CONSTRAINTS[ unit ].default,
+			bottom: MARGIN_CONSTRAINTS[ unit ].default,
 		} );
 	};
 

--- a/packages/block-library/src/separator/separator-settings.native.js
+++ b/packages/block-library/src/separator/separator-settings.native.js
@@ -8,34 +8,78 @@ import { PanelBody, UnitControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { HEIGHT_CSS_UNITS } from './shared';
+import { CSS_UNITS, parseUnit } from './shared';
 
 const SeparatorSettings = ( props ) => {
 	const {
 		color,
 		setColor,
-		height,
-		heightUnit,
-		minHeight,
-		maxHeight,
-		updateHeight,
-		updateHeightUnit,
+		marginConstraints,
+		marginUnit,
+		separatorStyles: style,
+		setAttributes,
 	} = props;
+
+	const { top, bottom } = style?.spacing?.margin || {};
+	const topUnit = parseUnit( top );
+	const bottomUnit = parseUnit( bottom );
+	const topValue = top ? parseFloat( top ) : undefined;
+	const bottomValue = bottom ? parseFloat( bottom ) : undefined;
+
+	const updateMargins = ( margins ) => {
+		setAttributes( {
+			style: {
+				...style,
+				spacing: {
+					...style?.spacing,
+					margin: margins,
+				},
+			},
+		} );
+	};
+
+	const createHandleMarginChange = ( side ) => ( value ) => {
+		updateMargins( {
+			...style?.spacing?.margin,
+			[ side ]: `${ value }${ marginUnit }`,
+		} );
+	};
+
+	const onUnitChange = ( unit ) => {
+		const defaultValue = marginConstraints[ unit ].default;
+		// Updating the margins doesn't update the UnitControl field's input immediately :(
+		updateMargins( {
+			top: defaultValue,
+			bottom: defaultValue,
+		} );
+	};
 
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Separator settings' ) }>
 				<UnitControl
-					label={ __( 'Height' ) }
-					min={ minHeight }
-					max={ maxHeight }
-					onChange={ updateHeight }
-					onUnitChange={ updateHeightUnit }
-					value={ height }
-					unit={ heightUnit }
-					units={ HEIGHT_CSS_UNITS }
+					label={ __( 'Top margin' ) }
+					min={ marginConstraints[ topUnit ].min }
+					max={ marginConstraints[ topUnit ].max }
+					value={ topValue }
+					unit={ topUnit }
+					units={ CSS_UNITS }
+					onChange={ createHandleMarginChange( 'top' ) }
+					onUnitChange={ onUnitChange }
 					decimalNum={ 1 }
-					key={ heightUnit }
+					key={ 'separator-top-margin' }
+				/>
+				<UnitControl
+					label={ __( 'Bottom margin' ) }
+					min={ marginConstraints[ bottomUnit ].min }
+					max={ marginConstraints[ bottomUnit ].max }
+					value={ bottomValue }
+					unit={ bottomUnit }
+					units={ CSS_UNITS }
+					onChange={ createHandleMarginChange( 'bottom' ) }
+					onUnitChange={ onUnitChange }
+					decimalNum={ 1 }
+					key={ 'separator-bottom-margin' }
 				/>
 			</PanelBody>
 			<PanelColorSettings

--- a/packages/block-library/src/separator/separator-settings.native.js
+++ b/packages/block-library/src/separator/separator-settings.native.js
@@ -61,25 +61,29 @@ const SeparatorSettings = ( props ) => {
 					label={ __( 'Top margin' ) }
 					min={ MARGIN_CONSTRAINTS[ topUnit ].min }
 					max={ MARGIN_CONSTRAINTS[ topUnit ].max }
-					value={ topValue }
+					value={ topValue || MARGIN_CONSTRAINTS[ topUnit ].min }
 					unit={ topUnit }
 					units={ CSS_UNITS }
 					onChange={ createHandleMarginChange( 'top' ) }
 					onUnitChange={ onUnitChange }
 					decimalNum={ 1 }
-					key={ 'separator-top-margin' }
+					key={ `separator-top-margin-${ topUnit }` }
+					step={ topUnit === 'px' ? 1 : 0.1 }
 				/>
 				<UnitControl
 					label={ __( 'Bottom margin' ) }
 					min={ MARGIN_CONSTRAINTS[ bottomUnit ].min }
 					max={ MARGIN_CONSTRAINTS[ bottomUnit ].max }
-					value={ bottomValue }
+					value={
+						bottomValue || MARGIN_CONSTRAINTS[ bottomUnit ].min
+					}
 					unit={ bottomUnit }
 					units={ CSS_UNITS }
 					onChange={ createHandleMarginChange( 'bottom' ) }
 					onUnitChange={ onUnitChange }
 					decimalNum={ 1 }
-					key={ 'separator-bottom-margin' }
+					key={ `separator-bottom-margin-${ bottomUnit }` }
+					step={ bottomUnit === 'px' ? 1 : 0.1 }
 				/>
 			</PanelBody>
 			<PanelColorSettings

--- a/packages/block-library/src/separator/separator-settings.native.js
+++ b/packages/block-library/src/separator/separator-settings.native.js
@@ -8,13 +8,12 @@ import { PanelBody, UnitControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { CSS_UNITS, parseUnit } from './shared';
+import { CSS_UNITS, MARGIN_CONSTRAINTS, parseUnit } from './shared';
 
 const SeparatorSettings = ( props ) => {
 	const {
 		color,
 		setColor,
-		marginConstraints,
 		marginUnit,
 		separatorStyles: style,
 		setAttributes,
@@ -46,7 +45,8 @@ const SeparatorSettings = ( props ) => {
 	};
 
 	const onUnitChange = ( unit ) => {
-		const defaultValue = marginConstraints[ unit ].default;
+		const defaultValue = MARGIN_CONSTRAINTS[ unit ].default;
+
 		// Updating the margins doesn't update the UnitControl field's input immediately :(
 		updateMargins( {
 			top: defaultValue,
@@ -59,8 +59,8 @@ const SeparatorSettings = ( props ) => {
 			<PanelBody title={ __( 'Separator settings' ) }>
 				<UnitControl
 					label={ __( 'Top margin' ) }
-					min={ marginConstraints[ topUnit ].min }
-					max={ marginConstraints[ topUnit ].max }
+					min={ MARGIN_CONSTRAINTS[ topUnit ].min }
+					max={ MARGIN_CONSTRAINTS[ topUnit ].max }
 					value={ topValue }
 					unit={ topUnit }
 					units={ CSS_UNITS }
@@ -71,8 +71,8 @@ const SeparatorSettings = ( props ) => {
 				/>
 				<UnitControl
 					label={ __( 'Bottom margin' ) }
-					min={ marginConstraints[ bottomUnit ].min }
-					max={ marginConstraints[ bottomUnit ].max }
+					min={ MARGIN_CONSTRAINTS[ bottomUnit ].min }
+					max={ MARGIN_CONSTRAINTS[ bottomUnit ].max }
 					value={ bottomValue }
 					unit={ bottomUnit }
 					units={ CSS_UNITS }

--- a/packages/block-library/src/separator/shared.js
+++ b/packages/block-library/src/separator/shared.js
@@ -4,16 +4,16 @@
 import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-//Separator height related constants.
-export const MIN_PX_HEIGHT = 20;
-export const MIN_EM_HEIGHT = 1;
-export const MIN_REM_HEIGHT = 1;
-export const MAX_PX_HEIGHT = 500;
-export const MAX_EM_HEIGHT = 30;
-export const MAX_REM_HEIGHT = 30;
+//Separator margin related constants.
+export const MIN_PX_MARGIN = 10;
+export const MIN_EM_MARGIN = 0.5;
+export const MIN_REM_MARGIN = 0.5;
+export const MAX_PX_MARGIN = 300;
+export const MAX_EM_MARGIN = 20;
+export const MAX_REM_MARGIN = 20;
 
 const isWeb = Platform.OS === 'web';
-export const HEIGHT_CSS_UNITS = [
+export const CSS_UNITS = [
 	{ value: 'px', label: isWeb ? 'px' : __( 'Pixels (px)' ), default: 0 },
 	{
 		value: 'em',
@@ -27,22 +27,35 @@ export const HEIGHT_CSS_UNITS = [
 	},
 ];
 
-export const getHeightConstraints = ( minimumScale = 1 ) => {
+export const getMarginConstraints = ( minimumScale = 1 ) => {
 	return {
 		px: {
-			min: minimumScale * MIN_PX_HEIGHT,
-			max: MAX_PX_HEIGHT,
-			default: minimumScale * MIN_PX_HEIGHT,
+			min: minimumScale * MIN_PX_MARGIN,
+			max: MAX_PX_MARGIN,
+			default: `${ minimumScale * MIN_PX_MARGIN }px`,
 		},
 		em: {
-			min: minimumScale * MIN_EM_HEIGHT,
-			max: MAX_EM_HEIGHT,
-			default: 1,
+			min: minimumScale * MIN_EM_MARGIN,
+			max: MAX_EM_MARGIN,
+			default: '1em',
 		},
 		rem: {
-			min: minimumScale * MIN_REM_HEIGHT,
-			max: MAX_REM_HEIGHT,
-			default: 1,
+			min: minimumScale * MIN_REM_MARGIN,
+			max: MAX_REM_MARGIN,
+			default: '1rem',
 		},
 	};
+};
+
+export const parseUnit = ( cssValue ) => {
+	if ( ! cssValue ) {
+		return 'px';
+	}
+
+	const matches = cssValue.trim().match( /[\d.\-+]*\s*([a-zA-Z]*)$/ );
+	if ( ! matches ) {
+		return 'px';
+	}
+	const [ , unit ] = matches;
+	return ( unit || 'px' ).toLowerCase();
 };

--- a/packages/block-library/src/separator/shared.js
+++ b/packages/block-library/src/separator/shared.js
@@ -1,18 +1,27 @@
 /**
+ * External dependencies
+ */
+import { clamp } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 //Separator margin related constants.
-export const MIN_PX_MARGIN = 10;
-export const MIN_EM_MARGIN = 0.5;
-export const MIN_REM_MARGIN = 0.5;
+export const MIN_PX_MARGIN = 15;
+export const MIN_EM_MARGIN = 0.75;
+export const MIN_REM_MARGIN = 0.75;
 export const MAX_PX_MARGIN = 300;
 export const MAX_EM_MARGIN = 20;
 export const MAX_REM_MARGIN = 20;
 
 const isWeb = Platform.OS === 'web';
+
+/**
+ * Available CSS units for specifying Separator margins.
+ */
 export const CSS_UNITS = [
 	{ value: 'px', label: isWeb ? 'px' : __( 'Pixels (px)' ), default: 0 },
 	{
@@ -27,26 +36,34 @@ export const CSS_UNITS = [
 	},
 ];
 
-export const getMarginConstraints = ( minimumScale = 1 ) => {
-	return {
-		px: {
-			min: minimumScale * MIN_PX_MARGIN,
-			max: MAX_PX_MARGIN,
-			default: `${ minimumScale * MIN_PX_MARGIN }px`,
-		},
-		em: {
-			min: minimumScale * MIN_EM_MARGIN,
-			max: MAX_EM_MARGIN,
-			default: '1em',
-		},
-		rem: {
-			min: minimumScale * MIN_REM_MARGIN,
-			max: MAX_REM_MARGIN,
-			default: '1rem',
-		},
-	};
+/**
+ * Separator margin constraints for available CSS units.
+ */
+export const MARGIN_CONSTRAINTS = {
+	px: {
+		min: MIN_PX_MARGIN,
+		max: MAX_PX_MARGIN,
+		default: `${ MIN_PX_MARGIN }px`,
+		minHeight: `${ MIN_PX_MARGIN * 2 }px`,
+	},
+	em: {
+		min: MIN_EM_MARGIN,
+		max: MAX_EM_MARGIN,
+		default: '1em',
+	},
+	rem: {
+		min: MIN_REM_MARGIN,
+		max: MAX_REM_MARGIN,
+		default: '1rem',
+	},
 };
 
+/**
+ * Extracts CSS unit from string.
+ *
+ * @param { string } cssValue CSS string containing unit and value.
+ * @return { string }         CSS unit. Defaults to 'px'.
+ */
 export const parseUnit = ( cssValue ) => {
 	if ( ! cssValue ) {
 		return 'px';
@@ -58,4 +75,53 @@ export const parseUnit = ( cssValue ) => {
 	}
 	const [ , unit ] = matches;
 	return ( unit || 'px' ).toLowerCase();
+};
+
+/**
+ * Calculates a height and corresponding CSS value.
+ *
+ * @param { Object } style Separator block's style prop.
+ * @param { string } unit  Current CSS unit.
+ */
+export const getHeightFromStyle = ( style, unit ) => {
+	const { top, bottom } = style?.spacing?.margin || {};
+	const height = parseFloat( top || 0 ) + parseFloat( bottom || 0 );
+	return {
+		height,
+		cssHeight: `${ height }${ unit }`,
+	};
+};
+
+/**
+ * Splits a new height value into appropriate top and bottom margin values
+ * to store in the block's `style.spacing.margin` attribute.
+ *
+ * @param { number } newHeight New Separator height.
+ * @param {*} currentTop       Current top margin.
+ * @param {*} currentBottom    Current bottom margin.
+ */
+export const calculateMargins = ( newHeight, currentTop, currentBottom ) => {
+	const { min, max } = MARGIN_CONSTRAINTS.px;
+
+	// Split the new height between margins by default.
+	let top = Math.floor( newHeight / 2 );
+	let bottom = Math.ceil( newHeight / 2 );
+
+	// Handle existing ratio between top and bottom margins if available.
+	if ( currentTop && currentBottom ) {
+		const marginTop = parseFloat( currentTop || 0 );
+		const marginBottom = parseFloat( currentBottom || 0 );
+		const totalMargin = marginTop + marginBottom;
+
+		top = newHeight * ( marginTop / totalMargin );
+		bottom = newHeight * ( marginBottom / totalMargin );
+	}
+
+	top = clamp( Math.round( top ), min, max );
+	bottom = clamp( Math.round( bottom ), min, max );
+
+	return {
+		top: `${ top }px`,
+		bottom: `${ bottom }px`,
+	};
 };

--- a/packages/primitives/src/horizontal-rule/index.native.js
+++ b/packages/primitives/src/horizontal-rule/index.native.js
@@ -21,7 +21,12 @@ const HR = ( { getStylesFromColorScheme, style, ...props } ) => {
 		: {};
 
 	return (
-		<View style={ styles.container }>
+		<View
+			style={ {
+				marginTop: style?.marginTop,
+				marginBottom: style?.marginBottom,
+			} }
+		>
 			<Hr
 				{ ...props }
 				lineStyle={ {

--- a/packages/primitives/src/horizontal-rule/styles.native.scss
+++ b/packages/primitives/src/horizontal-rule/styles.native.scss
@@ -1,13 +1,3 @@
-.container {
-	align-items: center;
-	bottom: 0;
-	justify-content: center;
-	left: 0;
-	position: absolute;
-	right: 0;
-	top: 0;
-}
-
 .line {
 	background-color: $gray-lighten-20;
 	height: 2;


### PR DESCRIPTION
## Description
Trial exploring splitting a custom separator height into both top and bottom margins, while still providing the ability to drag a resizable box handle to visually set the height. 

This PR is based off https://github.com/WordPress/gutenberg/pull/28409

* This does not extend the spacing block support to provide margins control
* It does use `style.spacing.margin.top` and `style.spacing.margin.bottom` attributes to store the values
* Should the spacing block support get the margins feature merged this should be a simple opt in, then remove the current margin controls.

#### Next Steps
- [ ] Fix bug in native controls where after default values are applied after unit change, the input doesn't reflect the new value.

## How has this been tested?
Manually.

#### Testing Instructions

TBA

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/60436221/106734517-d6b3d200-665e-11eb-80db-fcaf4edac19f.gif" width="400" />


## Types of changes
New feature.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
