### PR TITLE
Remove duplication of editor styles

### DIFF
--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -1,62 +1,57 @@
 /**
  * External dependencies
  */
-import { compact, map } from 'lodash';
 import tinycolor from 'tinycolor2';
 
 /**
  * WordPress dependencies
  */
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import transformStyles from '../../utils/transform-styles';
 
-function syncDarkThemeBodyClassname( node ) {
-	const backgroundColor = window
-		.getComputedStyle( node, null )
-		.getPropertyValue( 'background-color' );
+const EDITOR_STYLES_SELECTOR = '.editor-styles-wrapper';
 
-	const { ownerDocument } = node;
-	const body = ownerDocument.getElementsByTagName( 'body' )[ 0 ];
-
-	if ( tinycolor( backgroundColor ).getLuminance() > 0.5 ) {
-		body.classList.remove( 'is-dark-theme' );
-	} else {
-		body.classList.add( 'is-dark-theme' );
-	}
-}
-
-export default function useEditorStyles( styles ) {
-	const nodes = useRef( [] );
-
+function useDarkThemeBodyClassName( styles ) {
 	return useCallback(
 		( node ) => {
 			if ( ! node ) {
-				nodes.current.forEach( ( styleElement ) =>
-					styleElement.ownerDocument.body.removeChild( styleElement )
-				);
 				return;
 			}
 
-			const updatedStyles = transformStyles(
-				styles,
-				'.editor-styles-wrapper'
-			);
-
 			const { ownerDocument } = node;
-			nodes.current = map( compact( updatedStyles ), ( updatedCSS ) => {
-				const styleElement = ownerDocument.createElement( 'style' );
-				styleElement.innerHTML = updatedCSS;
-				ownerDocument.body.appendChild( styleElement );
+			const { defaultView, body } = ownerDocument;
+			const canvas = ownerDocument.querySelector(
+				EDITOR_STYLES_SELECTOR
+			);
+			const backgroundColor = defaultView
+				.getComputedStyle( canvas, null )
+				.getPropertyValue( 'background-color' );
 
-				return styleElement;
-			} );
-
-			syncDarkThemeBodyClassname( node );
+			if ( tinycolor( backgroundColor ).getLuminance() > 0.5 ) {
+				body.classList.remove( 'is-dark-theme' );
+			} else {
+				body.classList.add( 'is-dark-theme' );
+			}
 		},
 		[ styles ]
+	);
+}
+
+export default function EditorStyles( { styles } ) {
+	return (
+		<>
+			{ /* Use an empty style element to have a document reference,
+			     but this could be any element. */ }
+			<style ref={ useDarkThemeBodyClassName( styles ) } />
+			{ transformStyles( styles, EDITOR_STYLES_SELECTOR ).map(
+				( css, index ) => (
+					<style key={ index }>{ css }</style>
+				)
+			) }
+		</>
 	);
 }

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -132,7 +132,7 @@ function setHead( doc, head ) {
 		'<style>body{margin:0}</style>' + head;
 }
 
-function Iframe( { contentRef, children, head, ...props }, ref ) {
+function Iframe( { contentRef, children, head, headHTML, ...props }, ref ) {
 	const [ iframeDocument, setIframeDocument ] = useState();
 
 	const setRef = useCallback( ( node ) => {
@@ -148,18 +148,18 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 				return false;
 			}
 
-			setIframeDocument( contentDocument );
-			setHead( contentDocument, head );
-			setBodyClassName( contentDocument );
-			styleSheetsCompat( contentDocument );
-			bubbleEvents( contentDocument );
-			setBodyClassName( contentDocument );
-
 			if ( typeof contentRef === 'function' ) {
 				contentRef( body );
 			} else if ( contentRef ) {
 				contentRef.current = body;
 			}
+
+			setHead( contentDocument, headHTML );
+			setBodyClassName( contentDocument );
+			styleSheetsCompat( contentDocument );
+			bubbleEvents( contentDocument );
+			setBodyClassName( contentDocument );
+			setIframeDocument( contentDocument );
 
 			return true;
 		}
@@ -183,6 +183,7 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 			name="editor-canvas"
 		>
 			{ iframeDocument && createPortal( children, iframeDocument.body ) }
+			{ iframeDocument && createPortal( head, iframeDocument.head ) }
 		</iframe>
 	);
 }

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -142,19 +142,24 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 
 		function setDocumentIfReady() {
 			const { contentDocument } = node;
-			const { readyState } = contentDocument;
+			const { readyState, body } = contentDocument;
 
 			if ( readyState !== 'interactive' && readyState !== 'complete' ) {
 				return false;
 			}
 
-			contentRef.current = contentDocument.body;
 			setIframeDocument( contentDocument );
 			setHead( contentDocument, head );
 			setBodyClassName( contentDocument );
 			styleSheetsCompat( contentDocument );
 			bubbleEvents( contentDocument );
 			setBodyClassName( contentDocument );
+
+			if ( typeof contentRef === 'function' ) {
+				contentRef( body );
+			} else if ( contentRef ) {
+				contentRef.current = body;
+			}
 
 			return true;
 		}

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -1,26 +1,14 @@
 /**
- * External dependencies
- */
-import { compact, map } from 'lodash';
-import tinycolor from 'tinycolor2';
-
-/**
  * WordPress dependencies
  */
 import {
 	useState,
 	createPortal,
 	useCallback,
-	useEffect,
 	forwardRef,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMergeRefs } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import transformStyles from '../../utils/transform-styles';
 
 const BODY_CLASS_NAME = 'editor-styles-wrapper';
 const BLOCK_PREFIX = 'wp-block';
@@ -144,34 +132,8 @@ function setHead( doc, head ) {
 		'<style>body{margin:0}</style>' + head;
 }
 
-function updateEditorStyles( doc, styles ) {
-	if ( ! doc ) {
-		return;
-	}
-
-	const backgroundColor = window
-		.getComputedStyle( doc.body, null )
-		.getPropertyValue( 'background-color' );
-	if ( tinycolor( backgroundColor ).getLuminance() > 0.5 ) {
-		doc.body.classList.remove( 'is-dark-theme' );
-	} else {
-		doc.body.classList.add( 'is-dark-theme' );
-	}
-
-	const updatedStyles = transformStyles( styles, '.editor-styles-wrapper' );
-	map( compact( updatedStyles ), ( updatedStyle ) => {
-		const styleElement = doc.createElement( 'style' );
-		styleElement.innerHTML = updatedStyle;
-		doc.body.appendChild( styleElement );
-	} );
-}
-
-function Iframe( { contentRef, editorStyles, children, head, ...props }, ref ) {
+function Iframe( { contentRef, children, head, ...props }, ref ) {
 	const [ iframeDocument, setIframeDocument ] = useState();
-
-	useEffect( () => {
-		updateEditorStyles( iframeDocument, editorStyles );
-	}, [ editorStyles ] );
 
 	const setRef = useCallback( ( node ) => {
 		if ( ! node ) {
@@ -191,7 +153,6 @@ function Iframe( { contentRef, editorStyles, children, head, ...props }, ref ) {
 			setHead( contentDocument, head );
 			setBodyClassName( contentDocument );
 			styleSheetsCompat( contentDocument );
-			updateEditorStyles( contentDocument, editorStyles );
 			bubbleEvents( contentDocument );
 			setBodyClassName( contentDocument );
 

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -96,7 +96,7 @@ export {
 	useClipboardHandler as __unstableUseClipboardHandler,
 } from './copy-handler';
 export { default as DefaultBlockAppender } from './default-block-appender';
-export { default as __unstableUseEditorStyles } from './editor-styles';
+export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
 export { default as __experimentalLibrary } from './inserter/library';
 export { default as __experimentalSearchForm } from './inserter/search-form';

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -16,11 +16,10 @@ import {
 	__experimentalBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableUseCanvasClickRedirect as useCanvasClickRedirect,
-	__unstableUseEditorStyles as useEditorStyles,
+	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 import { Popover } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
-import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -59,14 +58,14 @@ export default function VisualEditor( { styles } ) {
 	useClipboardHandler( ref );
 	useTypingObserver( ref );
 	useCanvasClickRedirect( ref );
-	const editorStylesRef = useEditorStyles( styles );
 
 	return (
 		<div className="edit-post-visual-editor">
+			<EditorStyles styles={ styles } />
 			<VisualEditorGlobalKeyboardShortcuts />
 			<Popover.Slot name="block-toolbar" />
 			<div
-				ref={ useMergeRefs( [ ref, editorStylesRef ] ) }
+				ref={ ref }
 				className="editor-styles-wrapper"
 				style={ resizedCanvasStyles || desktopCanvasStyles }
 			>

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -52,6 +52,7 @@
 		"file-saver": "^2.0.2",
 		"jszip": "^3.2.2",
 		"lodash": "^4.17.19",
+		"react-merge-refs": "^1.0.0",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -52,7 +52,6 @@
 		"file-saver": "^2.0.2",
 		"jszip": "^3.2.2",
 		"lodash": "^4.17.19",
-		"react-merge-refs": "^1.0.0",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -73,10 +73,9 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const resizedCanvasStyles = useResizeCanvas( deviceType, true );
 	const ref = useRef();
 	const contentRef = useRef();
+	const editorStylesRef = useEditorStyles( settings.styles );
 
 	useMouseMoveTypingReset( ref );
-	// Ideally this should be moved to the place where the styles are applied (iframe)
-	const editorStylesRef = useEditorStyles( settings.styles );
 
 	// Allow scrolling "through" popovers over the canvas. This is only called
 	// for as long as the pointer is over a popover.
@@ -124,7 +123,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 						[]
 					) }
 				>
-					<Canvas body={ contentRef } styles={ settings.styles } />
+					<Canvas body={ contentRef } />
 				</Iframe>
 			</div>
 		</BlockEditorProvider>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -70,9 +70,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const contentRef = useRef();
 
 	useMouseMoveTypingReset( ref );
-	// This updates the host document styles.
-	// It is necessary to make sure the preset CSS Custom Properties
-	// are in scope for the sidebar UI controls that use them.
+	// Ideally this should be moved to the place where the styles are applied (iframe)
 	const editorStylesRef = useEditorStyles( settings.styles );
 
 	// Allow scrolling "through" popovers over the canvas. This is only called
@@ -114,7 +112,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				<Popover.Slot name="block-toolbar" />
 				<Iframe
 					style={ resizedCanvasStyles }
-					editorStyles={ settings.styles }
 					head={ window.__editorStyles.html }
 					ref={ ref }
 					contentRef={ contentRef }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import mergeRefs from 'react-merge-refs';
+
+/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -114,7 +119,10 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					style={ resizedCanvasStyles }
 					head={ window.__editorStyles.html }
 					ref={ ref }
-					contentRef={ contentRef }
+					contentRef={ useCallback(
+						mergeRefs( [ contentRef, editorStylesRef ] ),
+						[]
+					) }
 				>
 					<Canvas body={ contentRef } styles={ settings.styles } />
 				</Iframe>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -15,11 +15,10 @@ import {
 	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 	__unstableUseTypingObserver as useTypingObserver,
 	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
-	__unstableUseEditorStyles as useEditorStyles,
+	__unstableEditorStyles as EditorStyles,
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
 import { DropZoneProvider, Popover } from '@wordpress/components';
-import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -69,7 +68,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const resizedCanvasStyles = useResizeCanvas( deviceType, true );
 	const ref = useRef();
 	const contentRef = useRef();
-	const editorStylesRef = useEditorStyles( settings.styles );
 
 	useMouseMoveTypingReset( ref );
 
@@ -104,20 +102,14 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			<SidebarInspectorFill>
 				<BlockInspector />
 			</SidebarInspectorFill>
-			<div
-				ref={ editorStylesRef }
-				className="edit-site-visual-editor"
-				onWheel={ onWheel }
-			>
+			<div className="edit-site-visual-editor" onWheel={ onWheel }>
 				<Popover.Slot name="block-toolbar" />
 				<Iframe
 					style={ resizedCanvasStyles }
-					head={ window.__editorStyles.html }
+					headHTML={ window.__editorStyles.html }
+					head={ <EditorStyles styles={ settings.styles } /> }
 					ref={ ref }
-					contentRef={ useMergeRefs( [
-						contentRef,
-						editorStylesRef,
-					] ) }
+					contentRef={ contentRef }
 				>
 					<Canvas body={ contentRef } />
 				</Iframe>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import mergeRefs from 'react-merge-refs';
-
-/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -24,6 +19,7 @@ import {
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
 import { DropZoneProvider, Popover } from '@wordpress/components';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -118,10 +114,10 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					style={ resizedCanvasStyles }
 					head={ window.__editorStyles.html }
 					ref={ ref }
-					contentRef={ useCallback(
-						mergeRefs( [ contentRef, editorStylesRef ] ),
-						[]
-					) }
+					contentRef={ useMergeRefs( [
+						contentRef,
+						editorStylesRef,
+					] ) }
 				>
 					<Canvas body={ contentRef } />
 				</Iframe>

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -7,10 +7,7 @@ import {
 	useViewportMatch,
 } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
-import {
-	__experimentalLibrary as Library,
-	__unstableUseEditorStyles as useEditorStyles,
-} from '@wordpress/block-editor';
+import { __experimentalLibrary as Library } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -54,7 +51,6 @@ function Interface( { blockEditorSettings } ) {
 		} ),
 		[]
 	);
-	const editorStylesRef = useEditorStyles( blockEditorSettings.styles );
 
 	// Inserter and Sidebars are mutually exclusive
 	useEffect( () => {
@@ -75,7 +71,6 @@ function Interface( { blockEditorSettings } ) {
 
 	return (
 		<InterfaceSkeleton
-			ref={ editorStylesRef }
 			labels={ interfaceLabels }
 			header={ <Header /> }
 			secondarySidebar={

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -8,6 +8,7 @@ import {
 	BlockSelectionClearer,
 	WritingFlow,
 	ObserveTyping,
+	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 
 /**
@@ -16,9 +17,12 @@ import {
 import Notices from '../notices';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 
-export default function WidgetAreasBlockEditorContent() {
+export default function WidgetAreasBlockEditorContent( {
+	blockEditorSettings,
+} ) {
 	return (
 		<div className="edit-widgets-block-editor editor-styles-wrapper">
+			<EditorStyles styles={ blockEditorSettings.styles } />
 			<KeyboardShortcuts />
 			<BlockEditorKeyboardShortcuts />
 			<Notices />


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Rewrites #28731 to avoid duplication of code.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
