### PR TITLE
Add a filter to allow re-ordering of the block inserter tabs

### DIFF
--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -4,6 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { applyFilters, hasFilter } from '@wordpress/hooks';
 
 const blocksTab = {
 	name: 'blocks',
@@ -28,7 +29,7 @@ function InserterTabs( {
 	onSelect,
 } ) {
 	const tabs = useMemo( () => {
-		const tempTabs = [ blocksTab ];
+		let tempTabs = [ blocksTab ];
 
 		if ( showPatterns ) {
 			tempTabs.push( patternsTab );
@@ -37,7 +38,12 @@ function InserterTabs( {
 		if ( showReusableBlocks ) {
 			tempTabs.push( reusableBlocksTab );
 		}
-
+		if ( hasFilter( 'editor.BlockInserterTabs.order' ) ) {
+			tempTabs = applyFilters(
+				'editor.BlockInserterTabs.order',
+				tempTabs
+			);
+		}
 		return tempTabs;
 	}, [
 		blocksTab,

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -38,11 +38,8 @@ function InserterTabs( {
 		if ( showReusableBlocks ) {
 			tempTabs.push( reusableBlocksTab );
 		}
-		if ( hasFilter( 'editor.BlockInserterTabs.order' ) ) {
-			tempTabs = applyFilters(
-				'editor.BlockInserterTabs.order',
-				tempTabs
-			);
+		if ( hasFilter( 'editor.BlockInserterTabs' ) ) {
+			tempTabs = applyFilters( 'editor.BlockInserterTabs', tempTabs );
 		}
 		return tempTabs;
 	}, [


### PR DESCRIPTION
## Description
Currently there is no way for plugin developers to change the order of the panel tabs on the block inserter, ie. some sites may want to favour the use of patterns over individual blocks and so have the patterns tab as the first selected item when the inserter is opened.

## How has this been tested?

Can be tested by checking out this PR and adding the following code at bottom of the tabs.js file.

```
addFilter(
	'editor.BlockInserterTabs.order',
	'myplugin/inserter-order',
	(tabs) => tabs.reverse()
);
```

Before:
<img width="352" alt="Screen Shot 2021-02-04 at 8 59 20 AM" src="https://user-images.githubusercontent.com/3629020/106802323-ace2c580-66c7-11eb-972f-d279b3a84caf.png">

After:
<img width="354" alt="Screen Shot 2021-02-04 at 9 00 07 AM" src="https://user-images.githubusercontent.com/3629020/106802338-b0764c80-66c7-11eb-8e67-a1f770b9e82d.png">

## Types of changes
Adds a filter

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
