### PR TITLE
Fix <Modal> component so it is possible to use the aria.labelledby prop

### DIFF
--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -37,7 +37,7 @@ Modals are used for:
 ![A modal diagram with labels](https://wordpress.org/gutenberg/files/2019/04/Modal-diagram.png)
 
 1. Container
-2. Title (optional)
+2. Title
 3. Supporting text
 4. Buttons
 5. Scrim
@@ -52,6 +52,7 @@ To clarify that the rest of the screen is inaccessible and to focus attention on
 ### Title
 
 A modal’s purpose is communicated through its title and button text.
+All modals should have a title for accessibility reasons (the `contentLabel` prop can be used to set titles that aren't visible).
 
 Titles should:
 
@@ -151,10 +152,12 @@ Props not included in this set will be applied to the input elements.
 
 #### title
 
-This property is used as the modal header's title. It is required for accessibility reasons.
+This property is used as the modal header's title.
+
+Titles are required for accessibility reasons, see `aria.labelledby` and `contentLabel` for other ways to provide a title.
 
 - Type: `String`
-- Required: Yes
+- Required: No
 
 #### onRequestClose
 
@@ -166,7 +169,8 @@ This function is called to indicate that the modal should be closed.
 #### contentLabel
 
 If this property is added, it will be added to the modal content `div` as `aria-label`.
-You are encouraged to use this if `aria.labelledby` is not provided.
+
+Titles are required for accessibility reasons, see `aria.labelledby` and `title` for other ways to provide a title.
 
 - Type: `String`
 - Required: No
@@ -174,11 +178,13 @@ You are encouraged to use this if `aria.labelledby` is not provided.
 #### aria.labelledby
 
 If this property is added, it will be added to the modal content `div` as `aria-labelledby`.
-You are encouraged to use this when the modal is visually labelled.
+Use this when you are rendering the title yourself within the modal's content area instead of using the `title` prop. This ensures the title is usable by assistive technology.
+
+Titles are required for accessibility reasons, see `contentLabel` and `title` for other ways to provide a title.
 
 - Type: `String`
 - Required: No
-- Default: `modal-heading`
+- Default: if the `title` prop is provided, this will default to the id of the element that renders `title`
 
 #### aria.describedby
 

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -116,8 +116,9 @@ class Modal extends Component {
 			...otherProps
 		} = this.props;
 
-		const headingId =
-			aria.labelledby || `components-modal-header-${ instanceId }`;
+		const headingId = title
+			? `components-modal-header-${ instanceId }`
+			: aria.labelledby;
 
 		if ( isDismissable ) {
 			deprecated( 'isDismissable prop of the Modal component', {
@@ -131,7 +132,7 @@ class Modal extends Component {
 			<ModalFrame
 				onRequestClose={ onRequestClose }
 				aria={ {
-					labelledby: title ? headingId : null,
+					labelledby: headingId,
 					describedby: aria.describedby,
 				} }
 				{ ...otherProps }
@@ -139,7 +140,7 @@ class Modal extends Component {
 				<div className={ 'components-modal__content' } role="document">
 					<ModalHeader
 						closeLabel={ closeButtonLabel }
-						headingId={ headingId }
+						headingId={ title && headingId }
 						icon={ icon }
 						isDismissible={ isDismissible || isDismissable }
 						onClose={ onRequestClose }

--- a/packages/components/src/modal/test/index.js
+++ b/packages/components/src/modal/test/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { render, screen, within } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Modal from '../';
+
+describe( 'Modal', () => {
+	it( 'applies the aria-describedby attribute when provided', () => {
+		render(
+			<Modal aria={ { describedby: 'description-id' } }>
+				{ /* eslint-disable-next-line no-restricted-syntax */ }
+				<p id="description-id">Description</p>
+			</Modal>
+		);
+		expect( screen.getByRole( 'dialog' ) ).toHaveAttribute(
+			'aria-describedby',
+			'description-id'
+		);
+	} );
+
+	it( 'applies the aria-labelledby attribute when provided', () => {
+		render(
+			<Modal aria={ { labelledby: 'title-id' } }>
+				{ /* eslint-disable-next-line no-restricted-syntax */ }
+				<h1 id="title-id">Test Title</h1>
+			</Modal>
+		);
+		expect( screen.getByRole( 'dialog' ) ).toHaveAttribute(
+			'aria-labelledby',
+			'title-id'
+		);
+	} );
+
+	it( 'prefers the aria label of the title prop over the aria.labelledby prop', () => {
+		render(
+			<Modal title="Test Title" aria={ { labelledby: 'title-id' } }>
+				{ /* eslint-disable-next-line no-restricted-syntax */ }
+				<h1 id="title-id">Wrong Title</h1>
+			</Modal>
+		);
+		const dialog = screen.getByRole( 'dialog' );
+		const titleId = within( dialog ).getByText( 'Test Title' ).id;
+		expect( dialog ).toHaveAttribute( 'aria-labelledby', titleId );
+	} );
+} );


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes a bug where `<Modal>` wasn't forwarding the `aria.labelledby` prop to `<ModalFrame>` if the `title` prop was missing. However the purpose of `labelledby` is to allow modals to provide their own title element, in which case they won't want to use the `title` prop.

The `aria.labelledby` prop is now correctly forwarded to `<ModalFrame>` if no title is provided. The `title` prop will take precedent over `aria.labelledby`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Added new unit tests that check the modal aria props are set correctly in the DOM.

I tested this in a dev environment by changing [the preferences modal](https://github.com/WordPress/gutenberg/blob/6ef9e821a8f88eac7bf93275965fe9f90311a4e4/packages/edit-post/src/components/preferences-modal/index.js#L317) to render its own heading itself rather than use the `title` prop.

<img width="454" alt="Screenshot 2021-02-16 at 4 49 12 PM" src="https://user-images.githubusercontent.com/1500769/108016243-ea0b6800-7076-11eb-8a09-08a7ad3808cc.png">

Inspecting in the Firefox a11y tools, the modal's name is still listed as "Preferences".
![Screen Shot on 2021-02-16 at 16:53:54](https://user-images.githubusercontent.com/1500769/108016528-9cdbc600-7077-11eb-92b8-771f566d5ea9.png)


Dev's will still need to test how their specific modal behaves in a screen reader as the DOM ordering could still impact the user experience. This PR just makes it possible to set the `aria-labelledby` attribute where it wasn't really possible to do so before.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
