### PR TITLE
blocks package: Replace hardcoded store names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11903,6 +11903,7 @@
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-default-parser": "file:packages/block-serialization-default-parser",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -30,6 +30,7 @@
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -11,6 +11,7 @@ import { Component, isValidElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -144,7 +145,7 @@ export function getBlockLabel( blockType, attributes, context = 'visual' ) {
 	// Attempt to find entity title if block is a template part.
 	// Require slug to request, otherwise entity is uncreated and will throw 404.
 	if ( 'core/template-part' === blockType.name && attributes.slug ) {
-		const entity = select( 'core' ).getEntityRecord(
+		const entity = select( coreStore ).getEntityRecord(
 			'postType',
 			'wp_template_part',
 			attributes.theme + '//' + attributes.slug


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related to https://github.com/WordPress/gutenberg/issues/27088
Replace hardcoded store names with their store object.
## How has this been tested?
Make sure tests are passing. Smoke test.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
