### PR TITLE
Typo in plugin-document-setting-panel.md

### DIFF
--- a/docs/designers-developers/developers/slotfills/plugin-document-setting-panel.md
+++ b/docs/designers-developers/developers/slotfills/plugin-document-setting-panel.md
@@ -33,7 +33,7 @@ registerPlugin( 'plugin-document-setting-panel-demo', {
 ## Accessing a panel programmatically
 
 Custom panels are namespaced with the plugin name that was passed to `registerPlugin`.
-In order to access the panels using function such as `wp.data.dispatch( 'core/edit-post' ).toggleEditorPanelOpened` or `wp.data.dispatch( 'core/edit-post' ).toggleEditorPanelEnabled` be sure to prepend the namepace.
+In order to access the panels using function such as `wp.data.dispatch( 'core/edit-post' ).toggleEditorPanelOpened` or `wp.data.dispatch( 'core/edit-post' ).toggleEditorPanelEnabled` be sure to prepend the namespace.
 
 To programmatically toggle the custom panel added in the example above, use the following:
 


### PR DESCRIPTION
## Description
Typo: line 36: 'namepace'->'namespace'.

## How has this been tested?
n/a

## Types of changes
Docs/Test/Typo
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
