### PR TITLE
Fix issue with invisible reset template hover state.

### DIFF
--- a/packages/editor/src/components/template-validation-notice/index.js
+++ b/packages/editor/src/components/template-validation-notice/index.js
@@ -37,7 +37,6 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 				{
 					label: __( 'Reset the template' ),
 					onClick: confirmSynchronization,
-					isPrimary: true,
 				},
 			] }
 		>


### PR DESCRIPTION
## Description

When you make a custom post template and open the editor, then change the custom post template and reload the editor, you get a notice that the template has changed. Observe how the hover is a bit broken:

![notice button](https://user-images.githubusercontent.com/1204802/107494895-a359d180-6b8f-11eb-84cf-f89feabd0cd5.gif)

That's because the 2nd button is both `primary` and `secondary`.

Making it just secondary fixes the issue:

![after](https://user-images.githubusercontent.com/1204802/107494943-b66ca180-6b8f-11eb-88a6-ece6b730fcf8.gif)

## How has this been tested?

Try pasting this in your functions.php:

```
/**
 * Custom post type and template
 */

// 1. Create a custom post type
function myplugin_custom_post_type() {
	register_post_type( 'podcast',
		array(
			'labels' => array(
				'name' => __( 'Podcasts' ),
				'singular_name' => __( 'Podcast' )
			),
			'public' => true,
			'has_archive' => true,
			'rewrite' => array('slug' => 'podcast'),
			'show_in_rest' => true,
		)
	);
}
add_action( 'init', 'myplugin_custom_post_type' );

// 2. Assign a post template to our custom post type
function myplugin_register_template() {
	$post_type_object = get_post_type_object( 'podcast' );
	$post_type_object->template = array(
		array( 'core/heading', array( 'level' => 3, 'content' => 'Description' ) ),
		array( 'core/paragraph', array( 'placeholder' => 'Add description', ) ),
		array( 'core/heading', array( 'level' => 3, 'content' => 'Show Notes' ) ),
		array( 'core/paragraph', array( 'placeholder' => 'Add show notes', ) ),
	);

	// Lock the template from being rearranged or items deleted.
	$post_type_object->template_lock = 'all'; // Can be "all" or "insert", the latter allows moving blocks around.
}
add_action( 'init', 'myplugin_register_template' );
```

Then create a new "podcast". Then while that podcast screen is open, edit the block template, save, and reload.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
