### PR TITLE
Show page titles special characters in the parent page selector

### DIFF
--- a/packages/components/src/form-token-field/suggestions-list.js
+++ b/packages/components/src/form-token-field/suggestions-list.js
@@ -105,31 +105,6 @@ class SuggestionsList extends Component {
 					);
 
 					/* eslint-disable jsx-a11y/click-events-have-key-events */
-
-					    var label = suggestion.label;
-
-					    var decodeEntities = (function() {
-					      // this prevents any overhead from creating the object each time
-					      var element = document.createElement('div');
-
-					      function decodeHTMLEntities (str) {
-						if(str && typeof str === 'string') {
-						  // strip script/html tags
-						  str = str.replace(/<script[^>]*>([\S\s]*?)<\/script>/gmi, '');
-						  str = str.replace(/<\/?\w(?:[^"'>]|"[^"]*"|'[^']*')*>/gmi, '');
-						  element.innerHTML = str;
-						  str = element.textContent;
-						  element.textContent = '';
-						}
-
-						return str;
-					      }
-
-					      return decodeHTMLEntities;
-					    })();
-
-					    suggestion.label = decodeEntities(label);
-
 					return (
 						<li
 							id={ `components-form-token-suggestions-${ this.props.instanceId }-${ index }` }

--- a/packages/components/src/form-token-field/suggestions-list.js
+++ b/packages/components/src/form-token-field/suggestions-list.js
@@ -105,6 +105,31 @@ class SuggestionsList extends Component {
 					);
 
 					/* eslint-disable jsx-a11y/click-events-have-key-events */
+
+					    var label = suggestion.label;
+
+					    var decodeEntities = (function() {
+					      // this prevents any overhead from creating the object each time
+					      var element = document.createElement('div');
+
+					      function decodeHTMLEntities (str) {
+						if(str && typeof str === 'string') {
+						  // strip script/html tags
+						  str = str.replace(/<script[^>]*>([\S\s]*?)<\/script>/gmi, '');
+						  str = str.replace(/<\/?\w(?:[^"'>]|"[^"]*"|'[^']*')*>/gmi, '');
+						  element.innerHTML = str;
+						  str = element.textContent;
+						  element.textContent = '';
+						}
+
+						return str;
+					      }
+
+					      return decodeHTMLEntities;
+					    })();
+
+					    suggestion.label = decodeEntities(label);
+
 					return (
 						<li
 							id={ `components-form-token-suggestions-${ this.props.instanceId }-${ index }` }

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { ComboboxControl } from '@wordpress/components';
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -25,7 +26,7 @@ import { buildTermsTree } from '../../utils/terms';
 
 function getTitle( post ) {
 	return post?.title?.rendered
-		? post.title.rendered
+		? decodeEntities( post.title.rendered )
 		: `#${ post.id } (${ __( 'no title' ) })`;
 }
 


### PR DESCRIPTION
Hello everyone ) This is patch for correct right apostrophe display from ticket https://core.trac.wordpress.org/ticket/52415 from my branch of gutenberg 

