### PR TITLE
Site Editor: Organise semantic template parts

### DIFF
--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -75,7 +75,8 @@ describe( 'Document Settings', () => {
 			// Navigate to a template part
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
-			await navigationPanel.navigate( 'Template Parts' );
+			// TODO: Change General to Headers once TT1 blocks categorise the template parts
+			await navigationPanel.navigate( [ 'Template Parts', 'General' ] );
 			await navigationPanel.clickItemByText( 'header' );
 
 			// Evaluate the document settings title

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -146,7 +146,8 @@ describe( 'Multi-entity editor states', () => {
 
 	it( 'should not dirty an entity by switching to it in the template dropdown', async () => {
 		await siteEditor.visit();
-		await clickTemplateItem( 'Template Parts', 'header' );
+		// TODO: Change General to Headers once TT1 blocks categorise the template parts
+		await clickTemplateItem( [ 'Template Parts', 'General' ], 'header' );
 		await page.waitForFunction( () =>
 			Array.from( window.frames ).find(
 				( { name } ) => name === 'editor-canvas'

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -20,7 +20,7 @@ import { navigationPanel, siteEditor } from '../../experimental-features';
 
 describe( 'Template Part', () => {
 	beforeAll( async () => {
-		await activateTheme( 'tt1-blocks' );
+		await activateTheme( 'theme-experiments/tt1-blocks' );
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
 	} );
@@ -39,7 +39,8 @@ describe( 'Template Part', () => {
 			// Switch to editing the header template part.
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
-			await navigationPanel.navigate( 'Template Parts' );
+			// TODO: Change General to Headers once TT1 blocks categorise the template parts
+			await navigationPanel.navigate( [ 'Template Parts', 'General' ] );
 			await navigationPanel.clickItemByText( 'header' );
 
 			// Edit it.

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -20,7 +20,7 @@ import { navigationPanel, siteEditor } from '../../experimental-features';
 
 describe( 'Template Part', () => {
 	beforeAll( async () => {
-		await activateTheme( 'theme-experiments/tt1-blocks' );
+		await activateTheme( 'tt1-blocks' );
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
 	} );

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
@@ -1,3 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 export const TEMPLATES_GENERAL = [
 	'front-page',
 	'archive',
@@ -30,3 +35,35 @@ export const MENU_TEMPLATES_PAGES = 'templates-pages';
 export const MENU_TEMPLATES_POSTS = 'templates-posts';
 
 export const SEARCH_DEBOUNCE_IN_MS = 75;
+
+export const MENU_TEMPLATE_PARTS_HEADERS = 'template-parts-headers';
+export const MENU_TEMPLATE_PARTS_FOOTERS = 'template-parts-footers';
+export const MENU_TEMPLATE_PARTS_SIDEBARS = 'template-parts-sidebars';
+export const MENU_TEMPLATE_PARTS_GENERAL = 'template-parts-general';
+
+export const TEMPLATE_PART_AREA_HEADER = 'header';
+export const TEMPLATE_PART_AREA_FOOTER = 'footer';
+export const TEMPLATE_PART_AREA_SIDEBAR = 'sidebar';
+
+export const TEMPLATE_PARTS_SUB_MENUS = [
+	{
+		area: TEMPLATE_PART_AREA_HEADER,
+		menu: MENU_TEMPLATE_PARTS_HEADERS,
+		title: __( 'Headers' ),
+	},
+	{
+		area: TEMPLATE_PART_AREA_FOOTER,
+		menu: MENU_TEMPLATE_PARTS_FOOTERS,
+		title: __( 'Footers' ),
+	},
+	{
+		area: TEMPLATE_PART_AREA_SIDEBAR,
+		menu: MENU_TEMPLATE_PARTS_SIDEBARS,
+		title: __( 'Sidebars' ),
+	},
+	{
+		area: null,
+		menu: MENU_TEMPLATE_PARTS_GENERAL,
+		title: __( 'General' ),
+	},
+];

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
@@ -62,7 +62,7 @@ export const TEMPLATE_PARTS_SUB_MENUS = [
 		title: __( 'Sidebars' ),
 	},
 	{
-		area: null,
+		area: 'uncategorized',
 		menu: MENU_TEMPLATE_PARTS_GENERAL,
 		title: __( 'General' ),
 	},

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts-sub.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts-sub.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __experimentalNavigationMenu as NavigationMenu } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import TemplateNavigationItem from '../template-navigation-item';
+import { MENU_TEMPLATE_PARTS } from '../constants';
+
+export default function TemplatePartsSubMenu( { menu, title, templateParts } ) {
+	return (
+		<NavigationMenu
+			menu={ menu }
+			title={ title }
+			parentMenu={ MENU_TEMPLATE_PARTS }
+			isEmpty={ ! templateParts || templateParts.length === 0 }
+		>
+			{ map( templateParts, ( templatePart ) => (
+				<TemplateNavigationItem
+					item={ templatePart }
+					key={ `wp_template_part-${ templatePart.id }` }
+				/>
+			) ) }
+		</NavigationMenu>
+	);
+}

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy, omit } from 'lodash';
+import { groupBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -32,35 +32,24 @@ export default function TemplatePartsMenu() {
 		setSearch( value );
 	} );
 
-	const {
-		isLoading,
-		templateParts,
-		templatePartsByArea,
-		generalTemplateParts,
-	} = useSelect( ( select ) => {
-		const templatePartRecords = select( coreStore ).getEntityRecords(
-			'postType',
-			'wp_template_part'
-		);
+	const { isLoading, templateParts, templatePartsByArea } = useSelect(
+		( select ) => {
+			const templatePartRecords = select( coreStore ).getEntityRecords(
+				'postType',
+				'wp_template_part'
+			);
 
-		const _templateParts = templatePartRecords || [];
-		const _templatePartsByArea = groupBy( _templateParts, 'area' );
-		const areasUsedBySubMenus = TEMPLATE_PARTS_SUB_MENUS.map(
-			( { area } ) => area
-		).filter( ( area ) => !! area );
-		const _generalTemplateParts = [].concat(
-			...Object.values(
-				omit( _templatePartsByArea, areasUsedBySubMenus )
-			)
-		);
+			const _templateParts = templatePartRecords || [];
+			const _templatePartsByArea = groupBy( _templateParts, 'area' );
 
-		return {
-			isLoading: templateParts === null,
-			templateParts: _templateParts,
-			templatePartsByArea: _templatePartsByArea,
-			generalTemplateParts: _generalTemplateParts,
-		};
-	}, [] );
+			return {
+				isLoading: templatePartRecords === null,
+				templateParts: _templateParts,
+				templatePartsByArea: _templatePartsByArea,
+			};
+		},
+		[]
+	);
 
 	return (
 		<>
@@ -96,11 +85,7 @@ export default function TemplatePartsMenu() {
 					key={ `template-parts-menu-${ menu }` }
 					menu={ menu }
 					title={ title }
-					templateParts={
-						area
-							? templatePartsByArea[ area ]
-							: generalTemplateParts
-					}
+					templateParts={ templatePartsByArea[ area ] }
 				/>
 			) ) }
 		</>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+import { groupBy, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,13 +13,18 @@ import {
 	__experimentalNavigationItem as NavigationItem,
 } from '@wordpress/components';
 import { useState, useCallback } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import TemplateNavigationItem from '../template-navigation-item';
-import { MENU_ROOT, MENU_TEMPLATE_PARTS } from '../constants';
+import {
+	MENU_ROOT,
+	MENU_TEMPLATE_PARTS,
+	TEMPLATE_PARTS_SUB_MENUS,
+} from '../constants';
 import SearchResults from '../search-results';
+import TemplatePartsSubMenu from './template-parts-sub';
 
 export default function TemplatePartsMenu() {
 	const [ search, setSearch ] = useState( '' );
@@ -27,39 +32,77 @@ export default function TemplatePartsMenu() {
 		setSearch( value );
 	} );
 
-	const templateParts = useSelect(
-		( select ) =>
-			select( 'core' ).getEntityRecords(
-				'postType',
-				'wp_template_part'
-			) || [],
-		[]
-	);
+	const {
+		isLoading,
+		templateParts,
+		templatePartsByArea,
+		generalTemplateParts,
+	} = useSelect( ( select ) => {
+		const templatePartRecords = select( coreStore ).getEntityRecords(
+			'postType',
+			'wp_template_part'
+		);
+
+		const _templateParts = templatePartRecords || [];
+		const _templatePartsByArea = groupBy( _templateParts, 'area' );
+		const areasUsedBySubMenus = TEMPLATE_PARTS_SUB_MENUS.map(
+			( { area } ) => area
+		).filter( ( area ) => !! area );
+		const _generalTemplateParts = [].concat(
+			...Object.values(
+				omit( _templatePartsByArea, areasUsedBySubMenus )
+			)
+		);
+
+		return {
+			isLoading: templateParts === null,
+			templateParts: _templateParts,
+			templatePartsByArea: _templatePartsByArea,
+			generalTemplateParts: _generalTemplateParts,
+		};
+	}, [] );
 
 	return (
-		<NavigationMenu
-			menu={ MENU_TEMPLATE_PARTS }
-			title={ __( 'Template Parts' ) }
-			parentMenu={ MENU_ROOT }
-			hasSearch={ true }
-			onSearch={ onSearch }
-			search={ search }
-		>
-			{ search && (
-				<SearchResults items={ templateParts } search={ search } />
-			) }
+		<>
+			<NavigationMenu
+				menu={ MENU_TEMPLATE_PARTS }
+				title={ __( 'Template Parts' ) }
+				parentMenu={ MENU_ROOT }
+				hasSearch={ true }
+				onSearch={ onSearch }
+				search={ search }
+			>
+				{ search && (
+					<SearchResults items={ templateParts } search={ search } />
+				) }
 
-			{ ! search &&
-				map( templateParts, ( templatePart ) => (
-					<TemplateNavigationItem
-						item={ templatePart }
-						key={ `wp_template_part-${ templatePart.id }` }
-					/>
-				) ) }
+				{ ! search &&
+					TEMPLATE_PARTS_SUB_MENUS.map( ( { title, menu } ) => (
+						<NavigationItem
+							key={ `template-parts-navigate-to-${ menu }` }
+							navigateToMenu={ menu }
+							title={ title }
+							hideIfTargetMenuEmpty
+						/>
+					) ) }
 
-			{ ! search && templateParts === null && (
-				<NavigationItem title={ __( 'Loading…' ) } isText />
-			) }
-		</NavigationMenu>
+				{ ! search && isLoading && (
+					<NavigationItem title={ __( 'Loading…' ) } isText />
+				) }
+			</NavigationMenu>
+
+			{ TEMPLATE_PARTS_SUB_MENUS.map( ( { area, menu, title } ) => (
+				<TemplatePartsSubMenu
+					key={ `template-parts-menu-${ menu }` }
+					menu={ menu }
+					title={ title }
+					templateParts={
+						area
+							? templatePartsByArea[ area ]
+							: generalTemplateParts
+					}
+				/>
+			) ) }
+		</>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes https://github.com/WordPress/gutenberg/issues/27877
* Create sub-menus inside the Template Parts menu for Headers, Footers, and Sidebars.
* Put the rest of the template parts into General.
* Empty menus are hidden.

## How has this been tested?
1. Open site editor
2. Open browsing sidebar
3. Click on template parts
4. You should see Headers if you have header template parts
5. You should see Footers if you have footer template parts
6. You should see Sidebars if you have sidebar template parts
7. You should see General if you have any other templates parts that don't fit into headers, footers, and sidebars

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/108050421-dac1f580-7049-11eb-9f98-46eeeb8e4cb0.png)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
