### PR TITLE
Refactored Gallery: Fix gallery gutter size css variable

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -345,7 +345,7 @@ function GalleryEdit( props ) {
 		className: classnames( className, 'has-nested-images' ),
 		style: {
 			'--gallery-block--gutter-size':
-				gutterSize !== undefined && `${ gutterSize }px`,
+				gutterSize !== undefined ? `${ gutterSize }px` : undefined,
 		},
 	} );
 

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -23,7 +23,7 @@ export default function save( { attributes } ) {
 
 	const style = {
 		'--gallery-block--gutter-size':
-			gutterSize !== undefined && `${ gutterSize }px`,
+			gutterSize !== undefined ? `${ gutterSize }px` : undefined,
 	};
 
 	return (


### PR DESCRIPTION
## Description
Previous check for gutter size resulted in style getting assigned `false`, it needed to be `undefined` for the style to not be included inline.

## How has this been tested?
Manually.

#### Testing Instructions
1. Checkout this PR
2. Create a new post and add a gallery
3. Save post and view on frontend. Gallery layout should be as per the editor.
4. Switch back to editor and ensure adjusting gutter size still works. Save and re-view on frontend.

## Screenshots <!-- if applicable -->
<img width="2174" alt="Screen Shot 2021-02-05 at 11 09 36 am" src="https://user-images.githubusercontent.com/60436221/106975761-d91f4480-67a2-11eb-9568-bfce9fd66eb0.png">

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
