### PR TITLE
Adjust defaults for COMPONENT_SYSTEM_PHASE variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"config": {
 		"GUTENBERG_PHASE": 2,
-		"COMPONENT_SYSTEM_PHASE": 0
+		"COMPONENT_SYSTEM_PHASE": 1
 	},
 	"dependencies": {
 		"@wordpress/a11y": "file:packages/a11y",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,7 +128,7 @@ module.exports = {
 				parseInt(
 					process.env.npm_package_config_COMPONENT_SYSTEM_PHASE,
 					10
-				) || 1
+				) || 0
 			),
 			'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
 				process.env.FORCE_REDUCED_MOTION


### PR DESCRIPTION
## Description
This is a pretty small change to adjust how this new variable works to be similar to GUTENBERG_PHASE. Everything should be the same in practice.

The idea of the change is that the webpack fallback represents the feature being disabled, and then it can be easily toggled on or off in the package.json.

----

As a separate conversation, I wonder if we should consider simplifying how this works. We generally end up removing the these flags when a feature is stabilised. Given the way the usage has evolved, it could be expressed as a single boolean, e.g.

`process.env.PLUGIN_ONLY === true`

## How has this been tested?
1. Checkout this branch
2. Run `npm run dev`
3. Inspect the Font Size Picker, it should have `data-g2` properties.

## Types of changes
Task
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
