### PR TITLE
Blocks: Prefer settings returned from the server over client

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -186,11 +186,12 @@ export function registerBlockType( name, settings ) {
 		supports: {},
 		styles: [],
 		save: () => null,
+		...settings,
+		// Use the existing definition from the server as a source of truth.
 		...pickBy(
 			get( serverSideBlockDefinitions, name, {} ),
 			( value ) => ! isNil( value )
 		),
-		...settings,
 	};
 
 	if ( typeof name !== 'string' ) {

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -350,6 +350,58 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		it( 'should prefer values returned from the server', () => {
+			const blockName = 'core/test-block-prefer-server-values';
+			unstable__bootstrapServerSideBlockDefinitions( {
+				[ blockName ]: {
+					title: 'Server',
+					description: 'Set on the server',
+					icon: 'server',
+					attributes: {
+						foo: {
+							type: 'string',
+							default: 'server',
+						},
+					},
+					keywords: [ 'server' ],
+				},
+			} );
+
+			const blockType = {
+				title: 'Client',
+				description: 'Set on the client',
+				icon: 'client',
+				attributes: {
+					foo: {
+						type: 'string',
+						default: 'client',
+					},
+				},
+				keywords: [ 'client' ],
+			};
+			registerBlockType( blockName, blockType );
+			expect( getBlockType( blockName ) ).toEqual( {
+				name: blockName,
+				save: expect.any( Function ),
+				title: 'Server',
+				description: 'Set on the server',
+				icon: {
+					src: 'server',
+				},
+				attributes: {
+					foo: {
+						type: 'string',
+						default: 'server',
+					},
+				},
+				providesContext: {},
+				usesContext: [],
+				keywords: [ 'server' ],
+				supports: {},
+				styles: [],
+			} );
+		} );
+
 		it( 'should validate the icon', () => {
 			const blockType = {
 				save: noop,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

With https://core.trac.wordpress.org/ticket/52301, all the functionalities of `register_block_type_from_metadata` is ready to work with `block.json` as defined in:
https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-metadata.md

We already register all core blocks on the server. The only metadata that still needs to be moved to the `block.json` depends on WordPress 5.7 release and it's related to i18n support as explained in https://github.com/WordPress/gutenberg/issues/23636.

The way block API works is that it overrides metadata set on the server if the client passes something else with `registerBlockType`. The question is whether we should leave it as is and make it explicit in the documentation when using both the server and client for block registration. The alternative is as proposed in this PR to always assume that the server is a source of truth. I picked the latter just to make it more evident what we have to take into account:
- the block type definition in the future will be loaded with REST API which means that all clients will have common knowledge of the block definition
- the role of the client is to enrich the experience rather than modify it in the first place
- there are hooks on the client and the server that allow modifying the block definition that makes it even more confusing, now you have another place `registerBlockType` that allows further modification

I guess every approach is good as long as it's well explained in the docs. This PR is meant to clarify it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run test-unit`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Enhancement - ensures that data from the server remains a source of truth.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
