### PR TITLE
Site Editor: Fix misalignment with navigation toggle and header

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -14,6 +14,11 @@
 
 	body.is-navigation-sidebar-open & {
 		display: flex;
+
+		.edit-site-navigation-toggle__button {
+			border-bottom: 1px solid transparent;
+			border-radius: 0;
+		}
 	}
 }
 
@@ -24,6 +29,11 @@
 	height: $header-height + $border-width; // Cover header border
 	width: $header-height;
 	z-index: 1;
+
+	// Adds a bottom border to match the header toolbar
+	border-bottom: 1px solid #e0e0e0;
+	// Prevents the bottom border from being clipped by border-bottom radius
+	border-radius: 2px 2px 0 0;
 
 	&.has-icon {
 		min-width: $header-height;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -31,7 +31,7 @@
 	z-index: 1;
 
 	// Adds a bottom border to match the header toolbar
-	border-bottom: 1px solid #e0e0e0;
+	border-bottom: 1px solid $gray-200;
 	// Prevents the bottom border from being clipped by border-bottom radius
 	border-radius: 2px 2px 0 0;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Visually, it appeared as if the height of the navigation toggle was different then the header. The issue was actually that the header had a 1px bottom border, which the navigation toggle _did not_ have.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Enable the full site editor locally
2. Navigate to the site editor
3. Verify that the navigation toggle has a 1px bottom border
4. Open the navigation sidebar
5. Verify that the toggle still looks visually correct when focused

## Screenshots <!-- if applicable -->
### Before
<img width="1392" alt="Screen Shot 2021-02-17 at 1 37 47 PM" src="https://user-images.githubusercontent.com/5414230/108271317-796f5480-7125-11eb-91ab-9785314bda2f.png">

### After
<img width="1392" alt="Screen Shot 2021-02-17 at 1 37 23 PM" src="https://user-images.githubusercontent.com/5414230/108271333-7e340880-7125-11eb-8fb3-b10c1e2e657f.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
