### PR TITLE
Fix top toolbar arrow gap

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -578,6 +578,11 @@
 		min-width: $block-toolbar-height/2;
 		width: $block-toolbar-height/2;
 	}
+}
+
+// Position mover arrows for both toolbars.
+.block-editor-block-contextual-toolbar,
+.edit-post-header-toolbar__block-toolbar {
 
 	.block-editor-block-mover:not(.is-horizontal) {
 		// Position SVGs.


### PR DESCRIPTION
The gap between arrows in the block toolbar is carefully spaced:

<img width="276" alt="Screenshot 2021-02-08 at 10 10 23" src="https://user-images.githubusercontent.com/1204802/107208749-4da3ee80-6a02-11eb-88e5-94d95f6bbe2a.png">

This was off in the top toolbar:

<img width="535" alt="Screenshot 2021-02-08 at 10 10 30" src="https://user-images.githubusercontent.com/1204802/107208769-5399cf80-6a02-11eb-99ea-ef05295a7f67.png">

This PR fixes it:

<img width="201" alt="Screenshot 2021-02-08 at 11 37 43" src="https://user-images.githubusercontent.com/1204802/107208780-572d5680-6a02-11eb-9ab3-b1a584716787.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
