### PR TITLE
i18n: add new APIs for React bindings

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Export the default `I18n` instance as `defaultI18n`, in addition to already exported bound methods.
+- Add new `getLocaleData` method to get the internal Tannin locale data object.
+- Add new `subscribe` method to subscribe to changes in the internal locale data.
+- Add new `hasTranslation` method to determine whether a translation for a string is available.
+
 ## 3.17.0 (2020-12-17)
 
 ### Enhancements

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -35,11 +35,45 @@ _Parameters_
 
 -   _initialData_ `[LocaleData]`: Locale data configuration.
 -   _initialDomain_ `[string]`: Domain for which configuration applies.
--   _hooks_ `[ApplyFiltersInterface]`: Hooks implementation.
+-   _hooks_ `[Hooks]`: Hooks implementation.
 
 _Returns_
 
 -   `I18n`: I18n instance
+
+<a name="defaultI18n" href="#defaultI18n">#</a> **defaultI18n**
+
+Default, singleton instance of `I18n`.
+
+<a name="getLocaleData" href="#getLocaleData">#</a> **getLocaleData**
+
+Returns locale data by domain in a Jed-formatted JSON object shape.
+
+_Related_
+
+-   <http://messageformat.github.io/Jed/>
+
+_Parameters_
+
+-   _domain_ `[string]`: Domain for which to get the data.
+
+_Returns_
+
+-   `LocaleData`: Locale data.
+
+<a name="hasTranslation" href="#hasTranslation">#</a> **hasTranslation**
+
+Check if there is a translation for a given string (in singular form).
+
+_Parameters_
+
+-   _single_ `string`: Singular form of the string to look up.
+-   _context_ `[string]`: Context information for the translators.
+-   _domain_ `[string]`: Domain to retrieve the translated text.
+
+_Returns_
+
+-   `boolean`: Whether the translation exists or not.
 
 <a name="isRTL" href="#isRTL">#</a> **isRTL**
 
@@ -85,6 +119,18 @@ _Parameters_
 _Returns_
 
 -   `string`: The formatted string.
+
+<a name="subscribe" href="#subscribe">#</a> **subscribe**
+
+Subscribes to changes of locale data
+
+_Parameters_
+
+-   _callback_ `SubscribeCallback`: Subscription callback
+
+_Returns_
+
+-   `UnsubscribeCallback`: Unsubscribe callback
 
 <a name="_n" href="#_n">#</a> **\_n**
 

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -24,9 +24,9 @@ const DEFAULT_LOCALE_DATA = {
 
 /*
  * Regular expression that matches i18n hooks like `i18n.gettext`, `i18n.ngettext`,
- * `i18n.gettext_domain` or `i18n.ngettext_with_context`
+ * `i18n.gettext_domain` or `i18n.ngettext_with_context` or `i18n.has_translation`.
  */
-const I18N_HOOK_REGEXP = /^i18n\.(n?)gettext(_|$)/;
+const I18N_HOOK_REGEXP = /^i18n\.(n?gettext|has_translation)(_|$)/;
 
 /**
  * @typedef {(domain?: string) => LocaleData} GetLocaleData

--- a/packages/i18n/src/default-i18n.js
+++ b/packages/i18n/src/default-i18n.js
@@ -1,14 +1,19 @@
 /**
- * WordPress dependencies
- */
-import { applyFilters } from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
 import { createI18n } from './create-i18n';
 
-const i18n = createI18n( undefined, undefined, { applyFilters } );
+/**
+ * WordPress dependencies
+ */
+import { defaultHooks } from '@wordpress/hooks';
+
+const i18n = createI18n( undefined, undefined, defaultHooks );
+
+/**
+ * Default, singleton instance of `I18n`.
+ */
+export default i18n;
 
 /*
  * Comments in this file are duplicated from ./i18n due to
@@ -17,7 +22,19 @@ const i18n = createI18n( undefined, undefined, { applyFilters } );
 
 /**
  * @typedef {import('./create-i18n').LocaleData} LocaleData
+ * @typedef {import('./create-i18n').SubscribeCallback} SubscribeCallback
+ * @typedef {import('./create-i18n').UnsubscribeCallback} UnsubscribeCallback
  */
+
+/**
+ * Returns locale data by domain in a Jed-formatted JSON object shape.
+ *
+ * @see http://messageformat.github.io/Jed/
+ *
+ * @param {string} [domain] Domain for which to get the data.
+ * @return {LocaleData} Locale data.
+ */
+export const getLocaleData = i18n.getLocaleData.bind( i18n );
 
 /**
  * Merges locale data into the Tannin instance by domain. Accepts data in a
@@ -29,6 +46,14 @@ const i18n = createI18n( undefined, undefined, { applyFilters } );
  * @param {string}     [domain] Domain for which configuration applies.
  */
 export const setLocaleData = i18n.setLocaleData.bind( i18n );
+
+/**
+ * Subscribes to changes of locale data
+ *
+ * @param {SubscribeCallback} callback Subscription callback
+ * @return {UnsubscribeCallback} Unsubscribe callback
+ */
+export const subscribe = i18n.subscribe.bind( i18n );
 
 /**
  * Retrieve the translation of text.
@@ -99,3 +124,13 @@ export const _nx = i18n._nx.bind( i18n );
  * @return {boolean} Whether locale is RTL.
  */
 export const isRTL = i18n.isRTL.bind( i18n );
+
+/**
+ * Check if there is a translation for a given string (in singular form).
+ *
+ * @param {string} single Singular form of the string to look up.
+ * @param {string} [context] Context information for the translators.
+ * @param {string} [domain] Domain to retrieve the translated text.
+ * @return {boolean} Whether the translation exists or not.
+ */
+export const hasTranslation = i18n.hasTranslation.bind( i18n );

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -1,3 +1,14 @@
 export { sprintf } from './sprintf';
 export * from './create-i18n';
-export { setLocaleData, __, _x, _n, _nx, isRTL } from './default-i18n';
+export {
+	default as defaultI18n,
+	setLocaleData,
+	getLocaleData,
+	subscribe,
+	__,
+	_x,
+	_n,
+	_nx,
+	isRTL,
+	hasTranslation,
+} from './default-i18n';

--- a/packages/i18n/src/test/create-i18n.js
+++ b/packages/i18n/src/test/create-i18n.js
@@ -1,6 +1,11 @@
 /* eslint-disable @wordpress/i18n-text-domain, @wordpress/i18n-translator-comments */
 
 /**
+ * WordPress dependencies
+ */
+import { createHooks } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import { createI18n } from '..';
@@ -192,61 +197,164 @@ describe( 'createI18n', () => {
 } );
 
 describe( 'i18n filters', () => {
+	function createHooksWithI18nFilters() {
+		const hooks = createHooks();
+		hooks.addFilter(
+			'i18n.gettext',
+			'test',
+			( translation ) => translation + '/i18n.gettext'
+		);
+		hooks.addFilter(
+			'i18n.gettext_default',
+			'test',
+			( translation ) => translation + '/i18n.gettext_default'
+		);
+		hooks.addFilter(
+			'i18n.gettext_domain',
+			'test',
+			( translation ) => translation + '/i18n.gettext_domain'
+		);
+
+		hooks.addFilter(
+			'i18n.ngettext',
+			'test',
+			( translation ) => translation + '/i18n.ngettext'
+		);
+		hooks.addFilter(
+			'i18n.ngettext_default',
+			'test',
+			( translation ) => translation + '/i18n.ngettext_default'
+		);
+		hooks.addFilter(
+			'i18n.ngettext_domain',
+			'test',
+			( translation ) => translation + '/i18n.ngettext_domain'
+		);
+
+		hooks.addFilter(
+			'i18n.gettext_with_context',
+			'test',
+			( translation, text, context ) =>
+				translation + `/i18n.gettext_with_${ context }`
+		);
+		hooks.addFilter(
+			'i18n.gettext_with_context_default',
+			'test',
+			( translation, text, context ) =>
+				translation + `/i18n.gettext_with_${ context }_default`
+		);
+		hooks.addFilter(
+			'i18n.gettext_with_context_domain',
+			'test',
+			( translation, text, context ) =>
+				translation + `/i18n.gettext_with_${ context }_domain`
+		);
+
+		hooks.addFilter(
+			'i18n.ngettext_with_context',
+			'test',
+			( translation, single, plural, number, context ) =>
+				translation + `/i18n.ngettext_with_${ context }`
+		);
+		hooks.addFilter(
+			'i18n.ngettext_with_context_default',
+			'test',
+			( translation, single, plural, number, context ) =>
+				translation + `/i18n.ngettext_with_${ context }_default`
+		);
+		hooks.addFilter(
+			'i18n.ngettext_with_context_domain',
+			'test',
+			( translation, single, plural, number, context ) =>
+				translation + `/i18n.ngettext_with_${ context }_domain`
+		);
+		hooks.addFilter(
+			'i18n.has_translation',
+			'test',
+			( hasTranslation, single, context, domain ) => {
+				if (
+					single === 'Always' &&
+					! context &&
+					( domain ?? 'default' ) === 'default'
+				) {
+					return true;
+				}
+
+				return hasTranslation;
+			}
+		);
+		return hooks;
+	}
+
 	test( '__() calls filters', () => {
-		const i18n = createI18n( undefined, undefined, {
-			applyFilters: ( filter, translation ) => translation + filter,
-		} );
+		const hooks = createHooksWithI18nFilters();
+		const i18n = createI18n( undefined, undefined, hooks );
+
 		expect( i18n.__( 'hello' ) ).toEqual(
-			'helloi18n.gettexti18n.gettext_default'
+			'hello/i18n.gettext/i18n.gettext_default'
 		);
 		expect( i18n.__( 'hello', 'domain' ) ).toEqual(
-			'helloi18n.gettexti18n.gettext_domain'
+			'hello/i18n.gettext/i18n.gettext_domain'
 		);
 	} );
+
 	test( '_x() calls filters', () => {
-		const i18n = createI18n( undefined, undefined, {
-			applyFilters: ( filter, translation ) => translation + filter,
-		} );
-		expect( i18n._x( 'hello', 'context' ) ).toEqual(
-			'helloi18n.gettext_with_contexti18n.gettext_with_context_default'
+		const hooks = createHooksWithI18nFilters();
+		const i18n = createI18n( undefined, undefined, hooks );
+
+		expect( i18n._x( 'hello', 'ctx' ) ).toEqual(
+			'hello/i18n.gettext_with_ctx/i18n.gettext_with_ctx_default'
 		);
-		expect( i18n._x( 'hello', 'context', 'domain' ) ).toEqual(
-			'helloi18n.gettext_with_contexti18n.gettext_with_context_domain'
+		expect( i18n._x( 'hello', 'ctx', 'domain' ) ).toEqual(
+			'hello/i18n.gettext_with_ctx/i18n.gettext_with_ctx_domain'
 		);
 	} );
+
 	test( '_n() calls filters', () => {
-		const i18n = createI18n( undefined, undefined, {
-			applyFilters: ( filter, translation ) => translation + filter,
-		} );
+		const hooks = createHooksWithI18nFilters();
+		const i18n = createI18n( undefined, undefined, hooks );
+
 		expect( i18n._n( 'hello', 'hellos', 1 ) ).toEqual(
-			'helloi18n.ngettexti18n.ngettext_default'
+			'hello/i18n.ngettext/i18n.ngettext_default'
 		);
 		expect( i18n._n( 'hello', 'hellos', 1, 'domain' ) ).toEqual(
-			'helloi18n.ngettexti18n.ngettext_domain'
+			'hello/i18n.ngettext/i18n.ngettext_domain'
 		);
 		expect( i18n._n( 'hello', 'hellos', 2 ) ).toEqual(
-			'hellosi18n.ngettexti18n.ngettext_default'
+			'hellos/i18n.ngettext/i18n.ngettext_default'
 		);
 		expect( i18n._n( 'hello', 'hellos', 2, 'domain' ) ).toEqual(
-			'hellosi18n.ngettexti18n.ngettext_domain'
+			'hellos/i18n.ngettext/i18n.ngettext_domain'
 		);
 	} );
+
 	test( '_nx() calls filters', () => {
-		const i18n = createI18n( undefined, undefined, {
-			applyFilters: ( filter, translation ) => translation + filter,
-		} );
-		expect( i18n._nx( 'hello', 'hellos', 1, 'context' ) ).toEqual(
-			'helloi18n.ngettext_with_contexti18n.ngettext_with_context_default'
+		const hooks = createHooksWithI18nFilters();
+		const i18n = createI18n( undefined, undefined, hooks );
+
+		expect( i18n._nx( 'hello', 'hellos', 1, 'ctx' ) ).toEqual(
+			'hello/i18n.ngettext_with_ctx/i18n.ngettext_with_ctx_default'
 		);
-		expect( i18n._nx( 'hello', 'hellos', 1, 'context', 'domain' ) ).toEqual(
-			'helloi18n.ngettext_with_contexti18n.ngettext_with_context_domain'
+		expect( i18n._nx( 'hello', 'hellos', 1, 'ctx', 'domain' ) ).toEqual(
+			'hello/i18n.ngettext_with_ctx/i18n.ngettext_with_ctx_domain'
 		);
-		expect( i18n._nx( 'hello', 'hellos', 2, 'context' ) ).toEqual(
-			'hellosi18n.ngettext_with_contexti18n.ngettext_with_context_default'
+		expect( i18n._nx( 'hello', 'hellos', 2, 'ctx' ) ).toEqual(
+			'hellos/i18n.ngettext_with_ctx/i18n.ngettext_with_ctx_default'
 		);
-		expect( i18n._nx( 'hello', 'hellos', 2, 'context', 'domain' ) ).toEqual(
-			'hellosi18n.ngettext_with_contexti18n.ngettext_with_context_domain'
+		expect( i18n._nx( 'hello', 'hellos', 2, 'ctx', 'domain' ) ).toEqual(
+			'hellos/i18n.ngettext_with_ctx/i18n.ngettext_with_ctx_domain'
 		);
+	} );
+
+	test( 'hasTranslation() calls filters', () => {
+		const hooks = createHooksWithI18nFilters();
+		const { hasTranslation } = createI18n( frenchLocale, undefined, hooks );
+
+		expect( hasTranslation( 'hello' ) ).toBe( true );
+		expect( hasTranslation( 'hello', 'not a greeting' ) ).toBe( false );
+		expect( hasTranslation( 'Always' ) ).toBe( true );
+		expect( hasTranslation( 'Always', 'other context' ) ).toBe( false );
+		expect( hasTranslation( 'Always', undefined, 'domain' ) ).toBe( false );
 	} );
 } );
 

--- a/packages/i18n/src/test/subscribe-i18n.js
+++ b/packages/i18n/src/test/subscribe-i18n.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { createI18n } from '..';
+
+/**
+ * WordPress dependencies
+ */
+import { createHooks } from '@wordpress/hooks';
+
+describe( 'i18n updates', () => {
+	it( 'updates on setLocaleData', () => {
+		const hooks = createHooks();
+		const i18n = createI18n( undefined, undefined, hooks );
+
+		const doneTranslations = [];
+
+		function doTranslation() {
+			doneTranslations.push( i18n.__( 'original' ) );
+		}
+
+		i18n.subscribe( doTranslation );
+
+		// do translation on empty instance with no translation data
+		doTranslation();
+
+		// set translation data
+		i18n.setLocaleData( {
+			original: [ 'translated' ],
+		} );
+
+		// add a filter and then remove it
+		const filter = ( text ) => '[' + text + ']';
+		hooks.addFilter( 'i18n.gettext', 'test', filter );
+		hooks.removeFilter( 'i18n.gettext', 'test', filter );
+
+		expect( doneTranslations ).toEqual( [
+			'original', // no translations before setLocaleData
+			'translated', // after setLocaleData
+			'[translated]', // after addFilter
+			'translated', // after removeFilter
+		] );
+	} );
+} );


### PR DESCRIPTION
Spinoff from #28465 that adds several new APIs to `@wordpress/i18n`, with documentations and tests:
- `defaultI18n` export that exports the default `I18n` instance, in addition to already existing one-by-one method exports
- `getLocaleData` to retrieve the internal Tannin structure. Counterpart to existing `setLocaleData`
- `hasTranslation` to check if a given translation exists. Customizable with the `has_translation` filter
- `subscribe` to subscribe to updates when `setLocaleData` is called or hooks added or removed -- anything that makes a `__( ... )` translation call return a different result

Details were already discussed in #28465. Cc @leewillis77 for review.