### PR TITLE
Site Editor: Expose edit-site store

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -48,7 +48,7 @@ const interfaceLabels = {
 	drawer: __( 'Navigation Sidebar' ),
 };
 
-function Editor() {
+function Editor( { initialSettings } ) {
 	const {
 		isFullscreenActive,
 		isInserterOpen,
@@ -94,7 +94,12 @@ function Editor() {
 		};
 	}, [] );
 	const { updateEditorSettings } = useDispatch( 'core/editor' );
-	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
+	const { setPage, setIsInserterOpened, updateSettings } = useDispatch(
+		editSiteStore
+	);
+	useEffect( () => {
+		updateSettings( initialSettings );
+	}, [ initialSettings ] );
 
 	// Keep the defaultTemplateTypes in the core/editor settings too,
 	// so that they can be selected with core/editor selectors in any editor.
@@ -151,6 +156,11 @@ function Editor() {
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 	} );
+
+	// Don't render the Editor until the settings are set and loaded
+	if ( ! settings?.siteUrl ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -99,7 +99,7 @@ function Editor( { initialSettings } ) {
 	);
 	useEffect( () => {
 		updateSettings( initialSettings );
-	}, [ initialSettings ] );
+	}, [] );
 
 	// Keep the defaultTemplateTypes in the core/editor settings too,
 	// so that they can be selected with core/editor selectors in any editor.

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -15,7 +15,7 @@ import { render } from '@wordpress/element';
  */
 import './plugins';
 import './hooks';
-import registerEditSiteStore from './store';
+import './store';
 import Editor from './components/editor';
 
 const fetchLinkSuggestions = ( search, { perPage = 20 } = {} ) =>
@@ -54,14 +54,15 @@ export function initialize( id, settings ) {
 	settings.__experimentalFetchLinkSuggestions = fetchLinkSuggestions;
 	settings.__experimentalSpotlightEntityBlocks = [ 'core/template-part' ];
 
-	registerEditSiteStore( { settings } );
-
 	registerCoreBlocks();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		__experimentalRegisterExperimentalCoreBlocks( true );
 	}
 
-	render( <Editor />, document.getElementById( id ) );
+	render(
+		<Editor initialSettings={ settings } />,
+		document.getElementById( id )
+	);
 }
 
 export { default as __experimentalMainDashboardButton } from './components/main-dashboard-button';

--- a/packages/edit-site/src/store/index.js
+++ b/packages/edit-site/src/store/index.js
@@ -12,24 +12,14 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 import { STORE_NAME } from './constants';
 
-export let store = null;
+export const storeConfig = {
+	reducer,
+	actions,
+	selectors,
+	controls,
+	persist: [ 'preferences' ],
+};
 
-export default function registerEditSiteStore( initialState ) {
-	if ( store !== null ) {
-		return;
-	}
+export const store = createReduxStore( STORE_NAME, storeConfig );
 
-	const _store = createReduxStore( STORE_NAME, {
-		reducer,
-		actions,
-		selectors,
-		controls,
-		persist: [ 'preferences' ],
-		initialState,
-	} );
-	register( _store );
-
-	store = _store;
-
-	return _store;
-}
+register( store );

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import registerEditSiteStore from '..';
 import {
 	toggleFeature,
 	setTemplate,
@@ -12,8 +11,6 @@ import {
 	showHomepage,
 	setHomeTemplateId,
 } from '../actions';
-
-registerEditSiteStore();
 
 describe( 'actions', () => {
 	describe( 'toggleFeature', () => {

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -22,9 +22,6 @@ import {
 	setIsNavigationPanelOpened,
 	setIsInserterOpened,
 } from '../actions';
-import registerEditSiteStore from '..';
-
-registerEditSiteStore();
 
 describe( 'state', () => {
 	describe( 'preferences()', () => {

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import registerEditSiteStore from '..';
 import {
 	isFeatureActive,
 	getCanUserCreateMedia,
@@ -14,8 +13,6 @@ import {
 	isNavigationOpened,
 	isInserterOpened,
 } from '../selectors';
-
-registerEditSiteStore();
 
 describe( 'selectors', () => {
 	const canUser = jest.fn( () => true );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
In Gutenberg all the stores are exposed from the `store` file, except a few like `core/edit-site`. This PR aims to refactor `core/edit-site` store to work the same way as other stores.

Rather than preloading the settings into the `store`, we are passing the initial state to the editor which takes care of updating the settings in the store.

This change allows us to use the `store` object properly together with `select` etc. (No more hacky global variable)

## How has this been tested?
Make sure tests are passing, CI passing, and smoke test!

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Code quality

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
