### PR TITLE
[RNMobile] Separate Inserter items to a search results component

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -17,9 +17,6 @@ import { getClipboard } from '@wordpress/components';
 import InserterSearchResults from './search-results';
 import { store as blockEditorStore } from '../../store';
 
-// This should handle showing the insertion point and the items
-// the search results component will handle picking and inserting
-
 function InserterMenu( {
 	onSelect,
 	onDismiss,
@@ -72,7 +69,6 @@ function InserterMenu( {
 
 	const { getBlockType } = useSelect( ( select ) => select( blocksStore ) );
 
-	// Show/Hide insertion point on Mount/Dismount
 	useEffect( () => {
 		if ( shouldReplaceBlock ) {
 			const count = getBlockCount();
@@ -90,13 +86,14 @@ function InserterMenu( {
 				removeBlock( blockToReplace, false );
 			}
 		}
+	  // Show/Hide insertion point on Mount/Dismount
 		showInsertionPoint( destinationRootClientId, insertionIndex );
 		return hideInsertionPoint;
 	}, [] );
 
 	const onClose = useCallback( () => {
-		// if should replace but didn't insert any block
-		// re-insert default block
+		// If should replace but didn't insert any block
+		// re-insert default block.
 		if ( shouldReplaceBlock ) {
 			insertDefaultBlock( {}, destinationRootClientId, insertionIndex );
 		}

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -8,7 +8,6 @@ import {
 	TouchableWithoutFeedback,
 	Dimensions,
 } from 'react-native';
-import { pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -33,7 +32,6 @@ import {
  */
 import styles from './style.scss';
 import { store as blockEditorStore } from '../../store';
-//import useInsertionPoint from './hooks/use-insertion-point';
 
 const MIN_COL_NUM = 3;
 
@@ -176,27 +174,27 @@ function InserterMenu( {
 			( { name } ) => name !== 'core/block'
 		);
 
-		const clipboard = getClipboard();
-		const clipboardBlock =
-			clipboard && rawHandler( { HTML: clipboard } )[ 0 ];
-		const shouldAddClipboardBlock =
-			clipboardBlock &&
-			canInsertBlockType( clipboardBlock.name, destinationRootClientId );
+		const clipboardBlock = rawHandler( { HTML: getClipboard() } )[ 0 ];
+		const shouldAddClipboardBlock = canInsertBlockType(
+			clipboardBlock?.name,
+			destinationRootClientId
+		);
 
-		return shouldAddClipboardBlock
-			? [
-					{
-						...pick( getBlockType( clipboardBlock.name ), [
-							'name',
-							'icon',
-						] ),
-						id: 'clipboard',
-						initialAttributes: clipboardBlock.attributes,
-						innerBlocks: clipboardBlock.innerBlocks,
-					},
-					...itemsToDisplay,
-			  ]
-			: itemsToDisplay;
+		if ( shouldAddClipboardBlock ) {
+			const { name, icon } = getBlockType( clipboardBlock.name );
+			return [
+				{
+					name,
+					icon,
+					id: 'clipboard',
+					initialAttributes: clipboardBlock.attributes,
+					innerBlocks: clipboardBlock.innerBlocks,
+				},
+				...itemsToDisplay,
+			];
+		}
+
+		return itemsToDisplay;
 	}
 
 	function onBlockSelect( item ) {

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -1,0 +1,170 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	createBlock,
+	rawHandler,
+	store as blocksStore,
+} from '@wordpress/blocks';
+import { getClipboard } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+import InserterSearchResults from './search-results';
+import { store as blockEditorStore } from '../../store';
+
+// This should handle showing the insertion point and the items
+// the search results component will handle picking and inserting
+
+function InserterMenu( {
+	onSelect,
+	onDismiss,
+	rootClientId,
+	clientId,
+	isAppender,
+	shouldReplaceBlock,
+	insertionIndex,
+} ) {
+	const {
+		showInsertionPoint,
+		hideInsertionPoint,
+		clearSelectedBlock,
+		insertBlock,
+		removeBlock,
+		resetBlocks,
+		insertDefaultBlock,
+	} = useDispatch( blockEditorStore );
+
+	const {
+		items,
+		destinationRootClientId,
+		getBlockOrder,
+		getBlockCount,
+		canInsertBlockType,
+	} = useSelect( ( select ) => {
+		const {
+			getInserterItems,
+			getBlockRootClientId,
+			getBlockSelectionEnd,
+			...selectBlockEditorStore
+		} = select( blockEditorStore );
+
+		let targetRootClientId = rootClientId;
+		if ( ! targetRootClientId && ! clientId && ! isAppender ) {
+			const end = getBlockSelectionEnd();
+			if ( end ) {
+				targetRootClientId = getBlockRootClientId( end ) || undefined;
+			}
+		}
+
+		return {
+			items: getInserterItems( targetRootClientId ),
+			destinationRootClientId: targetRootClientId,
+			getBlockOrder: selectBlockEditorStore.getBlockOrder,
+			getBlockCount: selectBlockEditorStore.getBlockCount,
+			canInsertBlockType: selectBlockEditorStore.canInsertBlockType,
+		};
+	} );
+
+	const { getBlockType } = useSelect( ( select ) => select( blocksStore ) );
+
+	// Show/Hide insertion point on Mount/Dismount
+	useEffect( () => {
+		if ( shouldReplaceBlock ) {
+			const count = getBlockCount();
+			// Check if there is a rootClientId because that means it is a nested replaceable block
+			// and we don't want to clear/reset all blocks.
+			if ( count === 1 && ! rootClientId ) {
+				// Removing the last block is not possilble with `removeBlock` action.
+				// It always inserts a default block if the last of the blocks have been removed.
+				clearSelectedBlock();
+				resetBlocks( [] );
+			} else {
+				const blockToReplace = getBlockOrder( destinationRootClientId )[
+					insertionIndex
+				];
+				removeBlock( blockToReplace, false );
+			}
+		}
+		showInsertionPoint( destinationRootClientId, insertionIndex );
+		return hideInsertionPoint;
+	}, [] );
+
+	const onClose = useCallback( () => {
+		// if should replace but didn't insert any block
+		// re-insert default block
+		if ( shouldReplaceBlock ) {
+			insertDefaultBlock( {}, destinationRootClientId, insertionIndex );
+		}
+		onDismiss();
+	}, [ shouldReplaceBlock, destinationRootClientId, insertionIndex ] );
+
+	const onInsert = useCallback(
+		( item ) => {
+			const { name, initialAttributes, innerBlocks } = item;
+
+			const newBlock = createBlock(
+				name,
+				initialAttributes,
+				innerBlocks
+			);
+
+			insertBlock( newBlock, insertionIndex, destinationRootClientId );
+		},
+		[ insertBlock, destinationRootClientId, insertionIndex ]
+	);
+
+	/**
+	 * Processes the inserter items to check
+	 * if there's any copied block in the clipboard
+	 * to add it as an extra item
+	 */
+	function getItems() {
+		// Filter out reusable blocks (they will be added in another tab)
+		const itemsToDisplay = items.filter(
+			( { name } ) => name !== 'core/block'
+		);
+
+		const clipboard = getClipboard();
+		let clipboardBlock = rawHandler( { HTML: clipboard } )[ 0 ];
+
+		const canAddClipboardBlock = canInsertBlockType(
+			clipboardBlock?.name,
+			destinationRootClientId
+		);
+
+		if ( ! canAddClipboardBlock ) {
+			return itemsToDisplay;
+		}
+
+		const { icon, name } = getBlockType( clipboardBlock.name );
+		const { attributes: initialAttributes, innerBlocks } = clipboardBlock;
+
+		clipboardBlock = {
+			id: 'clipboard',
+			name,
+			icon,
+			initialAttributes,
+			innerBlocks,
+		};
+
+		return [ clipboardBlock, ...itemsToDisplay ];
+	}
+
+	return (
+		<InserterSearchResults
+			onClose={ onClose }
+			items={ getItems() }
+			onSelect={ ( item ) => {
+				onInsert( item );
+				onSelect( item );
+			} }
+		/>
+	);
+}
+
+export default InserterMenu;

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -86,7 +86,7 @@ function InserterMenu( {
 				removeBlock( blockToReplace, false );
 			}
 		}
-	  // Show/Hide insertion point on Mount/Dismount
+		// Show/Hide insertion point on Mount/Dismount
 		showInsertionPoint( destinationRootClientId, insertionIndex );
 		return hideInsertionPoint;
 	}, [] );

--- a/packages/block-editor/src/components/inserter/search-results.native.js
+++ b/packages/block-editor/src/components/inserter/search-results.native.js
@@ -35,7 +35,7 @@ import { store as blockEditorStore } from '../../store';
 
 const MIN_COL_NUM = 3;
 
-function InserterMenu( {
+function InserterSearchResults( {
 	insertionIndex,
 	onDismiss,
 	onSelect,
@@ -260,4 +260,4 @@ function InserterMenu( {
 	);
 }
 
-export default withInstanceId( InserterMenu );
+export default withInstanceId( InserterSearchResults );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This separates displaying the inserter menu items into a new display only component. This does not introduce any behavioral changes to the inserter. Instead this change set is a foundational refactor to allow for the upcoming inserter block search flows.

Part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/2570

## How has this been tested?
Since this is a refactor there are no new behaviors to test. 

### Testing Steps

- Try opening the inserter. 
    -  The insertion point notification should appear as expected. 
    - The block menu should appear as expected.
- Try inserting a block into a post. 
    - The block should be added in the expected insertion point.

- Add a buttons block to a post
- With the the buttons block selected press the inserter button
   - The block menu should only show the button block

- Copy a block
- Press the inserter button.
- If the block can be copied (e.g. 
    - It should appear as the first block in the menu
    - The copy should be inserted as expected.
  
     
## Types of changes
- Convert RN `InserterMenu` to a functional component.
- Add RN `InserterSearchResults` component.
- Move inserter menu  item display logic to `InserterSearchResults` component.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
