### PR TITLE
Make navigation editor end-to-end tests more robust

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -93,6 +93,9 @@ async function visitNavigationEditor() {
 		page: 'gutenberg-navigation',
 	} );
 	await visitAdminPage( '/admin.php', query );
+
+	// Wait for loading to finish.
+	await page.waitForXPath( '//h2[.="Loading …"]', { hidden: true } );
 }
 
 async function getSerializedBlocks() {

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -93,9 +93,6 @@ async function visitNavigationEditor() {
 		page: 'gutenberg-navigation',
 	} );
 	await visitAdminPage( '/admin.php', query );
-
-	// Wait for loading to finish.
-	await page.waitForXPath( '//h2[.="Loading …"]', { hidden: true } );
 }
 
 async function getSerializedBlocks() {
@@ -129,7 +126,9 @@ describe( 'Navigation editor', () => {
 		await visitNavigationEditor();
 
 		// Wait for the header to show that no menus are available.
-		await page.waitForXPath( '//h2[contains(., "No menus available")]' );
+		await page.waitForXPath( '//h2[contains(., "No menus available")]', {
+			visible: true,
+		} );
 
 		// Prepare the menu endpoint for creating a menu.
 		await setUpResponseMocking( [
@@ -169,6 +168,10 @@ describe( 'Navigation editor', () => {
 		);
 		await addAllPagesButton.click();
 
+		// When the block is created the root element changes from a div (for the placeholder)
+		// to a nav (for the navigation itself). Wait for this to happen.
+		await page.waitForSelector( 'nav[aria-label="Block: Navigation"]' );
+
 		expect( await getSerializedBlocks() ).toMatchSnapshot();
 	} );
 
@@ -180,7 +183,12 @@ describe( 'Navigation editor', () => {
 		await visitNavigationEditor();
 
 		// Wait for the header to show the menu name.
-		await page.waitForXPath( '//h2[contains(., "Editing: Test Menu 1")]' );
+		await page.waitForXPath( '//h2[contains(., "Editing: Test Menu 1")]', {
+			visible: true,
+		} );
+
+		// Wait for the block to be present.
+		await page.waitForSelector( 'nav[aria-label="Block: Navigation"]' );
 
 		expect( await getSerializedBlocks() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28903

Both navigation editor tests have been failing intermittently.

I haven't completely worked out why! The most common failure was on this line:
```js
await page.waitForXPath( '//h2[contains(., "No menus available")]' );
```

Changing this to seems to fix things
```js
await page.waitForXPath( '//h2[contains(., "No menus available")]', {
	visible: true,
} );
```

I went from some failures to none locally. I had a quick look at puppeteer's code and it seems that using the `visible` or `hidden` options switches the wait from using a `MutationObserver` to `requestAnimationFrame` polling. It might be that there's an underlying issue in puppeteer when waiting for `innerText` to change using a `MutationObserver`, but I couldn't see what.

I added in a few other `waitForSelector` calls to fix a second issue, where the snapshot is sometimes tested before before any blocks have been created.

## How has this been tested?
Ran the tests a bunch of times locally

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
