### PR TITLE
Add mechanism to translate custom page templates

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -118,16 +118,19 @@ class WP_Theme_JSON_Resolver {
 	private static function extract_paths_to_translate( $i18n_partial, $current_path = array() ) {
 		$result = array();
 		foreach ( $i18n_partial as $property => $partial_child ) {
-			if ( is_numeric( $property ) ) {
-				foreach ( $partial_child as $key => $context ) {
-					return array(
-						array(
-							'path'    => $current_path,
-							'key'     => $key,
-							'context' => $context,
-						),
-					);
-				}
+			if (
+				is_array( $partial_child ) &&
+				array_key_exists( 'key', $partial_child ) &&
+				array_key_exists( 'context', $partial_child )
+			) {
+				$last_key = is_numeric( $property ) ? '*' : $property;
+				return array(
+					array(
+						'path'    => array_merge( $current_path, [ $last_key ] ),
+						'key'     => $partial_child['key'],
+						'context' => $partial_child['context'],
+					),
+				);
 			}
 			$result = array_merge(
 				$result,

--- a/lib/experimental-i18n-theme.json
+++ b/lib/experimental-i18n-theme.json
@@ -14,5 +14,8 @@
 				"gradients": [ { "name": "Gradient name" } ]
 			}
 		}
+	},
+	"customTemplates": {
+		"*": { "title": "Title of the CPT" }
 	}
 }

--- a/lib/experimental-i18n-theme.json
+++ b/lib/experimental-i18n-theme.json
@@ -2,20 +2,23 @@
 	"settings": {
 		"*": {
 			"typography": {
-				"fontSizes": [ { "name": "Font size name" } ],
-				"fontStyles": [ { "name": "Font style name" } ],
-				"fontWeights": [ { "name": "Font weight name" } ],
-				"fontFamilies": [ { "name": "Font family name" } ],
-				"textTransforms": [ { "name": "Text transform name" } ],
-				"textDecorations": [ { "name": "Text decoration name" } ]
+				"fontSizes": [ { "key": "name", "context": "Font size name" } ],
+				"fontStyles": [ { "key": "name", "context": "Font style name" } ],
+				"fontWeights": [ { "key": "name", "context": "Font weight name" } ],
+				"fontFamilies": [ { "key": "name", "context": "Font family name" } ],
+				"textTransforms": [ { "key": "name", "context": "Text transform name" } ],
+				"textDecorations": [ { "key": "name", "context": "Text decoration name" } ]
 			},
 			"color": {
-				"palette": [ { "name": "Color name" } ],
-				"gradients": [ { "name": "Gradient name" } ]
+				"palette": [ { "key": "name", "context": "Color name" } ],
+				"gradients": [ { "key": "name", "context": "Gradient name" } ]
 			}
 		}
 	},
 	"customTemplates": {
-		"*": [ { "title": "Title of the custom template" } ]
+		"*": {
+			"key": "title",
+			"context": "Title of the custom template"
+		}
 	}
 }

--- a/lib/experimental-i18n-theme.json
+++ b/lib/experimental-i18n-theme.json
@@ -16,6 +16,6 @@
 		}
 	},
 	"customTemplates": {
-		"*": { "title": "Title of the CPT" }
+		"*": [ { "title": "Title of the custom template" } ]
 	}
 }

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -13,42 +13,42 @@ class WP_Theme_JSON_Resolver_Test extends WP_UnitTestCase {
 
 		$expected = array(
 			array(
-				'path'    => array( 'settings', '*', 'typography', 'fontSizes' ),
+				'path'    => array( 'settings', '*', 'typography', 'fontSizes', '*' ),
 				'key'     => 'name',
 				'context' => 'Font size name',
 			),
 			array(
-				'path'    => array( 'settings', '*', 'typography', 'fontStyles' ),
+				'path'    => array( 'settings', '*', 'typography', 'fontStyles', '*' ),
 				'key'     => 'name',
 				'context' => 'Font style name',
 			),
 			array(
-				'path'    => array( 'settings', '*', 'typography', 'fontWeights' ),
+				'path'    => array( 'settings', '*', 'typography', 'fontWeights', '*' ),
 				'key'     => 'name',
 				'context' => 'Font weight name',
 			),
 			array(
-				'path'    => array( 'settings', '*', 'typography', 'fontFamilies' ),
+				'path'    => array( 'settings', '*', 'typography', 'fontFamilies', '*' ),
 				'key'     => 'name',
 				'context' => 'Font family name',
 			),
 			array(
-				'path'    => array( 'settings', '*', 'typography', 'textTransforms' ),
+				'path'    => array( 'settings', '*', 'typography', 'textTransforms', '*' ),
 				'key'     => 'name',
 				'context' => 'Text transform name',
 			),
 			array(
-				'path'    => array( 'settings', '*', 'typography', 'textDecorations' ),
+				'path'    => array( 'settings', '*', 'typography', 'textDecorations', '*' ),
 				'key'     => 'name',
 				'context' => 'Text decoration name',
 			),
 			array(
-				'path'    => array( 'settings', '*', 'color', 'palette' ),
+				'path'    => array( 'settings', '*', 'color', 'palette', '*' ),
 				'key'     => 'name',
 				'context' => 'Color name',
 			),
 			array(
-				'path'    => array( 'settings', '*', 'color', 'gradients' ),
+				'path'    => array( 'settings', '*', 'color', 'gradients', '*' ),
 				'key'     => 'name',
 				'context' => 'Gradient name',
 			),

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -52,6 +52,11 @@ class WP_Theme_JSON_Resolver_Test extends WP_UnitTestCase {
 				'key'     => 'name',
 				'context' => 'Gradient name',
 			),
+			array(
+				'path'    => array( 'customTemplates', '*' ),
+				'key'     => 'title',
+				'context' => 'Title of the custom template',
+			),
 		);
 
 		$this->assertEquals( $expected, $actual );


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/27778 introduced a new field in the `theme.json` file, the `pageTemplates` to declare custom page templates to be shown to the user in places like:

![Captura de ecrã de 2021-02-04 14-21-55](https://user-images.githubusercontent.com/583546/106898345-5cce2800-66f4-11eb-8d88-5ee1f20df17f.png)

https://github.com/WordPress/gutenberg/pull/28700 integrated the processing of that field into the `WP_Theme_JSON` / `WP_Theme_JSON_Resolver` classes. This is the next step of that integration: make it translatable.

Changes:

- [x] Added a new in `experimental-i18n-theme.json`, so wp-cli can understand what needs to be translated.
- [ ] Update `WP_Theme_JSON_Resolver` to retrieve the translated version of this field.
