### PR TITLE
Navigation screen: Fix failing request for menu items

### DIFF
--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -61,7 +61,7 @@ export default function Header( {
 						showTooltip: false,
 						children: __( 'Select menu' ),
 						isTertiary: true,
-						disabled: ! menus,
+						disabled: ! menus?.length,
 						__experimentalIsFocusable: true,
 					} }
 					popoverProps={ {

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -37,6 +37,7 @@ export default function Layout( { blockEditorSettings } ) {
 		navigationPost,
 		selectMenu,
 		deleteMenu,
+		hasLoadedMenus,
 	} = useNavigationEditor();
 
 	const [ blocks, onInput, onChange ] = useNavigationBlockEditor(
@@ -56,7 +57,7 @@ export default function Layout( { blockEditorSettings } ) {
 
 					<div className="edit-navigation-layout">
 						<Header
-							isPending={ ! navigationPost }
+							isPending={ ! hasLoadedMenus }
 							menus={ menus }
 							selectedMenuId={ selectedMenuId }
 							onSelectMenu={ selectMenu }
@@ -78,11 +79,11 @@ export default function Layout( { blockEditorSettings } ) {
 								saveBlocks={ savePost }
 							/>
 							<Toolbar
-								isPending={ ! navigationPost }
+								isPending={ ! hasLoadedMenus }
 								navigationPost={ navigationPost }
 							/>
 							<Editor
-								isPending={ ! navigationPost }
+								isPending={ ! hasLoadedMenus }
 								blocks={ blocks }
 							/>
 							<InspectorAdditions

--- a/packages/edit-navigation/src/components/layout/use-navigation-editor.js
+++ b/packages/edit-navigation/src/components/layout/use-navigation-editor.js
@@ -10,10 +10,16 @@ import { useState, useEffect } from '@wordpress/element';
 import { store as editNavigationStore } from '../../store';
 
 export default function useNavigationEditor() {
-	const menus = useSelect(
-		( select ) => select( 'core' ).getMenus( { per_page: -1 } ),
-		[]
-	);
+	const { menus, hasLoadedMenus } = useSelect( ( select ) => {
+		const selectors = select( 'core' );
+		const params = { per_page: -1 };
+		return {
+			menus: selectors.getMenus( params ),
+			hasLoadedMenus: selectors.hasFinishedResolution( 'getMenus', [
+				params,
+			] ),
+		};
+	}, [] );
 
 	const [ selectedMenuId, setSelectedMenuId ] = useState( null );
 
@@ -52,5 +58,6 @@ export default function useNavigationEditor() {
 		navigationPost,
 		selectMenu,
 		deleteMenu,
+		hasLoadedMenus,
 	};
 }

--- a/packages/edit-navigation/src/components/toolbar/save-button.js
+++ b/packages/edit-navigation/src/components/toolbar/save-button.js
@@ -20,6 +20,7 @@ export default function SaveButton( { navigationPost } ) {
 			onClick={ () => {
 				saveNavigationPost( navigationPost );
 			} }
+			disabled={ ! navigationPost }
 		>
 			{ __( 'Save' ) }
 		</Button>

--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -25,6 +25,10 @@ import { KIND, POST_TYPE, buildNavigationPostId } from './utils';
  * @return {void}
  */
 export function* getNavigationPostForMenu( menuId ) {
+	if ( ! menuId ) {
+		return;
+	}
+
 	const stubPost = createStubPost( menuId );
 	// Persist an empty post to warm up the state
 	yield persistPost( stubPost );

--- a/packages/edit-navigation/src/store/test/resolvers.js
+++ b/packages/edit-navigation/src/store/test/resolvers.js
@@ -24,6 +24,12 @@ jest.mock( '@wordpress/blocks', () => {
 } );
 
 describe( 'getNavigationPostForMenu', () => {
+	it( 'returns early when a menuId is not provided', () => {
+		const generator = getNavigationPostForMenu( null );
+		expect( generator.next().value ).toBeUndefined();
+		expect( generator.next().done ).toBe( true );
+	} );
+
 	it( 'gets navigation post for menu id', () => {
 		const menuId = 123;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
The navigation editor seems to make a malformed request for menu items resulting in a 400 status HTTP response:
<img width="449" alt="Screenshot 2021-02-05 at 12 19 43 pm" src="https://user-images.githubusercontent.com/677833/106989223-a8440d00-67ac-11eb-8dc2-0115a4da6057.png">

This seems to be caused by the preceding request for a menu and menu id not being resolved yet. The menu id is needed as a param in the request that's failing.

It seems like an easy enough fix to return early from the resolver for fetching menu items, since this whole process is repeated and completes successfully once a menu id is known.

I've also had to push some fixes for the isPending state of the editor, as otherwise the loading state shows forever when there are no menus with this change. This is already previously buggy, https://github.com/WordPress/gutenberg/issues/28124 covers a proper fix.

## How has this been tested?
1. Open dev tools on the network tab
2. Open the navigation screen.
3. If there are no menus, create one with some menu items and reload
4. Check network requests, there should be no failed requests
5. Menus should load correctly (including menu items.)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
