### PR TITLE
Chore: Format TS files according to coding styles

### DIFF
--- a/packages/components/src/ui/flex/types.ts
+++ b/packages/components/src/ui/flex/types.ts
@@ -1,7 +1,9 @@
 import { CSSProperties } from 'react';
 import { ResponsiveCSSValue } from '../utils/types';
 
-export type FlexDirection = ResponsiveCSSValue< CSSProperties[ 'flexDirection' ] >;
+export type FlexDirection = ResponsiveCSSValue<
+	CSSProperties[ 'flexDirection' ]
+>;
 
 export type FlexProps = {
 	/**

--- a/packages/components/src/ui/form-group/types.ts
+++ b/packages/components/src/ui/form-group/types.ts
@@ -3,7 +3,7 @@ import { CSSProperties, ReactNode, ReactText } from 'react';
 /**
  * Internal dependencies
  */
-import { Props as ControlLabelProps } from '../control-label/types'; 
+import { Props as ControlLabelProps } from '../control-label/types';
 import { Props as GridProps } from '../grid/types';
 
 export type FormGroupLabelProps = ControlLabelProps & {
@@ -24,6 +24,6 @@ type Horizontal = GridProps & {
 	horizontal: true;
 };
 
-type Vertical = { horizontal: false; };
+type Vertical = { horizontal: false };
 
-export type FormGroupProps = FormGroupContentProps & (Horizontal | Vertical);
+export type FormGroupProps = FormGroupContentProps & ( Horizontal | Vertical );

--- a/packages/components/src/ui/grid/types.ts
+++ b/packages/components/src/ui/grid/types.ts
@@ -1,6 +1,6 @@
 import { CSSProperties } from 'react';
 
-type ResponsiveCSSValue<T> = Array<T | undefined> | T;
+type ResponsiveCSSValue< T > = Array< T | undefined > | T;
 
 type GridAlignment =
 	| 'bottom'

--- a/packages/components/src/ui/h-stack/types.ts
+++ b/packages/components/src/ui/h-stack/types.ts
@@ -19,7 +19,7 @@ export type AlignmentProps = {
 	align?: CSSProperties[ 'alignItems' ];
 };
 
-export type Alignments = Record<HStackAlignment, AlignmentProps>;
+export type Alignments = Record< HStackAlignment, AlignmentProps >;
 
 export type Props = Omit< FlexProps, 'align' | 'gap' > & {
 	/**

--- a/packages/components/src/ui/text/types.ts
+++ b/packages/components/src/ui/text/types.ts
@@ -80,7 +80,7 @@ export interface Props extends TruncateProps {
 	/**
 	 * Array of search words. String search terms are automatically cast to RegExps unless `highlightEscape` is true.
 	 */
-	highlightSanitize?: import( 'highlight-words-core' ).FindAllArgs[ 'sanitize' ];
+	highlightSanitize?: import('highlight-words-core').FindAllArgs[ 'sanitize' ];
 	/**
 	 * Sets `Text` to have `display: block`.
 	 */
@@ -169,24 +169,24 @@ export interface Props extends TruncateProps {
 	 * Adjusts letter-spacing of the text.
 	 */
 	letterSpacing?: CSSProperties[ 'letterSpacing' ];
-		/**
-	* Letters or words within `Text` can be highlighted using `highlightWords`.
-	*
-	* @example
-	* ```jsx
-	* import { Text } from `@wordpress/components/ui`
-	*
-	* function Example() {
-	*   return (
-	*     <Text highlightWords={["the"]}>
-	*       Where the north wind meets the sea, there's a river full of memory. Sleep,
-	*       my darling, safe and sound, for in this river all is found. In her waters,
-	*       deep and true, lay the answers and a path for you. Dive down deep into her
-	*       sound, but not too far or you'll be drowned
-	*     </Text>
-	*   )
-	* }
-	* ```
-	*/
+	/**
+	 * Letters or words within `Text` can be highlighted using `highlightWords`.
+	 *
+	 * @example
+	 * ```jsx
+	 * import { Text } from `@wordpress/components/ui`
+	 *
+	 * function Example() {
+	 *   return (
+	 *     <Text highlightWords={["the"]}>
+	 *       Where the north wind meets the sea, there's a river full of memory. Sleep,
+	 *       my darling, safe and sound, for in this river all is found. In her waters,
+	 *       deep and true, lay the answers and a path for you. Dive down deep into her
+	 *       sound, but not too far or you'll be drowned
+	 *     </Text>
+	 *   )
+	 * }
+	 * ```
+	 */
 	highlightWords?: string[];
-};
+}

--- a/packages/components/src/ui/utils/types.ts
+++ b/packages/components/src/ui/utils/types.ts
@@ -1,11 +1,11 @@
 import { As } from 'reakit-utils/types';
 import { ViewOwnProps } from '@wp-g2/create-styles';
 
-export type Options<T extends As, P extends ViewOwnProps<{}, T>> = {
+export type Options< T extends As, P extends ViewOwnProps< {}, T > > = {
 	as: T;
 	name: string;
-	useHook: (props: P) => any;
+	useHook: ( props: P ) => any;
 	memo?: boolean;
 };
 
-export type ResponsiveCSSValue<T> = Array<T | undefined> | T;
+export type ResponsiveCSSValue< T > = Array< T | undefined > | T;

--- a/packages/components/src/utils/types.ts
+++ b/packages/components/src/utils/types.ts
@@ -7,7 +7,7 @@ export type SizeRangeDefault =
 
 export type SizeRangeReduced = 'large' | 'medium' | 'small';
 
-export type FormElementProps<V> = {
+export type FormElementProps< V > = {
 	/**
 	 * The default (initial) state to use if `value` is undefined.
 	 */

--- a/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
+++ b/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
@@ -3,16 +3,16 @@ import { Compiler } from 'webpack';
 export = DependencyExtractionWebpackPlugin;
 
 declare class DependencyExtractionWebpackPlugin {
-    constructor(options: DependencyExtractionWebpackPluginOptions);
-    apply(compiler: Compiler): void;
+	constructor( options: DependencyExtractionWebpackPluginOptions );
+	apply( compiler: Compiler ): void;
 }
 
 declare interface DependencyExtractionWebpackPluginOptions {
-    injectPolyfill?: boolean;
-    useDefaults?: boolean;
-    outputFormat?: 'php' | 'json';
-    requestToExternal?: (request: string) => string | string[] | undefined;
-    requestToHandle?: (request: string) => string | undefined;
-    combinedOutputFile?: string | null;
-    combineAssets?: boolean;
+	injectPolyfill?: boolean;
+	useDefaults?: boolean;
+	outputFormat?: 'php' | 'json';
+	requestToExternal?: ( request: string ) => string | string[] | undefined;
+	requestToHandle?: ( request: string ) => string | undefined;
+	combinedOutputFile?: string | null;
+	combineAssets?: boolean;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

When looking at #29060, I noticed that TS files aren't formatted correctly. This PR fixes it.

## How has this been tested?
`npm run format-js`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
