### PR TITLE
Border Radius Support: Fix application of zero radius values

### DIFF
--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -32,7 +32,7 @@ export function BorderRadiusEdit( props ) {
 	}
 
 	const onChange = ( newRadius ) => {
-		const newStyle = {
+		let newStyle = {
 			...style,
 			border: {
 				...style?.border,
@@ -40,7 +40,11 @@ export function BorderRadiusEdit( props ) {
 			},
 		};
 
-		setAttributes( { style: cleanEmptyObject( newStyle ) } );
+		if ( newRadius === undefined ) {
+			newStyle = cleanEmptyObject( newStyle );
+		}
+
+		setAttributes( { style: newStyle } );
 	};
 
 	return (


### PR DESCRIPTION
## Description
Fixes problem where explicitly setting a border radius of zero wasn't honoured #27667 (review)

_Note: This splits out the fix for zero values from exploration on setting min/max values etc in https://github.com/WordPress/gutenberg/pull/28541_

## How has this been tested?
Manually.

#### Testing instructions

1. Checkout this PR
2. Update your theme.json file to opt into the border radius support and define a border radius style for the image block context. [Example theme.json gist](https://gist.github.com/aaronrobertshaw/8736ff074de23d1b5a4fa147b6bcda2e).
3. Create a new post and add an image block. It should display with the default radius set in your theme.json
4. Select the block and confirm that you can apply a 0 value border radius and it takes affect.

## Screenshots <!-- if applicable -->
| Before | After |
|-|-|
| ![ZeroBorderRadius](https://user-images.githubusercontent.com/60436221/107922652-10200200-6fbc-11eb-982b-29cfcca147ee.gif) | ![ZeroBorderRadius-Fix](https://user-images.githubusercontent.com/60436221/107922664-13b38900-6fbc-11eb-9609-f18d6ca56343.gif) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
