### PR TITLE
Block Editor Component: Fix function call in justify toolbar

### DIFF
--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -24,6 +24,17 @@ export function JustifyToolbar( {
 	value,
 	popoverProps,
 } ) {
+	// If the control is already selected we want a click
+	// again on the control to deselect the item, so we
+	// call onChange( undefined )
+	const handleClick = ( next ) => {
+		if ( next === value ) {
+			onChange( undefined );
+		} else {
+			onChange( next );
+		}
+	};
+
 	const icon = value ? icons[ value ] : icons.left;
 	const allControls = [
 		{
@@ -31,28 +42,28 @@ export function JustifyToolbar( {
 			icon: justifyLeft,
 			title: __( 'Justify items left' ),
 			isActive: 'left' === value,
-			onClick: () => onChange( 'left' ),
+			onClick: () => handleClick( 'left' ),
 		},
 		{
 			name: 'center',
 			icon: justifyCenter,
 			title: __( 'Justify items center' ),
 			isActive: 'center' === value,
-			onClick: () => onChange( 'center' ),
+			onClick: () => handleClick( 'center' ),
 		},
 		{
 			name: 'right',
 			icon: justifyRight,
 			title: __( 'Justify items right' ),
 			isActive: 'right' === value,
-			onClick: () => onChange( 'right' ),
+			onClick: () => handleClick( 'right' ),
 		},
 		{
 			name: 'space-between',
 			icon: justifySpaceBetween,
 			title: __( 'Space between items' ),
 			isActive: 'space-between' === value,
-			onClick: () => onChange( 'space-between' ),
+			onClick: () => handleClick( 'space-between' ),
 		},
 	];
 

--- a/packages/block-editor/src/components/justify-toolbar/index.js
+++ b/packages/block-editor/src/components/justify-toolbar/index.js
@@ -31,28 +31,28 @@ export function JustifyToolbar( {
 			icon: justifyLeft,
 			title: __( 'Justify items left' ),
 			isActive: 'left' === value,
-			onClick: onChange( 'left' ),
+			onClick: () => onChange( 'left' ),
 		},
 		{
 			name: 'center',
 			icon: justifyCenter,
 			title: __( 'Justify items center' ),
 			isActive: 'center' === value,
-			onClick: onChange( 'center' ),
+			onClick: () => onChange( 'center' ),
 		},
 		{
 			name: 'right',
 			icon: justifyRight,
 			title: __( 'Justify items right' ),
 			isActive: 'right' === value,
-			onClick: onChange( 'right' ),
+			onClick: () => onChange( 'right' ),
 		},
 		{
 			name: 'space-between',
 			icon: justifySpaceBetween,
 			title: __( 'Space between items' ),
 			isActive: 'space-between' === value,
-			onClick: onChange( 'space-between' ),
+			onClick: () => onChange( 'space-between' ),
 		},
 	];
 

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -42,23 +42,15 @@ function ButtonsEdit( {
 		templateInsertUpdatesSelection: true,
 	} );
 
-	function handleItemsAlignment( align ) {
-		return () => {
-			const justification =
-				contentJustification === align ? undefined : align;
-			setAttributes( {
-				contentJustification: justification,
-			} );
-		};
-	}
-
 	return (
 		<>
 			<BlockControls>
 				<JustifyToolbar
 					allowedControls={ [ 'left', 'center', 'right' ] }
 					value={ contentJustification }
-					onChange={ handleItemsAlignment }
+					onChange={ ( value ) =>
+						setAttributes( { contentJustification: value } )
+					}
 					popoverProps={ {
 						position: 'bottom right',
 						isAlternate: true,

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -107,23 +107,15 @@ function Navigation( {
 		);
 	}
 
-	function handleItemsAlignment( align ) {
-		return () => {
-			const itemsJustification =
-				attributes.itemsJustification === align ? undefined : align;
-			setAttributes( {
-				itemsJustification,
-			} );
-		};
-	}
-
 	return (
 		<>
 			<BlockControls>
 				{ hasItemJustificationControls && (
 					<JustifyToolbar
 						value={ attributes.itemsJustification }
-						onChange={ handleItemsAlignment }
+						onChange={ ( value ) =>
+							setAttributes( { itemsJustification: value } )
+						}
 						popoverProps={ {
 							position: 'bottom right',
 							isAlternate: true,


### PR DESCRIPTION

## Description

The onChange function in the Justify Toolbar was calling the function on render instead of registering the function onClick, it needed to be wrapped in a function call. This added complexity was missed in the consumers of the component since they were wrapped in an extra function call. This PR fixes the issue and corrects the downstream consumers, simplifying the implementation.

This will likely also fix the issue in #28893 


## How has this been tested?

There should no visible change when using.

1. Test by adding Navigation links and changing items justification (align left, right, center, space-between)
2. Test by adding Buttons and changing items justification (align left, right, center) 


## Types of changes

Fix function call in component
