### PR TITLE
useBlockProps: use ref callback

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -106,11 +106,12 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const isHovered = useIsHovered( ref );
 	const blockMovingModeClassNames = useBlockMovingModeClassNames( clientId );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
+	const mergedRefs = useMergeRefs( [ ref, useEventHandlers( clientId ) ] );
 
 	return {
 		...wrapperProps,
 		...props,
-		ref: useMergeRefs( [ ref, useEventHandlers( clientId ) ] ),
+		ref: mergedRefs,
 		id: `block-${ clientId }${ htmlSuffix }`,
 		tabIndex: 0,
 		role: 'group',

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -10,6 +10,7 @@ import { omit } from 'lodash';
 import { useRef, useEffect, useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -92,7 +93,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 
 	useFocusFirstElement( ref, clientId );
-	useEventHandlers( ref, clientId );
 
 	// Block Reordering animation
 	useMovingAnimation(
@@ -110,7 +110,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	return {
 		...wrapperProps,
 		...props,
-		ref,
+		ref: useMergeRefs( [ ref, useEventHandlers( clientId ) ] ),
 		id: `block-${ clientId }${ htmlSuffix }`,
 		tabIndex: 0,
 		role: 'group',

--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useContext } from '@wordpress/element';
+import { useCallback, useContext } from '@wordpress/element';
 import { isTextField } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -13,8 +13,6 @@ import { isInsideRootBlock } from '../../../utils/dom';
 import { SelectionStart } from '../../writing-flow';
 import { store as blockEditorStore } from '../../../store';
 
-/** @typedef {import('@wordpress/element').RefObject} RefObject */
-
 /**
  * Adds block behaviour:
  *   - Selects the block if it receives focus.
@@ -23,10 +21,9 @@ import { store as blockEditorStore } from '../../../store';
  *   - Initiates selection start for multi-selection.
  *   - Disables dragging of block contents.
  *
- * @param {RefObject} ref React ref with the block element.
- * @param {string}    clientId Block client ID.
+ * @param {string} clientId Block client ID.
  */
-export function useEventHandlers( ref, clientId ) {
+export function useEventHandlers( clientId ) {
 	const onSelectionStart = useContext( SelectionStart );
 	const { isSelected, rootClientId, index } = useSelect(
 		( select ) => {
@@ -48,100 +45,103 @@ export function useEventHandlers( ref, clientId ) {
 		blockEditorStore
 	);
 
-	useEffect( () => {
-		if ( ! isSelected ) {
+	return useCallback(
+		( node ) => {
+			if ( ! isSelected ) {
+				/**
+				 * Marks the block as selected when focused and not already
+				 * selected. This specifically handles the case where block does not
+				 * set focus on its own (via `setFocus`), typically if there is no
+				 * focusable input in the block.
+				 *
+				 * @param {FocusEvent} event Focus event.
+				 */
+				function onFocus( event ) {
+					// If an inner block is focussed, that block is resposible for
+					// setting the selected block.
+					if ( ! isInsideRootBlock( node, event.target ) ) {
+						return;
+					}
+
+					selectBlock( clientId );
+				}
+
+				node.addEventListener( 'focusin', onFocus );
+
+				return () => {
+					node.removeEventListener( 'focusin', onFocus );
+				};
+			}
+
 			/**
-			 * Marks the block as selected when focused and not already
-			 * selected. This specifically handles the case where block does not
-			 * set focus on its own (via `setFocus`), typically if there is no
-			 * focusable input in the block.
+			 * Interprets keydown event intent to remove or insert after block if
+			 * key event occurs on wrapper node. This can occur when the block has
+			 * no text fields of its own, particularly after initial insertion, to
+			 * allow for easy deletion and continuous writing flow to add additional
+			 * content.
 			 *
-			 * @param {FocusEvent} event Focus event.
+			 * @param {KeyboardEvent} event Keydown event.
 			 */
-			function onFocus( event ) {
-				// If an inner block is focussed, that block is resposible for
-				// setting the selected block.
-				if ( ! isInsideRootBlock( ref.current, event.target ) ) {
+			function onKeyDown( event ) {
+				const { keyCode, target } = event;
+
+				if (
+					keyCode !== ENTER &&
+					keyCode !== BACKSPACE &&
+					keyCode !== DELETE
+				) {
 					return;
 				}
 
-				selectBlock( clientId );
+				if ( target !== node || isTextField( target ) ) {
+					return;
+				}
+
+				event.preventDefault();
+
+				if ( keyCode === ENTER ) {
+					insertDefaultBlock( {}, rootClientId, index + 1 );
+				} else {
+					removeBlock( clientId );
+				}
 			}
 
-			ref.current.addEventListener( 'focusin', onFocus );
+			function onMouseLeave( { buttons } ) {
+				// The primary button must be pressed to initiate selection.
+				// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+				if ( buttons === 1 ) {
+					onSelectionStart( clientId );
+				}
+			}
+
+			/**
+			 * Prevents default dragging behavior within a block. To do: we must
+			 * handle this in the future and clean up the drag target.
+			 *
+			 * @param {DragEvent} event Drag event.
+			 */
+			function onDragStart( event ) {
+				event.preventDefault();
+			}
+
+			node.addEventListener( 'keydown', onKeyDown );
+			node.addEventListener( 'mouseleave', onMouseLeave );
+			node.addEventListener( 'dragstart', onDragStart );
 
 			return () => {
-				ref.current.removeEventListener( 'focusin', onFocus );
+				node.removeEventListener( 'mouseleave', onMouseLeave );
+				node.removeEventListener( 'keydown', onKeyDown );
+				node.removeEventListener( 'dragstart', onDragStart );
 			};
-		}
-
-		/**
-		 * Interprets keydown event intent to remove or insert after block if
-		 * key event occurs on wrapper node. This can occur when the block has
-		 * no text fields of its own, particularly after initial insertion, to
-		 * allow for easy deletion and continuous writing flow to add additional
-		 * content.
-		 *
-		 * @param {KeyboardEvent} event Keydown event.
-		 */
-		function onKeyDown( event ) {
-			const { keyCode, target } = event;
-
-			if (
-				keyCode !== ENTER &&
-				keyCode !== BACKSPACE &&
-				keyCode !== DELETE
-			) {
-				return;
-			}
-
-			if ( target !== ref.current || isTextField( target ) ) {
-				return;
-			}
-
-			event.preventDefault();
-
-			if ( keyCode === ENTER ) {
-				insertDefaultBlock( {}, rootClientId, index + 1 );
-			} else {
-				removeBlock( clientId );
-			}
-		}
-
-		function onMouseLeave( { buttons } ) {
-			// The primary button must be pressed to initiate selection.
-			// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
-			if ( buttons === 1 ) {
-				onSelectionStart( clientId );
-			}
-		}
-
-		/**
-		 * Prevents default dragging behavior within a block. To do: we must
-		 * handle this in the future and clean up the drag target.
-		 *
-		 * @param {DragEvent} event Drag event.
-		 */
-		function onDragStart( event ) {
-			event.preventDefault();
-		}
-
-		ref.current.addEventListener( 'keydown', onKeyDown );
-		ref.current.addEventListener( 'mouseleave', onMouseLeave );
-		ref.current.addEventListener( 'dragstart', onDragStart );
-
-		return () => {
-			ref.current.removeEventListener( 'mouseleave', onMouseLeave );
-			ref.current.removeEventListener( 'keydown', onKeyDown );
-			ref.current.removeEventListener( 'dragstart', onDragStart );
-		};
-	}, [
-		isSelected,
-		rootClientId,
-		index,
-		onSelectionStart,
-		insertDefaultBlock,
-		removeBlock,
-		selectBlock,
-	] );
+		},
+		[
+			isSelected,
+			rootClientId,
+			index,
+			onSelectionStart,
+			insertDefaultBlock,
+			removeBlock,
+			selectBlock,
+		]
+	);
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useContext } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 import { isTextField } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -45,7 +46,7 @@ export function useEventHandlers( clientId ) {
 		blockEditorStore
 	);
 
-	return useCallback(
+	return useRefEffect(
 		( node ) => {
 			if ( ! isSelected ) {
 				/**

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -328,7 +328,18 @@ _Returns_
 
 <a name="useRefEffect" href="#useRefEffect">#</a> **useRefEffect**
 
-Effect-like ref callback.
+Effect-like ref callback. Just like with `useEffect`, this allows you to
+return a cleanup function to be run if the ref changes or one of the
+dependencies changes. The ref is provided as an argument to the callback
+functions. The main difference between this and `useEffect` is that
+the `useEffect` callback is not called when the ref changes, but this is.
+Pass the returned ref callback as the component's ref and merge multiple refs
+with `useMergeRefs`.
+
+It's worth noting that if the dependencies array is empty, there's not
+strictly a need to clean up event handlers for example, because the node is
+to be removed. It _is_ necessary if you add dependencies because the ref
+callback will be called multiple times for the same node.
 
 _Parameters_
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -326,6 +326,19 @@ _Returns_
 
 -   `boolean`: Reduced motion preference value.
 
+<a name="useRefEffect" href="#useRefEffect">#</a> **useRefEffect**
+
+Effect-like ref callback.
+
+_Parameters_
+
+-   _calllback_ `Function`: Callback with ref as argument.
+-   _dependencies_ `Array`: Dependencies of the callback.
+
+_Returns_
+
+-   `Function`: Ref callback.
+
 <a name="useResizeObserver" href="#useResizeObserver">#</a> **useResizeObserver**
 
 Hook which allows to listen the resize event of any target element when it changes sizes.

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -41,13 +41,8 @@ export default function useMergeRefs( refs ) {
 				ref !== previousRef &&
 				didElementChange.current === false
 			) {
-				if ( typeof previousRef.cleanup === 'function' ) {
-					previousRef.cleanup();
-				} else {
-					previousRef( null );
-				}
-
-				ref.cleanup = ref( element.current );
+				previousRef( null );
+				ref( element.current );
 			}
 		} );
 
@@ -70,11 +65,7 @@ export default function useMergeRefs( refs ) {
 		// Update the latest refs.
 		refsToUpdate.forEach( ( ref ) => {
 			if ( typeof ref === 'function' ) {
-				if ( ! value && typeof ref.cleanup === 'function' ) {
-					ref.cleanup();
-				} else {
-					ref.cleanup = ref( value );
-				}
+				ref( value );
 			} else if ( ref && ref.hasOwnProperty( 'current' ) ) {
 				ref.current = value;
 			}

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -41,8 +41,13 @@ export default function useMergeRefs( refs ) {
 				ref !== previousRef &&
 				didElementChange.current === false
 			) {
-				previousRef( null );
-				ref( element.current );
+				if ( typeof previousRef.cleanup === 'function' ) {
+					previousRef.cleanup();
+				} else {
+					previousRef( null );
+				}
+
+				ref.cleanup = ref( element.current );
 			}
 		} );
 
@@ -65,7 +70,11 @@ export default function useMergeRefs( refs ) {
 		// Update the latest refs.
 		refsToUpdate.forEach( ( ref ) => {
 			if ( typeof ref === 'function' ) {
-				ref( value );
+				if ( ! value && typeof ref.cleanup === 'function' ) {
+					ref.cleanup();
+				} else {
+					ref.cleanup = ref( value );
+				}
 			} else if ( ref && ref.hasOwnProperty( 'current' ) ) {
 				ref.current = value;
 			}

--- a/packages/compose/src/hooks/use-ref-effect/index.js
+++ b/packages/compose/src/hooks/use-ref-effect/index.js
@@ -4,7 +4,18 @@
 import { useCallback, useRef } from '@wordpress/element';
 
 /**
- * Effect-like ref callback.
+ * Effect-like ref callback. Just like with `useEffect`, this allows you to
+ * return a cleanup function to be run if the ref changes or one of the
+ * dependencies changes. The ref is provided as an argument to the callback
+ * functions. The main difference between this and `useEffect` is that
+ * the `useEffect` callback is not called when the ref changes, but this is.
+ * Pass the returned ref callback as the component's ref and merge multiple refs
+ * with `useMergeRefs`.
+ *
+ * It's worth noting that if the dependencies array is empty, there's not
+ * strictly a need to clean up event handlers for example, because the node is
+ * to be removed. It *is* necessary if you add dependencies because the ref
+ * callback will be called multiple times for the same node.
  *
  * @param {Function} calllback    Callback with ref as argument.
  * @param {Array}    dependencies Dependencies of the callback.
@@ -16,7 +27,7 @@ export default function useRefEffect( calllback, dependencies ) {
 	return useCallback( ( node ) => {
 		if ( node ) {
 			cleanup.current = calllback( node );
-		} else {
+		} else if ( cleanup.current ) {
 			cleanup.current();
 		}
 	}, dependencies );

--- a/packages/compose/src/hooks/use-ref-effect/index.js
+++ b/packages/compose/src/hooks/use-ref-effect/index.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useRef } from '@wordpress/element';
+
+/**
+ * Effect-like ref callback.
+ *
+ * @param {Function} calllback    Callback with ref as argument.
+ * @param {Array}    dependencies Dependencies of the callback.
+ *
+ * @return {Function} Ref callback.
+ */
+export default function useRefEffect( calllback, dependencies ) {
+	const cleanup = useRef();
+	return useCallback( ( node ) => {
+		if ( node ) {
+			cleanup.current = calllback( node );
+		} else {
+			cleanup.current();
+		}
+	}, dependencies );
+}

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -33,3 +33,4 @@ export { default as useWarnOnChange } from './hooks/use-warn-on-change';
 export { default as useDebounce } from './hooks/use-debounce';
 export { default as useThrottle } from './hooks/use-throttle';
 export { default as useMergeRefs } from './hooks/use-merge-refs';
+export { default as useRefEffect } from './hooks/use-ref-effect';

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/keycodes';
 import deprecated from '@wordpress/deprecated';
 import { getFilesFromDataTransfer } from '@wordpress/dom';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -162,8 +163,9 @@ function RichText(
 		__unstableOnCreateUndoLevel: onCreateUndoLevel,
 		__unstableIsSelected: isSelected,
 	},
-	ref
+	forwardedRef
 ) {
+	const ref = useRef();
 	const [ activeFormats = [], setActiveFormats ] = useState();
 	const {
 		formatTypes,
@@ -1073,7 +1075,7 @@ function RichText(
 		role: 'textbox',
 		'aria-multiline': true,
 		'aria-label': placeholder,
-		ref,
+		ref: useMergeRefs( [ forwardedRef, ref ] ),
 		style: defaultStyle,
 		className: 'rich-text',
 		onPaste: handlePaste,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/28880
Alternative to #28658.

I added a `useEffect`-like cleanup pattern to `useMergeRefs`, which allows something to be cleaned up more easily than with the current way ref callbacks work. Ref callbacks are normally called with `null` when a new one is called, but unless you set the node as a property of the ref callback, you don't have access to it. It's probably possible to do, but it makes the code much harder to understand than the `useEffect` pattern that everyone already knows. So if a ref callback returns a cleanup function, we'll call the cleanup function instead of calling the callback a second time with null. It's still possible to have the old behaviour by simply not returning a cleanup function. I think this pattern will be very useful for many components switching from an effect hook to a ref callback.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
