### PR TITLE
[RNMobile] Underline selected text as soon as LinkTo field is populated

### DIFF
--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -22,7 +22,10 @@ const ModalLinkUI = ( { isVisible, ...restProps } ) => {
 			>
 				<BottomSheet.NavigationContainer animate main>
 					<BottomSheet.NavigationScreen name={ screens.settings }>
-						<LinkSettingsScreen { ...restProps } />
+						<LinkSettingsScreen
+							isVisible={ isVisible }
+							{ ...restProps }
+						/>
 					</BottomSheet.NavigationScreen>
 					<BottomSheet.NavigationScreen
 						name={ screens.picker }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3058

Ref to gb-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3156

## Description

PR introduces the feature to underline the selected text as soon as `Link To` field is populated and clean once it's empty.

## How has this been tested?

1. Add link to text

<details>
<summary>Details</summary>

1. Add `Paragraph`
2. Write some text
3. Select it
4. Press link icon
5. Add link to selected text eg `google.com`
**Expect selected text is underlined**

![add_link_to_text](https://user-images.githubusercontent.com/22746080/108059212-75740180-7055-11eb-860d-4c98beb0cb95.gif)
</details>

2. Clear link

<details>
<summary>Details</summary>

1. Have linked selected text
2. Press link icon
3. Clear link and press `Apply`
**Expect text isn't underlined**
![clear_link_correct](https://user-images.githubusercontent.com/22746080/108059430-c71c8c00-7055-11eb-9152-2068a6aa64cc.gif)
</details>

3. Add link and remove it

<details>
<summary>Details</summary>

1. Add `Paragraph`
2. Write some text
3. Select it
4. Press link icon
5. Add link to selected text eg `google.com`
**Expect selected text is underlined**
6. Press `Remove link`
**Expect text isn't underlined**

<img src="https://user-images.githubusercontent.com/22746080/108059744-3d20f300-7056-11eb-89aa-90e0cbea0bd1.gif" width="300" />
</details>

4. Add link and link text

<details>
<summary>Details</summary>

1. Add `Paragraph`
2. Press link icon
3. Add link eg. `google.com`
4. Change link text eg `Google`
**Expect selected text is underlined**


![add_link_and_text](https://user-images.githubusercontent.com/22746080/108059923-7ce7da80-7056-11eb-800f-7aaa6438648f.gif)
</details>

5. With URL in clipboard

<details>
<summary>Details</summary>

1. Make sure to have link in clipboard
2. Write some text
3. Select it
4. Press link icon
**Expect link is autopopulated and selected text is underlined**
![clipboard](https://user-images.githubusercontent.com/22746080/108061634-e668e880-7058-11eb-9d50-3bcea9d3a2f7.gif)
</details>

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Attached above

## Types of changes

Feature
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
