### PR TITLE
Template Part Block: Fallback to missing state if slug or theme is invalid

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -60,7 +60,7 @@ export default function TemplatePartEdit( {
 				: false;
 
 			return {
-				innerBlocks: templatePartId ? getBlocks( clientId ) : [],
+				innerBlocks: getBlocks( clientId ),
 				isResolved: hasResolvedEntity,
 				isMissing: hasResolvedEntity && ! entityRecord,
 			};
@@ -72,7 +72,12 @@ export default function TemplatePartEdit( {
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing;
 
-	if ( ( slug && ! theme ) || ( slug && isMissing ) ) {
+	// We don't want to render a missing state if we have any inner blocks.
+	// A new template part is automatically created if we have any inner blocks but no entity.
+	if (
+		innerBlocks.length === 0 &&
+		( ( slug && ! theme ) || ( slug && isMissing ) )
+	) {
 		return (
 			<TagName { ...blockProps }>
 				<Warning>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -72,7 +72,7 @@ export default function TemplatePartEdit( {
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing;
 
-	if ( ( ! isPlaceholder && isMissing ) || ! templatePartId ) {
+	if ( ( slug && ! theme ) || ( slug && isMissing ) ) {
 		return (
 			<TagName { ...blockProps }>
 				<Warning>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -60,7 +60,7 @@ export default function TemplatePartEdit( {
 				: false;
 
 			return {
-				innerBlocks: getBlocks( clientId ),
+				innerBlocks: templatePartId ? getBlocks( clientId ) : [],
 				isResolved: hasResolvedEntity,
 				isMissing: hasResolvedEntity && ! entityRecord,
 			};
@@ -72,7 +72,7 @@ export default function TemplatePartEdit( {
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing;
 
-	if ( ! isPlaceholder && isMissing ) {
+	if ( ( ! isPlaceholder && isMissing ) || ! templatePartId ) {
 		return (
 			<TagName { ...blockProps }>
 				<Warning>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Template part block with undefined theme attribute caused the block to render itself.

## How has this been tested?
1. Create a `test` template part file in your theme (TT1 blocks) with the content below:
```html
<!-- wp:template-part {"slug":"header"} /-->
```
2. Open site editor
3. Add template part block
4. Choose existing, select the template part you just created: `test`
5. It should show the missing state

## Screenshots <!-- if applicable -->
| before | after |
| - | - |
| ![image](https://user-images.githubusercontent.com/2256104/108072148-d22be800-7066-11eb-9aa7-37d082419401.png) | ![image](https://user-images.githubusercontent.com/2256104/108072184-dc4de680-7066-11eb-8149-74be4fb29c2e.png) |


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
