### PR TITLE
Hooks: export the defaultHooks singleton instance

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+- Export the default `createHooks` singleton instance as `defaultHooks`, in addition to exporting the individual methods.
+
 ## 2.11.0 (2020-12-17)
 
 ### New Feature

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -22,7 +22,13 @@ myObject.hooks = createHooks();
 myObject.hooks.addAction(); //etc...
 ```
 
-In the WordPress context, API functions can be called via the global `wp.hooks` like this `wp.hooks.addAction()`, etc. One notable difference from the PHP API is that `addAction()` and `addFilter()` also need to include a namespace as the second argument.
+#### The global instance
+
+In the above example, we are creating a custom instance of the `Hooks` object and registering hooks there. The package also creates a default global instance that's accessible through the `defaultHooks` named exports, and its methods are also separately exported one-by-one.
+
+In the WordPress context, that enables API functions to be called via the global `wp.hooks` object, like `wp.hooks.addAction()`, etc.
+
+One notable difference between the JS and PHP hooks API is that in the JS version, `addAction()` and `addFilter()` also need to include a namespace as the second argument.
 
 ### API Usage
 
@@ -43,6 +49,7 @@ In the WordPress context, API functions can be called via the global `wp.hooks` 
 * `hasFilter( 'hookName', 'namespace' )`
 * `actions`
 * `filters`
+* `defaultHooks`
 
 
 ### Events on action/filter add or remove

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -36,6 +36,8 @@ import createHooks from './createHooks';
  * @typedef {import('./createHooks').Hooks} Hooks
  */
 
+export const defaultHooks = createHooks();
+
 const {
 	addAction,
 	addFilter,
@@ -55,7 +57,7 @@ const {
 	didFilter,
 	actions,
 	filters,
-} = createHooks();
+} = defaultHooks;
 
 export {
 	createHooks,


### PR DESCRIPTION
In addition to exporting hooks methods one by one, this PR also exports the default hooks instance as a whole, under the `defaultHooks` name.

The immediate use case will be passing it as a `hooks` parameter to a `createI18n` factory function in `@wordpress/i18n`. The `I18n` class uses multiple hooks methods, like `addAction`, `removeAction` or `applyFilters`.

Spinoff from #28465.