### PR TITLE
Try: Media & Text max-width rule.

### DIFF
--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -13,7 +13,3 @@
 	// The resizer sets an inline height but for the image fill we set it to full height.
 	height: 100% !important;
 }
-
-.wp-block-media-text > .block-editor-block-list__layout > .block-editor-block-list__block {
-	max-width: unset;
-}

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -67,7 +67,8 @@
 
 .wp-block-media-text__media img,
 .wp-block-media-text__media video {
-	max-width: unset;
+	min-width: 0;
+	max-width: 100%;
 	width: 100%;
 	vertical-align: middle;
 }


### PR DESCRIPTION
## Description

Make the media & text image rules more resilient to CSS bleed. Fixes #17787, props @Wingo5315, alternative to #28822.

## How has this been tested?

Insert a Media & Text block, try adding a small image, a big image, or a video. All three should behave predictably in the editor, and the frontend should look identical.

## Screenshots

If a theme has CSS to style the `img` tag (such as setting widths, min-widths or max-widths), those styles will affect the image inside media & text as well.

Here's what could happen with a min-width:

<img width="802" alt="Screenshot 2021-02-10 at 17 01 14" src="https://user-images.githubusercontent.com/1204802/107536385-03696b80-6bc2-11eb-9fcf-e5bd6c316276.png">

Here's what could happen with a too-high max-width:

<img width="940" alt="Screenshot 2021-02-10 at 17 01 30" src="https://user-images.githubusercontent.com/1204802/107536427-0bc1a680-6bc2-11eb-9cba-c457c5c2ed44.png">


This PR adds explicit min and max-widths, but keeps the width, to make the behavior consistent.




## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
