### PR TITLE
Fix transparent navigation block submenus

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -28,6 +28,7 @@
 		margin: $grid-unit-10 * 2;
 		margin-left: $grid-unit-10 * 1.25;
 		margin-top: $grid-unit-10 * 1.25;
+		margin-right: auto;
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -7,6 +7,12 @@
 		// several times, so care needs to be taken.
 		background-color: $white;
 		color: $gray-900;
+	}
+}
+
+.wp-block-navigation .wp-block-navigation__container {
+	.wp-block-navigation__container {
+		align-items: unset;
 		min-width: 200px;
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -12,7 +12,7 @@
 
 .wp-block-navigation .wp-block-navigation__container {
 	.wp-block-navigation__container {
-		align-items: unset;
+		align-items: stretch;
 		min-width: 200px;
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,15 +1,19 @@
+// Default background and font color
+.wp-block-navigation:not(.has-background) .wp-block-navigation__container {
+	.wp-block-navigation__container {
+		// Set a background color for submenus so that they're not transparent.
+		// NOTE TO DEVS - if refactoring this code, please double-check that
+		// submenus have a default background color, this feature has regressed
+		// several times, so care needs to be taken.
+		background-color: $white;
+		color: $gray-900;
+		min-width: 200px;
+	}
+}
+
 .wp-block-navigation__container {
 	// Vertically align child blocks, like Social Links or Search.
 	align-items: center;
-
-	// Default background and font color
-	&:not(.has-background) .wp-block-navigation__container {
-		.wp-block-navigation__container {
-			color: $gray-900;
-			background-color: $white;
-			min-width: 200px;
-		}
-	}
 }
 
 .items-justified-center > ul {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -12,7 +12,7 @@
 
 .wp-block-navigation .wp-block-navigation__container {
 	.wp-block-navigation__container {
-		align-items: stretch;
+		align-items: normal;
 		min-width: 200px;
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28906

Fixes some issues with navigation block styles:
- Since #28836, submenus lost their default background color. Looks like the selector was refactored, but the outermost class was probably misread as `.wp-block-navigation__container`.
- #28836 also caused submenu items to be aligned centrally, which resulted in an issue with the positioning of the flyout menu. This is now restored to `normal`.
- Submenus without a background color had a min-width of 200px, but curiously when selecting a background they didn't. This fixes that so the min-width is applied regardless.

I haven't gone into the realm of fixing issues with background colors, there's a separate PR https://github.com/WordPress/gutenberg/pull/28868.

## How has this been tested?
1. Add a navigation block (horizontal)
2. Add paragraphs with text after the nav block
3. Add submenus to the nav block
4. The submenus should be opaque so that the paragraph text behind isn't visible.


## Screenshots <!-- if applicable -->
<img width="459" alt="Screenshot 2021-02-10 at 12 53 07 pm" src="https://user-images.githubusercontent.com/677833/107466433-f424f680-6b9e-11eb-8113-b7454747e1f3.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
