### PR TITLE
Code Quality: Relax JSDoc validation for typed packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 const { escapeRegExp } = require( 'lodash' );
+const glob = require( 'glob' ).sync;
+const { join } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -27,6 +29,11 @@ const developmentFiles = [
 	'**/@(__mocks__|__tests__|test)/**/*.js',
 	'**/@(storybook|stories)/**/*.js',
 ];
+
+// All files from packages that have types provided with TypeScript.
+const typedFiles = glob( 'packages/*/package.json' )
+	.filter( ( fileName ) => require( join( __dirname, fileName ) ).types )
+	.map( ( fileName ) => fileName.replace( 'package.json', '**/*.js' ) );
 
 module.exports = {
 	root: true,
@@ -200,6 +207,13 @@ module.exports = {
 			files: [ 'bin/**/*.js' ],
 			rules: {
 				'no-console': 'off',
+			},
+		},
+		{
+			files: typedFiles,
+			rules: {
+				'jsdoc/no-undefined-types': 'off',
+				'jsdoc/valid-types': 'off',
 			},
 		},
 	],

--- a/packages/components/src/ui/utils/create-component.js
+++ b/packages/components/src/ui/utils/create-component.js
@@ -9,14 +9,14 @@ import { identity } from 'lodash';
  */
 import { View } from '../view';
 
-/* eslint-disable jsdoc/require-returns-description */
 /**
+ * Factory that creates a React component.
+ *
  * @template {import('reakit-utils/types').As} T
  * @template {import('@wp-g2/create-styles').ViewOwnProps<{}, T>} P
- * @param {import('./types').Options<T, P>} options
- * @return {import('@wp-g2/create-styles').PolymorphicComponent<T, import('@wp-g2/create-styles').PropsFromViewOwnProps<P>>}
+ * @param {import('./types').Options<T, P>} options Options to customize the component.
+ * @return {import('@wp-g2/create-styles').PolymorphicComponent<T, import('@wp-g2/create-styles').PropsFromViewOwnProps<P>>} New React component.
  */
-/* eslint-enable jsdoc/require-returns-description */
 /* eslint-disable jsdoc/no-undefined-types */
 export const createComponent = ( {
 	as,

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -22,7 +22,6 @@ const DEFAULT_LOCALE_DATA = {
 	},
 };
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @typedef {(data?: LocaleData, domain?: string) => void} SetLocaleData
  * Merges locale data into the Tannin instance by domain. Accepts data in a
@@ -77,7 +76,6 @@ const DEFAULT_LOCALE_DATA = {
 /**
  * @typedef {{ applyFilters: (hookName:string, ...args: unknown[]) => unknown}} ApplyFiltersInterface
  */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * An i18n instance

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -37,14 +37,12 @@ import { isAppleOS } from './platform';
  * @typedef {Record<WPKeycodeModifier, T>} WPModifierHandler
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @template T
  *
  * @typedef {(character: string, isApple?: () => boolean) => T} WPKeyHandler
  */
 /** @typedef {(event: KeyboardEvent, character: string, isApple?: () => boolean) => boolean} WPEventKeyHandler */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * Keycode for BACKSPACE key.

--- a/packages/token-list/src/index.js
+++ b/packages/token-list/src/index.js
@@ -27,9 +27,6 @@ export default class TokenList {
 		/* eslint-enable no-unused-expressions */
 	}
 
-	// Disable reason: JSDoc lint doesn't understand TypeScript types
-	/* eslint-disable jsdoc/valid-types */
-
 	/**
 	 * @param {Parameters<Array<string>['entries']>} args
 	 */
@@ -57,8 +54,6 @@ export default class TokenList {
 	values( ...args ) {
 		return this._valueAsArray.values( ...args );
 	}
-
-	/* eslint-enable jsdoc/valid-types */
 
 	/**
 	 * Returns the associated set as string.

--- a/packages/url/src/get-query-arg.js
+++ b/packages/url/src/get-query-arg.js
@@ -3,11 +3,9 @@
  */
 import { getQueryArgs } from './get-query-args';
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @typedef {{[key: string]: QueryArgParsed}} QueryArgObject
  */
-/* eslint-enable */
 
 /**
  * @typedef {string|string[]|QueryArgObject} QueryArgParsed


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Triggered by @saramarcondes in https://github.com/WordPress/gutenberg/pull/28568#issuecomment-771189747:

> It's just that the JSDoc parser that is used for our JSDoc linter doesn't understand complex types like function signatures and imports. If you check out other parts of the code based that are typed you'll notice that they're littered with /* eslint-disable jsdoc/valid-types */. This is unfortunate but I'm not sure what we can do about it other than disable the rule (but then we might start getting actually invalid types committed... who knows.
> 
> have y'all given any thought to disabling that rule? jsdoc/no-undefined-types is another that tends to give us trouble when typing JavaScript files.

Solution based on the proposal from @sirreal in https://github.com/WordPress/gutenberg/pull/28568#issuecomment-772399095:

> Looking at `include` in `tsconfig` is going to be complex, I believe. We might need to inspect `files`, `include`, and `exclude`. I may have a good idea for an alternative heuristic 🙂 
> 
> Our convention is to write types to the `dist-types` for publish. This requires a field to be added to the package.json when we're ready to publish the types, and we're only doing that when packages are fully typed. We may be able to check `package.json` for the presence of this, and disable the JSDoc type linter if it's present:
> 
> https://github.com/WordPress/gutenberg/blob/92baa9be10e45d91e5ce940600d3cb816630cac9/packages/a11y/package.json#L26

This PR relaxes JSDoc validation for packages typed with TypeScript. It's redundant since TypeScript does the validation already, so it only enforces folks to disable the rule when JSDoc doesn't understand TS type.

## How has this been tested?
`npm run lint-js`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
