### PR TITLE
Add preload_paths filter for widgets screen and full site editing

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -85,30 +85,27 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );
 /**
  * Initialize a block-based editor.
  *
- * @param array $settings {
+ * @param string $editor_name          Editor name.
+ * @param string $editor_script_handle Editor script handle.
+ * @param array  $settings {
  *      Elements to initialize a block-based editor.
  *
- *      @type array  $preload_paths        paths need to be preloaded.
- *      @type string $editor_name          editor name.
- *      @type string $editor_script_handle editor script handle.
- *      @type string $initializer_name     editor initialization function name.
- *      @type array  $editor_settings      editor settings.
+ *      @type array  $preload_paths        Array of paths to preload.
+ *      @type string $initializer_name     Editor initialization function name.
+ *      @type array  $editor_settings      Editor settings.
  * }
  * @return void
  */
-function gutenberg_initialize_editor( $settings ) {
+function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $settings ) {
 
 	$defaults = array(
-		'preload_paths'        => array(),
-		'editor_name'          => 'widgets_editor',
-		'editor_script_handle' => 'edit-widgets',
-		'initializer_name'     => 'initialize',
-		'editor_settings'      => array(),
+		'preload_paths'    => array(),
+		'initializer_name' => 'initialize',
+		'editor_settings'  => array(),
 	);
 
 	$settings = wp_parse_args( $settings, $defaults );
 
-	$editor_name = $settings['editor_name'];
 	/**
 	 * Preload common data by specifying an array of REST API paths that will be preloaded.
 	 *
@@ -132,12 +129,12 @@ function gutenberg_initialize_editor( $settings ) {
 		'after'
 	);
 	wp_add_inline_script(
-		"wp-{$settings['editor_script_handle']}",
+		"wp-{$editor_script_handle}",
 		sprintf(
 			'wp.domReady( function() {
 				wp.%s.%s( "%s", %s );
 			} );',
-			lcfirst( str_replace( '-', '', ucwords( $settings['editor_script_handle'], '-' ) ) ),
+			lcfirst( str_replace( '-', '', ucwords( $editor_script_handle, '-' ) ) ),
 			$settings['initializer_name'],
 			str_replace( '_', '-', $editor_name ),
 			wp_json_encode( $settings['editor_settings'] )

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -108,7 +108,8 @@ function gutenberg_initialize_editor( $settings ) {
 
 	$settings = wp_parse_args( $settings, $defaults );
 
-	$preload_paths = apply_filters( "{$settings['editor_name']}_preload_paths", $settings['preload_paths'] );
+	$editor_name   = $settings['editor_name'];
+	$preload_paths = apply_filters( "{$editor_name}_preload_paths", $settings['preload_paths'] );
 
 	$preload_data = array_reduce(
 		$preload_paths,
@@ -131,7 +132,7 @@ function gutenberg_initialize_editor( $settings ) {
 			} );',
 			lcfirst( str_replace( '-', '', ucwords( $settings['editor_script_handle'], '-' ) ) ),
 			$settings['initializer_name'],
-			str_replace( '_', '-', $settings['editor_name'] ),
+			str_replace( '_', '-', $editor_name ),
 			wp_json_encode( $settings['editor_settings'] )
 		)
 	);

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -85,14 +85,14 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );
 /**
  * Initialize a block-based editor.
  *
- * @param $settings {
+ * @param array $settings {
  *      Elements to initialize a block-based editor.
  *
- *      @param array $preload_paths         paths need to be preloaded.
- *      @param string $editor_name          editor name.
- *      @param string $editor_script_handle editor script handle.
- *      @param string $initializer_name     editor initialization function name.
- *      @param array $editor_settings       editor settings.
+ *      @type array  $preload_paths        paths need to be preloaded.
+ *      @type string $editor_name          editor name.
+ *      @type string $editor_script_handle editor script handle.
+ *      @type string $initializer_name     editor initialization function name.
+ *      @type array  $editor_settings      editor settings.
  * }
  * @return void
  */
@@ -110,7 +110,7 @@ function gutenberg_initialize_editor( $settings ) {
 
 	$preload_paths = apply_filters( "{$settings['editor_name']}_preload_paths", $settings['preload_paths'] );
 
-	$preload_data  = array_reduce(
+	$preload_data = array_reduce(
 		$preload_paths,
 		'rest_preload_api_request',
 		array()

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -108,7 +108,14 @@ function gutenberg_initialize_editor( $settings ) {
 
 	$settings = wp_parse_args( $settings, $defaults );
 
-	$editor_name   = $settings['editor_name'];
+	$editor_name = $settings['editor_name'];
+	/**
+	 * Preload common data by specifying an array of REST API paths that will be preloaded.
+	 *
+	 * Filters the array of paths that will be preloaded.
+	 *
+	 * @param string[] $preload_paths Array of paths to preload.
+	 */
 	$preload_paths = apply_filters( "{$editor_name}_preload_paths", $settings['preload_paths'] );
 
 	$preload_data = array_reduce(

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -113,45 +113,21 @@ function gutenberg_edit_site_init( $hook ) {
 	);
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
-	// Preload block editor paths.
-	// most of these are copied from edit-forms-blocks.php.
-	$preload_paths = array(
-		'/?context=edit',
-		'/wp/v2/types?context=edit',
-		'/wp/v2/taxonomies?context=edit',
-		'/wp/v2/pages?context=edit',
-		'/wp/v2/themes?status=active',
-		array( '/wp/v2/media', 'OPTIONS' ),
-	);
-
-	$preload_paths = apply_filters( 'edit_site_editor_preload_paths', $preload_paths );
-
-	$preload_data  = array_reduce(
-		$preload_paths,
-		'rest_preload_api_request',
-		array()
-	);
-	wp_add_inline_script(
-		'wp-api-fetch',
-		sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),
-		'after'
-	);
-
-	// Initialize editor.
-	wp_add_inline_script(
-		'wp-edit-site',
-		sprintf(
-			'wp.domReady( function() {
-				wp.editSite.initialize( "edit-site-editor", %s );
-			} );',
-			wp_json_encode( $settings )
+	gutenberg_initialize_editor(
+		array(
+			'preload_paths'        => array(
+				array( '/wp/v2/media', 'OPTIONS' ),
+				'/?context=edit',
+				'/wp/v2/types?context=edit',
+				'/wp/v2/taxonomies?context=edit',
+				'/wp/v2/pages?context=edit',
+				'/wp/v2/themes?status=active',
+			),
+			'editor_name'          => 'edit_site_editor',
+			'editor_script_handle' => 'edit-site',
+			'initializer_name'     => 'initialize',
+			'editor_settings'      => $settings,
 		)
-	);
-
-	wp_add_inline_script(
-		'wp-blocks',
-		sprintf( 'wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode( get_block_editor_server_block_settings() ) ),
-		'after'
 	);
 
 	wp_add_inline_script(

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -114,8 +114,10 @@ function gutenberg_edit_site_init( $hook ) {
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	gutenberg_initialize_editor(
+		'edit_site_editor',
+		'edit-site',
 		array(
-			'preload_paths'        => array(
+			'preload_paths'    => array(
 				array( '/wp/v2/media', 'OPTIONS' ),
 				'/?context=edit',
 				'/wp/v2/types?context=edit',
@@ -123,10 +125,8 @@ function gutenberg_edit_site_init( $hook ) {
 				'/wp/v2/pages?context=edit',
 				'/wp/v2/themes?status=active',
 			),
-			'editor_name'          => 'edit_site_editor',
-			'editor_script_handle' => 'edit-site',
-			'initializer_name'     => 'initialize',
-			'editor_settings'      => $settings,
+			'initializer_name' => 'initialize',
+			'editor_settings'  => $settings,
 		)
 	);
 

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -123,6 +123,9 @@ function gutenberg_edit_site_init( $hook ) {
 		'/wp/v2/themes?status=active',
 		array( '/wp/v2/media', 'OPTIONS' ),
 	);
+
+	$preload_paths = apply_filters( 'edit_site_editor_preload_paths', $preload_paths );
+
 	$preload_data  = array_reduce(
 		$preload_paths,
 		'rest_preload_api_request',

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -40,6 +40,23 @@ function gutenberg_navigation_init( $hook ) {
 	);
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
+	// Preload block editor paths.
+	// most of these are copied from edit-forms-blocks.php.
+	$preload_paths = array();
+
+	$preload_paths = apply_filters( 'navigation_editor_preload_paths', $preload_paths );
+
+	$preload_data  = array_reduce(
+		$preload_paths,
+		'rest_preload_api_request',
+		array()
+	);
+	wp_add_inline_script(
+		'wp-api-fetch',
+		sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),
+		'after'
+	);
+
 	wp_add_inline_script(
 		'wp-edit-navigation',
 		sprintf(

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -40,37 +40,13 @@ function gutenberg_navigation_init( $hook ) {
 	);
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
-	// Preload block editor paths.
-	// most of these are copied from edit-forms-blocks.php.
-	$preload_paths = array();
-
-	$preload_paths = apply_filters( 'navigation_editor_preload_paths', $preload_paths );
-
-	$preload_data  = array_reduce(
-		$preload_paths,
-		'rest_preload_api_request',
-		array()
-	);
-	wp_add_inline_script(
-		'wp-api-fetch',
-		sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),
-		'after'
-	);
-
-	wp_add_inline_script(
-		'wp-edit-navigation',
-		sprintf(
-			'wp.domReady( function() {
-				wp.editNavigation.initialize( "navigation-editor", %s );
-			} );',
-			wp_json_encode( $settings )
+	gutenberg_initialize_editor(
+		array(
+			'editor_name'          => 'navigation_editor',
+			'editor_script_handle' => 'edit-navigation',
+			'initializer_name'     => 'initialize',
+			'editor_settings'      => $settings,
 		)
-	);
-
-	// Preload server-registered block schemas.
-	wp_add_inline_script(
-		'wp-blocks',
-		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 	);
 
 	wp_enqueue_script( 'wp-edit-navigation' );

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -41,11 +41,11 @@ function gutenberg_navigation_init( $hook ) {
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	gutenberg_initialize_editor(
+		'navigation_editor',
+		'edit-navigation',
 		array(
-			'editor_name'          => 'navigation_editor',
-			'editor_script_handle' => 'edit-navigation',
-			'initializer_name'     => 'initialize',
-			'editor_settings'      => $settings,
+			'initializer_name' => 'initialize',
+			'editor_settings'  => $settings,
 		)
 	);
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -53,6 +53,8 @@ function gutenberg_widgets_init( $hook ) {
 	$settings = gutenberg_extend_block_editor_styles( $settings );
 
 	gutenberg_initialize_editor(
+		'widgets_editor',
+		'edit-widgets',
 		array(
 			'preload_paths'   => array(
 				array( '/wp/v2/media', 'OPTIONS' ),

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -59,6 +59,9 @@ function gutenberg_widgets_init( $hook ) {
 		'/wp/v2/sidebars?context=edit&per_page=-1',
 		'/wp/v2/widgets?context=edit&per_page=-1',
 	);
+
+	$preload_paths = apply_filters( 'widgets_editor_preload_paths', $preload_paths );
+
 	$preload_data  = array_reduce(
 		$preload_paths,
 		'rest_preload_api_request',

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -41,8 +41,6 @@ function gutenberg_widgets_init( $hook ) {
 		return;
 	}
 
-	$initializer_name = 'initialize';
-
 	$settings = array_merge(
 		gutenberg_get_common_block_editor_settings(),
 		gutenberg_get_legacy_widget_settings()
@@ -54,43 +52,15 @@ function gutenberg_widgets_init( $hook ) {
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 	$settings = gutenberg_extend_block_editor_styles( $settings );
 
-	$preload_paths = array(
-		array( '/wp/v2/media', 'OPTIONS' ),
-		'/wp/v2/sidebars?context=edit&per_page=-1',
-		'/wp/v2/widgets?context=edit&per_page=-1',
-	);
-
-	$preload_paths = apply_filters( 'widgets_editor_preload_paths', $preload_paths );
-
-	$preload_data  = array_reduce(
-		$preload_paths,
-		'rest_preload_api_request',
-		array()
-	);
-	wp_add_inline_script(
-		'wp-api-fetch',
-		sprintf(
-			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-			wp_json_encode( $preload_data )
-		),
-		'after'
-	);
-
-	wp_add_inline_script(
-		'wp-edit-widgets',
-		sprintf(
-			'wp.domReady( function() {
-				wp.editWidgets.%s( "widgets-editor", %s );
-			} );',
-			$initializer_name,
-			wp_json_encode( $settings )
+	gutenberg_initialize_editor(
+		array(
+			'preload_paths'   => array(
+				array( '/wp/v2/media', 'OPTIONS' ),
+				'/wp/v2/sidebars?context=edit&per_page=-1',
+				'/wp/v2/widgets?context=edit&per_page=-1',
+			),
+			'editor_settings' => $settings,
 		)
-	);
-
-	// Preload server-registered block schemas.
-	wp_add_inline_script(
-		'wp-blocks',
-		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 	);
 
 	wp_enqueue_script( 'wp-edit-widgets' );


### PR DESCRIPTION
## Description
This PR propose to fix https://github.com/WordPress/gutenberg/issues/28690 by adding a filter for widgets screen and full site editing features to be able to preloading datas before the pages is loaded.

**Edit:** I've just updated this PR and the issue with a comment because I saw I had forgotten the navigation editor.