### PR TITLE
Try: Ignore stylelint "selector-class-pattern" rule on mobile SCSS files

### DIFF
--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 /** @format */
 
 // Hugo's new WordPress shades of gray, from http://codepen.io/hugobaeta/pen/grJjVp.

--- a/packages/block-editor/src/components/block-caption/styles.native.scss
+++ b/packages/block-editor/src/components/block-caption/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .container {
 	flex: 1;
 }

--- a/packages/block-editor/src/components/block-icon/style.native.scss
+++ b/packages/block-editor/src/components/block-icon/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .iconPlaceholder {
 	fill: $gray-dark;
 }

--- a/packages/block-editor/src/components/block-list-appender/style.native.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.native.scss
@@ -1,4 +1,4 @@
-
+/* stylelint-disable selector-class-pattern */
 .blockListAppender {
 	padding-left: 16;
 	padding-right: 16;

--- a/packages/block-editor/src/components/block-list/block-list-item.native.scss
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .stretch {
 	flex: 1;
 }

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.scss
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .selectionButtonContainer {
 	flex-direction: row;
 	align-items: center;

--- a/packages/block-editor/src/components/block-list/block.native.scss
+++ b/packages/block-editor/src/components/block-list/block.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .blockHolder {
 	flex: 1 1 auto;
 }

--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .container {
 	flex: 1;
 	justify-content: flex-start;

--- a/packages/block-editor/src/components/block-media-update-progress/styles.native.scss
+++ b/packages/block-editor/src/components/block-media-update-progress/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .mediaUploadProgress {
 	flex: 1;
 	z-index: 1;

--- a/packages/block-editor/src/components/block-mobile-toolbar/style.native.scss
+++ b/packages/block-editor/src/components/block-mobile-toolbar/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .toolbar {
 	flex-direction: row;
 	height: $mobile-block-toolbar-height;

--- a/packages/block-editor/src/components/block-settings/container.native.scss
+++ b/packages/block-editor/src/components/block-settings/container.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .content {
 	padding-left: 0;
 	padding-right: 0;

--- a/packages/block-editor/src/components/block-styles/style.native.scss
+++ b/packages/block-editor/src/components/block-styles/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 $image-height: 64px;
 
 .image {

--- a/packages/block-editor/src/components/block-variation-picker/style.native.scss
+++ b/packages/block-editor/src/components/block-variation-picker/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .contentContainerStyle {
 	flex-direction: row;
 	padding-bottom: $grid-unit-15;

--- a/packages/block-editor/src/components/button-block-appender/styles.native.scss
+++ b/packages/block-editor/src/components/button-block-appender/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .appender {
 	flex: 1;
 	align-items: center;

--- a/packages/block-editor/src/components/default-block-appender/style.native.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 // @format
 
 .blockHolder {

--- a/packages/block-editor/src/components/floating-toolbar/floatingToolbar.android.scss
+++ b/packages/block-editor/src/components/floating-toolbar/floatingToolbar.android.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .floatingToolbarOffset {
 	top: 0;
 	margin-top: 8px;

--- a/packages/block-editor/src/components/floating-toolbar/floatingToolbar.ios.scss
+++ b/packages/block-editor/src/components/floating-toolbar/floatingToolbar.ios.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .floatingToolbarOffset {
 	top: - ($mobile-floating-toolbar-height + $mobile-floating-toolbar-margin);
 }

--- a/packages/block-editor/src/components/floating-toolbar/styles.native.scss
+++ b/packages/block-editor/src/components/floating-toolbar/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 @import "floatingToolbar";
 
 .floatingToolbar {

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 /** @format */
 
 .rowSeparator {

--- a/packages/block-editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/block-editor/src/components/media-placeholder/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .emptyStateContainer {
 	flex: 1;
 	height: 142;

--- a/packages/block-editor/src/components/media-upload-progress/styles.native.scss
+++ b/packages/block-editor/src/components/media-upload-progress/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .mediaUploadProgress {
 	flex: 1;
 	z-index: 1;

--- a/packages/block-editor/src/components/plain-text/style.native.scss
+++ b/packages/block-editor/src/components/plain-text/style.native.scss
@@ -1,4 +1,4 @@
-
+/* stylelint-disable selector-class-pattern */
 .block-editor-plain-text {
 	font-family: $default-regular-font;
 	box-shadow: none;

--- a/packages/block-editor/src/components/video-player/styles.native.scss
+++ b/packages/block-editor/src/components/video-player/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 // @format
 
 $play-icon-size: 50;

--- a/packages/block-editor/src/components/warning/style.native.scss
+++ b/packages/block-editor/src/components/warning/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 /** @format */
 
 .container {

--- a/packages/block-library/src/audio/style.native.scss
+++ b/packages/block-library/src/audio/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .progressContainer {
 	border-radius: 4px;
 	overflow: hidden;

--- a/packages/block-library/src/block/editor.native.scss
+++ b/packages/block-library/src/block/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .titleContainer {
 	flex-direction: row;
 	align-items: center;

--- a/packages/block-library/src/button/editor.native.scss
+++ b/packages/block-library/src/button/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .richTextWrapper {
 	overflow: visible;
 	align-self: flex-start;

--- a/packages/block-library/src/button/rich-text.android.scss
+++ b/packages/block-library/src/button/rich-text.android.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .richText {
 	background-color: transparent;
 	padding-left: $grid-unit-20;

--- a/packages/block-library/src/button/rich-text.ios.scss
+++ b/packages/block-library/src/button/rich-text.ios.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .richText {
 	margin: 10px $grid-unit-20;
 	background-color: transparent;

--- a/packages/block-library/src/buttons/editor.native.scss
+++ b/packages/block-library/src/buttons/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .parent {
 	margin: $block-edge-to-content;
 }

--- a/packages/block-library/src/code/theme.native.scss
+++ b/packages/block-library/src/code/theme.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 /* stylelint-disable font-family-no-missing-generic-family-keyword */
 
 .blockCode {

--- a/packages/block-library/src/column/editor.native.scss
+++ b/packages/block-library/src/column/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .columnPlaceholderNotSelected {
 	padding-top: $block-selected-to-content;
 }

--- a/packages/block-library/src/columns/editor.native.scss
+++ b/packages/block-library/src/columns/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .columnsContainer {
 	min-width: $block-edge-to-content *  2;
 	margin-left: $block-edge-to-content;

--- a/packages/block-library/src/cover/style.native.scss
+++ b/packages/block-library/src/cover/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .icon {
 	fill: $gray-dark;
 	height: 24px;

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .container {
 	margin-top: 2px;
 }

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 $gallery-image-container-height: 150px;
 $overlay-border-width: 2px;
 $caption-background-color: rgba(0, 0, 0, 0.4);

--- a/packages/block-library/src/gallery/gallery-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .galleryTilesContainerSelected {
 	margin-bottom: 16px;
 }

--- a/packages/block-library/src/gallery/styles.native.scss
+++ b/packages/block-library/src/gallery/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .icon {
 	fill: $gray-dark;
 }

--- a/packages/block-library/src/gallery/tiles-styles.native.scss
+++ b/packages/block-library/src/gallery/tiles-styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .containerStyle {
 	flex-direction: row;
 	flex-wrap: wrap;

--- a/packages/block-library/src/group/editor.native.scss
+++ b/packages/block-library/src/group/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .groupPlaceholder {
 	padding: $block-selected-to-content;
 	margin: $block-edge-to-content;

--- a/packages/block-library/src/image/styles.native.scss
+++ b/packages/block-library/src/image/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 // @format
 
 .content {

--- a/packages/block-library/src/latest-posts/style.native.scss
+++ b/packages/block-library/src/latest-posts/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .latestPostBlock {
 	height: 142;
 	background-color: $gray-lighten-30;

--- a/packages/block-library/src/media-text/style.native.scss
+++ b/packages/block-library/src/media-text/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 $media-to-text: 12px;
 
 .wp-block-media-text {

--- a/packages/block-library/src/missing/style.native.scss
+++ b/packages/block-library/src/missing/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 /** @format */
 .content {
 	padding-top: 8;

--- a/packages/block-library/src/more/editor.native.scss
+++ b/packages/block-library/src/more/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 // @format
 
 .moreLine {

--- a/packages/block-library/src/nextpage/editor.native.scss
+++ b/packages/block-library/src/nextpage/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 // @format
 
 .nextpageLine {

--- a/packages/block-library/src/preformatted/styles.native.scss
+++ b/packages/block-library/src/preformatted/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 %wpBlockPreformattedLightColor {
 	background-color: $gray-light;
 }

--- a/packages/block-library/src/pullquote/blockquote.native.scss
+++ b/packages/block-library/src/pullquote/blockquote.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .quote {
 	font-size: 18px;
 }

--- a/packages/block-library/src/pullquote/figure.native.scss
+++ b/packages/block-library/src/pullquote/figure.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 %shared {
 	border-width: 3px 0;
 	padding: 21px 16px;

--- a/packages/block-library/src/shortcode/style.native.scss
+++ b/packages/block-library/src/shortcode/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .blockTitle {
 	font-weight: 500;
 	font-size: 10px;

--- a/packages/block-library/src/social-link/editor.native.scss
+++ b/packages/block-library/src/social-link/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 @import "./socials-with-bg.scss";
 
 .linkSettingsPanel {

--- a/packages/block-library/src/social-links/editor.native.scss
+++ b/packages/block-library/src/social-links/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .spacing {
 	margin: 2 * $block-selected-margin;
 }

--- a/packages/block-library/src/spacer/editor.native.scss
+++ b/packages/block-library/src/spacer/editor.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .staticSpacer {
 	height: 20px;
 	background-color: transparent;

--- a/packages/block-library/src/video/style.native.scss
+++ b/packages/block-library/src/video/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 // @format
 
 .video {

--- a/packages/components/src/color-indicator/style.native.scss
+++ b/packages/components/src/color-indicator/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .selected {
 	height: 28px;
 	width: 28px;

--- a/packages/components/src/color-palette/style.native.scss
+++ b/packages/components/src/color-palette/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .contentContainer {
 	flex-direction: row-reverse;
 	padding: 0 $grid-unit-20;

--- a/packages/components/src/color-picker/style.native.scss
+++ b/packages/components/src/color-picker/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .footer {
 	border-top-width: $border-width;
 	border-color: $light-gray-400;

--- a/packages/components/src/custom-gradient-picker/style.native.scss
+++ b/packages/components/src/custom-gradient-picker/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .angleControl {
 	padding-top: $grid-unit-20 / 2;
 }

--- a/packages/components/src/mobile/bottom-sheet/borderStyles.android.scss
+++ b/packages/components/src/mobile/bottom-sheet/borderStyles.android.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .borderStyle {
 	border-bottom-width: 1px;
 }

--- a/packages/components/src/mobile/bottom-sheet/borderStyles.ios.scss
+++ b/packages/components/src/mobile/bottom-sheet/borderStyles.ios.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .isSelected {
 	border-width: 2px;
 	border-color: $blue-wordpress;

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .background {
 	background-color: $modal-background;
 }

--- a/packages/components/src/mobile/bottom-sheet/cellStyles.android.scss
+++ b/packages/components/src/mobile/bottom-sheet/cellStyles.android.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .labelIconSeparator {
 	width: 32px;
 }

--- a/packages/components/src/mobile/bottom-sheet/cellStyles.ios.scss
+++ b/packages/components/src/mobile/bottom-sheet/cellStyles.ios.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .labelIconSeparator {
 	width: 12px;
 }

--- a/packages/components/src/mobile/bottom-sheet/link-suggestion-styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/link-suggestion-styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .titleStyle {
 	text-align: left;
 	font-weight: bold;

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .sliderIOS {
 	flex-grow: 1;
 	min-height: $grid-unit-60;

--- a/packages/components/src/mobile/bottom-sheet/ripple.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/ripple.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .ripple {
 	background-color: rgba(0, 0, 0, 0.2);
 }

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/style.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .container {
 	flex-grow: 1;
 	flex-direction: row;

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 //Bottom Sheet
 
 .bottomModal {

--- a/packages/components/src/mobile/color-settings/style.native.scss
+++ b/packages/components/src/mobile/color-settings/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 
 .horizontalSeparator {
 	border-bottom-width: $border-width;

--- a/packages/components/src/mobile/gradient/style.native.scss
+++ b/packages/components/src/mobile/gradient/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .overflow {
 	overflow: hidden;
 }

--- a/packages/components/src/mobile/html-text-input/style-common.native.scss
+++ b/packages/components/src/mobile/html-text-input/style-common.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 $padding: 8;
 $htmlFont: $default-monospace-font;
 $textColorDark: $white;

--- a/packages/components/src/mobile/html-text-input/style.android.scss
+++ b/packages/components/src/mobile/html-text-input/style.android.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 @import "./style-common.scss";
 
 .htmlView {

--- a/packages/components/src/mobile/html-text-input/style.ios.scss
+++ b/packages/components/src/mobile/html-text-input/style.ios.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 @import "./style-common.scss";
 
 $title-height: 32;

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .container {
 	flex-grow: 1;
 }

--- a/packages/components/src/mobile/inserter-button/style.native.scss
+++ b/packages/components/src/mobile/inserter-button/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 /** @format */
 .touchableArea {
 	border-radius: 8px 8px 8px 8px;

--- a/packages/components/src/mobile/keyboard-avoiding-view/styles.native.scss
+++ b/packages/components/src/mobile/keyboard-avoiding-view/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .animatedChildStyle {
 	position: absolute;
 	width: 100%;

--- a/packages/components/src/mobile/link-picker/styles.native.scss
+++ b/packages/components/src/mobile/link-picker/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .omniCell {
 	border-bottom-width: 1px;
 	border-bottom-color: $light-gray-400;

--- a/packages/components/src/mobile/link-settings/style.native.scss
+++ b/packages/components/src/mobile/link-settings/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .linkSettingsPanel {
 	padding-left: 0;
 	padding-right: 0;

--- a/packages/components/src/mobile/picker/styles.native.scss
+++ b/packages/components/src/mobile/picker/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .separator {
 	margin-top: $grid-unit-20 / 2;
 	margin-bottom: $grid-unit-20 / 2;

--- a/packages/components/src/mobile/preview/styles.native.scss
+++ b/packages/components/src/mobile/preview/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .previewContent {
 	flex: 1;
 	background-color: $white;

--- a/packages/components/src/mobile/readable-content-view/style.native.scss
+++ b/packages/components/src/mobile/readable-content-view/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .container {
 	align-items: center;
 }

--- a/packages/components/src/mobile/segmented-control/style.native.scss
+++ b/packages/components/src/mobile/segmented-control/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 $container-height: 32px;
 $segment-height: 28px;
 $segment-spacing: 2px;

--- a/packages/components/src/notice/style.native.scss
+++ b/packages/components/src/notice/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .text {
 	color: #212121;
 	align-self: center;

--- a/packages/components/src/panel/actions.native.scss
+++ b/packages/components/src/panel/actions.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .panelActionsContainer {
 	border-top-color: $light-gray-400;
 	border-top-width: 1px;

--- a/packages/components/src/panel/body.native.scss
+++ b/packages/components/src/panel/body.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .panelContainer {
 	padding: 0 16px;
 }

--- a/packages/components/src/panel/bottom-separator-cover.native.scss
+++ b/packages/components/src/panel/bottom-separator-cover.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .coverSeparator {
 	height: 2px;
 	margin-top: -2px;

--- a/packages/components/src/resizable-box/style.native.scss
+++ b/packages/components/src/resizable-box/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .staticSpacer {
 	height: 20px;
 	background-color: transparent;

--- a/packages/components/src/spinner/style.native.scss
+++ b/packages/components/src/spinner/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .spinner {
 	height: 6;
 	background: $blue-wordpress;

--- a/packages/components/src/toolbar-group/style.native.scss
+++ b/packages/components/src/toolbar-group/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .container {
 	flex-direction: row;
 	border-left-width: 1px;

--- a/packages/components/src/toolbar/style.native.scss
+++ b/packages/components/src/toolbar/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .container {
 	flex-direction: row;
 	border-left-width: 1px;

--- a/packages/components/src/unit-control/style.native.scss
+++ b/packages/components/src/unit-control/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .unitButtonText {
 	color: $blue-wordpress;
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.native.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 
 .container {
 	height: $mobile-header-toolbar-height;

--- a/packages/edit-post/src/components/layout/style.native.scss
+++ b/packages/edit-post/src/components/layout/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 
 .container {
 	flex: 1;

--- a/packages/edit-post/src/components/visual-editor/style.native.scss
+++ b/packages/edit-post/src/components/visual-editor/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .blockHolderFullBordered {
 	border-top-width: $block-selected-border-width;
 	border-bottom-width: $block-selected-border-width;

--- a/packages/editor/src/components/post-title/style.native.scss
+++ b/packages/editor/src/components/post-title/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 
 .titleContainer {
 	padding-left: 12;

--- a/packages/format-library/src/link/modal.native.scss
+++ b/packages/format-library/src/link/modal.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .clearLinkButton {
 	color: $alert-red;
 }

--- a/packages/primitives/src/block-quotation/style.native.scss
+++ b/packages/primitives/src/block-quotation/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 %wpBlockQuote-shared {
 	border-left-width: 4px;
 	border-left-style: solid;

--- a/packages/primitives/src/horizontal-rule/styles.native.scss
+++ b/packages/primitives/src/horizontal-rule/styles.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .line {
 	background-color: $gray-lighten-20;
 	height: 2;

--- a/packages/primitives/src/svg/style.native.scss
+++ b/packages/primitives/src/svg/style.native.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 .dashicon-light,
 .components-toolbar__control-light {
 	color: $toolbar-button;

--- a/packages/react-native-editor/src/_native.android.scss
+++ b/packages/react-native-editor/src/_native.android.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 /** @format */
 
 // Fonts

--- a/packages/react-native-editor/src/_native.ios.scss
+++ b/packages/react-native-editor/src/_native.ios.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 /** @format */
 
 // Fonts

--- a/packages/rich-text/src/component/style.native.scss
+++ b/packages/rich-text/src/component/style.native.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 
 .richText {
 	font-family: $default-regular-font;

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -2,7 +2,9 @@
 
 module.exports = {
 	extends: 'stylelint-config-recommended',
+	plugins: [ './plugins/ignore-mobile-files-class-selector-rule' ],
 	rules: {
+		'wordpress/ignore-mobile-files-class-selector-rule': true,
 		'at-rule-empty-line-before': [
 			'always',
 			{

--- a/packages/stylelint-config/plugins/ignore-mobile-files-class-selector-rule.js
+++ b/packages/stylelint-config/plugins/ignore-mobile-files-class-selector-rule.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+const stylelint = require( 'stylelint' );
+
+const { report, ruleMessages } = stylelint.utils;
+const ruleName = 'wordpress/ignore-mobile-files-class-selector-rule';
+const mobileScssExtensions = [ '.native.scss', '.android.scss', '.ios.scss' ];
+const messages = ruleMessages( ruleName, {
+	expected: ( extension ) =>
+		`For *${ extension } files, the "selector-class-pattern" rule must be disabled. To disable it, add "/* stylelint-disable selector-class-pattern */" as the file's first line.`,
+} );
+
+const getMatchingExtension = ( fileName ) =>
+	mobileScssExtensions.find( ( extension ) =>
+		fileName.endsWith( extension )
+	);
+
+const isMobileScssFile = ( fileName ) => !! getMatchingExtension( fileName );
+
+const isDisablingSelectorClassPattern = ( firstNode ) =>
+	firstNode.type === 'comment' &&
+	firstNode.text.trim() === 'stylelint-disable selector-class-pattern';
+
+module.exports = stylelint.createPlugin(
+	ruleName,
+	function getPlugin( primaryOption, secondaryOptionObject, context ) {
+		return function lint( postcssRoot, postcssResult ) {
+			const isAutoFixing = Boolean( context.fix );
+			const fileName = postcssRoot.source.input.from;
+
+			if (
+				isMobileScssFile( fileName ) &&
+				! isDisablingSelectorClassPattern( postcssRoot.first )
+			) {
+				if ( ! isAutoFixing ) {
+					report( {
+						ruleName,
+						result: postcssResult,
+						message: messages.expected(
+							getMatchingExtension( fileName )
+						),
+						node: postcssRoot.first,
+					} );
+				} else {
+					postcssRoot.prepend(
+						'/* stylelint-disable selector-class-pattern */'
+					);
+				}
+			}
+		};
+	}
+);
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/packages/stylelint-config/test/commenting.js
+++ b/packages/stylelint-config/test/commenting.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid commenting css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid commenting css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/functions.js
+++ b/packages/stylelint-config/test/functions.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid functions css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid functions css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/index.js
+++ b/packages/stylelint-config/test/index.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/media-queries.js
+++ b/packages/stylelint-config/test/media-queries.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
-
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 /**
  * Internal dependencies
  */
@@ -23,6 +23,7 @@ describe( 'flags no warnings with valid media queries css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +45,7 @@ describe( 'flags warnings with invalid media queries css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/properties.js
+++ b/packages/stylelint-config/test/properties.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid properties css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid properties css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/scss.js
+++ b/packages/stylelint-config/test/scss.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid scss', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validScss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid scss', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidScss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/selectors-scss.js
+++ b/packages/stylelint-config/test/selectors-scss.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid selectors scss', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validScss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid selectors scss', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidScss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/selectors.js
+++ b/packages/stylelint-config/test/selectors.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid selectors css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid selectors css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/structure.js
+++ b/packages/stylelint-config/test/structure.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid structure css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid structure css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/themes.js
+++ b/packages/stylelint-config/test/themes.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ describe( 'flags no warnings with valid css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/values.js
+++ b/packages/stylelint-config/test/values.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'flags no warnings with valid values css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );
@@ -44,6 +46,7 @@ describe( 'flags warnings with invalid values css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: invalidCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );

--- a/packages/stylelint-config/test/vendor-prefixes.js
+++ b/packages/stylelint-config/test/vendor-prefixes.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const fs = require( 'fs' ),
-	stylelint = require( 'stylelint' );
+	stylelint = require( 'stylelint' ),
+	{ resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ describe( 'flags no warnings with valid vendor prefixes css', () => {
 	beforeEach( () => {
 		result = stylelint.lint( {
 			code: validCss,
+			configBasedir: resolve( __dirname, '..' ),
 			config,
 		} );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Adds a `stylelint` plugin to ignore the `selector-class-pattern` rule on mobile SCSS files (`.(native|ios|android).scss`).

When editing `.(native|ios|android).scss` files, if your code editor is compatible with `stylelint`, it will warn you to add a [commented line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/ignore-code.md#within-files) to ignore the `selector-class-pattern` rule, as this rule must not be applied to these files.

The plugin's `fix` option was implemented, so I also ran `npx stylelint "**/*.(native|ios|android).scss" --fix`, which already added the comment to ignore the rule.

## How has this been tested?
`npm run test`.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
### Before applying the plugin suggested fix
![before_plugin_fix](https://user-images.githubusercontent.com/18705930/107867377-3f6a2e00-6e59-11eb-8588-ed0837470a44.png)

### After applying the suggested fix
![after_plugin_fix](https://user-images.githubusercontent.com/18705930/107867440-9cfe7a80-6e59-11eb-95b9-fad41bc6330d.png)


## Types of changes
New feature.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
