### PR TITLE
Query pagination: remove div

### DIFF
--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -8,23 +8,16 @@ export default function QueryPaginationNextEdit( {
 	attributes: { label },
 	setAttributes,
 } ) {
-	const placeholder = __( 'Next Page' );
 	return (
-		<>
-			<div { ...useBlockProps() }>
-				{
-					<RichText
-						tagName="a"
-						aria-label={ __( 'Next page link' ) }
-						placeholder={ placeholder }
-						value={ label }
-						allowedFormats={ [ 'core/bold', 'core/italic' ] }
-						onChange={ ( newLabel ) =>
-							setAttributes( { label: newLabel } )
-						}
-					/>
-				}
-			</div>
-		</>
+		<RichText
+			tagName="a"
+			aria-label={ __( 'Next page link' ) }
+			placeholder={ __( 'Next Page' ) }
+			value={ label }
+			withoutInteractiveFormatting
+			keepPlaceholderOnFocus
+			onChange={ ( newLabel ) => setAttributes( { label: newLabel } ) }
+			{ ...useBlockProps() }
+		/>
 	);
 }

--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -2,19 +2,19 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useBlockProps, RichText } from '@wordpress/block-editor';
+import { useBlockProps, PlainText } from '@wordpress/block-editor';
 
 export default function QueryPaginationNextEdit( {
 	attributes: { label },
 	setAttributes,
 } ) {
 	return (
-		<RichText
+		<PlainText
+			__experimentalVersion={ 2 }
 			tagName="a"
 			aria-label={ __( 'Next page link' ) }
 			placeholder={ __( 'Next Page' ) }
 			value={ label }
-			withoutInteractiveFormatting
 			keepPlaceholderOnFocus
 			onChange={ ( newLabel ) => setAttributes( { label: newLabel } ) }
 			{ ...useBlockProps() }

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -2,19 +2,19 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useBlockProps, RichText } from '@wordpress/block-editor';
+import { useBlockProps, PlainText } from '@wordpress/block-editor';
 
 export default function QueryPaginationPreviousEdit( {
 	attributes: { label },
 	setAttributes,
 } ) {
 	return (
-		<RichText
+		<PlainText
+			__experimentalVersion={ 2 }
 			tagName="a"
 			aria-label={ __( 'Previous page link' ) }
 			placeholder={ __( 'Previous Page' ) }
 			value={ label }
-			withoutInteractiveFormatting
 			keepPlaceholderOnFocus
 			onChange={ ( newLabel ) => setAttributes( { label: newLabel } ) }
 			{ ...useBlockProps() }

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -8,23 +8,16 @@ export default function QueryPaginationPreviousEdit( {
 	attributes: { label },
 	setAttributes,
 } ) {
-	const placeholder = __( 'Previous Page' );
 	return (
-		<>
-			<div { ...useBlockProps() }>
-				{
-					<RichText
-						tagName="a"
-						aria-label={ __( 'Previous page link' ) }
-						placeholder={ placeholder }
-						value={ label }
-						allowedFormats={ [ 'core/bold', 'core/italic' ] }
-						onChange={ ( newLabel ) =>
-							setAttributes( { label: newLabel } )
-						}
-					/>
-				}
-			</div>
-		</>
+		<RichText
+			tagName="a"
+			aria-label={ __( 'Previous page link' ) }
+			placeholder={ __( 'Previous Page' ) }
+			value={ label }
+			withoutInteractiveFormatting
+			keepPlaceholderOnFocus
+			onChange={ ( newLabel ) => setAttributes( { label: newLabel } ) }
+			{ ...useBlockProps() }
+		/>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

See #28125.

* Removes the extra div that is not displayed on the front-end. 
* Keep placeholder on focus so the element doesn't collapse.
* Allow any formatting as long as it is not interactive, since the parent element is a link. Honestly I'm not sure if we should allow formatting here at all since this is a strange place for it. Formatting is supposed to be semantic. Styles need to be applied on the button.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
