### PR TITLE
Allow blank GitHub issues again

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: General help request
     url: https://wordpress.org/support/forum/how-to-and-troubleshooting/


### PR DESCRIPTION
Not allowing blank issues seemed like a good idea at the time (https://github.com/WordPress/gutenberg/pull/27570) but in practice it's annoying for when we are creating issues that don't fit in with any particular template: discussions, overviews, collecting dev notes, tasks, etc.

This PR flips the `blank_issues_enabled` flag back to how it was before https://github.com/WordPress/gutenberg/pull/27570.

Documentation: https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser