### PR TITLE
Docs: Replacing 'below' typo in documentation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -445,7 +445,7 @@ After:
 ### Enhancements
 
 - Improve the Reusable Blocks UI by relying on multi entity save flow. ([27887](https://github.com/WordPress/gutenberg/pull/27887)) ([27885](https://github.com/WordPress/gutenberg/pull/27885))
-- Show the insertion point indicator bellow the inbetween inserter. ([27842](https://github.com/WordPress/gutenberg/pull/27842))
+- Show the insertion point indicator below the inbetween inserter. ([27842](https://github.com/WordPress/gutenberg/pull/27842))
 - Add block transforms previews. ([27861](https://github.com/WordPress/gutenberg/pull/27861))
 - URL: RemoveQueryArgs should remove the ? char after removing all args. ([27812](https://github.com/WordPress/gutenberg/pull/27812))
 - Deburr the input of the Post Author and Parent Page controls when filitering results. ([26611](https://github.com/WordPress/gutenberg/pull/26611))

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -51,10 +51,10 @@ $z-layers: (
 	// The floated blocks should be above the other blocks to allow selection.
 	"{core/image aligned left or right} .wp-block": 21,
 
-	// Needs to be bellow media library that has a z-index of 160000.
+	// Needs to be below media library that has a z-index of 160000.
 	"{core/video track editor popover}": 160000 - 10,
 
-	// Needs to be bellow media library that has a z-index of 160000.
+	// Needs to be below media library that has a z-index of 160000.
 	".block-editor-format-toolbar__image-popover": 160000 - 10,
 
 	// Small screen inner blocks overlay must be displayed above drop zone,
@@ -86,7 +86,7 @@ $z-layers: (
 	".edit-site-editor__toggle-save-panel": 100000,
 
 	// Show sidebar in greater than small viewports above editor related elements
-	// but bellow #adminmenuback { z-index: 100 }
+	// but below #adminmenuback { z-index: 100 }
 	".interface-interface-skeleton__sidebar {greater than small}": 90,
 	".edit-site-sidebar {greater than small}": 90,
 	".edit-widgets-sidebar {greater than small}": 90,
@@ -151,7 +151,7 @@ $z-layers: (
 	// Needs to be higher than any other element as this is an overlay to catch all events
 	".components-tooltip .event-catcher": 100002,
 
-	// Needs to appear bellow other color circular picker related UI elements.
+	// Needs to appear below other color circular picker related UI elements.
 	".components-circular-option-picker__option-wrapper::before": -1,
 
 	".components-circular-option-picker__option.is-pressed": 1,

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -196,7 +196,7 @@
 	z-index: z-index(".wp-block-cover__image-background");
 }
 
-// Styles bellow only exist to support older versions of the block.
+// Styles below only exist to support older versions of the block.
 // Versions that not had inner blocks and used an h2 heading had a section (and not a div) with a class wp-block-cover-image (and not a wp-block-cover).
 // We are using the previous referred differences to target old versions.
 

--- a/packages/interface/README.md
+++ b/packages/interface/README.md
@@ -23,7 +23,7 @@ This component was named after a [complementatry landmark](https://www.w3.org/TR
 
 It is possible to control which complementary is enabled by using the store:
 
-Bellow are some examples of how to control the active complementary area using the store:
+Below are some examples of how to control the active complementary area using the store:
 ```js
 wp.data.select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-post' );
 // -> "edit-post/document"

--- a/packages/interface/src/components/action-item/README.md
+++ b/packages/interface/src/components/action-item/README.md
@@ -5,7 +5,7 @@ ActionItem
 
 ## ActionItem.Slot
 
-The props not referred bellow are passed to the container component.
+The props not referred below are passed to the container component.
 
 ## Props
 
@@ -33,7 +33,7 @@ Defaults to `ButtonGroup` and `Button`can be changed to `MenuGroup` and `MenuIte
 
 ## ActionItem
 
-The props not referred bellow are passed to the item component.
+The props not referred below are passed to the item component.
 
 ### name
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Just a documentation change, updating **"bellow"** to **"below"**.
I didn't know if I should change the `changelog.txt` file, so I did.

## How has this been tested?
No need to test it, just documentation changes.

## Types of changes
Documentation.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
