### PR TITLE
Components: Safe access to window in FocalPointPickerGrid

### DIFF
--- a/packages/components/src/focal-point-picker/grid.js
+++ b/packages/components/src/focal-point-picker/grid.js
@@ -13,7 +13,8 @@ import {
 } from './styles/focal-point-picker-style';
 import { useUpdateEffect } from '../utils/hooks';
 
-const { clearTimeout, setTimeout } = window;
+const { clearTimeout, setTimeout } =
+	typeof window !== 'undefined' ? window : {};
 
 export default function FocalPointPickerGrid( {
 	bounds = {},


### PR DESCRIPTION
## Description

This PR changes the `FocalPointPicker` component tooltip utils to safely access `window`. This is helpful for the instances where the component is used in a Node context. 

Related to #29038.

## How has this been tested?
* Open a post for editing.
* Insert a Cover block.
* Pick a video in the block.
* Verify the focal point picker in the sidebar still works well.
* Verify that there are no console errors.
* Verify the storybook examples still work like before.
* Verify all tests still pass. 

## Types of changes
This is an enhancement for a component, aiming at providing better SSR support for the `<FocalPointPicker />` component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
