### PR TITLE
[Mobile] - Fix link selection

### DIFF
--- a/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
+++ b/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
@@ -92,8 +92,15 @@ const LinkSettingsScreen = ( {
 			// transform selected text into link
 			newAttributes = applyFormat( value, format );
 		}
-		//move selection to end of link
-		newAttributes.start = newAttributes.end;
+		// move selection to end of link
+		const textLength = newAttributes.text.length;
+		// check for zero width spaces
+		if ( newAttributes.end > textLength ) {
+			newAttributes.start = textLength;
+			newAttributes.end = textLength;
+		} else {
+			newAttributes.start = newAttributes.end;
+		}
 		newAttributes.activeFormats = [];
 		onChange( { ...newAttributes, needsSelectionUpdate: true } );
 		if ( ! isValidHref( url ) ) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3057

## Description
On **iOS**, there is a case when a zero width space is added from Aztec causing the added link to remain selected instead of moving the cursor to the end because it's counting this extra character. Now it will check the actual text length and move the cursor to the right position.

This PR does not handle the different behavior for Android where the block loses focus after adding a link, it will be worked on [another issue](https://github.com/WordPress/gutenberg/issues/28748).

## How has this been tested?

- Open the app with metro running.
- Add some text to the paragraph block with an extra space at the end.
- Switch to the browser app and copy a URL into your clipboard.
- Go back to the editor and highlight some text including the last trailing whitespace, make sure to select to the very end.
- Open the link settings
- **Expect** the URL to be auto-populated
- Dismiss the settings box by swiping down
- **Expect** the text to have the link format and **to not** be selected and the cursor is at the **end** of it.

## Screenshots

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/106930529-f1954d80-6715-11eb-9908-2783d25d3258.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/106930536-f3f7a780-6715-11eb-9318-1964ffe2b78e.gif" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
