### PR TITLE
Fix spacing in new contributor welcome message

### DIFF
--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -58,7 +58,7 @@ async function firstTimeContributorLabel( payload, octokit ) {
 		body:
 			':wave: Thanks for your first Pull Request and for helping build the future of Gutenberg and WordPress, @' +
 			author +
-			"!. In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/)," +
+			"! In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/), " +
 			'where we hold [regularly weekly meetings](https://make.wordpress.org/core/tag/core-editor-summary/) open to anyone to coordinate with each other.\n\n' +
 			'If you want to learn more about WordPress development in general, check out the [Core Handbook](https://make.wordpress.org/core/handbook/) full of helpful information.',
 	} );

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
@@ -64,8 +64,8 @@ describe( 'firstTimeContributorLabel', () => {
 
 		const expectedComment =
 			':wave: Thanks for your first Pull Request and for helping build the future of Gutenberg and WordPress, @ghost' +
-			"!. In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/)," +
-			'where we hold [regularly weekly meetings](https://make.wordpress.org/core/tag/core-editor-summary/) open to anyone to coordinate with each other.\n\n' +
+			"! In case you missed it, we'd love to have you join us in our [Slack community](https://make.wordpress.org/chat/)," +
+			' where we hold [regularly weekly meetings](https://make.wordpress.org/core/tag/core-editor-summary/) open to anyone to coordinate with each other.\n\n' +
 			'If you want to learn more about WordPress development in general, check out the [Core Handbook](https://make.wordpress.org/core/handbook/) full of helpful information.';
 
 		await firstTimeContributorLabel( payload, octokit );


### PR DESCRIPTION
## Description
After committing this new welcome message https://github.com/WordPress/gutenberg/pull/28118, I noticed a few minor spacing issues in the implementation. This PR is a very simple fix to get proper spacing in place!

## Screenshots 

Current implementation [where you can see typos/spacing issues:](https://github.com/WordPress/gutenberg/pull/28854#issuecomment-775323426)

<img width="1032" alt="Screen Shot 2021-02-11 at 5 31 08 PM" src="https://user-images.githubusercontent.com/26996883/107716580-f23a6080-6c8e-11eb-858d-336c1a4850f5.png">

## Types of changes

This is a minor "bug" fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
