### PR TITLE
Rename pageTemplates config to customTemplates in theme.json

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -13,6 +13,7 @@ This is documentation for the current direction and work in progress about how t
 - Specification
     - Settings
     - Styles
+    - Other theme metadata
 - FAQ
   - The naming schema of CSS Custom Properties
   - Why using -- as a separator?
@@ -475,6 +476,24 @@ These are the current typography properties supported by blocks:
 | Verse | Yes | Yes | - | - | - | - | - |
 
 [1] The heading block represents 6 distinct HTML elements: H1-H6. It comes with selectors to target each individual element (ex: core/heading/h1 for H1, etc).
+
+
+### Other theme metadata
+
+There's a growing need to add more theme metadata to the theme.json. This section lists those other fields:
+
+**customTemplates**: within this field themes can list the custom templates present in the `block-templates` folder, the keys should match the custom template name. For example, for a custom template named `my-custom-template.html`, the `theme.json` can declare what post types can use it and what's the title to show the user:
+
+```json
+{
+  "customTemplates": {
+    "my-custom-template": {
+      "title": "The template title", /* Mandatory */
+      "postTypes": [ "page", "post", "my-cpt" ] /* Optional, will only apply to "page" by default. */
+    }
+  }
+}
+```
 
 ## Frequently Asked Questions
 

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -103,8 +103,8 @@ class WP_Theme_JSON {
 	 * }
 	 */
 	const SCHEMA = array(
-		'pageTemplates' => null,
-		'styles'        => array(
+		'customTemplates' => null,
+		'styles'          => array(
 			'border'     => array(
 				'radius' => null,
 				'color'  => null,
@@ -135,7 +135,7 @@ class WP_Theme_JSON {
 				'textTransform'  => null,
 			),
 		),
-		'settings'      => array(
+		'settings'        => array(
 			'border'     => array(
 				'customRadius' => null,
 				'customColor'  => null,
@@ -1056,11 +1056,11 @@ class WP_Theme_JSON {
 	 *
 	 * @return array
 	 */
-	public function get_page_templates() {
-		if ( ! isset( $this->theme_json['pageTemplates'] ) ) {
+	public function get_custom_templates() {
+		if ( ! isset( $this->theme_json['customTemplates'] ) ) {
 			return array();
 		} else {
-			return $this->theme_json['pageTemplates'];
+			return $this->theme_json['customTemplates'];
 		}
 	}
 

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -11,27 +11,27 @@
  * @param array    $templates Page templates.
  * @param WP_Theme $theme     WP_Theme instance.
  * @param WP_Post  $post      The post being edited, provided for context, or null.
+ * @param string   $post_type Post type to get the templates for.
  * @return array (Maybe) modified page templates array.
  */
-function gutenberg_load_block_page_templates( $templates, $theme, $post ) {
+function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
 	if ( ! gutenberg_is_fse_theme() ) {
 		return $templates;
 	}
 
-	$resolver       = new WP_Theme_JSON_Resolver();
-	$data           = $resolver->get_theme_data()->get_page_templates();
-	$page_templates = array();
+	$resolver         = new WP_Theme_JSON_Resolver();
+	$data             = $resolver->get_theme_data()->get_custom_templates();
+	$custom_templates = array();
 	if ( isset( $data ) ) {
-		foreach ( $data  as $key => $page_template ) {
-			if ( ( ! isset( $page_template['postTypes'] ) && 'page' === $post->post_type ) ||
-				( isset( $page_template['postTypes'] ) && in_array( $post->post_type, $page_template['postTypes'], true ) )
+		foreach ( $data  as $key => $template ) {
+			if ( ( ! isset( $template['postTypes'] ) && 'page' === $post_type ) ||
+				( isset( $template['postTypes'] ) && in_array( $post_type, $template['postTypes'], true ) )
 			) {
-				$page_templates[ $key ] = $page_template['title'];
+				$custom_templates[ $key ] = $template['title'];
 			}
 		}
 	}
 
-	return $page_templates;
+	return $custom_templates;
 }
-add_filter( 'theme_post_templates', 'gutenberg_load_block_page_templates', 10, 3 );
-add_filter( 'theme_page_templates', 'gutenberg_load_block_page_templates', 10, 3 );
+add_filter( 'theme_templates', 'gutenberg_load_block_page_templates', 10, 4 );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -738,10 +738,10 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $result );
 	}
 
-	function test_get_page_templates() {
+	function test_get_custom_templates() {
 		$theme_json = new WP_Theme_JSON(
 			array(
-				'pageTemplates' => array(
+				'customTemplates' => array(
 					'page-home' => array(
 						'title' => 'Some title',
 					),
@@ -749,7 +749,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$page_templates = $theme_json->get_page_templates();
+		$page_templates = $theme_json->get_custom_templates();
 
 		$this->assertEqualSetsWithIndex(
 			$page_templates,


### PR DESCRIPTION
Addresses comments in https://github.com/WordPress/gutenberg/pull/27778#pullrequestreview-584290384

 - Uses the right hook (theme_templates)
 - Renames the key to avoid to "customTemplates" in theme.json

**Testing instructions**

 -  Add custom files like `about.html`/ `custom.html` ... to the `block-templates` folder.
 - Add a `customTemplates` property to the root level of `experimental-theme.json` like so

```
	"customTemplates": {
		"custom": "My Custom Template",
                "postTypes": ["page", "post", "mycpt"]
	}
``` 

Makes sure the the templates show up on the "page attributes" panel of the editor sidebar.