### PR TITLE
Fix inline style inheritance in Navigation block

### DIFF
--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -37,7 +37,8 @@
 		"customBackgroundColor",
 		"fontSize",
 		"customFontSize",
-		"showSubmenuIcon"
+		"showSubmenuIcon",
+		"style"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { escape, get, head, find } from 'lodash';
+import { escape, head } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -134,8 +134,7 @@ function NavigationLinkEdit( {
 	insertLinkBlock,
 	textColor,
 	backgroundColor,
-	rgbTextColor,
-	rgbBackgroundColor,
+	inlineStyles,
 	selectedBlockHasDescendants,
 	userCanCreatePages = false,
 	userCanCreatePosts = false,
@@ -255,14 +254,15 @@ function NavigationLinkEdit( {
 			'is-dragging-within': isDraggingWithin,
 			'has-link': !! url,
 			'has-child': hasDescendants,
-			'has-text-color': rgbTextColor,
+			'has-text-color': !! textColor || !! inlineStyles?.color?.text,
 			[ `has-${ textColor }-color` ]: !! textColor,
-			'has-background': rgbBackgroundColor,
+			'has-background':
+				!! backgroundColor || !! inlineStyles?.color?.background,
 			[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
 		} ),
 		style: {
-			color: rgbTextColor,
-			backgroundColor: rgbBackgroundColor,
+			color: inlineStyles?.color?.text,
+			backgroundColor: inlineStyles?.color?.background,
 		},
 	} );
 
@@ -454,27 +454,6 @@ function NavigationLinkEdit( {
 	);
 }
 
-/**
- * Returns the color object matching the slug, or undefined.
- *
- * @param {Array}  colors      The editor settings colors array.
- * @param {string} colorSlug   A string containing the color slug.
- * @param {string} customColor A string containing the custom color value.
- *
- * @return {Object} Color object included in the editor settings colors, or Undefined.
- */
-const getColorObjectByColorSlug = ( colors, colorSlug, customColor ) => {
-	if ( customColor ) {
-		return customColor;
-	}
-
-	if ( ! colors || ! colors.length ) {
-		return;
-	}
-
-	return get( find( colors, { slug: colorSlug } ), 'color' );
-};
-
 export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
@@ -483,18 +462,17 @@ export default compose( [
 			hasSelectedInnerBlock,
 			getBlockParentsByBlockName,
 			getSelectedBlockClientId,
-			getSettings,
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 		const rootBlock = head(
 			getBlockParentsByBlockName( clientId, 'core/navigation' )
 		);
 		const navigationBlockAttributes = getBlockAttributes( rootBlock );
-		const colors = get( getSettings(), 'colors', [] );
 		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] )
 			.length;
 		const showSubmenuIcon =
 			!! navigationBlockAttributes.showSubmenuIcon && hasDescendants;
+		const inlineStyles = navigationBlockAttributes.style;
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 		const isImmediateParentOfSelectedBlock = hasSelectedInnerBlock(
 			clientId,
@@ -511,20 +489,11 @@ export default compose( [
 			hasDescendants,
 			selectedBlockHasDescendants,
 			showSubmenuIcon,
+			inlineStyles,
 			textColor: navigationBlockAttributes.textColor,
 			backgroundColor: navigationBlockAttributes.backgroundColor,
 			userCanCreatePages: select( 'core' ).canUser( 'create', 'pages' ),
 			userCanCreatePosts: select( 'core' ).canUser( 'create', 'posts' ),
-			rgbTextColor: getColorObjectByColorSlug(
-				colors,
-				navigationBlockAttributes.textColor,
-				navigationBlockAttributes.customTextColor
-			),
-			rgbBackgroundColor: getColorObjectByColorSlug(
-				colors,
-				navigationBlockAttributes.backgroundColor,
-				navigationBlockAttributes.customBackgroundColor
-			),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -20,7 +20,7 @@ function block_core_navigation_link_build_css_colors( $context ) {
 
 	// Text color.
 	$has_named_text_color  = array_key_exists( 'textColor', $context );
-	$has_custom_text_color = array_key_exists( 'customTextColor', $context );
+	$has_custom_text_color = isset( $context['style']['color']['text'] );
 
 	// If has text color.
 	if ( $has_custom_text_color || $has_named_text_color ) {
@@ -33,12 +33,12 @@ function block_core_navigation_link_build_css_colors( $context ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-color', $context['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $context['customTextColor'] );
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $context['style']['color']['text'] );
 	}
 
 	// Background color.
 	$has_named_background_color  = array_key_exists( 'backgroundColor', $context );
-	$has_custom_background_color = array_key_exists( 'customBackgroundColor', $context );
+	$has_custom_background_color = isset( $context['style']['color']['background'] );
 
 	// If has background color.
 	if ( $has_custom_background_color || $has_named_background_color ) {
@@ -51,7 +51,7 @@ function block_core_navigation_link_build_css_colors( $context ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $context['backgroundColor'] );
 	} elseif ( $has_custom_background_color ) {
 		// Add the custom background-color inline style.
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $context['customBackgroundColor'] );
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $context['style']['color']['background'] );
 	}
 
 	return $colors;
@@ -72,14 +72,14 @@ function block_core_navigation_link_build_css_font_sizes( $context ) {
 	);
 
 	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = array_key_exists( 'customFontSize', $context );
+	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
 
 	if ( $has_named_font_size ) {
 		// Add the font size class.
 		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
 	} elseif ( $has_custom_font_size ) {
 		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf( 'font-size: %spx;', $context['customFontSize'] );
+		$font_sizes['inline_styles'] = sprintf( 'font-size: %spx;', $context['style']['typography']['fontSize'] );
 	}
 
 	return $font_sizes;
@@ -123,7 +123,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
-	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] );
+	$style_attribute = ( $colors['inline_styles'] . $font_sizes['inline_styles'] );
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -39,7 +39,8 @@
 		"customBackgroundColor": "customBackgroundColor",
 		"fontSize": "fontSize",
 		"customFontSize": "customFontSize",
-		"showSubmenuIcon": "showSubmenuIcon"
+		"showSubmenuIcon": "showSubmenuIcon",
+		"style": "style"
 	},
 	"supports": {
 		"align": [

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -25,6 +25,12 @@
 	opacity: 1;
 }
 
+// Low specificity default to ensure background color applies to submenus.
+.wp-block-navigation__container,
+.wp-block-navigation-link {
+	background-color: inherit;
+}
+
 // Styles for submenu flyout
 .has-child {
 	// Only show the flyout when the parent menu item is selected.

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -9,7 +9,8 @@
 		"customBackgroundColor",
 		"fontSize",
 		"customFontSize",
-		"showSubmenuIcon"
+		"showSubmenuIcon",
+		"style"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -11,7 +11,8 @@ import { useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
 export default function PageListEdit( { context } ) {
-	const { textColor, backgroundColor, showSubmenuIcon } = context || {};
+	const { textColor, backgroundColor, showSubmenuIcon, style } =
+		context || {};
 
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -21,6 +22,7 @@ export default function PageListEdit( { context } ) {
 			[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
 			'show-submenu-icons': !! showSubmenuIcon,
 		} ),
+		style: { ...style?.color },
 	} );
 
 	return (

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -20,7 +20,7 @@ function block_core_page_list_build_css_colors( $context ) {
 
 	// Text color.
 	$has_named_text_color  = array_key_exists( 'textColor', $context );
-	$has_custom_text_color = array_key_exists( 'customTextColor', $context );
+	$has_custom_text_color = isset( $context['style']['color']['text'] );
 
 	// If has text color.
 	if ( $has_custom_text_color || $has_named_text_color ) {
@@ -33,12 +33,12 @@ function block_core_page_list_build_css_colors( $context ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-color', $context['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $context['customTextColor'] );
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $context['style']['color']['text'] );
 	}
 
 	// Background color.
 	$has_named_background_color  = array_key_exists( 'backgroundColor', $context );
-	$has_custom_background_color = array_key_exists( 'customBackgroundColor', $context );
+	$has_custom_background_color = isset( $context['style']['color']['background'] );
 
 	// If has background color.
 	if ( $has_custom_background_color || $has_named_background_color ) {
@@ -51,7 +51,7 @@ function block_core_page_list_build_css_colors( $context ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $context['backgroundColor'] );
 	} elseif ( $has_custom_background_color ) {
 		// Add the custom background-color inline style.
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $context['customBackgroundColor'] );
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $context['style']['color']['background'] );
 	}
 
 	return $colors;
@@ -72,14 +72,14 @@ function block_core_page_list_build_css_font_sizes( $context ) {
 	);
 
 	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = array_key_exists( 'customFontSize', $context );
+	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
 
 	if ( $has_named_font_size ) {
 		// Add the font size class.
 		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
 	} elseif ( $has_custom_font_size ) {
 		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf( 'font-size: %spx;', $context['customFontSize'] );
+		$font_sizes['inline_styles'] = sprintf( 'font-size: %spx;', $context['style']['typography']['fontSize'] );
 	}
 
 	return $font_sizes;
@@ -182,7 +182,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
-	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] );
+	$style_attribute = ( $colors['inline_styles'] . $font_sizes['inline_styles'] );
 	$css_classes     = trim( implode( ' ', $classes ) );
 
 	if ( $block->context && $block->context['showSubmenuIcon'] ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Added the `style` attribute to context provided by the Navigation block, so that its child blocks can access custom colors set in the Navigation block. 

So far, with regards to the styles that can be set in Navigation block, this is only useful for `background-color`, as both `color` and all typography styles are inherited by child elements anyway. For this reason, I haven't explicitly added all the extra typography properties Navigation sets in addition to `font-size`.

By the same reasoning, we could probably remove the logic for setting inline `font-size` altogether. Thoughts?

Also, not sure if this will need a deprecation, as it seems this feature has been broken for a while, and previous changes to Navigation Link didn't add one.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Add Navigation block and a few child items; create at least one submenu. Set a custom background color on Navigation and verify that submenu dropdown inherits that background color.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
