### PR TITLE
Navigation: Experiment with adding navigation link variations

### DIFF
--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -10,6 +10,9 @@
 		"type": {
 			"type": "string"
 		},
+	  	"objectType": {
+			"type": "string"
+	  	},
 		"description": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -109,9 +109,10 @@ const useIsDraggingWithin = ( elementRef ) => {
  * /wp/v2/search.
  *
  * @param {string} type Link block's type attribute.
+ * @param {string} objectType Link block's object type attribute. (post-type|taxonomy)
  * @return {{ type?: string, subtype?: string }} Search query params.
  */
-function getSuggestionsQuery( type ) {
+function getSuggestionsQuery( type, objectType ) {
 	switch ( type ) {
 		case 'post':
 		case 'page':
@@ -121,6 +122,12 @@ function getSuggestionsQuery( type ) {
 		case 'tag':
 			return { type: 'term', subtype: 'post_tag' };
 		default:
+			if ( objectType === 'taxonomy' ) {
+				return { type: 'term', subtype: type };
+			}
+			if ( objectType === 'post-type' ) {
+				return { type: 'post', subtype: type };
+			}
 			return {};
 	}
 }
@@ -152,6 +159,7 @@ function NavigationLinkEdit( {
 		description,
 		rel,
 		title,
+		objectType,
 	} = attributes;
 	const link = {
 		url,
@@ -406,7 +414,10 @@ function NavigationLinkEdit( {
 								} }
 								noDirectEntry={ !! type }
 								noURLSuggestion={ !! type }
-								suggestionsQuery={ getSuggestionsQuery( type ) }
+								suggestionsQuery={ getSuggestionsQuery(
+									type,
+									objectType
+								) }
 								onChange={ ( {
 									title: newTitle = '',
 									url: newURL = '',

--- a/packages/block-library/src/navigation-link/variations.js
+++ b/packages/block-library/src/navigation-link/variations.js
@@ -8,6 +8,10 @@ import {
 	postTitle as postIcon,
 	tag as tagIcon,
 } from '@wordpress/icons';
+
+import apiFetch from '@wordpress/api-fetch';
+import { registerBlockVariation } from '@wordpress/blocks';
+
 const variations = [
 	{
 		name: 'link',
@@ -15,34 +19,6 @@ const variations = [
 		title: __( 'Link' ),
 		description: __( 'A link to a URL.' ),
 		attributes: {},
-	},
-	{
-		name: 'post',
-		icon: postIcon,
-		title: __( 'Post Link' ),
-		description: __( 'A link to a post.' ),
-		attributes: { type: 'post' },
-	},
-	{
-		name: 'page',
-		icon: pageIcon,
-		title: __( 'Page Link' ),
-		description: __( 'A link to a page.' ),
-		attributes: { type: 'page' },
-	},
-	{
-		name: 'category',
-		icon: categoryIcon,
-		title: __( 'Category Link' ),
-		description: __( 'A link to a category.' ),
-		attributes: { type: 'category' },
-	},
-	{
-		name: 'tag',
-		icon: tagIcon,
-		title: __( 'Tag Link' ),
-		description: __( 'A link to a tag.' ),
-		attributes: { type: 'tag' },
 	},
 ];
 
@@ -55,6 +31,67 @@ variations.forEach( ( variation ) => {
 	if ( variation.isActive ) return;
 	variation.isActive = ( blockAttributes, variationAttributes ) =>
 		blockAttributes.type === variationAttributes.type;
+} );
+
+const ICON_MAP = {
+	post: postIcon,
+	page: pageIcon,
+	tag: tagIcon,
+	category: categoryIcon,
+};
+
+Promise.all( [
+	apiFetch( {
+		path: '/wp/v2/types?context=edit&per_page=-1&show_in_nav_menus=true',
+		type: 'GET',
+	} ),
+	apiFetch( {
+		path:
+			'/wp/v2/taxonomies?context=edit&per_page=-1&show_in_nav_menus=true',
+		type: 'GET',
+	} ),
+] ).then( function ( [ postTypes, taxonomies ] ) {
+	const postTypeKeys = Object.keys( postTypes );
+	for ( const type of postTypeKeys ) {
+		const postType = postTypes[ type ];
+		//customizer actually sets type = 'post-type', and 'object' = $post_type->name
+		registerBlockVariation( 'core/navigation-link', {
+			name: postType.slug, //TODO: can this be trusted to be unique?
+			attributes: { type: postType.slug, objectType: 'post-type' },
+			title: postType?.labels?.menu_name, //TODO: should this be passed through as a new type.label for description
+			...( ICON_MAP[ postType.slug ] && {
+				icon: ICON_MAP[ postType.slug ],
+			} ), //TODO: what about custom post type/taxonomy icons?
+		} );
+	}
+	const taxonomyKeys = Object.keys( taxonomies );
+	for ( const taxonomyKey of taxonomyKeys ) {
+		//customizer actually sets type = 'taxonomy', and 'object' = $taxonomy->name
+		//it also has a custom hook for: $item_types = apply_filters( 'customize_nav_menu_available_item_types', $item_types );
+		//TODO needs research for data structure choices, we likely need taxonomy|post_type and name, or term/post_type id
+		const taxonomy = taxonomies[ taxonomyKey ];
+		//tag is post_tag
+		if ( taxonomyKey === 'post_tag' ) {
+			registerBlockVariation( 'core/navigation-link', {
+				name: 'tag',
+				attributes: { type: 'tag', objectType: 'taxonomy' },
+				title: taxonomy?.labels?.menu_name,
+				icon: ICON_MAP.tag,
+			} );
+		} else {
+			registerBlockVariation( 'core/navigation-link', {
+				name: taxonomy.slug, //TODO: can this be trusted to be unique?
+				attributes: {
+					type: taxonomy.slug,
+					objectType: 'taxonomy',
+				},
+				title: taxonomy?.labels?.menu_name,
+				...( ICON_MAP[ taxonomy.slug ] && {
+					icon: ICON_MAP[ taxonomy.slug ],
+				} ),
+			} );
+		}
+	}
 } );
 
 export default variations;


### PR DESCRIPTION
WIP Part of https://github.com/WordPress/gutenberg/issues/24814 this PR experiments with registering navigation link variants.

This approach requires https://github.com/WordPress/wordpress-develop/pull/1002 to test.

<img width="866" alt="Screen Shot 2021-02-15 at 12 08 21 PM" src="https://user-images.githubusercontent.com/1270189/107989223-ad604380-6f86-11eb-83af-c0f7fa38f9a3.png">

https://user-images.githubusercontent.com/1270189/107990032-607d6c80-6f88-11eb-9934-d4af9959cb20.mp4

### Request For Feedback

cc @noisysocks @gziolo 

I put together a pretty quick draft of what this looks like if we populate navigation link variations from the API

1. **Do we need an API update?** As for as I can tell, this requires some API updates to allow filtering, or show the extra visibility properties. I quickly drafted this in https://github.com/WordPress/wordpress-develop/pull/1002. Let me know if I mislooked anything and this an API update is unnecessary.
2. **Where should this live, and when should it fire?** Placement of the `registerBlockVariation` calls is a bit awkward. I had trouble finding a good spot. Our core data stores work best with a react component, so I instead opted for a direct `apiFetch` call which might not be ideal. 
3. **Rethinking Block Attributes** Reading customizer code and what we have here, I think `type` sort of corresponds to a taxonomy.slug or postType.slug value (with a hardcoded exception to tag, which is `post_type`). At a minimum I think I need to pass through if it's a `taxonomy` or `post-type`. I'm also not sure if slug is dependable, beyond the default built-ins. Can slug be renamed. Are collisions allowed? Eg should we be using a post type id/taxonomy id instead?

### TODO
- [x] Finish Search suggestion support handling
- [ ] Verify that we should populate from the API
- [ ] What should we do about custom post type labels/descriptions?
- [ ] Should we allow customization of the inserter icon?
- [ ] Should we respect the `customize_nav_menu_available_item_types` filter?
- [ ] Can we trust a taxonomy/post-type slug, or do we need to rely on ID/term_id
- [ ] Verify what data should be stored in the block / what deprecations should be made

### Testing Instructions
- Start up a local wordpress instance using changes in https://github.com/WordPress/wordpress-develop/pull/1002
- Install the gutenberg plugin with this branch
- Install a plugin with some custom post types and taxonomies
- Click on the block inserter, and add a navigation block
- Click start with empty
- Click on the block inserter in navigation
- Click on show more