### PR TITLE
Try/add drag handle to select mode

### DIFF
--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -9,7 +9,7 @@
 	background-color: $gray-900;
 	border-radius: $radius-block-ui;
 	border: $border-width solid $gray-900;
-	box-shadow: 0 4px 6px rgba($black, 0.3);
+	box-shadow: 0 6px 8px rgba($black, 0.3);
 	color: $white;
 	cursor: grabbing;
 	display: inline-flex;

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -8,14 +8,12 @@
 .block-editor-block-draggable-chip {
 	background-color: $gray-900;
 	border-radius: $radius-block-ui;
-	border: $border-width solid $gray-900;
 	box-shadow: 0 6px 8px rgba($black, 0.3);
 	color: $white;
 	cursor: grabbing;
 	display: inline-flex;
 	height: $block-toolbar-height;
-	min-width: $button-size * 2;
-	padding: 0 $grid-unit-15;
+	padding: 0 ( $grid-unit-15 + $border-width );
 	user-select: none;
 
 	svg {
@@ -24,6 +22,21 @@
 
 	.block-editor-block-draggable-chip__content {
 		margin: auto;
+		justify-content: flex-start;
+
+		> .components-flex__item {
+			margin-right: $grid-unit-15 / 2;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+
+		// Drag handle is smaller than the others.
+		.block-editor-block-icon svg {
+			min-width: 18px;
+			min-height: 18px;
+		}
 	}
 
 	.components-flex__item {

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { dragHandle } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -27,12 +28,14 @@ import {
 } from '@wordpress/blocks';
 import { speak } from '@wordpress/a11y';
 import { focus } from '@wordpress/dom';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import BlockTitle from '../block-title';
 import { store as blockEditorStore } from '../../store';
+import BlockDraggable from '../block-draggable';
 
 /**
  * Returns true if the user is using windows.
@@ -256,13 +259,33 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 		}
 	);
 
+	const dragHandleLabel = __( 'Drag' );
+
 	return (
 		<div className={ classNames }>
+			<BlockDraggable
+				clientIds={ [ clientId ] }
+				cloneClassname="block-editor-block-mover__drag-clone"
+			>
+				{ ( draggableProps ) => (
+					<Button
+						icon={ dragHandle }
+						className="block-selection-button_drag-handle"
+						aria-hidden="true"
+						label={ dragHandleLabel }
+						// Should not be able to tab to drag handle as this
+						// button can only be used with a pointer device.
+						tabIndex="-1"
+						{ ...draggableProps }
+					/>
+				) }
+			</BlockDraggable>
 			<Button
 				ref={ ref }
 				onClick={ () => setNavigationMode( false ) }
 				onKeyDown={ onKeyDown }
 				label={ label }
+				className="block-selection-button_select-button"
 			>
 				<BlockTitle clientId={ clientId } />
 			</Button>

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { dragHandle } from '@wordpress/icons';
-import { Button } from '@wordpress/components';
+import { Button, Flex, FlexItem } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import {
@@ -34,6 +34,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockTitle from '../block-title';
+import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 import BlockDraggable from '../block-draggable';
 
@@ -96,9 +97,12 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 			const {
 				__unstableGetBlockWithoutInnerBlocks,
 				getBlockIndex,
+				getBlockName,
 				hasBlockMovingClientId,
 				getBlockListSettings,
 			} = select( blockEditorStore );
+			const blockName = getBlockName( clientId );
+			const blockType = getBlockType( blockName );
 			const index = getBlockIndex( clientId, rootClientId );
 			const { name, attributes } = __unstableGetBlockWithoutInnerBlocks(
 				clientId
@@ -110,11 +114,19 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 				attributes,
 				blockMovingMode,
 				orientation: getBlockListSettings( rootClientId )?.orientation,
+				icon: blockType.icon,
 			};
 		},
 		[ clientId, rootClientId ]
 	);
-	const { index, name, attributes, blockMovingMode, orientation } = selected;
+	const {
+		index,
+		name,
+		attributes,
+		blockMovingMode,
+		orientation,
+		icon,
+	} = selected;
 	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
 
@@ -263,32 +275,41 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 
 	return (
 		<div className={ classNames }>
-			<BlockDraggable
-				clientIds={ [ clientId ] }
-				cloneClassname="block-editor-block-mover__drag-clone"
+			<Flex
+				justify="center"
+				className="block-editor-block-list__block-selection-button__content"
 			>
-				{ ( draggableProps ) => (
+				<FlexItem>
+					<BlockIcon icon={ icon } showColors />
+				</FlexItem>
+				<FlexItem>
+					<BlockDraggable clientIds={ [ clientId ] }>
+						{ ( draggableProps ) => (
+							<Button
+								icon={ dragHandle }
+								className="block-selection-button_drag-handle"
+								aria-hidden="true"
+								label={ dragHandleLabel }
+								// Should not be able to tab to drag handle as this
+								// button can only be used with a pointer device.
+								tabIndex="-1"
+								{ ...draggableProps }
+							/>
+						) }
+					</BlockDraggable>
+				</FlexItem>
+				<FlexItem>
 					<Button
-						icon={ dragHandle }
-						className="block-selection-button_drag-handle"
-						aria-hidden="true"
-						label={ dragHandleLabel }
-						// Should not be able to tab to drag handle as this
-						// button can only be used with a pointer device.
-						tabIndex="-1"
-						{ ...draggableProps }
-					/>
-				) }
-			</BlockDraggable>
-			<Button
-				ref={ ref }
-				onClick={ () => setNavigationMode( false ) }
-				onKeyDown={ onKeyDown }
-				label={ label }
-				className="block-selection-button_select-button"
-			>
-				<BlockTitle clientId={ clientId } />
-			</Button>
+						ref={ ref }
+						onClick={ () => setNavigationMode( false ) }
+						onKeyDown={ onKeyDown }
+						label={ label }
+						className="block-selection-button_select-button"
+					>
+						<BlockTitle clientId={ clientId } />
+					</Button>
+				</FlexItem>
+			</Flex>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -615,30 +615,35 @@
 
 .block-editor-block-list__block-selection-button {
 	display: inline-flex;
-	padding: 0 20px;
+	padding: 0 ( $grid-unit-15 + $border-width );
 	z-index: z-index(".block-editor-block-list__block-selection-button");
+
 	// Dark block UI appearance.
 	border-radius: $radius-block-ui;
 	background-color: $gray-900;
 
 	font-size: $default-font-size;
-	height: $block-toolbar-height + 2 * $border-width;
+	height: $block-toolbar-height;
 
 	.block-editor-block-list__block-selection-button__content {
 		margin: auto;
 		display: inline-flex;
 		align-items: center;
+
+		> .components-flex__item {
+			margin-right: $grid-unit-15 / 2;
+		}
 	}
 	.components-button.has-icon.block-selection-button_drag-handle {
 		cursor: grab;
 		padding: 0;
-		height: 24px;
-		min-width: 24px;
-		margin-right: 8px;
+		height: $grid-unit-30;
+		min-width: $grid-unit-30;
 
+		// Drag handle is smaller than the others.
 		svg {
-			min-width: 20px;
-			min-height: 20px;
+			min-width: 18px;
+			min-height: 18px;
 		}
 	}
 
@@ -652,7 +657,7 @@
 	.components-button {
 		min-width: $button-size;
 		color: $white;
-		height: $block-toolbar-height + 2 * $border-width;
+		height: $block-toolbar-height;
 
 		// When button is focused, it receives a box-shadow instead of the border.
 		&:focus {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -616,10 +616,10 @@
 .block-editor-block-list__block-selection-button {
 	display: flex;
 	z-index: z-index(".block-editor-block-list__block-selection-button");
-	// Block UI appearance.
-	box-shadow: 0 0 0 $border-width $gray-900;
-	border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-	background-color: $white;
+
+	// Dark block UI appearance.
+	border-radius: $radius-block-ui;
+	background-color: $gray-900;
 
 	font-size: $default-font-size;
 	height: $block-toolbar-height - $border-width - $border-width;
@@ -632,19 +632,20 @@
 
 	// The button here has a special style to appear as a toolbar.
 	.components-button {
+		color: $white;
 		height: $block-toolbar-height - $border-width - $border-width;
+
 		// When button is focused, it receives a box-shadow instead of the border.
 		&:focus {
 			box-shadow: none;
 			border: none;
 		}
-		padding: 6px;
+		padding: $grid-unit-15 / 2;
 	}
 
 	.components-button.block-selection-button_select-button {
 		padding-left: 0;
 	}
-
 }
 
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -614,41 +614,58 @@
  */
 
 .block-editor-block-list__block-selection-button {
-	display: flex;
+	display: inline-flex;
+	padding: 0 20px;
 	z-index: z-index(".block-editor-block-list__block-selection-button");
-
 	// Dark block UI appearance.
 	border-radius: $radius-block-ui;
 	background-color: $gray-900;
 
 	font-size: $default-font-size;
-	height: $block-toolbar-height - $border-width - $border-width;
-	padding: 0;
+	height: $block-toolbar-height + 2 * $border-width;
 
+	.block-editor-block-list__block-selection-button__content {
+		margin: auto;
+		display: inline-flex;
+	}
 	.components-button.has-icon.block-selection-button_drag-handle {
-		flex-grow: 1;
 		cursor: grab;
+		padding: 0;
+		height: 24px;
+		min-width: 24px;
+		margin-right: 8px;
+
+		svg {
+			min-width: 20px;
+			min-height: 20px;
+		}
+	}
+
+	.block-editor-block-icon {
+		font-size: $default-font-size;
+		color: $white;
+		height: $block-toolbar-height;
 	}
 
 	// The button here has a special style to appear as a toolbar.
 	.components-button {
+		min-width: $button-size;
 		color: $white;
-		height: $block-toolbar-height - $border-width - $border-width;
+		height: $block-toolbar-height + 2 * $border-width;
 
 		// When button is focused, it receives a box-shadow instead of the border.
 		&:focus {
 			box-shadow: none;
 			border: none;
 		}
-		padding: $grid-unit-15 / 2;
 
 		&:active {
 			color: $white;
 		}
+		display: flex;
 	}
-
-	.components-button.block-selection-button_select-button {
-		padding-left: 0;
+	.block-selection-button_select-button.components-button {
+		padding: 0;
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -641,6 +641,10 @@
 			border: none;
 		}
 		padding: $grid-unit-15 / 2;
+
+		&:active {
+			color: $white;
+		}
 	}
 
 	.components-button.block-selection-button_select-button {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -614,29 +614,37 @@
  */
 
 .block-editor-block-list__block-selection-button {
-	display: block;
+	display: flex;
 	z-index: z-index(".block-editor-block-list__block-selection-button");
+	// Block UI appearance.
+	box-shadow: 0 0 0 $border-width $gray-900;
+	border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
+	background-color: $white;
+
+	font-size: $default-font-size;
+	height: $block-toolbar-height - $border-width - $border-width;
+	padding: 0;
+
+	.components-button.has-icon.block-selection-button_drag-handle {
+		flex-grow: 1;
+		cursor: grab;
+	}
 
 	// The button here has a special style to appear as a toolbar.
 	.components-button {
-		font-size: $default-font-size;
 		height: $block-toolbar-height - $border-width - $border-width;
-		padding: $grid-unit-15 $grid-unit-20;
-
-		// Position this to align with the block toolbar.
-		position: relative;
-		top: -$border-width;
-
-		// Block UI appearance.
-		box-shadow: 0 0 0 $border-width $gray-900;
-		border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-		background-color: $white;
-
 		// When button is focused, it receives a box-shadow instead of the border.
 		&:focus {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: none;
+			border: none;
 		}
+		padding: 6px;
 	}
+
+	.components-button.block-selection-button_select-button {
+		padding-left: 0;
+	}
+
 }
 
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -627,6 +627,7 @@
 	.block-editor-block-list__block-selection-button__content {
 		margin: auto;
 		display: inline-flex;
+		align-items: center;
 	}
 	.components-button.has-icon.block-selection-button_drag-handle {
 		cursor: grab;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Advances #24092

Adds a drag handle to the block selector button when in navigation mode. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots


https://user-images.githubusercontent.com/107534/110501772-2e80a580-8103-11eb-81d5-c9aa3a43c8d7.mp4


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
