### PR TITLE
[Mobile] - Removes rootBlockId from getBlockCount call

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -366,7 +366,6 @@ export default compose( [
 				getSelectedBlockClientId,
 				isBlockInsertionPointVisible,
 				getSettings,
-				getBlockHierarchyRootClientId,
 			} = select( blockEditorStore );
 
 			const isStackedHorizontally = orientation === 'horizontal';
@@ -382,10 +381,7 @@ export default compose( [
 			const { maxWidth } = getSettings();
 			const isReadOnly = getSettings().readOnly;
 
-			const rootBlockId = getBlockHierarchyRootClientId(
-				selectedBlockClientId
-			);
-			const blockCount = getBlockCount( rootBlockId );
+			const blockCount = getBlockCount();
 			const hasRootInnerBlocks = !! blockCount;
 
 			const isFloatingToolbarVisible =


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3146
`gutenberg-mobile` PR: TODO

## Description
Removes `rootBlockId` from `getBlockCount` since the `blockCount` value is only used in the `addBlockToEndOfPost` function and only for the root block list.

## How has this been tested?
1. Create a paragraph with some content
2. Tap on empty space below the paragraph
3. Verify that a new paragraph block is inserted at the end

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
