### PR TITLE
Invalid font-family list

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -49,9 +49,8 @@ function gutenberg_get_editor_styles() {
 		),
 	);
 
-	$locale_font_family = '-apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif';
-	$styles[]           = array(
-		'css' => "body { font-family: $locale_font_family }",
+	$styles[] = array(
+		'css' => 'body { font-family: -apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif }',
 	);
 
 	if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -49,7 +49,6 @@ function gutenberg_get_editor_styles() {
 		),
 	);
 
-	/* translators: Use this to specify the CSS font family for the default font. */
 	$locale_font_family = '-apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif';
 	$styles[]           = array(
 		'css' => "body { font-family: $locale_font_family }",

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -52,7 +52,7 @@ function gutenberg_get_editor_styles() {
 	/* translators: Use this to specify the CSS font family for the default font. */
 	$locale_font_family = '-apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif';
 	$styles[]           = array(
-		'css' => "body { font-family: '$locale_font_family' }",
+		'css' => "body { font-family: $locale_font_family }",
 	);
 
 	if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
After #26822 I was seeing the incorrect font stack being used on WordPress.org, as it turned out the font-family was a quoted list of fonts rather than an unquoted list. See below image.

Slack discussion:
https://wordpress.slack.com/archives/C02RP4Y3K/p1613013216437900

This change also needs to be sync'd to WordPress trunk: https://core.trac.wordpress.org/ticket/46169#comment:43

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Altered PHP
Loaded editor with correct fonts.

## Screenshots <!-- if applicable -->
<img width="585" alt="Screen Shot 2021-02-11 at 1 28 28 pm" src="https://user-images.githubusercontent.com/767313/107725886-0a63bb80-6d33-11eb-8c75-2129bc1947ce.png">
<img width="329" alt="Screen Shot 2021-02-11 at 1 23 03 pm" src="https://user-images.githubusercontent.com/767313/107725888-0c2d7f00-6d33-11eb-938e-cc4132cdd34c.png">

<img width="997" alt="Screen Shot 2021-02-12 at 1 08 30 pm" src="https://user-images.githubusercontent.com/767313/107726085-95dd4c80-6d33-11eb-8704-150922752cb9.png">
<img width="1003" alt="Screen Shot 2021-02-12 at 1 07 42 pm" src="https://user-images.githubusercontent.com/767313/107726087-970e7980-6d33-11eb-9e0e-cfd6a34be159.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
