### PR TITLE
Fix positioning of nested submenus in Nav screen

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -73,6 +73,11 @@
 		border-radius: $radius-block-ui;
 	}
 
+	// Override Nav block styling for deeply nested submenus.
+	.has-child .wp-block-navigation__container .wp-block-navigation__container {
+		left: auto;
+	}
+
 	// When editing a link with children, highlight the parent
 	// and adjust the spacing and submenu icon.
 	.wp-block-navigation-link.has-child.is-editing {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Small CSS override for default Navigation block nested submenu styles. Fixes horizontal scrollbar in the Nav screen:

<img width="1051" alt="Screen Shot 2021-02-11 at 4 20 03 pm" src="https://user-images.githubusercontent.com/8096000/107607343-16953d80-6c8d-11eb-8140-790825bc80ce.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

In the Nav screen, create a menu with more than 4 nesting levels. Verify that no horizontal scrollbar occurs.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
