### PR TITLE
Polish social links when inside navigation.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,9 +1,14 @@
-// Default background and font color
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container {
-	.wp-block-navigation__container {
-		color: $gray-900;
-		background-color: $white;
-		min-width: 200px;
+.wp-block-navigation__container {
+	// Vertically align child blocks, like Social Links or Search.
+	align-items: center;
+
+	// Default background and font color
+	&:not(.has-background) .wp-block-navigation__container {
+		.wp-block-navigation__container {
+			color: $gray-900;
+			background-color: $white;
+			min-width: 200px;
+		}
 	}
 }
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -22,7 +22,7 @@
 	transition: all 0.1s ease-in-out;
 	@include reduce-motion("transition");
 
-	.is-selected & {
+	.is-selected > & {
 		opacity: 0.1;
 	}
 
@@ -40,7 +40,7 @@
 	// Wrap the remaining placeholders in a container so the plus can overlap.
 	> .wp-block-social-links__social-placeholder-icons {
 		display: flex;
-		position: absolute;
+		//position: absolute;
 	}
 
 	& + .block-list-appender,
@@ -67,6 +67,10 @@
 }
 
 // Polish the Appender.
+.wp-block-social-links .wp-block-social-links__social-placeholder + .block-list-appender {
+	position: absolute;
+}
+
 .wp-block-social-links .block-list-appender {
 	padding: 0;
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -40,7 +40,6 @@
 	// Wrap the remaining placeholders in a container so the plus can overlap.
 	> .wp-block-social-links__social-placeholder-icons {
 		display: flex;
-		//position: absolute;
 	}
 
 	& + .block-list-appender,


### PR DESCRIPTION
The Social Links block, when used inside the Navigation block, is rather broken:

<img width="1235" alt="before" src="https://user-images.githubusercontent.com/1204802/107215907-471a7480-6a0c-11eb-92a7-df6b30ca08af.png">

You can't really insert any items at all, and it fades out to suggest it's selected even when it isn't. This PR fixes that:

![after](https://user-images.githubusercontent.com/1204802/107215963-58fc1780-6a0c-11eb-8db0-b163a83bd9e6.gif)

It:

- Vertically centers the social links block inside the taller navigation block.
- Makes it so the social links placeholder doesn't collapse, making the appender buttons overlap.
- Only "fades out" the social links placeholder state when the block is actually selected. Not just when any ancestor is selected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
