### PR TITLE
Components: Safe window access in ResizableBox utils

### DIFF
--- a/packages/components/src/resizable-box/resize-tooltip/utils.js
+++ b/packages/components/src/resizable-box/resize-tooltip/utils.js
@@ -9,7 +9,8 @@ import useResizeAware from 'react-resize-aware';
  */
 import { useEffect, useRef, useState } from '@wordpress/element';
 
-const { clearTimeout, setTimeout } = window;
+const { clearTimeout, setTimeout } =
+	typeof window !== 'undefined' ? window : {};
 
 export const POSITIONS = {
 	bottom: 'bottom',


### PR DESCRIPTION
## Description

This PR changes the `ResizableBox` component tooltip utils to safely access `window`. This is helpful for the instances where the component is used in a Node context. 

Related to #29038.

## How has this been tested?
* Open a post for editing.
* Insert a Search block.
* Verify that you can resize the search box just like before.
* Verify that there are no console errors.
* Verify the storybook examples still work like before.
* Verify all tests still pass. 

## Types of changes
This is an enhancement for a component, aiming at providing better SSR support for the `<ResizableBox />` component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
