### PR TITLE
build-worker: call callback with error when no task for extension

### DIFF
--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -178,7 +178,7 @@ module.exports = async ( file, callback ) => {
 	const task = BUILD_TASK_BY_EXTENSION[ extension ];
 
 	if ( ! task ) {
-		return;
+		callback( new Error( `No handler for extension: ${ extension }` ) );
 	}
 
 	try {


### PR DESCRIPTION
If the `build-worker` cannot find a task handler for a given file extension, it should call the `callback` with error. This can happen when we want to build a file with an unsupported extension, e.g., `.tsx`. In such case, the build process hanged forever, because the async task never called its completion callback.

Spinoff from #28465 where I encountered this bug when trying to add TypeScript support.