### PR TITLE
Fix insertUsage persistence in block-editor store

### DIFF
--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -233,15 +233,16 @@ persistencePlugin.__unstableMigrate = ( pluginOptions ) => {
 	const state = persistence.get();
 
 	// Migrate 'insertUsage' from 'core/editor' to 'core/block-editor'
-	const insertUsage = get( state, [
-		'core/editor',
-		'preferences',
-		'insertUsage',
-	] );
-	if ( insertUsage ) {
+	const editorInsertUsage = state[ 'core/editor' ]?.preferences?.insertUsage;
+	if ( editorInsertUsage ) {
+		const blockEditorInsertUsage =
+			state[ 'core/block-editor' ]?.preferences?.insertUsage;
 		persistence.set( 'core/block-editor', {
 			preferences: {
-				insertUsage,
+				insertUsage: {
+					...editorInsertUsage,
+					...blockEditorInsertUsage,
+				},
 			},
 		} );
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Somewhere down the road the `insertUsage` preferences stoped working properly. This setting is being taken into account for the ordering of blocks in any block Inserter.

This is related to moving the specific option from `core/editor` store to `core/block-editor` store - although that happened a while ago. There is a bug that overrides the `block-editor` `insertUsage` preferences with the `editor`'s ones, which default to empty object.

This PR fixes that by merging `insertUsage` from both stores, giving priority to the currently used store (block-editor).




## Testing instructions
1. In a post/page add some blocks and check the blocks in `Most used blocks` or any inserter.
2. Reload the page and see that the same blocks are shown.