### PR TITLE
Image options are not visible in pop up on clicking replace button from Image block

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -12,6 +12,11 @@ jobs:
       with:
         fetch-depth: 1
 
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+
     - uses: preactjs/compressed-size-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9887,12 +9887,6 @@
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
-				"caniuse-lite": {
-					"version": "1.0.30001124",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-					"integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
-					"dev": true
-				},
 				"chokidar": {
 					"version": "3.4.2",
 					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
@@ -14672,21 +14666,6 @@
 			"integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
 			"dev": true
 		},
-		"@types/archiver": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
-			"integrity": "sha512-baFOhanb/hxmcOd1Uey2TfFg43kTSmM6py1Eo7Rjbv/ivcl7PXLhY0QgXGf50Hx/eskGCFqPfhs/7IZLb15C5g==",
-			"dev": true,
-			"requires": {
-				"@types/glob": "*"
-			}
-		},
-		"@types/atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==",
-			"dev": true
-		},
 		"@types/babel-types": {
 			"version": "7.0.7",
 			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
@@ -14793,15 +14772,6 @@
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
 		},
-		"@types/fs-extra": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.4.tgz",
-			"integrity": "sha512-50GO5ez44lxK5MDH90DYHFFfqxH7+fTqEEnvguQRzJ/tY9qFrMSHLiYHite+F3SNmf7+LHC1eMXojuD+E3Qcyg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/glob": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -14905,33 +14875,6 @@
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
 			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
 			"dev": true
-		},
-		"@types/lodash.clonedeep": {
-			"version": "4.5.6",
-			"resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-			"integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-			"dev": true,
-			"requires": {
-				"@types/lodash": "*"
-			}
-		},
-		"@types/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
-			"dev": true,
-			"requires": {
-				"@types/lodash": "*"
-			}
-		},
-		"@types/lodash.merge": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-			"integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
-			"dev": true,
-			"requires": {
-				"@types/lodash": "*"
-			}
 		},
 		"@types/markdown-to-jsx": {
 			"version": "6.11.2",
@@ -15046,24 +14989,6 @@
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
 			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
-		},
-		"@types/puppeteer": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.0.tgz",
-			"integrity": "sha512-zTYDLjnHjgzokrwKt7N0rgn7oZPYo1J0m8Ghu+gXqzLCEn8RWbELa2uprE2UFJ0jU/Sk0x9jXXdOH/5QQLFHhQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/puppeteer-core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-2.0.0.tgz",
-			"integrity": "sha512-JvoEb7KgEkUet009ZDrtpUER3hheXoHgQByuYpJZ5WWT7LWwMH+0NTqGQXGgoOKzs+G5NA1T4DZwXK79Bhnejw==",
-			"dev": true,
-			"requires": {
-				"@types/puppeteer": "*"
-			}
 		},
 		"@types/q": {
 			"version": "1.5.2",
@@ -15315,12 +15240,6 @@
 					"dev": true
 				}
 			}
-		},
-		"@types/ua-parser-js": {
-			"version": "0.7.33",
-			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-			"integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
-			"dev": true
 		},
 		"@types/uglify-js": {
 			"version": "3.9.2",
@@ -19293,16 +19212,9 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
 					"integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"@dabh/diagnostics": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
-					"integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-					"requires": {
-						"colorspace": "1.1.x"
 					}
 				},
 				"@jimp/bmp": {
@@ -19405,15 +19317,6 @@
 						"core-js": "^3.4.1"
 					}
 				},
-				"@jimp/plugin-circle": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.10.3.tgz",
-					"integrity": "sha512-51GAPIVelqAcfuUpaM5JWJ0iWl4vEjNXB7p4P7SX5udugK5bxXUjO6KA2qgWmdpHuCKtoNgkzWU9fNSuYp7tCA==",
-					"requires": {
-						"@babel/runtime": "^7.7.2",
-						"core-js": "^3.4.1"
-					}
-				},
 				"@jimp/plugin-color": {
 					"version": "0.9.5",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.5.tgz",
@@ -19478,15 +19381,6 @@
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.9.5",
-						"core-js": "^3.4.1"
-					}
-				},
-				"@jimp/plugin-fisheye": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.10.3.tgz",
-					"integrity": "sha512-RRZb1wqe+xdocGcFtj2xHU7sF7xmEZmIa6BmrfSchjyA2b32TGPWKnP3qyj7p6LWEsXn+19hRYbjfyzyebPElQ==",
-					"requires": {
-						"@babel/runtime": "^7.7.2",
 						"core-js": "^3.4.1"
 					}
 				},
@@ -19590,24 +19484,6 @@
 						"core-js": "^3.4.1"
 					}
 				},
-				"@jimp/plugin-shadow": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.10.3.tgz",
-					"integrity": "sha512-/nkFXpt2zVcdP4ETdkAUL0fSzyrC5ZFxdcphbYBodqD7fXNqChS/Un1eD4xCXWEpW8cnG9dixZgQgStjywH0Mg==",
-					"requires": {
-						"@babel/runtime": "^7.7.2",
-						"core-js": "^3.4.1"
-					}
-				},
-				"@jimp/plugin-threshold": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.10.3.tgz",
-					"integrity": "sha512-Dzh0Yq2wXP2SOnxcbbiyA4LJ2luwrdf1MghNIt9H+NX7B+IWw/N8qA2GuSm9n4BPGSLluuhdAWJqHcTiREriVA==",
-					"requires": {
-						"@babel/runtime": "^7.7.2",
-						"core-js": "^3.4.1"
-					}
-				},
 				"@jimp/plugins": {
 					"version": "0.9.5",
 					"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.5.tgz",
@@ -19646,14 +19522,6 @@
 						"@jimp/utils": "^0.9.5",
 						"core-js": "^3.4.1",
 						"pngjs": "^3.3.3"
-					},
-					"dependencies": {
-						"pngjs": {
-							"version": "3.4.0",
-							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
-						}
 					}
 				},
 				"@jimp/tiff": {
@@ -19693,120 +19561,18 @@
 						"core-js": "^3.4.1"
 					}
 				},
-				"@sindresorhus/is": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.0.0.tgz",
-					"integrity": "sha512-kqA5I6Yun7PBHk8WN9BBP1c7FfN2SrD05GuVSEYPqDb4nerv7HqYfgBfMIKmT/EuejURkJKLZuLyGKGs6WEG9w==",
-					"dev": true
-				},
-				"@szmarczak/http-timer": {
-					"version": "4.0.5",
-					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-					"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
-					"dev": true,
-					"requires": {
-						"defer-to-connect": "^2.0.0"
-					}
-				},
-				"@types/cacheable-request": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-					"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
-					"dev": true,
-					"requires": {
-						"@types/http-cache-semantics": "*",
-						"@types/keyv": "*",
-						"@types/node": "*",
-						"@types/responselike": "*"
-					}
-				},
-				"@types/caseless": {
-					"version": "0.12.2",
-					"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-					"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-					"dev": true
-				},
 				"@types/color-name": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 					"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 					"dev": true
 				},
-				"@types/http-cache-semantics": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-					"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
-					"dev": true
-				},
-				"@types/keyv": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-					"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*"
-					}
-				},
 				"@types/node": {
 					"version": "13.9.0",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
-				},
-				"@types/request": {
-					"version": "2.48.5",
-					"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
-					"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==",
 					"dev": true,
-					"requires": {
-						"@types/caseless": "*",
-						"@types/node": "*",
-						"@types/tough-cookie": "*",
-						"form-data": "^2.5.0"
-					},
-					"dependencies": {
-						"form-data": {
-							"version": "2.5.1",
-							"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-							"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-							"dev": true,
-							"requires": {
-								"asynckit": "^0.4.0",
-								"combined-stream": "^1.0.6",
-								"mime-types": "^2.1.12"
-							}
-						}
-					}
-				},
-				"@types/responselike": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-					"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*"
-					}
-				},
-				"@types/tough-cookie": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-					"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
-					"dev": true
-				},
-				"@types/uuid": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-					"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
-					"dev": true
-				},
-				"@types/yauzl": {
-					"version": "2.9.1",
-					"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-					"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"@types/node": "*"
-					}
+					"optional": true
 				},
 				"@wdio/config": {
 					"version": "5.18.4",
@@ -19894,11 +19660,6 @@
 						"yauzl": "^2.7.0"
 					}
 				},
-				"agent-base": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
-				},
 				"aggregate-error": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -19919,14 +19680,6 @@
 						"fast-json-stable-stringify": "^2.0.0",
 						"json-schema-traverse": "^0.4.1",
 						"uri-js": "^4.2.2"
-					},
-					"dependencies": {
-						"fast-deep-equal": {
-							"version": "3.1.3",
-							"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-							"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-							"dev": true
-						}
 					}
 				},
 				"ansi-gray": {
@@ -20116,14 +19869,6 @@
 						"xmldom": "^0.1.19",
 						"xpath": "0.0.27",
 						"yargs": "^15.0.1"
-					},
-					"dependencies": {
-						"xmldom": {
-							"version": "0.1.31",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-							"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-							"dev": true
-						}
 					}
 				},
 				"appium-flutter-driver": {
@@ -20136,927 +19881,6 @@
 						"appium-uiautomator2-driver": "^1.35.1",
 						"appium-xcuitest-driver": "^3.0.0",
 						"rpc-websockets": "^4.5.1"
-					},
-					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							},
-							"dependencies": {
-								"mkdirp": {
-									"version": "0.5.5",
-									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-									"dev": true,
-									"requires": {
-										"minimist": "^1.2.5"
-									}
-								}
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.14.0"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"jpeg-js": "^0.4.0"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.14.0",
-								"@jimp/plugin-blur": "^0.14.0",
-								"@jimp/plugin-circle": "^0.14.0",
-								"@jimp/plugin-color": "^0.14.0",
-								"@jimp/plugin-contain": "^0.14.0",
-								"@jimp/plugin-cover": "^0.14.0",
-								"@jimp/plugin-crop": "^0.14.0",
-								"@jimp/plugin-displace": "^0.14.0",
-								"@jimp/plugin-dither": "^0.14.0",
-								"@jimp/plugin-fisheye": "^0.14.0",
-								"@jimp/plugin-flip": "^0.14.0",
-								"@jimp/plugin-gaussian": "^0.14.0",
-								"@jimp/plugin-invert": "^0.14.0",
-								"@jimp/plugin-mask": "^0.14.0",
-								"@jimp/plugin-normalize": "^0.14.0",
-								"@jimp/plugin-print": "^0.14.0",
-								"@jimp/plugin-resize": "^0.14.0",
-								"@jimp/plugin-rotate": "^0.14.0",
-								"@jimp/plugin-scale": "^0.14.0",
-								"@jimp/plugin-shadow": "^0.14.0",
-								"@jimp/plugin-threshold": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"pngjs": "^3.3.3"
-							},
-							"dependencies": {
-								"pngjs": {
-									"version": "3.4.0",
-									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-									"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-									"dev": true
-								}
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.14.0",
-								"@jimp/gif": "^0.14.0",
-								"@jimp/jpeg": "^0.14.0",
-								"@jimp/png": "^0.14.0",
-								"@jimp/tiff": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"@wdio/config": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.4.tgz",
-							"integrity": "sha512-M22EunI+n/mmYOQqb9+BTVRqrfmPw+7rR1AHeD36vOXCnZ55Nrl4ZU4d6QzPHp9cLdMZqV786iDmkonnb6jb8w==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "6.10.4",
-								"deepmerge": "^4.0.0",
-								"glob": "^7.1.2"
-							}
-						},
-						"@wdio/logger": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.4.tgz",
-							"integrity": "sha512-I+1I/5CtQigy59QJen56PHuwV0yiQdnZaOxmXIP6FzpWkeXLjcoUNaCRDuKwJx5GKrUSDqmGlMWSH53scwwzHg==",
-							"dev": true,
-							"requires": {
-								"chalk": "^4.0.0",
-								"loglevel": "^1.6.0",
-								"loglevel-plugin-prefix": "^0.8.4",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"@wdio/protocols": {
-							"version": "6.10.0",
-							"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.0.tgz",
-							"integrity": "sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==",
-							"dev": true
-						},
-						"@wdio/repl": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.10.4.tgz",
-							"integrity": "sha512-VwucPyUqAxU6CWWoEVf14asjtLGTgyaJwp47kEFegr06ZBG43zVQ6JqKFiGDxUJ+fZVRhdd7nRVHd+6UllK18w==",
-							"dev": true,
-							"requires": {
-								"@wdio/utils": "6.10.4"
-							}
-						},
-						"@wdio/utils": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.10.4.tgz",
-							"integrity": "sha512-DkFguYGKUcv9TmIYuuwS/pxpiGcgyv8gWUWRXffirt2OYpFXJNwB+S96CSQnjgb4B5MqSFgEti+gl8A2wsdDgQ==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "6.10.4"
-							}
-						},
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
-						"appium-base-driver": {
-							"version": "5.8.1",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-5.8.1.tgz",
-							"integrity": "sha512-k5ybExgP0kJx7vsR0Y8GeEay+Vr0yCs0muzYtdrIDbqOCz5bFX0skyZubSSsm/lOE4KvgHhm4cRwWJM0DlHvRA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-support": "^2.46.0",
-								"async-lock": "^1.0.0",
-								"asyncbox": "^2.3.1",
-								"axios": "^0.19.2",
-								"bluebird": "^3.5.3",
-								"body-parser": "^1.18.2",
-								"colors": "^1.1.2",
-								"es6-error": "^4.1.1",
-								"express": "^4.16.2",
-								"http-status-codes": "^1.3.0",
-								"lodash": "^4.0.0",
-								"lru-cache": "^5.0.0",
-								"method-override": "^3.0.0",
-								"morgan": "^1.9.0",
-								"request": "^2.88.2",
-								"request-promise": "^4.2.5",
-								"serve-favicon": "^2.4.5",
-								"source-map-support": "^0.5.5",
-								"validate.js": "^0.13.0",
-								"webdriverio": "^6.0.2",
-								"ws": "^7.0.0"
-							}
-						},
-						"appium-support": {
-							"version": "2.49.0",
-							"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
-							"integrity": "sha512-PtUsfpCjdGqZTTuRyH5U9iOGq9SpEVHg0H6/2HrazkX6ZvSQ+kIVYHTAGIXVeBJecfN9/syqgMmEekVgD15BGA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"archiver": "^5.0.0",
-								"axios": "^0.20.0",
-								"base64-stream": "^1.0.0",
-								"bluebird": "^3.5.1",
-								"bplist-creator": "^0",
-								"bplist-parser": "^0.2",
-								"form-data": "^3.0.0",
-								"get-stream": "^6.0.0",
-								"glob": "^7.1.2",
-								"jimp": "^0.14.0",
-								"jsftp": "^2.1.2",
-								"klaw": "^3.0.0",
-								"lockfile": "^1.0.4",
-								"lodash": "^4.2.1",
-								"mjpeg-server": "^0.3.0",
-								"mkdirp": "^1.0.0",
-								"moment": "^2.24.0",
-								"mv": "^2.1.1",
-								"ncp": "^2.0.0",
-								"npmlog": "^4.1.2",
-								"plist": "^3.0.1",
-								"pluralize": "^8.0.0",
-								"pngjs": "^5.0.0",
-								"rimraf": "^3.0.0",
-								"sanitize-filename": "^1.6.1",
-								"semver": "^7.0.0",
-								"shell-quote": "^1.7.2",
-								"source-map-support": "^0.5.5",
-								"teen_process": "^1.5.1",
-								"uuid": "^8.0.0",
-								"which": "^2.0.0",
-								"yauzl": "^2.7.0"
-							},
-							"dependencies": {
-								"axios": {
-									"version": "0.20.0",
-									"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-									"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-									"dev": true,
-									"requires": {
-										"follow-redirects": "^1.10.0"
-									}
-								}
-							}
-						},
-						"archiver": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
-							"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"async": "^3.2.0",
-								"buffer-crc32": "^0.2.1",
-								"readable-stream": "^3.6.0",
-								"readdir-glob": "^1.0.0",
-								"tar-stream": "^2.1.4",
-								"zip-stream": "^4.0.4"
-							}
-						},
-						"archiver-utils": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.4",
-								"graceful-fs": "^4.2.0",
-								"lazystream": "^1.0.0",
-								"lodash.defaults": "^4.2.0",
-								"lodash.difference": "^4.5.0",
-								"lodash.flatten": "^4.4.0",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.union": "^4.6.0",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.0.0"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
-							}
-						},
-						"async": {
-							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-							"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-							"dev": true
-						},
-						"bl": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-							"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-							"dev": true,
-							"requires": {
-								"buffer": "^5.5.0",
-								"inherits": "^2.0.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"chalk": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"compress-commons": {
-							"version": "4.0.2",
-							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-							"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
-							"dev": true,
-							"requires": {
-								"buffer-crc32": "^0.2.13",
-								"crc32-stream": "^4.0.1",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^3.6.0"
-							}
-						},
-						"crc32-stream": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
-							"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
-							"dev": true,
-							"requires": {
-								"crc-32": "^1.2.0",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"devtools": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.10.4.tgz",
-							"integrity": "sha512-53LoeU2S4q4cLJGKgo2Or7WU9Kc5RQscC0DbBAZcodkot1lKFbMg/z6/cQTq+XKl4kgYr5VA/s5kzNU7ScBctQ==",
-							"dev": true,
-							"requires": {
-								"@types/puppeteer-core": "^2.0.0",
-								"@types/ua-parser-js": "^0.7.33",
-								"@types/uuid": "^8.3.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"chrome-launcher": "^0.13.1",
-								"edge-paths": "^2.1.0",
-								"puppeteer-core": "^5.1.0",
-								"ua-parser-js": "^0.7.21",
-								"uuid": "^8.0.0"
-							},
-							"dependencies": {
-								"@types/uuid": {
-									"version": "8.3.0",
-									"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-									"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
-									"dev": true
-								}
-							}
-						},
-						"extract-zip": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-							"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-							"dev": true,
-							"requires": {
-								"@types/yauzl": "^2.9.1",
-								"debug": "^4.1.1",
-								"get-stream": "^5.1.0",
-								"yauzl": "^2.10.0"
-							},
-							"dependencies": {
-								"get-stream": {
-									"version": "5.2.0",
-									"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-									"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-									"dev": true,
-									"requires": {
-										"pump": "^3.0.0"
-									}
-								}
-							}
-						},
-						"fast-deep-equal": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-							"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-							"dev": true
-						},
-						"follow-redirects": {
-							"version": "1.13.0",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-							"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-							"dev": true
-						},
-						"form-data": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-							"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-							"dev": true,
-							"requires": {
-								"asynckit": "^0.4.0",
-								"combined-stream": "^1.0.8",
-								"mime-types": "^2.1.12"
-							}
-						},
-						"get-stream": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-							"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-							"dev": true
-						},
-						"jimp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/custom": "^0.14.0",
-								"@jimp/plugins": "^0.14.0",
-								"@jimp/types": "^0.14.0",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"jpeg-js": {
-							"version": "0.4.2",
-							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-							"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
-							"dev": true
-						},
-						"minimist": {
-							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-							"dev": true
-						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-							"dev": true
-						},
-						"pngjs": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-							"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-							"dev": true
-						},
-						"puppeteer-core": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-							"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-							"dev": true,
-							"requires": {
-								"debug": "^4.1.0",
-								"devtools-protocol": "0.0.818844",
-								"extract-zip": "^2.0.0",
-								"https-proxy-agent": "^4.0.0",
-								"node-fetch": "^2.6.1",
-								"pkg-dir": "^4.2.0",
-								"progress": "^2.0.1",
-								"proxy-from-env": "^1.0.0",
-								"rimraf": "^3.0.2",
-								"tar-fs": "^2.0.0",
-								"unbzip2-stream": "^1.3.3",
-								"ws": "^7.2.3"
-							},
-							"dependencies": {
-								"pkg-dir": {
-									"version": "4.2.0",
-									"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-									"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-									"dev": true,
-									"requires": {
-										"find-up": "^4.0.0"
-									}
-								}
-							}
-						},
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						},
-						"resq": {
-							"version": "1.10.0",
-							"resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
-							"integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
-							"dev": true,
-							"requires": {
-								"fast-deep-equal": "^2.0.1"
-							}
-						},
-						"rgb2hex": {
-							"version": "0.2.3",
-							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
-							"integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
-							"dev": true
-						},
-						"serialize-error": {
-							"version": "7.0.1",
-							"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-							"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-							"dev": true,
-							"requires": {
-								"type-fest": "^0.13.1"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						},
-						"tar-stream": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-							"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-							"dev": true,
-							"requires": {
-								"bl": "^4.0.3",
-								"end-of-stream": "^1.4.1",
-								"fs-constants": "^1.0.0",
-								"inherits": "^2.0.3",
-								"readable-stream": "^3.1.1"
-							}
-						},
-						"type-fest": {
-							"version": "0.13.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-							"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-							"dev": true
-						},
-						"uuid": {
-							"version": "8.3.1",
-							"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-							"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-							"dev": true
-						},
-						"webdriver": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.10.4.tgz",
-							"integrity": "sha512-N2FkEy22QWAJMeyz1219ik9wyt3/SOT/RtsY6JheEriZ1GptzZyK0OibkOnCoaIAt+nvSxnSmTTlmXQMGBE6Mw==",
-							"dev": true,
-							"requires": {
-								"@types/lodash.merge": "^4.6.6",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"got": "^11.0.2",
-								"lodash.merge": "^4.6.1"
-							}
-						},
-						"webdriverio": {
-							"version": "6.10.5",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.10.5.tgz",
-							"integrity": "sha512-TLIKVOOM0Oszn2mLxZcMQk0vq1bOWpsZNXMxMtpBXKLvcOCLedftxotwh0o1LqRiq8ODiubJ/vNOLgCN/oLFJQ==",
-							"dev": true,
-							"requires": {
-								"@types/archiver": "^5.1.0",
-								"@types/atob": "^2.1.2",
-								"@types/fs-extra": "^9.0.2",
-								"@types/lodash.clonedeep": "^4.5.6",
-								"@types/lodash.isplainobject": "^4.0.6",
-								"@types/puppeteer-core": "^2.0.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/repl": "6.10.4",
-								"@wdio/utils": "6.10.4",
-								"archiver": "^5.0.0",
-								"atob": "^2.1.2",
-								"css-shorthand-properties": "^1.1.1",
-								"css-value": "^0.0.1",
-								"devtools": "6.10.4",
-								"fs-extra": "^9.0.1",
-								"get-port": "^5.1.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"minimatch": "^3.0.4",
-								"puppeteer-core": "^5.1.0",
-								"resq": "^1.9.1",
-								"rgb2hex": "^0.2.0",
-								"serialize-error": "^7.0.0",
-								"webdriver": "6.10.4"
-							},
-							"dependencies": {
-								"@types/archiver": {
-									"version": "5.1.0",
-									"resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
-									"integrity": "sha512-baFOhanb/hxmcOd1Uey2TfFg43kTSmM6py1Eo7Rjbv/ivcl7PXLhY0QgXGf50Hx/eskGCFqPfhs/7IZLb15C5g==",
-									"dev": true,
-									"requires": {
-										"@types/glob": "*"
-									}
-								},
-								"atob": {
-									"version": "2.1.2",
-									"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-									"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-									"dev": true
-								},
-								"fs-extra": {
-									"version": "9.0.1",
-									"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-									"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-									"dev": true,
-									"requires": {
-										"at-least-node": "^1.0.0",
-										"graceful-fs": "^4.2.0",
-										"jsonfile": "^6.0.1",
-										"universalify": "^1.0.0"
-									}
-								},
-								"get-port": {
-									"version": "5.1.1",
-									"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-									"integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-									"dev": true
-								}
-							}
-						},
-						"zip-stream": {
-							"version": "4.0.4",
-							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-							"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"compress-commons": "^4.0.2",
-								"readable-stream": "^3.6.0"
-							}
-						}
 					}
 				},
 				"appium-idb": {
@@ -21075,369 +19899,6 @@
 						"teen_process": "^1.11.0"
 					},
 					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							},
-							"dependencies": {
-								"mkdirp": {
-									"version": "0.5.5",
-									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-									"dev": true,
-									"requires": {
-										"minimist": "^1.2.5"
-									}
-								}
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.14.0"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"jpeg-js": "^0.4.0"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.14.0",
-								"@jimp/plugin-blur": "^0.14.0",
-								"@jimp/plugin-circle": "^0.14.0",
-								"@jimp/plugin-color": "^0.14.0",
-								"@jimp/plugin-contain": "^0.14.0",
-								"@jimp/plugin-cover": "^0.14.0",
-								"@jimp/plugin-crop": "^0.14.0",
-								"@jimp/plugin-displace": "^0.14.0",
-								"@jimp/plugin-dither": "^0.14.0",
-								"@jimp/plugin-fisheye": "^0.14.0",
-								"@jimp/plugin-flip": "^0.14.0",
-								"@jimp/plugin-gaussian": "^0.14.0",
-								"@jimp/plugin-invert": "^0.14.0",
-								"@jimp/plugin-mask": "^0.14.0",
-								"@jimp/plugin-normalize": "^0.14.0",
-								"@jimp/plugin-print": "^0.14.0",
-								"@jimp/plugin-resize": "^0.14.0",
-								"@jimp/plugin-rotate": "^0.14.0",
-								"@jimp/plugin-scale": "^0.14.0",
-								"@jimp/plugin-shadow": "^0.14.0",
-								"@jimp/plugin-threshold": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"pngjs": "^3.3.3"
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.14.0",
-								"@jimp/gif": "^0.14.0",
-								"@jimp/jpeg": "^0.14.0",
-								"@jimp/png": "^0.14.0",
-								"@jimp/tiff": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
 						"appium-support": {
 							"version": "2.49.0",
 							"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
@@ -21479,11 +19940,14 @@
 								"yauzl": "^2.7.0"
 							},
 							"dependencies": {
-								"pngjs": {
-									"version": "5.0.0",
-									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-									"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-									"dev": true
+								"lockfile": {
+									"version": "1.0.4",
+									"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+									"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+									"dev": true,
+									"requires": {
+										"signal-exit": "^3.0.2"
+									}
 								}
 							}
 						},
@@ -21537,21 +20001,6 @@
 								}
 							}
 						},
-						"async": {
-							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-							"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-							"dev": true
-						},
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
-							}
-						},
 						"bl": {
 							"version": "4.0.3",
 							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -21573,6 +20022,23 @@
 								"crc32-stream": "^4.0.1",
 								"normalize-path": "^3.0.0",
 								"readable-stream": "^3.6.0"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
 							}
 						},
 						"crc32-stream": {
@@ -21585,16 +20051,10 @@
 								"readable-stream": "^3.4.0"
 							}
 						},
-						"follow-redirects": {
-							"version": "1.13.0",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-							"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-							"dev": true
-						},
 						"form-data": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-							"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+							"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
 							"dev": true,
 							"requires": {
 								"asynckit": "^0.4.0",
@@ -21606,31 +20066,6 @@
 							"version": "6.0.0",
 							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
 							"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-							"dev": true
-						},
-						"jimp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/custom": "^0.14.0",
-								"@jimp/plugins": "^0.14.0",
-								"@jimp/types": "^0.14.0",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"jpeg-js": {
-							"version": "0.4.2",
-							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-							"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
-							"dev": true
-						},
-						"minimist": {
-							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 							"dev": true
 						},
 						"normalize-path": {
@@ -21731,60 +20166,6 @@
 						"yargs": "^15.0.1"
 					},
 					"dependencies": {
-						"@wdio/config": {
-							"version": "5.22.4",
-							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-5.22.4.tgz",
-							"integrity": "sha512-i5dJQWb80darcRA//tfG0guMeQCeRUXroZNnHjGNb1qzvTRZmcIIhdxaD+DbK/5dWEx6aoMfoi6wjVp/CXwdAg==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "5.16.10",
-								"deepmerge": "^4.0.0",
-								"glob": "^7.1.2"
-							}
-						},
-						"@wdio/logger": {
-							"version": "5.16.10",
-							"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-5.16.10.tgz",
-							"integrity": "sha512-hRKhxgd9uB48Dtj2xe2ckxU4KwI/RO8IwguySuaI2SLFj6EDbdonwzpVkq111/fjBuq7R1NauAaNcm3AMEbIFA==",
-							"dev": true,
-							"requires": {
-								"chalk": "^3.0.0",
-								"loglevel": "^1.6.0",
-								"loglevel-plugin-prefix": "^0.8.4",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"@wdio/protocols": {
-							"version": "5.22.1",
-							"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-5.22.1.tgz",
-							"integrity": "sha512-GdoWb/HTrb09Qb0S/7sLp1NU94LAhTsF1NnFj5sEFSUpecrl0S07pnhVg54pUImectN/woaqSl7uJGjlSGZcdQ==",
-							"dev": true
-						},
-						"@wdio/repl": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-5.23.0.tgz",
-							"integrity": "sha512-cKG9m0XuqcQenQmoup0yJX1fkDQEdY06QXuwt636ZQf6XgDoeoAdNOgnRnNruQ0+JsC2eqHFoSNto1q8wcLH/g==",
-							"dev": true,
-							"requires": {
-								"@wdio/utils": "5.23.0"
-							}
-						},
-						"@wdio/utils": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-5.23.0.tgz",
-							"integrity": "sha512-dWPEkDiaNUqJXPO6L2di2apI7Rle7Er4euh67Wlb5+3MrPNjCKhiF8gHcpQeL8oe6A1MH/f89kpSEEXe4BMkAw==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "5.16.10",
-								"deepmerge": "^4.0.0"
-							}
-						},
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
 						"appium-remote-debugger": {
 							"version": "4.5.0",
 							"resolved": "https://registry.npmjs.org/appium-remote-debugger/-/appium-remote-debugger-4.5.0.tgz",
@@ -21838,125 +20219,6 @@
 								}
 							}
 						},
-						"archiver": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-							"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"async": "^2.6.3",
-								"buffer-crc32": "^0.2.1",
-								"glob": "^7.1.4",
-								"readable-stream": "^3.4.0",
-								"tar-stream": "^2.1.0",
-								"zip-stream": "^2.1.2"
-							}
-						},
-						"archiver-utils": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.4",
-								"graceful-fs": "^4.2.0",
-								"lazystream": "^1.0.0",
-								"lodash.defaults": "^4.2.0",
-								"lodash.difference": "^4.5.0",
-								"lodash.flatten": "^4.4.0",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.union": "^4.6.0",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.0.0"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
-							}
-						},
-						"async": {
-							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-							"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.14"
-							}
-						},
-						"bl": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-							"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-							"dev": true,
-							"requires": {
-								"buffer": "^5.5.0",
-								"inherits": "^2.0.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"compress-commons": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-							"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
-							"dev": true,
-							"requires": {
-								"buffer-crc32": "^0.2.13",
-								"crc32-stream": "^3.0.1",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.3.6"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
-							}
-						},
-						"crc32-stream": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-							"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
-							"dev": true,
-							"requires": {
-								"crc": "^3.4.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
 						"node-simctl": {
 							"version": "5.3.0",
 							"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-5.3.0.tgz",
@@ -21973,104 +20235,6 @@
 								"teen_process": "^1.5.1"
 							}
 						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-							"dev": true
-						},
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						},
-						"rgb2hex": {
-							"version": "0.1.10",
-							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.10.tgz",
-							"integrity": "sha512-vKz+kzolWbL3rke/xeTE2+6vHmZnNxGyDnaVW4OckntAIcc7DcZzWkQSfxMDwqHS8vhgySnIFyBUH7lIk6PxvQ==",
-							"dev": true
-						},
-						"serialize-error": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
-							"integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
-							"dev": true,
-							"requires": {
-								"type-fest": "^0.8.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						},
-						"tar-stream": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-							"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-							"dev": true,
-							"requires": {
-								"bl": "^4.0.3",
-								"end-of-stream": "^1.4.1",
-								"fs-constants": "^1.0.0",
-								"inherits": "^2.0.3",
-								"readable-stream": "^3.1.1"
-							}
-						},
-						"type-fest": {
-							"version": "0.8.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-							"dev": true
-						},
-						"webdriver": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-5.23.0.tgz",
-							"integrity": "sha512-r7IrbZ2SuTIRyWV8mv4a4hZoFcT9Qt4MznOkdRWPE1sPpZ8lyLZsIEjKCEbHelOzPwURqk+biwGrm4z2OZRAiw==",
-							"dev": true,
-							"requires": {
-								"@types/request": "^2.48.4",
-								"@wdio/config": "5.22.4",
-								"@wdio/logger": "5.16.10",
-								"@wdio/protocols": "5.22.1",
-								"@wdio/utils": "5.23.0",
-								"lodash.merge": "^4.6.1",
-								"request": "^2.83.0"
-							}
-						},
-						"webdriverio": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-5.23.0.tgz",
-							"integrity": "sha512-hxt6Nuu2bBrTsVk7GfoFRTh63l4fRVXlK9U30RtPbHoWO5tcFdyUz2UTgeHEZ54ea1DQEVPfsgFiLnJULkWp1Q==",
-							"dev": true,
-							"requires": {
-								"@wdio/config": "5.22.4",
-								"@wdio/logger": "5.16.10",
-								"@wdio/repl": "5.23.0",
-								"@wdio/utils": "5.23.0",
-								"archiver": "^3.0.0",
-								"css-value": "^0.0.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"resq": "^1.6.0",
-								"rgb2hex": "^0.1.0",
-								"serialize-error": "^5.0.0",
-								"webdriver": "5.23.0"
-							}
-						},
 						"xmldom": {
 							"version": "0.2.1",
 							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.2.1.tgz",
@@ -22082,17 +20246,6 @@
 							"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.24.tgz",
 							"integrity": "sha1-Gt4WLhzFI8jTn8fQavwW6iFvKfs=",
 							"dev": true
-						},
-						"zip-stream": {
-							"version": "2.1.3",
-							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
-							"integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"compress-commons": "^2.1.1",
-								"readable-stream": "^3.4.0"
-							}
 						}
 					}
 				},
@@ -22133,931 +20286,6 @@
 						"source-map-support": "^0.5.5",
 						"teen_process": "^1.15.0",
 						"yargs": "^15.0.1"
-					},
-					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							},
-							"dependencies": {
-								"mkdirp": {
-									"version": "0.5.5",
-									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-									"dev": true,
-									"requires": {
-										"minimist": "^1.2.5"
-									}
-								}
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.14.0"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"jpeg-js": "^0.4.0"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.14.0",
-								"@jimp/plugin-blur": "^0.14.0",
-								"@jimp/plugin-circle": "^0.14.0",
-								"@jimp/plugin-color": "^0.14.0",
-								"@jimp/plugin-contain": "^0.14.0",
-								"@jimp/plugin-cover": "^0.14.0",
-								"@jimp/plugin-crop": "^0.14.0",
-								"@jimp/plugin-displace": "^0.14.0",
-								"@jimp/plugin-dither": "^0.14.0",
-								"@jimp/plugin-fisheye": "^0.14.0",
-								"@jimp/plugin-flip": "^0.14.0",
-								"@jimp/plugin-gaussian": "^0.14.0",
-								"@jimp/plugin-invert": "^0.14.0",
-								"@jimp/plugin-mask": "^0.14.0",
-								"@jimp/plugin-normalize": "^0.14.0",
-								"@jimp/plugin-print": "^0.14.0",
-								"@jimp/plugin-resize": "^0.14.0",
-								"@jimp/plugin-rotate": "^0.14.0",
-								"@jimp/plugin-scale": "^0.14.0",
-								"@jimp/plugin-shadow": "^0.14.0",
-								"@jimp/plugin-threshold": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"pngjs": "^3.3.3"
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.14.0",
-								"@jimp/gif": "^0.14.0",
-								"@jimp/jpeg": "^0.14.0",
-								"@jimp/png": "^0.14.0",
-								"@jimp/tiff": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"@wdio/config": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.4.tgz",
-							"integrity": "sha512-M22EunI+n/mmYOQqb9+BTVRqrfmPw+7rR1AHeD36vOXCnZ55Nrl4ZU4d6QzPHp9cLdMZqV786iDmkonnb6jb8w==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "6.10.4",
-								"deepmerge": "^4.0.0",
-								"glob": "^7.1.2"
-							}
-						},
-						"@wdio/logger": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.4.tgz",
-							"integrity": "sha512-I+1I/5CtQigy59QJen56PHuwV0yiQdnZaOxmXIP6FzpWkeXLjcoUNaCRDuKwJx5GKrUSDqmGlMWSH53scwwzHg==",
-							"dev": true,
-							"requires": {
-								"chalk": "^4.0.0",
-								"loglevel": "^1.6.0",
-								"loglevel-plugin-prefix": "^0.8.4",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"@wdio/protocols": {
-							"version": "6.10.0",
-							"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.0.tgz",
-							"integrity": "sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==",
-							"dev": true
-						},
-						"@wdio/repl": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.10.4.tgz",
-							"integrity": "sha512-VwucPyUqAxU6CWWoEVf14asjtLGTgyaJwp47kEFegr06ZBG43zVQ6JqKFiGDxUJ+fZVRhdd7nRVHd+6UllK18w==",
-							"dev": true,
-							"requires": {
-								"@wdio/utils": "6.10.4"
-							}
-						},
-						"@wdio/utils": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.10.4.tgz",
-							"integrity": "sha512-DkFguYGKUcv9TmIYuuwS/pxpiGcgyv8gWUWRXffirt2OYpFXJNwB+S96CSQnjgb4B5MqSFgEti+gl8A2wsdDgQ==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "6.10.4"
-							}
-						},
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
-						"appium-base-driver": {
-							"version": "5.8.1",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-5.8.1.tgz",
-							"integrity": "sha512-k5ybExgP0kJx7vsR0Y8GeEay+Vr0yCs0muzYtdrIDbqOCz5bFX0skyZubSSsm/lOE4KvgHhm4cRwWJM0DlHvRA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-support": "^2.46.0",
-								"async-lock": "^1.0.0",
-								"asyncbox": "^2.3.1",
-								"axios": "^0.19.2",
-								"bluebird": "^3.5.3",
-								"body-parser": "^1.18.2",
-								"colors": "^1.1.2",
-								"es6-error": "^4.1.1",
-								"express": "^4.16.2",
-								"http-status-codes": "^1.3.0",
-								"lodash": "^4.0.0",
-								"lru-cache": "^5.0.0",
-								"method-override": "^3.0.0",
-								"morgan": "^1.9.0",
-								"request": "^2.88.2",
-								"request-promise": "^4.2.5",
-								"serve-favicon": "^2.4.5",
-								"source-map-support": "^0.5.5",
-								"validate.js": "^0.13.0",
-								"webdriverio": "^6.0.2",
-								"ws": "^7.0.0"
-							},
-							"dependencies": {
-								"appium-support": {
-									"version": "2.49.0",
-									"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
-									"integrity": "sha512-PtUsfpCjdGqZTTuRyH5U9iOGq9SpEVHg0H6/2HrazkX6ZvSQ+kIVYHTAGIXVeBJecfN9/syqgMmEekVgD15BGA==",
-									"dev": true,
-									"requires": {
-										"@babel/runtime": "^7.0.0",
-										"archiver": "^5.0.0",
-										"axios": "^0.20.0",
-										"base64-stream": "^1.0.0",
-										"bluebird": "^3.5.1",
-										"bplist-creator": "^0",
-										"bplist-parser": "^0.2",
-										"form-data": "^3.0.0",
-										"get-stream": "^6.0.0",
-										"glob": "^7.1.2",
-										"jimp": "^0.14.0",
-										"jsftp": "^2.1.2",
-										"klaw": "^3.0.0",
-										"lockfile": "^1.0.4",
-										"lodash": "^4.2.1",
-										"mjpeg-server": "^0.3.0",
-										"mkdirp": "^1.0.0",
-										"moment": "^2.24.0",
-										"mv": "^2.1.1",
-										"ncp": "^2.0.0",
-										"npmlog": "^4.1.2",
-										"plist": "^3.0.1",
-										"pluralize": "^8.0.0",
-										"pngjs": "^5.0.0",
-										"rimraf": "^3.0.0",
-										"sanitize-filename": "^1.6.1",
-										"semver": "^7.0.0",
-										"shell-quote": "^1.7.2",
-										"source-map-support": "^0.5.5",
-										"teen_process": "^1.5.1",
-										"uuid": "^8.0.0",
-										"which": "^2.0.0",
-										"yauzl": "^2.7.0"
-									},
-									"dependencies": {
-										"archiver": {
-											"version": "5.1.0",
-											"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
-											"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
-											"dev": true,
-											"requires": {
-												"archiver-utils": "^2.1.0",
-												"async": "^3.2.0",
-												"buffer-crc32": "^0.2.1",
-												"readable-stream": "^3.6.0",
-												"readdir-glob": "^1.0.0",
-												"tar-stream": "^2.1.4",
-												"zip-stream": "^4.0.4"
-											}
-										},
-										"axios": {
-											"version": "0.20.0",
-											"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-											"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-											"dev": true,
-											"requires": {
-												"follow-redirects": "^1.10.0"
-											}
-										},
-										"follow-redirects": {
-											"version": "1.13.0",
-											"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-											"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-											"dev": true
-										},
-										"form-data": {
-											"version": "3.0.0",
-											"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-											"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-											"dev": true,
-											"requires": {
-												"asynckit": "^0.4.0",
-												"combined-stream": "^1.0.8",
-												"mime-types": "^2.1.12"
-											}
-										},
-										"get-stream": {
-											"version": "6.0.0",
-											"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-											"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-											"dev": true
-										},
-										"jimp": {
-											"version": "0.14.0",
-											"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-											"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
-											"dev": true,
-											"requires": {
-												"@babel/runtime": "^7.7.2",
-												"@jimp/custom": "^0.14.0",
-												"@jimp/plugins": "^0.14.0",
-												"@jimp/types": "^0.14.0",
-												"regenerator-runtime": "^0.13.3"
-											}
-										},
-										"pngjs": {
-											"version": "5.0.0",
-											"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-											"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-											"dev": true
-										},
-										"uuid": {
-											"version": "8.3.1",
-											"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-											"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-											"dev": true
-										}
-									}
-								}
-							}
-						},
-						"archiver": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
-							"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"async": "^3.2.0",
-								"buffer-crc32": "^0.2.1",
-								"readable-stream": "^3.6.0",
-								"readdir-glob": "^1.0.0",
-								"tar-stream": "^2.1.4",
-								"zip-stream": "^4.0.4"
-							}
-						},
-						"archiver-utils": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.4",
-								"graceful-fs": "^4.2.0",
-								"lazystream": "^1.0.0",
-								"lodash.defaults": "^4.2.0",
-								"lodash.difference": "^4.5.0",
-								"lodash.flatten": "^4.4.0",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.union": "^4.6.0",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.0.0"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
-							}
-						},
-						"async": {
-							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-							"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-							"dev": true
-						},
-						"bl": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-							"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-							"dev": true,
-							"requires": {
-								"buffer": "^5.5.0",
-								"inherits": "^2.0.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"chalk": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"compress-commons": {
-							"version": "4.0.2",
-							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-							"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
-							"dev": true,
-							"requires": {
-								"buffer-crc32": "^0.2.13",
-								"crc32-stream": "^4.0.1",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^3.6.0"
-							}
-						},
-						"crc32-stream": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
-							"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
-							"dev": true,
-							"requires": {
-								"crc-32": "^1.2.0",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"devtools": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.10.4.tgz",
-							"integrity": "sha512-53LoeU2S4q4cLJGKgo2Or7WU9Kc5RQscC0DbBAZcodkot1lKFbMg/z6/cQTq+XKl4kgYr5VA/s5kzNU7ScBctQ==",
-							"dev": true,
-							"requires": {
-								"@types/puppeteer-core": "^2.0.0",
-								"@types/ua-parser-js": "^0.7.33",
-								"@types/uuid": "^8.3.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"chrome-launcher": "^0.13.1",
-								"edge-paths": "^2.1.0",
-								"puppeteer-core": "^5.1.0",
-								"ua-parser-js": "^0.7.21",
-								"uuid": "^8.0.0"
-							},
-							"dependencies": {
-								"@types/uuid": {
-									"version": "8.3.0",
-									"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-									"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
-									"dev": true
-								}
-							}
-						},
-						"extract-zip": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-							"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-							"dev": true,
-							"requires": {
-								"@types/yauzl": "^2.9.1",
-								"debug": "^4.1.1",
-								"get-stream": "^5.1.0",
-								"yauzl": "^2.10.0"
-							}
-						},
-						"fast-deep-equal": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-							"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-							"dev": true
-						},
-						"jpeg-js": {
-							"version": "0.4.2",
-							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-							"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
-							"dev": true
-						},
-						"minimist": {
-							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-							"dev": true
-						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-							"dev": true
-						},
-						"puppeteer-core": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-							"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-							"dev": true,
-							"requires": {
-								"debug": "^4.1.0",
-								"devtools-protocol": "0.0.818844",
-								"extract-zip": "^2.0.0",
-								"https-proxy-agent": "^4.0.0",
-								"node-fetch": "^2.6.1",
-								"pkg-dir": "^4.2.0",
-								"progress": "^2.0.1",
-								"proxy-from-env": "^1.0.0",
-								"rimraf": "^3.0.2",
-								"tar-fs": "^2.0.0",
-								"unbzip2-stream": "^1.3.3",
-								"ws": "^7.2.3"
-							},
-							"dependencies": {
-								"pkg-dir": {
-									"version": "4.2.0",
-									"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-									"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-									"dev": true,
-									"requires": {
-										"find-up": "^4.0.0"
-									}
-								}
-							}
-						},
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						},
-						"resq": {
-							"version": "1.10.0",
-							"resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
-							"integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
-							"dev": true,
-							"requires": {
-								"fast-deep-equal": "^2.0.1"
-							}
-						},
-						"rgb2hex": {
-							"version": "0.2.3",
-							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
-							"integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
-							"dev": true
-						},
-						"serialize-error": {
-							"version": "7.0.1",
-							"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-							"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-							"dev": true,
-							"requires": {
-								"type-fest": "^0.13.1"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						},
-						"tar-stream": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-							"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-							"dev": true,
-							"requires": {
-								"bl": "^4.0.3",
-								"end-of-stream": "^1.4.1",
-								"fs-constants": "^1.0.0",
-								"inherits": "^2.0.3",
-								"readable-stream": "^3.1.1"
-							}
-						},
-						"type-fest": {
-							"version": "0.13.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-							"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-							"dev": true
-						},
-						"uuid": {
-							"version": "8.3.1",
-							"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-							"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-							"dev": true
-						},
-						"webdriver": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.10.4.tgz",
-							"integrity": "sha512-N2FkEy22QWAJMeyz1219ik9wyt3/SOT/RtsY6JheEriZ1GptzZyK0OibkOnCoaIAt+nvSxnSmTTlmXQMGBE6Mw==",
-							"dev": true,
-							"requires": {
-								"@types/lodash.merge": "^4.6.6",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"got": "^11.0.2",
-								"lodash.merge": "^4.6.1"
-							}
-						},
-						"webdriverio": {
-							"version": "6.10.5",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.10.5.tgz",
-							"integrity": "sha512-TLIKVOOM0Oszn2mLxZcMQk0vq1bOWpsZNXMxMtpBXKLvcOCLedftxotwh0o1LqRiq8ODiubJ/vNOLgCN/oLFJQ==",
-							"dev": true,
-							"requires": {
-								"@types/archiver": "^5.1.0",
-								"@types/atob": "^2.1.2",
-								"@types/fs-extra": "^9.0.2",
-								"@types/lodash.clonedeep": "^4.5.6",
-								"@types/lodash.isplainobject": "^4.0.6",
-								"@types/puppeteer-core": "^2.0.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/repl": "6.10.4",
-								"@wdio/utils": "6.10.4",
-								"archiver": "^5.0.0",
-								"atob": "^2.1.2",
-								"css-shorthand-properties": "^1.1.1",
-								"css-value": "^0.0.1",
-								"devtools": "6.10.4",
-								"fs-extra": "^9.0.1",
-								"get-port": "^5.1.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"minimatch": "^3.0.4",
-								"puppeteer-core": "^5.1.0",
-								"resq": "^1.9.1",
-								"rgb2hex": "^0.2.0",
-								"serialize-error": "^7.0.0",
-								"webdriver": "6.10.4"
-							},
-							"dependencies": {
-								"@types/archiver": {
-									"version": "5.1.0",
-									"resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
-									"integrity": "sha512-baFOhanb/hxmcOd1Uey2TfFg43kTSmM6py1Eo7Rjbv/ivcl7PXLhY0QgXGf50Hx/eskGCFqPfhs/7IZLb15C5g==",
-									"dev": true,
-									"requires": {
-										"@types/glob": "*"
-									}
-								},
-								"atob": {
-									"version": "2.1.2",
-									"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-									"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-									"dev": true
-								},
-								"fs-extra": {
-									"version": "9.0.1",
-									"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-									"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-									"dev": true,
-									"requires": {
-										"at-least-node": "^1.0.0",
-										"graceful-fs": "^4.2.0",
-										"jsonfile": "^6.0.1",
-										"universalify": "^1.0.0"
-									}
-								},
-								"get-port": {
-									"version": "5.1.1",
-									"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-									"integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-									"dev": true
-								}
-							}
-						},
-						"zip-stream": {
-							"version": "4.0.4",
-							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-							"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"compress-commons": "^4.0.2",
-								"readable-stream": "^3.6.0"
-							}
-						}
 					}
 				},
 				"appium-remote-debugger": {
@@ -23077,481 +20305,6 @@
 						"source-map-support": "^0.5.5"
 					},
 					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							},
-							"dependencies": {
-								"mkdirp": {
-									"version": "0.5.5",
-									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-									"dev": true,
-									"requires": {
-										"minimist": "^1.2.5"
-									}
-								}
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.14.0"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"jpeg-js": "^0.4.0"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.14.0",
-								"@jimp/plugin-blur": "^0.14.0",
-								"@jimp/plugin-circle": "^0.14.0",
-								"@jimp/plugin-color": "^0.14.0",
-								"@jimp/plugin-contain": "^0.14.0",
-								"@jimp/plugin-cover": "^0.14.0",
-								"@jimp/plugin-crop": "^0.14.0",
-								"@jimp/plugin-displace": "^0.14.0",
-								"@jimp/plugin-dither": "^0.14.0",
-								"@jimp/plugin-fisheye": "^0.14.0",
-								"@jimp/plugin-flip": "^0.14.0",
-								"@jimp/plugin-gaussian": "^0.14.0",
-								"@jimp/plugin-invert": "^0.14.0",
-								"@jimp/plugin-mask": "^0.14.0",
-								"@jimp/plugin-normalize": "^0.14.0",
-								"@jimp/plugin-print": "^0.14.0",
-								"@jimp/plugin-resize": "^0.14.0",
-								"@jimp/plugin-rotate": "^0.14.0",
-								"@jimp/plugin-scale": "^0.14.0",
-								"@jimp/plugin-shadow": "^0.14.0",
-								"@jimp/plugin-threshold": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"pngjs": "^3.3.3"
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.14.0",
-								"@jimp/gif": "^0.14.0",
-								"@jimp/jpeg": "^0.14.0",
-								"@jimp/png": "^0.14.0",
-								"@jimp/tiff": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"@wdio/config": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.4.tgz",
-							"integrity": "sha512-M22EunI+n/mmYOQqb9+BTVRqrfmPw+7rR1AHeD36vOXCnZ55Nrl4ZU4d6QzPHp9cLdMZqV786iDmkonnb6jb8w==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "6.10.4",
-								"deepmerge": "^4.0.0",
-								"glob": "^7.1.2"
-							}
-						},
-						"@wdio/logger": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.4.tgz",
-							"integrity": "sha512-I+1I/5CtQigy59QJen56PHuwV0yiQdnZaOxmXIP6FzpWkeXLjcoUNaCRDuKwJx5GKrUSDqmGlMWSH53scwwzHg==",
-							"dev": true,
-							"requires": {
-								"chalk": "^4.0.0",
-								"loglevel": "^1.6.0",
-								"loglevel-plugin-prefix": "^0.8.4",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"@wdio/protocols": {
-							"version": "6.10.0",
-							"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.0.tgz",
-							"integrity": "sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==",
-							"dev": true
-						},
-						"@wdio/repl": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.10.4.tgz",
-							"integrity": "sha512-VwucPyUqAxU6CWWoEVf14asjtLGTgyaJwp47kEFegr06ZBG43zVQ6JqKFiGDxUJ+fZVRhdd7nRVHd+6UllK18w==",
-							"dev": true,
-							"requires": {
-								"@wdio/utils": "6.10.4"
-							}
-						},
-						"@wdio/utils": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.10.4.tgz",
-							"integrity": "sha512-DkFguYGKUcv9TmIYuuwS/pxpiGcgyv8gWUWRXffirt2OYpFXJNwB+S96CSQnjgb4B5MqSFgEti+gl8A2wsdDgQ==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "6.10.4"
-							}
-						},
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
-						"appium-base-driver": {
-							"version": "5.8.1",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-5.8.1.tgz",
-							"integrity": "sha512-k5ybExgP0kJx7vsR0Y8GeEay+Vr0yCs0muzYtdrIDbqOCz5bFX0skyZubSSsm/lOE4KvgHhm4cRwWJM0DlHvRA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-support": "^2.46.0",
-								"async-lock": "^1.0.0",
-								"asyncbox": "^2.3.1",
-								"axios": "^0.19.2",
-								"bluebird": "^3.5.3",
-								"body-parser": "^1.18.2",
-								"colors": "^1.1.2",
-								"es6-error": "^4.1.1",
-								"express": "^4.16.2",
-								"http-status-codes": "^1.3.0",
-								"lodash": "^4.0.0",
-								"lru-cache": "^5.0.0",
-								"method-override": "^3.0.0",
-								"morgan": "^1.9.0",
-								"request": "^2.88.2",
-								"request-promise": "^4.2.5",
-								"serve-favicon": "^2.4.5",
-								"source-map-support": "^0.5.5",
-								"validate.js": "^0.13.0",
-								"webdriverio": "^6.0.2",
-								"ws": "^7.0.0"
-							},
-							"dependencies": {
-								"axios": {
-									"version": "0.19.2",
-									"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-									"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-									"dev": true,
-									"requires": {
-										"follow-redirects": "1.5.10"
-									}
-								},
-								"debug": {
-									"version": "3.1.0",
-									"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-									"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-									"dev": true,
-									"requires": {
-										"ms": "2.0.0"
-									}
-								},
-								"follow-redirects": {
-									"version": "1.5.10",
-									"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-									"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-									"dev": true,
-									"requires": {
-										"debug": "=3.1.0"
-									}
-								}
-							}
-						},
 						"appium-support": {
 							"version": "2.49.0",
 							"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
@@ -23593,11 +20346,14 @@
 								"yauzl": "^2.7.0"
 							},
 							"dependencies": {
-								"pngjs": {
-									"version": "5.0.0",
-									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-									"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-									"dev": true
+								"lockfile": {
+									"version": "1.0.4",
+									"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+									"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+									"dev": true,
+									"requires": {
+										"signal-exit": "^3.0.2"
+									}
 								}
 							}
 						},
@@ -23651,21 +20407,6 @@
 								}
 							}
 						},
-						"async": {
-							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-							"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-							"dev": true
-						},
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
-							}
-						},
 						"bl": {
 							"version": "4.0.3",
 							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -23675,16 +20416,6 @@
 								"buffer": "^5.5.0",
 								"inherits": "^2.0.4",
 								"readable-stream": "^3.4.0"
-							}
-						},
-						"chalk": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
 							}
 						},
 						"compress-commons": {
@@ -23697,6 +20428,23 @@
 								"crc32-stream": "^4.0.1",
 								"normalize-path": "^3.0.0",
 								"readable-stream": "^3.6.0"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
 							}
 						},
 						"crc32-stream": {
@@ -23709,65 +20457,10 @@
 								"readable-stream": "^3.4.0"
 							}
 						},
-						"devtools": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.10.4.tgz",
-							"integrity": "sha512-53LoeU2S4q4cLJGKgo2Or7WU9Kc5RQscC0DbBAZcodkot1lKFbMg/z6/cQTq+XKl4kgYr5VA/s5kzNU7ScBctQ==",
-							"dev": true,
-							"requires": {
-								"@types/puppeteer-core": "^2.0.0",
-								"@types/ua-parser-js": "^0.7.33",
-								"@types/uuid": "^8.3.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"chrome-launcher": "^0.13.1",
-								"edge-paths": "^2.1.0",
-								"puppeteer-core": "^5.1.0",
-								"ua-parser-js": "^0.7.21",
-								"uuid": "^8.0.0"
-							}
-						},
-						"extract-zip": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-							"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-							"dev": true,
-							"requires": {
-								"@types/yauzl": "^2.9.1",
-								"debug": "^4.1.1",
-								"get-stream": "^5.1.0",
-								"yauzl": "^2.10.0"
-							},
-							"dependencies": {
-								"get-stream": {
-									"version": "5.2.0",
-									"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-									"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-									"dev": true,
-									"requires": {
-										"pump": "^3.0.0"
-									}
-								}
-							}
-						},
-						"fast-deep-equal": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-							"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-							"dev": true
-						},
-						"follow-redirects": {
-							"version": "1.13.0",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-							"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-							"dev": true
-						},
 						"form-data": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-							"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+							"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
 							"dev": true,
 							"requires": {
 								"asynckit": "^0.4.0",
@@ -23781,62 +20474,11 @@
 							"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
 							"dev": true
 						},
-						"jimp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/custom": "^0.14.0",
-								"@jimp/plugins": "^0.14.0",
-								"@jimp/types": "^0.14.0",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"jpeg-js": {
-							"version": "0.4.2",
-							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-							"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
-							"dev": true
-						},
-						"minimist": {
-							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-							"dev": true
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						},
 						"normalize-path": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 							"dev": true
-						},
-						"puppeteer-core": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-							"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-							"dev": true,
-							"requires": {
-								"debug": "^4.1.0",
-								"devtools-protocol": "0.0.818844",
-								"extract-zip": "^2.0.0",
-								"https-proxy-agent": "^4.0.0",
-								"node-fetch": "^2.6.1",
-								"pkg-dir": "^4.2.0",
-								"progress": "^2.0.1",
-								"proxy-from-env": "^1.0.0",
-								"rimraf": "^3.0.2",
-								"tar-fs": "^2.0.0",
-								"unbzip2-stream": "^1.3.3",
-								"ws": "^7.2.3"
-							}
 						},
 						"readable-stream": {
 							"version": "3.6.0",
@@ -23847,39 +20489,6 @@
 								"inherits": "^2.0.3",
 								"string_decoder": "^1.1.1",
 								"util-deprecate": "^1.0.1"
-							}
-						},
-						"resq": {
-							"version": "1.10.0",
-							"resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
-							"integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
-							"dev": true,
-							"requires": {
-								"fast-deep-equal": "^2.0.1"
-							}
-						},
-						"rgb2hex": {
-							"version": "0.2.3",
-							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
-							"integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
-							"dev": true
-						},
-						"serialize-error": {
-							"version": "7.0.1",
-							"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-							"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-							"dev": true,
-							"requires": {
-								"type-fest": "^0.13.1"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
 							}
 						},
 						"tar-stream": {
@@ -23895,68 +20504,11 @@
 								"readable-stream": "^3.1.1"
 							}
 						},
-						"type-fest": {
-							"version": "0.13.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-							"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-							"dev": true
-						},
 						"uuid": {
 							"version": "8.3.1",
 							"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
 							"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
 							"dev": true
-						},
-						"webdriver": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.10.4.tgz",
-							"integrity": "sha512-N2FkEy22QWAJMeyz1219ik9wyt3/SOT/RtsY6JheEriZ1GptzZyK0OibkOnCoaIAt+nvSxnSmTTlmXQMGBE6Mw==",
-							"dev": true,
-							"requires": {
-								"@types/lodash.merge": "^4.6.6",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"got": "^11.0.2",
-								"lodash.merge": "^4.6.1"
-							}
-						},
-						"webdriverio": {
-							"version": "6.10.5",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.10.5.tgz",
-							"integrity": "sha512-TLIKVOOM0Oszn2mLxZcMQk0vq1bOWpsZNXMxMtpBXKLvcOCLedftxotwh0o1LqRiq8ODiubJ/vNOLgCN/oLFJQ==",
-							"dev": true,
-							"requires": {
-								"@types/archiver": "^5.1.0",
-								"@types/atob": "^2.1.2",
-								"@types/fs-extra": "^9.0.2",
-								"@types/lodash.clonedeep": "^4.5.6",
-								"@types/lodash.isplainobject": "^4.0.6",
-								"@types/puppeteer-core": "^2.0.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/repl": "6.10.4",
-								"@wdio/utils": "6.10.4",
-								"archiver": "^5.0.0",
-								"atob": "^2.1.2",
-								"css-shorthand-properties": "^1.1.1",
-								"css-value": "^0.0.1",
-								"devtools": "6.10.4",
-								"fs-extra": "^9.0.1",
-								"get-port": "^5.1.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"minimatch": "^3.0.4",
-								"puppeteer-core": "^5.1.0",
-								"resq": "^1.9.1",
-								"rgb2hex": "^0.2.0",
-								"serialize-error": "^7.0.0",
-								"webdriver": "6.10.4"
-							}
 						},
 						"zip-stream": {
 							"version": "4.0.4",
@@ -24348,75 +20900,11 @@
 								"core-js": "^2.5.7"
 							}
 						},
-						"@wdio/config": {
-							"version": "5.22.4",
-							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-5.22.4.tgz",
-							"integrity": "sha512-i5dJQWb80darcRA//tfG0guMeQCeRUXroZNnHjGNb1qzvTRZmcIIhdxaD+DbK/5dWEx6aoMfoi6wjVp/CXwdAg==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "5.16.10",
-								"deepmerge": "^4.0.0",
-								"glob": "^7.1.2"
-							}
-						},
-						"@wdio/logger": {
-							"version": "5.16.10",
-							"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-5.16.10.tgz",
-							"integrity": "sha512-hRKhxgd9uB48Dtj2xe2ckxU4KwI/RO8IwguySuaI2SLFj6EDbdonwzpVkq111/fjBuq7R1NauAaNcm3AMEbIFA==",
-							"dev": true,
-							"requires": {
-								"chalk": "^3.0.0",
-								"loglevel": "^1.6.0",
-								"loglevel-plugin-prefix": "^0.8.4",
-								"strip-ansi": "^6.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "5.0.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-									"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "6.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-									"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^5.0.0"
-									}
-								}
-							}
-						},
-						"@wdio/protocols": {
-							"version": "5.22.1",
-							"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-5.22.1.tgz",
-							"integrity": "sha512-GdoWb/HTrb09Qb0S/7sLp1NU94LAhTsF1NnFj5sEFSUpecrl0S07pnhVg54pUImectN/woaqSl7uJGjlSGZcdQ==",
-							"dev": true
-						},
-						"@wdio/repl": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-5.23.0.tgz",
-							"integrity": "sha512-cKG9m0XuqcQenQmoup0yJX1fkDQEdY06QXuwt636ZQf6XgDoeoAdNOgnRnNruQ0+JsC2eqHFoSNto1q8wcLH/g==",
-							"dev": true,
-							"requires": {
-								"@wdio/utils": "5.23.0"
-							}
-						},
-						"@wdio/utils": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-5.23.0.tgz",
-							"integrity": "sha512-dWPEkDiaNUqJXPO6L2di2apI7Rle7Er4euh67Wlb5+3MrPNjCKhiF8gHcpQeL8oe6A1MH/f89kpSEEXe4BMkAw==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "5.16.10",
-								"deepmerge": "^4.0.0"
-							}
-						},
 						"ansi-regex": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
 						},
 						"appium-base-driver": {
 							"version": "3.21.2",
@@ -24449,86 +20937,6 @@
 								"ws": "^7.0.0"
 							}
 						},
-						"archiver": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-							"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"async": "^2.6.3",
-								"buffer-crc32": "^0.2.1",
-								"glob": "^7.1.4",
-								"readable-stream": "^3.4.0",
-								"tar-stream": "^2.1.0",
-								"zip-stream": "^2.1.2"
-							}
-						},
-						"archiver-utils": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.4",
-								"graceful-fs": "^4.2.0",
-								"lazystream": "^1.0.0",
-								"lodash.defaults": "^4.2.0",
-								"lodash.difference": "^4.5.0",
-								"lodash.flatten": "^4.4.0",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.union": "^4.6.0",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.0.0"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
-							}
-						},
-						"async": {
-							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-							"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.14"
-							}
-						},
-						"bl": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-							"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-							"dev": true,
-							"requires": {
-								"buffer": "^5.5.0",
-								"inherits": "^2.0.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
 						"cliui": {
 							"version": "4.1.0",
 							"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -24538,52 +20946,6 @@
 								"string-width": "^2.1.1",
 								"strip-ansi": "^4.0.0",
 								"wrap-ansi": "^2.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "3.0.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^3.0.0"
-									}
-								}
-							}
-						},
-						"compress-commons": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-							"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
-							"dev": true,
-							"requires": {
-								"buffer-crc32": "^0.2.13",
-								"crc32-stream": "^3.0.1",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.3.6"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
 							}
 						},
 						"core-js": {
@@ -24591,16 +20953,6 @@
 							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
 							"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
 							"dev": true
-						},
-						"crc32-stream": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-							"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
-							"dev": true,
-							"requires": {
-								"crc": "^3.4.4",
-								"readable-stream": "^3.4.0"
-							}
 						},
 						"find-up": {
 							"version": "3.0.0",
@@ -24646,12 +20998,6 @@
 								"path-exists": "^3.0.0"
 							}
 						},
-						"minimist": {
-							"version": "0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-							"dev": true
-						},
 						"mkdirp": {
 							"version": "0.5.1",
 							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -24660,12 +21006,6 @@
 							"requires": {
 								"minimist": "0.0.8"
 							}
-						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-							"dev": true
 						},
 						"p-locate": {
 							"version": "3.0.0",
@@ -24682,43 +21022,11 @@
 							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 							"dev": true
 						},
-						"pngjs": {
-							"version": "3.4.0",
-							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
-						},
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						},
 						"require-main-filename": {
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 							"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 							"dev": true
-						},
-						"rgb2hex": {
-							"version": "0.1.10",
-							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.10.tgz",
-							"integrity": "sha512-vKz+kzolWbL3rke/xeTE2+6vHmZnNxGyDnaVW4OckntAIcc7DcZzWkQSfxMDwqHS8vhgySnIFyBUH7lIk6PxvQ==",
-							"dev": true
-						},
-						"serialize-error": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
-							"integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
-							"dev": true,
-							"requires": {
-								"type-fest": "^0.8.0"
-							}
 						},
 						"string-width": {
 							"version": "2.1.1",
@@ -24728,88 +21036,15 @@
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
 								"strip-ansi": "^4.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "3.0.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^3.0.0"
-									}
-								}
 							}
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
-							}
-						},
-						"tar-stream": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-							"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-							"dev": true,
-							"requires": {
-								"bl": "^4.0.3",
-								"end-of-stream": "^1.4.1",
-								"fs-constants": "^1.0.0",
-								"inherits": "^2.0.3",
-								"readable-stream": "^3.1.1"
-							}
-						},
-						"type-fest": {
-							"version": "0.8.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-							"dev": true
-						},
-						"webdriver": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-5.23.0.tgz",
-							"integrity": "sha512-r7IrbZ2SuTIRyWV8mv4a4hZoFcT9Qt4MznOkdRWPE1sPpZ8lyLZsIEjKCEbHelOzPwURqk+biwGrm4z2OZRAiw==",
-							"dev": true,
-							"requires": {
-								"@types/request": "^2.48.4",
-								"@wdio/config": "5.22.4",
-								"@wdio/logger": "5.16.10",
-								"@wdio/protocols": "5.22.1",
-								"@wdio/utils": "5.23.0",
-								"lodash.merge": "^4.6.1",
-								"request": "^2.83.0"
-							}
-						},
-						"webdriverio": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-5.23.0.tgz",
-							"integrity": "sha512-hxt6Nuu2bBrTsVk7GfoFRTh63l4fRVXlK9U30RtPbHoWO5tcFdyUz2UTgeHEZ54ea1DQEVPfsgFiLnJULkWp1Q==",
-							"dev": true,
-							"requires": {
-								"@wdio/config": "5.22.4",
-								"@wdio/logger": "5.16.10",
-								"@wdio/repl": "5.23.0",
-								"@wdio/utils": "5.23.0",
-								"archiver": "^3.0.0",
-								"css-value": "^0.0.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"resq": "^1.6.0",
-								"rgb2hex": "^0.1.0",
-								"serialize-error": "^5.0.0",
-								"webdriver": "5.23.0"
 							}
 						},
 						"wrap-ansi": {
@@ -24887,17 +21122,6 @@
 							"requires": {
 								"camelcase": "^5.0.0",
 								"decamelize": "^1.2.0"
-							}
-						},
-						"zip-stream": {
-							"version": "2.1.3",
-							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
-							"integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"compress-commons": "^2.1.1",
-								"readable-stream": "^3.4.0"
 							}
 						}
 					}
@@ -25101,856 +21325,6 @@
 						"source-map-support": "^0.5.12",
 						"stream-equal": "^1.1.1",
 						"teen_process": "^1.14.1"
-					},
-					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							},
-							"dependencies": {
-								"mkdirp": {
-									"version": "0.5.5",
-									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-									"dev": true,
-									"requires": {
-										"minimist": "^1.2.5"
-									}
-								}
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.14.0"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"jpeg-js": "^0.4.0"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.14.0",
-								"@jimp/plugin-blur": "^0.14.0",
-								"@jimp/plugin-circle": "^0.14.0",
-								"@jimp/plugin-color": "^0.14.0",
-								"@jimp/plugin-contain": "^0.14.0",
-								"@jimp/plugin-cover": "^0.14.0",
-								"@jimp/plugin-crop": "^0.14.0",
-								"@jimp/plugin-displace": "^0.14.0",
-								"@jimp/plugin-dither": "^0.14.0",
-								"@jimp/plugin-fisheye": "^0.14.0",
-								"@jimp/plugin-flip": "^0.14.0",
-								"@jimp/plugin-gaussian": "^0.14.0",
-								"@jimp/plugin-invert": "^0.14.0",
-								"@jimp/plugin-mask": "^0.14.0",
-								"@jimp/plugin-normalize": "^0.14.0",
-								"@jimp/plugin-print": "^0.14.0",
-								"@jimp/plugin-resize": "^0.14.0",
-								"@jimp/plugin-rotate": "^0.14.0",
-								"@jimp/plugin-scale": "^0.14.0",
-								"@jimp/plugin-shadow": "^0.14.0",
-								"@jimp/plugin-threshold": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"pngjs": "^3.3.3"
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.14.0",
-								"@jimp/gif": "^0.14.0",
-								"@jimp/jpeg": "^0.14.0",
-								"@jimp/png": "^0.14.0",
-								"@jimp/tiff": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"@wdio/config": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.4.tgz",
-							"integrity": "sha512-M22EunI+n/mmYOQqb9+BTVRqrfmPw+7rR1AHeD36vOXCnZ55Nrl4ZU4d6QzPHp9cLdMZqV786iDmkonnb6jb8w==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "6.10.4",
-								"deepmerge": "^4.0.0",
-								"glob": "^7.1.2"
-							}
-						},
-						"@wdio/logger": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.4.tgz",
-							"integrity": "sha512-I+1I/5CtQigy59QJen56PHuwV0yiQdnZaOxmXIP6FzpWkeXLjcoUNaCRDuKwJx5GKrUSDqmGlMWSH53scwwzHg==",
-							"dev": true,
-							"requires": {
-								"chalk": "^4.0.0",
-								"loglevel": "^1.6.0",
-								"loglevel-plugin-prefix": "^0.8.4",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"@wdio/protocols": {
-							"version": "6.10.0",
-							"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.0.tgz",
-							"integrity": "sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==",
-							"dev": true
-						},
-						"@wdio/repl": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.10.4.tgz",
-							"integrity": "sha512-VwucPyUqAxU6CWWoEVf14asjtLGTgyaJwp47kEFegr06ZBG43zVQ6JqKFiGDxUJ+fZVRhdd7nRVHd+6UllK18w==",
-							"dev": true,
-							"requires": {
-								"@wdio/utils": "6.10.4"
-							}
-						},
-						"@wdio/utils": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.10.4.tgz",
-							"integrity": "sha512-DkFguYGKUcv9TmIYuuwS/pxpiGcgyv8gWUWRXffirt2OYpFXJNwB+S96CSQnjgb4B5MqSFgEti+gl8A2wsdDgQ==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "6.10.4"
-							}
-						},
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
-						"appium-base-driver": {
-							"version": "5.8.1",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-5.8.1.tgz",
-							"integrity": "sha512-k5ybExgP0kJx7vsR0Y8GeEay+Vr0yCs0muzYtdrIDbqOCz5bFX0skyZubSSsm/lOE4KvgHhm4cRwWJM0DlHvRA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-support": "^2.46.0",
-								"async-lock": "^1.0.0",
-								"asyncbox": "^2.3.1",
-								"axios": "^0.19.2",
-								"bluebird": "^3.5.3",
-								"body-parser": "^1.18.2",
-								"colors": "^1.1.2",
-								"es6-error": "^4.1.1",
-								"express": "^4.16.2",
-								"http-status-codes": "^1.3.0",
-								"lodash": "^4.0.0",
-								"lru-cache": "^5.0.0",
-								"method-override": "^3.0.0",
-								"morgan": "^1.9.0",
-								"request": "^2.88.2",
-								"request-promise": "^4.2.5",
-								"serve-favicon": "^2.4.5",
-								"source-map-support": "^0.5.5",
-								"validate.js": "^0.13.0",
-								"webdriverio": "^6.0.2",
-								"ws": "^7.0.0"
-							},
-							"dependencies": {
-								"appium-support": {
-									"version": "2.49.0",
-									"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
-									"integrity": "sha512-PtUsfpCjdGqZTTuRyH5U9iOGq9SpEVHg0H6/2HrazkX6ZvSQ+kIVYHTAGIXVeBJecfN9/syqgMmEekVgD15BGA==",
-									"dev": true,
-									"requires": {
-										"@babel/runtime": "^7.0.0",
-										"archiver": "^5.0.0",
-										"axios": "^0.20.0",
-										"base64-stream": "^1.0.0",
-										"bluebird": "^3.5.1",
-										"bplist-creator": "^0",
-										"bplist-parser": "^0.2",
-										"form-data": "^3.0.0",
-										"get-stream": "^6.0.0",
-										"glob": "^7.1.2",
-										"jimp": "^0.14.0",
-										"jsftp": "^2.1.2",
-										"klaw": "^3.0.0",
-										"lockfile": "^1.0.4",
-										"lodash": "^4.2.1",
-										"mjpeg-server": "^0.3.0",
-										"mkdirp": "^1.0.0",
-										"moment": "^2.24.0",
-										"mv": "^2.1.1",
-										"ncp": "^2.0.0",
-										"npmlog": "^4.1.2",
-										"plist": "^3.0.1",
-										"pluralize": "^8.0.0",
-										"pngjs": "^5.0.0",
-										"rimraf": "^3.0.0",
-										"sanitize-filename": "^1.6.1",
-										"semver": "^7.0.0",
-										"shell-quote": "^1.7.2",
-										"source-map-support": "^0.5.5",
-										"teen_process": "^1.5.1",
-										"uuid": "^8.0.0",
-										"which": "^2.0.0",
-										"yauzl": "^2.7.0"
-									},
-									"dependencies": {
-										"axios": {
-											"version": "0.20.0",
-											"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-											"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-											"dev": true,
-											"requires": {
-												"follow-redirects": "^1.10.0"
-											}
-										}
-									}
-								},
-								"get-stream": {
-									"version": "6.0.0",
-									"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-									"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-									"dev": true
-								},
-								"pngjs": {
-									"version": "5.0.0",
-									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-									"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-									"dev": true
-								}
-							}
-						},
-						"archiver": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
-							"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"async": "^3.2.0",
-								"buffer-crc32": "^0.2.1",
-								"readable-stream": "^3.6.0",
-								"readdir-glob": "^1.0.0",
-								"tar-stream": "^2.1.4",
-								"zip-stream": "^4.0.4"
-							}
-						},
-						"archiver-utils": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.4",
-								"graceful-fs": "^4.2.0",
-								"lazystream": "^1.0.0",
-								"lodash.defaults": "^4.2.0",
-								"lodash.difference": "^4.5.0",
-								"lodash.flatten": "^4.4.0",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.union": "^4.6.0",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.0.0"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
-							}
-						},
-						"async": {
-							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-							"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-							"dev": true
-						},
-						"bl": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-							"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-							"dev": true,
-							"requires": {
-								"buffer": "^5.5.0",
-								"inherits": "^2.0.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"chalk": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"compress-commons": {
-							"version": "4.0.2",
-							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-							"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
-							"dev": true,
-							"requires": {
-								"buffer-crc32": "^0.2.13",
-								"crc32-stream": "^4.0.1",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^3.6.0"
-							}
-						},
-						"crc32-stream": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
-							"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
-							"dev": true,
-							"requires": {
-								"crc-32": "^1.2.0",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"devtools": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.10.4.tgz",
-							"integrity": "sha512-53LoeU2S4q4cLJGKgo2Or7WU9Kc5RQscC0DbBAZcodkot1lKFbMg/z6/cQTq+XKl4kgYr5VA/s5kzNU7ScBctQ==",
-							"dev": true,
-							"requires": {
-								"@types/puppeteer-core": "^2.0.0",
-								"@types/ua-parser-js": "^0.7.33",
-								"@types/uuid": "^8.3.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"chrome-launcher": "^0.13.1",
-								"edge-paths": "^2.1.0",
-								"puppeteer-core": "^5.1.0",
-								"ua-parser-js": "^0.7.21",
-								"uuid": "^8.0.0"
-							}
-						},
-						"extract-zip": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-							"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-							"dev": true,
-							"requires": {
-								"@types/yauzl": "^2.9.1",
-								"debug": "^4.1.1",
-								"get-stream": "^5.1.0",
-								"yauzl": "^2.10.0"
-							}
-						},
-						"fast-deep-equal": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-							"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-							"dev": true
-						},
-						"follow-redirects": {
-							"version": "1.13.0",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-							"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-							"dev": true
-						},
-						"form-data": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-							"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-							"dev": true,
-							"requires": {
-								"asynckit": "^0.4.0",
-								"combined-stream": "^1.0.8",
-								"mime-types": "^2.1.12"
-							}
-						},
-						"jimp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/custom": "^0.14.0",
-								"@jimp/plugins": "^0.14.0",
-								"@jimp/types": "^0.14.0",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"jpeg-js": {
-							"version": "0.4.2",
-							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-							"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
-							"dev": true
-						},
-						"minimist": {
-							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-							"dev": true
-						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-							"dev": true
-						},
-						"puppeteer-core": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-							"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-							"dev": true,
-							"requires": {
-								"debug": "^4.1.0",
-								"devtools-protocol": "0.0.818844",
-								"extract-zip": "^2.0.0",
-								"https-proxy-agent": "^4.0.0",
-								"node-fetch": "^2.6.1",
-								"pkg-dir": "^4.2.0",
-								"progress": "^2.0.1",
-								"proxy-from-env": "^1.0.0",
-								"rimraf": "^3.0.2",
-								"tar-fs": "^2.0.0",
-								"unbzip2-stream": "^1.3.3",
-								"ws": "^7.2.3"
-							}
-						},
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						},
-						"resq": {
-							"version": "1.10.0",
-							"resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
-							"integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
-							"dev": true,
-							"requires": {
-								"fast-deep-equal": "^2.0.1"
-							}
-						},
-						"rgb2hex": {
-							"version": "0.2.3",
-							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
-							"integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
-							"dev": true
-						},
-						"serialize-error": {
-							"version": "7.0.1",
-							"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-							"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-							"dev": true,
-							"requires": {
-								"type-fest": "^0.13.1"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						},
-						"tar-stream": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-							"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-							"dev": true,
-							"requires": {
-								"bl": "^4.0.3",
-								"end-of-stream": "^1.4.1",
-								"fs-constants": "^1.0.0",
-								"inherits": "^2.0.3",
-								"readable-stream": "^3.1.1"
-							}
-						},
-						"type-fest": {
-							"version": "0.13.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-							"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-							"dev": true
-						},
-						"uuid": {
-							"version": "8.3.1",
-							"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-							"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-							"dev": true
-						},
-						"webdriver": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.10.4.tgz",
-							"integrity": "sha512-N2FkEy22QWAJMeyz1219ik9wyt3/SOT/RtsY6JheEriZ1GptzZyK0OibkOnCoaIAt+nvSxnSmTTlmXQMGBE6Mw==",
-							"dev": true,
-							"requires": {
-								"@types/lodash.merge": "^4.6.6",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"got": "^11.0.2",
-								"lodash.merge": "^4.6.1"
-							}
-						},
-						"webdriverio": {
-							"version": "6.10.5",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.10.5.tgz",
-							"integrity": "sha512-TLIKVOOM0Oszn2mLxZcMQk0vq1bOWpsZNXMxMtpBXKLvcOCLedftxotwh0o1LqRiq8ODiubJ/vNOLgCN/oLFJQ==",
-							"dev": true,
-							"requires": {
-								"@types/archiver": "^5.1.0",
-								"@types/atob": "^2.1.2",
-								"@types/fs-extra": "^9.0.2",
-								"@types/lodash.clonedeep": "^4.5.6",
-								"@types/lodash.isplainobject": "^4.0.6",
-								"@types/puppeteer-core": "^2.0.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/repl": "6.10.4",
-								"@wdio/utils": "6.10.4",
-								"archiver": "^5.0.0",
-								"atob": "^2.1.2",
-								"css-shorthand-properties": "^1.1.1",
-								"css-value": "^0.0.1",
-								"devtools": "6.10.4",
-								"fs-extra": "^9.0.1",
-								"get-port": "^5.1.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"minimatch": "^3.0.4",
-								"puppeteer-core": "^5.1.0",
-								"resq": "^1.9.1",
-								"rgb2hex": "^0.2.0",
-								"serialize-error": "^7.0.0",
-								"webdriver": "6.10.4"
-							}
-						},
-						"zip-stream": {
-							"version": "4.0.4",
-							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-							"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"compress-commons": "^4.0.2",
-								"readable-stream": "^3.6.0"
-							}
-						}
 					}
 				},
 				"appium-windows-driver": {
@@ -26022,917 +21396,6 @@
 						"yargs": "^15.0.1"
 					},
 					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							},
-							"dependencies": {
-								"mkdirp": {
-									"version": "0.5.5",
-									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-									"dev": true,
-									"requires": {
-										"minimist": "^1.2.5"
-									}
-								}
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.14.0"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"jpeg-js": "^0.4.0"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.14.0",
-								"@jimp/plugin-blur": "^0.14.0",
-								"@jimp/plugin-circle": "^0.14.0",
-								"@jimp/plugin-color": "^0.14.0",
-								"@jimp/plugin-contain": "^0.14.0",
-								"@jimp/plugin-cover": "^0.14.0",
-								"@jimp/plugin-crop": "^0.14.0",
-								"@jimp/plugin-displace": "^0.14.0",
-								"@jimp/plugin-dither": "^0.14.0",
-								"@jimp/plugin-fisheye": "^0.14.0",
-								"@jimp/plugin-flip": "^0.14.0",
-								"@jimp/plugin-gaussian": "^0.14.0",
-								"@jimp/plugin-invert": "^0.14.0",
-								"@jimp/plugin-mask": "^0.14.0",
-								"@jimp/plugin-normalize": "^0.14.0",
-								"@jimp/plugin-print": "^0.14.0",
-								"@jimp/plugin-resize": "^0.14.0",
-								"@jimp/plugin-rotate": "^0.14.0",
-								"@jimp/plugin-scale": "^0.14.0",
-								"@jimp/plugin-shadow": "^0.14.0",
-								"@jimp/plugin-threshold": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"pngjs": "^3.3.3"
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.14.0",
-								"@jimp/gif": "^0.14.0",
-								"@jimp/jpeg": "^0.14.0",
-								"@jimp/png": "^0.14.0",
-								"@jimp/tiff": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"@wdio/config": {
-							"version": "5.22.4",
-							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-5.22.4.tgz",
-							"integrity": "sha512-i5dJQWb80darcRA//tfG0guMeQCeRUXroZNnHjGNb1qzvTRZmcIIhdxaD+DbK/5dWEx6aoMfoi6wjVp/CXwdAg==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "5.16.10",
-								"deepmerge": "^4.0.0",
-								"glob": "^7.1.2"
-							}
-						},
-						"@wdio/logger": {
-							"version": "5.16.10",
-							"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-5.16.10.tgz",
-							"integrity": "sha512-hRKhxgd9uB48Dtj2xe2ckxU4KwI/RO8IwguySuaI2SLFj6EDbdonwzpVkq111/fjBuq7R1NauAaNcm3AMEbIFA==",
-							"dev": true,
-							"requires": {
-								"chalk": "^3.0.0",
-								"loglevel": "^1.6.0",
-								"loglevel-plugin-prefix": "^0.8.4",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"@wdio/protocols": {
-							"version": "5.22.1",
-							"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-5.22.1.tgz",
-							"integrity": "sha512-GdoWb/HTrb09Qb0S/7sLp1NU94LAhTsF1NnFj5sEFSUpecrl0S07pnhVg54pUImectN/woaqSl7uJGjlSGZcdQ==",
-							"dev": true
-						},
-						"@wdio/repl": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-5.23.0.tgz",
-							"integrity": "sha512-cKG9m0XuqcQenQmoup0yJX1fkDQEdY06QXuwt636ZQf6XgDoeoAdNOgnRnNruQ0+JsC2eqHFoSNto1q8wcLH/g==",
-							"dev": true,
-							"requires": {
-								"@wdio/utils": "5.23.0"
-							}
-						},
-						"@wdio/utils": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-5.23.0.tgz",
-							"integrity": "sha512-dWPEkDiaNUqJXPO6L2di2apI7Rle7Er4euh67Wlb5+3MrPNjCKhiF8gHcpQeL8oe6A1MH/f89kpSEEXe4BMkAw==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "5.16.10",
-								"deepmerge": "^4.0.0"
-							}
-						},
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
-						"appium-base-driver": {
-							"version": "5.8.1",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-5.8.1.tgz",
-							"integrity": "sha512-k5ybExgP0kJx7vsR0Y8GeEay+Vr0yCs0muzYtdrIDbqOCz5bFX0skyZubSSsm/lOE4KvgHhm4cRwWJM0DlHvRA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-support": "^2.46.0",
-								"async-lock": "^1.0.0",
-								"asyncbox": "^2.3.1",
-								"axios": "^0.19.2",
-								"bluebird": "^3.5.3",
-								"body-parser": "^1.18.2",
-								"colors": "^1.1.2",
-								"es6-error": "^4.1.1",
-								"express": "^4.16.2",
-								"http-status-codes": "^1.3.0",
-								"lodash": "^4.0.0",
-								"lru-cache": "^5.0.0",
-								"method-override": "^3.0.0",
-								"morgan": "^1.9.0",
-								"request": "^2.88.2",
-								"request-promise": "^4.2.5",
-								"serve-favicon": "^2.4.5",
-								"source-map-support": "^0.5.5",
-								"validate.js": "^0.13.0",
-								"webdriverio": "^6.0.2",
-								"ws": "^7.0.0"
-							},
-							"dependencies": {
-								"axios": {
-									"version": "0.19.2",
-									"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-									"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-									"dev": true,
-									"requires": {
-										"follow-redirects": "1.5.10"
-									}
-								},
-								"debug": {
-									"version": "3.1.0",
-									"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-									"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-									"dev": true,
-									"requires": {
-										"ms": "2.0.0"
-									}
-								},
-								"follow-redirects": {
-									"version": "1.5.10",
-									"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-									"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-									"dev": true,
-									"requires": {
-										"debug": "=3.1.0"
-									}
-								}
-							}
-						},
-						"appium-ios-driver": {
-							"version": "4.8.0",
-							"resolved": "https://registry.npmjs.org/appium-ios-driver/-/appium-ios-driver-4.8.0.tgz",
-							"integrity": "sha512-jjZWJ5DR0x8J9HCCf4EDihwJmd+BV0SEIUOQyVLQj1FZq99DWIIBnpTDbu1LaU9WIMNC2a8JqvKp/T/6XnzQGg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-base-driver": "^7.0.0",
-								"appium-ios-simulator": "^3.24.0",
-								"appium-remote-debugger": "^5.7.0",
-								"appium-support": "^2.41.0",
-								"appium-xcode": "^3.1.0",
-								"asyncbox": "^2.3.1",
-								"axios": "^0.20.0",
-								"bluebird": "^3.5.1",
-								"colors": "^1.1.2",
-								"js2xmlparser2": "^0.2.0",
-								"lodash": "^4.13.1",
-								"moment": "^2.24.0",
-								"moment-timezone": "^0.5.26",
-								"node-idevice": "^0.1.6",
-								"pem": "^1.8.3",
-								"portfinder": "^1.0.13",
-								"safari-launcher": "^2.0.5",
-								"source-map-support": "^0.5.5",
-								"teen_process": "^1.6.0",
-								"through": "^2.3.8",
-								"xmldom": "^0.3.0",
-								"xpath": "^0.0.24",
-								"yargs": "^16.0.0"
-							},
-							"dependencies": {
-								"@wdio/protocols": {
-									"version": "6.10.0",
-									"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.0.tgz",
-									"integrity": "sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==",
-									"dev": true
-								},
-								"appium-base-driver": {
-									"version": "7.3.3",
-									"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.3.3.tgz",
-									"integrity": "sha512-1xcTEUTlpzf/FedRAquPl7mgPnNncHHmq98nbQLJFCDa05nwx3L4+YFDDxmbQzGdE4sZ+CXQFqYkQDqFoSr84A==",
-									"dev": true,
-									"requires": {
-										"@babel/runtime": "^7.0.0",
-										"appium-support": "^2.48.0",
-										"async-lock": "^1.0.0",
-										"asyncbox": "^2.3.1",
-										"axios": "^0.21.0",
-										"bluebird": "^3.5.3",
-										"body-parser": "^1.18.2",
-										"colors": "^1.1.2",
-										"es6-error": "^4.1.1",
-										"express": "^4.16.2",
-										"http-status-codes": "^2.1.1",
-										"lodash": "^4.0.0",
-										"lru-cache": "^6.0.0",
-										"method-override": "^3.0.0",
-										"morgan": "^1.9.0",
-										"serve-favicon": "^2.4.5",
-										"source-map-support": "^0.5.5",
-										"validate.js": "^0.13.0",
-										"webdriverio": "^6.0.2",
-										"ws": "^7.0.0"
-									},
-									"dependencies": {
-										"@wdio/config": {
-											"version": "6.10.4",
-											"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.4.tgz",
-											"integrity": "sha512-M22EunI+n/mmYOQqb9+BTVRqrfmPw+7rR1AHeD36vOXCnZ55Nrl4ZU4d6QzPHp9cLdMZqV786iDmkonnb6jb8w==",
-											"dev": true,
-											"requires": {
-												"@wdio/logger": "6.10.4",
-												"deepmerge": "^4.0.0",
-												"glob": "^7.1.2"
-											}
-										},
-										"@wdio/logger": {
-											"version": "6.10.4",
-											"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.4.tgz",
-											"integrity": "sha512-I+1I/5CtQigy59QJen56PHuwV0yiQdnZaOxmXIP6FzpWkeXLjcoUNaCRDuKwJx5GKrUSDqmGlMWSH53scwwzHg==",
-											"dev": true,
-											"requires": {
-												"chalk": "^4.0.0",
-												"loglevel": "^1.6.0",
-												"loglevel-plugin-prefix": "^0.8.4",
-												"strip-ansi": "^6.0.0"
-											}
-										},
-										"@wdio/repl": {
-											"version": "6.10.4",
-											"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.10.4.tgz",
-											"integrity": "sha512-VwucPyUqAxU6CWWoEVf14asjtLGTgyaJwp47kEFegr06ZBG43zVQ6JqKFiGDxUJ+fZVRhdd7nRVHd+6UllK18w==",
-											"dev": true,
-											"requires": {
-												"@wdio/utils": "6.10.4"
-											}
-										},
-										"@wdio/utils": {
-											"version": "6.10.4",
-											"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.10.4.tgz",
-											"integrity": "sha512-DkFguYGKUcv9TmIYuuwS/pxpiGcgyv8gWUWRXffirt2OYpFXJNwB+S96CSQnjgb4B5MqSFgEti+gl8A2wsdDgQ==",
-											"dev": true,
-											"requires": {
-												"@wdio/logger": "6.10.4"
-											}
-										},
-										"archiver": {
-											"version": "5.1.0",
-											"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
-											"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
-											"dev": true,
-											"requires": {
-												"archiver-utils": "^2.1.0",
-												"async": "^3.2.0",
-												"buffer-crc32": "^0.2.1",
-												"readable-stream": "^3.6.0",
-												"readdir-glob": "^1.0.0",
-												"tar-stream": "^2.1.4",
-												"zip-stream": "^4.0.4"
-											}
-										},
-										"axios": {
-											"version": "0.21.0",
-											"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
-											"integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
-											"dev": true,
-											"requires": {
-												"follow-redirects": "^1.10.0"
-											}
-										},
-										"http-status-codes": {
-											"version": "2.1.4",
-											"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
-											"integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg==",
-											"dev": true
-										},
-										"lru-cache": {
-											"version": "6.0.0",
-											"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-											"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-											"dev": true,
-											"requires": {
-												"yallist": "^4.0.0"
-											}
-										},
-										"rgb2hex": {
-											"version": "0.2.3",
-											"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
-											"integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
-											"dev": true
-										},
-										"serialize-error": {
-											"version": "7.0.1",
-											"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-											"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-											"dev": true,
-											"requires": {
-												"type-fest": "^0.13.1"
-											}
-										},
-										"webdriver": {
-											"version": "6.10.4",
-											"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.10.4.tgz",
-											"integrity": "sha512-N2FkEy22QWAJMeyz1219ik9wyt3/SOT/RtsY6JheEriZ1GptzZyK0OibkOnCoaIAt+nvSxnSmTTlmXQMGBE6Mw==",
-											"dev": true,
-											"requires": {
-												"@types/lodash.merge": "^4.6.6",
-												"@wdio/config": "6.10.4",
-												"@wdio/logger": "6.10.4",
-												"@wdio/protocols": "6.10.0",
-												"@wdio/utils": "6.10.4",
-												"got": "^11.0.2",
-												"lodash.merge": "^4.6.1"
-											}
-										},
-										"webdriverio": {
-											"version": "6.10.5",
-											"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.10.5.tgz",
-											"integrity": "sha512-TLIKVOOM0Oszn2mLxZcMQk0vq1bOWpsZNXMxMtpBXKLvcOCLedftxotwh0o1LqRiq8ODiubJ/vNOLgCN/oLFJQ==",
-											"dev": true,
-											"requires": {
-												"@types/archiver": "^5.1.0",
-												"@types/atob": "^2.1.2",
-												"@types/fs-extra": "^9.0.2",
-												"@types/lodash.clonedeep": "^4.5.6",
-												"@types/lodash.isplainobject": "^4.0.6",
-												"@types/puppeteer-core": "^2.0.0",
-												"@wdio/config": "6.10.4",
-												"@wdio/logger": "6.10.4",
-												"@wdio/repl": "6.10.4",
-												"@wdio/utils": "6.10.4",
-												"archiver": "^5.0.0",
-												"atob": "^2.1.2",
-												"css-shorthand-properties": "^1.1.1",
-												"css-value": "^0.0.1",
-												"devtools": "6.10.4",
-												"fs-extra": "^9.0.1",
-												"get-port": "^5.1.1",
-												"grapheme-splitter": "^1.0.2",
-												"lodash.clonedeep": "^4.5.0",
-												"lodash.isobject": "^3.0.2",
-												"lodash.isplainobject": "^4.0.6",
-												"lodash.zip": "^4.2.0",
-												"minimatch": "^3.0.4",
-												"puppeteer-core": "^5.1.0",
-												"resq": "^1.9.1",
-												"rgb2hex": "^0.2.0",
-												"serialize-error": "^7.0.0",
-												"webdriver": "6.10.4"
-											}
-										},
-										"yallist": {
-											"version": "4.0.0",
-											"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-											"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-											"dev": true
-										}
-									}
-								},
-								"appium-ios-device": {
-									"version": "0.10.5",
-									"resolved": "https://registry.npmjs.org/appium-ios-device/-/appium-ios-device-0.10.5.tgz",
-									"integrity": "sha512-O0H+iyOVPG9NbLEPLi+fR/yGZEqTa0fESzNWgDfa8JizkgvDbbItzv5ZJbiYPSZ/+hhNLfdkHF0KAVIaFYJMJg==",
-									"dev": true,
-									"requires": {
-										"@babel/runtime": "^7.0.0",
-										"appium-support": "^2.30.0",
-										"bluebird": "^3.1.1",
-										"semver": "^6.1.2",
-										"source-map-support": "^0.5.5"
-									}
-								},
-								"appium-remote-debugger": {
-									"version": "5.7.0",
-									"resolved": "https://registry.npmjs.org/appium-remote-debugger/-/appium-remote-debugger-5.7.0.tgz",
-									"integrity": "sha512-dAudf+YgQbCktUjHgrFejEmOZaARdw7CAbGQ85MQJHAjjYaoCuO1rD7ro7hRmj/WsUMh1TdFGL+94yOEsoRujw==",
-									"dev": true,
-									"requires": {
-										"@babel/runtime": "^7.0.0",
-										"appium-base-driver": "^4.0.0",
-										"appium-ios-device": "^0.10.0",
-										"appium-support": "^2.28.0",
-										"asyncbox": "^2.5.2",
-										"bluebird": "^3.4.7",
-										"lodash": "^4.17.11",
-										"source-map-support": "^0.5.5"
-									},
-									"dependencies": {
-										"appium-base-driver": {
-											"version": "4.5.1",
-											"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-4.5.1.tgz",
-											"integrity": "sha512-g7sI5mzmGdZhIFg3+A5f9ewtihYKS0b33wZWbN6R/PYYTEmXbNhFPGfVqzoAzFANuLjlTlvEEsqGcUtjrMO2Bw==",
-											"dev": true,
-											"requires": {
-												"@babel/runtime": "^7.0.0",
-												"appium-support": "^2.33.1",
-												"async-lock": "^1.0.0",
-												"asyncbox": "^2.3.1",
-												"bluebird": "^3.5.3",
-												"body-parser": "^1.18.2",
-												"colors": "^1.1.2",
-												"es6-error": "^4.1.1",
-												"express": "^4.16.2",
-												"http-status-codes": "^1.3.0",
-												"lodash": "^4.0.0",
-												"lru-cache": "^5.0.0",
-												"method-override": "^3.0.0",
-												"morgan": "^1.9.0",
-												"request": "^2.83.0",
-												"request-promise": "^4.2.2",
-												"sanitize-filename": "^1.6.1",
-												"serve-favicon": "^2.4.5",
-												"source-map-support": "^0.5.5",
-												"uuid-js": "^0.7.5",
-												"validate.js": "^0.13.0",
-												"webdriverio": "^5.10.9",
-												"ws": "^7.0.0"
-											}
-										}
-									}
-								},
-								"async": {
-									"version": "3.2.0",
-									"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-									"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-									"dev": true
-								},
-								"chalk": {
-									"version": "4.1.0",
-									"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-									"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^4.1.0",
-										"supports-color": "^7.1.0"
-									}
-								},
-								"compress-commons": {
-									"version": "4.0.2",
-									"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-									"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
-									"dev": true,
-									"requires": {
-										"buffer-crc32": "^0.2.13",
-										"crc32-stream": "^4.0.1",
-										"normalize-path": "^3.0.0",
-										"readable-stream": "^3.6.0"
-									}
-								},
-								"http-status-codes": {
-									"version": "1.4.0",
-									"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
-									"integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==",
-									"dev": true
-								},
-								"lru-cache": {
-									"version": "5.1.1",
-									"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-									"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-									"dev": true,
-									"requires": {
-										"yallist": "^3.0.2"
-									}
-								},
-								"semver": {
-									"version": "6.3.0",
-									"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-									"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-									"dev": true
-								},
-								"type-fest": {
-									"version": "0.13.1",
-									"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-									"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-									"dev": true
-								},
-								"webdriverio": {
-									"version": "5.23.0",
-									"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-5.23.0.tgz",
-									"integrity": "sha512-hxt6Nuu2bBrTsVk7GfoFRTh63l4fRVXlK9U30RtPbHoWO5tcFdyUz2UTgeHEZ54ea1DQEVPfsgFiLnJULkWp1Q==",
-									"dev": true,
-									"requires": {
-										"@wdio/config": "5.22.4",
-										"@wdio/logger": "5.16.10",
-										"@wdio/repl": "5.23.0",
-										"@wdio/utils": "5.23.0",
-										"archiver": "^3.0.0",
-										"css-value": "^0.0.1",
-										"grapheme-splitter": "^1.0.2",
-										"lodash.clonedeep": "^4.5.0",
-										"lodash.isobject": "^3.0.2",
-										"lodash.isplainobject": "^4.0.6",
-										"lodash.zip": "^4.2.0",
-										"resq": "^1.6.0",
-										"rgb2hex": "^0.1.0",
-										"serialize-error": "^5.0.0",
-										"webdriver": "5.23.0"
-									}
-								},
-								"yallist": {
-									"version": "3.1.1",
-									"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-									"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-									"dev": true
-								},
-								"yargs": {
-									"version": "16.1.1",
-									"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.1.tgz",
-									"integrity": "sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==",
-									"dev": true,
-									"requires": {
-										"cliui": "^7.0.2",
-										"escalade": "^3.1.1",
-										"get-caller-file": "^2.0.5",
-										"require-directory": "^2.1.1",
-										"string-width": "^4.2.0",
-										"y18n": "^5.0.5",
-										"yargs-parser": "^20.2.2"
-									}
-								},
-								"zip-stream": {
-									"version": "4.0.4",
-									"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-									"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
-									"dev": true,
-									"requires": {
-										"archiver-utils": "^2.1.0",
-										"compress-commons": "^4.0.2",
-										"readable-stream": "^3.6.0"
-									}
-								}
-							}
-						},
-						"appium-ios-simulator": {
-							"version": "3.24.0",
-							"resolved": "https://registry.npmjs.org/appium-ios-simulator/-/appium-ios-simulator-3.24.0.tgz",
-							"integrity": "sha512-L41PTIik8hzP9Ar98tvM+5jny7J+2pXxJuhi2o/f6Bv1M/gPy6fXcYRLO9cEJjIOz5Qw7orsROxvNM+JvY9Biw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-support": "^2.44.0",
-								"appium-xcode": "^3.1.0",
-								"async-lock": "^1.0.0",
-								"asyncbox": "^2.3.1",
-								"bluebird": "^3.5.1",
-								"lodash": "^4.2.1",
-								"node-simctl": "^6.3.0",
-								"openssl-wrapper": "^0.3.4",
-								"semver": "^7.0.0",
-								"source-map-support": "^0.5.3",
-								"teen_process": "^1.3.0"
-							},
-							"dependencies": {
-								"node-simctl": {
-									"version": "6.3.4",
-									"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-6.3.4.tgz",
-									"integrity": "sha512-kjNtuyuKW5FXJI1hu2YRD+kP4eb9LnuwUWH1NfZYWtkbq/rDki0mhMnUOUtloqaHaLRMPN3ZbHkgJbww6NWJmw==",
-									"dev": true,
-									"requires": {
-										"@babel/runtime": "^7.0.0",
-										"asyncbox": "^2.3.1",
-										"bluebird": "^3.5.1",
-										"lodash": "^4.2.1",
-										"npmlog": "^4.1.2",
-										"rimraf": "^3.0.0",
-										"semver": "^7.0.0",
-										"source-map-support": "^0.5.5",
-										"teen_process": "^1.5.1",
-										"uuid": "^8.0.0",
-										"which": "^2.0.0"
-									}
-								}
-							}
-						},
 						"appium-support": {
 							"version": "2.49.0",
 							"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
@@ -26974,54 +21437,13 @@
 								"yauzl": "^2.7.0"
 							},
 							"dependencies": {
-								"archiver": {
-									"version": "5.1.0",
-									"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
-									"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
+								"lockfile": {
+									"version": "1.0.4",
+									"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+									"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
 									"dev": true,
 									"requires": {
-										"archiver-utils": "^2.1.0",
-										"async": "^3.2.0",
-										"buffer-crc32": "^0.2.1",
-										"readable-stream": "^3.6.0",
-										"readdir-glob": "^1.0.0",
-										"tar-stream": "^2.1.4",
-										"zip-stream": "^4.0.4"
-									}
-								},
-								"async": {
-									"version": "3.2.0",
-									"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-									"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-									"dev": true
-								},
-								"compress-commons": {
-									"version": "4.0.2",
-									"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-									"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
-									"dev": true,
-									"requires": {
-										"buffer-crc32": "^0.2.13",
-										"crc32-stream": "^4.0.1",
-										"normalize-path": "^3.0.0",
-										"readable-stream": "^3.6.0"
-									}
-								},
-								"pngjs": {
-									"version": "5.0.0",
-									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-									"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-									"dev": true
-								},
-								"zip-stream": {
-									"version": "4.0.4",
-									"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-									"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
-									"dev": true,
-									"requires": {
-										"archiver-utils": "^2.1.0",
-										"compress-commons": "^4.0.2",
-										"readable-stream": "^3.6.0"
+										"signal-exit": "^3.0.2"
 									}
 								}
 							}
@@ -27076,24 +21498,6 @@
 								}
 							}
 						},
-						"async": {
-							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-							"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.14"
-							}
-						},
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
-							}
-						},
 						"bl": {
 							"version": "4.0.3",
 							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -27103,27 +21507,6 @@
 								"buffer": "^5.5.0",
 								"inherits": "^2.0.4",
 								"readable-stream": "^3.4.0"
-							}
-						},
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"cliui": {
-							"version": "7.0.4",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-							"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-							"dev": true,
-							"requires": {
-								"string-width": "^4.2.0",
-								"strip-ansi": "^6.0.0",
-								"wrap-ansi": "^7.0.0"
 							}
 						},
 						"compress-commons": {
@@ -27182,121 +21565,15 @@
 							"version": "4.0.1",
 							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
 							"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
-							"dev": true,
 							"requires": {
 								"crc-32": "^1.2.0",
 								"readable-stream": "^3.4.0"
 							}
 						},
-						"devtools": {
-							"version": "6.10.4",
-							"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.10.4.tgz",
-							"integrity": "sha512-53LoeU2S4q4cLJGKgo2Or7WU9Kc5RQscC0DbBAZcodkot1lKFbMg/z6/cQTq+XKl4kgYr5VA/s5kzNU7ScBctQ==",
-							"dev": true,
-							"requires": {
-								"@types/puppeteer-core": "^2.0.0",
-								"@types/ua-parser-js": "^0.7.33",
-								"@types/uuid": "^8.3.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/protocols": "6.10.0",
-								"@wdio/utils": "6.10.4",
-								"chrome-launcher": "^0.13.1",
-								"edge-paths": "^2.1.0",
-								"puppeteer-core": "^5.1.0",
-								"ua-parser-js": "^0.7.21",
-								"uuid": "^8.0.0"
-							},
-							"dependencies": {
-								"@wdio/config": {
-									"version": "6.10.4",
-									"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.4.tgz",
-									"integrity": "sha512-M22EunI+n/mmYOQqb9+BTVRqrfmPw+7rR1AHeD36vOXCnZ55Nrl4ZU4d6QzPHp9cLdMZqV786iDmkonnb6jb8w==",
-									"dev": true,
-									"requires": {
-										"@wdio/logger": "6.10.4",
-										"deepmerge": "^4.0.0",
-										"glob": "^7.1.2"
-									}
-								},
-								"@wdio/logger": {
-									"version": "6.10.4",
-									"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.4.tgz",
-									"integrity": "sha512-I+1I/5CtQigy59QJen56PHuwV0yiQdnZaOxmXIP6FzpWkeXLjcoUNaCRDuKwJx5GKrUSDqmGlMWSH53scwwzHg==",
-									"dev": true,
-									"requires": {
-										"chalk": "^4.0.0",
-										"loglevel": "^1.6.0",
-										"loglevel-plugin-prefix": "^0.8.4",
-										"strip-ansi": "^6.0.0"
-									}
-								},
-								"@wdio/protocols": {
-									"version": "6.10.0",
-									"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.0.tgz",
-									"integrity": "sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==",
-									"dev": true
-								},
-								"@wdio/utils": {
-									"version": "6.10.4",
-									"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.10.4.tgz",
-									"integrity": "sha512-DkFguYGKUcv9TmIYuuwS/pxpiGcgyv8gWUWRXffirt2OYpFXJNwB+S96CSQnjgb4B5MqSFgEti+gl8A2wsdDgQ==",
-									"dev": true,
-									"requires": {
-										"@wdio/logger": "6.10.4"
-									}
-								},
-								"chalk": {
-									"version": "4.1.0",
-									"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-									"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^4.1.0",
-										"supports-color": "^7.1.0"
-									}
-								}
-							}
-						},
-						"extract-zip": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-							"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-							"dev": true,
-							"requires": {
-								"@types/yauzl": "^2.9.1",
-								"debug": "^4.1.1",
-								"get-stream": "^5.1.0",
-								"yauzl": "^2.10.0"
-							},
-							"dependencies": {
-								"get-stream": {
-									"version": "5.2.0",
-									"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-									"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-									"dev": true,
-									"requires": {
-										"pump": "^3.0.0"
-									}
-								}
-							}
-						},
-						"fast-deep-equal": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-							"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-							"dev": true
-						},
-						"follow-redirects": {
-							"version": "1.13.0",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-							"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-							"dev": true
-						},
 						"form-data": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-							"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+							"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
 							"dev": true,
 							"requires": {
 								"asynckit": "^0.4.0",
@@ -27310,131 +21587,20 @@
 							"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
 							"dev": true
 						},
-						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-							"dev": true
-						},
-						"jimp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/custom": "^0.14.0",
-								"@jimp/plugins": "^0.14.0",
-								"@jimp/types": "^0.14.0",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"jpeg-js": {
-							"version": "0.4.2",
-							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-							"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
-							"dev": true
-						},
-						"minimist": {
-							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-							"dev": true
-						},
-						"moment-timezone": {
-							"version": "0.5.28",
-							"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-							"integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
-							"dev": true,
-							"requires": {
-								"moment": ">= 2.9.0"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						},
 						"normalize-path": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 							"dev": true
 						},
-						"puppeteer-core": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-							"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-							"dev": true,
-							"requires": {
-								"debug": "^4.1.0",
-								"devtools-protocol": "0.0.818844",
-								"extract-zip": "^2.0.0",
-								"https-proxy-agent": "^4.0.0",
-								"node-fetch": "^2.6.1",
-								"pkg-dir": "^4.2.0",
-								"progress": "^2.0.1",
-								"proxy-from-env": "^1.0.0",
-								"rimraf": "^3.0.2",
-								"tar-fs": "^2.0.0",
-								"unbzip2-stream": "^1.3.3",
-								"ws": "^7.2.3"
-							}
-						},
 						"readable-stream": {
 							"version": "3.6.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
 							"requires": {
 								"inherits": "^2.0.3",
 								"string_decoder": "^1.1.1",
 								"util-deprecate": "^1.0.1"
-							}
-						},
-						"resq": {
-							"version": "1.10.0",
-							"resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
-							"integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
-							"dev": true,
-							"requires": {
-								"fast-deep-equal": "^2.0.1"
-							}
-						},
-						"rgb2hex": {
-							"version": "0.1.10",
-							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.10.tgz",
-							"integrity": "sha512-vKz+kzolWbL3rke/xeTE2+6vHmZnNxGyDnaVW4OckntAIcc7DcZzWkQSfxMDwqHS8vhgySnIFyBUH7lIk6PxvQ==",
-							"dev": true
-						},
-						"serialize-error": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
-							"integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
-							"dev": true,
-							"requires": {
-								"type-fest": "^0.8.0"
-							}
-						},
-						"string-width": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-							"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-							"dev": true,
-							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
 							}
 						},
 						"tar-stream": {
@@ -27450,300 +21616,16 @@
 								"readable-stream": "^3.1.1"
 							}
 						},
-						"type-fest": {
-							"version": "0.8.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-							"dev": true
-						},
 						"uuid": {
 							"version": "8.3.1",
 							"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
 							"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
 							"dev": true
 						},
-						"webdriver": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-5.23.0.tgz",
-							"integrity": "sha512-r7IrbZ2SuTIRyWV8mv4a4hZoFcT9Qt4MznOkdRWPE1sPpZ8lyLZsIEjKCEbHelOzPwURqk+biwGrm4z2OZRAiw==",
-							"dev": true,
-							"requires": {
-								"@types/request": "^2.48.4",
-								"@wdio/config": "5.22.4",
-								"@wdio/logger": "5.16.10",
-								"@wdio/protocols": "5.22.1",
-								"@wdio/utils": "5.23.0",
-								"lodash.merge": "^4.6.1",
-								"request": "^2.83.0"
-							}
-						},
-						"webdriverio": {
-							"version": "6.10.5",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.10.5.tgz",
-							"integrity": "sha512-TLIKVOOM0Oszn2mLxZcMQk0vq1bOWpsZNXMxMtpBXKLvcOCLedftxotwh0o1LqRiq8ODiubJ/vNOLgCN/oLFJQ==",
-							"dev": true,
-							"requires": {
-								"@types/archiver": "^5.1.0",
-								"@types/atob": "^2.1.2",
-								"@types/fs-extra": "^9.0.2",
-								"@types/lodash.clonedeep": "^4.5.6",
-								"@types/lodash.isplainobject": "^4.0.6",
-								"@types/puppeteer-core": "^2.0.0",
-								"@wdio/config": "6.10.4",
-								"@wdio/logger": "6.10.4",
-								"@wdio/repl": "6.10.4",
-								"@wdio/utils": "6.10.4",
-								"archiver": "^5.0.0",
-								"atob": "^2.1.2",
-								"css-shorthand-properties": "^1.1.1",
-								"css-value": "^0.0.1",
-								"devtools": "6.10.4",
-								"fs-extra": "^9.0.1",
-								"get-port": "^5.1.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"minimatch": "^3.0.4",
-								"puppeteer-core": "^5.1.0",
-								"resq": "^1.9.1",
-								"rgb2hex": "^0.2.0",
-								"serialize-error": "^7.0.0",
-								"webdriver": "6.10.4"
-							},
-							"dependencies": {
-								"@wdio/config": {
-									"version": "6.10.4",
-									"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.4.tgz",
-									"integrity": "sha512-M22EunI+n/mmYOQqb9+BTVRqrfmPw+7rR1AHeD36vOXCnZ55Nrl4ZU4d6QzPHp9cLdMZqV786iDmkonnb6jb8w==",
-									"dev": true,
-									"requires": {
-										"@wdio/logger": "6.10.4",
-										"deepmerge": "^4.0.0",
-										"glob": "^7.1.2"
-									}
-								},
-								"@wdio/logger": {
-									"version": "6.10.4",
-									"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.4.tgz",
-									"integrity": "sha512-I+1I/5CtQigy59QJen56PHuwV0yiQdnZaOxmXIP6FzpWkeXLjcoUNaCRDuKwJx5GKrUSDqmGlMWSH53scwwzHg==",
-									"dev": true,
-									"requires": {
-										"chalk": "^4.0.0",
-										"loglevel": "^1.6.0",
-										"loglevel-plugin-prefix": "^0.8.4",
-										"strip-ansi": "^6.0.0"
-									}
-								},
-								"@wdio/protocols": {
-									"version": "6.10.0",
-									"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.0.tgz",
-									"integrity": "sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==",
-									"dev": true
-								},
-								"@wdio/repl": {
-									"version": "6.10.4",
-									"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.10.4.tgz",
-									"integrity": "sha512-VwucPyUqAxU6CWWoEVf14asjtLGTgyaJwp47kEFegr06ZBG43zVQ6JqKFiGDxUJ+fZVRhdd7nRVHd+6UllK18w==",
-									"dev": true,
-									"requires": {
-										"@wdio/utils": "6.10.4"
-									}
-								},
-								"@wdio/utils": {
-									"version": "6.10.4",
-									"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.10.4.tgz",
-									"integrity": "sha512-DkFguYGKUcv9TmIYuuwS/pxpiGcgyv8gWUWRXffirt2OYpFXJNwB+S96CSQnjgb4B5MqSFgEti+gl8A2wsdDgQ==",
-									"dev": true,
-									"requires": {
-										"@wdio/logger": "6.10.4"
-									}
-								},
-								"archiver": {
-									"version": "5.1.0",
-									"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
-									"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
-									"dev": true,
-									"requires": {
-										"archiver-utils": "^2.1.0",
-										"async": "^3.2.0",
-										"buffer-crc32": "^0.2.1",
-										"readable-stream": "^3.6.0",
-										"readdir-glob": "^1.0.0",
-										"tar-stream": "^2.1.4",
-										"zip-stream": "^4.0.4"
-									}
-								},
-								"async": {
-									"version": "3.2.0",
-									"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-									"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-									"dev": true
-								},
-								"chalk": {
-									"version": "4.1.0",
-									"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-									"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^4.1.0",
-										"supports-color": "^7.1.0"
-									}
-								},
-								"compress-commons": {
-									"version": "4.0.2",
-									"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-									"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
-									"dev": true,
-									"requires": {
-										"buffer-crc32": "^0.2.13",
-										"crc32-stream": "^4.0.1",
-										"normalize-path": "^3.0.0",
-										"readable-stream": "^3.6.0"
-									}
-								},
-								"rgb2hex": {
-									"version": "0.2.3",
-									"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
-									"integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
-									"dev": true
-								},
-								"serialize-error": {
-									"version": "7.0.1",
-									"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-									"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-									"dev": true,
-									"requires": {
-										"type-fest": "^0.13.1"
-									}
-								},
-								"type-fest": {
-									"version": "0.13.1",
-									"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-									"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-									"dev": true
-								},
-								"webdriver": {
-									"version": "6.10.4",
-									"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.10.4.tgz",
-									"integrity": "sha512-N2FkEy22QWAJMeyz1219ik9wyt3/SOT/RtsY6JheEriZ1GptzZyK0OibkOnCoaIAt+nvSxnSmTTlmXQMGBE6Mw==",
-									"dev": true,
-									"requires": {
-										"@types/lodash.merge": "^4.6.6",
-										"@wdio/config": "6.10.4",
-										"@wdio/logger": "6.10.4",
-										"@wdio/protocols": "6.10.0",
-										"@wdio/utils": "6.10.4",
-										"got": "^11.0.2",
-										"lodash.merge": "^4.6.1"
-									}
-								},
-								"zip-stream": {
-									"version": "4.0.4",
-									"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-									"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
-									"dev": true,
-									"requires": {
-										"archiver-utils": "^2.1.0",
-										"compress-commons": "^4.0.2",
-										"readable-stream": "^3.6.0"
-									}
-								}
-							}
-						},
-						"wrap-ansi": {
-							"version": "7.0.0",
-							"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-							"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.0.0",
-								"string-width": "^4.1.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
 						"xmldom": {
 							"version": "0.3.0",
 							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
 							"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
-							"dev": true
-						},
-						"xpath": {
-							"version": "0.0.24",
-							"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.24.tgz",
-							"integrity": "sha1-Gt4WLhzFI8jTn8fQavwW6iFvKfs=",
-							"dev": true
-						},
-						"y18n": {
-							"version": "5.0.5",
-							"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-							"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
-							"dev": true
-						},
-						"yargs": {
-							"version": "15.4.1",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-							"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-							"dev": true,
-							"requires": {
-								"cliui": "^6.0.0",
-								"decamelize": "^1.2.0",
-								"find-up": "^4.1.0",
-								"get-caller-file": "^2.0.1",
-								"require-directory": "^2.1.1",
-								"require-main-filename": "^2.0.0",
-								"set-blocking": "^2.0.0",
-								"string-width": "^4.2.0",
-								"which-module": "^2.0.0",
-								"y18n": "^4.0.0",
-								"yargs-parser": "^18.1.2"
-							},
-							"dependencies": {
-								"cliui": {
-									"version": "6.0.0",
-									"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-									"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-									"dev": true,
-									"requires": {
-										"string-width": "^4.2.0",
-										"strip-ansi": "^6.0.0",
-										"wrap-ansi": "^6.2.0"
-									}
-								},
-								"wrap-ansi": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-									"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^4.0.0",
-										"string-width": "^4.1.0",
-										"strip-ansi": "^6.0.0"
-									}
-								},
-								"y18n": {
-									"version": "4.0.1",
-									"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-									"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-									"dev": true
-								},
-								"yargs-parser": {
-									"version": "18.1.3",
-									"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-									"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-									"dev": true,
-									"requires": {
-										"camelcase": "^5.0.0",
-										"decamelize": "^1.2.0"
-									}
-								}
-							}
-						},
-						"yargs-parser": {
-							"version": "20.2.4",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-							"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
 							"dev": true
 						},
 						"zip-stream": {
@@ -27783,60 +21665,6 @@
 						"teen_process": "^1.15.0"
 					},
 					"dependencies": {
-						"@wdio/config": {
-							"version": "5.22.4",
-							"resolved": "https://registry.npmjs.org/@wdio/config/-/config-5.22.4.tgz",
-							"integrity": "sha512-i5dJQWb80darcRA//tfG0guMeQCeRUXroZNnHjGNb1qzvTRZmcIIhdxaD+DbK/5dWEx6aoMfoi6wjVp/CXwdAg==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "5.16.10",
-								"deepmerge": "^4.0.0",
-								"glob": "^7.1.2"
-							}
-						},
-						"@wdio/logger": {
-							"version": "5.16.10",
-							"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-5.16.10.tgz",
-							"integrity": "sha512-hRKhxgd9uB48Dtj2xe2ckxU4KwI/RO8IwguySuaI2SLFj6EDbdonwzpVkq111/fjBuq7R1NauAaNcm3AMEbIFA==",
-							"dev": true,
-							"requires": {
-								"chalk": "^3.0.0",
-								"loglevel": "^1.6.0",
-								"loglevel-plugin-prefix": "^0.8.4",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"@wdio/protocols": {
-							"version": "5.22.1",
-							"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-5.22.1.tgz",
-							"integrity": "sha512-GdoWb/HTrb09Qb0S/7sLp1NU94LAhTsF1NnFj5sEFSUpecrl0S07pnhVg54pUImectN/woaqSl7uJGjlSGZcdQ==",
-							"dev": true
-						},
-						"@wdio/repl": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-5.23.0.tgz",
-							"integrity": "sha512-cKG9m0XuqcQenQmoup0yJX1fkDQEdY06QXuwt636ZQf6XgDoeoAdNOgnRnNruQ0+JsC2eqHFoSNto1q8wcLH/g==",
-							"dev": true,
-							"requires": {
-								"@wdio/utils": "5.23.0"
-							}
-						},
-						"@wdio/utils": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-5.23.0.tgz",
-							"integrity": "sha512-dWPEkDiaNUqJXPO6L2di2apI7Rle7Er4euh67Wlb5+3MrPNjCKhiF8gHcpQeL8oe6A1MH/f89kpSEEXe4BMkAw==",
-							"dev": true,
-							"requires": {
-								"@wdio/logger": "5.16.10",
-								"deepmerge": "^4.0.0"
-							}
-						},
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
 						"appium-base-driver": {
 							"version": "4.5.1",
 							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-4.5.1.tgz",
@@ -27868,125 +21696,6 @@
 								"ws": "^7.0.0"
 							}
 						},
-						"archiver": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-							"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"async": "^2.6.3",
-								"buffer-crc32": "^0.2.1",
-								"glob": "^7.1.4",
-								"readable-stream": "^3.4.0",
-								"tar-stream": "^2.1.0",
-								"zip-stream": "^2.1.2"
-							}
-						},
-						"archiver-utils": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.4",
-								"graceful-fs": "^4.2.0",
-								"lazystream": "^1.0.0",
-								"lodash.defaults": "^4.2.0",
-								"lodash.difference": "^4.5.0",
-								"lodash.flatten": "^4.4.0",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.union": "^4.6.0",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.0.0"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
-							}
-						},
-						"async": {
-							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-							"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.14"
-							}
-						},
-						"bl": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-							"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-							"dev": true,
-							"requires": {
-								"buffer": "^5.5.0",
-								"inherits": "^2.0.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"compress-commons": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-							"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
-							"dev": true,
-							"requires": {
-								"buffer-crc32": "^0.2.13",
-								"crc32-stream": "^3.0.1",
-								"normalize-path": "^3.0.0",
-								"readable-stream": "^2.3.6"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "2.3.7",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.3",
-										"isarray": "~1.0.0",
-										"process-nextick-args": "~2.0.0",
-										"safe-buffer": "~5.1.1",
-										"string_decoder": "~1.1.1",
-										"util-deprecate": "~1.0.1"
-									}
-								}
-							}
-						},
-						"crc32-stream": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-							"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
-							"dev": true,
-							"requires": {
-								"crc": "^3.4.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
 						"node-simctl": {
 							"version": "5.3.0",
 							"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-5.3.0.tgz",
@@ -28001,115 +21710,6 @@
 								"semver": "^7.0.0",
 								"source-map-support": "^0.5.5",
 								"teen_process": "^1.5.1"
-							}
-						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-							"dev": true
-						},
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						},
-						"rgb2hex": {
-							"version": "0.1.10",
-							"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.10.tgz",
-							"integrity": "sha512-vKz+kzolWbL3rke/xeTE2+6vHmZnNxGyDnaVW4OckntAIcc7DcZzWkQSfxMDwqHS8vhgySnIFyBUH7lIk6PxvQ==",
-							"dev": true
-						},
-						"serialize-error": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
-							"integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
-							"dev": true,
-							"requires": {
-								"type-fest": "^0.8.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						},
-						"tar-stream": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-							"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-							"dev": true,
-							"requires": {
-								"bl": "^4.0.3",
-								"end-of-stream": "^1.4.1",
-								"fs-constants": "^1.0.0",
-								"inherits": "^2.0.3",
-								"readable-stream": "^3.1.1"
-							}
-						},
-						"type-fest": {
-							"version": "0.8.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-							"dev": true
-						},
-						"webdriver": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-5.23.0.tgz",
-							"integrity": "sha512-r7IrbZ2SuTIRyWV8mv4a4hZoFcT9Qt4MznOkdRWPE1sPpZ8lyLZsIEjKCEbHelOzPwURqk+biwGrm4z2OZRAiw==",
-							"dev": true,
-							"requires": {
-								"@types/request": "^2.48.4",
-								"@wdio/config": "5.22.4",
-								"@wdio/logger": "5.16.10",
-								"@wdio/protocols": "5.22.1",
-								"@wdio/utils": "5.23.0",
-								"lodash.merge": "^4.6.1",
-								"request": "^2.83.0"
-							}
-						},
-						"webdriverio": {
-							"version": "5.23.0",
-							"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-5.23.0.tgz",
-							"integrity": "sha512-hxt6Nuu2bBrTsVk7GfoFRTh63l4fRVXlK9U30RtPbHoWO5tcFdyUz2UTgeHEZ54ea1DQEVPfsgFiLnJULkWp1Q==",
-							"dev": true,
-							"requires": {
-								"@wdio/config": "5.22.4",
-								"@wdio/logger": "5.16.10",
-								"@wdio/repl": "5.23.0",
-								"@wdio/utils": "5.23.0",
-								"archiver": "^3.0.0",
-								"css-value": "^0.0.1",
-								"grapheme-splitter": "^1.0.2",
-								"lodash.clonedeep": "^4.5.0",
-								"lodash.isobject": "^3.0.2",
-								"lodash.isplainobject": "^4.0.6",
-								"lodash.zip": "^4.2.0",
-								"resq": "^1.6.0",
-								"rgb2hex": "^0.1.0",
-								"serialize-error": "^5.0.0",
-								"webdriver": "5.23.0"
-							}
-						},
-						"zip-stream": {
-							"version": "2.1.3",
-							"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
-							"integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
-							"dev": true,
-							"requires": {
-								"archiver-utils": "^2.1.0",
-								"compress-commons": "^2.1.1",
-								"readable-stream": "^3.4.0"
 							}
 						}
 					}
@@ -28149,23 +21749,6 @@
 						"lodash": "^4.8.0",
 						"normalize-path": "^2.0.0",
 						"readable-stream": "^2.0.0"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						}
 					}
 				},
 				"are-we-there-yet": {
@@ -28176,23 +21759,6 @@
 					"requires": {
 						"delegates": "^1.0.0",
 						"readable-stream": "^2.0.6"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						}
 					}
 				},
 				"argparse": {
@@ -28317,12 +21883,7 @@
 				"asynckit": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-				},
-				"atob": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-					"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 					"dev": true
 				},
 				"aws-sign2": {
@@ -28336,15 +21897,6 @@
 					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
 					"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 					"dev": true
-				},
-				"axios": {
-					"version": "0.19.2",
-					"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-					"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-					"dev": true,
-					"requires": {
-						"follow-redirects": "1.5.10"
-					}
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
@@ -28373,12 +21925,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"dev": true
 				},
 				"base64-js": {
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-					"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+					"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+					"dev": true
 				},
 				"base64-stream": {
 					"version": "1.0.0",
@@ -28495,6 +22049,7 @@
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -28504,10 +22059,27 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
 					"integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+					"dev": true,
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
 					}
+				},
+				"buffer-alloc": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+					"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+					"dev": true,
+					"requires": {
+						"buffer-alloc-unsafe": "^1.1.0",
+						"buffer-fill": "^1.0.0"
+					}
+				},
+				"buffer-alloc-unsafe": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+					"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+					"dev": true
 				},
 				"buffer-crc32": {
 					"version": "0.2.13",
@@ -28519,6 +22091,12 @@
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
 					"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
+					"dev": true
+				},
+				"buffer-fill": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+					"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
 					"dev": true
 				},
 				"buffer-from": {
@@ -28538,27 +22116,6 @@
 					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
 					"dev": true
-				},
-				"cacheable-lookup": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz",
-					"integrity": "sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w==",
-					"dev": true
-				},
-				"cacheable-request": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-					"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-					"dev": true,
-					"requires": {
-						"clone-response": "^1.0.2",
-						"get-stream": "^5.1.0",
-						"http-cache-semantics": "^4.0.0",
-						"keyv": "^4.0.0",
-						"lowercase-keys": "^2.0.0",
-						"normalize-url": "^4.1.0",
-						"responselike": "^2.0.0"
-					}
 				},
 				"camelcase": {
 					"version": "5.3.1",
@@ -28587,39 +22144,6 @@
 					"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 					"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
 					"dev": true
-				},
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-				},
-				"chrome-launcher": {
-					"version": "0.13.4",
-					"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
-					"integrity": "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==",
-					"requires": {
-						"@types/node": "*",
-						"escape-string-regexp": "^1.0.5",
-						"is-wsl": "^2.2.0",
-						"lighthouse-logger": "^1.0.0",
-						"mkdirp": "^0.5.3",
-						"rimraf": "^3.0.2"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-						},
-						"mkdirp": {
-							"version": "0.5.5",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-							"requires": {
-								"minimist": "^1.2.5"
-							}
-						}
-					}
 				},
 				"circular-json": {
 					"version": "0.5.9",
@@ -28684,15 +22208,6 @@
 					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 					"dev": true
 				},
-				"clone-response": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-					"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-					"dev": true,
-					"requires": {
-						"mimic-response": "^1.0.0"
-					}
-				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -28703,6 +22218,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
 					"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.1",
 						"color-string": "^1.5.2"
@@ -28712,6 +22228,7 @@
 							"version": "1.9.3",
 							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 							"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+							"dev": true,
 							"requires": {
 								"color-name": "1.1.3"
 							}
@@ -28719,7 +22236,8 @@
 						"color-name": {
 							"version": "1.1.3",
 							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+							"dev": true
 						}
 					}
 				},
@@ -28735,12 +22253,14 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
 				},
 				"color-string": {
 					"version": "1.5.3",
 					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
 					"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+					"dev": true,
 					"requires": {
 						"color-name": "^1.0.0",
 						"simple-swizzle": "^0.2.2"
@@ -28750,6 +22270,12 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 					"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+					"dev": true
+				},
+				"colornames": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+					"integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
 					"dev": true
 				},
 				"colors": {
@@ -28762,6 +22288,7 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
 					"integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+					"dev": true,
 					"requires": {
 						"color": "3.0.x",
 						"text-hex": "1.0.x"
@@ -28771,6 +22298,7 @@
 					"version": "1.0.8",
 					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 					"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+					"dev": true,
 					"requires": {
 						"delayed-stream": "~1.0.0"
 					}
@@ -28797,29 +22325,25 @@
 						"crc32-stream": "^2.0.0",
 						"normalize-path": "^2.0.0",
 						"readable-stream": "^2.0.0"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						}
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"concat-stream": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
+					}
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
@@ -28867,7 +22391,8 @@
 				"core-js": {
 					"version": "3.6.4",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -28936,6 +22461,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -28945,23 +22471,6 @@
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
-				},
-				"decompress-response": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-					"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-					"dev": true,
-					"requires": {
-						"mimic-response": "^3.1.0"
-					},
-					"dependencies": {
-						"mimic-response": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-							"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-							"dev": true
-						}
-					}
 				},
 				"deep-eql": {
 					"version": "0.1.3",
@@ -28978,16 +22487,11 @@
 					"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 					"dev": true
 				},
-				"defer-to-connect": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-					"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
-					"dev": true
-				},
 				"delayed-stream": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
@@ -29007,14 +22511,15 @@
 					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
 					"dev": true
 				},
-				"devtools": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.2.0.tgz",
-					"integrity": "sha512-PmDKnIlDdP5+b6VurEnrIiLdzpSuWeWfge8tXJWjvFPhoqvwzdw4j5YSFo/QRWusS37Mk/j/rNUUawYP0u/ZKg==",
+				"diagnostics": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+					"integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+					"dev": true,
 					"requires": {
-						"chrome-launcher": "^0.13.1",
-						"puppeteer-core": "^4.0.0",
-						"ua-parser-js": "^0.7.21"
+						"colorspace": "1.1.x",
+						"enabled": "1.0.x",
+						"kuler": "1.0.x"
 					}
 				},
 				"dom-walk": {
@@ -29064,6 +22569,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
 					"integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+					"dev": true,
 					"requires": {
 						"env-variable": "0.0.x"
 					}
@@ -29078,9 +22584,16 @@
 					"version": "1.4.4",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 					"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+					"dev": true,
 					"requires": {
 						"once": "^1.4.0"
 					}
+				},
+				"env-variable": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+					"integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg==",
+					"dev": true
 				},
 				"es6-error": {
 					"version": "4.1.1",
@@ -29103,22 +22616,11 @@
 					"integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==",
 					"dev": true
 				},
-				"escalade": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-					"dev": true
-				},
 				"escape-html": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
 					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"etag": {
 					"version": "1.8.1",
@@ -29299,7 +22801,8 @@
 				"fast-deep-equal": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+					"dev": true
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.1.0",
@@ -29397,37 +22900,6 @@
 						"taskkill": "^3.0.0"
 					}
 				},
-				"fn.name": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-					"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-				},
-				"follow-redirects": {
-					"version": "1.5.10",
-					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-					"dev": true,
-					"requires": {
-						"debug": "=3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-							"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -29438,6 +22910,7 @@
 					"version": "2.3.3",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
 						"combined-stream": "^1.0.6",
@@ -29459,29 +22932,19 @@
 				"fs-constants": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-					"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-				},
-				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-					"dev": true,
-					"requires": {
-						"at-least-node": "^1.0.0",
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
-					}
+					"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+					"dev": true
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"dev": true
 				},
 				"fsevents": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-					"integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 					"dev": true,
 					"optional": true
 				},
@@ -29542,12 +23005,6 @@
 					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 					"dev": true
 				},
-				"get-port": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-					"integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-					"dev": true
-				},
 				"get-prototype-of": {
 					"version": "0.0.0",
 					"resolved": "https://registry.npmjs.org/get-prototype-of/-/get-prototype-of-0.0.0.tgz",
@@ -29576,6 +23033,7 @@
 					"version": "7.1.6",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -29593,25 +23051,6 @@
 					"requires": {
 						"min-document": "^2.19.0",
 						"process": "~0.5.1"
-					}
-				},
-				"got": {
-					"version": "11.5.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-11.5.0.tgz",
-					"integrity": "sha512-vOZEcEaK0b6x11uniY0HcblZObKPRO75Jvz53VKuqGSaKCM/zEt0sj2LGYVdqDYJzO3wYdG+FPQQ1hsgoXy7vQ==",
-					"dev": true,
-					"requires": {
-						"@sindresorhus/is": "^3.0.0",
-						"@szmarczak/http-timer": "^4.0.5",
-						"@types/cacheable-request": "^6.0.1",
-						"@types/responselike": "^1.0.0",
-						"cacheable-lookup": "^5.0.3",
-						"cacheable-request": "^7.0.1",
-						"decompress-response": "^6.0.0",
-						"http2-wrapper": "^1.0.0-beta.4.8",
-						"lowercase-keys": "^2.0.0",
-						"p-cancelable": "^2.0.0",
-						"responselike": "^2.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -29654,12 +23093,6 @@
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true
 				},
-				"http-cache-semantics": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-					"dev": true
-				},
 				"http-errors": {
 					"version": "1.7.2",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -29698,25 +23131,6 @@
 					"integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==",
 					"dev": true
 				},
-				"http2-wrapper": {
-					"version": "1.0.0-beta.5.2",
-					"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-					"integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
-					"dev": true,
-					"requires": {
-						"quick-lru": "^5.1.1",
-						"resolve-alpn": "^1.0.0"
-					}
-				},
-				"https-proxy-agent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-					"requires": {
-						"agent-base": "5",
-						"debug": "4"
-					}
-				},
 				"human-signals": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -29735,7 +23149,8 @@
 				"ieee754": {
 					"version": "1.1.13",
 					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-					"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+					"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+					"dev": true
 				},
 				"immediate": {
 					"version": "3.0.6",
@@ -29753,6 +23168,7 @@
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -29790,7 +23206,8 @@
 				"is-arrayish": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
@@ -29809,11 +23226,6 @@
 					"resolved": "https://registry.npmjs.org/is-class/-/is-class-0.0.4.tgz",
 					"integrity": "sha1-4FdFFwW7NOOePjNZjJOpg3KWtzY=",
 					"dev": true
-				},
-				"is-docker": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-					"integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
@@ -29850,14 +23262,6 @@
 					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 					"dev": true
-				},
-				"is-wsl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-					"requires": {
-						"is-docker": "^2.0.0"
-					}
 				},
 				"isarray": {
 					"version": "1.0.0",
@@ -29934,12 +23338,6 @@
 						}
 					}
 				},
-				"json-buffer": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-					"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-					"dev": true
-				},
 				"json-schema": {
 					"version": "0.2.3",
 					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -29957,24 +23355,6 @@
 					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 					"dev": true
-				},
-				"jsonfile": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6",
-						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
-					}
 				},
 				"jsprim": {
 					"version": "1.4.1",
@@ -29998,23 +23378,6 @@
 						"pako": "~1.0.2",
 						"readable-stream": "~2.3.6",
 						"set-immediate-shim": "~1.0.1"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						}
 					}
 				},
 				"keypather": {
@@ -30024,15 +23387,6 @@
 					"dev": true,
 					"requires": {
 						"101": "^1.0.0"
-					}
-				},
-				"keyv": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
-					"integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
-					"dev": true,
-					"requires": {
-						"json-buffer": "3.0.1"
 					}
 				},
 				"klaw": {
@@ -30048,6 +23402,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
 					"integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+					"dev": true,
 					"requires": {
 						"colornames": "^1.1.1"
 					}
@@ -30059,23 +23414,6 @@
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.0.5"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						}
 					}
 				},
 				"lcid": {
@@ -30094,30 +23432,6 @@
 					"dev": true,
 					"requires": {
 						"immediate": "~3.0.5"
-					}
-				},
-				"lighthouse-logger": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
-					"integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
-					"requires": {
-						"debug": "^2.6.8",
-						"marky": "^1.2.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-						}
 					}
 				},
 				"load-bmfont": {
@@ -30143,15 +23457,6 @@
 					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
-					}
-				},
-				"lockfile": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-					"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
-					"dev": true,
-					"requires": {
-						"signal-exit": "^3.0.2"
 					}
 				},
 				"lodash": {
@@ -30254,12 +23559,6 @@
 						"source-map-support": "0.3.2 - 1.0.0"
 					}
 				},
-				"lowercase-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-					"dev": true
-				},
 				"lru-cache": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -30278,11 +23577,6 @@
 						"p-defer": "^1.0.0"
 					}
 				},
-				"marky": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
-					"integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ=="
-				},
 				"md5": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -30293,6 +23587,12 @@
 						"crypt": "~0.0.1",
 						"is-buffer": "~1.1.1"
 					}
+				},
+				"md5-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
+					"integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==",
+					"dev": true
 				},
 				"media-typer": {
 					"version": "0.3.0",
@@ -30367,12 +23667,14 @@
 				"mime-db": {
 					"version": "1.43.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-					"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+					"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.26",
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
 					"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+					"dev": true,
 					"requires": {
 						"mime-db": "1.43.0"
 					}
@@ -30381,12 +23683,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				},
-				"mimic-response": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
 					"dev": true
 				},
 				"min-document": {
@@ -30402,6 +23698,7 @@
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -30411,11 +23708,6 @@
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
-				},
-				"mitt": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/mitt/-/mitt-2.0.1.tgz",
-					"integrity": "sha512-FhuJY+tYHLnPcBHQhbUFzscD5512HumCPE4URXZUgPi3IvOJi4Xva5IIgy3xX56GqCmw++MAm5UURG6kDBYTdg=="
 				},
 				"mjpeg-server": {
 					"version": "0.3.0",
@@ -30428,11 +23720,6 @@
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
 					"integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
 					"dev": true
-				},
-				"mkdirp-classic": {
-					"version": "0.5.3",
-					"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-					"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 				},
 				"moment": {
 					"version": "2.24.0",
@@ -30471,12 +23758,6 @@
 								"ms": "2.0.0"
 							}
 						},
-						"depd": {
-							"version": "1.1.2",
-							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-							"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-							"dev": true
-						},
 						"ms": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -30488,7 +23769,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"mv": {
 					"version": "2.1.1",
@@ -30583,12 +23865,6 @@
 						"remove-trailing-separator": "^1.0.1"
 					}
 				},
-				"normalize-url": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-					"dev": true
-				},
 				"npm-run-path": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -30653,6 +23929,7 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -30785,12 +24062,6 @@
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true
 				},
-				"p-cancelable": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-					"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
-					"dev": true
-				},
 				"p-defer": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -30894,7 +24165,8 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"dev": true
 				},
 				"path-key": {
 					"version": "3.1.1",
@@ -31055,23 +24327,6 @@
 					"dev": true,
 					"requires": {
 						"pngjs": "^3.0.0"
-					},
-					"dependencies": {
-						"pngjs": {
-							"version": "3.4.0",
-							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
-						}
-					}
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
 					}
 				},
 				"plist": {
@@ -31116,15 +24371,6 @@
 						"mkdirp": "^0.5.1"
 					},
 					"dependencies": {
-						"async": {
-							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-							"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.14"
-							}
-						},
 						"debug": {
 							"version": "3.2.6",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -31153,17 +24399,6 @@
 					"requires": {
 						"async": "^2.6.0",
 						"is-number-like": "^1.0.3"
-					},
-					"dependencies": {
-						"async": {
-							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-							"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.14"
-							}
-						}
 					}
 				},
 				"process": {
@@ -31195,11 +24430,6 @@
 					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 					"dev": true
 				},
-				"progress": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-					"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
-				},
 				"proxy-addr": {
 					"version": "2.0.6",
 					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -31209,11 +24439,6 @@
 						"forwarded": "~0.1.2",
 						"ipaddr.js": "1.9.1"
 					}
-				},
-				"proxy-from-env": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-					"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 				},
 				"ps-list": {
 					"version": "7.0.0",
@@ -31237,6 +24462,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -31248,39 +24474,10 @@
 					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 					"dev": true
 				},
-				"puppeteer-core": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-4.0.1.tgz",
-					"integrity": "sha512-8OfHmUkEXU/k7Bmcdm6KRWhIIfmayv/ce1AUDkP0nTLK2IpjulFggxq1dZhWgWHXebeLILbieMvAor7tSf3EqQ==",
-					"requires": {
-						"debug": "^4.1.0",
-						"https-proxy-agent": "^4.0.0",
-						"mime": "^2.0.3",
-						"mitt": "^2.0.1",
-						"progress": "^2.0.1",
-						"proxy-from-env": "^1.0.0",
-						"rimraf": "^3.0.2",
-						"tar-fs": "^2.0.0",
-						"unbzip2-stream": "^1.3.3",
-						"ws": "^7.2.3"
-					},
-					"dependencies": {
-						"mime": {
-							"version": "2.4.6",
-							"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-							"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
-						}
-					}
-				},
 				"qs": {
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-				},
-				"quick-lru": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 					"dev": true
 				},
 				"range-parser": {
@@ -31328,7 +24525,14 @@
 				"regenerator-runtime": {
 					"version": "0.13.4",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-					"integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+					"integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+					"dev": true
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+					"dev": true
 				},
 				"request": {
 					"version": "2.88.2",
@@ -31356,31 +24560,6 @@
 						"tough-cookie": "~2.5.0",
 						"tunnel-agent": "^0.6.0",
 						"uuid": "^3.3.2"
-					},
-					"dependencies": {
-						"form-data": {
-							"version": "2.3.3",
-							"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-							"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-							"dev": true,
-							"requires": {
-								"asynckit": "^0.4.0",
-								"combined-stream": "^1.0.6",
-								"mime-types": "^2.1.12"
-							}
-						},
-						"qs": {
-							"version": "6.5.2",
-							"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-							"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-							"dev": true
-						},
-						"uuid": {
-							"version": "3.4.0",
-							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-							"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-							"dev": true
-						}
 					}
 				},
 				"request-promise": {
@@ -31425,21 +24604,6 @@
 						"path-parse": "^1.0.6"
 					}
 				},
-				"resolve-alpn": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
-					"integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==",
-					"dev": true
-				},
-				"responselike": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-					"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-					"dev": true,
-					"requires": {
-						"lowercase-keys": "^2.0.0"
-					}
-				},
 				"resq": {
 					"version": "1.7.1",
 					"resolved": "https://registry.npmjs.org/resq/-/resq-1.7.1.tgz",
@@ -31467,6 +24631,7 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -31486,12 +24651,6 @@
 						"ws": "^5.2.2"
 					},
 					"dependencies": {
-						"uuid": {
-							"version": "3.4.0",
-							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-							"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-							"dev": true
-						},
 						"ws": {
 							"version": "5.2.2",
 							"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
@@ -31742,6 +24901,7 @@
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
 					"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.3.1"
 					}
@@ -31819,6 +24979,15 @@
 						"through": "~2.3.4"
 					}
 				},
+				"stream-equal": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-1.1.1.tgz",
+					"integrity": "sha512-SaZxkvxujYBR6NTumhRTg/yztw2p30fzZ/jvSgQtlZFEGI7tdSNDaPbvT47QF92hx6Tar8hAhpr7ErpTNvtuCQ==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*"
+					}
+				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -31866,51 +25035,6 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				},
-				"tar-fs": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-					"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
-					"requires": {
-						"chownr": "^1.1.1",
-						"mkdirp-classic": "^0.5.2",
-						"pump": "^3.0.0",
-						"tar-stream": "^2.0.0"
-					},
-					"dependencies": {
-						"bl": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-							"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-							"requires": {
-								"buffer": "^5.5.0",
-								"inherits": "^2.0.4",
-								"readable-stream": "^3.4.0"
-							}
-						},
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						},
-						"tar-stream": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-							"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-							"requires": {
-								"bl": "^4.0.3",
-								"end-of-stream": "^1.4.1",
-								"fs-constants": "^1.0.0",
-								"inherits": "^2.0.3",
-								"readable-stream": "^3.1.1"
-							}
-						}
 					}
 				},
 				"tar-stream": {
@@ -31980,12 +25104,14 @@
 				"text-hex": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-					"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+					"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+					"dev": true
 				},
 				"through": {
 					"version": "2.3.8",
 					"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+					"dev": true
 				},
 				"time-stamp": {
 					"version": "1.1.0",
@@ -32013,6 +25139,12 @@
 					"requires": {
 						"os-tmpdir": "~1.0.1"
 					}
+				},
+				"to-buffer": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+					"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+					"dev": true
 				},
 				"toidentifier": {
 					"version": "1.0.0",
@@ -32082,24 +25214,10 @@
 						"mime-types": "~2.1.24"
 					}
 				},
-				"ua-parser-js": {
-					"version": "0.7.21",
-					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-					"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
-				},
-				"unbzip2-stream": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-					"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-					"requires": {
-						"buffer": "^5.2.1",
-						"through": "^2.3.8"
-					}
-				},
-				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+				"typedarray": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 					"dev": true
 				},
 				"unorm": {
@@ -32169,7 +25287,8 @@
 				"uuid": {
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				},
 				"uuid-js": {
 					"version": "0.7.5",
@@ -32199,6 +25318,12 @@
 						"core-util-is": "1.0.2",
 						"extsprintf": "^1.2.0"
 					}
+				},
+				"walkdir": {
+					"version": "0.0.11",
+					"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+					"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+					"dev": true
 				},
 				"webdriver": {
 					"version": "5.19.0",
@@ -32448,23 +25573,6 @@
 					"requires": {
 						"readable-stream": "^2.3.6",
 						"triple-beam": "^1.2.0"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						}
 					}
 				},
 				"word-wrap": {
@@ -32521,12 +25629,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
 				},
 				"ws": {
 					"version": "7.2.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-					"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+					"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+					"dev": true
 				},
 				"xhr": {
 					"version": "2.5.0",
@@ -33422,12 +26532,6 @@
 				"postcss-value-parser": "^4.1.0"
 			},
 			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30001148",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-					"integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
-					"dev": true
-				},
 				"colorette": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
@@ -33472,6 +26576,15 @@
 			"dev": true,
 			"requires": {
 				"axe-core": "^3.5.3"
+			}
+		},
+		"axios": {
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+			"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+			"dev": true,
+			"requires": {
+				"follow-redirects": "^1.10.0"
 			}
 		},
 		"axobject-query": {
@@ -35447,12 +28560,6 @@
 				"node-releases": "^1.1.60"
 			},
 			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30001117",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz",
-					"integrity": "sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==",
-					"dev": true
-				},
 				"electron-to-chromium": {
 					"version": "1.3.544",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.544.tgz",
@@ -35797,9 +28904,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000998",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000998.tgz",
-			"integrity": "sha512-8Tj5sPZR9kMHeDD9SZXIVr5m9ofufLLCG2Y4QwQrH18GIwG+kCc+zYdlR036ZRkuKjVVetyxeAgGA1xF7XdmzQ==",
+			"version": "1.0.30001187",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz",
+			"integrity": "sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -36489,38 +29596,11 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.1.0.tgz",
 			"integrity": "sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg=="
 		},
-		"colornames": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
-			"integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
-		},
 		"colors": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
 			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
 			"dev": true
-		},
-		"colorspace": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
-			"integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
-			"dev": true,
-			"requires": {
-				"color": "3.0.x",
-				"text-hex": "1.0.x"
-			},
-			"dependencies": {
-				"color": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-					"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.1",
-						"color-string": "^1.5.2"
-					}
-				}
-			}
 		},
 		"columnify": {
 			"version": "1.5.4",
@@ -37535,7 +30615,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
 			"integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
-			"dev": true,
 			"requires": {
 				"exit-on-epipe": "~1.0.1",
 				"printj": "~1.1.0"
@@ -37881,12 +30960,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
 			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
-			"dev": true
-		},
-		"css-shorthand-properties": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
-			"integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==",
 			"dev": true
 		},
 		"css-to-react-native": {
@@ -38593,12 +31666,6 @@
 				}
 			}
 		},
-		"devtools-protocol": {
-			"version": "0.0.818844",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-			"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
-			"dev": true
-		},
 		"dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -38607,17 +31674,6 @@
 			"requires": {
 				"asap": "^2.0.0",
 				"wrappy": "1"
-			}
-		},
-		"diagnostics": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
-			"integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
-			"dev": true,
-			"requires": {
-				"colorspace": "1.1.x",
-				"enabled": "1.0.x",
-				"kuler": "1.0.x"
 			}
 		},
 		"didyoumean": {
@@ -38897,12 +31953,6 @@
 				"jsbn": "~0.1.0"
 			}
 		},
-		"edge-paths": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-2.1.0.tgz",
-			"integrity": "sha512-ZpIN1Vm5hlo9dkkST/1s8QqPNne2uwk3Plf6HcVUhnpfal0WnDRLdNj/wdQo3xRc+wnN3C25wPpPlV2E6aOunQ==",
-			"dev": true
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -38989,15 +32039,6 @@
 				}
 			}
 		},
-		"enabled": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-			"integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
-			"dev": true,
-			"requires": {
-				"env-variable": "0.0.x"
-			}
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -39063,11 +32104,6 @@
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
 			"integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
 			"dev": true
-		},
-		"env-variable": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
-			"integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
 		},
 		"envinfo": {
 			"version": "7.5.0",
@@ -41333,8 +34369,7 @@
 		"exit-on-epipe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-			"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
-			"dev": true
+			"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
@@ -42623,6 +35658,12 @@
 			"integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==",
 			"dev": true
 		},
+		"follow-redirects": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+			"integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
+			"dev": true
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -43184,16 +36225,6 @@
 			"requires": {
 				"encoding": "^0.1.12",
 				"safe-buffer": "^5.1.1"
-			}
-		},
-		"gifwrap": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.2.tgz",
-			"integrity": "sha512-fcIswrPaiCDAyO8xnWvHSZdWChjKXUanKKpAiWWJ/UTkEi/aYKn5+90e7DE820zbEaVR9CE2y4z9bzhQijZ0BA==",
-			"dev": true,
-			"requires": {
-				"image-q": "^1.1.1",
-				"omggif": "^1.0.10"
 			}
 		},
 		"git-raw-commits": {
@@ -44697,12 +37728,6 @@
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
-		},
-		"image-q": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/image-q/-/image-q-1.1.1.tgz",
-			"integrity": "sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY=",
-			"dev": true
 		},
 		"image-size": {
 			"version": "0.6.3",
@@ -51338,15 +44363,6 @@
 			"integrity": "sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA==",
 			"dev": true
 		},
-		"kuler": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
-			"integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
-			"dev": true,
-			"requires": {
-				"colornames": "^1.1.1"
-			}
-		},
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -52738,12 +45754,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
 			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-			"dev": true
-		},
-		"md5-file": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
-			"integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==",
 			"dev": true
 		},
 		"md5.js": {
@@ -56206,12 +49216,6 @@
 			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
 			"dev": true
 		},
-		"omggif": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-			"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
-			"dev": true
-		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -58077,8 +51081,7 @@
 		"printj": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
-			"dev": true
+			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
 		},
 		"prismjs": {
 			"version": "1.19.0",
@@ -59311,12 +52314,6 @@
 						"node-releases": "^1.1.52",
 						"pkg-up": "^3.1.0"
 					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001124",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-					"integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
-					"dev": true
 				},
 				"chalk": {
 					"version": "2.4.2",
@@ -64124,15 +57121,6 @@
 				"stream-shift": "^1.0.0"
 			}
 		},
-		"stream-equal": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-1.1.1.tgz",
-			"integrity": "sha512-SaZxkvxujYBR6NTumhRTg/yztw2p30fzZ/jvSgQtlZFEGI7tdSNDaPbvT47QF92hx6Tar8hAhpr7ErpTNvtuCQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"stream-http": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
@@ -65235,12 +58223,6 @@
 						"node-releases": "^1.1.53",
 						"pkg-up": "^2.0.0"
 					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001081",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001081.tgz",
-					"integrity": "sha512-iZdh3lu09jsUtLE6Bp8NAbJskco4Y3UDtkR3GTCJGsbMowBU5IWDFF79sV2ws7lSqTzWyKazxam2thasHymENQ==",
-					"dev": true
 				},
 				"cosmiconfig": {
 					"version": "6.0.0",
@@ -66604,12 +59586,6 @@
 			"integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
 			"dev": true
 		},
-		"text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
-		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -67945,12 +60921,6 @@
 					"dev": true
 				}
 			}
-		},
-		"walkdir": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
-			"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
-			"dev": true
 		},
 		"walker": {
 			"version": "1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58728,15 +58728,15 @@
 					"dev": true
 				},
 				"base64-js": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-					"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 					"dev": true
 				},
 				"bl": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+					"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",
@@ -58753,9 +58753,9 @@
 					}
 				},
 				"buffer": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
-					"integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
 					"dev": true,
 					"requires": {
 						"base64-js": "^1.3.1",
@@ -58769,9 +58769,9 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -58815,18 +58815,18 @@
 					"dev": true
 				},
 				"mime-db": {
-					"version": "1.44.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+					"version": "1.45.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+					"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
 					"dev": true
 				},
 				"mime-types": {
-					"version": "2.1.27",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-					"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+					"version": "2.1.28",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+					"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.44.0"
+						"mime-db": "1.45.0"
 					}
 				},
 				"ms": {
@@ -58857,21 +58857,21 @@
 					}
 				},
 				"tar-fs": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-					"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+					"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 					"dev": true,
 					"requires": {
 						"chownr": "^1.1.1",
 						"mkdirp-classic": "^0.5.2",
 						"pump": "^3.0.0",
-						"tar-stream": "^2.0.0"
+						"tar-stream": "^2.1.4"
 					}
 				},
 				"tar-stream": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-					"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+					"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
 					"dev": true,
 					"requires": {
 						"bl": "^4.0.3",
@@ -58882,9 +58882,9 @@
 					}
 				},
 				"ws": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+					"integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
 					"dev": true
 				},
 				"yauzl": {
@@ -67147,15 +67147,15 @@
 			},
 			"dependencies": {
 				"base64-js": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-					"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 					"dev": true
 				},
 				"buffer": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
-					"integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
 					"dev": true,
 					"requires": {
 						"base64-js": "^1.3.1",

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -11,6 +11,11 @@
 	padding-top: $grid-unit-20;
 }
 
+// Prevents the popover content from being scrolled out of view.
+.block-editor-media-replace-flow__options .components-popover__content {
+	overflow-y: unset;
+}
+
 .block-editor-media-replace-flow__indicator {
 	margin-left: 4px;
 }


### PR DESCRIPTION
This is a more specific approach to fixing #28604, targeting only the popover in question and in a branch off of `wp/5.6`.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
