### PR TITLE
Unit Tests Workflow: Enable for documentation-only PRs

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,13 +1,11 @@
 name: Unit Tests
 
+# Since Unit Tests are now required to pass for each PR,
+# we cannot disable them for documentation-only changes.
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
   push:
     branches: [master, wp-trunk]
-    paths-ignore:
-    - '**.md'
 
 jobs:
   unit-js:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-# Since Unit Tests are now required to pass for each PR,
+# Since Unit Tests are required to pass for each PR,
 # we cannot disable them for documentation-only changes.
 on:
   pull_request:


### PR DESCRIPTION
I've recently made the PHP and JS unit tests required -- meaning they _have_ to pass before a PR can be merged.
(This is in the wake of a recent issue that left PHP unit tests in a broken state -- also for subsequent PRs.)

@nosolosw then discovered that this affected documentation-only PRs (such as #28639): Since the unit test workflow had a [condition](https://github.com/WordPress/gutenberg/blob/d8d208927e964bf4f928a9e6b378902ed5fc421e/.github/workflows/unit-test.yml#L3-L10) that exempted it from running on such PRs, it never passed -- and the 'required' check criterion was never fulfilled.

This PR removes that condition from the workflow (so that the unit tests workflow always runs).

I was originally trying in https://github.com/WordPress/gutenberg/pull/28669 to be smart and enable the workflow, but keep skipping unit tests for documentation-only PRs. Unfortunately, this has turned out harder than expected (see [this comment](https://github.com/WordPress/gutenberg/pull/28669#issuecomment-772460253)).

(Given the choice between saving some time by not running them on doc fixes, and making them mandatory for all PRs, I have a clear preference for the latter.)