### PR TITLE
[RnMobile] Enable default keyboard as default on link picker text fields

### DIFF
--- a/packages/components/src/mobile/link-settings/index.native.js
+++ b/packages/components/src/mobile/link-settings/index.native.js
@@ -273,7 +273,7 @@ function LinkSettings( {
 								onSubmit={ onCloseSettingsSheet }
 								autoCapitalize="none"
 								autoCorrect={ false }
-								keyboardType="url"
+								keyboardType="default"
 							/>
 						) }
 					</>


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2733
`Gutenberg-Mobile PR:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/3170

## Description
<!-- Please describe what you have changed or added -->
Before you couldn't fully modify the Link Rel field because it used the URL keyboard which doesn't allow spaces.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add `Buttons` block or `Image` Block
1. Open link [settings](https://github.com/wordpress-mobile/test-cases/blob/be95fab2c52f92f369bd7ac9b4a0377304e484ab/test-cases/resources/button-link-settings.png)
1. Edit the URL field and add a link
1. Switch on `Open in new tab`
1. Edit `Link Rel` field
1. Type space to add a new link rel
1. **Expect** To see the default keyboard

## Screenshots

Before | After
--- | ---
<kbd><a href="https://user-images.githubusercontent.com/1845482/96280466-4a5ea000-0fd8-11eb-8e8d-926b334381c8.jpeg"><img width="300" src="https://user-images.githubusercontent.com/1845482/96280466-4a5ea000-0fd8-11eb-8e8d-926b334381c8.jpeg"/></a></kbd> | <kbd><a href="https://user-images.githubusercontent.com/3384451/108255305-17fdb480-712a-11eb-97d2-41b74e012c39.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/108255305-17fdb480-712a-11eb-97d2-41b74e012c39.png"/></a></kbd>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
