### PR TITLE
Try: Allow vertical inserter in the nav block.

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	align-items: center;
 	position: relative;
-	margin: 0;
+	margin: 0 0.5em 0 0;
 
 	.wp-block-navigation-link__container:empty {
 		display: none;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -12,8 +12,16 @@
 	}
 
 	// Unset horizontal and vertical margin rules from editor normalization stylesheet.
+	// Both margin-left: auto; and margin-right: auto; from .wp-block, and also
+	// margin: revert; from .editor-styles-wrapper ul li.
 	.block-editor-block-list__block {
 		margin: 0;
+
+		// This CSS provides a little spacing between blocks.
+		// It matches a rule in style.scss exactly, but needs higher specificity due to the unsetting of inherited styles above.
+		&.wp-block-navigation-link {
+			margin: 0 0.5em 0 0;
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -5,7 +5,6 @@
 		list-style: none;
 
 		// Overrides generic ".entry-content li" styles on the front end.
-		margin: 0;
 		padding: 0;
 	}
 }


### PR DESCRIPTION
Fixes #28313.

This PR refactors the margins of navigation menu items to have 8px space between them. This allows the vertical sibling inserter to work:

<img width="422" alt="Screenshot 2021-02-08 at 11 55 06" src="https://user-images.githubusercontent.com/1204802/107210685-c7d57280-6a04-11eb-87a6-3f76de0d1da9.png">

This is a bit of an opinionated change, because:

- It adds 8px margin between menu items. But counterpoint: zero margin between menu items is also opinionated, and themes can and should override this.
- The sibling inserter still doesn't work when a theme overrides the margin to be nil. Counterpoint: the vertical sibling inserter won't be a good experience when there's no clearance to invoke it in, so maybe it's good that isn't the case. And people can still insert and move blocks around.

Penny for your thoughts?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
