### PR TITLE
build-worker: extract the functions that build CSS and JS

### DIFF
--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -76,101 +76,101 @@ function getBuildPath( file, buildFolder ) {
 	return path.resolve( pkgBuildPath, relativeToSrcPath );
 }
 
+async function buildCSS( file ) {
+	const outputFile = getBuildPath(
+		file.replace( '.scss', '.css' ),
+		'build-style'
+	);
+	const outputFileRTL = getBuildPath(
+		file.replace( '.scss', '-rtl.css' ),
+		'build-style'
+	);
+
+	const [ , contents ] = await Promise.all( [
+		makeDir( path.dirname( outputFile ) ),
+		readFile( file, 'utf8' ),
+	] );
+	const builtSass = await renderSass( {
+		file,
+		includePaths: [ path.join( PACKAGES_DIR, 'base-styles' ) ],
+		data:
+			[
+				'colors',
+				'breakpoints',
+				'variables',
+				'mixins',
+				'animations',
+				'z-index',
+			]
+				// Editor styles should be excluded from the default CSS vars output.
+				.concat(
+					file.includes( 'common.scss' ) ||
+						( ! file.includes( 'block-library' ) &&
+							! file.includes( 'editor-styles.scss' ) )
+						? [ 'default-custom-properties' ]
+						: []
+				)
+				.map( ( imported ) => `@import "${ imported }";` )
+				.join( ' ' ) + contents,
+	} );
+
+	const result = await postcss(
+		require( '@wordpress/postcss-plugins-preset' )
+	).process( builtSass.css, {
+		from: 'src/app.css',
+		to: 'dest/app.css',
+	} );
+
+	const resultRTL = await postcss( [ require( 'rtlcss' )() ] ).process(
+		result.css,
+		{
+			from: 'src/app.css',
+			to: 'dest/app.css',
+		}
+	);
+
+	await Promise.all( [
+		writeFile( outputFile, result.css ),
+		writeFile( outputFileRTL, resultRTL.css ),
+	] );
+}
+
+async function buildJS( file ) {
+	for ( const [ environment, buildDir ] of Object.entries(
+		JS_ENVIRONMENTS
+	) ) {
+		const destPath = getBuildPath( file, buildDir );
+		const babelOptions = getBabelConfig(
+			environment,
+			file.replace( PACKAGES_DIR, '@wordpress' )
+		);
+
+		const [ , transformed ] = await Promise.all( [
+			makeDir( path.dirname( destPath ) ),
+			babel.transformFileAsync( file, babelOptions ),
+		] );
+
+		await Promise.all( [
+			writeFile( destPath + '.map', JSON.stringify( transformed.map ) ),
+			writeFile(
+				destPath,
+				transformed.code +
+					'\n//# sourceMappingURL=' +
+					path.basename( destPath ) +
+					'.map'
+			),
+		] );
+	}
+}
+
 /**
  * Object of build tasks per file extension.
  *
  * @type {Object<string,Function>}
  */
 const BUILD_TASK_BY_EXTENSION = {
-	async '.scss'( file ) {
-		const outputFile = getBuildPath(
-			file.replace( '.scss', '.css' ),
-			'build-style'
-		);
-		const outputFileRTL = getBuildPath(
-			file.replace( '.scss', '-rtl.css' ),
-			'build-style'
-		);
-
-		const [ , contents ] = await Promise.all( [
-			makeDir( path.dirname( outputFile ) ),
-			readFile( file, 'utf8' ),
-		] );
-		const builtSass = await renderSass( {
-			file,
-			includePaths: [ path.join( PACKAGES_DIR, 'base-styles' ) ],
-			data:
-				[
-					'colors',
-					'breakpoints',
-					'variables',
-					'mixins',
-					'animations',
-					'z-index',
-				]
-					// Editor styles should be excluded from the default CSS vars output.
-					.concat(
-						file.includes( 'common.scss' ) ||
-							( ! file.includes( 'block-library' ) &&
-								! file.includes( 'editor-styles.scss' ) )
-							? [ 'default-custom-properties' ]
-							: []
-					)
-					.map( ( imported ) => `@import "${ imported }";` )
-					.join( ' ' ) + contents,
-		} );
-
-		const result = await postcss(
-			require( '@wordpress/postcss-plugins-preset' )
-		).process( builtSass.css, {
-			from: 'src/app.css',
-			to: 'dest/app.css',
-		} );
-
-		const resultRTL = await postcss( [ require( 'rtlcss' )() ] ).process(
-			result.css,
-			{
-				from: 'src/app.css',
-				to: 'dest/app.css',
-			}
-		);
-
-		await Promise.all( [
-			writeFile( outputFile, result.css ),
-			writeFile( outputFileRTL, resultRTL.css ),
-		] );
-	},
-
-	async '.js'( file ) {
-		for ( const [ environment, buildDir ] of Object.entries(
-			JS_ENVIRONMENTS
-		) ) {
-			const destPath = getBuildPath( file, buildDir );
-			const babelOptions = getBabelConfig(
-				environment,
-				file.replace( PACKAGES_DIR, '@wordpress' )
-			);
-
-			const [ , transformed ] = await Promise.all( [
-				makeDir( path.dirname( destPath ) ),
-				babel.transformFileAsync( file, babelOptions ),
-			] );
-
-			await Promise.all( [
-				writeFile(
-					destPath + '.map',
-					JSON.stringify( transformed.map )
-				),
-				writeFile(
-					destPath,
-					transformed.code +
-						'\n//# sourceMappingURL=' +
-						path.basename( destPath ) +
-						'.map'
-				),
-			] );
-		}
-	},
+	'.scss': buildCSS,
+	'.js': buildJS,
 };
 
 module.exports = async ( file, callback ) => {


### PR DESCRIPTION
A simple refactoring that extracts the two functions that were defined inline in the `BUILD_TASK_BY_EXTENSION` object. The object will soon support multiple extensions (like the TypeScript `.ts` and `.tsx`, maybe even matched by a regexp, and having the functions separate will make changes much easier.

Spinoff from #28465 that changes no behavior and should be easy to review and test.
