### PR TITLE
Reflect text size in FontSizePicker choices

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -48,7 +48,7 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 		name: option.name,
 		size: option.size,
 		style: {
-			fontSize: `min( ${ option.size }, ${ MAX_FONT_SIZE_DISPLAY } )`,
+			fontSize: `min( ${ option.size }px, ${ MAX_FONT_SIZE_DISPLAY } )`,
 		},
 	} ) );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
The font size picker choices do not reflect the font size style.  #28738

## Screenshots
<img width="271" alt="スクリーンショット 2021-02-04 15 34 25" src="https://user-images.githubusercontent.com/1094306/106977204-3b754680-679d-11eb-8556-17109d8677a7.png">


## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
