### PR TITLE
block-library: Replace store name literals

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -17,6 +17,7 @@ import {
 	MediaReplaceFlow,
 	RichText,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -43,7 +44,7 @@ function AudioEdit( {
 	const { id, autoplay, caption, loop, preload, src } = attributes;
 	const blockProps = useBlockProps();
 	const mediaUpload = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return getSettings().mediaUpload;
 	}, [] );
 

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -13,11 +13,15 @@ import {
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { useEntityBlockEditor } from '@wordpress/core-data';
+import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import { BottomSheet, Icon, Disabled } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
+import {
+	BlockEditorProvider,
+	BlockList,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { help } from '@wordpress/icons';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
@@ -55,20 +59,20 @@ export default function ReusableBlockEdit( {
 
 	const { reusableBlock, hasResolved, isEditing, settings } = useSelect(
 		( select ) => {
-			const { getSettings } = select( 'core/block-editor' );
+			const { getSettings } = select( blockEditorStore );
 
 			return {
-				reusableBlock: select( 'core' ).getEditedEntityRecord(
+				reusableBlock: select( coreStore ).getEditedEntityRecord(
 					...recordArgs
 				),
-				hasResolved: select( 'core' ).hasFinishedResolution(
+				hasResolved: select( coreStore ).hasFinishedResolution(
 					'getEditedEntityRecord',
 					recordArgs
 				),
-				isSaving: select( 'core' ).isSavingEntityRecord(
+				isSaving: select( coreStore ).isSavingEntityRecord(
 					...recordArgs
 				),
-				canUserUpdate: select( 'core' ).canUser(
+				canUserUpdate: select( coreStore ).canUser(
 					'update',
 					'blocks',
 					ref

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -13,6 +13,7 @@ import {
 	InspectorControls,
 	BlockControls,
 	withGradient,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -443,7 +444,7 @@ export default compose( [
 	withSelect( ( select, { clientId, isSelected } ) => {
 		const { isEditorSidebarOpened } = select( 'core/edit-post' );
 		const { getBlockCount, getBlockRootClientId, getSettings } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 		const { maxWidth } = getSettings();
 

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -11,6 +11,7 @@ import {
 	BlockControls,
 	InnerBlocks,
 	JustifyToolbar,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useResizeObserver } from '@wordpress/compose';
@@ -47,7 +48,7 @@ export default function ButtonsEdit( {
 				getBlockOrder: _getBlockOrder,
 				getBlockParents,
 				getSelectedBlockClientId,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const selectedBlockClientId = getSelectedBlockClientId();
 			const selectedBlockParents = getBlockParents(
 				selectedBlockClientId,
@@ -68,7 +69,7 @@ export default function ButtonsEdit( {
 	);
 
 	const { insertBlock, removeBlock, selectBlock } = useDispatch(
-		'core/block-editor'
+		blockEditorStore
 	);
 
 	useEffect( () => {

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -11,6 +11,7 @@ import { Disabled } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import ServerSideRender from '@wordpress/server-side-render';
 import { useBlockProps } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 
 const getYearMonth = memoize( ( date ) => {
 	if ( ! date ) {
@@ -25,7 +26,7 @@ const getYearMonth = memoize( ( date ) => {
 
 export default function CalendarEdit( { attributes } ) {
 	const date = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getEditedPostAttribute } = select( editorStore );
 
 		const postType = getEditedPostAttribute( 'type' );
 		// Dates are used to overwrite year and month used on the calendar.

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -18,6 +18,7 @@ import { useSelect } from '@wordpress/data';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 export default function CategoriesEdit( {
 	attributes: { displayAsDropdown, showHierarchy, showPostCounts },
@@ -25,7 +26,7 @@ export default function CategoriesEdit( {
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 	const { categories, isRequesting } = useSelect( ( select ) => {
-		const { getEntityRecords } = select( 'core' );
+		const { getEntityRecords } = select( coreStore );
 		const { isResolving } = select( 'core/data' );
 		const query = { per_page: -1, hide_empty: true };
 		return {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -13,6 +13,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -38,7 +39,7 @@ function ColumnEdit( {
 	const { hasChildBlocks, rootClientId } = useSelect(
 		( select ) => {
 			const { getBlockOrder, getBlockRootClientId } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 
 			return {
@@ -49,7 +50,7 @@ function ColumnEdit( {
 		[ clientId ]
 	);
 
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const updateAlignment = ( value ) => {
 		// Update own alignment.

--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -14,6 +14,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -231,7 +232,7 @@ export default compose( [
 			getBlocks,
 			getBlockOrder,
 			getBlockAttributes,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const selectedBlockClientId = getSelectedBlockClientId();
 		const isSelected = selectedBlockClientId === clientId;

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -17,6 +17,7 @@ import {
 	BlockVerticalAlignmentToolbar,
 	__experimentalBlockVariationPicker,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -57,7 +58,7 @@ function ColumnsEditContainer( {
 	const { count } = useSelect(
 		( select ) => {
 			return {
-				count: select( 'core/block-editor' ).getBlockCount( clientId ),
+				count: select( blockEditorStore ).getBlockCount( clientId ),
 			};
 		},
 		[ clientId ]
@@ -118,8 +119,8 @@ const ColumnsEditContainerWrapper = withDispatch(
 		 */
 		updateAlignment( verticalAlignment ) {
 			const { clientId, setAttributes } = ownProps;
-			const { updateBlockAttributes } = dispatch( 'core/block-editor' );
-			const { getBlockOrder } = registry.select( 'core/block-editor' );
+			const { updateBlockAttributes } = dispatch( blockEditorStore );
+			const { getBlockOrder } = registry.select( blockEditorStore );
 
 			// Update own alignment.
 			setAttributes( { verticalAlignment } );
@@ -142,8 +143,8 @@ const ColumnsEditContainerWrapper = withDispatch(
 		 */
 		updateColumns( previousColumns, newColumns ) {
 			const { clientId } = ownProps;
-			const { replaceInnerBlocks } = dispatch( 'core/block-editor' );
-			const { getBlocks } = registry.select( 'core/block-editor' );
+			const { replaceInnerBlocks } = dispatch( blockEditorStore );
+			const { getBlocks } = registry.select( blockEditorStore );
 
 			let innerBlocks = getBlocks( clientId );
 			const hasExplicitWidths = hasExplicitPercentColumnWidths(
@@ -220,7 +221,7 @@ function Placeholder( { clientId, name, setAttributes } ) {
 		},
 		[ name ]
 	);
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const blockProps = useBlockProps();
 
 	return (
@@ -253,7 +254,7 @@ const ColumnsEdit = ( props ) => {
 	const { clientId } = props;
 	const hasInnerBlocks = useSelect(
 		( select ) =>
-			select( 'core/block-editor' ).getBlocks( clientId ).length > 0,
+			select( blockEditorStore ).getBlocks( clientId ).length > 0,
 		[ clientId ]
 	);
 	const Component = hasInnerBlocks

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -22,6 +22,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	BlockVariationPicker,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { withDispatch, useSelect } from '@wordpress/data';
 import {
@@ -301,8 +302,8 @@ const ColumnsEditContainerWrapper = withDispatch(
 		 */
 		updateAlignment( verticalAlignment ) {
 			const { clientId, setAttributes } = ownProps;
-			const { updateBlockAttributes } = dispatch( 'core/block-editor' );
-			const { getBlockOrder } = registry.select( 'core/block-editor' );
+			const { updateBlockAttributes } = dispatch( blockEditorStore );
+			const { getBlockOrder } = registry.select( blockEditorStore );
 
 			// Update own alignment.
 			setAttributes( { verticalAlignment } );
@@ -316,7 +317,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 			} );
 		},
 		updateInnerColumnWidth( value, columnId ) {
-			const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+			const { updateBlockAttributes } = dispatch( blockEditorStore );
 
 			updateBlockAttributes( columnId, {
 				width: value,
@@ -324,7 +325,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 		},
 		updateBlockSettings( settings ) {
 			const { clientId } = ownProps;
-			const { updateBlockListSettings } = dispatch( 'core/block-editor' );
+			const { updateBlockListSettings } = dispatch( blockEditorStore );
 			updateBlockListSettings( clientId, settings );
 		},
 		/**
@@ -336,9 +337,9 @@ const ColumnsEditContainerWrapper = withDispatch(
 		 */
 		updateColumns( previousColumns, newColumns ) {
 			const { clientId } = ownProps;
-			const { replaceInnerBlocks } = dispatch( 'core/block-editor' );
+			const { replaceInnerBlocks } = dispatch( blockEditorStore );
 			const { getBlocks, getBlockAttributes } = registry.select(
-				'core/block-editor'
+				blockEditorStore
 			);
 
 			let innerBlocks = getBlocks( clientId );
@@ -405,10 +406,10 @@ const ColumnsEditContainerWrapper = withDispatch(
 		onAddNextColumn: () => {
 			const { clientId } = ownProps;
 			const { replaceInnerBlocks, selectBlock } = dispatch(
-				'core/block-editor'
+				blockEditorStore
 			);
 			const { getBlocks, getBlockAttributes } = registry.select(
-				'core/block-editor'
+				blockEditorStore
 			);
 
 			// Get verticalAlignment from Columns block to set the same to new Column
@@ -429,7 +430,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 		},
 		onDeleteBlock: () => {
 			const { clientId } = ownProps;
-			const { removeBlock } = dispatch( 'core/block-editor' );
+			const { removeBlock } = dispatch( blockEditorStore );
 			removeBlock( clientId );
 		},
 	} )
@@ -451,7 +452,7 @@ const ColumnsEdit = ( props ) => {
 				getBlocks,
 				getBlockParents,
 				getBlockAttributes,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const { isEditorSidebarOpened } = select( 'core/edit-post' );
 			const innerBlocks = getBlocks( clientId );
 

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -38,6 +38,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalBlockAlignmentMatrixToolbar as BlockAlignmentMatrixToolbar,
 	__experimentalBlockFullHeightAligmentToolbar as FullHeightAlignment,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { withDispatch } from '@wordpress/data';
@@ -621,7 +622,7 @@ function CoverEdit( {
 
 export default compose( [
 	withDispatch( ( dispatch ) => {
-		const { toggleSelection } = dispatch( 'core/block-editor' );
+		const { toggleSelection } = dispatch( blockEditorStore );
 
 		return {
 			toggleSelection,

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -48,6 +48,7 @@ import {
 	withColors,
 	__experimentalUseGradient,
 	__experimentalUseEditorFeature as useEditorFeature,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -621,11 +622,11 @@ const Cover = ( {
 export default compose( [
 	withColors( { overlayColor: 'background-color' } ),
 	withSelect( ( select, { clientId } ) => {
-		const { getSelectedBlockClientId } = select( 'core/block-editor' );
+		const { getSelectedBlockClientId } = select( blockEditorStore );
 
 		const selectedBlockClientId = getSelectedBlockClientId();
 
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 
 		return {
 			settings: getSettings(),
@@ -634,7 +635,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {
 		const { openGeneralSidebar } = dispatch( 'core/edit-post' );
-		const { selectBlock } = dispatch( 'core/block-editor' );
+		const { selectBlock } = dispatch( blockEditorStore );
 
 		return {
 			openGeneralSidebar: () => openGeneralSidebar( 'edit-post/block' ),

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -26,6 +26,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 function getResponsiveHelp( checked ) {
 	return checked
@@ -75,7 +76,7 @@ const EmbedEdit = ( props ) => {
 				isPreviewEmbedFallback,
 				isRequestingEmbedPreview,
 				getThemeSupports,
-			} = select( 'core' );
+			} = select( coreStore );
 			if ( ! attributesUrl ) {
 				return { fetching: false, cannotEmbed: false };
 			}

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -21,11 +21,13 @@ import {
 	MediaReplaceFlow,
 	RichText,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { useCopyOnClick } from '@wordpress/compose';
 import { __, _x } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -61,9 +63,10 @@ function FileEdit( { attributes, setAttributes, noticeUI, noticeOperations } ) {
 	const { media, mediaUpload } = useSelect(
 		( select ) => ( {
 			media:
-				id === undefined ? undefined : select( 'core' ).getMedia( id ),
-			mediaUpload: select( 'core/block-editor' ).getSettings()
-				.mediaUpload,
+				id === undefined
+					? undefined
+					: select( coreStore ).getMedia( id ),
+			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
 		} ),
 		[ id ]
 	);

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -44,6 +44,7 @@ import { __, _x } from '@wordpress/i18n';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { getProtocol } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -588,7 +589,9 @@ export default compose( [
 		const { isEditorSidebarOpened } = select( 'core/edit-post' );
 		const isNotFileHref = id && getProtocol( href ) !== 'file:';
 		return {
-			media: isNotFileHref ? select( 'core' ).getMedia( id ) : undefined,
+			media: isNotFileHref
+				? select( coreStore ).getMedia( id )
+				: undefined,
 			isSidebarOpened: isSelected && isEditorSidebarOpened(),
 		};
 	} ),

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -9,6 +9,7 @@ import { includes } from 'lodash';
 import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 const transforms = {
 	from: [
@@ -87,7 +88,7 @@ const transforms = {
 				if ( ! id ) {
 					return false;
 				}
-				const { getMedia } = select( 'core' );
+				const { getMedia } = select( coreStore );
 				const media = getMedia( id );
 				return !! media && includes( media.mime_type, 'audio' );
 			},
@@ -107,7 +108,7 @@ const transforms = {
 				if ( ! id ) {
 					return false;
 				}
-				const { getMedia } = select( 'core' );
+				const { getMedia } = select( coreStore );
 				const media = getMedia( id );
 				return !! media && includes( media.mime_type, 'video' );
 			},
@@ -127,7 +128,7 @@ const transforms = {
 				if ( ! id ) {
 					return false;
 				}
-				const { getMedia } = select( 'core' );
+				const { getMedia } = select( coreStore );
 				const media = getMedia( id );
 				return !! media && includes( media.mime_type, 'image' );
 			},

--- a/packages/block-library/src/freeform/convert-to-blocks-button.js
+++ b/packages/block-library/src/freeform/convert-to-blocks-button.js
@@ -5,12 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { rawHandler, serialize } from '@wordpress/blocks';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 const ConvertToBlocksButton = ( { clientId } ) => {
-	const { replaceBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const block = useSelect(
 		( select ) => {
-			return select( 'core/block-editor' ).getBlock( clientId );
+			return select( blockEditorStore ).getBlock( clientId );
 		},
 		[ clientId ]
 	);

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -29,6 +29,7 @@ import {
 	MediaPlaceholder,
 	InspectorControls,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { Platform, useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -36,6 +37,7 @@ import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { useDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { View } from '@wordpress/primitives';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -90,7 +92,7 @@ function GalleryEdit( props ) {
 	const [ selectedImage, setSelectedImage ] = useState();
 	const [ attachmentCaptions, setAttachmentCaptions ] = useState();
 	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
-		'core/block-editor'
+		blockEditorStore
 	);
 
 	function setAttributes( newAttrs ) {
@@ -410,8 +412,8 @@ function GalleryEdit( props ) {
 
 export default compose( [
 	withSelect( ( select, { attributes: { ids }, isSelected } ) => {
-		const { getMedia } = select( 'core' );
-		const { getSettings } = select( 'core/block-editor' );
+		const { getMedia } = select( coreStore );
+		const { getSettings } = select( blockEditorStore );
 		const { imageSizes, mediaUpload } = getSettings();
 
 		const resizedImages = useMemo( () => {

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -12,7 +12,11 @@ import { Button, Spinner, ButtonGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { RichText, MediaPlaceholder } from '@wordpress/block-editor';
+import {
+	RichText,
+	MediaPlaceholder,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { isBlobURL } from '@wordpress/blob';
 import { compose } from '@wordpress/compose';
 import {
@@ -22,6 +26,7 @@ import {
 	edit,
 	image as imageIcon,
 } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -295,7 +300,7 @@ class GalleryImage extends Component {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { getMedia } = select( 'core' );
+		const { getMedia } = select( coreStore );
 		const { id } = ownProps;
 
 		return {
@@ -304,7 +309,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { __unstableMarkNextChangeAsNotPersistent } = dispatch(
-			'core/block-editor'
+			blockEditorStore
 		);
 		return {
 			__unstableMarkNextChangeAsNotPersistent,

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -16,7 +16,10 @@ import Tiles from './tiles';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { BlockCaption } from '@wordpress/block-editor';
+import {
+	BlockCaption,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
 import { mediaUploadSync } from '@wordpress/react-native-bridge';
 import { useSelect } from '@wordpress/data';
@@ -35,7 +38,7 @@ export const Gallery = ( props ) => {
 	useEffect( mediaUploadSync, [] );
 
 	const isRTL = useSelect( ( select ) => {
-		return !! select( 'core/block-editor' ).getSettings().isRTL;
+		return !! select( blockEditorStore ).getSettings().isRTL;
 	}, [] );
 
 	const {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -7,6 +7,7 @@ import {
 	useBlockProps,
 	InspectorAdvancedControls,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	SelectControl,
@@ -18,7 +19,7 @@ const { __Visualizer: BoxControlVisualizer } = BoxControl;
 function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const hasInnerBlocks = useSelect(
 		( select ) => {
-			const { getBlock } = select( 'core/block-editor' );
+			const { getBlock } = select( blockEditorStore );
 			const block = getBlock( clientId );
 			return !! ( block && block.innerBlocks.length );
 		},

--- a/packages/block-library/src/group/edit.native.js
+++ b/packages/block-library/src/group/edit.native.js
@@ -12,7 +12,10 @@ import {
 	withPreferredColorScheme,
 	useResizeObserver,
 } from '@wordpress/compose';
-import { InnerBlocks } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useCallback } from '@wordpress/element';
 import { alignmentHelpers } from '@wordpress/components';
 
@@ -106,7 +109,7 @@ export default compose( [
 			getBlockRootClientId,
 			getSelectedBlockClientId,
 			getBlockAttributes,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const block = getBlock( clientId );
 		const hasInnerBlocks = !! ( block && block.innerBlocks.length );

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -8,6 +8,7 @@ import {
 	PlainText,
 	transformStyles,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	ToolbarButton,
@@ -35,7 +36,7 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 		return [
 			defaultStyles,
 			...transformStyles(
-				select( 'core/block-editor' ).getSettings().styles
+				select( blockEditorStore ).getSettings().styles
 			),
 		];
 	}, [] );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -16,6 +16,7 @@ import {
 	BlockIcon,
 	MediaPlaceholder,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -104,7 +105,7 @@ export function ImageEdit( {
 
 	const ref = useRef();
 	const mediaUpload = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return getSettings().mediaUpload;
 	} );
 

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -36,6 +36,7 @@ import {
 	InspectorControls,
 	BlockAlignmentToolbar,
 	BlockStyles,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { getProtocol, hasQueryArg } from '@wordpress/url';
@@ -48,6 +49,7 @@ import {
 	replace,
 	expand,
 } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -555,8 +557,8 @@ export class ImageEdit extends Component {
 
 export default compose( [
 	withSelect( ( select, props ) => {
-		const { getMedia } = select( 'core' );
-		const { getSettings } = select( 'core/block-editor' );
+		const { getMedia } = select( coreStore );
+		const { getSettings } = select( blockEditorStore );
 		const {
 			attributes: { id, url },
 			isSelected,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -27,6 +27,7 @@ import {
 	__experimentalImageSizeControl as ImageSizeControl,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	MediaReplaceFlow,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
@@ -38,6 +39,7 @@ import {
 } from '@wordpress/blocks';
 import { crop, textColor, upload } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -89,13 +91,13 @@ export default function Image( {
 	const prevUrl = usePrevious( url );
 	const { block, currentId, image, multiImageSelection } = useSelect(
 		( select ) => {
-			const { getMedia } = select( 'core' );
+			const { getMedia } = select( coreStore );
 			const {
 				getMultiSelectedBlockClientIds,
 				getBlockName,
 				getSelectedBlock,
 				getSelectedBlockClientId,
-			} = select( 'core/block-editor' );
+			} = select( blockEditorStore );
 			const multiSelectedClientIds = getMultiSelectedBlockClientIds();
 			return {
 				block: getSelectedBlock(),
@@ -113,7 +115,7 @@ export default function Image( {
 	);
 	const { imageEditing, imageSizes, maxWidth, mediaUpload } = useSelect(
 		( select ) => {
-			const { getSettings } = select( 'core/block-editor' );
+			const { getSettings } = select( blockEditorStore );
 			return pick( getSettings(), [
 				'imageEditing',
 				'imageSizes',
@@ -122,9 +124,7 @@ export default function Image( {
 			] );
 		}
 	);
-	const { replaceBlocks, toggleSelection } = useDispatch(
-		'core/block-editor'
-	);
+	const { replaceBlocks, toggleSelection } = useDispatch( blockEditorStore );
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
 		noticesStore
 	);

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -29,9 +29,11 @@ import {
 	BlockControls,
 	__experimentalImageSizeControl as ImageSizeControl,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { pin, list, grid } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -80,8 +82,8 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		defaultImageHeight,
 	} = useSelect(
 		( select ) => {
-			const { getEntityRecords, getMedia } = select( 'core' );
-			const { getSettings } = select( 'core/block-editor' );
+			const { getEntityRecords, getMedia } = select( coreStore );
+			const { getSettings } = select( blockEditorStore );
 			const { imageSizes, imageDimensions } = getSettings();
 			const catIds =
 				categories && categories.length > 0

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -18,6 +18,7 @@ import {
 	useBlockProps,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	__experimentalImageSizeControl as ImageSizeControl,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -28,6 +29,7 @@ import {
 	FocalPointPicker,
 } from '@wordpress/components';
 import { pullLeft, pullRight } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -138,7 +140,9 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 
 	const image = useSelect(
 		( select ) =>
-			mediaId && isSelected ? select( 'core' ).getMedia( mediaId ) : null,
+			mediaId && isSelected
+				? select( coreStore ).getMedia( mediaId )
+				: null,
 		[ isSelected, mediaId ]
 	);
 
@@ -198,7 +202,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 	};
 
 	const imageSizes = useSelect( ( select ) => {
-		const settings = select( 'core/block-editor' ).getSettings();
+		const settings = select( blockEditorStore ).getSettings();
 		return settings?.imageSizes;
 	} );
 	const imageSizeOptions = map(

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -16,6 +16,7 @@ import {
 	withColors,
 	MEDIA_TYPE_IMAGE,
 	MEDIA_TYPE_VIDEO,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import {
@@ -398,7 +399,7 @@ export default compose(
 			getSelectedBlockClientId,
 			getBlockParents,
 			getSettings,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 
 		const parents = getBlockParents( clientId, true );
 

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -13,6 +13,7 @@ import {
 	BlockIcon,
 	MediaPlaceholder,
 	MediaReplaceFlow,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
@@ -108,7 +109,7 @@ function MediaContainer( props ) {
 		onWidthChange,
 	} = props;
 
-	const { toggleSelection } = useDispatch( 'core/block-editor' );
+	const { toggleSelection } = useDispatch( blockEditorStore );
 
 	if ( mediaType && mediaUrl ) {
 		const onResizeStart = () => {

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -6,7 +6,11 @@ import { RawHTML } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { getBlockType, createBlock } from '@wordpress/blocks';
 import { withDispatch } from '@wordpress/data';
-import { Warning, useBlockProps } from '@wordpress/block-editor';
+import {
+	Warning,
+	useBlockProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 
 function MissingBlockWarning( { attributes, convertToHTML } ) {
 	const { originalName, originalUndelimitedContent } = attributes;
@@ -47,7 +51,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 }
 
 const MissingEdit = withDispatch( ( dispatch, { clientId, attributes } ) => {
-	const { replaceBlock } = dispatch( 'core/block-editor' );
+	const { replaceBlock } = dispatch( blockEditorStore );
 	return {
 		convertToHTML() {
 			replaceBlock(

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -25,6 +25,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { help, plugins } from '@wordpress/icons';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -277,7 +278,7 @@ export class UnsupportedBlockEdit extends Component {
 
 export default compose( [
 	withSelect( ( select, { attributes } ) => {
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return {
 			isUnsupportedBlockEditorSupported:
 				getSettings( 'capabilities' ).unsupportedBlockEditor === true,
@@ -290,7 +291,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
-		const { selectBlock } = dispatch( 'core/block-editor' );
+		const { selectBlock } = dispatch( blockEditorStore );
 		return {
 			selectBlock() {
 				selectBlock( ownProps.clientId );

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -34,6 +34,7 @@ import {
 	RichText,
 	__experimentalLinkControl as LinkControl,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import {
@@ -45,6 +46,7 @@ import {
 } from '@wordpress/element';
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { link as linkIcon } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -155,7 +157,7 @@ function NavigationLinkEdit( {
 		url,
 		opensInNewTab,
 	};
-	const { saveEntityRecord } = useDispatch( 'core' );
+	const { saveEntityRecord } = useDispatch( coreStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const listItemRef = useRef( null );
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
@@ -163,7 +165,7 @@ function NavigationLinkEdit( {
 	const ref = useRef();
 
 	const isDraggingBlocks = useSelect(
-		( select ) => select( 'core/block-editor' ).isDraggingBlocks(),
+		( select ) => select( blockEditorStore ).isDraggingBlocks(),
 		[]
 	);
 
@@ -462,7 +464,7 @@ export default compose( [
 			hasSelectedInnerBlock,
 			getBlockParentsByBlockName,
 			getSelectedBlockClientId,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const { clientId } = ownProps;
 		const rootBlock = head(
 			getBlockParentsByBlockName( clientId, 'core/navigation' )
@@ -492,8 +494,14 @@ export default compose( [
 			inlineStyles,
 			textColor: navigationBlockAttributes.textColor,
 			backgroundColor: navigationBlockAttributes.backgroundColor,
-			userCanCreatePages: select( 'core' ).canUser( 'create', 'pages' ),
-			userCanCreatePosts: select( 'core' ).canUser( 'create', 'posts' ),
+			userCanCreatePages: select( coreStore ).canUser(
+				'create',
+				'pages'
+			),
+			userCanCreatePosts: select( coreStore ).canUser(
+				'create',
+				'posts'
+			),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {
@@ -501,7 +509,7 @@ export default compose( [
 			insertLinkBlock() {
 				const { clientId } = ownProps;
 
-				const { insertBlock } = dispatch( 'core/block-editor' );
+				const { insertBlock } = dispatch( blockEditorStore );
 
 				const { getClientIdsOfDescendants } = registry.select(
 					'core/block-editor'

--- a/packages/block-library/src/navigation/block-navigation-list.js
+++ b/packages/block-library/src/navigation/block-navigation-list.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalBlockNavigationTree } from '@wordpress/block-editor';
+import {
+	__experimentalBlockNavigationTree,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 export default function BlockNavigationList( {
@@ -11,7 +14,7 @@ export default function BlockNavigationList( {
 	const { block, selectedBlockClientId } = useSelect(
 		( select ) => {
 			const { getSelectedBlockClientId, getBlock } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 
 			return {
@@ -22,7 +25,7 @@ export default function BlockNavigationList( {
 		[ clientId ]
 	);
 
-	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const { selectBlock } = useDispatch( blockEditorStore );
 
 	return (
 		<__experimentalBlockNavigationTree

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -14,6 +14,7 @@ import {
 	JustifyToolbar,
 	BlockControls,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
@@ -46,7 +47,7 @@ function Navigation( {
 		! hasExistingNavItems
 	);
 
-	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const { selectBlock } = useDispatch( blockEditorStore );
 
 	const blockProps = useBlockProps( {
 		className: classnames( className, {
@@ -151,12 +152,12 @@ function Navigation( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const innerBlocks = select( 'core/block-editor' ).getBlocks( clientId );
+		const innerBlocks = select( blockEditorStore ).getBlocks( clientId );
 		const {
 			getClientIdsOfDescendants,
 			hasSelectedInnerBlock,
 			getSelectedBlockClientId,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const isImmediateParentOfSelectedBlock = hasSelectedInnerBlock(
 			clientId,
 			false
@@ -177,7 +178,7 @@ export default compose( [
 				if ( blocks?.length === 0 ) {
 					return false;
 				}
-				dispatch( 'core/block-editor' ).replaceInnerBlocks(
+				dispatch( blockEditorStore ).replaceInnerBlocks(
 					clientId,
 					blocks,
 					true

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -23,6 +23,7 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -119,7 +120,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 				getMenuItems,
 				isResolving,
 				hasFinishedResolution,
-			} = select( 'core' );
+			} = select( coreStore );
 			const pagesParameters = [
 				'postType',
 				'page',

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -16,6 +16,7 @@ import {
 	useBlockProps,
 	getFontSize,
 	__experimentalUseEditorFeature as useEditorFeature,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
@@ -87,7 +88,7 @@ function ParagraphBlock( {
 	const inlineFontSize = style?.fontSize;
 	const size = useSelect(
 		( select ) => {
-			const { fontSizes } = select( 'core/block-editor' ).getSettings();
+			const { fontSizes } = select( blockEditorStore ).getSettings();
 			return getFontSize( fontSizes, fontSize, inlineFontSize ).size;
 		},
 		[ fontSize, inlineFontSize ]

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -7,6 +7,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -22,7 +23,7 @@ function ParagraphBlock( {
 	style,
 } ) {
 	const isRTL = useSelect( ( select ) => {
-		return !! select( 'core/block-editor' ).getSettings().isRTL;
+		return !! select( blockEditorStore ).getSettings().isRTL;
 	}, [] );
 
 	const { align, content, placeholder } = attributes;

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -17,6 +17,7 @@ import {
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 	const { postType, postId } = context;
@@ -24,7 +25,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 	const { authorId, authorDetails, authors } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, getUser, getUsers } = select(
-				'core'
+				coreStore
 			);
 			const _authorId = getEditedEntityRecord(
 				'postType',
@@ -41,7 +42,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 		[ postType, postId ]
 	);
 
-	const { editEntityRecord } = useDispatch( 'core' );
+	const { editEntityRecord } = useDispatch( coreStore );
 
 	const { textAlign, showAvatar, showBio, byline } = attributes;
 

--- a/packages/block-library/src/post-comment-author/edit.js
+++ b/packages/block-library/src/post-comment-author/edit.js
@@ -4,13 +4,14 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 export default function Edit( { attributes, context } ) {
 	const { className } = attributes;
 	const { commentId } = context;
 
 	const displayName = useSelect( ( select ) => {
-		const { getEntityRecord } = select( 'core' );
+		const { getEntityRecord } = select( coreStore );
 
 		const comment = getEntityRecord( 'root', 'comment', commentId );
 		const authorName = comment?.author_name; // eslint-disable-line camelcase

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -15,11 +15,12 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
 
 function PostCommentsDisplay( { postId } ) {
 	return useSelect(
 		( select ) => {
-			const comments = select( 'core' ).getEntityRecords(
+			const comments = select( coreStore ).getEntityRecords(
 				'root',
 				'comment',
 				{

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import {
 	Icon,
@@ -43,7 +43,7 @@ function PostFeaturedImageDisplay( {
 	);
 	const media = useSelect(
 		( select ) =>
-			featuredImage && select( 'core' ).getMedia( featuredImage ),
+			featuredImage && select( coreStore ).getMedia( featuredImage ),
 		[ featuredImage ]
 	);
 	const onSelectImage = ( value ) => {

--- a/packages/block-library/src/post-hierarchical-terms/edit.js
+++ b/packages/block-library/src/post-hierarchical-terms/edit.js
@@ -18,6 +18,7 @@ import { store as blocksStore } from '@wordpress/blocks';
 import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -54,7 +55,7 @@ export default function PostHierarchicalTermsEdit( {
 	const selectedTerm = useSelect(
 		( select ) => {
 			if ( ! term ) return {};
-			const taxonomies = select( 'core' ).getTaxonomies( {
+			const taxonomies = select( coreStore ).getTaxonomies( {
 				per_page: -1,
 			} );
 			return (

--- a/packages/block-library/src/post-hierarchical-terms/use-hierarchical-term-links.js
+++ b/packages/block-library/src/post-hierarchical-terms/use-hierarchical-term-links.js
@@ -6,7 +6,7 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
 export default function useHierarchicalTermLinks( { postId, postType, term } ) {
@@ -21,7 +21,7 @@ export default function useHierarchicalTermLinks( { postId, postType, term } ) {
 
 	const { hierarchicalTermLinks, isLoadingHierarchicalTermLinks } = useSelect(
 		( select ) => {
-			const { getEntityRecord } = select( 'core' );
+			const { getEntityRecord } = select( coreStore );
 
 			let loaded = true;
 

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import {
 	BlockControls,
 	Warning,
@@ -27,7 +27,7 @@ export default function PostTagsEdit( { context, attributes, setAttributes } ) {
 	);
 	const tagLinks = useSelect(
 		( select ) => {
-			const { getEntityRecord } = select( 'core' );
+			const { getEntityRecord } = select( coreStore );
 			let loaded = true;
 
 			const links = tags?.map( ( tagId ) => {

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -21,6 +21,7 @@ import {
 	PanelBody,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -36,14 +37,14 @@ export default function PostTitleEdit( {
 
 	const post = useSelect(
 		( select ) =>
-			select( 'core' ).getEditedEntityRecord(
+			select( coreStore ).getEditedEntityRecord(
 				'postType',
 				postType,
 				postId
 			),
 		[ postType, postId ]
 	);
-	const { editEntityRecord } = useDispatch( 'core' );
+	const { editEntityRecord } = useDispatch( coreStore );
 
 	const blockProps = useBlockProps( {
 		className: classnames( {

--- a/packages/block-library/src/pullquote/deprecated.js
+++ b/packages/block-library/src/pullquote/deprecated.js
@@ -11,6 +11,7 @@ import {
 	getColorClassName,
 	getColorObjectByAttributeValues,
 	RichText,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { select } from '@wordpress/data';
 
@@ -208,7 +209,7 @@ const deprecated = [
 				// as there is no expectation that themes create classes that set border colors.
 			} else if ( mainColor ) {
 				const colors = get(
-					select( 'core/block-editor' ).getSettings(),
+					select( blockEditorStore ).getSettings(),
 					[ 'colors' ],
 					[]
 				);

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -14,7 +14,9 @@ import {
 	BlockPreview,
 	useBlockProps,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -53,8 +55,8 @@ export default function QueryLoopEdit( {
 
 	const { posts, blocks } = useSelect(
 		( select ) => {
-			const { getEntityRecords } = select( 'core' );
-			const { getBlocks } = select( 'core/block-editor' );
+			const { getEntityRecords } = select( coreStore );
+			const { getBlocks } = select( blockEditorStore );
 			const query = {
 				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
 				categories: categoryIds,

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -8,6 +8,7 @@ import {
 	BlockControls,
 	useBlockProps,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 
 /**
@@ -30,7 +31,7 @@ export function QueryContent( {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( {}, { template: TEMPLATE } );
 	const { postsPerPage } = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( blockEditorStore );
 		return {
 			postsPerPage:
 				+getSettings().postsPerPage || DEFAULTS_POSTS_PER_PAGE,
@@ -89,7 +90,7 @@ const QueryEdit = ( props ) => {
 	const { clientId } = props;
 	const hasInnerBlocks = useSelect(
 		( select ) =>
-			!! select( 'core/block-editor' ).getBlocks( clientId ).length,
+			!! select( blockEditorStore ).getBlocks( clientId ).length,
 		[ clientId ]
 	);
 	const Component = hasInnerBlocks ? QueryContent : QueryPlaceholder;

--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -28,6 +28,7 @@ import {
 	useMemo,
 	createInterpolateElement,
 } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -74,7 +75,7 @@ export default function QueryInspectorControls( {
 	const [ showSticky, setShowSticky ] = useState( postType === 'post' );
 	const { authorList, categories, tags, postTypes } = useSelect(
 		( select ) => {
-			const { getEntityRecords, getPostTypes } = select( 'core' );
+			const { getEntityRecords, getPostTypes } = select( coreStore );
 			const termsQuery = { per_page: MAX_FETCHED_TERMS };
 			const _categories = getEntityRecords(
 				'taxonomy',

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -6,6 +6,7 @@ import {
 	useBlockProps,
 	__experimentalBlockVariationPicker,
 	__experimentalGetMatchingVariation as getMatchingVariation,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	createBlocksFromInnerBlocksTemplate,
@@ -35,7 +36,7 @@ const QueryPlaceholder = ( { clientId, name, attributes, setAttributes } ) => {
 		},
 		[ name ]
 	);
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const blockProps = useBlockProps();
 	const matchingVariation = getMatchingVariation( attributes, allVariations );
 	const icon = matchingVariation?.icon || blockType?.icon?.src;

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -27,9 +27,11 @@ import {
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { trash } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -59,13 +61,13 @@ const SiteLogo = ( {
 	const isWideAligned = includes( [ 'wide', 'full' ], align );
 	const isResizable = ! isWideAligned && isLargeViewport;
 	const [ { naturalWidth, naturalHeight }, setNaturalSize ] = useState( {} );
-	const { toggleSelection } = useDispatch( 'core/block-editor' );
+	const { toggleSelection } = useDispatch( blockEditorStore );
 	const classes = classnames( {
 		'is-transient': isBlobURL( logoUrl ),
 	} );
 	const { maxWidth, title } = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
-		const siteEntities = select( 'core' ).getEditedEntityRecord(
+		const { getSettings } = select( blockEditorStore );
+		const siteEntities = select( coreStore ).getEditedEntityRecord(
 			'root',
 			'site'
 		);
@@ -231,11 +233,11 @@ export default function LogoEdit( {
 	const [ error, setError ] = useState();
 	const ref = useRef();
 	const { mediaItemData, sitelogo, url } = useSelect( ( select ) => {
-		const siteSettings = select( 'core' ).getEditedEntityRecord(
+		const siteSettings = select( coreStore ).getEditedEntityRecord(
 			'root',
 			'site'
 		);
-		const mediaItem = select( 'core' ).getEntityRecord(
+		const mediaItem = select( coreStore ).getEntityRecord(
 			'root',
 			'media',
 			siteSettings.sitelogo
@@ -250,7 +252,7 @@ export default function LogoEdit( {
 		};
 	}, [] );
 
-	const { editEntityRecord } = useDispatch( 'core' );
+	const { editEntityRecord } = useDispatch( coreStore );
 	const setLogo = ( newValue ) =>
 		editEntityRecord( 'root', 'site', undefined, {
 			sitelogo: newValue,

--- a/packages/block-library/src/social-link/edit.native.js
+++ b/packages/block-library/src/social-link/edit.native.js
@@ -6,7 +6,10 @@ import { View, Animated, Easing, TouchableWithoutFeedback } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { BlockControls } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useEffect, useState, useRef, useCallback } from '@wordpress/element';
 import {
 	ToolbarGroup,
@@ -202,7 +205,7 @@ const SocialLinkEdit = ( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getBlock } = select( 'core/block-editor' );
+		const { getBlock } = select( blockEditorStore );
 
 		const block = getBlock( clientId );
 		const name = block?.name.substring( 17 );

--- a/packages/block-library/src/social-links/edit.native.js
+++ b/packages/block-library/src/social-links/edit.native.js
@@ -5,7 +5,10 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { useRef, useEffect, useState } from '@wordpress/element';
 import { compose, usePreferredColorSchemeStyle } from '@wordpress/compose';
@@ -115,7 +118,7 @@ export default compose(
 			getSelectedBlockClientId,
 			getBlocks,
 			getBlock,
-		} = select( 'core/block-editor' );
+		} = select( blockEditorStore );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		const selectedBlockParents = getBlockParents(
 			selectedBlockClientId,
@@ -135,7 +138,7 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {
-		const { removeBlock } = dispatch( 'core/block-editor' );
+		const { removeBlock } = dispatch( blockEditorStore );
 
 		return {
 			onDelete: () => {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -7,7 +7,11 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { PanelBody, ResizableBox, RangeControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
@@ -99,7 +103,7 @@ const SpacerEdit = ( {
 
 export default compose( [
 	withDispatch( ( dispatch ) => {
-		const { toggleSelection } = dispatch( 'core/block-editor' );
+		const { toggleSelection } = dispatch( blockEditorStore );
 
 		return {
 			onResizeStart: () => toggleSelection( false ),

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -11,6 +11,7 @@ import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
+import { store as coreStore } from '@wordpress/core-data';
 
 function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 	const { taxonomy, showTagCounts } = attributes;
@@ -72,6 +73,6 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 
 export default withSelect( ( select ) => {
 	return {
-		taxonomies: select( 'core' ).getTaxonomies( { per_page: -1 } ),
+		taxonomies: select( coreStore ).getTaxonomies( { per_page: -1 } ),
 	};
 } )( TagCloudEdit );

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -8,6 +8,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 	Warning,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	SelectControl,
@@ -19,6 +20,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronUp, chevronDown } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -40,8 +42,10 @@ export default function TemplatePartEdit( {
 	// new edits to trigger this.
 	const { isResolved, innerBlocks, isMissing } = useSelect(
 		( select ) => {
-			const { getEntityRecord, hasFinishedResolution } = select( 'core' );
-			const { getBlocks } = select( 'core/block-editor' );
+			const { getEntityRecord, hasFinishedResolution } = select(
+				coreStore
+			);
+			const { getBlocks } = select( blockEditorStore );
 
 			const getEntityArgs = [
 				'postType',

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -7,6 +7,7 @@ import { useDispatch } from '@wordpress/data';
 import { Placeholder, Dropdown, Button, Spinner } from '@wordpress/components';
 import { blockDefault } from '@wordpress/icons';
 import { serialize } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ export default function TemplatePartPlaceholder( {
 	setAttributes,
 	innerBlocks,
 } ) {
-	const { saveEntityRecord } = useDispatch( 'core' );
+	const { saveEntityRecord } = useDispatch( coreStore );
 	const onCreate = useCallback( async () => {
 		const title = __( 'Untitled Template Part' );
 		const templatePart = await saveEntityRecord(

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
 
 function PreviewPlaceholder() {
 	return (
@@ -206,7 +207,7 @@ export default function TemplatePartPreviews( {
 	const composite = useCompositeState();
 	const templateParts = useSelect( ( select ) => {
 		return (
-			select( 'core' ).getEntityRecords(
+			select( coreStore ).getEntityRecords(
 				'postType',
 				'wp_template_part'
 			) || []

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -19,6 +19,7 @@ import {
 	MediaReplaceFlow,
 	RichText,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useRef, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -52,7 +53,7 @@ function VideoEdit( {
 	const posterImageButton = useRef();
 	const { id, caption, controls, poster, src, tracks } = attributes;
 	const mediaUpload = useSelect(
-		( select ) => select( 'core/block-editor' ).getSettings().mediaUpload
+		( select ) => select( blockEditorStore ).getSettings().mediaUpload
 	);
 
 	useEffect( () => {

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -17,7 +17,11 @@ import {
 	TextControl,
 	SelectControl,
 } from '@wordpress/components';
-import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import {
+	MediaUpload,
+	MediaUploadCheck,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { upload, media } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -186,7 +190,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 
 export default function TracksEditor( { tracks = [], onChange } ) {
 	const mediaUpload = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getSettings().mediaUpload;
+		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
 	const [ trackBeingEdited, setTrackBeingEdited ] = useState( null );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
- Skipped `core/post-edit` in native files to avoid cross-references.
- Skipped `core/data`, we don't have a way to reference that store yet.
- 
## How has this been tested?
- Tests should pass
- Smoke test

## Types of changes
Code quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
