### PR TITLE
Text: Fix import in example of README file

### DIFF
--- a/packages/components/src/text/README.md
+++ b/packages/components/src/text/README.md
@@ -5,7 +5,7 @@ A component for rendering text.
 ## Usage
 
 ```jsx
-import { Text } from '@wordpress/components';
+import { __experimentalText as Text } from '@wordpress/components';
 
 const HeroPanel = () => (
 	<>


### PR DESCRIPTION
This update fixes the example of the `Text` component within README file.
Specifically, updating the `import` statement to include the `__experimental` prefix:

```jsx
import { __experimentalText as Text } from '@wordpress/components';

const HeroPanel = () => (
	<>
		<Text variant="title.large" as="h1">
			Hello World!
		</Text>
		<Text variant="body">Greetings to you!</Text>
	</>
);
```

Resolves https://github.com/WordPress/gutenberg/pull/21088#issuecomment-752297993

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
