### PR TITLE
Add navigation editor block deselection when clicking canvas background

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -182,7 +182,6 @@ describe( 'Navigation editor', () => {
 		expect( await getSerializedBlocks() ).toMatchSnapshot();
 	} );
 
-	// Regressed—to be reimplemented.
 	it( 'shows a submenu when a link is selected and hides it when clicking the editor to deselect it', async () => {
 		await setUpResponseMocking( [
 			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),
@@ -208,7 +207,7 @@ describe( 'Navigation editor', () => {
 		expect( submenuLinkVisible ).toBeDefined();
 
 		// Click the editor canvas.
-		await page.click( '.edit-navigation-editor__block-view' );
+		await page.click( '.edit-navigation-layout__canvas' );
 
 		// There should be a submenu in the DOM, but it should be hidden.
 		const submenuLinkHidden = await page.waitForXPath( submenuLinkXPath, {

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -183,7 +183,7 @@ describe( 'Navigation editor', () => {
 	} );
 
 	// Regressed—to be reimplemented.
-	it.skip( 'shows a submenu when a link is selected and hides it when clicking the editor to deselect it', async () => {
+	it( 'shows a submenu when a link is selected and hides it when clicking the editor to deselect it', async () => {
 		await setUpResponseMocking( [
 			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),
 			...getMenuItemMocks( { GET: menuItemsFixture } ),

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -2,7 +2,8 @@
 	background: $white;
 	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
-	margin-top: $grid-unit-50 * 2;
+	max-width: 420px;
+	margin: auto;
 
 	.components-spinner {
 		display: block;

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -2,7 +2,6 @@
 	display: flex;
 	align-items: center;
 	padding: $grid-unit-15;
-	margin-bottom: $grid-unit-40;
 }
 
 .edit-navigation-header__title-subtitle {

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -84,7 +84,7 @@ export default function Layout( { blockEditorSettings } ) {
 								saveBlocks={ savePost }
 							/>
 							<div
-								className="navigation-editor-canvas"
+								className="edit-navigation-layout__canvas"
 								ref={ canvasRef }
 							>
 								<Editor

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -11,7 +11,9 @@ import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockInspector,
+	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 } from '@wordpress/block-editor';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -28,6 +30,9 @@ import InspectorAdditions from '../inspector-additions';
 import { store as editNavigationStore } from '../../store';
 
 export default function Layout( { blockEditorSettings } ) {
+	const canvasRef = useRef();
+	useBlockSelectionClearer( canvasRef );
+
 	const { saveNavigationPost } = useDispatch( editNavigationStore );
 	const savePost = () => saveNavigationPost( navigationPost );
 
@@ -78,7 +83,10 @@ export default function Layout( { blockEditorSettings } ) {
 							<NavigationEditorShortcuts
 								saveBlocks={ savePost }
 							/>
-							<div className="navigation-editor-canvas">
+							<div
+								className="navigation-editor-canvas"
+								ref={ canvasRef }
+							>
 								<Editor
 									isPending={ ! navigationPost }
 									blocks={ blocks }

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -26,7 +26,7 @@
 
 	.navigation-editor-canvas {
 		// Provide space for the floating block toolbar.
-		padding-top: $grid-unit-50 * 2;
+		padding-top: $grid-unit-40 * 3;
 
 		// Ensure the entire layout is full-height, the background
 		// of the editing canvas needs to be full-height for block

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -9,7 +9,7 @@
 .edit-navigation-layout {
 	display: flex;
 	flex-direction: column;
-	margin-right: 280px;
+	margin-right: $sidebar-width;
 
 	.navigation-editor-canvas {
 		// Provide space for the floating block toolbar.

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -7,10 +7,12 @@
 }
 
 .edit-navigation-layout {
+	display: flex;
+	flex-direction: column;
 	margin-right: 280px;
 
 	.navigation-editor-canvas {
-		max-width: 420px;
-		margin: auto;
+		// Provide space for the floating block toolbar.
+		padding-top: $grid-unit-50 * 2;
 	}
 }

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -4,15 +4,33 @@
 	#wpcontent {
 		padding-left: 0;
 	}
+
+	// Ensure the entire layout is full-height, the background
+	// of the editing canvas needs to be full-height for block
+	// deselection to work.
+	#wpwrap,
+	#wpcontent,
+	#wpbody,
+	#wpbody-content,
+	.edit-navigation,
+	.components-drop-zone__provider,
+	.edit-navigation-layout {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+	}
 }
 
 .edit-navigation-layout {
-	display: flex;
-	flex-direction: column;
 	margin-right: $sidebar-width;
 
 	.navigation-editor-canvas {
 		// Provide space for the floating block toolbar.
 		padding-top: $grid-unit-50 * 2;
+
+		// Ensure the entire layout is full-height, the background
+		// of the editing canvas needs to be full-height for block
+		// deselection to work.
+		flex-grow: 1;
 	}
 }

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -24,7 +24,7 @@
 .edit-navigation-layout {
 	margin-right: $sidebar-width;
 
-	.navigation-editor-canvas {
+	.edit-navigation-layout__canvas {
 		// Provide space for the floating block toolbar.
 		padding-top: $grid-unit-40 * 3;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Reimplements #28382, which had regressed (been accidentally removed).

## How has this been tested?
e2e tests were already written and have been renabled

Manual testing:
1. Add some blocks and ensure one is selected
2. Click the grey background of the editor
3. Observe that the block is deselected.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
