### PR TITLE
Add optional dependency array to the usePrevious hook

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -290,10 +290,11 @@ Based on <https://usehooks.com/usePrevious/>.
 _Parameters_
 
 -   _value_ `T`: The value to track.
+-   _optionalDependencyList_ `Array<T>`: of dependencies describing on change of which parameter a value should be cached. By default previous value is saved every time the value changes.
 
 _Returns_
 
--   `(T|undefined)`: The value from the previous render.
+-   `(T|undefined)`: The value cached, when no optional dependencies provided, previous value is equal to value from the previous render.
 
 <a name="useReducedMotion" href="#useReducedMotion">#</a> **useReducedMotion**
 

--- a/packages/compose/src/hooks/use-previous/README.md
+++ b/packages/compose/src/hooks/use-previous/README.md
@@ -4,6 +4,7 @@ Sometimes you need to get the value something had on the previous render. `usePr
 
 ## Usage
 
+Save previous value on every rerender
 ```jsx
 /**
  * WordPress dependencies
@@ -15,6 +16,39 @@ function MyCustomElement() {
 	const [ myNumber, setMyNumber ] = useState( 5 );
 	const [ lastChange, setLastChange ] = useState( 'none' );
 	const prevNumber = usePrevious( myNumber );
+
+	useEffect( () => {
+		// On the first render, prevNumber will be undefined.
+		if ( prevNumber !== undefined ) {
+			if ( myNumber > prevNumber ) {
+				setLastChange( 'up' );
+			} else if ( myNumber < prevNumber ) {
+				setLastChange( 'down' );
+			}
+		}
+	}, [ myNumber ] );
+
+	return (
+		<p>
+			My number is { myNumber }. Last change: { lastChange }
+		</p>
+	);
+}
+```
+
+Save previous value on every change of dependencies
+```jsx
+/**
+ * WordPress dependencies
+ */
+import { usePrevious } from '@wordpress/compose';
+import { useEffect, useState } from '@wordpress/element';
+
+function MyCustomElement({userAction}) {
+	const [ myNumber, setMyNumber ] = useState( 5 );
+	const [ lastChange, setLastChange ] = useState( 'none' );
+	// prevNumber is saved on every userAction update
+	const prevNumber = usePrevious( myNumber, [userAction] );
 
 	useEffect( () => {
 		// On the first render, prevNumber will be undefined.

--- a/packages/compose/src/hooks/use-previous/index.js
+++ b/packages/compose/src/hooks/use-previous/index.js
@@ -26,7 +26,7 @@ export default function usePrevious(
 	// Store current value in ref.
 	useEffect( () => {
 		ref.current = value;
-	}, optionalDependencyList ); // Re-run when value changes.
+	}, optionalDependencyList ); // Re-run when any dependency changes.
 
 	// Return previous value (happens before update in useEffect above).
 	return ref.current;

--- a/packages/compose/src/hooks/use-previous/index.js
+++ b/packages/compose/src/hooks/use-previous/index.js
@@ -7,13 +7,15 @@ import { useEffect, useRef } from '@wordpress/element';
  * Use something's value from the previous render.
  * Based on https://usehooks.com/usePrevious/.
  *
- * @template T
- *
+ * @template T T
  * @param {T} value The value to track.
- *
- * @return {T|undefined} The value from the previous render.
+ * @param {T[]} optionalDependencyList of dependencies describing on change of which parameter a value should be cached. By default previous value is saved every time the value changes.
+ * @return {T|undefined} The value cached, when no optional dependencies provided, previous value is equal to value from the previous render.
  */
-export default function usePrevious( value ) {
+export default function usePrevious(
+	value,
+	optionalDependencyList = [ value ]
+) {
 	// Disable reason: without an explicit type detail, the type of ref will be
 	// inferred based on the initial useRef argument, which is undefined.
 	// https://github.com/WordPress/gutenberg/pull/22597#issuecomment-633588366
@@ -24,7 +26,7 @@ export default function usePrevious( value ) {
 	// Store current value in ref.
 	useEffect( () => {
 		ref.current = value;
-	}, [ value ] ); // Re-run when value changes.
+	}, optionalDependencyList ); // Re-run when value changes.
 
 	// Return previous value (happens before update in useEffect above).
 	return ref.current;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
Makes it possible to add array of dependencies indicating when to cache previous value


## Description
<!-- Please describe what you have changed or added -->
Sometimes it is handy not to save previous value on every value change but only when some other dependencies are updating. The proposed change does not affect any code that is already written.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tests run locally are passing

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
