### PR TITLE
Cover: Add missing align attr to deprecation

### DIFF
--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -30,9 +30,6 @@ import {
 } from './shared';
 
 const blockAttributes = {
-	align: {
-		type: 'string',
-	},
 	url: {
 		type: 'string',
 	},
@@ -91,6 +88,9 @@ const deprecated = [
 			customGradient: {
 				type: 'string',
 			},
+		},
+		supports: {
+			align: true,
 		},
 		save( { attributes } ) {
 			const {
@@ -222,6 +222,9 @@ const deprecated = [
 				type: 'string',
 			},
 		},
+		supports: {
+			align: true,
+		},
 		save( { attributes } ) {
 			const {
 				backgroundType,
@@ -324,6 +327,9 @@ const deprecated = [
 			customGradient: {
 				type: 'string',
 			},
+		},
+		supports: {
+			align: true,
 		},
 		save( { attributes } ) {
 			const {

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -30,6 +30,9 @@ import {
 } from './shared';
 
 const blockAttributes = {
+	align: {
+		type: 'string',
+	},
 	url: {
 		type: 'string',
 	},

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
@@ -35,6 +35,7 @@
         "name": "core/cover",
         "isValid": true,
         "attributes": {
+            "align": "full",
             "url": "https://example.com/some-background-image.png",
             "id": 1933,
             "hasParallax": false,

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
@@ -35,7 +35,6 @@
         "name": "core/cover",
         "isValid": true,
         "attributes": {
-            "align": "full",
             "url": "https://example.com/some-background-image.png",
             "id": 1933,
             "hasParallax": false,
@@ -50,7 +49,7 @@
             "isRepeated": false,
             "minHeight": 48,
             "minHeightUnit": "vw",
-            "className": "alignfull"
+            "align": "full"
         },
         "innerBlocks": [
             {

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
@@ -6,7 +6,7 @@
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->
 
-<!-- wp:cover {"url":"https://example.com/some-background-image.png","id":1933,"dimRatio":0,"focalPoint":{"x":"0.50","y":"0.40"},"minHeight":48,"minHeightUnit":"vw","className":"alignfull"} -->
+<!-- wp:cover {"url":"https://example.com/some-background-image.png","id":1933,"dimRatio":0,"focalPoint":{"x":"0.50","y":"0.40"},"minHeight":48,"minHeightUnit":"vw","align":"full","className":"alignfull"} -->
 <div class="wp-block-cover alignfull" style="min-height:48vw"><img class="wp-block-cover__image-background wp-image-1933" alt="" src="https://example.com/some-background-image.png" style="object-position:50% 40%" data-object-fit="cover" data-object-position="50% 40%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div></div>

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
@@ -6,7 +6,7 @@
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->
 
-<!-- wp:cover {"url":"https://example.com/some-background-image.png","id":1933,"dimRatio":0,"focalPoint":{"x":"0.50","y":"0.40"},"minHeight":48,"minHeightUnit":"vw","align":"full","className":"alignfull"} -->
+<!-- wp:cover {"url":"https://example.com/some-background-image.png","id":1933,"dimRatio":0,"focalPoint":{"x":"0.50","y":"0.40"},"minHeight":48,"minHeightUnit":"vw","align":"full"} -->
 <div class="wp-block-cover alignfull" style="min-height:48vw"><img class="wp-block-cover__image-background wp-image-1933" alt="" src="https://example.com/some-background-image.png" style="object-position:50% 40%" data-object-fit="cover" data-object-position="50% 40%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div></div>


### PR DESCRIPTION
## Description
The Cover align attribute may be lost during deprecation handling as can be observed in the deprecation test. The attribute should be parsed and preserved when the block is upgraded.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->