### PR TITLE
Prevent focused block from stealing focus when inserting a new block

### DIFF
--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -47,6 +47,14 @@ function useFocusReturn( onFocusReturn ) {
 
 			focusedBeforeMount.current = node.ownerDocument.activeElement;
 		} else if ( focusedBeforeMount.current ) {
+			const isFocused = ref.current.contains(
+				ref.current.ownerDocument.activeElement
+			);
+
+			if ( ref.current.isConnected && ! isFocused ) {
+				return;
+			}
+
 			// Defer to the component's own explicit focus return behavior, if
 			// specified. This allows for support that the `onFocusReturn`
 			// decides to allow the default behavior to occur under some


### PR DESCRIPTION
closes #28932 

When using the inserter, you can use `ctrl + click` to insert and focus the block. Doing to closes the inserter which triggers useFocusReturn, but the issue is that useFocusReturn restores the focus to the position it was before the inserter opens. In these situations useFocusReturn shouldn't trigger because the focus is already out of the inserter.

The problem though, is that with that logic, if a modal is removed from the DOM it loses focus before useFocusReturn being triggered which means we need to check if the node is attached first before applying the logic above.

**Testing instructions**

 - Check the `ctrl + enter` in the inserter doesn't cause focus steeling
 - Check that closing modals restores the focus properly.