### PR TITLE
Eslint plugin: Add suggestions to "data-no-store-string-literals" rule

### DIFF
--- a/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
@@ -37,6 +37,21 @@ const valid = [
 	`import { controls as controlsAlias } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; controlsAlias.resolveSelect( store );`,
 ];
 
+const createSuggestionTestCase = ( code, output ) => ( {
+	code,
+	errors: [
+		{
+			suggestions: [
+				{
+					desc:
+						'Replace literal with store definition. Import store if neccessary.',
+					output,
+				},
+			],
+		},
+	],
+} );
+
 const invalid = [
 	// Callback functions
 	`import { createRegistrySelector } from '@wordpress/data'; createRegistrySelector(( select ) => { select( 'core' ); });`,
@@ -59,83 +74,48 @@ const invalid = [
 	`import { controls as controlsAlias } from '@wordpress/data'; controlsAlias.resolveSelect( 'core' );`,
 
 	// Direct function calls suggestions
-	{
-		// Replace core with coreStore and import coreStore
-		code: `import { select } from '@wordpress/data'; select( 'core' );`,
-		errors: [
-			{
-				suggestions: [
-					{
-						desc:
-							'Replace literal with store definition. Import store if neccessary.',
-						output: `import { select } from '@wordpress/data';\nimport { store as coreStore } from '@wordpress/core-data'; select( coreStore );`,
-					},
-				],
-			},
-		],
-	},
-	{
-		// Replace core with coreStore. A @wordpress/core-data already exists, so it should append the import to that one.
-		code: `import { select } from '@wordpress/data'; import { something } from '@wordpress/core-data'; select( 'core' );`,
-		errors: [
-			{
-				suggestions: [
-					{
-						desc:
-							'Replace literal with store definition. Import store if neccessary.',
-						output: `import { select } from '@wordpress/data'; import { something,store as coreStore } from '@wordpress/core-data'; select( coreStore );`,
-					},
-				],
-			},
-		],
-	},
-	{
-		// Replace core with coreStore. A @wordpress/core-data already exists, so it should append the import to that one.
-		// This time there is a comma after the import.
-		code: `import { select } from '@wordpress/data'; import { something, } from '@wordpress/core-data'; select( 'core' );`,
-		errors: [
-			{
-				suggestions: [
-					{
-						desc:
-							'Replace literal with store definition. Import store if neccessary.',
-						output: `import { select } from '@wordpress/data'; import { something,store as coreStore, } from '@wordpress/core-data'; select( coreStore );`,
-					},
-				],
-			},
-		],
-	},
-	{
-		// Replace core with coreStore. Store import already exists. It shouldn't modify the import, just replace the literal with the store definition.
-		code: `import { select } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; select( 'core' );`,
-		errors: [
-			{
-				suggestions: [
-					{
-						desc:
-							'Replace literal with store definition. Import store if neccessary.',
-						output: `import { select } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; select( coreStore );`,
-					},
-				],
-			},
-		],
-	},
-	{
-		// Replace core with coreStore. There are internal and WordPress dependencies.
-		// It should append the import after the last WordPress dependency import.
-		code: `import { a } from './a'; import { select } from '@wordpress/data'; import { b } from './b'; select( 'core' );`,
-		errors: [
-			{
-				suggestions: [
-					{
-						desc:
-							'Replace literal with store definition. Import store if neccessary.',
-						output: `import { a } from './a'; import { select } from '@wordpress/data';\nimport { store as coreStore } from '@wordpress/core-data'; import { b } from './b'; select( coreStore );`,
-					},
-				],
-			},
-		],
-	},
+	// Replace core with coreStore and import coreStore
+	createSuggestionTestCase(
+		`import { select } from '@wordpress/data'; select( 'core' );`,
+		`import { select } from '@wordpress/data';\nimport { store as coreStore } from '@wordpress/core-data'; select( coreStore );`
+	),
+	// Replace core with coreStore. A @wordpress/core-data already exists, so it should append the import to that one.
+	createSuggestionTestCase(
+		`import { select } from '@wordpress/data'; import { something } from '@wordpress/core-data'; select( 'core' );`,
+		`import { select } from '@wordpress/data'; import { something,store as coreStore } from '@wordpress/core-data'; select( coreStore );`
+	),
+	// Replace core with coreStore. A @wordpress/core-data already exists, so it should append the import to that one.
+	// This time there is a comma after the import.
+	createSuggestionTestCase(
+		`import { select } from '@wordpress/data'; import { something, } from '@wordpress/core-data'; select( 'core' );`,
+		`import { select } from '@wordpress/data'; import { something,store as coreStore, } from '@wordpress/core-data'; select( coreStore );`
+	),
+	// Replace core with coreStore. Store import already exists. It shouldn't modify the import, just replace the literal with the store definition.
+	createSuggestionTestCase(
+		`import { select } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; select( 'core' );`,
+		`import { select } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; select( coreStore );`
+	),
+	// Replace core with coreStore. There are internal and WordPress dependencies.
+	// It should append the import after the last WordPress dependency import.
+	createSuggestionTestCase(
+		`import { a } from './a'; import { select } from '@wordpress/data'; import { b } from './b'; select( 'core' );`,
+		`import { a } from './a'; import { select } from '@wordpress/data';\nimport { store as coreStore } from '@wordpress/core-data'; import { b } from './b'; select( coreStore );`
+	),
+	// Replace block-editor with blockEditorStore
+	createSuggestionTestCase(
+		`import { select } from '@wordpress/data'; select( 'core/block-editor' );`,
+		`import { select } from '@wordpress/data';\nimport { store as blockEditorStore } from '@wordpress/block-editor'; select( blockEditorStore );`
+	),
+	// Replace notices with noticesStore
+	createSuggestionTestCase(
+		`import { select } from '@wordpress/data'; select( 'core/notices' );`,
+		`import { select } from '@wordpress/data';\nimport { store as noticesStore } from '@wordpress/notices'; select( noticesStore );`
+	),
+	// Replace edit-post with editPostStore
+	createSuggestionTestCase(
+		`import { select } from '@wordpress/data'; select( 'core/edit-post' );`,
+		`import { select } from '@wordpress/data';\nimport { store as editPostStore } from '@wordpress/edit-post'; select( editPostStore );`
+	),
 ];
 const errors = [
 	{

--- a/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
@@ -57,6 +57,85 @@ const invalid = [
 	`import { controls } from '@wordpress/data'; controls.dispatch( 'core' );`,
 	`import { controls } from '@wordpress/data'; controls.resolveSelect( 'core' );`,
 	`import { controls as controlsAlias } from '@wordpress/data'; controlsAlias.resolveSelect( 'core' );`,
+
+	// Direct function calls suggestions
+	{
+		// Replace core with coreStore and import coreStore
+		code: `import { select } from '@wordpress/data'; select( 'core' );`,
+		errors: [
+			{
+				suggestions: [
+					{
+						desc:
+							'Replace literal with store definition. Import store if neccessary.',
+						output: `import { select } from '@wordpress/data';\nimport { store as coreStore } from '@wordpress/core-data'; select( coreStore );`,
+					},
+				],
+			},
+		],
+	},
+	{
+		// Replace core with coreStore. A @wordpress/core-data already exists, so it should append the import to that one.
+		code: `import { select } from '@wordpress/data'; import { something } from '@wordpress/core-data'; select( 'core' );`,
+		errors: [
+			{
+				suggestions: [
+					{
+						desc:
+							'Replace literal with store definition. Import store if neccessary.',
+						output: `import { select } from '@wordpress/data'; import { something,store as coreStore } from '@wordpress/core-data'; select( coreStore );`,
+					},
+				],
+			},
+		],
+	},
+	{
+		// Replace core with coreStore. A @wordpress/core-data already exists, so it should append the import to that one.
+		// This time there is a comma after the import.
+		code: `import { select } from '@wordpress/data'; import { something, } from '@wordpress/core-data'; select( 'core' );`,
+		errors: [
+			{
+				suggestions: [
+					{
+						desc:
+							'Replace literal with store definition. Import store if neccessary.',
+						output: `import { select } from '@wordpress/data'; import { something,store as coreStore, } from '@wordpress/core-data'; select( coreStore );`,
+					},
+				],
+			},
+		],
+	},
+	{
+		// Replace core with coreStore. Store import already exists. It shouldn't modify the import, just replace the literal with the store definition.
+		code: `import { select } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; select( 'core' );`,
+		errors: [
+			{
+				suggestions: [
+					{
+						desc:
+							'Replace literal with store definition. Import store if neccessary.',
+						output: `import { select } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; select( coreStore );`,
+					},
+				],
+			},
+		],
+	},
+	{
+		// Replace core with coreStore. There are internal and WordPress dependencies.
+		// It should append the import after the last WordPress dependency import.
+		code: `import { a } from './a'; import { select } from '@wordpress/data'; import { b } from './b'; select( 'core' );`,
+		errors: [
+			{
+				suggestions: [
+					{
+						desc:
+							'Replace literal with store definition. Import store if neccessary.',
+						output: `import { a } from './a'; import { select } from '@wordpress/data';\nimport { store as coreStore } from '@wordpress/core-data'; import { b } from './b'; select( coreStore );`,
+					},
+				],
+			},
+		],
+	},
 ];
 const errors = [
 	{
@@ -66,5 +145,7 @@ const errors = [
 
 ruleTester.run( 'data-no-store-string-literals', rule, {
 	valid: valid.map( ( code ) => ( { code } ) ),
-	invalid: invalid.map( ( code ) => ( { code, errors } ) ),
+	invalid: invalid.map( ( code ) =>
+		typeof code === 'string' ? { code, errors } : code
+	),
 } );

--- a/packages/eslint-plugin/rules/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/data-no-store-string-literals.js
@@ -9,10 +9,10 @@ function storeNameToVariableNames( storeName ) {
 	return (
 		storeName
 			.split( '-' )
-			.map( ( s, index ) =>
+			.map( ( value, index ) =>
 				index === 0
-					? s.toLowerCase()
-					: s[ 0 ].toUpperCase() + s.slice( 1 ).toLowerCase()
+					? value.toLowerCase()
+					: value[ 0 ].toUpperCase() + value.slice( 1 ).toLowerCase()
 			)
 			.join( '' ) + 'Store'
 	);
@@ -152,9 +152,9 @@ function getFixes( fixer, context, callNode ) {
 
 	const imports = context
 		.getAncestors()[ 0 ]
-		.body.filter( ( n ) => n.type === 'ImportDeclaration' );
+		.body.filter( ( node ) => node.type === 'ImportDeclaration' );
 	const packageImports = imports.filter(
-		( n ) => n.source.value === importName
+		( node ) => node.source.value === importName
 	);
 	const packageImport =
 		packageImports.length > 0 ? packageImports[ 0 ] : null;
@@ -172,8 +172,8 @@ function getFixes( fixer, context, callNode ) {
 			);
 		}
 	} else {
-		const wpImports = imports.filter( ( n ) =>
-			n.source.value.startsWith( '@wordpress/' )
+		const wpImports = imports.filter( ( node ) =>
+			node.source.value.startsWith( '@wordpress/' )
 		);
 		const lastImport =
 			wpImports.length > 0

--- a/packages/eslint-plugin/rules/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/data-no-store-string-literals.js
@@ -1,3 +1,7 @@
+function arrayLast( array ) {
+	return array[ array.length - 1 ];
+}
+
 function getReferences( context, specifiers ) {
 	const variables = specifiers.reduce(
 		( acc, specifier ) =>
@@ -85,6 +89,123 @@ function collectAllNodesFromObjectPropertyFunctionCalls( context, node ) {
 	return possibleCallExpressionNodes;
 }
 
+function getSuggest( context, callNode ) {
+	return [
+		{
+			desc:
+				'Replace literal with store definition. Import store if neccessary.',
+			fix: ( fixer ) => getFixes( fixer, context, callNode ),
+		},
+	];
+}
+
+function getFixes( fixer, context, callNode ) {
+	const storeName = callNode.arguments[ 0 ].value;
+	const storeDefinitions = {
+		core: {
+			import: '@wordpress/core-data',
+			variable: 'coreStore',
+		},
+		'core/block-editor': {
+			import: '@wordpress/block-editor',
+			variable: 'blockEditorStore',
+		},
+		'core/block-directory': {
+			import: '@wordpress/block-directory',
+			variable: 'blockDirectoryStore',
+		},
+		'core/blocks': {
+			import: '@wordpress/blocks',
+			variable: 'blocksStore',
+		},
+		'core/editor': {
+			import: '@wordpress/editor',
+			variable: 'editorStore',
+		},
+		'core/notices': {
+			import: '@wordpress/notices',
+			variable: 'noticesStore',
+		},
+		'core/reusable-blocks': {
+			import: '@wordpress/reusable-blocks',
+			variable: 'reusableBlocksStore',
+		},
+		'core/keyboard-shortcuts': {
+			import: '@wordpress/keyboard-shortcuts',
+			variable: 'keyboardShortcutsStore',
+		},
+		'core/edit-post': {
+			import: '@wordpress/edit-post',
+			variable: 'editPostStore',
+		},
+		'core/edit-site': {
+			import: '@wordpress/edit-site',
+			variable: 'editSiteStore',
+		},
+		'core/interface': {
+			import: '@wordpress/interface',
+			variable: 'interfaceStore',
+		},
+		'core/viewport': {
+			import: '@wordpress/viewport',
+			variable: 'viewportStore',
+		},
+		'core/rich-text': {
+			import: '@wordpress/rich-text',
+			variable: 'richTextStore',
+		},
+	};
+	if ( ! storeDefinitions[ storeName ] ) {
+		return null;
+	}
+	const { variable: variableName, import: importName } = storeDefinitions[
+		storeName
+	];
+
+	const fixes = [
+		fixer.replaceText( callNode.arguments[ 0 ], variableName ),
+	];
+
+	const imports = context
+		.getAncestors()[ 0 ]
+		.body.filter( ( n ) => n.type === 'ImportDeclaration' );
+	const packageImports = imports.filter(
+		( n ) => n.source.value === importName
+	);
+	const i = packageImports.length > 0 ? packageImports[ 0 ] : null;
+	if ( i ) {
+		const alreadyHasStore = i.specifiers.some(
+			( s ) => s.imported.name === 'store'
+		);
+		if ( ! alreadyHasStore ) {
+			const lastSpecifier = arrayLast( i.specifiers );
+			fixes.push(
+				fixer.insertTextAfter(
+					lastSpecifier,
+					`,store as ${ variableName }`
+				)
+			);
+		}
+	} else {
+		const wpImports = imports.filter( ( n ) =>
+			n.source.value.startsWith( '@wordpress/' )
+		);
+		const lastImport =
+			wpImports.length > 0
+				? arrayLast( wpImports )
+				: arrayLast( imports );
+
+		fixes.push(
+			fixer.insertTextAfter(
+				lastImport,
+				`\nimport { store as ${ variableName } } from '${ importName }';`
+			)
+		);
+	}
+
+	return fixes;
+}
+
 module.exports = {
 	meta: {
 		type: 'problem',
@@ -131,6 +252,7 @@ module.exports = {
 							node: callNode.parent,
 							messageId: 'doNotUseStringLiteral',
 							data: { argument: callNode.arguments[ 0 ].value },
+							suggest: getSuggest( context, callNode ),
 						} );
 					} );
 			},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
In the https://github.com/WordPress/gutenberg/pull/28726 PR, we introduced a new rule for warning store string literals. This PR adds the functionality to replace them automatically throughout ESLint's suggestion feature.

**This auto-fix only runs manually to avoid breaking Gutenberg.**

This fix automatically adds the import for the store and replaces the literal with the correct name of the store. It also checks for existing store import and package imports.

There are a few cases that aren't handled:
- Internal imports - it always imports the store from the @wordpress/* package
- ~It is limited to the hardcoded store definitions (if something is missing let me know)~ it's now assuming variable is always camelcase version of the store name and store name is the same as package name. `core` is still hardcoded to point to `@wordpress/core-data`
- store is already imported as a different name than expected, the fix would use the hardcoded variable name
- there is possibly more 😅 

It helped me to replace all the warnings in `block-library` a lot faster without making any errors. Tests are also included to ensure it handles the expected cases.

Examples

1.
```js
import { select } from '@wordpress/data';

select( 'core/block-editor' );
```
becomes
```js
import { select } from '@wordpress/data';
import { store as blockEditorStore } from '@wordpress/block-editor';

select( blockEditorStore );
```

2.
```js
import { select } from '@wordpress/data';
import { something } from '@wordpress/block-editor';

select( 'core/block-editor' );
```
becomes
```js
import { select } from '@wordpress/data';
import { something, store as blockEditorStore } from '@wordpress/block-editor';

select( blockEditorStore );
```

## How has this been tested?
- Used it to create [this PR](https://github.com/WordPress/gutenberg/pull/28975)
- Tests should pass
- Test it in action

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/2256104/107798705-cbe2f680-6d5c-11eb-943d-abbb0a5b108d.mov

## Types of changes
Code quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
