### PR TITLE
Update the documentation - Remove the "theme" key value pair from the block templates

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-based-themes/README.md
+++ b/docs/designers-developers/developers/tutorials/block-based-themes/README.md
@@ -180,8 +180,6 @@ The HTML comments starts with `wp:template-part` which is the name of the templa
 <!-- wp:template-part {"slug":"footer"} /-->
 ```
 
-If you used a block template part slug, adjust the value for the "slug" key.
-
 Eventually, you will be able to create and combine templates and template parts directly in the site editor.
 
 ### Experimental-theme.json - Global styles

--- a/docs/designers-developers/developers/tutorials/block-based-themes/README.md
+++ b/docs/designers-developers/developers/tutorials/block-based-themes/README.md
@@ -172,7 +172,8 @@ Inside the block-templates folder, create an `index.html` file.
 
 In `index.html`, include the template parts by adding two HTML comments.
 
-The HTML comments starts with `wp:template-part` which is the name of the template-part block type. Inside the curly brackets there is key and its values: The "slug" is the key and the slug of the template part e.g. "header", or "footer" is its value.
+The HTML comments starts with `wp:template-part` which is the name of the template-part block type. The curly braces `{}` have key value pairs.
+In the below example, the "slug" is the key and "header", or "footer" is the value of the slug.
 
 ```
 <!-- wp:template-part {"slug":"header"} /-->

--- a/docs/designers-developers/developers/tutorials/block-based-themes/README.md
+++ b/docs/designers-developers/developers/tutorials/block-based-themes/README.md
@@ -175,9 +175,9 @@ In `index.html`, include the template parts by adding two HTML comments.
 The HTML comments starts with `wp:template-part` which is the name of the template-part block type. Inside the curly brackets there is key and its values: The "slug" is the key and the slug of the template part e.g. "header", or "footer" is its value.
 
 ```
-<!-- wp:template-part {"slug":"header","theme":"myfirsttheme"} /-->
+<!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:template-part {"slug":"footer","theme":"myfirsttheme"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->
 ```
 
 If you used a block template part slug, adjust the value for the "slug" key.

--- a/docs/designers-developers/developers/tutorials/block-based-themes/README.md
+++ b/docs/designers-developers/developers/tutorials/block-based-themes/README.md
@@ -172,7 +172,7 @@ Inside the block-templates folder, create an `index.html` file.
 
 In `index.html`, include the template parts by adding two HTML comments.
 
-The HTML comments starts with `wp:template-part` which is the name of the template-part block type. Inside the curly brackets are two keys and their values: The slug of the template part, and the theme name.
+The HTML comments starts with `wp:template-part` which is the name of the template-part block type. Inside the curly brackets there is key and its values: The "slug" is the key and the slug of the template part e.g. "header", or "footer" is its value.
 
 ```
 <!-- wp:template-part {"slug":"header","theme":"myfirsttheme"} /-->
@@ -180,7 +180,7 @@ The HTML comments starts with `wp:template-part` which is the name of the templa
 <!-- wp:template-part {"slug":"footer","theme":"myfirsttheme"} /-->
 ```
 
-If you used a different theme name, adjust the value for the theme key.
+If you used a block template part slug, adjust the value for the "slug" key.
 
 Eventually, you will be able to create and combine templates and template parts directly in the site editor.
 


### PR DESCRIPTION
## Description
- Removes the "theme" key value pair from the HTML comment of block templates, in the documentation.

As per the [recent changes in Gutenberg](https://github.com/WordPress/gutenberg/pull/28088) (as of 9.9) the "theme" attribute should be removed from the template-part blocks.