### PR TITLE
dom-ready: Safe access to document

### DIFF
--- a/packages/dom-ready/src/index.js
+++ b/packages/dom-ready/src/index.js
@@ -29,6 +29,10 @@
  * @return {void}
  */
 export default function domReady( callback ) {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+
 	if (
 		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
 		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.


### PR DESCRIPTION
## Description

This PR changes the `dom-ready` package to safely access `document`. This is helpful for the instances where the `domReady` utility is used in a Node context. 

Related to #29038.

## How has this been tested?
* Open a post for editing.
* Verify that messages still work well when using a screen reader.
* Verify that there are no console errors.
* Verify all tests still pass. 

## Types of changes
This is an enhancement, aiming at providing better SSR support for the `dom-ready` package.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
