### PR TITLE
[Mobile] - RichText - Restore onSelectionChange when its focused

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -756,6 +756,12 @@ export class RichText extends Component {
 
 		if ( isSelected && ! prevIsSelected ) {
 			this._editor.focus();
+			// Update selection props explicitly when component is selected as Aztec won't call onSelectionChange
+			// if its internal value hasn't change. When created, default value is 0, 0
+			this.onSelectionChange(
+				this.props.selectionStart || 0,
+				this.props.selectionEnd || 0
+			);
 		} else if ( ! isSelected && prevIsSelected ) {
 			this._editor.blur();
 		}


### PR DESCRIPTION
## Description
While running some tests on the ongoing `1.47.0` mobile editor release [some regressions](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3155#issuecomment-780104598) were found when splitting/merging paragraph blocks:

- [Splitting, merging, and splitting a text block on iOS results in two blocks with incorrect content](https://github.com/WordPress/gutenberg/issues/29046)
- [Unable to merge multiple blocks on Android via backspace/delete key](https://github.com/WordPress/gutenberg/issues/29047)

This is a regression from the [[RNMobile] Performance improvements](https://github.com/WordPress/gutenberg/pull/27446) PR, so this is a quick fix bringing back the code that was removed, I'll open a separate issue to continue the effort on optimizing some extra renders this piece of code is generating.

## How has this been tested?

#### Issue 1 - Splitting, merging, and splitting a text block on iOS results in two blocks with incorrect content

1. Create a new post.
2. Add a paragraph block.
3. Add text to the paragraph.
4. Place cursor in the middle of the paragraph.
5. Tap return key.
6. Tap delete key.
7. Tap return key.

**Expect**: Two blocks are present. The first containing the text before the cursor place meant. The second placing the text after the cursor placement.

#### Issue 2 - Unable to merge multiple blocks on Android via backspace/delete key

1. Launch **Android** app.
2. Create a new post.
3. Add a paragraph block.
4. Add text to paragraph block.
5. Place cursor in the middle of text.
6. Tap return key twice.
7. Tap delete key twice.

**Expect**: The multiple blocks are merged into one block.

## Screenshots <!-- if applicable -->

#### Issue 1 - Splitting, merging, and splitting a text block on iOS results in two blocks with incorrect content

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/108200680-17abec00-711f-11eb-9518-7361a057a4c3.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/108200692-1a0e4600-711f-11eb-98f3-22060111927a.gif" width="250" /></kbd> 

#### Issue 2 - Unable to merge multiple blocks on Android via backspace/delete key

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/108200747-2e524300-711f-11eb-821c-bc3887be34db.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/108200753-301c0680-711f-11eb-9d05-5e23b91effdc.gif" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
