### PR TITLE
i18n hooks: don't use typeof to check value falsiness

### DIFF
--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -156,16 +156,15 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 	};
 
 	/** @type {GetFilterDomain} */
-	const getFilterDomain = ( domain ) => {
-		if ( typeof domain === 'undefined' ) {
-			return 'default';
-		}
-		return domain;
-	};
+	const getFilterDomain = ( domain = 'default' ) => domain;
 
 	/** @type {__} */
 	const __ = ( text, domain ) => {
 		let translation = dcnpgettext( domain, undefined, text );
+		if ( ! hooks ) {
+			return translation;
+		}
+
 		/**
 		 * Filters text with its translation.
 		 *
@@ -173,9 +172,6 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 		 * @param {string} text        Text to translate.
 		 * @param {string} domain      Text domain. Unique identifier for retrieving translated strings.
 		 */
-		if ( typeof hooks === 'undefined' ) {
-			return translation;
-		}
 		translation = /** @type {string} */ (
 			/** @type {*} */ hooks.applyFilters(
 				'i18n.gettext',
@@ -197,6 +193,10 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 	/** @type {_x} */
 	const _x = ( text, context, domain ) => {
 		let translation = dcnpgettext( domain, context, text );
+		if ( ! hooks ) {
+			return translation;
+		}
+
 		/**
 		 * Filters text with its translation based on context information.
 		 *
@@ -205,9 +205,6 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 		 * @param {string} context     Context information for the translators.
 		 * @param {string} domain      Text domain. Unique identifier for retrieving translated strings.
 		 */
-		if ( typeof hooks === 'undefined' ) {
-			return translation;
-		}
 		translation = /** @type {string} */ (
 			/** @type {*} */ hooks.applyFilters(
 				'i18n.gettext_with_context',
@@ -237,9 +234,10 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 			plural,
 			number
 		);
-		if ( typeof hooks === 'undefined' ) {
+		if ( ! hooks ) {
 			return translation;
 		}
+
 		/**
 		 * Filters the singular or plural form of a string.
 		 *
@@ -280,9 +278,10 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 			plural,
 			number
 		);
-		if ( typeof hooks === 'undefined' ) {
+		if ( ! hooks ) {
 			return translation;
 		}
+
 		/**
 		 * Filters the singular or plural form of a string with gettext context.
 		 *


### PR DESCRIPTION
Another small spinoff from #28465, removing `typeof` usages that just check a variable value.

The advantage of `typeof x === 'undefined'` over just `! x` or `x === 'undefined'` is that `typeof` doesn't fail when `x` is not defined at all. That makes it convenient for checks like `typeof window` or `typeof document`. But for checking variables we know to exist, more classic conditions are OK.

Review request for @leewillis77 