### PR TITLE
Add Items Justification to Social Links

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -64,3 +64,20 @@
 .aligncenter {
 	clear: both;
 }
+
+// Justification.
+.items-justified-left {
+	justify-content: flex-start;
+}
+
+.items-justified-center {
+	justify-content: center;
+}
+
+.items-justified-right {
+	justify-content: flex-end;
+}
+
+.items-justified-space-between {
+	justify-content: space-between;
+}

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -14,6 +14,7 @@ import {
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	useBlockProps,
 	InspectorControls,
+	JustifyToolbar,
 	ContrastChecker,
 	PanelColorSettings,
 	withColors,
@@ -52,6 +53,7 @@ export function SocialLinksEdit( props ) {
 	const {
 		iconBackgroundColorValue,
 		iconColorValue,
+		justify,
 		openInNewTab,
 		size,
 	} = attributes;
@@ -156,6 +158,22 @@ export function SocialLinksEdit( props ) {
 						) }
 					</ToolbarItem>
 				</ToolbarGroup>
+				<JustifyToolbar
+					allowedControls={ [
+						'left',
+						'center',
+						'right',
+						'space-between',
+					] }
+					value={ justify }
+					onChange={ ( value ) =>
+						setAttributes( { justify: value } )
+					}
+					popoverProps={ {
+						position: 'bottom right',
+						isAlternate: true,
+					} }
+				/>
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -53,7 +53,7 @@ export function SocialLinksEdit( props ) {
 	const {
 		iconBackgroundColorValue,
 		iconColorValue,
-		justify,
+		itemsJustification,
 		openInNewTab,
 		size,
 	} = attributes;
@@ -88,6 +88,7 @@ export function SocialLinksEdit( props ) {
 		'has-icon-color': iconColor.color || iconColorValue,
 		'has-icon-background-color':
 			iconBackgroundColor.color || iconBackgroundColorValue,
+		[ `items-justified-${ itemsJustification }` ]: itemsJustification,
 	} );
 
 	const style = {
@@ -113,6 +114,22 @@ export function SocialLinksEdit( props ) {
 	return (
 		<Fragment>
 			<BlockControls>
+				<JustifyToolbar
+					allowedControls={ [
+						'left',
+						'center',
+						'right',
+						'space-between',
+					] }
+					value={ itemsJustification }
+					onChange={ ( value ) =>
+						setAttributes( { itemsJustification: value } )
+					}
+					popoverProps={ {
+						position: 'bottom right',
+						isAlternate: true,
+					} }
+				/>
 				<ToolbarGroup>
 					<ToolbarItem>
 						{ ( toggleProps ) => (
@@ -158,22 +175,6 @@ export function SocialLinksEdit( props ) {
 						) }
 					</ToolbarItem>
 				</ToolbarGroup>
-				<JustifyToolbar
-					allowedControls={ [
-						'left',
-						'center',
-						'right',
-						'space-between',
-					] }
-					value={ justify }
-					onChange={ ( value ) =>
-						setAttributes( { justify: value } )
-					}
-					popoverProps={ {
-						position: 'bottom right',
-						isAlternate: true,
-					} }
-				/>
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -10,12 +10,18 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( props ) {
 	const {
-		attributes: { iconBackgroundColorValue, iconColorValue, size },
+		attributes: {
+			iconBackgroundColorValue,
+			iconColorValue,
+			itemsJustification,
+			size,
+		},
 	} = props;
 
 	const className = classNames( size, {
 		'has-icon-color': iconColorValue,
 		'has-icon-background-color': iconBackgroundColorValue,
+		[ `items-justified-${ itemsJustification }` ]: itemsJustification,
 	} );
 
 	const style = {

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,7 +1,6 @@
 .wp-block-social-links {
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: flex-start;
 	padding-left: 0;
 	padding-right: 0;
 	// Some themes set text-indent on all <ul>


### PR DESCRIPTION
## Description

Adds justify toolbar controls to Social Links, allows for justifying items in the menu (left, center, right, and space-between). This matches the navigation and buttons features.

@jasmussen - the .wp-social-links class was hard-coded with a `justify-content: flex-start;` that I removed to get this to work. I'm not sure if we need it since `flex-start` is the default.


## How has this been tested?

1. Add a social links block with some social icons
2. Confirm everything works as expected
3. Apply PR and confirm existing blocks loads and no visual change
4. Use new Justify items menu item and confirm left, center, right, space-between works in editor and while viewing.

## Screenshots

![social-justify](https://user-images.githubusercontent.com/45363/107812456-8dc9e080-6d24-11eb-88ee-2c567d690817.gif)


## Types of changes

- Adds justify toolbar to social links

