### PR TITLE
BEM Naming Convention

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -79,22 +79,22 @@ export default function SearchEdit( {
 		return classnames(
 			className,
 			'button-inside' === buttonPosition
-				? 'wp-block-search__button-inside'
+				? 'wp-block-search--button-inside'
 				: undefined,
 			'button-outside' === buttonPosition
-				? 'wp-block-search__button-outside'
+				? 'wp-block-search--button-outside'
 				: undefined,
 			'no-button' === buttonPosition
-				? 'wp-block-search__no-button'
+				? 'wp-block-search--no-button'
 				: undefined,
 			'button-only' === buttonPosition
-				? 'wp-block-search__button-only'
+				? 'wp-block-search--button-only'
 				: undefined,
 			! buttonUseIcon && 'no-button' !== buttonPosition
-				? 'wp-block-search__text-button'
+				? 'wp-block-search--text-button'
 				: undefined,
 			buttonUseIcon && 'no-button' !== buttonPosition
-				? 'wp-block-search__icon-button'
+				? 'wp-block-search--icon-button'
 				: undefined
 		);
 	};

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -1,13 +1,13 @@
 .wp-block-search {
-	.wp-block-search__input {
+	&__input {
 		padding: $grid-unit-10;
 	}
 
-	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	&--button-inside &__inside-wrapper {
 		padding: $grid-unit-05;
 	}
 
-	.wp-block-search__button {
+	&__button {
 		height: auto;
 		border-radius: initial;
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -131,28 +131,28 @@ function classnames_for_block_core_search( $attributes ) {
 
 	if ( ! empty( $attributes['buttonPosition'] ) ) {
 		if ( 'button-inside' === $attributes['buttonPosition'] ) {
-			$classnames[] = 'wp-block-search__button-inside';
+			$classnames[] = 'wp-block-search--button-inside';
 		}
 
 		if ( 'button-outside' === $attributes['buttonPosition'] ) {
-			$classnames[] = 'wp-block-search__button-outside';
+			$classnames[] = 'wp-block-search--button-outside';
 		}
 
 		if ( 'no-button' === $attributes['buttonPosition'] ) {
-			$classnames[] = 'wp-block-search__no-button';
+			$classnames[] = 'wp-block-search--no-button';
 		}
 
 		if ( 'button-only' === $attributes['buttonPosition'] ) {
-			$classnames[] = 'wp-block-search__button-only';
+			$classnames[] = 'wp-block-search--button-only';
 		}
 	}
 
 	if ( isset( $attributes['buttonUseIcon'] ) ) {
 		if ( ! empty( $attributes['buttonPosition'] ) && 'no-button' !== $attributes['buttonPosition'] ) {
 			if ( $attributes['buttonUseIcon'] ) {
-				$classnames[] = 'wp-block-search__icon-button';
+				$classnames[] = 'wp-block-search--icon-button';
 			} else {
-				$classnames[] = 'wp-block-search__text-button';
+				$classnames[] = 'wp-block-search--text-button';
 			}
 		}
 	}

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,6 +1,6 @@
 .wp-block-search {
 
-	.wp-block-search__button {
+	&__button {
 		background: #f7f7f7;
 		border: 1px solid #ccc;
 		padding: 0.375em 0.625em;
@@ -18,30 +18,30 @@
 		}
 	}
 
-	.wp-block-search__inside-wrapper {
+	&__inside-wrapper {
 		display: flex;
 		flex: auto;
 		flex-wrap: nowrap;
 		max-width: 100%;
 	}
 
-	.wp-block-search__label {
+	&__label {
 		width: 100%;
 	}
 
-	.wp-block-search__input {
+	&__input {
 		flex-grow: 1;
 		min-width: 3em;
 		border: 1px solid $gray-600;
 	}
 
-	&.wp-block-search__button-only {
+	&--button-only {
 		.wp-block-search__button {
 			margin-left: 0;
 		}
 	}
 
-	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	&--button-inside &__inside-wrapper {
 		padding: $grid-unit-05;
 		border: 1px solid $gray-600;
 


### PR DESCRIPTION
The way block is using the BEM naming convention is incorrect.
For example, `button-inside` is our modifier and CSS class is formed as block’s name plus two dashes, giving us `wp-block-search--button-inside`.
Additionally, in CSS it is better to use class name selector only with no dependency on the block.
