### PR TITLE
Site Editor: Highlight list view blocks when canvas blocks are hovered

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -33,6 +33,8 @@ export function useIsHovered( ref ) {
 		};
 	}, [] );
 
+	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
+
 	function addHoverListener( eventType, value ) {
 		function listener( event ) {
 			if ( event.defaultPrevented ) {
@@ -40,6 +42,7 @@ export function useIsHovered( ref ) {
 			}
 
 			event.preventDefault();
+			toggleBlockHighlight( ref.current.dataset.block, true );
 			setHovered( value );
 		}
 

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -46,10 +46,11 @@ export default function BlockNavigationBlock( {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const { clientId } = block;
-	const { isDragging, blockParents } = useSelect(
+	const { isDragging, isHighlighted, blockParents } = useSelect(
 		( select ) => {
 			const {
 				isBlockBeingDragged,
+				isBlockHighlighted,
 				isAncestorBeingDragged,
 				getBlockParents,
 			} = select( blockEditorStore );
@@ -59,6 +60,7 @@ export default function BlockNavigationBlock( {
 					isBlockBeingDragged( clientId ) ||
 					isAncestorBeingDragged( clientId ),
 				blockParents: getBlockParents( clientId ),
+				isHighlighted: isBlockHighlighted( clientId ),
 			};
 		},
 		[ clientId ]
@@ -104,6 +106,7 @@ export default function BlockNavigationBlock( {
 			className={ classnames( {
 				'is-selected': isSelected,
 				'is-dragging': isDragging,
+				'is-highlighted': isHighlighted,
 			} ) }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -28,6 +28,11 @@
 		color: $white;
 	}
 
+	// TODO: Replicate highlighted state from mocks (this is a temporary placeholder)
+	&.is-highlighted {
+		border: 1px solid var(--wp-admin-theme-color);
+	}
+
 	&.is-dragging {
 		display: none;
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
- Jacopo is currently tackling the implementation of a persistent list view for full site editing in https://github.com/WordPress/gutenberg/pull/28637. 
- In it, he introduces functionality where, when a list view block is hovered, the corresponding canvas block is highlighted.
- This PR is a follow-up, and is meant to implement the converse functionality -- when a canvas block is hovered, the corresponding list view block will be highlighted.

See the GIF below for more context.

<img src="https://cldup.com/DE0Cw04-Dr.gif" />

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Spin up a local instance of Gutenberg
- Enable a block theme
- Navigate to the site editor
- Open the list view and 

## Screenshots <!-- if applicable -->
![2021-02-18 00 17 26](https://user-images.githubusercontent.com/5414230/108326558-3e017400-717f-11eb-8cbf-968bf38a1c4b.gif)

## To-dos
- Implement the `highlightBlocksOnHover` prop
- Investigate performance concerns from our approach to highlighting state management
- Fix list view block highlight styling
- E2E Tests
- Consider better naming 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature that addresses https://github.com/WordPress/gutenberg/issues/28699 and builds on top of https://github.com/WordPress/gutenberg/pull/28637

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
