### PR TITLE
Try: Mitigate CSS inheritance from wp-block auto margins

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -337,13 +337,17 @@
 	}
 }
 
-// Extra specificity needed to override default element margins like lists (ul).
-.block-editor-block-list__layout .wp-block {
+.wp-block {
+	// The following margin-CSS is editor-only, it is meant to center all blocks, when combined with a max-width, in a column.
 	margin-left: auto;
 	margin-right: auto;
-}
 
-.wp-block {
+	// Prevent inheritance.
+	.wp-block {
+		margin-left: initial;
+		margin-right: initial;
+	}
+
 	// Alignments.
 	&[data-align="left"],
 	&[data-align="right"] {


### PR DESCRIPTION
Currently this CSS is output in the editor:

```
.block-editor-block-list__layout .wp-block {
	margin-left: auto;
	margin-right: auto;
}
```

It was added a long time ago to help enable a centered column, by combining automatic left and right margins, with a max-width, enabling wide and fullwide in the process. It has since (#21971) been tweaked.

But in an editor that supports any level of nesting, it is increasingly problematic that every block, regardless of level, is born with automatic left/right margins. 

- It is a problem in the Navigation block where menu items have to add very high specificity in order for menu items to align correctly.
- It is a problem in flex containers such as Buttons, where without explicit overrides, we get a faux "space between" effect (https://github.com/WordPress/gutenberg/pull/28485).

In other words, the way it's being handled currently, is to override and add specificity where a margin other than `auto` is needed. But it's not intuitive, and it's building up a little technical debt.

In this PR, I tried to _keep the spirit of the initial code_, but both reduce the specificity and mitigate some of the overriding. Specifically this PR keeps the auto margin, but with lower specificity, and then overrides that to `initial` for nested blocks. 

I believe blocks still have to override the margin if they want a margin other than the default one elements come with, but it should require less specificity to do so.

Another option I pondered was this one:

```
// The following CSS is editor-only.
// It is meant to center all blocks, when combined with a max-width, in a column.
// The extra specificity is partially needed to override default element margins like lists (ul),
// but is also meant to only target direct root descendant blocks.
.is-root-container > .wp-block {
	margin-left: auto;
	margin-right: auto;
}
````

... but that would have added even more specificity, even if only for the top level blocks. So ultimately I went with the softer solution.

I have a feeling that the longer term and better solution is to address #20650, and to abstract away the centered column into a product of CSS classes that can be toggled by themes. But in the mean time, is this a good holdover?

**If yes, the next step I'd take** is to reduce and unify some of the CSS written for the Navigation Menu Item, so we don't have to repeat the margin in [3 places for example](https://github.com/WordPress/gutenberg/pull/28833#issuecomment-775857732). The margin rules for Buttons could potentially also be relaxed, and it will no doubt benefit Social Links.

## To test:

- Ideally, what you see in the editor, regardless of theme active, should be identical in this branch, to what it is in the master branch.
- All alignments should work as before.
- All blocks should look the same.

Something to look for in particular, are blocks that use `display: flex;`, where auto margins cause magical things to happen. So test Buttons, Navigation, Social Links.

Any block that is nested should look the same, but it's worth testing. So group, media & text and others.

Because this touches somewhat sensitive code, it would be good to get a lot of eyes on it.
 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
