### PR TITLE
wp-env.json: Pin tt1-blocks dependency to v0.4.3

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,7 +3,7 @@
 	"plugins": [
 		"."
 	],
-	"themes": [ "WordPress/theme-experiments/tt1-blocks" ],
+	"themes": [ "WordPress/theme-experiments/tt1-blocks#f3d2c0d" ],
 	"env": {
 		"tests": {
 			"mappings": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,7 +3,7 @@
 	"plugins": [
 		"."
 	],
-	"themes": [ "WordPress/theme-experiments/tt1-blocks#f3d2c0d" ],
+	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.3" ],
 	"env": {
 		"tests": {
 			"mappings": {

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -366,6 +366,7 @@ describe( 'readConfig', () => {
 							'WordPress/gutenberg',
 							'WordPress/gutenberg#master',
 							'WordPress/gutenberg#5.0',
+							'WordPress/theme-experiments/tt1-blocks#f3d2c0d',
 						],
 					} )
 				)
@@ -393,6 +394,16 @@ describe( 'readConfig', () => {
 						ref: '5.0',
 						path: expect.stringMatching( /^\/.*gutenberg$/ ),
 						basename: 'gutenberg',
+					},
+					{
+						type: 'git',
+						url:
+							'https://github.com/WordPress/theme-experiments.git',
+						ref: 'f3d2c0d',
+						path: expect.stringMatching(
+							/^\/.*theme-experiments\/tt1-blocks$/
+						),
+						basename: 'tt1-blocks',
 					},
 				],
 			};

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -366,7 +366,7 @@ describe( 'readConfig', () => {
 							'WordPress/gutenberg',
 							'WordPress/gutenberg#master',
 							'WordPress/gutenberg#5.0',
-							'WordPress/theme-experiments/tt1-blocks#f3d2c0d',
+							'WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.3',
 						],
 					} )
 				)
@@ -399,7 +399,7 @@ describe( 'readConfig', () => {
 						type: 'git',
 						url:
 							'https://github.com/WordPress/theme-experiments.git',
-						ref: 'f3d2c0d',
+						ref: 'tt1-blocks@0.4.3',
 						path: expect.stringMatching(
 							/^\/.*theme-experiments\/tt1-blocks$/
 						),

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -142,9 +142,7 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 
 	log( 'Fetching the specified ref.' );
 	const remote = await repository.getRemote( 'origin' );
-	const oid = NodeGit.Oid.fromString( source.ref );
-	const ref = NodeGit.Commit.lookupPrefix( repository, oid, 6 );
-	await remote.fetch( ref, gitFetchOptions.fetchOpts );
+	await remote.fetch( source.ref, gitFetchOptions.fetchOpts );
 	await remote.disconnect();
 	try {
 		log( 'Checking out the specified ref.' );
@@ -153,14 +151,16 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 				.getReference( 'FETCH_HEAD' )
 				// Sometimes git doesn't update FETCH_HEAD for things
 				// like tags so we try another method here.
-				.catch( repository.getReference.bind( repository, ref ) ),
+				.catch(
+					repository.getReference.bind( repository, source.ref )
+				),
 			{
 				checkoutStrategy: NodeGit.Checkout.STRATEGY.FORCE,
 			}
 		);
 	} catch ( error ) {
 		log( 'Ref needs to be set as detached.' );
-		await repository.setHeadDetached( ref );
+		await repository.setHeadDetached( source.ref );
 	}
 
 	onProgress( 1 );

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -142,9 +142,8 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 
 	log( 'Fetching the specified ref.' );
 	const remote = await repository.getRemote( 'origin' );
-	const oid = await NodeGit.Oid.fromString( source.ref );
-	const commit = await NodeGit.Commit.lookupPrefix( repository, oid, 6 );
-	const ref = commit.sha();
+	const oid = NodeGit.Oid.fromString( source.ref );
+	const ref = NodeGit.Commit.lookupPrefix( repository, oid, 6 );
 	await remote.fetch( ref, gitFetchOptions.fetchOpts );
 	await remote.disconnect();
 	try {

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -142,8 +142,9 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 
 	log( 'Fetching the specified ref.' );
 	const remote = await repository.getRemote( 'origin' );
-	const oid = NodeGit.Oid.fromString( source.ref );
-	const ref = NodeGit.Commit.lookupPrefix( repository, oid, 6 );
+	const oid = await NodeGit.Oid.fromString( source.ref );
+	const commit = await NodeGit.Commit.lookupPrefix( repository, oid, 6 );
+	const ref = commit.sha();
 	await remote.fetch( ref, gitFetchOptions.fetchOpts );
 	await remote.disconnect();
 	try {


### PR DESCRIPTION
## Description

Gutenberg's end-to-end tests were broken for a while after TT1 Blocks removed their `front-page` template (https://github.com/WordPress/theme-experiments/pull/179) -- which our e2e tests relied on. This was thankfully fixed on the Gutenberg side by @Addison-Stavlo in https://github.com/WordPress/gutenberg/pull/28638.

Per [discussion](https://github.com/WordPress/gutenberg/issues/28692#issuecomment-772797992) with @jeyip, we might be able to avoid a similar situation in the future by pinning our TT1 Blocks dependency to a given version.

See https://github.com/WordPress/gutenberg/issues/28692 for more background.

## How has this been tested?
Verify that automated tests pass.
