### PR TITLE
Refactor Buttons block to use JustifyToolbar controls

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -10,14 +10,13 @@ import {
 	BlockControls,
 	useBlockProps,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+	JustifyToolbar,
 } from '@wordpress/block-editor';
-import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { name as buttonBlockName } from '../button';
-import ContentJustificationDropdown from './content-justification-dropdown';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
@@ -42,24 +41,29 @@ function ButtonsEdit( {
 		},
 		templateInsertUpdatesSelection: true,
 	} );
+
+	function handleItemsAlignment( align ) {
+		return () => {
+			const justification =
+				contentJustification === align ? undefined : align;
+			setAttributes( {
+				contentJustification: justification,
+			} );
+		};
+	}
+
 	return (
 		<>
 			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarItem>
-						{ ( toggleProps ) => (
-							<ContentJustificationDropdown
-								toggleProps={ toggleProps }
-								value={ contentJustification }
-								onChange={ ( updatedValue ) => {
-									setAttributes( {
-										contentJustification: updatedValue,
-									} );
-								} }
-							/>
-						) }
-					</ToolbarItem>
-				</ToolbarGroup>
+				<JustifyToolbar
+					allowedControls={ [ 'left', 'center', 'right' ] }
+					value={ contentJustification }
+					onChange={ handleItemsAlignment }
+					popoverProps={ {
+						position: 'bottom right',
+						isAlternate: true,
+					} }
+				/>
 			</BlockControls>
 			<div { ...innerBlocksProps } />
 		</>


### PR DESCRIPTION

## Description

Updates the Buttons block to use the new Justify Toolbar controls introduced in #28439 

## How has this been tested?

1. Add Buttons block
2. Add several buttons
3. Use controls to justify items left, center, and right
4. Test horizontal and vertical variants

## Types of changes

Code refactoring to use same control, there should be no visible changes.

**NOTE:** This is not quite working right for horizontal for some difference in CSS that I'm missing.
@jasmussen can you try it out, the vertical variant works as expected. The horizontal does not seem to work for left and center, but does for right. There is something in CSS that I'm missing.

There is an additional file `content-justification-dropdown.js` that is still used for `edit.native.js` - I could update but I'm not sure how to test mobile properly. We can also follow with a mobile refactor.