### PR TITLE
Issue-29061 Fixing invalid HTML in search block

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,7 +80,7 @@ function render_block_core_search( $attributes ) {
 		}
 
 		$button_markup = sprintf(
-			'<button type="submit"class="wp-block-search__button ' . $button_classes . '">%s</button>',
+			'<button type="submit" class="wp-block-search__button ' . $button_classes . '">%s</button>',
 			$button_internal_markup
 		);
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Added a missing space in the HTML seach button to separate two attributes.

## How has this been tested?
To be honest I didn't. I was looking for a "good first issue" to gain expirience with the process. It's my first open source pull request ever!

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

