### PR TITLE
Full Site Editing: Fix template parts loading on frontend

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -19,7 +19,7 @@ function render_block_core_template_part( $attributes ) {
 		// If we have a post ID and the post exists, which means this template part
 		// is user-customized, render the corresponding post content.
 		$content = get_post( $attributes['postId'] )->post_content;
-	} elseif ( isset( $attributes['theme'] ) && basename( wp_get_theme()->get_stylesheet() ) === $attributes['theme'] ) {
+	} elseif ( isset( $attributes['theme'] ) && wp_get_theme()->get_stylesheet() === $attributes['theme'] ) {
 		$template_part_query = new WP_Query(
 			array(
 				'post_type'      => 'wp_template_part',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Template parts are not loading on the frontend of full site editing enabled sites when the block themes live in a nested directory relative to `wp-content/themes`. For example, when we place tt1-blocks in `wp-content/themes/test/tt1-blocks` instead of in the themes root `wp-content/themes/tt1-blocks`, template parts don't load.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
**Before applying this PR:**
- Ensure that the [theme-experiments](https://github.com/WordPress/theme-experiments/tree/e755034e596474b5481e3642cb9468bb2a54fa65) repo is downloaded locally
- Install and enable the tt1-blocks theme
- Open the front end and the site editor. It should load all the template parts.
- Install the TT1-blocks theme in a subdirectory of `wp-content/themes`.
   1. Add the following to `.wp-env.override.json`. This creates a copy of the locally installed TT1 theme in a "test" subdirectory in the WordPress volume.
   2. ```javascript 
      // .wp-env.override.json
      // Replace ~/work/theme-experiments/tt1-blocks with the path
      // to your locally installed TT1 block theme
      {
           "mappings": {
               "wp-content/themes/test/tt1-blocks": "~/work/theme-experiments/tt1-blocks",
           }
      }```
    3. `npx wp-env start`
- Activate TT1-blocks.
- Open the front end and the site editor: it should not be loading the header and footer template parts.

**Apply this PR:**
- Refresh the page
- The header and footer template parts should now load

## Screenshots <!-- if applicable -->
### Before
<img width="1278" alt="Screen Shot 2021-02-04 at 11 08 36 AM" src="https://user-images.githubusercontent.com/5414230/106942728-64cc9e80-66d9-11eb-87b2-88fa0bd39bf0.png">

### After
<img width="641" alt="Screen Shot 2021-02-04 at 11 08 26 AM" src="https://user-images.githubusercontent.com/5414230/106942739-68602580-66d9-11eb-8cf7-dfaf756e385a.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for https://github.com/WordPress/gutenberg/issues/28753

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
