### PR TITLE
[RNMobile] Move back disabled style for button in File block

### DIFF
--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -18,6 +18,10 @@
 	padding-right: $grid-unit-20;
 }
 
+.disabledButton {
+	opacity: 0.45;
+}
+
 .uploadFailedText {
 	color: #fff;
 	font-size: 14;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes: https://github.com/WordPress/gutenberg/issues/28706

That PR moves back style for disabled button in `File` block which was removed by mistake [in the PR](https://github.com/WordPress/gutenberg/pull/28224)
<!-- Please describe what you have changed or added -->

## How has this been tested?

1. Add file block
2. Add file from device
3. Observe the button
**Expect button opacity is lowered**

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/22746080/106802128-cef62c80-6662-11eb-9b31-1697bf4d2b2f.gif" width="300" />


## Types of changes
bug fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
