### PR TITLE
RangeControl: Fix input / slider widths

### DIFF
--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -271,18 +271,20 @@ export const Tooltip = styled.span`
 	) }
 `;
 
+// @todo: Refactor RangeControl with latest HStack configuration
+// @wordpress/components/ui/hstack
 export const InputNumber = styled( NumberControl )`
 	box-sizing: border-box;
 	display: inline-block;
 	font-size: 13px;
 	margin-top: 0;
-	width: ${ space( 8 ) };
+	width: ${ space( 8 ) } !important;
 
 	input[type='number']& {
 		${ rangeHeight };
 	}
 
-	${ rtl( { marginLeft: space( 2 ) } ) }
+	${ rtl( { marginLeft: `${ space( 2 ) } !important` } ) }
 `;
 
 export const ActionRightWrapper = styled.span`


### PR DESCRIPTION
This update fixes the UI regression for RangeControl from the latest [Flex component update](https://github.com/WordPress/gutenberg/pull/28609). The patch solution was to force the specific widths/margins for the inner `input`.

The longer term solution would be to refactor how layout rendering for `RangeControl` to use the new `HStack` components from `components/ui/hstack`.

## Screenshots

**Before**
<img width="277" alt="Screen Shot 2021-02-07 at 10 08 35 AM" src="https://user-images.githubusercontent.com/2322354/107150616-9c7f5480-692c-11eb-952d-69873d8c4168.png">


**After**
<img width="297" alt="Screen Shot 2021-02-07 at 10 06 03 AM" src="https://user-images.githubusercontent.com/2322354/107150547-4c07f700-692c-11eb-9ea6-a11af2b7e6ab.png">


## How has this been tested?

Tested in local Gutenberg

* Run `npm run dev`
* Add a Columns block
* Ensure the RangeControl slider looks correct

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
