### PR TITLE
Make get_blocks_metadata() call static

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -338,7 +338,7 @@ class WP_Theme_JSON {
 		// Remove top-level keys that aren't present in the schema.
 		$this->theme_json = array_intersect_key( $theme_json, self::SCHEMA );
 
-		$block_metadata = $this->get_blocks_metadata();
+		$block_metadata = self::get_blocks_metadata();
 		foreach ( array( 'settings', 'styles' ) as $subtree ) {
 			// Remove settings & styles subtrees if they aren't arrays.
 			if ( isset( $this->theme_json[ $subtree ] ) && ! is_array( $this->theme_json[ $subtree ] ) ) {
@@ -934,7 +934,7 @@ class WP_Theme_JSON {
 			return $stylesheet;
 		}
 
-		$metadata = $this->get_blocks_metadata();
+		$metadata = self::get_blocks_metadata();
 		foreach ( $this->theme_json['settings'] as $block_selector => $settings ) {
 			if ( empty( $metadata[ $block_selector ]['selector'] ) ) {
 				continue;
@@ -994,7 +994,7 @@ class WP_Theme_JSON {
 			return $stylesheet;
 		}
 
-		$metadata = $this->get_blocks_metadata();
+		$metadata = self::get_blocks_metadata();
 		foreach ( $metadata as $block_selector => $metadata ) {
 			if ( empty( $metadata['selector'] ) ) {
 				continue;


### PR DESCRIPTION
## Description

`get_blocks_metadata` is now a static method so should be called statically.

## Types of changes

Changed `$this->get_blocks_metadata()` to `self::get_blocks_metadata()`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
