### PR TITLE
Fix cursor on rich text blocks when outline mode is active

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -224,6 +224,10 @@
 		}
 	}
 
+	&.is-outline-mode.is-selected.is-hovered {
+		cursor: unset;
+	}
+
 	// Spotlight mode.
 	&.is-focus-mode:not(.is-multi-selected) {
 		opacity: 0.5;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -211,10 +211,6 @@
 		}
 	}
 
-	&.is-outline-mode.is-selected.rich-text {
-		cursor: unset;
-	}
-
 	&.is-outline-mode.is-hovered:not(.is-typing) {
 		cursor: default;
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -211,6 +211,10 @@
 		}
 	}
 
+	&.is-outline-mode.is-selected.rich-text {
+		cursor: unset;
+	}
+
 	&.is-outline-mode.is-hovered:not(.is-typing) {
 		cursor: default;
 


### PR DESCRIPTION
Somewhere along the road the incorrect cursor was applied to rich text elements when outline mode is active (IE in the site editor):

![before](https://user-images.githubusercontent.com/846565/108347341-4cc84500-71d8-11eb-81d4-1380f1522846.gif)

This PR fixes that. Here's the after:

![after](https://user-images.githubusercontent.com/846565/108347373-5487e980-71d8-11eb-8e35-aee1614f5905.gif)
