### PR TITLE
Add z-index to gallery fig caption to make sure it is still selectable over absolute positioned border

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -51,6 +51,9 @@ figure.wp-block-gallery {
 			left: 0;
 			z-index: 1;
 		}
+		figcaption {
+			z-index: 2;
+		}
 	}
 
 	figure.is-transient img {


### PR DESCRIPTION
Fixes: #28989

## Description
https://github.com/WordPress/gutenberg/pull/27312 introduced some absolute positioning to the gallery image border to fix some layout issues, but because this had a z-index specified it was sitting over the top of the caption which could no longer be selected. 

This PR just adds a z-index to caption also so it sits over the border.

## Testing

- Add a gallery block with several images
- Make sure borders display correctly when image is selected and that caption can be edited

##  Before:
![caption-before](https://user-images.githubusercontent.com/3629020/107888872-007ccb00-6f74-11eb-88a1-3666d2011ed1.gif)

##  After:
![caption-after](https://user-images.githubusercontent.com/3629020/107888875-112d4100-6f74-11eb-99c0-f36454fb6a28.gif)

## Types of changes
CSS change

