### PR TITLE
Fix admin menu scroll on editor page

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -49,6 +49,11 @@ body.block-editor-page {
 	@include wp-admin-reset( ".block-editor" );
 }
 
+// Fix issue with wp-admin menu not scrolling between 170% and 200% zoom.
+.block-editor-page #wpwrap {
+	overflow-y: auto;
+}
+
 // Target the editor UI excluding the metaboxes and custom fields areas.
 .edit-post-header,
 .edit-post-visual-editor,

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -52,6 +52,9 @@ body.block-editor-page {
 // Fix issue with wp-admin menu not scrolling between 170% and 200% zoom.
 .block-editor-page #wpwrap {
 	overflow-y: auto;
+	@include break-medium() {
+		overflow-y: initial;
+	}
 }
 
 // Target the editor UI excluding the metaboxes and custom fields areas.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #20943.
At certain zoom levels (between 170 - 200% on a 1300px wide window), the admin sidebar becomes unscrollable on the block editor page (it works fine in the rest of wp-admin). I'm not quite sure what causes this, but it's probably related to the content being scrollable independently from the menu. It is fixed by adding `overflow-y: auto` to `#wpwrap`, which doesn't break anything (the default overflow value is `visible`, which mostly behaves like `auto`). 🤷‍♀️ anyway, it works.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested across browsers, on macOS and Windows. 

Make the wp-admin visible in the block editor, then zoom in just until the menu folds up into a hamburger icon. Open the hamburger and verify the menu is scrollable.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
