### PR TITLE
wp-env: Use Simple Git instead of NodeGit

### DIFF
--- a/bin/plugin/lib/git.js
+++ b/bin/plugin/lib/git.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * External dependencies
  */

--- a/bin/plugin/lib/git.js
+++ b/bin/plugin/lib/git.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const SimpleGit = require( 'simple-git/promise' );
+const SimpleGit = require( 'simple-git' );
 
 /**
  * Internal dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -3996,6 +3996,38 @@
 				}
 			}
 		},
+		"@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"@kwsites/promise-deferred": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+			"dev": true
+		},
 		"@lerna/add": {
 			"version": "3.21.0",
 			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.21.0.tgz",
@@ -12355,11 +12387,39 @@
 				"got": "^10.7.0",
 				"inquirer": "^7.1.0",
 				"js-yaml": "^3.13.1",
-				"nodegit": "^0.27.0",
 				"ora": "^4.0.2",
 				"rimraf": "^3.0.2",
+				"simple-git": "^2.34.2",
 				"terminal-link": "^2.0.0",
 				"yargs": "^14.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"simple-git": {
+					"version": "2.34.2",
+					"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.34.2.tgz",
+					"integrity": "sha512-/EX4FtcpAj5L/Bs5zgaBGYDrnkrKflFVNppNLH9VXpIjZBLHx5cZ6/mOYJCoKXKlLRuk3iTvzrIsHo7v42zWHg==",
+					"dev": true,
+					"requires": {
+						"@kwsites/file-exists": "^1.1.1",
+						"@kwsites/promise-deferred": "^1.1.1",
+						"debug": "^4.3.1"
+					}
+				}
 			}
 		},
 		"@wordpress/escape-html": {
@@ -22853,16 +22913,6 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
-		"bl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
-			}
-		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -23317,32 +23367,10 @@
 				"isarray": "^1.0.0"
 			}
 		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true
-		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.0",
@@ -26368,12 +26396,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
 			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-			"dev": true
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 			"dev": true
 		},
 		"detect-newline": {
@@ -41548,7 +41570,8 @@
 		"nan": {
 			"version": "2.14.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+			"optional": true
 		},
 		"nanoid": {
 			"version": "3.1.16",
@@ -41605,34 +41628,6 @@
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
 					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
-				}
-			}
-		},
-		"needle": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-			"integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
-			"dev": true,
-			"requires": {
-				"debug": "^3.2.6",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
@@ -41731,58 +41726,6 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"node-gyp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
-			"integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.0.3",
-				"graceful-fs": "^4.1.2",
-				"mkdirp": "^0.5.0",
-				"nopt": "2 || 3",
-				"npmlog": "0 || 1 || 2 || 3 || 4",
-				"osenv": "0",
-				"request": "^2.87.0",
-				"rimraf": "2",
-				"semver": "~5.3.0",
-				"tar": "^4.4.8",
-				"which": "1"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					},
-					"dependencies": {
-						"glob": {
-							"version": "7.1.6",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-							"dev": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						}
-					}
-				},
-				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-					"dev": true
-				}
-			}
-		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -41850,102 +41793,6 @@
 				}
 			}
 		},
-		"node-pre-gyp": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
-			"integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
-			"dev": true,
-			"requires": {
-				"detect-libc": "^1.0.2",
-				"mkdirp": "^0.5.1",
-				"needle": "^2.2.1",
-				"nopt": "^4.0.1",
-				"npm-packlist": "^1.1.6",
-				"npmlog": "^4.0.2",
-				"rc": "^1.2.7",
-				"rimraf": "^2.6.1",
-				"semver": "^5.3.0",
-				"tar": "^4"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				},
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"nopt": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-					"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-					"dev": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				},
-				"tar": {
-					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-					"dev": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-					"dev": true
-				}
-			}
-		},
 		"node-releases": {
 			"version": "1.1.67",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
@@ -41958,45 +41805,6 @@
 			"integrity": "sha512-OOBiglke5SlRQT5WYfwXTmYqTfXjcTNBHpalyHLtLxDpQYVpVRkJqabcch1kmwJsjV/J4OZuzEafeb4soqtFZA==",
 			"dev": true
 		},
-		"nodegit": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/nodegit/-/nodegit-0.27.0.tgz",
-			"integrity": "sha512-E9K4gPjWiA0b3Tx5lfWCzG7Cvodi2idl3V5UD2fZrOrHikIfrN7Fc2kWLtMUqqomyoToYJLeIC8IV7xb1CYRLA==",
-			"dev": true,
-			"requires": {
-				"fs-extra": "^7.0.0",
-				"got": "^10.7.0",
-				"json5": "^2.1.0",
-				"lodash": "^4.17.14",
-				"nan": "^2.14.0",
-				"node-gyp": "^4.0.0",
-				"node-pre-gyp": "^0.13.0",
-				"ramda": "^0.25.0",
-				"tar-fs": "^1.16.3"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"json5": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				}
-			}
-		},
 		"nomnom": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
@@ -42005,15 +41813,6 @@
 			"requires": {
 				"colors": "0.5.x",
 				"underscore": "~1.4.4"
-			}
-		},
-		"nopt": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true,
-			"requires": {
-				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -45724,12 +45523,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
 			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
-			"dev": true
-		},
-		"ramda": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-			"integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
 			"dev": true
 		},
 		"randexp": {
@@ -52731,45 +52524,6 @@
 				}
 			}
 		},
-		"tar-fs": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-			"dev": true,
-			"requires": {
-				"chownr": "^1.0.1",
-				"mkdirp": "^0.5.1",
-				"pump": "^1.0.0",
-				"tar-stream": "^1.1.2"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
-			}
-		},
-		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-			"dev": true,
-			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
-				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
-			}
-		},
 		"telejson": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/telejson/-/telejson-5.1.0.tgz",
@@ -53461,12 +53215,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
-		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
 			"dev": true
 		},
 		"to-fast-properties": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22913,6 +22913,58 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+					"dev": true
+				},
+				"buffer": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
+					}
+				},
+				"ieee754": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+					"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+					"dev": true
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -45262,47 +45314,6 @@
 					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
 					"dev": true
 				},
-				"base64-js": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-					"dev": true
-				},
-				"bl": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-					"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.5.0",
-						"inherits": "^2.0.4",
-						"readable-stream": "^3.4.0"
-					},
-					"dependencies": {
-						"inherits": {
-							"version": "2.0.4",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-							"dev": true
-						}
-					}
-				},
-				"buffer": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-					"dev": true,
-					"requires": {
-						"base64-js": "^1.3.1",
-						"ieee754": "^1.1.13"
-					}
-				},
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				},
 				"debug": {
 					"version": "4.3.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -45352,12 +45363,6 @@
 						"agent-base": "5",
 						"debug": "4"
 					}
-				},
-				"ieee754": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-					"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-					"dev": true
 				},
 				"locate-path": {
 					"version": "5.0.0",
@@ -45411,52 +45416,6 @@
 					"dev": true,
 					"requires": {
 						"find-up": "^4.0.0"
-					}
-				},
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"tar-fs": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-					"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-					"dev": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"mkdirp-classic": "^0.5.2",
-						"pump": "^3.0.0",
-						"tar-stream": "^2.1.4"
-					}
-				},
-				"tar-stream": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-					"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-					"dev": true,
-					"requires": {
-						"bl": "^4.0.3",
-						"end-of-stream": "^1.4.1",
-						"fs-constants": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^3.1.1"
 					}
 				},
 				"yauzl": {
@@ -52523,6 +52482,62 @@
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true
+				}
+			}
+		},
+		"tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"dev": true,
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			},
+			"dependencies": {
+				"chownr": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"dev": true
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
+			}
+		},
+		"tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"requires": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -49898,27 +49898,29 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simple-git": {
-			"version": "1.113.0",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.113.0.tgz",
-			"integrity": "sha512-i9WVsrK2u0G/cASI9nh7voxOk9mhanWY9eGtWBDSYql6m49Yk5/Fan6uZsDr/xmzv8n+eQ8ahKCoEr8cvU3h+g==",
+			"version": "2.34.2",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.34.2.tgz",
+			"integrity": "sha512-/EX4FtcpAj5L/Bs5zgaBGYDrnkrKflFVNppNLH9VXpIjZBLHx5cZ6/mOYJCoKXKlLRuk3iTvzrIsHo7v42zWHg==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.0.1"
+				"@kwsites/file-exists": "^1.1.1",
+				"@kwsites/promise-deferred": "^1.1.1",
+				"debug": "^4.3.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12389,7 +12389,7 @@
 				"js-yaml": "^3.13.1",
 				"ora": "^4.0.2",
 				"rimraf": "^3.0.2",
-				"simple-git": "^2.34.2",
+				"simple-git": "^2.35.0",
 				"terminal-link": "^2.0.0",
 				"yargs": "^14.0.0"
 			},
@@ -49857,9 +49857,9 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simple-git": {
-			"version": "2.34.2",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.34.2.tgz",
-			"integrity": "sha512-/EX4FtcpAj5L/Bs5zgaBGYDrnkrKflFVNppNLH9VXpIjZBLHx5cZ6/mOYJCoKXKlLRuk3iTvzrIsHo7v42zWHg==",
+			"version": "2.35.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.35.0.tgz",
+			"integrity": "sha512-VuXs2/HyZmZm43Z5IjvU+ahTmURh/Hmb/egmgNdFZuu8OEnW2emCalnL/4jRQkXeJvfzCTnev6wo5jtDmWw0Dw==",
 			"dev": true,
 			"requires": {
 				"@kwsites/file-exists": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12410,9 +12410,9 @@
 					"dev": true
 				},
 				"simple-git": {
-					"version": "2.34.2",
-					"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.34.2.tgz",
-					"integrity": "sha512-/EX4FtcpAj5L/Bs5zgaBGYDrnkrKflFVNppNLH9VXpIjZBLHx5cZ6/mOYJCoKXKlLRuk3iTvzrIsHo7v42zWHg==",
+					"version": "2.35.0",
+					"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.35.0.tgz",
+					"integrity": "sha512-VuXs2/HyZmZm43Z5IjvU+ahTmURh/Hmb/egmgNdFZuu8OEnW2emCalnL/4jRQkXeJvfzCTnev6wo5jtDmWw0Dw==",
 					"dev": true,
 					"requires": {
 						"@kwsites/file-exists": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 		"sass": "1.26.11",
 		"sass-loader": "8.0.2",
 		"semver": "7.3.2",
-		"simple-git": "1.113.0",
+		"simple-git": "^2.34.2",
 		"snapshot-diff": "0.8.1",
 		"source-map-loader": "0.2.4",
 		"sprintf-js": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 		"sass": "1.26.11",
 		"sass-loader": "8.0.2",
 		"semver": "7.3.2",
-		"simple-git": "^2.34.2",
+		"simple-git": "^2.35.0",
 		"snapshot-diff": "0.8.1",
 		"source-map-loader": "0.2.4",
 		"sprintf-js": "1.1.1",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   "mappings" sources are now downloaded if they contain non-local sources.
 
+### Enhancement
+
+-   Migrate from `nodegit` to `simple-git`.
+
 ## 3.0.0 (2020-12-17)
 
 ### Breaking Changes

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   Migrate from `nodegit` to `simple-git`. This change now requires you to have a `git` binary installed locally to utilize the git sources feature of wp-env.json.
+
 ### Bug Fixes
 
 -   "mappings" sources are now downloaded if they contain non-local sources.
-
-### Enhancement
-
--   Migrate from `nodegit` to `simple-git`.
 
 ## 3.0.0 (2020-12-17)
 

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -120,6 +120,7 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 			'--depth': '1',
 			'--no-single-branch': null,
 		} );
+		await git.cwd( source.clonePath );
 	}
 
 	log( 'Fetching the specified ref.' );

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -106,8 +106,12 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 		: () => {};
 	onProgress( 0 );
 
+	const progressHandler = ( { progress } ) => {
+		onProgress( progress / 100 );
+	};
+
 	log( 'Cloning or getting the repo.' );
-	const git = SimpleGit();
+	const git = SimpleGit( { progress: progressHandler } );
 
 	const isRepo =
 		fs.existsSync( source.clonePath ) &&

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -111,7 +111,7 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 
 	const isRepo =
 		fs.existsSync( source.clonePath ) &&
-		( await git.cwd( source.clonePath ).checkIsRepo() );
+		( await git.cwd( source.clonePath ).checkIsRepo( 'root' ) );
 
 	if ( isRepo ) {
 		log( 'Repo already exists, using it.' );
@@ -124,8 +124,8 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 	}
 
 	log( 'Fetching the specified ref.' );
-
 	await git.fetch( 'origin', source.ref );
+
 	log( 'Checking out the specified ref.' );
 	await git.checkout( source.ref );
 

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 const util = require( 'util' );
-const NodeGit = require( 'nodegit' );
+const SimpleGit = require( 'simple-git' );
 const fs = require( 'fs' );
 const got = require( 'got' );
 const path = require( 'path' );
@@ -100,69 +100,33 @@ async function downloadSource( source, options ) {
 async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 	const log = debug
 		? ( message ) => {
-				spinner.info( `NodeGit: ${ message }` );
+				spinner.info( `SimpleGit: ${ message }` );
 				spinner.start();
 		  }
 		: () => {};
 	onProgress( 0 );
 
-	const gitFetchOptions = {
-		fetchOpts: {
-			callbacks: {
-				transferProgress( progress ) {
-					// Fetches are finished when all objects are received and indexed,
-					// so received objects plus indexed objects should equal twice
-					// the total number of objects when done.
-					onProgress(
-						( progress.receivedObjects() +
-							progress.indexedObjects() ) /
-							( progress.totalObjects() * 2 )
-					);
-				},
-				certificateCheck: () => 0,
-				credentials: ( url, userName ) => {
-					try {
-						return NodeGit.Cred.sshKeyFromAgent( userName );
-					} catch {
-						return NodeGit.Cred.defaultNew();
-					}
-				},
-			},
-		},
-	};
-
 	log( 'Cloning or getting the repo.' );
-	const repository = await NodeGit.Clone(
-		source.url,
-		source.clonePath,
-		gitFetchOptions
-	).catch( () => {
-		log( 'Repo already exists, get it.' );
-		return NodeGit.Repository.open( source.clonePath );
-	} );
+	const git = SimpleGit();
+
+	const isRepo =
+		fs.existsSync( source.clonePath ) &&
+		( await git.cwd( source.clonePath ).checkIsRepo() );
+
+	if ( isRepo ) {
+		log( 'Repo already exists, using it.' );
+	} else {
+		await git.clone( source.url, source.clonePath, {
+			'--depth': '1',
+			'--no-single-branch': null,
+		} );
+	}
 
 	log( 'Fetching the specified ref.' );
-	const remote = await repository.getRemote( 'origin' );
-	await remote.fetch( source.ref, gitFetchOptions.fetchOpts );
-	await remote.disconnect();
-	try {
-		log( 'Checking out the specified ref.' );
-		await repository.checkoutRef(
-			await repository
-				.getReference( 'FETCH_HEAD' )
-				// Sometimes git doesn't update FETCH_HEAD for things
-				// like tags so we try another method here.
-				.catch(
-					repository.getReference.bind( repository, source.ref )
-				),
-			{
-				checkoutStrategy: NodeGit.Checkout.STRATEGY.FORCE,
-			}
-		);
-	} catch ( error ) {
-		log( 'Ref needs to be set as detached.' );
-		await repository.setHeadDetached( source.ref );
-	}
+
+	await git.fetch( 'origin', source.ref );
+	log( 'Checking out the specified ref.' );
+	await git.checkout( source.ref );
 
 	onProgress( 1 );
 }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -39,9 +39,9 @@
 		"got": "^10.7.0",
 		"inquirer": "^7.1.0",
 		"js-yaml": "^3.13.1",
-		"nodegit": "^0.27.0",
 		"ora": "^4.0.2",
 		"rimraf": "^3.0.2",
+		"simple-git": "^2.34.2",
 		"terminal-link": "^2.0.0",
 		"yargs": "^14.0.0"
 	},

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -41,7 +41,7 @@
 		"js-yaml": "^3.13.1",
 		"ora": "^4.0.2",
 		"rimraf": "^3.0.2",
-		"simple-git": "^2.34.2",
+		"simple-git": "^2.35.0",
 		"terminal-link": "^2.0.0",
 		"yargs": "^14.0.0"
 	},


### PR DESCRIPTION
## Description
Fixes #26660. Alternative to #28804.

~Since `simple-git` doesn't expose download progress for `git clone`, we lose the progress meters (i.e. they only show 0% at the start, and 100% once the download is done, but no in-between states).~

Edit (see https://github.com/WordPress/gutenberg/pull/28848#issuecomment-780793265): Oh, turns out the [latest version of `simple-git`](https://github.com/steveukx/git-js/releases/tag/v2.35.0) (which was just released) now includes a proper [progress handler](https://github.com/steveukx/git-js#progress-events) :partying_face:

## How has this been tested?

- Remove your local `~/.wp-env` or `~/wp-env` folder (warning, this removes your local WP dev install).
- Run `./packages/env/bin/wp-env start`. Verify that it successfully clones the `WordPress` and `theme-experiments` repos, and starts a local WP install successfully.
- Furthermore, verify that CI tests pass.