### PR TITLE
Fix Navigation Links when post type is not Page or Post

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -105,7 +105,10 @@ function block_core_navigation_link_render_submenu_icon() {
  */
 function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Don't render the block's subtree if it is a draft.
-	if ( isset( $attributes['id'] ) && is_numeric( $attributes['id'] ) ) {
+	if (
+		isset( $attributes['id'] ) && is_numeric( $attributes['id'] ) &&
+		( 'post' === $attributes['type'] || 'page' === $attributes['type'] )
+	) {
 		$post = get_post( $attributes['id'] );
 		if ( 'publish' !== $post->post_status ) {
 			return '';

--- a/phpunit/class-block-library-navigation-link-test.php
+++ b/phpunit/class-block-library-navigation-link-test.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Tests server side rendering of core/navigation-link
+ *
+ * @package    Gutenberg
+ * @subpackage block-library
+ */
+
+/**
+ * Tests for various cases in Navigation Link rendering
+ */
+class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
+	private static $category;
+	private static $page;
+	private static $draft;
+
+	private static $pages;
+	private static $terms;
+
+	public static function wpSetUpBeforeClass() {
+
+		self::$draft   = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'draft',
+				'post_name'    => 'ceilingcat',
+				'post_title'   => 'Ceiling Cat',
+				'post_content' => 'Ceiling Cat content',
+				'post_excerpt' => 'Ceiling Cat',
+			)
+		);
+		self::$pages[] = self::$draft;
+
+		self::$page    = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_name'    => 'tabby',
+				'post_title'   => 'Tabby cats',
+				'post_content' => 'Tabby cat content',
+				'post_excerpt' => 'Tabby cat',
+			)
+		);
+		self::$pages[] = self::$page;
+
+		self::$category = self::factory()->category->create_and_get(
+			array(
+				'taxonomy'    => 'category',
+				'name'        => 'cats',
+				'slug'        => 'cats',
+				'description' => 'Cats Category',
+			)
+		);
+
+		self::$terms[] = self::$category;
+	}
+
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$pages as $page_to_delete ) {
+			wp_delete_post( $page_to_delete );
+		}
+		foreach ( self::$terms as $term_to_delete ) {
+			wp_delete_term( $term_to_delete->term_id, $term_to_delete->taxonomy );
+		}
+	}
+
+	function test_returns_link_when_post_is_published() {
+		$page_id = self::$page->ID;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Sample Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"http://localhost:8888/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'Sample Page'
+			) !== false
+		);
+	}
+
+	function test_returns_empty_when_label_is_missing() {
+		$page_id = self::$page->ID;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"type\":\"page\",\"id\":{$page_id},\"url\":\"http://localhost:8888/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			'',
+			gutenberg_render_block_core_navigation_link(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
+			)
+		);
+	}
+
+	function test_returns_empty_when_draft() {
+		$page_id = self::$draft->ID;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Draft Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"http://localhost:8888/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+
+		$this->assertEquals(
+			'',
+			gutenberg_render_block_core_navigation_link(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
+			)
+		);
+	}
+
+	function test_returns_link_for_category() {
+		$category_id = self::$category->term_id;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Cats\",\"type\":\"category\",\"id\":{$category_id},\"url\":\"http://localhost:8888/?cat={$category_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'Cats'
+			) !== false
+		);
+	}
+}


### PR DESCRIPTION
This adds a check in the navigation link render callback to verify if a link is a post, before checking publish status.

It doesn't look like we have any other examples of this sort of dynamic block test, so I tried to scope the unit as low as possible. Let me know if folks had preferences.

### Before

https://user-images.githubusercontent.com/81248/106830994-c1d24100-6654-11eb-97a3-41cb5a9ed843.mp4

## After

<img width="900" alt="Screen Shot 2021-02-09 at 5 22 52 PM" src="https://user-images.githubusercontent.com/1270189/107451336-e9fdec00-6afb-11eb-8886-4cc0107dca86.png">

<img width="1040" alt="Screen Shot 2021-02-09 at 5 24 40 PM" src="https://user-images.githubusercontent.com/1270189/107451387-07cb5100-6afc-11eb-94e8-95b50096faf0.png">

<img width="1052" alt="Screen Shot 2021-02-09 at 5 25 19 PM" src="https://user-images.githubusercontent.com/1270189/107451362-fa15cb80-6afb-11eb-8b12-e9c7d7a61bff.png">


### Manual Testing Instructions

- Add a new post or page. We're also assuming there's a post with ID = 1 in your WP instance already; you'll also use the default "Uncategorized" cat (which also has 1 as the ID);
- Add a horizontal or vertical Navigation block to the page. Add any number of links you'd like, but be sure to add at least one of type "Category" and select the "Uncategorized" cat;
- View the published page. You'll see that the navigation link for "Uncategorized" is shown;
- Now edit the post with ID = 1 and set it to private;
- Verify that the Category link is still visible.

Verify that tests pass:
run `npm run test-unit-php`

Fixes #28712