### PR TITLE
Fix: More resilient appender CSS.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -6,7 +6,8 @@
 	list-style: none;
 
 	// Add a little left margin when used horizontally.
-	margin: 0 0 0 $grid-unit-10;
+	// The right margin should be set to auto, so as to not shift layout in flex containers.
+	margin: 0 auto 0 $grid-unit-10;
 
 	// ... unless it's the only child.
 	&:first-child {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -25,10 +25,11 @@
 	}
 
 	.block-list-appender {
-		margin: $grid-unit-10 * 2;
-		margin-left: $grid-unit-10 * 1.25;
-		margin-top: $grid-unit-10 * 1.25;
+		margin-top: $grid-unit-20;
+		// The right margin should be set to auto, so as to not shift layout in flex containers.
 		margin-right: auto;
+		margin-bottom: $grid-unit-20;
+		margin-left: $grid-unit-20;
 	}
 }
 


### PR DESCRIPTION
## Description

This is a followup to #28904, and fixes #28906.

## How has this been tested?

Please test any block that uses nesting, but notably buttons, social links, navigation, and navigation submenus. Also test group and columns. The appender button both on hover and click should show up appropriately in all cases.

## Screenshots

<img width="667" alt="Screenshot 2021-02-10 at 09 41 44" src="https://user-images.githubusercontent.com/1204802/107485844-9d122800-6b84-11eb-928e-8edeba36b256.png">


## Types of changes

The Appender component has several shapes and forms. A full dedicated one that sits inside an empty group, a small plus that sits at the right of an empty paragraph, and the small plus that sits at the end of nesting containers.

One factor that adds complexity to this appender is that a bug in Firefox means that the `<li>` element has to be clickalbe, in addition to the `<button>` inside. This is one of the issues that #28464 meant to improve, ensuring that the list item and the button inside share the same space, so the focus style is appropriate.

Add to that the complexity of this button needing to be able to work in both vertical (default) contexts, as well as horizontal (buttons, social links) contexts. Some of these are flex containers, others are not, and in the case of flex containers, margins play a big role. A right margin of anything other than `auto`, will right align it.

#28906 was specifically caused because the right margin of the appender container was zero, but on hover, an ancestor became `flex`.

So there's not a lot in this PR, other than more explicit margins from the getgo.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
