### PR TITLE
Blocks: Move the logic for Template Part label to the block

### DIFF
--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -6,6 +6,8 @@ import { startCase } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { store as coreDataStore } from '@wordpress/core-data';
+import { select } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 
 /**
@@ -20,6 +22,23 @@ export { metadata, name };
 export const settings = {
 	title: _x( 'Template Part', 'block title' ),
 	keywords: [ __( 'template part' ) ],
-	__experimentalLabel: ( { slug } ) => startCase( slug ),
+	__experimentalLabel: ( { slug, theme } ) => {
+		// Attempt to find entity title if block is a template part.
+		// Require slug to request, otherwise entity is uncreated and will throw 404.
+		if ( ! slug ) {
+			return;
+		}
+
+		const entity = select( coreDataStore ).getEntityRecord(
+			'postType',
+			'wp_template_part',
+			theme + '//' + slug
+		);
+		if ( ! entity ) {
+			return;
+		}
+
+		return startCase( entity.title?.rendered || entity.slug );
+	},
 	edit,
 };

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, has, isFunction, isString, startCase, reduce } from 'lodash';
+import { every, has, isFunction, isString, reduce } from 'lodash';
 import { default as tinycolor, mostReadable } from 'tinycolor2';
 
 /**
@@ -10,7 +10,6 @@ import { default as tinycolor, mostReadable } from 'tinycolor2';
 import { Component, isValidElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
-import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -141,19 +140,6 @@ export function normalizeBlockType( blockTypeOrName ) {
  * @return {string} The block label.
  */
 export function getBlockLabel( blockType, attributes, context = 'visual' ) {
-	// Attempt to find entity title if block is a template part.
-	// Require slug to request, otherwise entity is uncreated and will throw 404.
-	if ( 'core/template-part' === blockType.name && attributes.slug ) {
-		const entity = select( 'core' ).getEntityRecord(
-			'postType',
-			'wp_template_part',
-			attributes.theme + '//' + attributes.slug
-		);
-		if ( entity ) {
-			return startCase( entity.title?.rendered || entity.slug );
-		}
-	}
-
 	const { __experimentalLabel: getLabel, title } = blockType;
 
 	const label = getLabel && getLabel( attributes, { context } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Replaces #28789.

This PR removes the cyclic dependency between `@wordpres/blocks` and `@wordpress/core-blocks` discovered in #28789.

See related comment from @youknowriad: https://github.com/WordPress/gutenberg/pull/28789#discussion_r571873548

> Yep, this should definitely be moved to the block itself :) I think we have a function for that right?

Template Part block should implement `__experimentalLabel` rather itself. Block API should be general and shouldn't know that Template Part block exists in the first place. It improves the implementation from #28330.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

CI tests pass.

Follow instructions from #28330 and ensure that everything works as before.

## Types of changes

Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
