### PR TITLE
Keycodes: Safe access to window

### DIFF
--- a/packages/keycodes/src/platform.js
+++ b/packages/keycodes/src/platform.js
@@ -6,11 +6,19 @@ import { includes } from 'lodash';
 /**
  * Return true if platform is MacOS.
  *
- * @param {Window} _window window object by default; used for DI testing.
+ * @param {Window?} _window window object by default; used for DI testing.
  *
  * @return {boolean} True if MacOS; false otherwise.
  */
-export function isAppleOS( _window = window ) {
+export function isAppleOS( _window = null ) {
+	if ( ! _window ) {
+		if ( typeof window === 'undefined' ) {
+			return false;
+		}
+
+		_window = window;
+	}
+
 	const { platform } = _window.navigator;
 
 	return (


### PR DESCRIPTION
## Description

This PR changes the `Keycodes` package to safely access `window`. This is helpful for the instances where the package is used in a Node context. 

Related to #29038.

## How has this been tested?
* Open a post for editing.
* Verify that inline inserter still works well (`/` triggers it, characters are recognized for block search, you can use arrows to navigate through available blocks, and Return/Enter key to insert the block).
* Verify that there are no console errors.
* Verify all tests still pass. 

## Types of changes
This is an enhancement for the Keycodes package, aiming at providing better SSR support.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
