### PR TITLE
wp-env: Fix issue where mappings sources were not downloaded

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   "mappings" sources are now downloaded if they contain non-local sources.
+
 ## 3.0.0 (2020-12-17)
 
 ### Breaking Changes

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -55,6 +55,7 @@ module.exports = function downloadSources( config, spinner ) {
 	for ( const env of Object.values( config.env ) ) {
 		env.pluginSources.forEach( addSource );
 		env.themeSources.forEach( addSource );
+		Object.values( env.mappings ).forEach( addSource );
 		addSource( env.coreSource );
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Our docs say "Several types of strings can be passed into the core, plugins, themes, and mappings fields." to describe that each can support .zip/github/local sources. However, we were never downloading "mappings" sources from git or .zip sources.

This PR begins downloading the mappings sources in the same way we download the others.

## How has this been tested?
Locally, with the following .wp-env.override.json file, I tested that this directory was added to the root wordpress instance.

```json
{
	"mappings": {
		"theme-unit-test": "WPTT/theme-unit-test#master"
	}
}
```

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
