### PR TITLE
Force navigation screen nav block to vertical orientation

### DIFF
--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -108,7 +108,13 @@ function createNavigationBlock( menuItems ) {
 
 	// menuItemsToTreeOfBlocks takes an array of top-level menu items and recursively creates all their innerBlocks
 	const innerBlocks = menuItemsToTreeOfBlocks( itemsByParentID[ 0 ] || [] );
-	const navigationBlock = createBlock( 'core/navigation', {}, innerBlocks );
+	const navigationBlock = createBlock(
+		'core/navigation',
+		{
+			orientation: 'vertical',
+		},
+		innerBlocks
+	);
 	return [ navigationBlock, menuItemIdToClientId ];
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Merges into the branch from #28675, rather than `master`

Changes the orientation of the nav block to vertical in the nav menu screen, which fixes the mover orientation.

## Screenshots <!-- if applicable -->
<img width="529" alt="Screenshot 2021-02-03 at 6 42 22 pm" src="https://user-images.githubusercontent.com/677833/106735765-99941380-664f-11eb-9e7a-d61730027919.png">
