### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45794,9 +45794,9 @@
 					"dev": true
 				},
 				"bl": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
+					"integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
 					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",


### PR DESCRIPTION
package-lock.json seems to be outdated (https://github.com/WordPress/gutenberg/pull/28602/checks?check_run_id=1830664870). This PR brings it back up to date.