### PR TITLE
[RNMobile] Ignore column width attribute when empty

### DIFF
--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -476,7 +476,7 @@ const ColumnsEdit = ( props ) => {
 				editorSidebarOpened: isSelected && isEditorSidebarOpened(),
 			};
 		},
-		[ clientId ]
+		[ clientId, isSelected ]
 	);
 
 	const memoizedInnerWidths = useMemo( () => {

--- a/packages/components/src/mobile/utils/use-unit-converter-to-mobile.native.js
+++ b/packages/components/src/mobile/utils/use-unit-converter-to-mobile.native.js
@@ -37,7 +37,7 @@ const getValueAndUnit = ( value, unit ) => {
 
 const convertUnitToMobile = ( containerSize, globalStyles, value, unit ) => {
 	const { width, height } = containerSize;
-	const { valueToConvert, valueUnit } = getValueAndUnit( value, unit );
+	const { valueToConvert, valueUnit } = getValueAndUnit( value, unit ) || {};
 	const { fontSize = 16 } = globalStyles || {};
 
 	switch ( valueUnit ) {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,6 +12,7 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 * [**] Make inserter long-press options "add to beginning" and "add to end" always available. [#28610]
 * [**] Add support for setting Cover block focal point. [#25810]
+* [*] Fix crash when Column block width attribute was empty. [#29015]
 
 ## 1.46.0
 * [***] New Block: Audio [#27401, #27467, #28594]


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/29017

The editor was crashing when attempting to render a column block which contained an empty width attribute (i.e `<!-- wp:column {"width":""} -->`.
The exception occurred when accessing a property of an undefined object, so adding a default object (`|| {}`) fixes this by allowing the property to be accessed.

## How has this been tested?
I tested by replacing the editor contents with the HTML snippet that caused the error:
```
<!-- wp:columns -->
	<div class="wp-block-columns">
		<!-- wp:column -->
			<div class="wp-block-column"></div>
		<!-- /wp:column -->

		<!-- wp:column {"width":""} -->
			<div class="wp-block-column"></div>
		<!-- /wp:column -->
	</div>
<!-- /wp:columns -->
```

I then smoke tested the Columns block, adding columns and changing their widths and looked there were no regressions.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
