### PR TITLE
Fix npm 7 compatability

### DIFF
--- a/patches/patch-xcode.js
+++ b/patches/patch-xcode.js
@@ -11,26 +11,29 @@ const path = require( 'path' );
 const nodeModulesDir = path.join( __dirname, '../', 'node_modules' );
 
 const fetchRNPackageDirs = ( dir ) => {
-	const dirList = fs.readdirSync( dir );
+	const dirList = fs.readdirSync( dir, { withFileTypes: true } );
 	const packageDirs = [];
-	dirList.forEach( ( packageName ) => {
-		const packageDir = path.join( dir, packageName );
-		if ( packageName.startsWith( '@' ) ) {
-			packageDirs.push( ...fetchRNPackageDirs( packageDir ) );
-		} else {
-			const files = fs.readdirSync( packageDir );
-			const podSpecs = files.filter( ( file ) =>
-				file.toLowerCase().endsWith( '.podspec' )
-			);
-			if ( podSpecs.length > 0 ) {
-				packageDirs.push( {
-					dir: packageDir,
-					files: podSpecs,
-					package: packageName,
-				} );
+	dirList
+		.filter( ( file ) => file.isDirectory() )
+		.map( ( file ) => file.name )
+		.forEach( ( packageName ) => {
+			const packageDir = path.join( dir, packageName );
+			if ( packageName.startsWith( '@' ) ) {
+				packageDirs.push( ...fetchRNPackageDirs( packageDir ) );
+			} else {
+				const files = fs.readdirSync( packageDir );
+				const podSpecs = files.filter( ( file ) =>
+					file.toLowerCase().endsWith( '.podspec' )
+				);
+				if ( podSpecs.length > 0 ) {
+					packageDirs.push( {
+						dir: packageDir,
+						files: podSpecs,
+						package: packageName,
+					} );
+				}
 			}
-		}
-	} );
+		} );
 	return packageDirs;
 };
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Upgrade to supports npm 7. See the changelog [here](https://github.blog/2021-02-02-npm-7-is-now-generally-available/).

This fixes an error when running `npm install` with npm 7:

```
Error: ENOTDIR: not a directory, scandir '/gutenberg/node_modules/.package-lock.json'
    at Object.readdirSync (fs.js:1021:3)
    at /gutenberg/patches/patch-xcode.js:21:21
    at Array.forEach (<anonymous>)
    at fetchRNPackageDirs (/gutenberg/patches/patch-xcode.js:16:10)
    at Object.<anonymous> (/gutenberg/patches/patch-xcode.js:37:29)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12) {
  errno: -20,
  syscall: 'scandir',
  code: 'ENOTDIR',
  path: '/gutenberg/node_modules/.package-lock.json'
}
```

The error is because, in `patches/patch-xcode`, we were assuming every file in the `node_modules` directory is a directory. Which apparently changes now that it also consists a `.package-lock.json` file.

~This PR also upgrades the version of the lock file format to version 2, which should also be backward-compatible to npm 6 users.~  Follow-up in progress: https://github.com/WordPress/gutenberg/pull/28849.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
```sh
npm i -g npm@latest
npm install
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
