### PR TITLE
Docs: Update release.md

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -91,12 +91,3 @@ jobs:
           asset_path: ./gutenberg.zip
           asset_name: gutenberg.zip
           asset_content_type: application/zip
-
-      - name: Publish Release
-        run: |
-          curl \
-            --request PATCH \
-            --url https://api.github.com/repos/${{ github.repository }}/releases/${{ steps.create_release.outputs.id }} \
-            --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-            --header "Accept: application/vnd.github.v3+json" \
-            --data-raw '{"draft":false}'

--- a/bin/plugin/commands/release.js
+++ b/bin/plugin/commands/release.js
@@ -159,7 +159,7 @@ async function runBumpPluginVersionUpdateChangelogAndCommitStep(
 				readmeFileContent.indexOf( '== Changelog ==' )
 			) +
 			'== Changelog ==\n\n' +
-			`To read the changelog for ${ config.name } ${ version }, please navigate to the <a href="${ config.wpRepositoryReleasesURL }v${ version }">release page</a>.` +
+			`To read the changelog for ${ config.name } ${ version }, please navigate to the <a href="${ config.wpRepositoryReleasesURL }tag/v${ version }">release page</a>.` +
 			'\n';
 		fs.writeFileSync( readmePath, newReadmeContent );
 
@@ -493,11 +493,10 @@ async function releaseRC() {
 			' version ' +
 			formats.success( version ) +
 			' has been successfully tagged.\n',
-		"In a few minutes, you'll be able to find the GitHub release here: " +
-			formats.success(
-				`${ config.wpRepositoryReleasesURL }v${ version }`
-			) +
+		"In a few minutes, you'll be able to find the GitHub release draft here: " +
+			formats.success( config.wpRepositoryReleasesURL ) +
 			'\n',
+		"Don't forget to publish the release once the draft is available!\n",
 		'Thanks for performing the release!\n'
 	);
 }
@@ -508,7 +507,7 @@ async function releaseStable() {
 		'Welcome! This tool is going to help you release a new stable version of the Plugin.\n',
 		'It goes through different steps: bumping the plugin version, tagging the release, and pushing the tag to GitHub.\n',
 		'Once the tag is pushed to GitHub, GitHub will build the plugin ZIP, and attach it to a release draft.\n',
-		"To perform a release you'll have to be a member of the " +
+		'To have the release uploaded to the WP.org plugin repository SVN, you need approval from a member of the ' +
 			config.team +
 			' Team.\n'
 	);
@@ -521,12 +520,18 @@ async function releaseStable() {
 			' ' +
 			formats.success( version ) +
 			' has been successfully tagged.\n',
-		"In a few minutes, you'll be able to find the GitHub release here: " +
-			formats.success(
-				`${ config.wpRepositoryReleasesURL }v${ version }`
-			) +
+		"In a few minutes, you'll be able to find the GitHub release draft here: " +
+			formats.success( config.wpRepositoryReleasesURL ) +
 			'\n',
-		"Once published, it'll be automatically uploaded to the WordPress plugin repository.\n",
+		"Don't forget to publish the release once the draft is available!\n",
+		'Once published, the upload to the WP.org plugin repository needs approval from a member of the ' +
+			config.team +
+			' Team at ' +
+			formats.success(
+				config.githubRepositoryURL +
+					'actions/workflows/upload-release-to-plugin-repo.yml '
+			) +
+			'.\n',
 		"Thanks for performing the release! and don't forget to publish the release post.\n"
 	);
 }

--- a/bin/plugin/commands/release.js
+++ b/bin/plugin/commands/release.js
@@ -482,7 +482,7 @@ async function releaseRC() {
 		formats.title( '\n💃 Time to release ' + config.name + ' 🕺\n\n' ),
 		'Welcome! This tool is going to help you release a new RC version of the Plugin.\n',
 		'It goes through different steps: creating the release branch, bumping the plugin version, tagging the release, and pushing the tag to GitHub.\n',
-		'Once the tag is pushed to GitHub, GitHub will build the plugin ZIP, attach it to a release, and publish it.\n',
+		'Once the tag is pushed to GitHub, GitHub will build the plugin ZIP, and attach it to a release draft.\n',
 		"To perform a release you'll have to be a member of the " +
 			config.team +
 			' Team.\n'
@@ -510,7 +510,7 @@ async function releaseStable() {
 		formats.title( '\n💃 Time to release ' + config.name + ' 🕺\n\n' ),
 		'Welcome! This tool is going to help you release a new stable version of the Plugin.\n',
 		'It goes through different steps: bumping the plugin version, tagging the release, and pushing the tag to GitHub.\n',
-		'Once the tag is pushed to GitHub, GitHub will build the plugin ZIP, attach it to a release, publish it, and push the release to the SVN repository.\n',
+		'Once the tag is pushed to GitHub, GitHub will build the plugin ZIP, and attach it to a release draft.\n',
 		"To perform a release you'll have to be a member of the " +
 			config.team +
 			' Team.\n'

--- a/bin/plugin/commands/release.js
+++ b/bin/plugin/commands/release.js
@@ -482,10 +482,7 @@ async function releaseRC() {
 		formats.title( '\n💃 Time to release ' + config.name + ' 🕺\n\n' ),
 		'Welcome! This tool is going to help you release a new RC version of the Plugin.\n',
 		'It goes through different steps: creating the release branch, bumping the plugin version, tagging the release, and pushing the tag to GitHub.\n',
-		'Once the tag is pushed to GitHub, GitHub will build the plugin ZIP, and attach it to a release draft.\n',
-		"To perform a release you'll have to be a member of the " +
-			config.team +
-			' Team.\n'
+		'Once the tag is pushed to GitHub, GitHub will build the plugin ZIP, and attach it to a release draft.\n'
 	);
 
 	const version = await releasePlugin( true );

--- a/bin/plugin/config.js
+++ b/bin/plugin/config.js
@@ -14,6 +14,7 @@ const gitRepoOwner = 'WordPress';
  * @property {string} githubRepositoryName Github Repository Name.
  * @property {string} pluginEntryPoint Plugin Entry Point File.
  * @property {string} buildZipCommand Build Plugin ZIP command.
+ * @property {string} githubRepositoryURL GitHub Repository URL.
  * @property {string} wpRepositoryReleasesURL WordPress Repository Tags URL.
  * @property {string} gitRepositoryURL Git Repository URL.
  * @property {string} svnRepositoryURL SVN Repository URL.
@@ -31,8 +32,8 @@ const config = {
 	githubRepositoryName: 'gutenberg',
 	pluginEntryPoint: 'gutenberg.php',
 	buildZipCommand: '/bin/bash bin/build-plugin-zip.sh',
-	wpRepositoryReleasesURL:
-		'https://github.com/WordPress/gutenberg/releases/tag/',
+	githubRepositoryURL: 'https://github.com/' + gitRepoOwner + '/gutenberg/',
+	wpRepositoryReleasesURL: 'https://github.com/WordPress/gutenberg/releases/',
 	gitRepositoryURL: 'https://github.com/' + gitRepoOwner + '/gutenberg.git',
 	svnRepositoryURL: 'https://plugins.svn.wordpress.org/gutenberg',
 };

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -12,7 +12,7 @@ We release a new major version approximately every two weeks. The current and ne
 
 -   **On the date of the current milestone**, we publish a release candidate and make it available for plugin authors and users to test. If any regressions are found with a release candidate, a new one can be published. On this date, all remaining PRs on the milestone are moved automatically to the next release. Release candidates should be versioned incrementally, starting with `-rc.1`, then `-rc.2`, and so on.
 
--   **Two days after the first release candidate**, the stable version is created based on the last release candidate and any necessary regression fixes. Once the stable version is released, a post [like this](https://make.wordpress.org/core/2019/06/26/whats-new-in-gutenberg-26th-june/) describing the changes and performing a [performance audit](/docs/block-editor/contributors/testing-overview/#performance-testing) is published.
+-   **One week after the first release candidate**, the stable version is created based on the last release candidate and any necessary regression fixes. Once the stable version is released, a post [like this](https://make.wordpress.org/core/2019/06/26/whats-new-in-gutenberg-26th-june/) describing the changes and performing a [performance audit](/docs/block-editor/contributors/testing-overview/#performance-testing) is published.
 
 If critical bugs are discovered on stable versions of the plugin, patch versions can be released at any time.
 

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -2,7 +2,7 @@
 
 This Repository is used to perform several types of releases. This document serves as a checklist for each one of these. It is helpful if you'd like to understand the different workflows.
 
-To release Gutenberg, you need commit access to the [WordPress.org plugin repository][plugin repository] as well as being part of the [WordPress organization at npm](https://www.npmjs.com/org/wordpress). 🙂
+To release Gutenberg, you need to be part of the [WordPress organization at npm](https://www.npmjs.com/org/wordpress). 🙂
 
 ## Plugin Releases
 

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -2,7 +2,9 @@
 
 This Repository is used to perform several types of releases. This document serves as a checklist for each one of these. It is helpful if you'd like to understand the different workflows.
 
-To release Gutenberg, you need to be part of the [WordPress organization at npm](https://www.npmjs.com/org/wordpress). 🙂
+To release a stable version of the Gutenberg plugin, you need approval from a member of the [`gutenberg-core` team](https://github.com/orgs/WordPress/teams/gutenberg-core) for the final step of the release process (upload to the WordPress.org plugin repo -- see below). If you aren't a member yourself, make sure to contact one ahead of time so they'll be around at the time of the release.
+
+To release Gutenberg's npm packages, you need to be part of the [WordPress organization at npm](https://www.npmjs.com/org/wordpress). 🙂
 
 ## Plugin Releases
 

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -38,6 +38,10 @@ During the release process, you'll be asked to provide:
 -   A [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line): have one ready beforehand by visiting [this page](https://github.com/settings/tokens/new?scopes=repo,admin:org,write:packages), if you haven't got one yet.
 -   User and password for your GitHub account: if 2FA is enabled for your account (it should), you need to provide a personal access token instead of password (you can use the one necessary for the release).
 
+The release script will create a `git` tag for the release and push it to GitHub. This triggers a GitHub workflow that builds the plugin, creates a release draft (based on the Changelog), and attaches the plugin zip. This will take a couple of minutes. You will then find the release draft at https://github.com/WordPress/gutenberg/releases. You can edit it further (but note that the changes won't be propagated to `changelog.txt`). Once you're happy with it, press the 'Publish' button.
+
+If you're releasing a stable version (rather than an RC), this will trigger a GitHub action that will upload the plugin to the WordPress.org plugin repository (SVN). This action needs approval by a member of the [`gutenberg-core` team](https://github.com/orgs/WordPress/teams/gutenberg-core). Locate the ["Upload Gutenberg plugin to WordPress.org plugin repo" workflow](https://github.com/WordPress/gutenberg/actions/workflows/upload-release-to-plugin-repo.yml) for the new version, and have it [approved](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments#approving-or-rejecting-a-job).
+
 ### Manual Release Process
 
 #### Creating the first Release Candidate


### PR DESCRIPTION
## Description
To reflect the updated release process. 

There's one functional change to the release GH workflow included in this PR: Rather than publishing the release right away, only create the draft, and let a human publish it.

The reason for this is twofold:
- The SVN upload action didn't trigger when the release was published. This is because [GH workflows don't trigger other GH workflows](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token) (to avoid recursions). (The workaround was to set the release to pre-release status, and then back.)
- This aligns better with the changes planned in #28138 anyway (where we'll remove the local build script altogether; instead, editing the release draft will be the opportunity for the release manager to actually edit the auto-generated changelog before publishing).

Changes to `release.md` thus include:
- A description of the GH-side steps:
  - Locate the release draft, edit and publish it.
  - The SVN upload action needing approval.
- Commit access to SVN no longer needed. Instead, a member of the `gutenberg-core` team needs to approve the upload.
- ~Two days~ -> One week between RC and stable release.

Finally, instructions in the `release.js` script are updated accordingly. (Keep in mind that that script is slated for removal once #28138 lands).