### PR TITLE
Fix label only mode parent selector.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -46,12 +46,25 @@
 
 .block-editor-block-contextual-toolbar.has-parent {
 	margin-left: calc(#{$grid-unit-60} + #{$grid-unit-10});
+
+	.show-icon-labels & {
+		margin-left: 0;
+	}
 }
 
 .block-editor-block-parent-selector {
 	position: absolute;
 	top: -$border-width;
 	left: calc(-#{$grid-unit-60} - #{$grid-unit-10} - #{$border-width});
+
+	.show-icon-labels & {
+		position: relative;
+		left: auto;
+		top: auto;
+		margin-top: -$border-width;
+		margin-left: -$border-width;
+		margin-bottom: -$border-width;
+	}
 }
 
 // Block controls.


### PR DESCRIPTION
This follows up on feedback in https://github.com/WordPress/gutenberg/pull/28598#issuecomment-772957544 where it was clear the text-label only mode regressed with the parent block selector. Sorry about that. So this is sort of a hotfix.

Icons:

<img width="752" alt="Screenshot 2021-02-04 at 09 48 39" src="https://user-images.githubusercontent.com/1204802/106868907-a22c2e80-66cf-11eb-9e2d-57fbbae80265.png">

Labels:

<img width="1163" alt="Screenshot 2021-02-04 at 09 56 44" src="https://user-images.githubusercontent.com/1204802/106868914-a3f5f200-66cf-11eb-87ef-66e2b9cc8427.png">

The little space between the selectors is non trivial to add, but happy to try in a followup. But just for the sake of the total width of the label-only toolbar, even saving those 10 pixels benefits this, so I decided this was a good first step.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
