### PR TITLE
Fix block insertion a11y string

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -1,9 +1,14 @@
 /**
+ * External dependencies
+ */
+import { castArray } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
-import { _n } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { useCallback } from '@wordpress/element';
 
@@ -127,11 +132,14 @@ function useInsertionPoint( {
 			}
 
 			if ( ! selectBlockOnInsert ) {
-				// translators: %d: the name of the block that has been added
-				const message = _n(
-					'%d block added.',
-					'%d blocks added.',
-					blocks.length
+				const message = sprintf(
+					// translators: %d: the name of the block that has been added
+					_n(
+						'%d block added.',
+						'%d blocks added.',
+						castArray( blocks ).length
+					),
+					castArray( blocks ).length
 				);
 				speak( message );
 			}


### PR DESCRIPTION
closes #28151 
extracted from #28191 

Just a small fix to the screen  reader message triggered when inserting blocks or patterns.