### PR TITLE
Build Workflow: Add comment with link to plugin zip to PR

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -63,6 +63,7 @@ jobs:
             repo: context.repo.repo,
             run_id: context.runId
           } );
+          console.log( artifacts );
           const pluginArtifact = artifacts.find( artifact => (
             artifact.name === 'gutenberg-plugin'
           ) );

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -58,11 +58,12 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          const artifacts = await github.actions.listWorkflowRunArtifacts( {
+          const artifactsResponse = await github.actions.listWorkflowRunArtifacts( {
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: context.runId
           } );
+          const artifacts = artifactsResponse.data.artifacts;
           console.log( artifacts );
           const pluginArtifact = artifacts.find( artifact => (
             artifact.name === 'gutenberg-plugin'

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -63,6 +63,7 @@ jobs:
             repo: context.repo.repo,
             run_id: context.runId
           } );
+          console.log( artifactsResponse );
           const artifacts = artifactsResponse.data.artifacts;
           console.log( artifacts );
           const pluginArtifact = artifacts.find( artifact => (

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -48,6 +48,32 @@ jobs:
           name: gutenberg-plugin
           path: ./gutenberg.zip
 
+  comment-on-pr:
+    name: Leave a comment with a link to the plugin build on the PR
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/github-script@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const artifacts = await github.actions.listWorkflowRunArtifacts( {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId
+          } );
+          const pluginArtifact = artifacts.find( artifact => (
+            artifact.name === 'gutenberg-plugin'
+          ) );
+          const pluginUrl = pluginArtifact.archive_download_url;
+          github.issues.createComment( {
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'The plugin zip for this PR is available for download from ' + pluginUrl
+          } )
+
   create-release:
     name: Create Release Draft and Attach Asset
     needs: build


### PR DESCRIPTION
## Description
We've been automatically building the plugin zip for every PR for a while (since https://github.com/WordPress/gutenberg/pull/26746), but it seems like the builds still aren't widely known.

This PR seeks to change that by adding a comment with a link to the plugin zip to every PR.

Based on this: https://github.com/WordPress/gutenberg/issues/28881#issuecomment-776055353

## How has this been tested?
A comment should be added to this PR, including a link to the plugin zip :crossed_fingers: 

## Screenshots <!-- if applicable -->
TBD