### PR TITLE
Try: Block Patterns: Add support for icons and display next to the pattern title in the inserter

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -241,3 +241,31 @@ function register_site_icon_url( $response ) {
 add_filter( 'rest_index', 'register_site_icon_url' );
 
 add_theme_support( 'widgets-block-editor' );
+
+function register_test_block_patterns() {
+	register_block_pattern(
+		'test-block-pattern-with-icon',
+		array(
+			'title'       => 'Test Block Pattern',
+			'description' => 'A description',
+			'content'     => '<!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph -->',
+			'keywords'    =>
+				array(
+					'apples',
+					'oranges'
+				),
+			'categories'  =>
+				array(
+					'gallery',
+					'text',
+					'twentytwentyone',
+				),
+			'icon' =>
+				array(
+					'src' => 'megaphone'
+				)
+		)
+	);
+}
+
+add_action( 'init', 'register_test_block_patterns' );

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import BlockIcon from '../block-icon';
 import BlockPreview from '../block-preview';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 
@@ -23,6 +24,13 @@ function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 	const blocks = useMemo( () => parse( content ), [ content ] );
 	const instanceId = useInstanceId( BlockPattern );
 	const descriptionId = `block-editor-block-patterns-list__item-description-${ instanceId }`;
+
+	const itemIconStyle = pattern.icon
+		? {
+				backgroundColor: pattern.icon.background,
+				color: pattern.icon.foreground,
+		  }
+		: {};
 
 	return (
 		<InserterDraggableBlocks isEnabled={ isDraggable } blocks={ blocks }>
@@ -50,6 +58,17 @@ function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 						/>
 						<div className="block-editor-block-patterns-list__item-title">
 							{ pattern.title }
+							{ pattern.icon ? (
+								<span
+									className="block-editor-block-patterns-list__item-icon"
+									style={ itemIconStyle }
+								>
+									<BlockIcon
+										icon={ pattern.icon }
+										showColors
+									/>
+								</span>
+							) : null }
 						</div>
 						{ !! pattern.description && (
 							<VisuallyHidden id={ descriptionId }>

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -30,8 +30,29 @@
 	}
 }
 
+.block-editor-block-patterns-list__item-icon {
+	padding: 0 4px;
+	border-radius: $radius-block-ui;
+	color: $gray-900;
+	transition: all 0.05s ease-in-out;
+	@include reduce-motion("transition");
+
+	svg {
+		transition: all 0.15s ease-out;
+		@include reduce-motion("transition");
+	}
+
+	.block-editor-block-types-list__list-item[draggable="true"] & {
+		cursor: grab;
+	}
+}
+
 .block-editor-block-patterns-list__item-title {
 	padding: $grid-unit-05;
 	font-size: 12px;
-	text-align: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: auto;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This is an exploration into adding icon support to block patterns, similar to how we can add an icon when registering a block pattern. The idea is that a plugin or theme might want to include an icon when registering a block pattern, to help highlight or distinguish between different kinds of block patterns.

For a user, when plugins or themes use an icon, it might make it easier to see where your patterns are coming from.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually. This is a draft PR at the moment, so I've hard-coded a test pattern that you can see under the Text category to demonstrate how it might look.

## To-dos

***Note:*** if this idea has merit, more work will need to be done to properly filter / update the icon object. For example:

* [ ] Run `pattern.icon` through [normalizeIconObject](https://github.com/WordPress/gutenberg/blob/5eca659a8cc26dda9f46d48c7d55485c8348ddf0/packages/blocks/src/api/registration.js#L280)
* [ ] Only allow the icon if it's a valid icon by calling [isValidIcon](https://github.com/WordPress/gutenberg/blob/5eca659a8cc26dda9f46d48c7d55485c8348ddf0/packages/blocks/src/api/registration.js#L281)

## Screenshots <!-- if applicable -->

An example of a (very) simple pattern with an icon added:

![image](https://user-images.githubusercontent.com/14988353/108020636-e70d7900-7070-11eb-9d7a-e1e698f63b88.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature (non-breaking change — patterns without an icon continue to render as before in the pattern inserter).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
