### PR TITLE
Scripts: Add Python 2.0 to other OSS licenses in license checker

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Make `check-licenses` command compatible with npm v7 ([#28909](https://github.com/WordPress/gutenberg/pull/28909)).
+-   Add `Python 2.0` to non-GPL compatible OSS licenses ([#29968](https://github.com/WordPress/gutenberg/pull/28968)).
 
 ## 13.0.0 (2021-01-21)
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   Make `check-licenses` command compatible with npm v7 ([#28909](https://github.com/WordPress/gutenberg/pull/28909)).
--   Add `Python 2.0` to non-GPL compatible OSS licenses ([#29968](https://github.com/WordPress/gutenberg/pull/28968)).
+-   Add `Python 2.0` to non-GPL compatible OSS licenses allowed for development in `check-licenses` command ([#29968](https://github.com/WordPress/gutenberg/pull/28968)).
 
 ## 13.0.0 (2021-01-21)
 

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -76,6 +76,7 @@ const otherOssLicenses = [
 	'CC-BY-3.0',
 	'CC-BY-SA-2.0',
 	'LGPL',
+	'Python-2.0',
 ];
 
 const licenses = [


### PR DESCRIPTION
## Description
Add the `Python-2.0` license to the array of other (non-GPL compatible) licenses in the license checker tool. Those licenses are considered to be okay for dependencies that aren't actually shipped as part of Gutenberg, but only used e.g. for development and/or building it.

Source: https://www.gnu.org/licenses/license-list.en.html#PythonOld

> This is a free software license but is incompatible with the GNU GPL.

This is mostly to unblock https://github.com/WordPress/gutenberg/pull/28890 -- see discussion there (especially https://github.com/WordPress/gutenberg/pull/28890#issuecomment-777799177 and https://github.com/WordPress/gutenberg/pull/28890#issuecomment-777866252).
