### PR TITLE
Iterate on the public API of WP_Theme_JSON_Resolver

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -407,7 +407,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @return WP_Theme_JSON
 	 */
-	public function get_merged_data( $theme_support_data = array(), $origin = 'user' ) {
+	public static function get_merged_data( $theme_support_data = array(), $origin = 'user' ) {
 		if ( 'theme' === $origin ) {
 			$result = new WP_Theme_JSON();
 			$result->merge( self::get_core_data() );

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -351,7 +351,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @return WP_Theme_JSON Entity that holds user data.
 	 */
-	private static function get_user_origin() {
+	public static function get_user_data() {
 		if ( null !== self::$user ) {
 			return self::$user;
 		}
@@ -415,7 +415,7 @@ class WP_Theme_JSON_Resolver {
 			$result = new WP_Theme_JSON();
 			$result->merge( self::get_core_data() );
 			$result->merge( $this->get_theme_data( $theme_support_data ) );
-			$result->merge( self::get_user_origin() );
+			$result->merge( self::get_user_data() );
 			return $result;
 		}
 
@@ -427,7 +427,7 @@ class WP_Theme_JSON_Resolver {
 		}
 
 		if ( 'user' === $origin ) {
-			return self::get_user_origin();
+			return self::get_user_data();
 		}
 
 		if ( 'theme' === $origin ) {

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -279,7 +279,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @return WP_Theme_JSON Entity that holds theme data.
 	 */
-	public function get_theme_data( $theme_support_data = array() ) {
+	public static function get_theme_data( $theme_support_data = array() ) {
 		if ( null === self::$theme ) {
 			$theme_json_data = self::get_from_file( locate_template( 'experimental-theme.json' ) );
 			self::translate_presets( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
@@ -411,13 +411,13 @@ class WP_Theme_JSON_Resolver {
 		if ( 'theme' === $origin ) {
 			$result = new WP_Theme_JSON();
 			$result->merge( self::get_core_data() );
-			$result->merge( $this->get_theme_data( $theme_support_data ) );
+			$result->merge( self::get_theme_data( $theme_support_data ) );
 			return $result;
 		}
 
 		$result = new WP_Theme_JSON();
 		$result->merge( self::get_core_data() );
-		$result->merge( $this->get_theme_data( $theme_support_data ) );
+		$result->merge( self::get_theme_data( $theme_support_data ) );
 		$result->merge( self::get_user_data() );
 		return $result;
 	}

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -384,57 +384,42 @@ class WP_Theme_JSON_Resolver {
 	}
 
 	/**
-	 * There are three sources of data for a site:
-	 * core, theme, and user.
+	 * There are three sources of data (origins) for a site:
+	 * core, theme, and user. The user's has higher priority
+	 * than the theme's, and the theme's higher than core's.
 	 *
-	 * The main function of the resolver is to
-	 * merge all this data following this algorithm:
-	 * theme overrides core, and user overrides
-	 * data coming from either theme or core.
+	 * Unlike the getters {@link get_core_data},
+	 * {@link get_theme_data}, and {@link get_user_data},
+	 * this method returns data after it has been merged
+	 * with the previous origins. This means that if the same piece of data
+	 * is declared in different origins (user, theme, and core),
+	 * the last origin overrides the previous.
 	 *
-	 * user data > theme data > core data
-	 *
-	 * The main use case for the resolver is to return
-	 * the merged data up to the user level.However,
-	 * there are situations in which we need the
-	 * data merged up to a different level (theme)
-	 * or no merged at all.
+	 * For example, if the user has set a background color
+	 * for the paragraph block, and the theme has done it as well,
+	 * the user preference wins.
 	 *
 	 * @param array   $theme_support_data Existing block editor settings.
 	 *                                    Empty array by default.
-	 * @param string  $origin The source of data the consumer wants.
-	 *                       Valid values are 'core', 'theme', 'user'.
+	 * @param string  $origin To what level should we merge data.
+	 *                       Valid values are 'theme' or 'user'.
 	 *                       Default is 'user'.
-	 * @param boolean $merged Whether the data should be merged
-	 *                        with the previous origins (the default).
 	 *
 	 * @return WP_Theme_JSON
 	 */
-	public function get_origin( $theme_support_data = array(), $origin = 'user', $merged = true ) {
-		if ( ( 'user' === $origin ) && $merged ) {
-			$result = new WP_Theme_JSON();
-			$result->merge( self::get_core_data() );
-			$result->merge( $this->get_theme_data( $theme_support_data ) );
-			$result->merge( self::get_user_data() );
-			return $result;
-		}
-
-		if ( ( 'theme' === $origin ) && $merged ) {
-			$result = new WP_Theme_JSON();
-			$result->merge( self::get_core_data() );
-			$result->merge( $this->get_theme_data( $theme_support_data ) );
-			return $result;
-		}
-
-		if ( 'user' === $origin ) {
-			return self::get_user_data();
-		}
-
+	public function get_merged_data( $theme_support_data = array(), $origin = 'user' ) {
 		if ( 'theme' === $origin ) {
-			return $this->get_theme_data( $theme_support_data );
+			$result = new WP_Theme_JSON();
+			$result->merge( self::get_core_data() );
+			$result->merge( $this->get_theme_data( $theme_support_data ) );
+			return $result;
 		}
 
-		return self::get_core_data();
+		$result = new WP_Theme_JSON();
+		$result->merge( self::get_core_data() );
+		$result->merge( $this->get_theme_data( $theme_support_data ) );
+		$result->merge( self::get_user_data() );
+		return $result;
 	}
 
 	/**

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -399,9 +399,9 @@ class WP_Theme_JSON_Resolver {
 	 * for the paragraph block, and the theme has done it as well,
 	 * the user preference wins.
 	 *
-	 * @param array   $theme_support_data Existing block editor settings.
-	 *                                    Empty array by default.
-	 * @param string  $origin To what level should we merge data.
+	 * @param array  $theme_support_data Existing block editor settings.
+	 *                                   Empty array by default.
+	 * @param string $origin To what level should we merge data.
 	 *                       Valid values are 'theme' or 'user'.
 	 *                       Default is 'user'.
 	 *

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -195,7 +195,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @return WP_Theme_JSON Entity that holds core data.
 	 */
-	private static function get_core_origin() {
+	public static function get_core_data() {
 		if ( null !== self::$core ) {
 			return self::$core;
 		}
@@ -413,7 +413,7 @@ class WP_Theme_JSON_Resolver {
 	public function get_origin( $theme_support_data = array(), $origin = 'user', $merged = true ) {
 		if ( ( 'user' === $origin ) && $merged ) {
 			$result = new WP_Theme_JSON();
-			$result->merge( self::get_core_origin() );
+			$result->merge( self::get_core_data() );
 			$result->merge( $this->get_theme_data( $theme_support_data ) );
 			$result->merge( self::get_user_origin() );
 			return $result;
@@ -421,7 +421,7 @@ class WP_Theme_JSON_Resolver {
 
 		if ( ( 'theme' === $origin ) && $merged ) {
 			$result = new WP_Theme_JSON();
-			$result->merge( self::get_core_origin() );
+			$result->merge( self::get_core_data() );
 			$result->merge( $this->get_theme_data( $theme_support_data ) );
 			return $result;
 		}
@@ -434,7 +434,7 @@ class WP_Theme_JSON_Resolver {
 			return $this->get_theme_data( $theme_support_data );
 		}
 
-		return self::get_core_origin();
+		return self::get_core_data();
 	}
 
 	/**

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -19,8 +19,7 @@ function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_t
 		return $templates;
 	}
 
-	$resolver         = new WP_Theme_JSON_Resolver();
-	$data             = $resolver->get_theme_data()->get_custom_templates();
+	$data             = WP_Theme_JSON_Resolver::get_theme_data()->get_custom_templates();
 	$custom_templates = array();
 	if ( isset( $data ) ) {
 		foreach ( $data  as $key => $template ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -170,8 +170,7 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 	$settings           = gutenberg_get_common_block_editor_settings();
 	$theme_support_data = gutenberg_experimental_global_styles_get_theme_support_settings( $settings );
 
-	$resolver = new WP_Theme_JSON_Resolver();
-	$all      = $resolver->get_merged_data( $theme_support_data );
+	$all = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data );
 
 	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );
 	if ( empty( $stylesheet ) ) {
@@ -201,8 +200,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	unset( $settings['fontSizes'] );
 	unset( $settings['gradients'] );
 
-	$resolver = new WP_Theme_JSON_Resolver();
-	$origin   = 'theme';
+	$origin = 'theme';
 	if (
 		WP_Theme_JSON_Resolver::theme_has_support() &&
 		gutenberg_is_fse_theme()
@@ -210,7 +208,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		// Only lookup for the user data if we need it.
 		$origin = 'user';
 	}
-	$tree = $resolver->get_merged_data( $theme_support_data, $origin );
+	$tree = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, $origin );
 
 	// STEP 1: ADD FEATURES
 	//
@@ -234,7 +232,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		gutenberg_is_fse_theme()
 	) {
 		$user_cpt_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
-		$base_styles = $resolver->get_merged_data( $theme_support_data, 'theme' )->get_raw_data();
+		$base_styles = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get_raw_data();
 
 		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $base_styles;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -171,7 +171,7 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 	$theme_support_data = gutenberg_experimental_global_styles_get_theme_support_settings( $settings );
 
 	$resolver = new WP_Theme_JSON_Resolver();
-	$all      = $resolver->get_origin( $theme_support_data );
+	$all      = $resolver->get_merged_data( $theme_support_data );
 
 	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );
 	if ( empty( $stylesheet ) ) {
@@ -210,7 +210,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		// Only lookup for the user data if we need it.
 		$origin = 'user';
 	}
-	$tree = $resolver->get_origin( $theme_support_data, $origin );
+	$tree = $resolver->get_merged_data( $theme_support_data, $origin );
 
 	// STEP 1: ADD FEATURES
 	//
@@ -234,7 +234,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		gutenberg_is_fse_theme()
 	) {
 		$user_cpt_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
-		$base_styles = $resolver->get_origin( $theme_support_data, 'theme' )->get_raw_data();
+		$base_styles = $resolver->get_merged_data( $theme_support_data, 'theme' )->get_raw_data();
 
 		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $base_styles;

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -247,7 +247,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						),
 						'misc'       => 'value',
 					),
-					'core/group' => array(
+					'core/group'     => array(
 						'custom' => array(
 							'base-font'   => 16,
 							'line-height' => array(


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/28700

This PR iterates on the public API of the `WP_Theme_JSON_Resolver` class. This is the whole API after the changes in this PR (all methods are static):

- `get_core_data` => returns core data as it is in the core's theme.json file.
- `get_theme_data` => returns theme data as it is in the theme.json file.
- `get_user_data` => returns user data as it is in the database (custom post type).
- `get_merged_data( $theme_data, $origin )` => returns the merged data at 
- `register_user_custom_post_type` => register the CPT to store user's data
- `get_user_custom_post_type_id` => returns the ID of the user CPT
- `theme_has_support` => whether the current theme has support for `theme.json`

Follow-ups:

- Substitute the use of `locate_template` by our own method https://github.com/WordPress/gutenberg/pull/28410#discussion_r572847813