### PR TITLE
block-editor package: Replace hardcoded store name strings

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -19,6 +19,7 @@ import { useMemo } from '@wordpress/element';
 import { searchBlockItems } from '../components/inserter/search-items';
 import useBlockTypesState from '../components/inserter/hooks/use-block-types-state';
 import BlockIcon from '../components/block-icon';
+import { store as blockEditorStore } from '../store';
 
 const SHOWN_BLOCK_TYPES = 9;
 
@@ -42,7 +43,7 @@ function createBlockCompleter() {
 						getSelectedBlockClientId,
 						getBlockName,
 						getBlockInsertionPoint,
-					} = select( 'core/block-editor' );
+					} = select( blockEditorStore );
 					const selectedBlockClientId = getSelectedBlockClientId();
 					return {
 						selectedBlockName: selectedBlockClientId

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -17,6 +17,7 @@ import {
  * Internal dependencies
  */
 import { useNotifyCopy } from '../copy-handler';
+import { store as blockEditorStore } from '../../store';
 
 export default function BlockActions( {
 	clientIds,
@@ -28,7 +29,7 @@ export default function BlockActions( {
 		getBlockRootClientId,
 		getBlocksByClientId,
 		getTemplateLock,
-	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
+	} = useSelect( ( select ) => select( blockEditorStore ), [] );
 	const { getDefaultBlockName, getGroupingBlockName } = useSelect(
 		( select ) => select( blocksStore ),
 		[]
@@ -59,7 +60,7 @@ export default function BlockActions( {
 		setBlockMovingClientId,
 		setNavigationMode,
 		selectBlock,
-	} = useDispatch( 'core/block-editor' );
+	} = useDispatch( blockEditorStore );
 
 	const notifyCopy = useNotifyCopy();
 

--- a/packages/block-editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-alignment-toolbar/index.js
@@ -16,6 +16,7 @@ import {
  * Internal dependencies
  */
 import { useLayout } from '../inner-blocks/layout';
+import { store as blockEditorStore } from '../../store';
 
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	left: {
@@ -55,7 +56,7 @@ export function BlockAlignmentToolbar( {
 	isCollapsed = true,
 } ) {
 	const { wideControlsEnabled = false } = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		const settings = getSettings();
 		return {
 			wideControlsEnabled: settings.alignWide,

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockTitle from '../block-title';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
@@ -16,15 +17,13 @@ import BlockTitle from '../block-title';
  * @return {WPElement} Block Breadcrumb.
  */
 function BlockBreadcrumb() {
-	const { selectBlock, clearSelectedBlock } = useDispatch(
-		'core/block-editor'
-	);
+	const { selectBlock, clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { clientId, parents, hasSelection } = useSelect( ( select ) => {
 		const {
 			getSelectionStart,
 			getSelectedBlockClientId,
 			getBlockParents,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
 			parents: getBlockParents( selectedBlockClientId ),

--- a/packages/block-editor/src/components/block-caption/index.native.js
+++ b/packages/block-editor/src/components/block-caption/index.native.js
@@ -14,6 +14,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import styles from './styles.scss';
+import { store as blockEditorStore } from '../../store';
 
 const BlockCaption = ( {
 	accessible,
@@ -44,7 +45,7 @@ const BlockCaption = ( {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 		const { caption } = getBlockAttributes( clientId ) || {};
 		const isBlockSelected = getSelectedBlockClientId() === clientId;
@@ -60,7 +61,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {
-		const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+		const { updateBlockAttributes } = dispatch( blockEditorStore );
 		return {
 			onChange: ( caption ) => {
 				updateBlockAttributes( clientId, { caption } );

--- a/packages/block-editor/src/components/block-caption/index.native.js
+++ b/packages/block-editor/src/components/block-caption/index.native.js
@@ -14,7 +14,6 @@ import { withDispatch, withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import styles from './styles.scss';
-import { store as blockEditorStore } from '../../store';
 
 const BlockCaption = ( {
 	accessible,
@@ -45,7 +44,7 @@ const BlockCaption = ( {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } = select(
-			blockEditorStore
+			'core/block-editor'
 		);
 		const { caption } = getBlockAttributes( clientId ) || {};
 		const isBlockSelected = getSelectedBlockClientId() === clientId;
@@ -61,7 +60,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {
-		const { updateBlockAttributes } = dispatch( blockEditorStore );
+		const { updateBlockAttributes } = dispatch( 'core/block-editor' );
 		return {
 			onChange: ( caption ) => {
 				updateBlockAttributes( clientId, { caption } );

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -11,6 +11,7 @@ import { useEffect, useRef } from '@wordpress/element';
  */
 import BlockDraggableChip from './draggable-chip';
 import useScrollWhenDragging from './use-scroll-when-dragging';
+import { store as blockEditorStore } from '../../store';
 
 const BlockDraggable = ( {
 	children,
@@ -26,7 +27,7 @@ const BlockDraggable = ( {
 				getBlockRootClientId,
 				getTemplateLock,
 				getBlockName,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 			const templateLock = rootClientId
 				? getTemplateLock( rootClientId )
@@ -49,7 +50,7 @@ const BlockDraggable = ( {
 	] = useScrollWhenDragging();
 
 	const { startDraggingBlocks, stopDraggingBlocks } = useDispatch(
-		'core/block-editor'
+		blockEditorStore
 	);
 
 	// Stop dragging blocks if the block draggable is unmounted

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -26,6 +26,7 @@ import MultiSelectionInspector from '../multi-selection-inspector';
 import DefaultStylePicker from '../default-style-picker';
 import BlockVariationTransforms from '../block-variation-transforms';
 import useBlockDisplayInformation from '../use-block-display-information';
+import { store as blockEditorStore } from '../../store';
 
 const BlockInspector = ( {
 	blockType,
@@ -137,7 +138,7 @@ export default withSelect( ( select ) => {
 		getSelectedBlockClientId,
 		getSelectedBlockCount,
 		getBlockName,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 	const { getBlockStyles } = select( blocksStore );
 	const selectedBlockClientId = getSelectedBlockClientId();
 	const selectedBlockName =

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -16,6 +16,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  */
 import DefaultBlockAppender from '../default-block-appender';
 import ButtonBlockAppender from '../button-block-appender';
+import { store as blockEditorStore } from '../../store';
 
 // A Context to store the map of the appender map.
 export const AppenderNodesContext = createContext();
@@ -110,7 +111,7 @@ export default withSelect( ( select, { rootClientId } ) => {
 		canInsertBlockType,
 		getTemplateLock,
 		getSelectedBlockClientId,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 
 	return {
 		isLocked: !! getTemplateLock( rootClientId ),

--- a/packages/block-editor/src/components/block-list-appender/index.native.js
+++ b/packages/block-editor/src/components/block-list-appender/index.native.js
@@ -14,6 +14,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  */
 import DefaultBlockAppender from '../default-block-appender';
 import styles from './style.scss';
+import { store as blockEditorStore } from '../../store';
 
 function BlockListAppender( {
 	blockClientIds,
@@ -48,7 +49,7 @@ function BlockListAppender( {
 
 export default withSelect( ( select, { rootClientId } ) => {
 	const { getBlockOrder, canInsertBlockType, getTemplateLock } = select(
-		'core/block-editor'
+		blockEditorStore
 	);
 
 	return {

--- a/packages/block-editor/src/components/block-list-appender/index.native.js
+++ b/packages/block-editor/src/components/block-list-appender/index.native.js
@@ -14,7 +14,6 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  */
 import DefaultBlockAppender from '../default-block-appender';
 import styles from './style.scss';
-import { store as blockEditorStore } from '../../store';
 
 function BlockListAppender( {
 	blockClientIds,
@@ -49,7 +48,7 @@ function BlockListAppender( {
 
 export default withSelect( ( select, { rootClientId } ) => {
 	const { getBlockOrder, canInsertBlockType, getTemplateLock } = select(
-		blockEditorStore
+		'core/block-editor'
 	);
 
 	return {

--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -15,6 +15,7 @@ import { useSelect } from '@wordpress/data';
  */
 import NavigableToolbar from '../navigable-toolbar';
 import { BlockToolbar } from '../';
+import { store as blockEditorStore } from '../../store';
 
 function BlockContextualToolbar( { focusOnMount, ...props } ) {
 	const { blockType, hasParents } = useSelect( ( select ) => {
@@ -22,7 +23,7 @@ function BlockContextualToolbar( { focusOnMount, ...props } ) {
 			getBlockName,
 			getBlockParents,
 			getSelectedBlockClientIds,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const { getBlockType } = select( blocksStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -16,13 +16,18 @@ import {
 	getSaveContent,
 } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 function BlockHTML( { clientId } ) {
 	const [ html, setHtml ] = useState( '' );
 	const block = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlock( clientId ),
+		( select ) => select( blockEditorStore ).getBlock( clientId ),
 		[ clientId ]
 	);
-	const { updateBlock } = useDispatch( 'core/block-editor' );
+	const { updateBlock } = useDispatch( blockEditorStore );
 	const onChange = () => {
 		const blockType = getBlockType( block.name );
 		const attributes = getBlockAttributes(

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -13,6 +13,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
  */
 import Warning from '../warning';
 import BlockCompare from '../block-compare';
+import { store as blockEditorStore } from '../../store';
 
 export function BlockInvalidWarning( {
 	convertToHTML,
@@ -103,10 +104,10 @@ const recoverBlock = ( { name, attributes, innerBlocks } ) =>
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => ( {
-		block: select( 'core/block-editor' ).getBlock( clientId ),
+		block: select( blockEditorStore ).getBlock( clientId ),
 	} ) ),
 	withDispatch( ( dispatch, { block } ) => {
-		const { replaceBlock } = dispatch( 'core/block-editor' );
+		const { replaceBlock } = dispatch( blockEditorStore );
 
 		return {
 			convertToClassic() {

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -17,6 +17,7 @@ import { ReadableContentView, alignmentHelpers } from '@wordpress/components';
 import BlockListBlock from './block';
 import BlockInsertionPoint from './insertion-point';
 import styles from './block-list-item.native.scss';
+import { store as blockEditorStore } from '../../store';
 
 const stretchStyle = {
 	flex: 1,
@@ -174,7 +175,7 @@ export default compose( [
 				getSettings,
 				getBlockParents,
 				__unstableGetBlockWithoutInnerBlocks,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 
 			const blockClientIds = getBlockOrder( rootClientId );
 			const insertionPoint = getBlockInsertionPoint();

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -17,7 +17,6 @@ import { ReadableContentView, alignmentHelpers } from '@wordpress/components';
 import BlockListBlock from './block';
 import BlockInsertionPoint from './insertion-point';
 import styles from './block-list-item.native.scss';
-import { store as blockEditorStore } from '../../store';
 
 const stretchStyle = {
 	flex: 1,
@@ -175,7 +174,7 @@ export default compose( [
 				getSettings,
 				getBlockParents,
 				__unstableGetBlockWithoutInnerBlocks,
-			} = select( blockEditorStore );
+			} = select( 'core/block-editor' );
 
 			const blockClientIds = getBlockOrder( rootClientId );
 			const insertionPoint = getBlockInsertionPoint();

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -29,6 +29,7 @@ import BlockContextualToolbar from './block-contextual-toolbar';
 import Inserter from '../inserter';
 import { BlockNodes } from './';
 import { getBlockDOMNode } from '../../utils/dom';
+import { store as blockEditorStore } from '../../store';
 
 function selector( select ) {
 	const {
@@ -39,7 +40,7 @@ function selector( select ) {
 		isCaretWithinFormattedText,
 		getSettings,
 		getLastMultiSelectedBlockClientId,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 	return {
 		isNavigationMode: isNavigationMode(),
 		isMultiSelecting: isMultiSelecting(),
@@ -71,7 +72,7 @@ function BlockPopover( {
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const blockNodes = useContext( BlockNodes );
-	const { stopTyping } = useDispatch( 'core/block-editor' );
+	const { stopTyping } = useDispatch( blockEditorStore );
 
 	// Controls when the side inserter on empty lines should
 	// be shown, including writing and selection modes.
@@ -265,7 +266,7 @@ function wrapperSelector( select ) {
 		__unstableGetBlockWithoutInnerBlocks,
 		getBlockParents,
 		__experimentalGetBlockListSettingsForBlocks,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 
 	const clientId =
 		getSelectedBlockClientId() || getFirstMultiSelectedBlockClientId();

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -32,6 +32,7 @@ import { focus } from '@wordpress/dom';
  * Internal dependencies
  */
 import BlockTitle from '../block-title';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Returns true if the user is using windows.
@@ -54,7 +55,7 @@ function selector( select ) {
 		getClientIdsOfDescendants,
 		canInsertBlockType,
 		getBlockName,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 
 	const selectedBlockClientId = getSelectedBlockClientId();
 	const selectionEndClientId = getMultiSelectedBlocksEndClientId();
@@ -94,7 +95,7 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 				getBlockIndex,
 				hasBlockMovingClientId,
 				getBlockListSettings,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const index = getBlockIndex( clientId, rootClientId );
 			const { name, attributes } = __unstableGetBlockWithoutInnerBlocks(
 				clientId
@@ -111,9 +112,7 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 		[ clientId, rootClientId ]
 	);
 	const { index, name, attributes, blockMovingMode, orientation } = selected;
-	const { setNavigationMode, removeBlock } = useDispatch(
-		'core/block-editor'
-	);
+	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
 
 	// Focus the breadcrumb in navigation mode.
@@ -142,7 +141,7 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 		clearSelectedBlock,
 		setBlockMovingClientId,
 		moveBlockToPosition,
-	} = useDispatch( 'core/block-editor' );
+	} = useDispatch( blockEditorStore );
 
 	function onKeyDown( event ) {
 		const { keyCode } = event;

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.js
@@ -16,7 +16,7 @@ import { View, Text, TouchableOpacity } from 'react-native';
  */
 import BlockTitle from '../block-title';
 import SubdirectorSVG from './subdirectory-icon';
-
+import { store as blockEditorStore } from '../../store';
 import styles from './block-selection-button.scss';
 
 const BlockSelectionButton = ( {
@@ -78,7 +78,7 @@ const BlockSelectionButton = ( {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockRootClientId, getBlockName, getSettings } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 
 		const blockName = getBlockName( clientId );

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.js
@@ -16,7 +16,7 @@ import { View, Text, TouchableOpacity } from 'react-native';
  */
 import BlockTitle from '../block-title';
 import SubdirectorSVG from './subdirectory-icon';
-import { store as blockEditorStore } from '../../store';
+
 import styles from './block-selection-button.scss';
 
 const BlockSelectionButton = ( {
@@ -78,7 +78,7 @@ const BlockSelectionButton = ( {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockRootClientId, getBlockName, getSettings } = select(
-			blockEditorStore
+			'core/block-editor'
 		);
 
 		const blockName = getBlockName( clientId );

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -45,6 +45,7 @@ import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
 import { useBlockProps } from './use-block-props';
+import { store as blockEditorStore } from '../../store';
 
 export const BlockListBlockContext = createContext();
 
@@ -116,7 +117,7 @@ function BlockListBlock( {
 				isBlockBeingDragged,
 				isBlockHighlighted,
 				getSettings,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			return {
 				isDragging: isBlockBeingDragged( clientId ),
 				isHighlighted: isBlockHighlighted( clientId ),
@@ -126,7 +127,7 @@ function BlockListBlock( {
 		},
 		[ clientId ]
 	);
-	const { removeBlock } = useDispatch( 'core/block-editor' );
+	const { removeBlock } = useDispatch( blockEditorStore );
 	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
 
 	// Handling the error state
@@ -286,7 +287,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 		getTemplateLock,
 		__unstableGetBlockWithoutInnerBlocks,
 		getMultiSelectedBlockClientIds,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 	const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 	const isSelected = isBlockSelected( clientId );
 	const templateLock = getTemplateLock( rootClientId );
@@ -350,7 +351,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 		replaceBlocks,
 		toggleSelection,
 		__unstableMarkLastChangeAsPersistent,
-	} = dispatch( 'core/block-editor' );
+	} = dispatch( blockEditorStore );
 
 	// Do not add new properties here, use `useDispatch` instead to avoid
 	// leaking new props to the public API (editor.BlockListBlock filter).
@@ -373,14 +374,14 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 		},
 		onInsertBlocksAfter( blocks ) {
 			const { clientId, rootClientId } = ownProps;
-			const { getBlockIndex } = select( 'core/block-editor' );
+			const { getBlockIndex } = select( blockEditorStore );
 			const index = getBlockIndex( clientId, rootClientId );
 			insertBlocks( blocks, index + 1, rootClientId );
 		},
 		onMerge( forward ) {
 			const { clientId } = ownProps;
 			const { getPreviousBlockClientId, getNextBlockClientId } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 
 			if ( forward ) {

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -27,7 +27,6 @@ import styles from './block.scss';
 import BlockEdit from '../block-edit';
 import BlockInvalidWarning from './block-invalid-warning';
 import BlockMobileToolbar from '../block-mobile-toolbar';
-import { store as blockEditorStore } from '../../store';
 
 function BlockForType( {
 	attributes,
@@ -308,7 +307,7 @@ export default compose( [
 			getLowestCommonAncestorWithSelectedBlock,
 			getBlockParents,
 			hasSelectedInnerBlock,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 
 		const order = getBlockIndex( clientId, rootClientId );
 		const isSelected = isBlockSelected( clientId );
@@ -375,7 +374,7 @@ export default compose( [
 			replaceBlocks,
 			selectBlock,
 			updateBlockAttributes,
-		} = dispatch( blockEditorStore );
+		} = dispatch( 'core/block-editor' );
 
 		return {
 			mergeBlocks( forward ) {
@@ -383,7 +382,7 @@ export default compose( [
 				const {
 					getPreviousBlockClientId,
 					getNextBlockClientId,
-				} = select( blockEditorStore );
+				} = select( 'core/block-editor' );
 
 				if ( forward ) {
 					const nextBlockClientId = getNextBlockClientId( clientId );

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -27,6 +27,7 @@ import styles from './block.scss';
 import BlockEdit from '../block-edit';
 import BlockInvalidWarning from './block-invalid-warning';
 import BlockMobileToolbar from '../block-mobile-toolbar';
+import { store as blockEditorStore } from '../../store';
 
 function BlockForType( {
 	attributes,
@@ -307,7 +308,7 @@ export default compose( [
 			getLowestCommonAncestorWithSelectedBlock,
 			getBlockParents,
 			hasSelectedInnerBlock,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const order = getBlockIndex( clientId, rootClientId );
 		const isSelected = isBlockSelected( clientId );
@@ -374,7 +375,7 @@ export default compose( [
 			replaceBlocks,
 			selectBlock,
 			updateBlockAttributes,
-		} = dispatch( 'core/block-editor' );
+		} = dispatch( blockEditorStore );
 
 		return {
 			mergeBlocks( forward ) {
@@ -382,7 +383,7 @@ export default compose( [
 				const {
 					getPreviousBlockClientId,
 					getNextBlockClientId,
-				} = select( 'core/block-editor' );
+				} = select( blockEditorStore );
 
 				if ( forward ) {
 					const nextBlockClientId = getNextBlockClientId( clientId );

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -17,6 +17,7 @@ import BlockListAppender from '../block-list-appender';
 import useBlockDropZone from '../use-block-drop-zone';
 import useInsertionPoint from './insertion-point';
 import BlockPopover from './block-popover';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -69,7 +70,7 @@ function Items( {
 			getGlobalBlockCount,
 			isTyping,
 			__experimentalGetActiveBlockIdByBlockNames,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		// Determine if there is an active entity area to spotlight.
 		const activeEntityBlockId = __experimentalGetActiveBlockIdByBlockNames(

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -25,6 +25,7 @@ import { __ } from '@wordpress/i18n';
 import styles from './style.scss';
 import BlockListAppender from '../block-list-appender';
 import BlockListItem from './block-list-item.native';
+import { store as blockEditorStore } from '../../store';
 
 const BlockListContext = createContext();
 
@@ -366,7 +367,7 @@ export default compose( [
 				isBlockInsertionPointVisible,
 				getSettings,
 				getBlockHierarchyRootClientId,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 
 			const isStackedHorizontally = orientation === 'horizontal';
 
@@ -406,7 +407,7 @@ export default compose( [
 	),
 	withDispatch( ( dispatch ) => {
 		const { insertBlock, replaceBlock, clearSelectedBlock } = dispatch(
-			'core/block-editor'
+			blockEditorStore
 		);
 
 		return {
@@ -457,7 +458,7 @@ const EmptyListComponentCompose = compose( [
 			getBlockOrder,
 			getBlockInsertionPoint,
 			isBlockInsertionPointVisible,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const isStackedHorizontally = orientation === 'horizontal';
 		const blockClientIds = getBlockOrder( rootClientId );

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -25,7 +25,6 @@ import { __ } from '@wordpress/i18n';
 import styles from './style.scss';
 import BlockListAppender from '../block-list-appender';
 import BlockListItem from './block-list-item.native';
-import { store as blockEditorStore } from '../../store';
 
 const BlockListContext = createContext();
 
@@ -367,7 +366,7 @@ export default compose( [
 				isBlockInsertionPointVisible,
 				getSettings,
 				getBlockHierarchyRootClientId,
-			} = select( blockEditorStore );
+			} = select( 'core/block-editor' );
 
 			const isStackedHorizontally = orientation === 'horizontal';
 
@@ -407,7 +406,7 @@ export default compose( [
 	),
 	withDispatch( ( dispatch ) => {
 		const { insertBlock, replaceBlock, clearSelectedBlock } = dispatch(
-			blockEditorStore
+			'core/block-editor'
 		);
 
 		return {
@@ -458,7 +457,7 @@ const EmptyListComponentCompose = compose( [
 			getBlockOrder,
 			getBlockInsertionPoint,
 			isBlockInsertionPointVisible,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 
 		const isStackedHorizontally = orientation === 'horizontal';
 		const blockClientIds = getBlockOrder( rootClientId );

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -22,6 +22,7 @@ import { isRTL } from '@wordpress/i18n';
  */
 import Inserter from '../inserter';
 import { getBlockDOMNode } from '../../utils/dom';
+import { store as blockEditorStore } from '../../store';
 
 function InsertionPointInserter( {
 	clientId,
@@ -55,7 +56,7 @@ function InsertionPointPopover( {
 	containerRef,
 	showInsertionPoint,
 } ) {
-	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const { selectBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
 
 	const {
@@ -75,7 +76,7 @@ function InsertionPointPopover( {
 				getSelectedBlockClientId,
 				hasMultiSelection,
 				getSettings,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const { ownerDocument } = containerRef.current;
 			const targetRootClientId = clientId
 				? getBlockRootClientId( clientId )
@@ -259,7 +260,7 @@ export default function useInsertionPoint( ref ) {
 			getBlockInsertionPoint,
 			getBlockOrder,
 			getBlockListSettings: _getBlockListSettings,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const insertionPoint = getBlockInsertionPoint();
 		const order = getBlockOrder( insertionPoint.rootClientId );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-moving-mode-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-moving-mode-class-names.js
@@ -9,6 +9,11 @@ import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
 
 /**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+/**
  * Returns the class names used for block moving mode.
  *
  * @param {string} clientId The block client ID to insert above.
@@ -24,7 +29,7 @@ export function useBlockMovingModeClassNames( clientId ) {
 				getBlockName,
 				getBlockRootClientId,
 				isBlockSelected,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 
 			// The classes are only relevant for the selected block. Avoid
 			// re-rendering all blocks!

--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -11,6 +11,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { isInsideRootBlock } from '../../../utils/dom';
 import { SelectionStart } from '../../writing-flow';
+import { store as blockEditorStore } from '../../../store';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
@@ -33,7 +34,7 @@ export function useEventHandlers( ref, clientId ) {
 				isBlockSelected,
 				getBlockRootClientId,
 				getBlockIndex,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 
 			return {
 				isSelected: isBlockSelected( clientId ),
@@ -44,7 +45,7 @@ export function useEventHandlers( ref, clientId ) {
 		[ clientId ]
 	);
 	const { insertDefaultBlock, removeBlock, selectBlock } = useDispatch(
-		'core/block-editor'
+		blockEditorStore
 	);
 
 	useEffect( () => {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -14,6 +14,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { isInsideRootBlock } from '../../../utils/dom';
+import { store as blockEditorStore } from '../../../store';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
@@ -33,7 +34,7 @@ function useInitialPosition( clientId ) {
 				isMultiSelecting,
 				isNavigationMode,
 				isBlockSelected,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 
 			if ( ! isBlockSelected( clientId ) ) {
 				return;

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -4,6 +4,11 @@
 import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
 /**
@@ -20,7 +25,7 @@ export function useIsHovered( ref ) {
 		const {
 			isNavigationMode: selectIsNavigationMode,
 			getSettings,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		return {
 			isNavigationMode: selectIsNavigationMode(),

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -25,10 +25,12 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { moreHorizontalMobile } from '@wordpress/icons';
 import { useRef, useState } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
 import { getMoversSetup } from '../block-mover/mover-description';
+import { store as blockEditorStore } from '../../store';
 
 const BlockActionsMenu = ( {
 	onDelete,
@@ -247,7 +249,7 @@ export default compose(
 			getBlocksByClientId,
 			getSelectedBlockClientIds,
 			canInsertBlockType,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const normalizedClientIds = castArray( clientIds );
 		const block = getBlock( normalizedClientIds );
 		const blockName = getBlockName( normalizedClientIds );
@@ -290,12 +292,12 @@ export default compose(
 				removeBlocks,
 				insertBlock,
 				replaceBlocks,
-			} = dispatch( 'core/block-editor' );
+			} = dispatch( blockEditorStore );
 			const { openGeneralSidebar } = dispatch( 'core/edit-post' );
 			const { getBlockSelectionEnd, getBlock } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
-			const { createSuccessNotice } = dispatch( 'core/notices' );
+			const { createSuccessNotice } = dispatch( noticesStore );
 
 			return {
 				onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -25,14 +25,10 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { moreHorizontalMobile } from '@wordpress/icons';
 import { useRef, useState } from '@wordpress/element';
-import { store as editPostStore } from '@wordpress/edit-post';
-import { store as noticesStore } from '@wordpress/notices';
-
 /**
  * Internal dependencies
  */
 import { getMoversSetup } from '../block-mover/mover-description';
-import { store as blockEditorStore } from '../../store';
 
 const BlockActionsMenu = ( {
 	onDelete,
@@ -251,7 +247,7 @@ export default compose(
 			getBlocksByClientId,
 			getSelectedBlockClientIds,
 			canInsertBlockType,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 		const normalizedClientIds = castArray( clientIds );
 		const block = getBlock( normalizedClientIds );
 		const blockName = getBlockName( normalizedClientIds );
@@ -294,12 +290,12 @@ export default compose(
 				removeBlocks,
 				insertBlock,
 				replaceBlocks,
-			} = dispatch( blockEditorStore );
-			const { openGeneralSidebar } = dispatch( editPostStore );
+			} = dispatch( 'core/block-editor' );
+			const { openGeneralSidebar } = dispatch( 'core/edit-post' );
 			const { getBlockSelectionEnd, getBlock } = select(
-				blockEditorStore
+				'core/block-editor'
 			);
-			const { createSuccessNotice } = dispatch( noticesStore );
+			const { createSuccessNotice } = dispatch( 'core/notices' );
 
 			return {
 				onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -25,10 +25,14 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { moreHorizontalMobile } from '@wordpress/icons';
 import { useRef, useState } from '@wordpress/element';
+import { store as editPostStore } from '@wordpress/edit-post';
+import { store as noticesStore } from '@wordpress/notices';
+
 /**
  * Internal dependencies
  */
 import { getMoversSetup } from '../block-mover/mover-description';
+import { store as blockEditorStore } from '../../store';
 
 const BlockActionsMenu = ( {
 	onDelete,
@@ -247,7 +251,7 @@ export default compose(
 			getBlocksByClientId,
 			getSelectedBlockClientIds,
 			canInsertBlockType,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const normalizedClientIds = castArray( clientIds );
 		const block = getBlock( normalizedClientIds );
 		const blockName = getBlockName( normalizedClientIds );
@@ -290,12 +294,12 @@ export default compose(
 				removeBlocks,
 				insertBlock,
 				replaceBlocks,
-			} = dispatch( 'core/block-editor' );
-			const { openGeneralSidebar } = dispatch( 'core/edit-post' );
+			} = dispatch( blockEditorStore );
+			const { openGeneralSidebar } = dispatch( editPostStore );
 			const { getBlockSelectionEnd, getBlock } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
-			const { createSuccessNotice } = dispatch( 'core/notices' );
+			const { createSuccessNotice } = dispatch( noticesStore );
 
 			return {
 				onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -29,6 +29,7 @@ import { useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { getMoversSetup } from '../block-mover/mover-description';
+import { store as blockEditorStore } from '../../store';
 
 const BlockActionsMenu = ( {
 	onDelete,
@@ -247,7 +248,7 @@ export default compose(
 			getBlocksByClientId,
 			getSelectedBlockClientIds,
 			canInsertBlockType,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const normalizedClientIds = castArray( clientIds );
 		const block = getBlock( normalizedClientIds );
 		const blockName = getBlockName( normalizedClientIds );
@@ -290,10 +291,10 @@ export default compose(
 				removeBlocks,
 				insertBlock,
 				replaceBlocks,
-			} = dispatch( 'core/block-editor' );
+			} = dispatch( blockEditorStore );
 			const { openGeneralSidebar } = dispatch( 'core/edit-post' );
 			const { getBlockSelectionEnd, getBlock } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 			const { createSuccessNotice } = dispatch( 'core/notices' );
 

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -29,7 +29,6 @@ import { useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { getMoversSetup } from '../block-mover/mover-description';
-import { store as blockEditorStore } from '../../store';
 
 const BlockActionsMenu = ( {
 	onDelete,
@@ -248,7 +247,7 @@ export default compose(
 			getBlocksByClientId,
 			getSelectedBlockClientIds,
 			canInsertBlockType,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 		const normalizedClientIds = castArray( clientIds );
 		const block = getBlock( normalizedClientIds );
 		const blockName = getBlockName( normalizedClientIds );
@@ -291,10 +290,10 @@ export default compose(
 				removeBlocks,
 				insertBlock,
 				replaceBlocks,
-			} = dispatch( blockEditorStore );
+			} = dispatch( 'core/block-editor' );
 			const { openGeneralSidebar } = dispatch( 'core/edit-post' );
 			const { getBlockSelectionEnd, getBlock } = select(
-				blockEditorStore
+				'core/block-editor'
 			);
 			const { createSuccessNotice } = dispatch( 'core/notices' );
 

--- a/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
@@ -17,6 +17,7 @@ import styles from './style.scss';
 import BlockMover from '../block-mover';
 import BlockActionsMenu from './block-actions-menu';
 import { BlockSettingsButton } from '../block-settings';
+import { store as blockEditorStore } from '../../store';
 
 // Defined breakpoints are used to get a point when
 // `settings` and `mover` controls should be wrapped into `BlockActionsMenu`
@@ -88,14 +89,14 @@ const BlockMobileToolbar = ( {
 
 export default compose(
 	withSelect( ( select, { clientId } ) => {
-		const { getBlockIndex } = select( 'core/block-editor' );
+		const { getBlockIndex } = select( blockEditorStore );
 
 		return {
 			order: getBlockIndex( clientId ),
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, rootClientId, onDelete } ) => {
-		const { removeBlock } = dispatch( 'core/block-editor' );
+		const { removeBlock } = dispatch( blockEditorStore );
 		return {
 			onDelete:
 				onDelete || ( () => removeBlock( clientId, rootClientId ) ),

--- a/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
@@ -17,7 +17,6 @@ import styles from './style.scss';
 import BlockMover from '../block-mover';
 import BlockActionsMenu from './block-actions-menu';
 import { BlockSettingsButton } from '../block-settings';
-import { store as blockEditorStore } from '../../store';
 
 // Defined breakpoints are used to get a point when
 // `settings` and `mover` controls should be wrapped into `BlockActionsMenu`
@@ -89,14 +88,14 @@ const BlockMobileToolbar = ( {
 
 export default compose(
 	withSelect( ( select, { clientId } ) => {
-		const { getBlockIndex } = select( blockEditorStore );
+		const { getBlockIndex } = select( 'core/block-editor' );
 
 		return {
 			order: getBlockIndex( clientId ),
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, rootClientId, onDelete } ) => {
-		const { removeBlock } = dispatch( blockEditorStore );
+		const { removeBlock } = dispatch( 'core/block-editor' );
 		return {
 			onDelete:
 				onDelete || ( () => removeBlock( clientId, rootClientId ) ),

--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -24,6 +24,7 @@ import {
 	chevronDown,
 } from '@wordpress/icons';
 import { getBlockMoverDescription } from './mover-description';
+import { store as blockEditorStore } from '../../store';
 
 const getArrowIcon = ( direction, orientation ) => {
 	if ( direction === 'up' ) {
@@ -79,7 +80,7 @@ const BlockMoverButton = forwardRef(
 					getBlockOrder,
 					getBlock,
 					getBlockListSettings,
-				} = select( 'core/block-editor' );
+				} = select( blockEditorStore );
 				const normalizedClientIds = castArray( clientIds );
 				const firstClientId = first( normalizedClientIds );
 				const blockRootClientId = getBlockRootClientId( firstClientId );
@@ -112,7 +113,7 @@ const BlockMoverButton = forwardRef(
 		);
 
 		const { moveBlocksDown, moveBlocksUp } = useDispatch(
-			'core/block-editor'
+			blockEditorStore
 		);
 		const moverFunction =
 			direction === 'up' ? moveBlocksUp : moveBlocksDown;

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
  */
 import BlockDraggable from '../block-draggable';
 import { BlockMoverUpButton, BlockMoverDownButton } from './button';
+import { store as blockEditorStore } from '../../store';
 
 function BlockMover( {
 	isFirst,
@@ -102,7 +103,7 @@ export default withSelect( ( select, { clientIds } ) => {
 		getTemplateLock,
 		getBlockOrder,
 		getBlockRootClientId,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 	const normalizedClientIds = castArray( clientIds );
 	const firstClientId = first( normalizedClientIds );
 	const block = getBlock( firstClientId );

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -17,6 +17,7 @@ import { useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { getMoversSetup } from './mover-description';
+import { store as blockEditorStore } from '../../store';
 
 export const BLOCK_MOVER_DIRECTION_TOP = 'blockPageMoverOptions-moveToTop';
 export const BLOCK_MOVER_DIRECTION_BOTTOM =
@@ -132,7 +133,7 @@ export default compose(
 			getTemplateLock,
 			getBlockRootClientId,
 			getBlockOrder,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const normalizedClientIds = castArray( clientIds );
 		const firstClientId = first( normalizedClientIds );
 		const rootClientId = getBlockRootClientId( firstClientId );
@@ -154,7 +155,7 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch, { clientIds, rootClientId } ) => {
 		const { moveBlocksDown, moveBlocksUp, moveBlocksToPosition } = dispatch(
-			'core/block-editor'
+			blockEditorStore
 		);
 		return {
 			onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -17,7 +17,6 @@ import { useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { getMoversSetup } from './mover-description';
-import { store as blockEditorStore } from '../../store';
 
 export const BLOCK_MOVER_DIRECTION_TOP = 'blockPageMoverOptions-moveToTop';
 export const BLOCK_MOVER_DIRECTION_BOTTOM =
@@ -133,7 +132,7 @@ export default compose(
 			getTemplateLock,
 			getBlockRootClientId,
 			getBlockOrder,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 		const normalizedClientIds = castArray( clientIds );
 		const firstClientId = first( normalizedClientIds );
 		const rootClientId = getBlockRootClientId( firstClientId );
@@ -155,7 +154,7 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch, { clientIds, rootClientId } ) => {
 		const { moveBlocksDown, moveBlocksUp, moveBlocksToPosition } = dispatch(
-			blockEditorStore
+			'core/block-editor'
 		);
 		return {
 			onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),

--- a/packages/block-editor/src/components/block-navigation/appender.js
+++ b/packages/block-editor/src/components/block-navigation/appender.js
@@ -17,6 +17,7 @@ import { useSelect } from '@wordpress/data';
 import BlockNavigationLeaf from './leaf';
 import Indentation from './indentation';
 import Inserter from '../inserter';
+import { store as blockEditorStore } from '../../store';
 
 export default function BlockNavigationAppender( {
 	parentBlockClientId,
@@ -28,7 +29,7 @@ export default function BlockNavigationAppender( {
 	const isDragging = useSelect(
 		( select ) => {
 			const { isBlockBeingDragged, isAncestorBeingDragged } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 
 			return (

--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -16,6 +16,7 @@ import { useBlockNavigationContext } from './context';
 import BlockNavigationBlockSlot from './block-slot';
 import BlockNavigationBlockSelectButton from './block-select-button';
 import BlockDraggable from '../block-draggable';
+import { store as blockEditorStore } from '../../store';
 
 const BlockNavigationBlockContents = forwardRef(
 	(
@@ -47,7 +48,7 @@ const BlockNavigationBlockContents = forwardRef(
 					getBlockRootClientId,
 					hasBlockMovingClientId,
 					getSelectedBlockClientId,
-				} = select( 'core/block-editor' );
+				} = select( blockEditorStore );
 				return {
 					rootClientId: getBlockRootClientId( clientId ) || '',
 					blockMovingClientId: hasBlockMovingClientId(),

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -28,6 +28,7 @@ import {
 import BlockNavigationBlockContents from './block-contents';
 import BlockSettingsDropdown from '../block-settings-menu/block-settings-dropdown';
 import { useBlockNavigationContext } from './context';
+import { store as blockEditorStore } from '../../store';
 
 export default function BlockNavigationBlock( {
 	block,
@@ -50,7 +51,7 @@ export default function BlockNavigationBlock( {
 				isBlockBeingDragged,
 				isAncestorBeingDragged,
 				getBlockParents,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 
 			return {
 				isDragging:
@@ -62,9 +63,7 @@ export default function BlockNavigationBlock( {
 		[ clientId ]
 	);
 
-	const { selectBlock: selectEditorBlock } = useDispatch(
-		'core/block-editor'
-	);
+	const { selectBlock: selectEditorBlock } = useDispatch( blockEditorStore );
 
 	const hasSiblings = siblingBlockCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -14,6 +14,7 @@ import { useCallback, forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import BlockNavigation from './';
+import { store as blockEditorStore } from '../../store';
 
 const MenuIcon = (
 	<SVG
@@ -71,7 +72,7 @@ function BlockNavigationDropdown(
 	ref
 ) {
 	const hasBlocks = useSelect(
-		( select ) => !! select( 'core/block-editor' ).getBlockCount(),
+		( select ) => !! select( blockEditorStore ).getBlockCount(),
 		[]
 	);
 	const isEnabled = hasBlocks && ! isDisabled;

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockNavigationTree from './tree';
+import { store as blockEditorStore } from '../../store';
 
 function BlockNavigation( {
 	rootBlock,
@@ -55,7 +56,7 @@ export default compose(
 			getBlockHierarchyRootClientId,
 			__unstableGetBlockWithBlockTree,
 			__unstableGetBlockTree,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
 			rootBlocks: __unstableGetBlockTree(),
@@ -70,7 +71,7 @@ export default compose(
 	withDispatch( ( dispatch, { onSelect = noop } ) => {
 		return {
 			selectBlock( clientId ) {
-				dispatch( 'core/block-editor' ).selectBlock( clientId );
+				dispatch( blockEditorStore ).selectBlock( clientId );
 				onSelect( clientId );
 			},
 		};

--- a/packages/block-editor/src/components/block-navigation/use-block-navigation-drop-zone.js
+++ b/packages/block-editor/src/components/block-navigation/use-block-navigation-drop-zone.js
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
  */
 import { getDistanceToNearestEdge } from '../../utils/math';
 import useOnBlockDrop from '../use-on-block-drop';
+import { store as blockEditorStore } from '../../store';
 
 /** @typedef {import('../../utils/math').WPPoint} WPPoint */
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
@@ -63,7 +64,7 @@ function useDropTargetBlocksData( ref, position, dragEventType ) {
 		getDraggedBlockClientIds,
 		canInsertBlocks,
 	} = useSelect( ( select ) => {
-		const selectors = select( 'core/block-editor' );
+		const selectors = select( blockEditorStore );
 		return {
 			canInsertBlocks: selectors.canInsertBlocks,
 			getBlockRootClientId: selectors.getBlockRootClientId,

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -12,6 +12,7 @@ import { useRef } from '@wordpress/element';
  */
 import BlockIcon from '../block-icon';
 import { useShowMoversGestures } from '../block-toolbar/utils';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Block parent selector component, displaying the hierarchy of the
@@ -21,7 +22,7 @@ import { useShowMoversGestures } from '../block-toolbar/utils';
  */
 export default function BlockParentSelector() {
 	const { selectBlock, toggleBlockHighlight } = useDispatch(
-		'core/block-editor'
+		blockEditorStore
 	);
 	const {
 		parentBlockType,
@@ -34,7 +35,7 @@ export default function BlockParentSelector() {
 			getBlockParents,
 			getSelectedBlockClientId,
 			getSettings,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const { hasBlockSupport } = select( blocksStore );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		const parents = getBlockParents( selectedBlockClientId );

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -15,6 +15,7 @@ import { memo, useMemo } from '@wordpress/element';
 import BlockEditorProvider from '../provider';
 import LiveBlockPreview from './live';
 import AutoHeightBlockPreview from './auto';
+import { store as blockEditorStore } from '../../store';
 
 export function BlockPreview( {
 	blocks,
@@ -24,7 +25,7 @@ export function BlockPreview( {
 	__experimentalOnClick,
 } ) {
 	const settings = useSelect(
-		( select ) => select( 'core/block-editor' ).getSettings(),
+		( select ) => select( blockEditorStore ).getSettings(),
 		[]
 	);
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -4,15 +4,20 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 export function useBlockSelectionClearer( ref ) {
 	const hasSelection = useSelect( ( select ) => {
 		const { hasSelectedBlock, hasMultiSelection } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 
 		return hasSelectedBlock() || hasMultiSelection();
 	} );
-	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	useEffect( () => {
 		if ( ! hasSelection ) {

--- a/packages/block-editor/src/components/block-settings-menu/block-html-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-html-convert-button.js
@@ -9,10 +9,11 @@ import { withSelect, withDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import BlockConvertButton from './block-convert-button';
+import { store as blockEditorStore } from '../../store';
 
 export default compose(
 	withSelect( ( select, { clientId } ) => {
-		const block = select( 'core/block-editor' ).getBlock( clientId );
+		const block = select( blockEditorStore ).getBlock( clientId );
 
 		return {
 			block,
@@ -21,7 +22,7 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch, { block } ) => ( {
 		onClick: () =>
-			dispatch( 'core/block-editor' ).replaceBlocks(
+			dispatch( blockEditorStore ).replaceBlocks(
 				block.clientId,
 				rawHandler( { HTML: getBlockContent( block ) } )
 			),

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -12,6 +12,11 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 export function BlockModeToggle( {
 	blockType,
 	mode,
@@ -35,7 +40,7 @@ export function BlockModeToggle( {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlock, getBlockMode, getSettings } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 		const block = getBlock( clientId );
 		const isCodeEditingEnabled = getSettings().codeEditingEnabled;
@@ -48,7 +53,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, { onToggle = noop, clientId } ) => ( {
 		onToggleMode() {
-			dispatch( 'core/block-editor' ).toggleBlockMode( clientId );
+			dispatch( blockEditorStore ).toggleBlockMode( clientId );
 			onToggle();
 		},
 	} ) ),

--- a/packages/block-editor/src/components/block-settings/button.native.js
+++ b/packages/block-editor/src/components/block-settings/button.native.js
@@ -5,7 +5,6 @@ import { createSlotFill, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withDispatch } from '@wordpress/data';
 import { cog } from '@wordpress/icons';
-import { store as editPostStore } from '@wordpress/edit-post';
 
 const { Fill, Slot } = createSlotFill( 'SettingsToolbarButton' );
 
@@ -24,7 +23,7 @@ const SettingsButtonFill = ( props ) => (
 );
 
 const SettingsToolbarButton = withDispatch( ( dispatch ) => {
-	const { openGeneralSidebar } = dispatch( editPostStore );
+	const { openGeneralSidebar } = dispatch( 'core/edit-post' );
 
 	return {
 		openGeneralSidebar: () => openGeneralSidebar( 'edit-post/block' ),

--- a/packages/block-editor/src/components/block-settings/button.native.js
+++ b/packages/block-editor/src/components/block-settings/button.native.js
@@ -5,6 +5,7 @@ import { createSlotFill, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withDispatch } from '@wordpress/data';
 import { cog } from '@wordpress/icons';
+import { store as editPostStore } from '@wordpress/edit-post';
 
 const { Fill, Slot } = createSlotFill( 'SettingsToolbarButton' );
 
@@ -23,7 +24,7 @@ const SettingsButtonFill = ( props ) => (
 );
 
 const SettingsToolbarButton = withDispatch( ( dispatch ) => {
-	const { openGeneralSidebar } = dispatch( 'core/edit-post' );
+	const { openGeneralSidebar } = dispatch( editPostStore );
 
 	return {
 		openGeneralSidebar: () => openGeneralSidebar( 'edit-post/block' ),

--- a/packages/block-editor/src/components/block-settings/container.native.js
+++ b/packages/block-editor/src/components/block-settings/container.native.js
@@ -13,6 +13,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import styles from './container.native.scss';
+import { store as blockEditorStore } from '../../store';
 
 export const blockSettingsScreens = {
 	settings: 'Settings',
@@ -63,7 +64,7 @@ function BottomSheetSettings( {
 export default compose( [
 	withSelect( ( select ) => {
 		const { isEditorSidebarOpened } = select( 'core/edit-post' );
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return {
 			settings: getSettings(),
 			editorSidebarOpened: isEditorSidebarOpened(),

--- a/packages/block-editor/src/components/block-settings/container.native.js
+++ b/packages/block-editor/src/components/block-settings/container.native.js
@@ -9,10 +9,13 @@ import {
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
+
 /**
  * Internal dependencies
  */
 import styles from './container.native.scss';
+import { store as blockEditorStore } from '../../store';
 
 export const blockSettingsScreens = {
 	settings: 'Settings',
@@ -62,15 +65,15 @@ function BottomSheetSettings( {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isEditorSidebarOpened } = select( 'core/edit-post' );
-		const { getSettings } = select( 'core/block-editor' );
+		const { isEditorSidebarOpened } = select( editPostStore );
+		const { getSettings } = select( blockEditorStore );
 		return {
 			settings: getSettings(),
 			editorSidebarOpened: isEditorSidebarOpened(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { closeGeneralSidebar } = dispatch( 'core/edit-post' );
+		const { closeGeneralSidebar } = dispatch( editPostStore );
 
 		return {
 			closeGeneralSidebar,

--- a/packages/block-editor/src/components/block-settings/container.native.js
+++ b/packages/block-editor/src/components/block-settings/container.native.js
@@ -13,7 +13,6 @@ import { withDispatch, withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import styles from './container.native.scss';
-import { store as blockEditorStore } from '../../store';
 
 export const blockSettingsScreens = {
 	settings: 'Settings',
@@ -63,15 +62,15 @@ function BottomSheetSettings( {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isEditorSidebarOpened } = select( blockEditorStore );
-		const { getSettings } = select( blockEditorStore );
+		const { isEditorSidebarOpened } = select( 'core/edit-post' );
+		const { getSettings } = select( 'core/block-editor' );
 		return {
 			settings: getSettings(),
 			editorSidebarOpened: isEditorSidebarOpened(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { closeGeneralSidebar } = dispatch( blockEditorStore );
+		const { closeGeneralSidebar } = dispatch( 'core/edit-post' );
 
 		return {
 			closeGeneralSidebar,

--- a/packages/block-editor/src/components/block-settings/container.native.js
+++ b/packages/block-editor/src/components/block-settings/container.native.js
@@ -9,13 +9,10 @@ import {
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { store as editPostStore } from '@wordpress/edit-post';
-
 /**
  * Internal dependencies
  */
 import styles from './container.native.scss';
-import { store as blockEditorStore } from '../../store';
 
 export const blockSettingsScreens = {
 	settings: 'Settings',
@@ -65,15 +62,15 @@ function BottomSheetSettings( {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isEditorSidebarOpened } = select( editPostStore );
-		const { getSettings } = select( blockEditorStore );
+		const { isEditorSidebarOpened } = select( 'core/edit-post' );
+		const { getSettings } = select( 'core/block-editor' );
 		return {
 			settings: getSettings(),
 			editorSidebarOpened: isEditorSidebarOpened(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { closeGeneralSidebar } = dispatch( editPostStore );
+		const { closeGeneralSidebar } = dispatch( 'core/edit-post' );
 
 		return {
 			closeGeneralSidebar,

--- a/packages/block-editor/src/components/block-settings/container.native.js
+++ b/packages/block-editor/src/components/block-settings/container.native.js
@@ -13,6 +13,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import styles from './container.native.scss';
+import { store as blockEditorStore } from '../../store';
 
 export const blockSettingsScreens = {
 	settings: 'Settings',
@@ -62,15 +63,15 @@ function BottomSheetSettings( {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isEditorSidebarOpened } = select( 'core/edit-post' );
-		const { getSettings } = select( 'core/block-editor' );
+		const { isEditorSidebarOpened } = select( blockEditorStore );
+		const { getSettings } = select( blockEditorStore );
 		return {
 			settings: getSettings(),
 			editorSidebarOpened: isEditorSidebarOpened(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { closeGeneralSidebar } = dispatch( 'core/edit-post' );
+		const { closeGeneralSidebar } = dispatch( blockEditorStore );
 
 		return {
 			closeGeneralSidebar,

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -23,6 +23,7 @@ import {
  */
 import { getActiveStyle, replaceActiveStyle } from './utils';
 import BlockPreview from '../block-preview';
+import { store as blockEditorStore } from '../../store';
 
 const useGenericPreviewBlock = ( block, type ) =>
 	useMemo(
@@ -43,7 +44,7 @@ function BlockStyles( {
 	itemRole,
 } ) {
 	const selector = ( select ) => {
-		const { getBlock } = select( 'core/block-editor' );
+		const { getBlock } = select( blockEditorStore );
 		const { getBlockStyles } = select( blocksStore );
 		const block = getBlock( clientId );
 		const blockType = getBlockType( block.name );
@@ -59,7 +60,7 @@ function BlockStyles( {
 		clientId,
 	] );
 
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const genericPreviewBlock = useGenericPreviewBlock( block, type );
 
 	if ( ! styles || styles.length === 0 ) {

--- a/packages/block-editor/src/components/block-styles/index.native.js
+++ b/packages/block-editor/src/components/block-styles/index.native.js
@@ -17,10 +17,11 @@ import { _x } from '@wordpress/i18n';
 import { getActiveStyle, replaceActiveStyle } from './utils';
 import StylePreview from './preview';
 import containerStyles from './style.scss';
+import { store as blockEditorStore } from '../../store';
 
 function BlockStyles( { clientId, url } ) {
 	const selector = ( select ) => {
-		const { getBlock } = select( 'core/block-editor' );
+		const { getBlock } = select( blockEditorStore );
 		const { getBlockStyles } = select( blocksStore );
 		const block = getBlock( clientId );
 		return {
@@ -31,7 +32,7 @@ function BlockStyles( { clientId, url } ) {
 
 	const { styles, className } = useSelect( selector, [ clientId ] );
 
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	if ( ! styles || styles.length === 0 ) {
 		return null;

--- a/packages/block-editor/src/components/block-styles/index.native.js
+++ b/packages/block-editor/src/components/block-styles/index.native.js
@@ -17,11 +17,10 @@ import { _x } from '@wordpress/i18n';
 import { getActiveStyle, replaceActiveStyle } from './utils';
 import StylePreview from './preview';
 import containerStyles from './style.scss';
-import { store as blockEditorStore } from '../../store';
 
 function BlockStyles( { clientId, url } ) {
 	const selector = ( select ) => {
-		const { getBlock } = select( blockEditorStore );
+		const { getBlock } = select( 'core/block-editor' );
 		const { getBlockStyles } = select( blocksStore );
 		const block = getBlock( clientId );
 		return {
@@ -32,7 +31,7 @@ function BlockStyles( { clientId, url } ) {
 
 	const { styles, className } = useSelect( selector, [ clientId ] );
 
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 
 	if ( ! styles || styles.length === 0 ) {
 		return null;

--- a/packages/block-editor/src/components/block-switcher/block-styles-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-styles-menu.js
@@ -5,7 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { MenuGroup } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { cloneBlock, getBlockFromExample } from '@wordpress/blocks';
+import {
+	cloneBlock,
+	getBlockFromExample,
+	store as blocksStore,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -19,7 +23,7 @@ export default function BlockStylesMenu( {
 } ) {
 	const [ hoveredClassName, setHoveredClassName ] = useState();
 	const blockType = useSelect(
-		( select ) => select( 'core/blocks' ).getBlockType( name ),
+		( select ) => select( blocksStore ).getBlockType( name ),
 		[ name ]
 	);
 

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -17,6 +17,7 @@ import {
  * Internal dependencies
  */
 import useBlockDisplayInformation from '../use-block-display-information';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Renders the block's configured title as a string, or empty if the title
@@ -43,7 +44,7 @@ export default function BlockTitle( { clientId } ) {
 				getBlockName,
 				getBlockAttributes,
 				__experimentalGetReusableBlockTitle,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const blockName = getBlockName( clientId );
 			if ( ! blockName ) {
 				return {};

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -22,6 +22,7 @@ import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 import BlockSettingsMenu from '../block-settings-menu';
 import { useShowMoversGestures } from './utils';
+import { store as blockEditorStore } from '../../store';
 
 export default function BlockToolbar( { hideDragHandle } ) {
 	const {
@@ -40,7 +41,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			isBlockValid,
 			getBlockRootClientId,
 			getSettings,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
 		const blockRootClientId = getBlockRootClientId( selectedBlockClientId );
@@ -66,7 +67,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 
 	// Handles highlighting the current block outline on hover or focus of the
 	// block type toolbar area.
-	const { toggleBlockHighlight } = useDispatch( 'core/block-editor' );
+	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 	const nodeRef = useRef();
 	const { showMovers, gestures: showMoversGestures } = useShowMoversGestures(
 		{

--- a/packages/block-editor/src/components/block-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-toolbar/index.native.js
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 import UngroupButton from '../ungroup-button';
+import { store as blockEditorStore } from '../../store';
 
 export default function BlockToolbar() {
 	const { blockClientIds, isValid, mode } = useSelect( ( select ) => {
@@ -16,7 +17,7 @@ export default function BlockToolbar() {
 			getBlockMode,
 			getSelectedBlockClientIds,
 			isBlockValid,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 
 		return {

--- a/packages/block-editor/src/components/block-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-toolbar/index.native.js
@@ -9,7 +9,6 @@ import { useSelect } from '@wordpress/data';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 import UngroupButton from '../ungroup-button';
-import { store as blockEditorStore } from '../../store';
 
 export default function BlockToolbar() {
 	const { blockClientIds, isValid, mode } = useSelect( ( select ) => {
@@ -17,7 +16,7 @@ export default function BlockToolbar() {
 			getBlockMode,
 			getSelectedBlockClientIds,
 			isBlockValid,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 
 		return {

--- a/packages/block-editor/src/components/block-variation-picker/index.native.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.native.js
@@ -32,11 +32,12 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import styles from './style.scss';
+import { store as blockEditorStore } from '../../store';
 
 const hitSlop = { top: 22, bottom: 22, left: 22, right: 22 };
 
 function BlockVariationPicker( { isVisible, onClose, clientId, variations } ) {
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const isIOS = Platform.OS === 'ios';
 
 	const cancelButtonStyle = usePreferredColorSchemeStyle(

--- a/packages/block-editor/src/components/block-variation-picker/index.native.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.native.js
@@ -32,12 +32,11 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import styles from './style.scss';
-import { store as blockEditorStore } from '../../store';
 
 const hitSlop = { top: 22, bottom: 22, left: 22, right: 22 };
 
 function BlockVariationPicker( { isVisible, onClose, clientId, variations } ) {
-	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
+	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 	const isIOS = Platform.OS === 'ios';
 
 	const cancelButtonStyle = usePreferredColorSchemeStyle(

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -16,15 +16,16 @@ import { chevronDown } from '@wordpress/icons';
  * Internal dependencies
  */
 import { __experimentalGetMatchingVariation as getMatchingVariation } from '../../utils';
+import { store as blockEditorStore } from '../../store';
 
 function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const [ selectedValue, setSelectedValue ] = useState();
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const { variations, blockAttributes } = useSelect(
 		( select ) => {
 			const { getBlockVariations } = select( blocksStore );
 			const { getBlockName, getBlockAttributes } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 			const blockName = blockClientId && getBlockName( blockClientId );
 			return {

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -26,6 +26,7 @@ import InspectorControls from '../inspector-controls';
 import { useBlockEditContext } from '../block-edit';
 import ColorPanel from './color-panel';
 import useEditorFeature from '../use-editor-feature';
+import { store as blockEditorStore } from '../../store';
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
@@ -66,14 +67,14 @@ export default function __experimentalUseColors(
 		useEditorFeature( 'color.palette' ) || DEFAULT_COLORS;
 	const { attributes } = useSelect(
 		( select ) => {
-			const { getBlockAttributes } = select( 'core/block-editor' );
+			const { getBlockAttributes } = select( blockEditorStore );
 			return {
 				attributes: getBlockAttributes( clientId ),
 			};
 		},
 		[ clientId ]
 	);
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const setAttributes = useCallback(
 		( newAttributes ) => updateBlockAttributes( clientId, newAttributes ),
 		[ updateBlockAttributes, clientId ]

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -19,10 +19,11 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { getPasteEventData } from '../../utils/get-paste-event-data';
+import { store as blockEditorStore } from '../../store';
 
 export function useNotifyCopy() {
 	const { getBlockName } = useSelect(
-		( select ) => select( 'core/block-editor' ),
+		( select ) => select( blockEditorStore ),
 		[]
 	);
 	const { getBlockType } = useSelect(
@@ -82,9 +83,9 @@ export function useClipboardHandler( ref ) {
 		getSelectedBlockClientIds,
 		hasMultiSelection,
 		getSettings,
-	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
+	} = useSelect( ( select ) => select( blockEditorStore ), [] );
 	const { flashBlock, removeBlocks, replaceBlocks } = useDispatch(
-		'core/block-editor'
+		blockEditorStore
 	);
 	const notifyCopy = useNotifyCopy();
 

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -16,6 +16,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import Inserter from '../inserter';
+import { store as blockEditorStore } from '../../store';
 
 export function DefaultBlockAppender( {
 	isLocked,
@@ -79,7 +80,7 @@ export default compose(
 			isBlockValid,
 			getSettings,
 			getTemplateLock,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
 		const isLastBlockDefault =
@@ -97,7 +98,7 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const { insertDefaultBlock, startTyping } = dispatch(
-			'core/block-editor'
+			blockEditorStore
 		);
 
 		return {

--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -18,6 +18,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  */
 import BlockInsertionPoint from '../block-list/insertion-point';
 import styles from './style.scss';
+import { store as blockEditorStore } from '../../store';
 
 export function DefaultBlockAppender( {
 	isLocked,
@@ -62,7 +63,7 @@ export default compose(
 			getBlockName,
 			isBlockValid,
 			getTemplateLock,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
 		const isLastBlockDefault =
@@ -77,7 +78,7 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const { insertDefaultBlock, startTyping } = dispatch(
-			'core/block-editor'
+			blockEditorStore
 		);
 
 		return {

--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -18,7 +18,6 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  */
 import BlockInsertionPoint from '../block-list/insertion-point';
 import styles from './style.scss';
-import { store as blockEditorStore } from '../../store';
 
 export function DefaultBlockAppender( {
 	isLocked,
@@ -63,7 +62,7 @@ export default compose(
 			getBlockName,
 			isBlockValid,
 			getTemplateLock,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
 		const isLastBlockDefault =
@@ -78,7 +77,7 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const { insertDefaultBlock, startTyping } = dispatch(
-			blockEditorStore
+			'core/block-editor'
 		);
 
 		return {

--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -7,6 +7,11 @@ import { __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 export default function DefaultStylePicker( { blockName } ) {
 	const {
 		preferredStyle,
@@ -14,7 +19,7 @@ export default function DefaultStylePicker( { blockName } ) {
 		styles,
 	} = useSelect(
 		( select ) => {
-			const settings = select( 'core/block-editor' ).getSettings();
+			const settings = select( blockEditorStore ).getSettings();
 			const preferredStyleVariations =
 				settings.__experimentalPreferredStyleVariations;
 			return {

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
 import styles from './styles.scss';
 import NavigateUpSVG from './nav-up-icon';
 import BlockSelectionButton from '../block-list/block-selection-button.native';
+import { store as blockEditorStore } from '../../store';
 
 const EASE_IN_DURATION = 250;
 const EASE_OUT_DURATION = 80;
@@ -108,7 +109,7 @@ export default compose( [
 			getBlockRootClientId,
 			getBlockCount,
 			getSettings,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const selectedClientId = getSelectedBlockClientId();
 
@@ -124,7 +125,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { selectBlock } = dispatch( 'core/block-editor' );
+		const { selectBlock } = dispatch( blockEditorStore );
 
 		return {
 			onNavigateUp( clientId, initialPosition ) {

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -18,7 +18,6 @@ import { __ } from '@wordpress/i18n';
 import styles from './styles.scss';
 import NavigateUpSVG from './nav-up-icon';
 import BlockSelectionButton from '../block-list/block-selection-button.native';
-import { store as blockEditorStore } from '../../store';
 
 const EASE_IN_DURATION = 250;
 const EASE_OUT_DURATION = 80;
@@ -109,7 +108,7 @@ export default compose( [
 			getBlockRootClientId,
 			getBlockCount,
 			getSettings,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 
 		const selectedClientId = getSelectedBlockClientId();
 
@@ -125,7 +124,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { selectBlock } = dispatch( blockEditorStore );
+		const { selectBlock } = dispatch( 'core/block-editor' );
 
 		return {
 			onNavigateUp( clientId, initialPosition ) {

--- a/packages/block-editor/src/components/gradients/use-gradient.js
+++ b/packages/block-editor/src/components/gradients/use-gradient.js
@@ -14,6 +14,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { useBlockEditContext } from '../block-edit';
 import useEditorFeature from '../use-editor-feature';
+import { store as blockEditorStore } from '../../store';
 
 const EMPTY_ARRAY = [];
 
@@ -69,7 +70,7 @@ export function __experimentalUseGradient( {
 	const gradients = useEditorFeature( 'color.gradients' ) || EMPTY_ARRAY;
 	const { gradient, customGradient } = useSelect(
 		( select ) => {
-			const { getBlockAttributes } = select( 'core/block-editor' );
+			const { getBlockAttributes } = select( blockEditorStore );
 			const attributes = getBlockAttributes( clientId ) || {};
 			return {
 				customGradient: attributes[ customGradientAttribute ],
@@ -79,7 +80,7 @@ export function __experimentalUseGradient( {
 		[ clientId, gradientAttribute, customGradientAttribute ]
 	);
 
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const setGradient = useCallback(
 		( newGradientValue ) => {
 			const slug = getGradientSlugByValue( gradients, newGradientValue );

--- a/packages/block-editor/src/components/inner-blocks/default-block-appender.js
+++ b/packages/block-editor/src/components/inner-blocks/default-block-appender.js
@@ -14,6 +14,7 @@ import { withSelect } from '@wordpress/data';
  */
 import BaseDefaultBlockAppender from '../default-block-appender';
 import withClientId from './with-client-id';
+import { store as blockEditorStore } from '../../store';
 
 export const DefaultBlockAppender = ( { clientId, lastBlockClientId } ) => {
 	return (
@@ -27,7 +28,7 @@ export const DefaultBlockAppender = ( { clientId, lastBlockClientId } ) => {
 export default compose( [
 	withClientId,
 	withSelect( ( select, { clientId } ) => {
-		const { getBlockOrder } = select( 'core/block-editor' );
+		const { getBlockOrder } = select( blockEditorStore );
 
 		const blockClientIds = getBlockOrder( clientId );
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -19,15 +19,12 @@ import DefaultBlockAppender from './default-block-appender';
 import useNestedSettingsUpdate from './use-nested-settings-update';
 import useInnerBlockTemplateSync from './use-inner-block-template-sync';
 import getBlockContext from './get-block-context';
-
-/**
- * Internal dependencies
- */
 import { BlockListItems } from '../block-list';
 import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { defaultLayout, LayoutProvider } from './layout';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -70,7 +67,7 @@ function UncontrolledInnerBlocks( props ) {
 
 	const context = useSelect(
 		( select ) => {
-			const block = select( 'core/block-editor' ).getBlock( clientId );
+			const block = select( blockEditorStore ).getBlock( clientId );
 			const blockType = getBlockType( block.name );
 
 			if ( ! blockType || ! blockType.providesContext ) {
@@ -150,7 +147,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				isBlockSelected,
 				hasSelectedInnerBlock,
 				isNavigationMode,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const enableClickThrough = isNavigationMode() || isSmallScreen;
 			return (
 				getBlockName( clientId ) !== 'core/template' &&

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -21,6 +21,7 @@ import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { BlockContextProvider } from '../block-context';
 import { defaultLayout, LayoutProvider } from './layout';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -55,7 +56,7 @@ function UncontrolledInnerBlocks( props ) {
 	} = props;
 
 	const block = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlock( clientId ),
+		( select ) => select( blockEditorStore ).getBlock( clientId ),
 		[ clientId ]
 	) || { innerBlocks: [] };
 

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -21,7 +21,6 @@ import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { BlockContextProvider } from '../block-context';
 import { defaultLayout, LayoutProvider } from './layout';
-import { store as blockEditorStore } from '../../store';
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -56,7 +55,7 @@ function UncontrolledInnerBlocks( props ) {
 	} = props;
 
 	const block = useSelect(
-		( select ) => select( blockEditorStore ).getBlock( clientId ),
+		( select ) => select( 'core/block-editor' ).getBlock( clientId ),
 		[ clientId ]
 	) || { innerBlocks: [] };
 

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -11,6 +11,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 
 /**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
  * This hook makes sure that a block's inner blocks stay in sync with the given
  * block "template". The template is a block hierarchy to which inner blocks must
  * conform. If the blocks get "out of sync" with the template and the template
@@ -35,10 +40,10 @@ export default function useInnerBlockTemplateSync(
 	templateLock,
 	templateInsertUpdatesSelection
 ) {
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
 	const innerBlocks = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlocks( clientId ),
+		( select ) => select( blockEditorStore ).getBlocks( clientId ),
 		[ clientId ]
 	);
 

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -6,6 +6,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
  * This hook is a side effect which updates the block-editor store when changes
  * happen to inner block settings. The given props are transformed into a
  * settings object, and if that is different from the current settings object in
@@ -30,18 +35,18 @@ export default function useNestedSettingsUpdate(
 	captureToolbars,
 	orientation
 ) {
-	const { updateBlockListSettings } = useDispatch( 'core/block-editor' );
+	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 
 	const { blockListSettings, parentLock } = useSelect(
 		( select ) => {
 			const rootClientId = select(
-				'core/block-editor'
+				blockEditorStore
 			).getBlockRootClientId( clientId );
 			return {
 				blockListSettings: select(
-					'core/block-editor'
+					blockEditorStore
 				).getBlockListSettings( clientId ),
-				parentLock: select( 'core/block-editor' ).getTemplateLock(
+				parentLock: select( blockEditorStore ).getTemplateLock(
 					rootClientId
 				),
 			};

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -10,6 +10,11 @@ import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 
 /**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+/**
  * Retrieves the block types inserter state.
  *
  * @param {string=}  rootClientId        Insertion's root client ID.
@@ -19,7 +24,7 @@ import { useCallback } from '@wordpress/element';
 const useBlockTypesState = ( rootClientId, onInsert ) => {
 	const { categories, collections, items } = useSelect(
 		( select ) => {
-			const { getInserterItems } = select( 'core/block-editor' );
+			const { getInserterItems } = select( blockEditorStore );
 			const { getCategories, getCollections } = select( blocksStore );
 
 			return {

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -8,6 +8,11 @@ import { speak } from '@wordpress/a11y';
 import { useCallback } from '@wordpress/element';
 
 /**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+/**
  * @typedef WPInserterConfig
  *
  * @property {string=}   rootClientId        If set, insertion will be into the
@@ -48,7 +53,7 @@ function useInsertionPoint( {
 				getBlockIndex,
 				getBlockOrder,
 				getBlockInsertionPoint,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 
 			let _destinationRootClientId, _destinationIndex;
 
@@ -95,7 +100,7 @@ function useInsertionPoint( {
 		insertBlocks,
 		showInsertionPoint,
 		hideInsertionPoint,
-	} = useDispatch( 'core/block-editor' );
+	} = useDispatch( blockEditorStore );
 
 	const onInsertBlocks = useCallback(
 		( blocks, meta ) => {

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -13,6 +13,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+/**
  * Retrieves the block patterns inserter state.
  *
  * @param {Function} onInsert function called when inserter a list of blocks.
@@ -24,7 +29,7 @@ const usePatternsState = ( onInsert ) => {
 		const {
 			__experimentalBlockPatterns,
 			__experimentalBlockPatternCategories,
-		} = select( 'core/block-editor' ).getSettings();
+		} = select( blockEditorStore ).getSettings();
 		return {
 			patterns: __experimentalBlockPatterns,
 			patternCategories: __experimentalBlockPatternCategories,

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -21,6 +21,7 @@ import { plus } from '@wordpress/icons';
  */
 import InserterMenu from './menu';
 import QuickInserter from './quick-inserter';
+import { store as blockEditorStore } from '../../store';
 
 const defaultRenderToggle = ( {
 	onToggle,
@@ -204,7 +205,7 @@ export default compose( [
 			getBlockRootClientId,
 			hasInserterItems,
 			__experimentalGetAllowedBlocks,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const { getBlockVariations } = select( blocksStore );
 
 		rootClientId =
@@ -255,7 +256,7 @@ export default compose( [
 						getBlockIndex,
 						getBlockSelectionEnd,
 						getBlockOrder,
-					} = select( 'core/block-editor' );
+					} = select( blockEditorStore );
 
 					// If the clientId is defined, we insert at the position of the block.
 					if ( clientId ) {
@@ -272,7 +273,7 @@ export default compose( [
 					return getBlockOrder( rootClientId ).length;
 				}
 
-				const { insertBlock } = dispatch( 'core/block-editor' );
+				const { insertBlock } = dispatch( blockEditorStore );
 
 				const blockToInsert = createBlock( allowedBlockType.name );
 

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -27,6 +27,7 @@ import {
 import styles from './style.scss';
 import InserterMenu from './menu';
 import BlockInsertionPoint from '../block-list/insertion-point';
+import { store as blockEditorStore } from '../../store';
 
 const VOICE_OVER_ANNOUNCEMENT_DELAY = 1000;
 
@@ -300,7 +301,7 @@ export default compose( [
 			getBlockOrder,
 			getBlockIndex,
 			getBlock,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const end = getBlockSelectionEnd();
 		// `end` argument (id) can refer to the component which is removed
@@ -320,7 +321,7 @@ export default compose( [
 			: undefined;
 
 		function getDefaultInsertionIndex() {
-			const { getSettings } = select( 'core/block-editor' );
+			const { getSettings } = select( blockEditorStore );
 
 			const {
 				__experimentalShouldInsertAtTheTop: shouldInsertAtTheTop,

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -27,7 +27,6 @@ import {
 import styles from './style.scss';
 import InserterMenu from './menu';
 import BlockInsertionPoint from '../block-list/insertion-point';
-import { store as blockEditorStore } from '../../store';
 
 const VOICE_OVER_ANNOUNCEMENT_DELAY = 1000;
 
@@ -301,7 +300,7 @@ export default compose( [
 			getBlockOrder,
 			getBlockIndex,
 			getBlock,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 
 		const end = getBlockSelectionEnd();
 		// `end` argument (id) can refer to the component which is removed
@@ -321,7 +320,7 @@ export default compose( [
 			: undefined;
 
 		function getDefaultInsertionIndex() {
-			const { getSettings } = select( blockEditorStore );
+			const { getSettings } = select( 'core/block-editor' );
 
 			const {
 				__experimentalShouldInsertAtTheTop: shouldInsertAtTheTop,

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -12,6 +12,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import InserterMenu from './menu';
+import { store as blockEditorStore } from '../../store';
 
 function InserterLibrary( {
 	rootClientId,
@@ -25,7 +26,7 @@ function InserterLibrary( {
 } ) {
 	const destinationRootClientId = useSelect(
 		( select ) => {
-			const { getBlockRootClientId } = select( 'core/block-editor' );
+			const { getBlockRootClientId } = select( blockEditorStore );
 
 			return (
 				rootClientId || getBlockRootClientId( clientId ) || undefined

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -18,6 +18,7 @@ import ReusableBlocksTab from './reusable-blocks-tab';
 import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
+import { store as blockEditorStore } from '../../store';
 
 function InserterMenu( {
 	rootClientId,
@@ -50,7 +51,7 @@ function InserterMenu( {
 		const {
 			__experimentalBlockPatterns,
 			__experimentalReusableBlocks,
-		} = select( 'core/block-editor' ).getSettings();
+		} = select( blockEditorStore ).getSettings();
 
 		return {
 			hasPatterns: !! __experimentalBlockPatterns?.length,

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -32,6 +32,7 @@ import {
  * Internal dependencies
  */
 import styles from './style.scss';
+import { store as blockEditorStore } from '../../store';
 
 const MIN_COL_NUM = 3;
 
@@ -226,7 +227,7 @@ export default compose(
 			getBlockSelectionEnd,
 			getSettings,
 			canInsertBlockType,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const { getChildBlockNames, getBlockType } = select( blocksStore );
 
 		let destinationRootClientId = rootClientId;
@@ -263,13 +264,13 @@ export default compose(
 			clearSelectedBlock,
 			insertBlock,
 			insertDefaultBlock,
-		} = dispatch( 'core/block-editor' );
+		} = dispatch( blockEditorStore );
 
 		return {
 			showInsertionPoint() {
 				if ( ownProps.shouldReplaceBlock ) {
 					const { getBlockOrder, getBlockCount } = select(
-						'core/block-editor'
+						blockEditorStore
 					);
 
 					const count = getBlockCount();

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -32,7 +32,6 @@ import {
  * Internal dependencies
  */
 import styles from './style.scss';
-import { store as blockEditorStore } from '../../store';
 
 const MIN_COL_NUM = 3;
 
@@ -227,7 +226,7 @@ export default compose(
 			getBlockSelectionEnd,
 			getSettings,
 			canInsertBlockType,
-		} = select( blockEditorStore );
+		} = select( 'core/block-editor' );
 		const { getChildBlockNames, getBlockType } = select( blocksStore );
 
 		let destinationRootClientId = rootClientId;
@@ -264,13 +263,13 @@ export default compose(
 			clearSelectedBlock,
 			insertBlock,
 			insertDefaultBlock,
-		} = dispatch( blockEditorStore );
+		} = dispatch( 'core/block-editor' );
 
 		return {
 			showInsertionPoint() {
 				if ( ownProps.shouldReplaceBlock ) {
 					const { getBlockOrder, getBlockCount } = select(
-						blockEditorStore
+						'core/block-editor'
 					);
 
 					const count = getBlockCount();

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -19,6 +19,7 @@ import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
+import { store as blockEditorStore } from '../../store';
 
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
@@ -53,9 +54,7 @@ export default function QuickInserter( {
 
 	const { setInserterIsOpened, blockIndex } = useSelect(
 		( select ) => {
-			const { getSettings, getBlockIndex } = select(
-				'core/block-editor'
-			);
+			const { getSettings, getBlockIndex } = select( blockEditorStore );
 			return {
 				setInserterIsOpened: getSettings()
 					.__experimentalSetIsInserterOpened,
@@ -71,7 +70,7 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
-	const { __unstableSetInsertionPoint } = useDispatch( 'core/block-editor' );
+	const { __unstableSetInsertionPoint } = useDispatch( blockEditorStore );
 
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -13,6 +13,11 @@ import {
 } from '@wordpress/keyboard-shortcuts';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 function KeyboardShortcuts() {
 	// Shortcuts Logic
 	const { clientIds, rootBlocksClientIds, rootClientId } = useSelect(
@@ -21,7 +26,7 @@ function KeyboardShortcuts() {
 				getSelectedBlockClientIds,
 				getBlockOrder,
 				getBlockRootClientId,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const selectedClientIds = getSelectedBlockClientIds();
 			const [ firstClientId ] = selectedClientIds;
 			return {
@@ -42,7 +47,7 @@ function KeyboardShortcuts() {
 		clearSelectedBlock,
 		moveBlocksUp,
 		moveBlocksDown,
-	} = useDispatch( 'core/block-editor' );
+	} = useDispatch( blockEditorStore );
 
 	// Moves selected block/blocks up
 	useShortcut(

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -15,6 +15,7 @@ import { startsWith } from 'lodash';
  */
 import isURLLike from './is-url-like';
 import { CREATE_TYPE } from './constants';
+import { store as blockEditorStore } from '../../store';
 
 export const handleNoop = () => Promise.resolve( [] );
 
@@ -109,7 +110,7 @@ export default function useSearchHandler(
 	withURLSuggestion
 ) {
 	const { fetchSearchSuggestions } = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return {
 			fetchSearchSuggestions: getSettings()
 				.__experimentalFetchLinkSuggestions,

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -26,6 +26,7 @@ import { keyboardReturn } from '@wordpress/icons';
 import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
 import URLPopover from '../url-popover';
+import { store as blockEditorStore } from '../../store';
 
 const InsertFromURLPopover = ( { src, onChange, onSubmit, onClose } ) => (
 	<URLPopover onClose={ onClose }>
@@ -76,7 +77,7 @@ export function MediaPlaceholder( {
 	children,
 } ) {
 	const mediaUpload = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return getSettings().mediaUpload;
 	}, [] );
 	const [ src, setSrc ] = useState( '' );

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -30,6 +30,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
 import LinkControl from '../link-control';
+import { store as blockEditorStore } from '../../store';
 
 const MediaReplaceFlow = ( {
 	mediaURL,
@@ -45,7 +46,7 @@ const MediaReplaceFlow = ( {
 } ) => {
 	const [ mediaURLValue, setMediaURLValue ] = useState( mediaURL );
 	const mediaUpload = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getSettings().mediaUpload;
+		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
 	const editMediaButtonRef = createRef();
 	const errorNoticeID = uniqueId(

--- a/packages/block-editor/src/components/media-upload/check.js
+++ b/packages/block-editor/src/components/media-upload/check.js
@@ -3,9 +3,14 @@
  */
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 export function MediaUploadCheck( { fallback = null, children } ) {
 	const hasUploadPermissions = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return !! getSettings().mediaUpload;
 	}, [] );
 	return hasUploadPermissions ? children : fallback;

--- a/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
@@ -14,6 +14,7 @@ import { getScrollContainer } from '@wordpress/dom';
  * Internal dependencies
  */
 import { getBlockDOMNode } from '../../utils/dom';
+import { store as blockEditorStore } from '../../store';
 
 export function useScrollMultiSelectionIntoView( ref ) {
 	const selectionEnd = useSelect( ( select ) => {
@@ -21,7 +22,7 @@ export function useScrollMultiSelectionIntoView( ref ) {
 			getBlockSelectionEnd,
 			hasMultiSelection,
 			isMultiSelecting,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const blockSelectionEnd = getBlockSelectionEnd();
 

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -11,6 +11,7 @@ import { stack } from '@wordpress/icons';
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
+import { store as blockEditorStore } from '../../store';
 
 function MultiSelectionInspector( { blocks } ) {
 	const words = wordCount( serialize( blocks ), 'words' );
@@ -39,7 +40,7 @@ function MultiSelectionInspector( { blocks } ) {
 }
 
 export default withSelect( ( select ) => {
-	const { getMultiSelectedBlocks } = select( 'core/block-editor' );
+	const { getMultiSelectedBlocks } = select( blockEditorStore );
 	return {
 		blocks: getMultiSelectedBlocks(),
 	};

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -15,6 +15,11 @@ import {
 	TAB,
 } from '@wordpress/keycodes';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
 /**
@@ -53,9 +58,9 @@ function isKeyDownEligibleForStartTyping( event ) {
  */
 export function useMouseMoveTypingReset( ref ) {
 	const isTyping = useSelect( ( select ) =>
-		select( 'core/block-editor' ).isTyping()
+		select( blockEditorStore ).isTyping()
 	);
-	const { stopTyping } = useDispatch( 'core/block-editor' );
+	const { stopTyping } = useDispatch( blockEditorStore );
 
 	useEffect( () => {
 		if ( ! isTyping ) {
@@ -111,9 +116,9 @@ export function useMouseMoveTypingReset( ref ) {
  */
 export function useTypingObserver( ref ) {
 	const isTyping = useSelect( ( select ) =>
-		select( 'core/block-editor' ).isTyping()
+		select( blockEditorStore ).isTyping()
 	);
-	const { startTyping, stopTyping } = useDispatch( 'core/block-editor' );
+	const { startTyping, stopTyping } = useDispatch( blockEditorStore );
 
 	useMouseMoveTypingReset( ref );
 	useEffect( () => {

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -9,13 +9,14 @@ import { useEffect } from '@wordpress/element';
  */
 import withRegistryProvider from './with-registry-provider';
 import useBlockSync from './use-block-sync';
+import { store as blockEditorStore } from '../../store';
 
 /** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
 
 function BlockEditorProvider( props ) {
 	const { children, settings } = props;
 
-	const { updateSettings } = useDispatch( 'core/block-editor' );
+	const { updateSettings } = useDispatch( blockEditorStore );
 	useEffect( () => {
 		updateSettings( settings );
 	}, [ settings ] );

--- a/packages/block-editor/src/components/provider/index.native.js
+++ b/packages/block-editor/src/components/provider/index.native.js
@@ -9,13 +9,14 @@ import { useEffect } from '@wordpress/element';
  */
 import withRegistryProvider from './with-registry-provider';
 import useBlockSync from './use-block-sync';
+import { store as blockEditorStore } from '../../store';
 
 /** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
 
 function BlockEditorProvider( props ) {
 	const { children, settings } = props;
 
-	const { updateSettings } = useDispatch( 'core/block-editor' );
+	const { updateSettings } = useDispatch( blockEditorStore );
 	useEffect( () => {
 		updateSettings( settings );
 	}, [ settings ] );

--- a/packages/block-editor/src/components/provider/index.native.js
+++ b/packages/block-editor/src/components/provider/index.native.js
@@ -9,14 +9,13 @@ import { useEffect } from '@wordpress/element';
  */
 import withRegistryProvider from './with-registry-provider';
 import useBlockSync from './use-block-sync';
-import { store as blockEditorStore } from '../../store';
 
 /** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
 
 function BlockEditorProvider( props ) {
 	const { children, settings } = props;
 
-	const { updateSettings } = useDispatch( blockEditorStore );
+	const { updateSettings } = useDispatch( 'core/block-editor' );
 	useEffect( () => {
 		updateSettings( settings );
 	}, [ settings ] );

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -14,7 +14,7 @@ import { create, act } from 'react-test-renderer';
 import useBlockSync from '../use-block-sync';
 import withRegistryProvider from '../with-registry-provider';
 import * as blockEditorActions from '../../../store/actions';
-import { store as blockEditorStore } from '../../store';
+import { store as blockEditorStore } from '../../../store';
 
 const TestWrapper = withRegistryProvider( ( props ) => {
 	if ( props.setRegistry ) {

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -14,6 +14,7 @@ import { create, act } from 'react-test-renderer';
 import useBlockSync from '../use-block-sync';
 import withRegistryProvider from '../with-registry-provider';
 import * as blockEditorActions from '../../../store/actions';
+import { store as blockEditorStore } from '../../store';
 
 const TestWrapper = withRegistryProvider( ( props ) => {
 	if ( props.setRegistry ) {
@@ -175,11 +176,11 @@ describe( 'useBlockSync hook', () => {
 		} );
 
 		registry
-			.dispatch( 'core/block-editor' )
+			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'a', { foo: 2 } );
 
 		const newBlockValue = registry
-			.select( 'core/block-editor' )
+			.select( blockEditorStore )
 			.getBlocks( 'test' );
 		replaceInnerBlocks.mockClear();
 
@@ -247,10 +248,10 @@ describe( 'useBlockSync hook', () => {
 
 		// Create a non-persistent change.
 		registry
-			.dispatch( 'core/block-editor' )
+			.dispatch( blockEditorStore )
 			.__unstableMarkNextChangeAsNotPersistent();
 		registry
-			.dispatch( 'core/block-editor' )
+			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'a', { foo: 2 } );
 
 		expect( onInput ).toHaveBeenCalledWith(
@@ -286,7 +287,7 @@ describe( 'useBlockSync hook', () => {
 
 		// Create a persistent change.
 		registry
-			.dispatch( 'core/block-editor' )
+			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'a', { foo: 2 } );
 
 		expect( onChange ).toHaveBeenCalledWith(
@@ -381,7 +382,7 @@ describe( 'useBlockSync hook', () => {
 		replaceInnerBlocks.mockClear();
 
 		registry
-			.dispatch( 'core/block-editor' )
+			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'a', { foo: 2 } );
 
 		expect( replaceInnerBlocks ).not.toHaveBeenCalled();
@@ -424,7 +425,7 @@ describe( 'useBlockSync hook', () => {
 
 		// Create a persistent change.
 		registry
-			.dispatch( 'core/block-editor' )
+			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'a', { foo: 2 } );
 
 		const updatedBlocks1 = [
@@ -459,7 +460,7 @@ describe( 'useBlockSync hook', () => {
 
 		// Create a persistent change.
 		registry
-			.dispatch( 'core/block-editor' )
+			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'b', { foo: 3 } );
 
 		// The first callback should not have been called.
@@ -516,7 +517,7 @@ describe( 'useBlockSync hook', () => {
 
 		// Create a persistent change.
 		registry
-			.dispatch( 'core/block-editor' )
+			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'b', { foo: 3 } );
 
 		// The first callback should never be called in this scenario.

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -11,6 +11,11 @@ import { useRegistry } from '@wordpress/data';
 import { cloneBlock } from '@wordpress/blocks';
 
 /**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
  * A function to call when the block value has been updated in the block-editor
  * store.
  *
@@ -80,8 +85,8 @@ export default function useBlockSync( {
 		replaceInnerBlocks,
 		setHasControlledInnerBlocks,
 		__unstableMarkNextChangeAsNotPersistent,
-	} = registry.dispatch( 'core/block-editor' );
-	const { getBlockName, getBlocks } = registry.select( 'core/block-editor' );
+	} = registry.dispatch( blockEditorStore );
+	const { getBlockName, getBlocks } = registry.select( blockEditorStore );
 
 	const pendingChanges = useRef( { incoming: null, outgoing: [] } );
 	const subscribed = useRef( false );
@@ -161,7 +166,7 @@ export default function useBlockSync( {
 			getSelectionEnd,
 			isLastBlockChangePersistent,
 			__unstableIsLastBlockChangeIgnored,
-		} = registry.select( 'core/block-editor' );
+		} = registry.select( blockEditorStore );
 
 		let blocks = getBlocks( clientId );
 		let isPersistent = isLastBlockChangePersistent();

--- a/packages/block-editor/src/components/provider/with-registry-provider.js
+++ b/packages/block-editor/src/components/provider/with-registry-provider.js
@@ -13,6 +13,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * Internal dependencies
  */
 import { storeConfig } from '../../store';
+import { STORE_NAME as blockEditorStoreName } from '../../store/constants';
 
 const withRegistryProvider = createHigherOrderComponent(
 	( WrappedComponent ) => {
@@ -28,7 +29,7 @@ const withRegistryProvider = createHigherOrderComponent(
 				useEffect( () => {
 					const newRegistry = createRegistry( {}, registry );
 					newRegistry.registerStore(
-						'core/block-editor',
+						blockEditorStoreName,
 						storeConfig
 					);
 					setSubRegistry( newRegistry );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -49,6 +49,7 @@ import { useBlockEditContext } from '../block-edit';
 import { RemoveBrowserShortcuts } from './remove-browser-shortcuts';
 import { filePasteHandler } from './file-paste-handler';
 import FormatToolbarContainer from './format-toolbar-container';
+import { store as blockEditorStore } from '../../store';
 
 const wrapperClasses = 'block-editor-rich-text';
 const classes = 'block-editor-rich-text__editable';
@@ -169,7 +170,7 @@ function RichTextWrapper(
 			__unstableGetBlockWithoutInnerBlocks,
 			isMultiSelecting,
 			hasMultiSelection,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
@@ -229,7 +230,7 @@ function RichTextWrapper(
 		exitFormattedText,
 		selectionChange,
 		__unstableMarkAutomaticChange,
-	} = useDispatch( 'core/block-editor' );
+	} = useDispatch( blockEditorStore );
 	const multilineTag = getMultilineTag( multiline );
 	const adjustedAllowedFormats = getAllowedFormats( {
 		allowedFormats,

--- a/packages/block-editor/src/components/skip-to-selected-block/index.js
+++ b/packages/block-editor/src/components/skip-to-selected-block/index.js
@@ -9,6 +9,7 @@ import { Button } from '@wordpress/components';
  * Internal dependencies
  */
 import { getBlockDOMNode } from '../../utils/dom';
+import { store as blockEditorStore } from '../../store';
 
 const SkipToSelectedBlock = ( { selectedBlockClientId } ) => {
 	const onClick = () => {
@@ -33,7 +34,7 @@ const SkipToSelectedBlock = ( { selectedBlockClientId } ) => {
 export default withSelect( ( select ) => {
 	return {
 		selectedBlockClientId: select(
-			'core/block-editor'
+			blockEditorStore
 		).getBlockSelectionStart(),
 	};
 } )( SkipToSelectedBlock );

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -14,6 +14,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
 import { Icon, edit as editIcon } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 const selectIcon = (
 	<SVG
 		xmlns="http://www.w3.org/2000/svg"
@@ -27,10 +32,10 @@ const selectIcon = (
 
 function ToolSelector( props, ref ) {
 	const isNavigationTool = useSelect(
-		( select ) => select( 'core/block-editor' ).isNavigationMode(),
+		( select ) => select( blockEditorStore ).isNavigationMode(),
 		[]
 	);
-	const { setNavigationMode } = useDispatch( 'core/block-editor' );
+	const { setNavigationMode } = useDispatch( blockEditorStore );
 
 	const onSwitchMode = ( mode ) => {
 		setNavigationMode( mode === 'edit' ? false : true );

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -6,13 +6,18 @@ import { computeCaretRect, getScrollContainer } from '@wordpress/dom';
 import { useSelect } from '@wordpress/data';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 const isIE = window.navigator.userAgent.indexOf( 'Trident' ) !== -1;
 const arrowKeyCodes = new Set( [ UP, DOWN, LEFT, RIGHT ] );
 const initialTriggerPercentage = 0.75;
 
 export function useTypewriter( ref ) {
 	const hasSelectedBlock = useSelect( ( select ) =>
-		select( 'core/block-editor' ).hasSelectedBlock()
+		select( blockEditorStore ).hasSelectedBlock()
 	);
 
 	useEffect( () => {

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -16,6 +16,7 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import UngroupIcon from './icon';
+import { store as blockEditorStore } from '../../store';
 
 export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 	if ( ! isUngroupable ) {
@@ -35,7 +36,7 @@ export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 export default compose( [
 	withSelect( ( select ) => {
 		const { getSelectedBlockClientId, getBlock } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 
 		const { getGroupingBlockName } = select( blocksStore );
@@ -59,7 +60,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, innerBlocks, onToggle = noop } ) => {
-		const { replaceBlocks } = dispatch( 'core/block-editor' );
+		const { replaceBlocks } = dispatch( blockEditorStore );
 
 		return {
 			onConvertFromGroup() {

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -16,7 +16,6 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import UngroupIcon from './icon';
-import { store as blockEditorStore } from '../../store';
 
 export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 	if ( ! isUngroupable ) {
@@ -36,7 +35,7 @@ export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 export default compose( [
 	withSelect( ( select ) => {
 		const { getSelectedBlockClientId, getBlock } = select(
-			blockEditorStore
+			'core/block-editor'
 		);
 
 		const { getGroupingBlockName } = select( blocksStore );
@@ -60,7 +59,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, innerBlocks, onToggle = noop } ) => {
-		const { replaceBlocks } = dispatch( blockEditorStore );
+		const { replaceBlocks } = dispatch( 'core/block-editor' );
 
 		return {
 			onConvertFromGroup() {

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -22,6 +22,11 @@ import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { isURL } from '@wordpress/url';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 class URLInput extends Component {
 	constructor( props ) {
 		super( props );
@@ -550,7 +555,7 @@ export default compose(
 		if ( isFunction( props.__experimentalFetchLinkSuggestions ) ) {
 			return;
 		}
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return {
 			__experimentalFetchLinkSuggestions: getSettings()
 				.__experimentalFetchLinkSuggestions,

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -10,6 +10,7 @@ import { useEffect, useState } from '@wordpress/element';
  */
 import useOnBlockDrop from '../use-on-block-drop';
 import { getDistanceToNearestEdge } from '../../utils/math';
+import { store as blockEditorStore } from '../../store';
 
 /** @typedef {import('../../utils/math').WPPoint} WPPoint */
 
@@ -101,7 +102,7 @@ export default function useBlockDropZone( {
 	const { isLockedAll, orientation } = useSelect(
 		( select ) => {
 			const { getBlockListSettings, getTemplateLock } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 			return {
 				isLockedAll: getTemplateLock( targetRootClientId ) === 'all',

--- a/packages/block-editor/src/components/use-display-block-controls/index.js
+++ b/packages/block-editor/src/components/use-display-block-controls/index.js
@@ -7,6 +7,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { useBlockEditContext } from '../block-edit/context';
+import { store as blockEditorStore } from '../../store';
 
 export default function useDisplayBlockControls() {
 	const { isSelected, clientId, name } = useBlockEditContext();
@@ -21,7 +22,7 @@ export default function useDisplayBlockControls() {
 				getBlockName,
 				isFirstMultiSelectedBlock,
 				getMultiSelectedBlockClientIds,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 
 			if ( ! isFirstMultiSelectedBlock( clientId ) ) {
 				return false;

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -13,6 +13,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { useBlockEditContext } from '../block-edit';
+import { store as blockEditorStore } from '../../store';
 
 const deprecatedFlags = {
 	'color.palette': ( settings ) =>
@@ -77,7 +78,7 @@ export default function useEditorFeature( featurePath ) {
 	const setting = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 			const settings = getSettings();
 			const blockType = select( blocksStore ).getBlockType( blockName );

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -8,6 +8,11 @@ import {
 } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
 /**
@@ -211,7 +216,7 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 			getBlockIndex: _getBlockIndex,
 			getClientIdsOfDescendants: _getClientIdsOfDescendants,
 			getSettings,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		return {
 			canInsertBlockType: _canInsertBlockType,
@@ -226,7 +231,7 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 		moveBlocksToPosition,
 		updateBlockAttributes,
 		clearSelectedBlock,
-	} = useDispatch( 'core/block-editor' );
+	} = useDispatch( blockEditorStore );
 
 	return {
 		onDrop: onBlockDrop(

--- a/packages/block-editor/src/components/writing-flow/focus-capture.js
+++ b/packages/block-editor/src/components/writing-flow/focus-capture.js
@@ -14,6 +14,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { getBlockDOMNode } from '../../utils/dom';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Renders focus capturing areas to redirect focus to the selected block if not
@@ -43,9 +44,9 @@ const FocusCapture = forwardRef(
 		ref
 	) => {
 		const isNavigationMode = useSelect( ( select ) =>
-			select( 'core/block-editor' ).isNavigationMode()
+			select( blockEditorStore ).isNavigationMode()
 		);
-		const { setNavigationMode } = useDispatch( 'core/block-editor' );
+		const { setNavigationMode } = useDispatch( blockEditorStore );
 
 		function onFocus() {
 			// Do not capture incoming focus if set by us in WritingFlow.

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -43,6 +43,7 @@ import {
 } from '../../utils/dom';
 import FocusCapture from './focus-capture';
 import useMultiSelection from './use-multi-selection';
+import { store as blockEditorStore } from '../../store';
 
 export const SelectionStart = createContext();
 
@@ -195,7 +196,7 @@ function selector( select ) {
 		getBlockSelectionStart,
 		isMultiSelecting,
 		getSettings,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 
 	const selectedBlockClientId = getSelectedBlockClientId();
 	const selectionStartClientId = getMultiSelectedBlocksStartClientId();
@@ -267,7 +268,7 @@ export default function WritingFlow( { children } ) {
 		keepCaretInsideBlock,
 	} = useSelect( selector, [] );
 	const { multiSelect, selectBlock, setNavigationMode } = useDispatch(
-		'core/block-editor'
+		blockEditorStore
 	);
 
 	function onMouseDown( event ) {

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -8,6 +8,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { getBlockClientId, getBlockDOMNode } from '../../utils/dom';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Returns for the deepest node at the start or end of a container node. Ignores
@@ -43,7 +44,7 @@ function selector( select ) {
 		hasMultiSelection,
 		getBlockParents,
 		getSelectedBlockClientId,
-	} = select( 'core/block-editor' );
+	} = select( blockEditorStore );
 
 	return {
 		isSelectionEnabled: isSelectionEnabled(),
@@ -81,7 +82,7 @@ export default function useMultiSelection( ref ) {
 		stopMultiSelect,
 		multiSelect,
 		selectBlock,
-	} = useDispatch( 'core/block-editor' );
+	} = useDispatch( blockEditorStore );
 	const rafId = useRef();
 	const startClientId = useRef();
 	const anchorElement = useRef();

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -20,6 +20,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { BlockControls, BlockAlignmentToolbar } from '../components';
+import { store as blockEditorStore } from '../store';
 
 /**
  * An array which includes all possible valid alignments,
@@ -162,8 +163,7 @@ export const withDataAlign = createHigherOrderComponent(
 		const { name, attributes } = props;
 		const { align } = attributes;
 		const hasWideEnabled = useSelect(
-			( select ) =>
-				!! select( 'core/block-editor' ).getSettings().alignWide,
+			( select ) => !! select( blockEditorStore ).getSettings().alignWide,
 			[]
 		);
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -25,6 +25,7 @@ import { create, insert, remove, toHTMLString } from '@wordpress/rich-text';
  * Internal dependencies
  */
 import { __unstableMarkAutomaticChangeFinalControl } from '../store/controls';
+import { STORE_NAME as blockEditorStoreName } from './constants';
 
 /**
  * Generator which will yield a default block insert action if there
@@ -33,7 +34,10 @@ import { __unstableMarkAutomaticChangeFinalControl } from '../store/controls';
  * replacement, etc).
  */
 function* ensureDefaultBlock() {
-	const count = yield controls.select( 'core/block-editor', 'getBlockCount' );
+	const count = yield controls.select(
+		blockEditorStoreName,
+		'getBlockCount'
+	);
 
 	// To avoid a focus loss when removing the last block, assure there is
 	// always a default block if the last of the blocks have been removed.
@@ -67,11 +71,11 @@ export function* resetBlocks( blocks ) {
  */
 export function* validateBlocksToTemplate( blocks ) {
 	const template = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getTemplate'
 	);
 	const templateLock = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getTemplateLock'
 	);
 
@@ -84,7 +88,7 @@ export function* validateBlocksToTemplate( blocks ) {
 
 	// Update if validity has changed.
 	const isValidTemplate = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'isValidTemplate'
 	);
 
@@ -200,7 +204,7 @@ export function selectBlock( clientId, initialPosition = null ) {
  */
 export function* selectPreviousBlock( clientId ) {
 	const previousBlockClientId = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getPreviousBlockClientId',
 		clientId
 	);
@@ -219,7 +223,7 @@ export function* selectPreviousBlock( clientId ) {
  */
 export function* selectNextBlock( clientId ) {
 	const nextBlockClientId = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getNextBlockClientId',
 		clientId
 	);
@@ -266,7 +270,7 @@ export function* multiSelect( start, end ) {
 	};
 
 	const blockCount = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getSelectedBlockCount'
 	);
 
@@ -358,10 +362,10 @@ export function* replaceBlocks(
 	clientIds = castArray( clientIds );
 	blocks = getBlocksWithDefaultStylesApplied(
 		castArray( blocks ),
-		yield controls.select( 'core/block-editor', 'getSettings' )
+		yield controls.select( blockEditorStoreName, 'getSettings' )
 	);
 	const rootClientId = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlockRootClientId',
 		first( clientIds )
 	);
@@ -369,7 +373,7 @@ export function* replaceBlocks(
 	for ( let index = 0; index < blocks.length; index++ ) {
 		const block = blocks[ index ];
 		const canInsertBlock = yield controls.select(
-			'core/block-editor',
+			blockEditorStoreName,
 			'canInsertBlockType',
 			block.name,
 			rootClientId
@@ -442,7 +446,7 @@ export function* moveBlocksToPosition(
 	index
 ) {
 	const templateLock = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getTemplateLock',
 		fromRootClientId
 	);
@@ -475,7 +479,7 @@ export function* moveBlocksToPosition(
 	}
 
 	const canInsertBlocks = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'canInsertBlocks',
 		clientIds,
 		toRootClientId
@@ -553,12 +557,12 @@ export function* insertBlocks(
 ) {
 	blocks = getBlocksWithDefaultStylesApplied(
 		castArray( blocks ),
-		yield controls.select( 'core/block-editor', 'getSettings' )
+		yield controls.select( blockEditorStoreName, 'getSettings' )
 	);
 	const allowedBlocks = [];
 	for ( const block of blocks ) {
 		const isValid = yield controls.select(
-			'core/block-editor',
+			blockEditorStoreName,
 			'canInsertBlockType',
 			block.name,
 			rootClientId
@@ -654,9 +658,9 @@ export function* synchronizeTemplate() {
 	yield {
 		type: 'SYNCHRONIZE_TEMPLATE',
 	};
-	const blocks = yield controls.select( 'core/block-editor', 'getBlocks' );
+	const blocks = yield controls.select( blockEditorStoreName, 'getBlocks' );
 	const template = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getTemplate'
 	);
 	const updatedBlockList = synchronizeBlocksWithTemplate( blocks, template );
@@ -679,7 +683,7 @@ export function* mergeBlocks( firstBlockClientId, secondBlockClientId ) {
 
 	const [ clientIdA, clientIdB ] = blocks;
 	const blockA = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlock',
 		clientIdA
 	);
@@ -692,13 +696,13 @@ export function* mergeBlocks( firstBlockClientId, secondBlockClientId ) {
 	}
 
 	const blockB = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlock',
 		clientIdB
 	);
 	const blockBType = getBlockType( blockB.name );
 	const { clientId, attributeKey, offset } = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getSelectionStart'
 	);
 	const selectedBlockType = clientId === clientIdA ? blockAType : blockBType;
@@ -845,12 +849,12 @@ export function* removeBlocks( clientIds, selectPrevious = true ) {
 
 	clientIds = castArray( clientIds );
 	const rootClientId = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlockRootClientId',
 		clientIds[ 0 ]
 	);
 	const isLocked = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getTemplateLock',
 		rootClientId
 	);
@@ -863,7 +867,7 @@ export function* removeBlocks( clientIds, selectPrevious = true ) {
 		previousBlockId = yield selectPreviousBlock( clientIds[ 0 ] );
 	} else {
 		previousBlockId = yield controls.select(
-			'core/block-editor',
+			blockEditorStoreName,
 			'getPreviousBlockClientId',
 			clientIds[ 0 ]
 		);
@@ -1193,12 +1197,12 @@ export function* duplicateBlocks( clientIds, updateSelection = true ) {
 		return;
 	}
 	const blocks = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlocksByClientId',
 		clientIds
 	);
 	const rootClientId = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlockRootClientId',
 		clientIds[ 0 ]
 	);
@@ -1218,7 +1222,7 @@ export function* duplicateBlocks( clientIds, updateSelection = true ) {
 	}
 
 	const lastSelectedIndex = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlockIndex',
 		last( castArray( clientIds ) ),
 		rootClientId
@@ -1249,12 +1253,12 @@ export function* insertBeforeBlock( clientId ) {
 		return;
 	}
 	const rootClientId = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlockRootClientId',
 		clientId
 	);
 	const isLocked = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getTemplateLock',
 		rootClientId
 	);
@@ -1263,7 +1267,7 @@ export function* insertBeforeBlock( clientId ) {
 	}
 
 	const firstSelectedIndex = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlockIndex',
 		clientId,
 		rootClientId
@@ -1281,12 +1285,12 @@ export function* insertAfterBlock( clientId ) {
 		return;
 	}
 	const rootClientId = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlockRootClientId',
 		clientId
 	);
 	const isLocked = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getTemplateLock',
 		rootClientId
 	);
@@ -1295,7 +1299,7 @@ export function* insertAfterBlock( clientId ) {
 	}
 
 	const firstSelectedIndex = yield controls.select(
-		'core/block-editor',
+		blockEditorStoreName,
 		'getBlockIndex',
 		clientId,
 		rootClientId

--- a/packages/block-editor/src/store/constants.js
+++ b/packages/block-editor/src/store/constants.js
@@ -1,0 +1,1 @@
+export const STORE_NAME = 'core/block-editor';

--- a/packages/block-editor/src/store/controls.js
+++ b/packages/block-editor/src/store/controls.js
@@ -3,6 +3,11 @@
  */
 import { createRegistryControl } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../store';
+
 export const __unstableMarkAutomaticChangeFinalControl = function () {
 	return {
 		type: 'MARK_AUTOMATIC_CHANGE_FINAL_CONTROL',
@@ -24,7 +29,7 @@ const controls = {
 			} = window;
 			requestIdleCallback( () =>
 				registry
-					.dispatch( 'core/block-editor' )
+					.dispatch( blockEditorStore )
 					.__unstableMarkAutomaticChangeFinal()
 			);
 		}

--- a/packages/block-editor/src/store/index.js
+++ b/packages/block-editor/src/store/index.js
@@ -10,11 +10,7 @@ import reducer from './reducer';
 import * as selectors from './selectors';
 import * as actions from './actions';
 import controls from './controls';
-
-/**
- * Module Constants
- */
-const STORE_NAME = 'core/block-editor';
+import { STORE_NAME } from './constants';
 
 /**
  * Block editor data store configuration.

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -22,7 +22,7 @@ import {
 import * as selectors from '../selectors';
 import reducer from '../reducer';
 import * as actions from '../actions';
-import '../..';
+import { store as blockEditorStore } from '../../store';
 
 const {
 	clearSelectedBlock,
@@ -180,7 +180,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getBlockRootClientId',
 					'chicken'
 				)
@@ -188,7 +188,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-block',
 					undefined
@@ -203,7 +203,7 @@ describe( 'actions', () => {
 			} );
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
-				controls.select( 'core/block-editor', 'getBlockCount' )
+				controls.select( blockEditorStore, 'getBlockCount' )
 			);
 
 			expect( replaceBlockGenerator.next( 1 ) ).toEqual( {
@@ -232,12 +232,12 @@ describe( 'actions', () => {
 			);
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
-				controls.select( 'core/block-editor', 'getSettings' )
+				controls.select( blockEditorStore, 'getSettings' )
 			);
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getBlockRootClientId',
 					'chicken'
 				)
@@ -245,7 +245,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-ribs',
 					undefined
@@ -254,7 +254,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next( true ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken',
 					undefined
@@ -289,7 +289,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getBlockRootClientId',
 					'chicken'
 				)
@@ -297,7 +297,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-ribs',
 					undefined
@@ -306,7 +306,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next( true ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken',
 					undefined
@@ -321,7 +321,7 @@ describe( 'actions', () => {
 			} );
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
-				controls.select( 'core/block-editor', 'getBlockCount' )
+				controls.select( blockEditorStore, 'getBlockCount' )
 			);
 
 			expect( replaceBlockGenerator.next( 1 ) ).toEqual( {
@@ -390,7 +390,7 @@ describe( 'actions', () => {
 
 			expect( insertBlockGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-block',
 					'testclientid'
@@ -435,7 +435,7 @@ describe( 'actions', () => {
 			);
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
-				controls.select( 'core/block-editor', 'getSettings' )
+				controls.select( blockEditorStore, 'getSettings' )
 			);
 
 			expect(
@@ -449,7 +449,7 @@ describe( 'actions', () => {
 				} ).value
 			).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -458,7 +458,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( true ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken',
 					'testrootid'
@@ -467,7 +467,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( true ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken-ribs',
 					'testrootid'
@@ -515,7 +515,7 @@ describe( 'actions', () => {
 			);
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
-				controls.select( 'core/block-editor', 'getSettings' )
+				controls.select( blockEditorStore, 'getSettings' )
 			);
 
 			expect(
@@ -528,7 +528,7 @@ describe( 'actions', () => {
 				} ).value
 			).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -579,7 +579,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -588,7 +588,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( true ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken',
 					'testrootid'
@@ -597,7 +597,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( false ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken-ribs',
 					'testrootid'
@@ -640,7 +640,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -649,7 +649,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( false ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken',
 					'testrootid'
@@ -691,7 +691,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -700,7 +700,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( true ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken',
 					'testrootid'
@@ -709,7 +709,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( false ).value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlockType',
 					'core/test-chicken-ribs',
 					'testrootid'
@@ -776,12 +776,12 @@ describe( 'actions', () => {
 
 			expect( result ).toEqual( [
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getBlockRootClientId',
 					clientId
 				),
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getTemplateLock',
 					undefined
 				),
@@ -790,7 +790,7 @@ describe( 'actions', () => {
 					type: 'REMOVE_BLOCKS',
 					clientIds,
 				},
-				controls.select( 'core/block-editor', 'getBlockCount' ),
+				controls.select( blockEditorStore, 'getBlockCount' ),
 			] );
 		} );
 	} );
@@ -805,11 +805,7 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select(
-					'core/block-editor',
-					'getTemplateLock',
-					'ribs'
-				)
+				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
 			);
 
 			expect(
@@ -834,11 +830,7 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select(
-					'core/block-editor',
-					'getTemplateLock',
-					'ribs'
-				)
+				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
 			);
 
 			expect( moveBlockToPositionGenerator.next( 'all' ) ).toEqual( {
@@ -856,11 +848,7 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select(
-					'core/block-editor',
-					'getTemplateLock',
-					'ribs'
-				)
+				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
 			);
 
 			expect( moveBlockToPositionGenerator.next( 'insert' ) ).toEqual( {
@@ -878,16 +866,12 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select(
-					'core/block-editor',
-					'getTemplateLock',
-					'ribs'
-				)
+				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlocks',
 					[ 'chicken' ],
 					'chicken-ribs'
@@ -917,16 +901,12 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select(
-					'core/block-editor',
-					'getTemplateLock',
-					'ribs'
-				)
+				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'canInsertBlocks',
 					[ 'chicken' ],
 					'chicken-ribs'
@@ -950,11 +930,7 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select(
-					'core/block-editor',
-					'getTemplateLock',
-					'ribs'
-				)
+				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual( {
@@ -977,12 +953,12 @@ describe( 'actions', () => {
 
 			expect( result ).toEqual( [
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getBlockRootClientId',
 					clientId
 				),
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getTemplateLock',
 					undefined
 				),
@@ -991,7 +967,7 @@ describe( 'actions', () => {
 					type: 'REMOVE_BLOCKS',
 					clientIds: [ clientId ],
 				},
-				controls.select( 'core/block-editor', 'getBlockCount' ),
+				controls.select( blockEditorStore, 'getBlockCount' ),
 			] );
 		} );
 
@@ -1002,17 +978,17 @@ describe( 'actions', () => {
 
 			expect( result ).toEqual( [
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getBlockRootClientId',
 					clientId
 				),
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getTemplateLock',
 					undefined
 				),
 				controls.select(
-					'core/block-editor',
+					blockEditorStore,
 					'getPreviousBlockClientId',
 					'myclientid'
 				),
@@ -1020,7 +996,7 @@ describe( 'actions', () => {
 					type: 'REMOVE_BLOCKS',
 					clientIds: [ clientId ],
 				},
-				controls.select( 'core/block-editor', 'getBlockCount' ),
+				controls.select( blockEditorStore, 'getBlockCount' ),
 			] );
 		} );
 	} );
@@ -1310,7 +1286,7 @@ describe( 'actions', () => {
 			expect( fulfillment.next( blockB ).value ).toEqual( {
 				args: [],
 				selectorName: 'getSelectionStart',
-				storeKey: 'core/block-editor',
+				storeKey: blockEditorStore,
 				type: '@@data/SELECT',
 			} );
 			// getSelectionStart
@@ -1388,7 +1364,7 @@ describe( 'actions', () => {
 			expect( fulfillment.next( blockB ).value ).toEqual( {
 				args: [],
 				selectorName: 'getSelectionStart',
-				storeKey: 'core/block-editor',
+				storeKey: blockEditorStore,
 				type: '@@data/SELECT',
 			} );
 			expect(
@@ -1426,7 +1402,7 @@ describe( 'actions', () => {
 	describe( 'validateBlocksToTemplate', () => {
 		let store;
 		beforeEach( () => {
-			store = createRegistry().registerStore( 'core/block-editor', {
+			store = createRegistry().registerStore( blockEditorStore, {
 				actions,
 				selectors,
 				reducer,

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -22,7 +22,7 @@ import {
 import * as selectors from '../selectors';
 import reducer from '../reducer';
 import * as actions from '../actions';
-import { store as blockEditorStore } from '../../store';
+import { STORE_NAME as blockEditorStoreName } from '../../store/constants';
 
 const {
 	clearSelectedBlock,
@@ -180,7 +180,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getBlockRootClientId',
 					'chicken'
 				)
@@ -188,7 +188,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-block',
 					undefined
@@ -203,7 +203,7 @@ describe( 'actions', () => {
 			} );
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getBlockCount' )
+				controls.select( blockEditorStoreName, 'getBlockCount' )
 			);
 
 			expect( replaceBlockGenerator.next( 1 ) ).toEqual( {
@@ -232,12 +232,12 @@ describe( 'actions', () => {
 			);
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getSettings' )
+				controls.select( blockEditorStoreName, 'getSettings' )
 			);
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getBlockRootClientId',
 					'chicken'
 				)
@@ -245,7 +245,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-ribs',
 					undefined
@@ -254,7 +254,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next( true ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken',
 					undefined
@@ -289,7 +289,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getBlockRootClientId',
 					'chicken'
 				)
@@ -297,7 +297,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-ribs',
 					undefined
@@ -306,7 +306,7 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next( true ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken',
 					undefined
@@ -321,7 +321,7 @@ describe( 'actions', () => {
 			} );
 
 			expect( replaceBlockGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getBlockCount' )
+				controls.select( blockEditorStoreName, 'getBlockCount' )
 			);
 
 			expect( replaceBlockGenerator.next( 1 ) ).toEqual( {
@@ -390,7 +390,7 @@ describe( 'actions', () => {
 
 			expect( insertBlockGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-block',
 					'testclientid'
@@ -435,7 +435,7 @@ describe( 'actions', () => {
 			);
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getSettings' )
+				controls.select( blockEditorStoreName, 'getSettings' )
 			);
 
 			expect(
@@ -449,7 +449,7 @@ describe( 'actions', () => {
 				} ).value
 			).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -458,7 +458,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( true ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken',
 					'testrootid'
@@ -467,7 +467,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( true ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken-ribs',
 					'testrootid'
@@ -515,7 +515,7 @@ describe( 'actions', () => {
 			);
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getSettings' )
+				controls.select( blockEditorStoreName, 'getSettings' )
 			);
 
 			expect(
@@ -528,7 +528,7 @@ describe( 'actions', () => {
 				} ).value
 			).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -579,7 +579,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -588,7 +588,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( true ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken',
 					'testrootid'
@@ -597,7 +597,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( false ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken-ribs',
 					'testrootid'
@@ -640,7 +640,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -649,7 +649,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( false ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken',
 					'testrootid'
@@ -691,7 +691,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-ribs',
 					'testrootid'
@@ -700,7 +700,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( true ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken',
 					'testrootid'
@@ -709,7 +709,7 @@ describe( 'actions', () => {
 
 			expect( insertBlocksGenerator.next( false ).value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlockType',
 					'core/test-chicken-ribs',
 					'testrootid'
@@ -776,12 +776,12 @@ describe( 'actions', () => {
 
 			expect( result ).toEqual( [
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getBlockRootClientId',
 					clientId
 				),
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getTemplateLock',
 					undefined
 				),
@@ -790,7 +790,7 @@ describe( 'actions', () => {
 					type: 'REMOVE_BLOCKS',
 					clientIds,
 				},
-				controls.select( blockEditorStore, 'getBlockCount' ),
+				controls.select( blockEditorStoreName, 'getBlockCount' ),
 			] );
 		} );
 	} );
@@ -805,7 +805,11 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
+				controls.select(
+					blockEditorStoreName,
+					'getTemplateLock',
+					'ribs'
+				)
 			);
 
 			expect(
@@ -830,7 +834,11 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
+				controls.select(
+					blockEditorStoreName,
+					'getTemplateLock',
+					'ribs'
+				)
 			);
 
 			expect( moveBlockToPositionGenerator.next( 'all' ) ).toEqual( {
@@ -848,7 +856,11 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
+				controls.select(
+					blockEditorStoreName,
+					'getTemplateLock',
+					'ribs'
+				)
 			);
 
 			expect( moveBlockToPositionGenerator.next( 'insert' ) ).toEqual( {
@@ -866,12 +878,16 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
+				controls.select(
+					blockEditorStoreName,
+					'getTemplateLock',
+					'ribs'
+				)
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlocks',
 					[ 'chicken' ],
 					'chicken-ribs'
@@ -901,12 +917,16 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
+				controls.select(
+					blockEditorStoreName,
+					'getTemplateLock',
+					'ribs'
+				)
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'canInsertBlocks',
 					[ 'chicken' ],
 					'chicken-ribs'
@@ -930,7 +950,11 @@ describe( 'actions', () => {
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual(
-				controls.select( blockEditorStore, 'getTemplateLock', 'ribs' )
+				controls.select(
+					blockEditorStoreName,
+					'getTemplateLock',
+					'ribs'
+				)
 			);
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual( {
@@ -953,12 +977,12 @@ describe( 'actions', () => {
 
 			expect( result ).toEqual( [
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getBlockRootClientId',
 					clientId
 				),
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getTemplateLock',
 					undefined
 				),
@@ -967,7 +991,7 @@ describe( 'actions', () => {
 					type: 'REMOVE_BLOCKS',
 					clientIds: [ clientId ],
 				},
-				controls.select( blockEditorStore, 'getBlockCount' ),
+				controls.select( blockEditorStoreName, 'getBlockCount' ),
 			] );
 		} );
 
@@ -978,17 +1002,17 @@ describe( 'actions', () => {
 
 			expect( result ).toEqual( [
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getBlockRootClientId',
 					clientId
 				),
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getTemplateLock',
 					undefined
 				),
 				controls.select(
-					blockEditorStore,
+					blockEditorStoreName,
 					'getPreviousBlockClientId',
 					'myclientid'
 				),
@@ -996,7 +1020,7 @@ describe( 'actions', () => {
 					type: 'REMOVE_BLOCKS',
 					clientIds: [ clientId ],
 				},
-				controls.select( blockEditorStore, 'getBlockCount' ),
+				controls.select( blockEditorStoreName, 'getBlockCount' ),
 			] );
 		} );
 	} );
@@ -1286,7 +1310,7 @@ describe( 'actions', () => {
 			expect( fulfillment.next( blockB ).value ).toEqual( {
 				args: [],
 				selectorName: 'getSelectionStart',
-				storeKey: blockEditorStore,
+				storeKey: blockEditorStoreName,
 				type: '@@data/SELECT',
 			} );
 			// getSelectionStart
@@ -1364,7 +1388,7 @@ describe( 'actions', () => {
 			expect( fulfillment.next( blockB ).value ).toEqual( {
 				args: [],
 				selectorName: 'getSelectionStart',
-				storeKey: blockEditorStore,
+				storeKey: blockEditorStoreName,
 				type: '@@data/SELECT',
 			} );
 			expect(
@@ -1402,7 +1426,7 @@ describe( 'actions', () => {
 	describe( 'validateBlocksToTemplate', () => {
 		let store;
 		beforeEach( () => {
-			store = createRegistry().registerStore( blockEditorStore, {
+			store = createRegistry().registerStore( blockEditorStoreName, {
 				actions,
 				selectors,
 				reducer,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related to https://github.com/WordPress/gutenberg/issues/27088
Replace hardcoded store names with their store object.
## How has this been tested?
Make sure tests are passing. Smoke test.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
