### PR TITLE
[RNMobile] Fix React Native error from function declaration hoisting

### DIFF
--- a/packages/components/src/higher-order/with-notices/index.js
+++ b/packages/components/src/higher-order/with-notices/index.js
@@ -22,15 +22,6 @@ import NoticeList from '../../notice/list';
  * @return {WPComponent} Wrapped component.
  */
 export default createHigherOrderComponent( ( OriginalComponent ) => {
-	let isForwardRef;
-	const { render } = OriginalComponent;
-	// Returns a forwardRef if OriginalComponent appears to be a forwardRef
-	if ( typeof render === 'function' ) {
-		isForwardRef = true;
-		return forwardRef( Component );
-	}
-	return Component;
-
 	function Component( props, ref ) {
 		const [ noticeList, setNoticeList ] = useState( [] );
 
@@ -97,4 +88,13 @@ export default createHigherOrderComponent( ( OriginalComponent ) => {
 			<OriginalComponent { ...propsOut } />
 		);
 	}
+
+	let isForwardRef;
+	const { render } = OriginalComponent;
+	// Returns a forwardRef if OriginalComponent appears to be a forwardRef
+	if ( typeof render === 'function' ) {
+		isForwardRef = true;
+		return forwardRef( Component );
+	}
+	return Component;
 } );


### PR DESCRIPTION
**Gutenberg Mobile:** wordpress-mobile/gutenberg-mobile#3150

## Description

Fixes wordpress-mobile/gutenberg-mobile#3149.

It is unknown why relying upon function declaration hoisting causes an
error in React Native, but it does occur. Recent changes with #28676
refactored a class to a functional component, including leveraging
function declaration hoisting. I.e. the function was referenced
prior to its declaration in terms of the order of the lines of code.

Re-ordering the code so that the function declaration occurs prior to
referencing it appears to resolve the error in React Native.

Related: https://git.io/JtXMm

<details>
<summary>Mobile Error</summary>

![ios-function-hoisting-error](https://user-images.githubusercontent.com/438664/107998723-56b93080-6fab-11eb-8330-788d15d8881b.png)

</details>

## How has this been tested?

Manually tested modifying the focal point for a Cover block in both the web editor (macOS Safari) and native editor (iOS).

## Screenshots

<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/438664/107998497-e3172380-6faa-11eb-9917-ab0aacb900e4.mov

</details>

<details>
<summary>Native Mobile</summary>

https://user-images.githubusercontent.com/438664/107998512-edd1b880-6faa-11eb-871b-6876225112a1.mov

</details>

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
