### PR TITLE
Enqueue comment-reply script when post-comments-form block gets rendered

### DIFF
--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -28,6 +28,10 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	$form               = ob_get_clean();
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
+	global $wp_scripts;
+	$wp_scripts->in_footer[] = 'comment-reply';
+	$wp_scripts->queue[]     = 'comment-reply';
+
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $form );
 }
 

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -28,6 +28,7 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	$form               = ob_get_clean();
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
+	// Enqueue the comment-reply script.
 	global $wp_scripts;
 	$wp_scripts->in_footer[] = 'comment-reply';
 	$wp_scripts->queue[]     = 'comment-reply';

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -29,9 +29,7 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
 	// Enqueue the comment-reply script.
-	global $wp_scripts;
-	$wp_scripts->in_footer[] = 'comment-reply';
-	$wp_scripts->queue[]     = 'comment-reply';
+	wp_enqueue_script( 'comment-reply' );
 
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $form );
 }


### PR DESCRIPTION
## Description

All WordPress themes are **required to enqueue the `comment-reply` script**.
They usually do this by adding code like this:

```php
add_action( 'wp_enqueue_scripts', function() {
	if ( is_singular() ) {
		wp_enqueue_script( 'comment-reply' );
	}
} );
```

In FSE themes we should automatically enqueue the script when needed instead of requiring authors to write PHP.

## Types of changes

This PR adds the script in `wp_footer` when the `post-comments-form` block gets rendered.
EDIT: Turns out `wp_enqueue_script()` works. ~~Due to the nature of blocks rendering, the `wp_enqueue_script()` function could not be used here, so instead of that, the PR adds the script in `$wp_scripts`.~~

## How has this been tested?

Tested with an FSE theme and verified that when the block exists in a page, the script gets properly enqueued in the footer.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
