### PR TITLE
Site Editor: Inject theme attribute into template parts too

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -184,14 +184,10 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 	$template_content       = file_get_contents( $template_file['path'] );
 	$theme                  = wp_get_theme()->get_stylesheet();
 
-	if ( 'wp_template' === $template_type ) {
-		$template_content = _inject_theme_attribute_in_content( $template_content );
-	}
-
 	$template            = new WP_Block_Template();
 	$template->id        = $theme . '//' . $template_file['slug'];
 	$template->theme     = $theme;
-	$template->content   = $template_content;
+	$template->content   = _inject_theme_attribute_in_content( $template_content );
 	$template->slug      = $template_file['slug'];
 	$template->is_custom = false;
 	$template->type      = $template_type;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
Fixes https://github.com/WordPress/gutenberg/issues/28814

## Description
https://github.com/WordPress/gutenberg/pull/28088/ introduced a feature that injects the theme attribute into templates. Template parts are untouched, this caused nested template part files to fail. This PR enables the theme attribute injection for template parts as well.

## How has this been tested?
1. Create a `test` template part file in your theme (TT1 blocks) with the content below:
```html
<!-- wp:template-part {"slug":"header"} /-->
```
2. Open site editor
3. Add template part block
4. Choose existing, select the template part you just created: `test`
5. `test` template part should contain the `header` template part

## Types of changes
Bug fix (non-breaking change which fixes an issue) ?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
