### PR TITLE
Global Styles: enqueue preset classes in the front-end

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -992,7 +992,7 @@ class WP_Theme_JSON {
 
 		$metadata = $this->get_blocks_metadata();
 		foreach ( $metadata as $block_selector => $metadata ) {
-			if ( empty( $metadata['selector'] ) || empty( $metadata['supports'] ) ) {
+			if ( empty( $metadata['selector'] ) ) {
 				continue;
 			}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -217,12 +217,13 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	}
 
 	function test_get_stylesheet() {
-		$root_name = WP_Theme_JSON::ROOT_BLOCK_NAME;
-		// See schema at WP_Theme_JSON::SCHEMA.
+		$root_name       = WP_Theme_JSON::ROOT_BLOCK_NAME;
+		$all_blocks_name = WP_Theme_JSON::ALL_BLOCKS_NAME;
+
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'settings' => array(
-					$root_name   => array(
+					$all_blocks_name => array(
 						'color'      => array(
 							'text'    => 'value',
 							'palette' => array(


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/28780

https://github.com/WordPress/gutenberg/pull/28533 split `global` into `root` and `defaults`, with the goal of making it easier to share settings among the different blocks and still be able to set the `root` block independently. In doing so, it missed that, in the frontend, the `defaults` presets should also enqueue the classes for them. This adds them back.

## How to test

- Install and activate the version of TT1-blocks available in the `master` branch.
- Go to the front-end of your site.
- Check that the classes generated for presets are present. Examples are: `.has-black-color`, `.has-dark-gray`, `.has-purple-to-yellow-gradient`, `.has-extra-small-font-size`, `.has-small-font-size`, etc.
