### PR TITLE
Fix PHP notice shown when rendering a navigation link block

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -106,7 +106,9 @@ function block_core_navigation_link_render_submenu_icon() {
 function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Don't render the block's subtree if it is a draft.
 	if (
-		isset( $attributes['id'] ) && is_numeric( $attributes['id'] ) &&
+		isset( $attributes['id'] ) &&
+		is_numeric( $attributes['id'] ) &&
+		isset( $attributes['type'] ) &&
 		( 'post' === $attributes['type'] || 'page' === $attributes['type'] )
 	) {
 		$post = get_post( $attributes['id'] );

--- a/phpunit/class-block-library-navigation-link-test.php
+++ b/phpunit/class-block-library-navigation-link-test.php
@@ -146,4 +146,24 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 			) !== false
 		);
 	}
+
+	function test_returns_link_for_plain_link() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:navigation-link {"label":"My Website","url":"https://example.com"} /-->'
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'My Website'
+			) !== false
+		);
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
An undefined index PHP notice is present in the page when using a nav link block that doesn't have a `type` property.

The standard 'Link' block doesn't seem to have a `type`.

## How has this been tested?
Added a unit test

Manual testing steps:
1. Add a nav block
2. Add a link block to the nav block
3. Save, reload and see there's no PHP notice.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
