### PR TITLE
Site and Widgets Editor: Fix complementary area not opening

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -78,7 +78,7 @@ function Editor() {
 			isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
 			sidebarIsOpened: !! select(
 				interfaceStore
-			).getActiveComplementaryArea( editSiteStore ),
+			).getActiveComplementaryArea( 'core/edit-site' ),
 			settings: getSettings(),
 			templateType: postType,
 			page: getPage(),

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -78,7 +78,7 @@ function Editor() {
 			isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
 			sidebarIsOpened: !! select(
 				interfaceStore
-			).getActiveComplementaryArea( 'core/edit-site' ),
+			).getActiveComplementaryArea( editSiteStore.name ),
 			settings: getSettings(),
 			templateType: postType,
 			page: getPage(),

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -48,7 +48,7 @@ function Interface( { blockEditorSettings } ) {
 	const { hasSidebarEnabled, isInserterOpened } = useSelect( ( select ) => ( {
 		hasSidebarEnabled: !! select(
 			interfaceStore
-		).getActiveComplementaryArea( editWidgetsStore ),
+		).getActiveComplementaryArea( editWidgetsStore.name ),
 		isInserterOpened: !! select( editWidgetsStore ).isInserterOpened(),
 	} ) );
 	const editorStylesRef = useEditorStyles( blockEditorSettings.styles );

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -39,7 +39,7 @@ function ComplementaryAreaTab( { identifier, label, isActive } ) {
 	return (
 		<Button
 			onClick={ () =>
-				enableComplementaryArea( editWidgetsStore, identifier )
+				enableComplementaryArea( editWidgetsStore.name, identifier )
 			}
 			className={ classnames( 'edit-widgets-sidebar__panel-tab', {
 				'is-active': isActive,
@@ -74,7 +74,7 @@ export default function Sidebar() {
 
 		const selectedBlock = getSelectedBlock();
 
-		let activeArea = getActiveComplementaryArea( editWidgetsStore );
+		let activeArea = getActiveComplementaryArea( editWidgetsStore.name );
 		if ( ! activeArea ) {
 			if ( selectedBlock ) {
 				activeArea = BLOCK_INSPECTOR_IDENTIFIER;


### PR DESCRIPTION
## Description

In #28695 we replaced the hardcoded `core/edit-site` strings to indicate a Redux store with the actual store, in an ongoing refactor.
Among the various correct replacements, a string that was actually supposed to be `core/edit-site` was replaced as well.
This string indicated the scope of `getActiveComplementaryArea`, a `core/interface` selector used to check the status of the right-side sidebar (block, document, global styles, plugins, etc.).
Passing the `core/edit-site` store instead of the `core/edit-site` string prevented the function to target the correct sidebars.

## How has this been tested?

Tested in the Site Editor and Widgets Editor.
(Note that typically FSE themes don't register sidebars, and therefore don't have the Widgets Editor, and vice versa).

Just make sure that the right-side sidebar can be toggled, by trying the block inspector, document settings, global styles, plugins, you name it.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
