### PR TITLE
Site Editor: Fix e2e test errors introduced by template sidebar

### DIFF
--- a/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
@@ -92,10 +92,7 @@ describe( 'Settings sidebar', () => {
 			await selectBlockByClientId( allBlocks[ 0 ].clientId );
 
 			await toggleSidebar();
-			// TODO: Remove when toolbar supports text fields
-			expect( console ).toHaveWarnedWith(
-				'Using custom components as toolbar controls is deprecated. Please use ToolbarItem or ToolbarButton components instead. See: https://developer.wordpress.org/block-editor/components/toolbar-button/#inside-blockcontrols'
-			);
+
 			expect( await getActiveTabLabel() ).toEqual( 'Block (selected)' );
 		} );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Looks like some changes were made in this PR #28835 that removed the custom component based toolbar control. The #28633 PR we just merged still included that check, which is now causing the e2e tests to fail on new PRs.

## How has this been tested?
CI tests should pass

## Types of changes
Automated testing

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
