### PR TITLE
Update/styles is default

### DIFF
--- a/packages/block-editor/src/components/block-styles/test/index.js
+++ b/packages/block-editor/src/components/block-styles/test/index.js
@@ -73,4 +73,14 @@ describe( 'replaceActiveStyle', () => {
 			'custom-class is-style-small'
 		);
 	} );
+
+	it( 'Should replace the previous active style with nothing if it is the default', () => {
+		const activeStyle = { name: 'large' };
+		const newStyle = { name: 'small', isDefault: true };
+		const className = 'custom-class is-style-large';
+
+		expect( replaceActiveStyle( className, activeStyle, newStyle ) ).toBe(
+			'custom-class'
+		);
+	} );
 } );

--- a/packages/block-editor/src/components/block-styles/utils.js
+++ b/packages/block-editor/src/components/block-styles/utils.js
@@ -32,8 +32,8 @@ export function getActiveStyle( styles, className ) {
 }
 
 /**
- * Replaces the active style in the block's className except
- * if it's the default style.
+ * Replaces the active style in the block's className except if it's the default
+ * style.
  *
  * @param {string}  className   Class name.
  * @param {Object?} activeStyle The replaced style.

--- a/packages/block-editor/src/components/block-styles/utils.js
+++ b/packages/block-editor/src/components/block-styles/utils.js
@@ -32,7 +32,8 @@ export function getActiveStyle( styles, className ) {
 }
 
 /**
- * Replaces the active style in the block's className.
+ * Replaces the active style in the block's className except
+ * if it's the default style.
  *
  * @param {string}  className   Class name.
  * @param {Object?} activeStyle The replaced style.
@@ -47,7 +48,9 @@ export function replaceActiveStyle( className, activeStyle, newStyle ) {
 		list.remove( 'is-style-' + activeStyle.name );
 	}
 
-	list.add( 'is-style-' + newStyle.name );
+	if ( ! newStyle.isDefault ) {
+		list.add( 'is-style-' + newStyle.name );
+	}
 
 	return list.value;
 }


### PR DESCRIPTION
## Description
Fixes #20706.
During block registration, [you can provide a styles argument](https://developer.wordpress.org/block-editor/developers/block-api/block-registration/#styles-optional) which allows you to set styles as an array of objects. In a particular styles object, if you pass "isDefault," that style will be selected by default. 

As described by issue #20706, no class will be applied when the block first loads, but if a user switches style away from the default and back to it again, the style "is-style-default" will be applied when previously there was none. In this PR, no style is applied if the user switches to and from the default style. In the code, newClass is checked by a conditional for the "isDefault" property and the tokenlist is not updated with "is-style-default" if that style is selected. 

## How has this been tested?
I added a test to make sure `replaceActiveStyle` in **gutenberg/packages/block-editor/src/components/block-styles/utils.js** returns no class if the style selected contains "isDefault."

`npm run test` and `npm run lint` were completed with no errors. 
Tested on Wordpress official docker image. Version 5.6.0. Mac OS, Catalina. 


## Types of changes
Resolves #20706

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
