### PR TITLE
Site Editor: Fix empty content when creating a new template

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
@@ -50,7 +50,7 @@ export default function NewTemplateDropdown() {
 			excerpt: description,
 			// Slugs need to be strings, so this is for template `404`
 			slug: slug.toString(),
-			status: 'draft',
+			status: 'publish',
 			title,
 		} );
 	};

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -81,15 +81,17 @@ export function* addTemplate( template ) {
 		template
 	);
 
-	yield controls.dispatch(
-		'core',
-		'editEntityRecord',
-		'postType',
-		'wp_template',
-		newTemplate.id,
-		{ blocks: parse( template.content ) },
-		{ undoIgnore: true }
-	);
+	if ( template.content ) {
+		yield controls.dispatch(
+			'core',
+			'editEntityRecord',
+			'postType',
+			'wp_template',
+			newTemplate.id,
+			{ blocks: parse( template.content ) },
+			{ undoIgnore: true }
+		);
+	}
 
 	return {
 		type: 'SET_TEMPLATE',

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { parse } from '@wordpress/blocks';
 import { controls } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
 import { getPathAndQueryString } from '@wordpress/url';
@@ -79,6 +80,17 @@ export function* addTemplate( template ) {
 		'wp_template',
 		template
 	);
+
+	yield controls.dispatch(
+		'core',
+		'editEntityRecord',
+		'postType',
+		'wp_template',
+		newTemplate.id,
+		{ blocks: parse( template.content ) },
+		{ undoIgnore: true }
+	);
+
 	return {
 		type: 'SET_TEMPLATE',
 		templateId: newTemplate.id,


### PR DESCRIPTION
## Description

#28229 surfaced a bug with the new template creation in the Site Editor (accessible from Navigation -> Templates -> `+` button).
The new template gets created correctly, added to the Redux state, and saved in the database.
Although, it should also inherit the content from the closest more generic template available (e.g. creating `front-page` would inherit `home` if it exists, or `index` otherwise).
The new template gets the correct content (it's there in both state and DB), but not in the editor.
Reloading the editor would make it show up; as it would opening the template alone in a Post Editor.
All the various contexts look good to me too.

The only issue I've noticed is that the `addTemplate` action (which internally uses `saveEntityRecord` to create the template, and `setTemplate` to switch the editor to the new template) doesn't create a new item in `'core'.root.entities.data.postType.wp_template.edits` for the new template, which is what the editor provider uses to populate the editor with blocks.

This PR adds an `editEntityRecord` dispatch, adding the new template's parsed content to the `edits`.

## How has this been tested?

- Activate an FSE theme such as TT1 Blocks.
- Open the Site Editor.
- Open the Navigation (click on the WP icon), navigate into Templates.
- Click on the `+` button, and add a new template.
- Make sure the editor contains some content (typically it should be the same as the `index` template).

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
