### PR TITLE
WP_Theme_JSON: simplify code by not passing tree by reference

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -367,7 +367,7 @@ class WP_Theme_JSON {
 						unset( $styles_schema[ $prop_meta['value'][0] ][ $prop_meta['value'][1] ] );
 					}
 				}
-				self::remove_keys_not_in_schema(
+				$this->theme_json['styles'][ $block_selector ] = self::remove_keys_not_in_schema(
 					$this->theme_json['styles'][ $block_selector ],
 					$styles_schema
 				);
@@ -386,7 +386,7 @@ class WP_Theme_JSON {
 				}
 
 				// Remove the properties that aren't present in the schema.
-				self::remove_keys_not_in_schema(
+				$this->theme_json['settings'][ $block_selector ] = self::remove_keys_not_in_schema(
 					$this->theme_json['settings'][ $block_selector ],
 					self::SCHEMA['settings']
 				);
@@ -596,19 +596,23 @@ class WP_Theme_JSON {
 	 *
 	 * @param array $tree Input to process.
 	 * @param array $schema Schema to adhere to.
+	 *
+	 * @return array Returns the modified $tree.
 	 */
-	private static function remove_keys_not_in_schema( &$tree, $schema ) {
+	private static function remove_keys_not_in_schema( $tree, $schema ) {
 		$tree = array_intersect_key( $tree, $schema );
 
 		foreach ( $schema as $key => $data ) {
 			if ( is_array( $schema[ $key ] ) && isset( $tree[ $key ] ) ) {
-				self::remove_keys_not_in_schema( $tree[ $key ], $schema[ $key ] );
+				$tree[ $key ] = self::remove_keys_not_in_schema( $tree[ $key ], $schema[ $key ] );
 
 				if ( empty( $tree[ $key ] ) ) {
 					unset( $tree[ $key ] );
 				}
 			}
 		}
+
+		return $tree;
 	}
 
 	/**


### PR DESCRIPTION
## Description

The `remove_keys_not_in_schema` method doesn't _need_ to pass the `$tree` by reference.
This PR changes the function argument to not get passed by reference and makes the necessary adjustments in methods that call `remove_keys_not_in_schema`.

## How has this been tested?

* Nothing breaks in an FSE theme, global-styles continue to be properly parsed & applied.
* Verify that automated tests don't fail.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
