### PR TITLE
Fix position and style of "Dashboard" link in Site Editor navigation. closes #29033

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -53,9 +53,9 @@
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {
 	border-radius: 0;
-	height: auto;
-	margin-left: -6px; // +2px to display the focus box-shadow
-	margin-top: 2px; // +2px to display the focus box-shadow
+	height: 36px;
+	margin-left: -10px; // +2px to display the focus box-shadow
+	margin-top: 24px; // +2px to display the focus box-shadow
 	padding: $grid-unit $grid-unit-20;
 	width: calc(100% + #{$grid-unit-15});
 

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -53,7 +53,6 @@
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {
 	border-radius: 0;
-	border-bottom: $border-width solid $gray-700;
 	height: auto;
 	margin-left: -6px; // +2px to display the focus box-shadow
 	margin-top: 2px; // +2px to display the focus box-shadow

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -53,9 +53,9 @@
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {
 	border-radius: 0;
-	height: 36px;
+	height: $button-size;
 	margin-left: -10px; // +2px to display the focus box-shadow
-	margin-top: 24px; // +2px to display the focus box-shadow
+	margin-top: $grid-unit-30;
 	padding: $grid-unit $grid-unit-20;
 	width: calc(100% + #{$grid-unit-15});
 


### PR DESCRIPTION
This PR ensures the position of the "Dashboard" link at the root level of the site editor navigation is consistently positioned and styled with the other "back" buttons in the navigation.

![position](https://user-images.githubusercontent.com/846565/108059938-21195380-704e-11eb-9d4a-f06d6a7c0c06.gif)

Notice that as I flick between tabs the position of the button is identical.

A before screenshot can be found in #29033.