### PR TITLE
Change apt command to apt-get command

### DIFF
--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -106,7 +106,7 @@ function dockerFileContents( image, xdebugMode ) {
 
 	return `FROM ${ image }
 
-RUN apt -qy install $PHPIZE_DEPS \\
+RUN apt-get -qy install $PHPIZE_DEPS \\
 	&& pecl install xdebug \\
 	&& docker-php-ext-enable xdebug
 


### PR DESCRIPTION
## Description
[The apt is a command for interactive usage, and the apt-get command should be used on shell scripts.](https://www.debian.org/doc/manuals/debian-reference/ch02.en.html#_literal_apt_literal_vs_literal_apt_get_literal_literal_apt_cache_literal_vs_literal_aptitude_literal)

## How has this been tested?

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
