### PR TITLE
Package Lock: Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45755,9 +45755,9 @@
 					"dev": true
 				},
 				"bl": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
-					"integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+					"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",


### PR DESCRIPTION
## Description
We're out of sync again.

Found via [failing static analysis tests](https://github.com/WordPress/gutenberg/pull/28741/checks?check_run_id=1863023511).

## How has this been tested?
Make sure CI goes green.