### PR TITLE
Global Styles: load styles in iframed site editor

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -3,6 +3,7 @@
  */
 import mergeRefs from 'react-merge-refs';
 import { compact, map } from 'lodash';
+import tinycolor from 'tinycolor2';
 
 /**
  * WordPress dependencies
@@ -148,8 +149,16 @@ function updateEditorStyles( doc, styles ) {
 		return;
 	}
 
-	const updatedStyles = transformStyles( styles, '.editor-styles-wrapper' );
+	const backgroundColor = window
+		.getComputedStyle( doc.body, null )
+		.getPropertyValue( 'background-color' );
+	if ( tinycolor( backgroundColor ).getLuminance() > 0.5 ) {
+		doc.body.classList.remove( 'is-dark-theme' );
+	} else {
+		doc.body.classList.add( 'is-dark-theme' );
+	}
 
+	const updatedStyles = transformStyles( styles, '.editor-styles-wrapper' );
 	map( compact( updatedStyles ), ( updatedStyle ) => {
 		const styleElement = doc.createElement( 'style' );
 		styleElement.innerHTML = updatedStyle;

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -70,7 +70,9 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const contentRef = useRef();
 
 	useMouseMoveTypingReset( ref );
-	// Ideally this should be moved to the place where the styles are applied (iframe)
+	// This updates the host document styles.
+	// It is necessary to make sure the preset CSS Custom Properties
+	// are in scope for the sidebar UI controls that use them.
 	const editorStylesRef = useEditorStyles( settings.styles );
 
 	// Allow scrolling "through" popovers over the canvas. This is only called

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -112,6 +112,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				<Popover.Slot name="block-toolbar" />
 				<Iframe
 					style={ resizedCanvasStyles }
+					editorStyles={ settings.styles }
 					head={ window.__editorStyles.html }
 					ref={ ref }
 					contentRef={ contentRef }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/28581

It looks like https://github.com/WordPress/gutenberg/pull/28233 refactored the `useEditorStyles` feature and removed it from the iframe, hence the styles aren't updated upon user changes. This fixes it by bringing it back.

This is what we need to have:

- The Global Styles sidebar needs the preset variables (CSS Custom Properties) in scope in its document, as they are used to power the UI controls values.
- The iframe needs both the preset variables and the block styles.

All of them (presets & block styles) can change upon user changes, so both the iframe and the host document need to be updated upon user changes.

## Test instructions

- Use the TT1-blocks theme.
- Load the site editor and verify that the styles are loaded.
- Change a style in the global sidebar and verify that it's reflected in the editor.
