### PR TITLE
Load page templates via theme.json abstractions

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -24,7 +24,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @var WP_Theme_JSON
 	 */
-	private $theme = null;
+	private static $theme = null;
 
 	/**
 	 * Container for data coming from the user.
@@ -273,14 +273,14 @@ class WP_Theme_JSON_Resolver {
 	 * @return WP_Theme_JSON Entity that holds theme data.
 	 */
 	public function get_theme_data( $theme_support_data = array() ) {
-		if ( null === $this->theme ) {
+		if ( null === self::$theme ) {
 			$theme_json_data = self::get_from_file( locate_template( 'experimental-theme.json' ) );
 			self::translate_presets( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-			$this->theme = new WP_Theme_JSON( $theme_json_data );
+			self::$theme = new WP_Theme_JSON( $theme_json_data );
 		}
 
 		if ( empty( $theme_support_data ) ) {
-			return $this->theme;
+			return self::$theme;
 		}
 
 		/*
@@ -288,7 +288,7 @@ class WP_Theme_JSON_Resolver {
 		 * to override the ones declared via add_theme_support.
 		 */
 		$with_theme_supports = new WP_Theme_JSON( $theme_support_data );
-		$with_theme_supports->merge( $this->theme );
+		$with_theme_supports->merge( self::$theme );
 
 		return $with_theme_supports;
 	}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -103,6 +103,7 @@ class WP_Theme_JSON {
 	 * }
 	 */
 	const SCHEMA = array(
+		'pageTemplates' => null,
 		'styles'   => array(
 			'border'     => array(
 				'radius' => null,
@@ -1047,6 +1048,19 @@ class WP_Theme_JSON {
 			return array();
 		} else {
 			return $this->theme_json['settings'];
+		}
+	}
+
+	/**
+	 * Returns the page templates of the current theme.
+	 *
+	 * @return array
+	 */
+	public function get_page_templates() {
+		if ( ! isset( $this->theme_json['pageTemplates'] ) ) {
+			return array();
+		} else {
+			return $this->theme_json['pageTemplates'];
 		}
 	}
 

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -104,7 +104,7 @@ class WP_Theme_JSON {
 	 */
 	const SCHEMA = array(
 		'pageTemplates' => null,
-		'styles'   => array(
+		'styles'        => array(
 			'border'     => array(
 				'radius' => null,
 				'color'  => null,
@@ -135,7 +135,7 @@ class WP_Theme_JSON {
 				'textTransform'  => null,
 			),
 		),
-		'settings' => array(
+		'settings'      => array(
 			'border'     => array(
 				'customRadius' => null,
 				'customColor'  => null,

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -17,17 +17,12 @@ function gutenberg_load_block_page_templates( $templates, $theme, $post ) {
 	if ( ! gutenberg_is_fse_theme() ) {
 		return $templates;
 	}
-	$config_file = locate_template( 'experimental-theme.json' );
-	if ( ! file_exists( $config_file ) ) {
-		return $templates;
-	}
-	$data           = json_decode(
-		file_get_contents( $config_file ),
-		true
-	);
+
+	$resolver       = new WP_Theme_JSON_Resolver();
+	$data           = $resolver->get_theme_data()->get_page_templates();
 	$page_templates = array();
-	if ( isset( $data['pageTemplates'] ) ) {
-		foreach ( $data['pageTemplates']  as $key => $page_template ) {
+	if ( isset( $data ) ) {
+		foreach ( $data  as $key => $page_template ) {
 			if ( ( ! isset( $page_template['postTypes'] ) && 'page' === $post->post_type ) ||
 				( isset( $page_template['postTypes'] ) && in_array( $post->post_type, $page_template['postTypes'], true ) )
 			) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -91,6 +91,12 @@ require __DIR__ . '/editor-settings.php';
 if ( ! class_exists( 'WP_Block_Template ' ) ) {
 	require __DIR__ . '/full-site-editing/class-wp-block-template.php';
 }
+
+// These are used by some FSE features
+// as well as global styles.
+require __DIR__ . '/class-wp-theme-json.php';
+require __DIR__ . '/class-wp-theme-json-resolver.php';
+
 require __DIR__ . '/full-site-editing/full-site-editing.php';
 require __DIR__ . '/full-site-editing/block-templates.php';
 require __DIR__ . '/full-site-editing/default-template-types.php';
@@ -109,8 +115,6 @@ require __DIR__ . '/widgets.php';
 require __DIR__ . '/navigation.php';
 require __DIR__ . '/navigation-page.php';
 require __DIR__ . '/experiments-page.php';
-require __DIR__ . '/class-wp-theme-json.php';
-require __DIR__ . '/class-wp-theme-json-resolver.php';
 require __DIR__ . '/global-styles.php';
 require __DIR__ . '/query-utils.php';
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -736,4 +736,22 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 		$this->assertEqualSetsWithIndex( $expected, $result );
 	}
+
+	function test_get_page_templates() {
+		$theme_json = new WP_Theme_JSON( array(
+			'pageTemplates' => array(
+				'page-home' => array(
+					'title' => 'Some title'
+				),
+			),
+		) );
+
+		$page_templates = $theme_json->get_page_templates();
+
+		$this->assertEqualSetsWithIndex( $page_templates, array(
+			'page-home' => array(
+				'title' => 'Some title',
+			),
+		) );
+	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -738,20 +738,25 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	}
 
 	function test_get_page_templates() {
-		$theme_json = new WP_Theme_JSON( array(
-			'pageTemplates' => array(
-				'page-home' => array(
-					'title' => 'Some title'
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'pageTemplates' => array(
+					'page-home' => array(
+						'title' => 'Some title',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		$page_templates = $theme_json->get_page_templates();
 
-		$this->assertEqualSetsWithIndex( $page_templates, array(
-			'page-home' => array(
-				'title' => 'Some title',
-			),
-		) );
+		$this->assertEqualSetsWithIndex(
+			$page_templates,
+			array(
+				'page-home' => array(
+					'title' => 'Some title',
+				),
+			)
+		);
 	}
 }


### PR DESCRIPTION
This PR is a follow up to https://github.com/WordPress/gutenberg/pull/27778 (which introduced the `pageTemplates` field in theme.json) and https://github.com/WordPress/gutenberg/pull/28110 https://github.com/WordPress/gutenberg/pull/28533 that refactored it to accommodate the new needs for this file https://github.com/WordPress/gutenberg/issues/28163

The idea is to mature the APIs we use to read data from theme.json, as to:

1. Minimize costly operations: read and parse JSON file, read from the database, etc.
2. Provide abstractions over how to access the underlying data (files in the case of core and theme data / CustomPostType in the case of user data).
3. Centralize logic so the hard parts are easier (things like merging core/theme/user data, translations, rearranging keys, etc).

An initial list of steps we need to check when adding new fields to `theme.json`:

- Add the new field to the theme.json schema.
- Does the field needs any special validation/escaping?
- Does this field needs to merge values from core, theme, and user origins?
- Add unit tests to cover the use case.
- Does this field needs to be translated?

While the role of the `WP_Theme_JSON` class in this space seems well established, the role of `WP_Theme_JSON_Resolver` needs to be accommodated to the new use cases we want to support beyond settings & styles. This PR is the first step to do that and uses `pageTemplates` as an example.

Proposed API for consumers:

```php
$resolver = WP_Theme_JSON_Resolver();
$resolver->get_theme_data()->get_page_templates();
```

## How to test

- Use and activate the TT1-blocks (latest `master` branch). It defines one page template: page-home whose text is "Page without title".
- Load a page and make sure it appears in the template selector (page sidebar > page attributes):
![Captura de ecrã de 2021-02-04 14-21-55](https://user-images.githubusercontent.com/583546/106898345-5cce2800-66f4-11eb-8d88-5ee1f20df17f.png)
- Go to the `experimental-theme.json` of the TT1-blocks theme and update the text to be "My home page".
- Reload the editor and verify the new text is present in the template selector.

## Follow-ups

This PR refactors code, it doesn't change any behavior. A follow up to this that adds new behavior is a PR that enables the page template title to be translated.

I think `WP_Theme_JSON_Resolver` needs more maturation. I'd like to create small and focused follow-up PRs to improve it. It'll allow us to move quickly by making reviews easier.