### PR TITLE
[RNMobile] Search Block - Add to inserter

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -226,6 +226,7 @@ export const registerCoreBlocks = () => {
 		file,
 		audio,
 		devOnly( reusableBlock ),
+		devOnly( search ),
 	].forEach( registerBlock );
 
 	registerBlockVariations( socialLink );

--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default function SearchEdit( { attributes, setAttributes } ) {
+	const { label, showLabel } = attributes;
+
+	return (
+		<View>
+			{ showLabel && (
+				<RichText
+					aria-label={ __( 'Label text' ) }
+					placeholder={ __( 'Add label…' ) }
+					withoutInteractiveFormatting
+					value={ label }
+					onChange={ ( html ) => setAttributes( { label: html } ) }
+				/>
+			) }
+		</View>
+	);
+}


### PR DESCRIPTION
## Description
This PR adds the search block to the Inserter **in dev mode only**. The block added is just a shell at this point. More functionality will be added in later PRs. This is part of a larger feature to add a mobile version of the search block as outlined in https://github.com/wordpress-mobile/gutenberg-mobile/issues/3073. 

## How has this been tested?
Ran the following steps in the demo app as well as the WordPress apps on both Android and iOS platforms:
1. From the editor, click to open the block inserter. Verify the Search block is displayed.
2. Click on the search block to add it to the post. Verify no errors and the search block shell has successfully been added. 

## Screenshots <!-- if applicable -->
iOS: block menu | iOS: block added
-- | --
![inserter-ios](https://user-images.githubusercontent.com/5810477/107839476-2474bc80-6d7a-11eb-8dea-832ffb4e9f55.png)|![block-ios](https://user-images.githubusercontent.com/5810477/107839478-263e8000-6d7a-11eb-8d19-93a87757b607.png)

Android: block menu | Android: block added
-- | --
![inserter-android](https://user-images.githubusercontent.com/5810477/107839481-2e96bb00-6d7a-11eb-9c0d-a987859daadb.png)|![block-android](https://user-images.githubusercontent.com/5810477/107839482-2fc7e800-6d7a-11eb-827d-dbbbf81e663c.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
