### PR TITLE
Categories block: display message instead of empty content

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -150,7 +150,15 @@ export default function CategoriesEdit( {
 					<Spinner />
 				</Placeholder>
 			) }
+			{ ! isRequesting && categories.length === 0 && (
+				<p>
+					{ __(
+						'Your site does not have any posts, so there is nothing to display here at the moment.'
+					) }
+				</p>
+			) }
 			{ ! isRequesting &&
+				categories.length > 0 &&
 				( displayAsDropdown
 					? renderCategoryDropdown()
 					: renderCategoryList() ) }


### PR DESCRIPTION
Fixes #28269

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Display a message indicating that there no posts (assigned to categories) to populate this block.

## How has this been tested?
Tested on default gutenberg dev environment.

## Screenshots <!-- if applicable -->
![categories-capture](https://user-images.githubusercontent.com/15197444/106771296-7bc2b080-6647-11eb-95cf-a1524777e402.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
