### PR TITLE
Block Editor: Fix is-hovered event listener

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -51,7 +51,7 @@ export function useIsHovered( ref ) {
 		}
 
 		if ( isHovered ) {
-			return addListener( 'mouseout', false );
+			return addListener( 'mouseleave', false );
 		}
 
 		if ( isOutlineMode || isNavigationMode ) {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -33,6 +33,21 @@ export function useIsHovered( ref ) {
 		};
 	}, [] );
 
+	const hasInnerBlocks = useSelect(
+		( select ) => {
+			if ( ref?.current?.dataset ) {
+				return (
+					select( 'core/block-editor' ).getBlocks(
+						ref?.current?.dataset?.block
+					).length > 0
+				);
+			}
+
+			return false;
+		},
+		[ ref?.current?.dataset ]
+	);
+
 	useEffect( () => {
 		function addListener( eventType, value ) {
 			function listener( event ) {
@@ -40,6 +55,7 @@ export function useIsHovered( ref ) {
 					return;
 				}
 
+				event.stopPropagation();
 				event.preventDefault();
 				setHovered( value );
 			}
@@ -51,7 +67,10 @@ export function useIsHovered( ref ) {
 		}
 
 		if ( isHovered ) {
-			return addListener( 'mouseleave', false );
+			if ( ! hasInnerBlocks ) {
+				return addListener( 'mouseleave', false );
+			}
+			return addListener( 'mouseout', false );
 		}
 
 		if ( isOutlineMode || isNavigationMode ) {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -21,31 +21,22 @@ import { store as blockEditorStore } from '../../../store';
 export function useIsHovered( ref ) {
 	const [ isHovered, setHovered ] = useState( false );
 
-	const { isNavigationMode, isOutlineMode } = useSelect( ( select ) => {
-		const {
-			isNavigationMode: selectIsNavigationMode,
-			getSettings,
-		} = select( blockEditorStore );
-
-		return {
-			isNavigationMode: selectIsNavigationMode(),
-			isOutlineMode: getSettings().outlineMode,
-		};
-	}, [] );
-
-	const hasInnerBlocks = useSelect(
+	const { hasInnerBlocks, isNavigationMode, isOutlineMode } = useSelect(
 		( select ) => {
-			if ( ref?.current?.dataset ) {
-				return (
-					select( 'core/block-editor' ).getBlocks(
-						ref?.current?.dataset?.block
-					).length > 0
-				);
-			}
+			const {
+				isNavigationMode: selectIsNavigationMode,
+				getBlocks,
+				getSettings,
+			} = select( blockEditorStore );
 
-			return false;
+			return {
+				hasInnerBlocks: !! getBlocks( ref?.current?.dataset?.block )
+					.length,
+				isNavigationMode: selectIsNavigationMode(),
+				isOutlineMode: getSettings().outlineMode,
+			};
 		},
-		[ ref?.current?.dataset ]
+		[]
 	);
 
 	function addHoverListener( eventType, value ) {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -21,23 +21,17 @@ import { store as blockEditorStore } from '../../../store';
 export function useIsHovered( ref ) {
 	const [ isHovered, setHovered ] = useState( false );
 
-	const { hasInnerBlocks, isNavigationMode, isOutlineMode } = useSelect(
-		( select ) => {
-			const {
-				isNavigationMode: selectIsNavigationMode,
-				getBlocks,
-				getSettings,
-			} = select( blockEditorStore );
+	const { isNavigationMode, isOutlineMode } = useSelect( ( select ) => {
+		const {
+			isNavigationMode: selectIsNavigationMode,
+			getSettings,
+		} = select( blockEditorStore );
 
-			return {
-				hasInnerBlocks: !! getBlocks( ref?.current?.dataset?.block )
-					.length,
-				isNavigationMode: selectIsNavigationMode(),
-				isOutlineMode: getSettings().outlineMode,
-			};
-		},
-		[]
-	);
+		return {
+			isNavigationMode: selectIsNavigationMode(),
+			isOutlineMode: getSettings().outlineMode,
+		};
+	}, [] );
 
 	function addHoverListener( eventType, value ) {
 		function listener( event ) {
@@ -56,11 +50,7 @@ export function useIsHovered( ref ) {
 	function addHoverListeners() {
 		const hoverListeners = [];
 
-		if ( ! hasInnerBlocks ) {
-			hoverListeners.push( addHoverListener( 'mouseleave', false ) );
-		} else {
-			hoverListeners.push( addHoverListener( 'mouseout', false ) );
-		}
+		hoverListeners.push( addHoverListener( 'mouseout', false ) );
 
 		if ( isOutlineMode || isNavigationMode ) {
 			hoverListeners.push( addHoverListener( 'mouseover', true ) );
@@ -77,7 +67,7 @@ export function useIsHovered( ref ) {
 				ref.current.removeEventListener( eventType, listener )
 			);
 		};
-	}, [ isOutlineMode, isNavigationMode, hasInnerBlocks ] );
+	}, [ isOutlineMode, isNavigationMode ] );
 
 	return isHovered;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Potentially addresses https://github.com/WordPress/gutenberg/issues/27296

We were seeing strange behavior when applying and removing the `is-hovered` class

![hovered](https://user-images.githubusercontent.com/846565/100343557-69891e00-2fd7-11eb-8b1b-89d8326c0098.gif)

![hovered-2](https://user-images.githubusercontent.com/846565/100349002-af49e480-2fdf-11eb-8288-11b11270d28d.gif)

I couldn't pinpoint the exact problem, but after lots of experimentation, the odd mouseover behavior seems to be the result of race conditions. Instead of assigning hover listeners a single time to each block, we were inadvertently reassigning them over and over again whenever we hovered a block. See the `isHovered` prop from line 60 of the code block below:

https://github.com/WordPress/gutenberg/blob/bd270f35fca4eddebb49e71af98c177469dda22e/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js#L36-L60

In practice, the flow of logic would look like this:
- On initial render, a block element would be assigned a `mouseover` event listener
- When a user would hover over the block, a `mouseout` event listener would be assigned as well
- Upon moving the cursor outside of the block, the `mouseover` event listener would be assigned again
- When a user would hover over the block again, another `mouseout` event listener would be assigned

I refactored the hover logic to ensure that hover event listeners are assigned once on initial load, and re-assigned only when `isOutlineMode` and `isNavigationMode` changes

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Open the site editor
2. Hover over a navigation block with navigation links
3. Ensure that only the block being hovered has an outline
4. Hover over column and columns blocks
5. Ensure that only the block being hovered has an outline
6. Hover over an image placeholder
7. Ensure that the blue outline around the placeholder doesn't flicker while mousing over its child elements
8. Smoke test other blocks and ensure that hover behaves as expected

## Screenshots <!-- if applicable -->
### Before
![2021-02-09 19 22 59](https://user-images.githubusercontent.com/5414230/107460078-4d901580-6b0c-11eb-8348-ae0e0711bbb3.gif)

### After
![2021-02-09 19 20 17](https://user-images.githubusercontent.com/5414230/107460083-51239c80-6b0c-11eb-9865-1f9bee1844f4.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug Fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
