### PR TITLE
Incorporate getBlockLabel into useBlockDisplayInformation

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -574,14 +574,16 @@ _Related_
 
 <a name="useBlockDisplayInformation" href="#useBlockDisplayInformation">#</a> **useBlockDisplayInformation**
 
-Hook used to try to find a matching block variation and return
-the appropriate information for display reasons. In order to
-to try to find a match we need to things:
+Hook used appropriate information for display reasons.
+It takes variations and custom `label` function into account.
+
+In order to try to find a variation match we need to things:
 1\. Block's client id to extract it's current attributes.
 2\. A block variation should have set `isActive` prop to a proper function.
 
-If for any reason a block variaton match cannot be found,
-the returned information come from the Block Type.
+Value from custom `label` function is prioritized, if that's not found
+then the block variation' information is returned. If both are missing
+then the information is returned from the Block Type.
 If no blockType is found with the provided clientId, returns null.
 
 _Parameters_

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -574,17 +574,18 @@ _Related_
 
 <a name="useBlockDisplayInformation" href="#useBlockDisplayInformation">#</a> **useBlockDisplayInformation**
 
-Hook used appropriate information for display reasons.
+Hook used to return appropriate information for display reasons.
 It takes variations and custom `label` function into account.
 
-In order to try to find a variation match we need to things:
-1\. Block's client id to extract it's current attributes.
+In order to try to find a variation match we need two things:
+1\. Block's client id to extract its current attributes.
 2\. A block variation should have set `isActive` prop to a proper function.
 
 Value from custom `label` function is prioritized, if that's not found
 then the block variation' information is returned. If both are missing
 then the information is returned from the Block Type.
-If no blockType is found with the provided clientId, returns null.
+
+If no `blockType` is found with the provided `clientId`, returns `null`.
 
 _Parameters_
 

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -7,11 +7,7 @@ import { truncate } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import {
-	getBlockType,
-	__experimentalGetBlockLabel as getBlockLabel,
-	isReusableBlock,
-} from '@wordpress/blocks';
+import { getBlockType, isReusableBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -35,7 +31,7 @@ import { store as blockEditorStore } from '../../store';
  * @return {?string} Block title.
  */
 export default function BlockTitle( { clientId } ) {
-	const { attributes, name, reusableBlockTitle } = useSelect(
+	const { name, reusableBlockTitle } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
 				return {};
@@ -51,7 +47,6 @@ export default function BlockTitle( { clientId } ) {
 			}
 			const isReusable = isReusableBlock( getBlockType( blockName ) );
 			return {
-				attributes: getBlockAttributes( clientId ),
 				name: blockName,
 				reusableBlockTitle:
 					isReusable &&
@@ -65,13 +60,7 @@ export default function BlockTitle( { clientId } ) {
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 	if ( ! name || ! blockInformation ) return null;
-	const blockType = getBlockType( name );
-	const label = reusableBlockTitle || getBlockLabel( blockType, attributes );
-	// Label will fallback to the title if no label is defined for the current
-	// label context. If the label is defined we prioritize it over possible
-	// possible block variation title match.
-	if ( label !== blockType.title ) {
-		return truncate( label, { length: 35 } );
-	}
-	return blockInformation.title;
+
+	const label = reusableBlockTitle || blockInformation.title;
+	return truncate( label, { length: 35 } );
 }

--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -30,26 +30,16 @@ jest.mock( '@wordpress/blocks', () => {
 					return { title: 'Block With Long Label' };
 			}
 		},
-		__experimentalGetBlockLabel( { title } ) {
-			switch ( title ) {
-				case 'Block With Label':
-					return 'Test Label';
-
-				case 'Block With Long Label':
-					return 'This is a longer label than typical for blocks to have.';
-
-				default:
-					return title;
-			}
-		},
 	};
 } );
 
 jest.mock( '../../use-block-display-information', () => {
 	const resultsMap = {
 		'id-name-exists': { title: 'Block Title' },
-		'id-name-with-label': { title: 'Block With Label' },
-		'id-name-with-long-label': { title: 'Block With Long Label' },
+		'id-name-with-label': { title: 'Test Label' },
+		'id-name-with-long-label': {
+			title: 'This is a longer label than typical for blocks to have.',
+		},
 	};
 	return jest.fn( ( clientId ) => resultsMap[ clientId ] );
 } );

--- a/packages/block-editor/src/components/use-block-display-information/README.md
+++ b/packages/block-editor/src/components/use-block-display-information/README.md
@@ -1,11 +1,16 @@
 # useBlockDisplayInformation
 
-A React Hook that tries to find a matching block variation and returns the appropriate information for display reasons. In order to try to find a match we need two things:
+Hook used appropriate information for display reasons.
+It takes variations and custom `label` function into account.
 
-1. Block's client id to extract its current attributes.
-2. A block variation has `isActive` prop defined with a matcher function.
+In order to try to find a variation match we need to things:
+1\. Block's client id to extract it's current attributes.
+2\. A block variation should have set `isActive` prop to a proper function.
 
-If for any reason a block variaton match cannot be found, the returned information come from the Block Type.
+Value from custom `label` function is prioritized, if that's not found
+then the block variation' information is returned. If both are missing
+then the information is returned from the Block Type.
+If no blockType is found with the provided clientId, returns null.
 
 ### Usage
 

--- a/packages/block-editor/src/components/use-block-display-information/README.md
+++ b/packages/block-editor/src/components/use-block-display-information/README.md
@@ -1,16 +1,17 @@
 # useBlockDisplayInformation
 
-Hook used appropriate information for display reasons.
+Hook used to return appropriate information for display reasons.
 It takes variations and custom `label` function into account.
 
-In order to try to find a variation match we need to things:
-1\. Block's client id to extract it's current attributes.
+In order to try to find a variation match we need two things:
+1\. Block's client id to extract its current attributes.
 2\. A block variation should have set `isActive` prop to a proper function.
 
 Value from custom `label` function is prioritized, if that's not found
 then the block variation' information is returned. If both are missing
 then the information is returned from the Block Type.
-If no blockType is found with the provided clientId, returns null.
+
+If no `blockType` is found with the provided `clientId`, returns `null`.
 
 ### Usage
 

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as blocksStore } from '@wordpress/blocks';
+import {
+	store as blocksStore,
+	__experimentalGetBlockLabel as getBlockLabel,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -22,49 +25,67 @@ import { store as blockEditorStore } from '../../store';
  */
 
 /**
- * Hook used to try to find a matching block variation and return
- * the appropriate information for display reasons. In order to
- * to try to find a match we need to things:
+ * Hook used appropriate information for display reasons.
+ * It takes variations and custom `label` function into account.
+ *
+ * In order to try to find a variation match we need to things:
  * 1. Block's client id to extract it's current attributes.
  * 2. A block variation should have set `isActive` prop to a proper function.
  *
- * If for any reason a block variaton match cannot be found,
- * the returned information come from the Block Type.
+ * Value from custom `label` function is prioritized, if that's not found
+ * then the block variation' information is returned. If both are missing
+ * then the information is returned from the Block Type.
  * If no blockType is found with the provided clientId, returns null.
  *
  * @param {string} clientId Block's client id.
  * @return {?WPBlockDisplayInformation} Block's display information, or `null` when the block or its type not found.
  */
-
 export default function useBlockDisplayInformation( clientId ) {
 	return useSelect(
 		( select ) => {
 			if ( ! clientId ) return null;
+
 			const { getBlockName, getBlockAttributes } = select(
 				blockEditorStore
 			);
 			const { getBlockType, getBlockVariations } = select( blocksStore );
+
 			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
 			if ( ! blockType ) return null;
+
 			const variations = getBlockVariations( blockName );
-			const blockTypeInfo = {
-				title: blockType.title,
-				icon: blockType.icon,
-				description: blockType.description,
-			};
-			if ( ! variations?.length ) return blockTypeInfo;
 			const attributes = getBlockAttributes( clientId );
-			const match = variations.find( ( variation ) =>
-				variation.isActive?.( attributes, variation.attributes )
-			);
-			if ( ! match ) return blockTypeInfo;
+
+			const dynamicTitle = getBlockLabel( blockType, attributes );
+			const variationInfo = getVariationInfo( variations, attributes );
+
+			const title =
+				dynamicTitle && dynamicTitle !== blockType.title
+					? dynamicTitle
+					: variationInfo.title || blockType.title;
+			const icon = variationInfo.icon || blockType.icon;
+			const description =
+				variationInfo.description || blockType.description;
+
 			return {
-				title: match.title || blockType.title,
-				icon: match.icon || blockType.icon,
-				description: match.description || blockType.description,
+				title,
+				icon,
+				description,
 			};
 		},
 		[ clientId ]
 	);
+}
+
+function getVariationInfo( variations, attributes ) {
+	const emptyInfo = { title: null, icon: null, description: null };
+	if ( ! variations?.length ) {
+		return emptyInfo;
+	}
+
+	const match = variations.find( ( variation ) =>
+		variation.isActive?.( attributes, variation.attributes )
+	);
+	return match || emptyInfo;
 }

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -25,17 +25,18 @@ import { store as blockEditorStore } from '../../store';
  */
 
 /**
- * Hook used appropriate information for display reasons.
+ * Hook used to return appropriate information for display reasons.
  * It takes variations and custom `label` function into account.
  *
- * In order to try to find a variation match we need to things:
- * 1. Block's client id to extract it's current attributes.
+ * In order to try to find a variation match we need two things:
+ * 1. Block's client id to extract its current attributes.
  * 2. A block variation should have set `isActive` prop to a proper function.
  *
  * Value from custom `label` function is prioritized, if that's not found
  * then the block variation' information is returned. If both are missing
  * then the information is returned from the Block Type.
- * If no blockType is found with the provided clientId, returns null.
+ *
+ * If no `blockType` is found with the provided `clientId`, returns `null`.
  *
  * @param {string} clientId Block's client id.
  * @return {?WPBlockDisplayInformation} Block's display information, or `null` when the block or its type not found.

--- a/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
@@ -54,7 +54,7 @@ async function getBlockCard() {
 
 describe( 'Settings sidebar', () => {
 	beforeAll( async () => {
-		await activateTheme( 'theme-experiments/tt1-blocks' );
+		await activateTheme( 'tt1-blocks' );
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
 	} );

--- a/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
@@ -39,9 +39,22 @@ async function getTemplateCard() {
 	};
 }
 
+async function getBlockCard() {
+	return {
+		title: await page.$eval(
+			'.block-editor-block-card__title',
+			( element ) => element.innerText
+		),
+		description: await page.$eval(
+			'.block-editor-block-card__description',
+			( element ) => element.innerText
+		),
+	};
+}
+
 describe( 'Settings sidebar', () => {
 	beforeAll( async () => {
-		await activateTheme( 'tt1-blocks' );
+		await activateTheme( 'theme-experiments/tt1-blocks' );
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
 	} );
@@ -94,6 +107,20 @@ describe( 'Settings sidebar', () => {
 			await toggleSidebar();
 
 			expect( await getActiveTabLabel() ).toEqual( 'Block (selected)' );
+		} );
+
+		it( `should show template part's name in the block card if a template part block is selected`, async () => {
+			const allBlocks = await getAllBlocks();
+			const headerTemplatePart = allBlocks.find(
+				( { name, attributes } ) =>
+					name === 'core/template-part' &&
+					attributes?.slug === 'header'
+			);
+			await selectBlockByClientId( headerTemplatePart.clientId );
+
+			await toggleSidebar();
+
+			expect( ( await getBlockCard() ).title ).toEqual( 'Header' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
Related https://github.com/WordPress/gutenberg/issues/27876
## Description
We introduced a function for blocks that returns a dynamic label based on the block's attributes: `__experimentalLabel`. ([Example](https://github.com/WordPress/gutenberg/blob/eeea281928071a348336fe4d875d79e7008e69e9/packages/block-library/src/template-part/index.js))

The Block inspector didn't take this into account.  To make sure this function is taken into account throughout the codebase, this PR incorporates it into the already existing and widely used `useBlockDisplayInformation` hook. This also simplified the code in `BlockTitle`.

## How has this been tested?
1. Open block editor
2. Select a `Template Part` block
3. Open block inspector
4. Make sure the inspector shows the name of the template part
5. Smoke test everything else

## Screenshots <!-- if applicable -->

(Block inspector says "Header" instead of "Template Part")
![image](https://user-images.githubusercontent.com/2256104/107976243-896a2580-6fb9-11eb-877c-eb56e776c4bf.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
