### PR TITLE
Avoid passing vars by reference in a foreach loop unless necessary

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -165,7 +165,7 @@ class WP_Theme_JSON_Resolver {
 		}
 
 		$preset_to_translate = self::get_presets_to_translate();
-		foreach ( $theme_json_structure['settings'] as &$settings ) {
+		foreach ( $theme_json_structure['settings'] as $settings ) {
 			if ( empty( $settings ) ) {
 				continue;
 			}
@@ -180,7 +180,7 @@ class WP_Theme_JSON_Resolver {
 					continue;
 				}
 
-				foreach ( $array_to_translate as &$item_to_translate ) {
+				foreach ( $array_to_translate as $item_to_translate ) {
 					if ( empty( $item_to_translate[ $key ] ) ) {
 						continue;
 					}
@@ -225,7 +225,7 @@ class WP_Theme_JSON_Resolver {
 			'vivid-purple'          => __( 'Vivid purple', 'gutenberg' ),
 		);
 		if ( ! empty( $config['settings'][ $all_blocks ]['color']['palette'] ) ) {
-			foreach ( $config['settings'][ $all_blocks ]['color']['palette'] as &$color ) {
+			foreach ( $config['settings'][ $all_blocks ]['color']['palette'] as $color ) {
 				$color['name'] = $default_colors_i18n[ $color['slug'] ];
 			}
 		}
@@ -245,7 +245,7 @@ class WP_Theme_JSON_Resolver {
 			'midnight'                             => __( 'Midnight', 'gutenberg' ),
 		);
 		if ( ! empty( $config['settings'][ $all_blocks ]['color']['gradients'] ) ) {
-			foreach ( $config['settings'][ $all_blocks ]['color']['gradients'] as &$gradient ) {
+			foreach ( $config['settings'][ $all_blocks ]['color']['gradients'] as $gradient ) {
 				$gradient['name'] = $default_gradients_i18n[ $gradient['slug'] ];
 			}
 		}
@@ -258,7 +258,7 @@ class WP_Theme_JSON_Resolver {
 			'huge'   => __( 'Huge', 'gutenberg' ),
 		);
 		if ( ! empty( $config['settings'][ $all_blocks ]['typography']['fontSizes'] ) ) {
-			foreach ( $config['settings'][ $all_blocks ]['typography']['fontSizes'] as &$font_size ) {
+			foreach ( $config['settings'][ $all_blocks ]['typography']['fontSizes'] as $font_size ) {
 				$font_size['name'] = $default_font_sizes_i18n[ $font_size['slug'] ];
 			}
 		}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -73,7 +73,7 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 	if ( isset( $settings['fontSizes'] ) ) {
 		$font_sizes = $settings['fontSizes'];
 		// Back-compatibility for presets without units.
-		foreach ( $font_sizes as &$font_size ) {
+		foreach ( $font_sizes as $font_size ) {
 			if ( is_numeric( $font_size['size'] ) ) {
 				$font_size['size'] = $font_size['size'] . 'px';
 			}

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -749,8 +749,8 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 			 * As the links for the post are "response_links" format in the data array we have to pull them out and parse them.
 			 */
 			$links = $data['_links'];
-			foreach ( $links as &$links_array ) {
-				foreach ( $links_array as &$link ) {
+			foreach ( $links as $links_array ) {
+				foreach ( $links_array as $link ) {
 					$attributes         = array_diff_key(
 						$link,
 						array(

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -749,8 +749,8 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 			 * As the links for the post are "response_links" format in the data array we have to pull them out and parse them.
 			 */
 			$links = $data['_links'];
-			foreach ( $links as $links_array ) {
-				foreach ( $links_array as $link ) {
+			foreach ( $links as &$links_array ) {
+				foreach ( $links_array as &$link ) {
 					$attributes         = array_diff_key(
 						$link,
 						array(


### PR DESCRIPTION
## Description

Remove `&` from some variables that don't need to be passed by reference in PHP.

## How has this been tested?
* Nothing breaks in an FSE theme, global-styles continue to be properly parsed & applied.
* Verify that automated tests don't fail.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] ~~My code follows the accessibility standards.~~ <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] ~~My code has proper inline documentation.~~ <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
