### PR TITLE
Iframe: Clone styles again when settings change

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -11,6 +11,7 @@ import {
 	createPortal,
 	useCallback,
 	forwardRef,
+	useEffect,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -136,7 +137,10 @@ function setHead( doc, head ) {
 		'<style>body{margin:0}</style>' + head;
 }
 
-function Iframe( { contentRef, children, head, ...props }, ref ) {
+function Iframe(
+	{ contentRef, children, head, settingsStyles, ...props },
+	ref
+) {
 	const [ iframeDocument, setIframeDocument ] = useState();
 
 	const setRef = useCallback( ( node ) => {
@@ -172,6 +176,12 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 			setDocumentIfReady();
 		} );
 	}, [] );
+
+	useEffect( () => {
+		if ( contentRef.current ) {
+			styleSheetsCompat( contentRef.current.ownerDocument );
+		}
+	}, [ settingsStyles ] );
 
 	return (
 		<iframe

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -115,6 +115,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					head={ window.__editorStyles.html }
 					ref={ ref }
 					contentRef={ contentRef }
+					settingsStyles={ settings.styles }
 				>
 					<Canvas body={ contentRef } styles={ settings.styles } />
 				</Iframe>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Styles aren't reloaded in the iframe after they changed. This causes issues in most browsers. To fix this, this PR clones the styles to the iframe when the settings change. This PR works together with #28585 

## How has this been tested?
1. Checkout this branch
2. Apply changes from #28585 (`git merge --no-commit --squash fix/28581`)
3. Load site editor
4. Make sure styles are loaded in every browser

## Screenshots <!-- if applicable -->

## Types of changes
Bug Fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
