### PR TITLE
Use a modal for the template part creation flow

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -127,6 +127,7 @@ $z-layers: (
 
 	// Should be above the popover (dropdown)
 	".reusable-blocks-menu-items__convert-modal": 1000001,
+	".edit-site-template-part-converter__modal": 1000001,
 
 	// ...Except for popovers immediately beneath wp-admin menu on large breakpoints
 	".components-popover.block-editor-inserter__popover": 99999,

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -2,9 +2,9 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { Placeholder, Dropdown, Button, Spinner } from '@wordpress/components';
+import { Placeholder, Dropdown, Button } from '@wordpress/components';
 import { blockDefault } from '@wordpress/icons';
 import { serialize } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
@@ -35,21 +35,6 @@ export default function TemplatePartPlaceholder( {
 			theme: templatePart.theme,
 		} );
 	}, [ setAttributes ] );
-
-	// If there are inner blocks present, the content for creation is clear.
-	// Therefore immediately create the template part with the given inner blocks as its content.
-	useEffect( () => {
-		if ( innerBlocks.length ) {
-			onCreate();
-		}
-	}, [] );
-	if ( innerBlocks.length ) {
-		return (
-			<Placeholder>
-				<Spinner />
-			</Placeholder>
-		);
-	}
 
 	return (
 		<Placeholder

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -18,6 +18,9 @@ import {
  */
 import { navigationPanel, siteEditor } from '../../experimental-features';
 
+const templatePartNameInput =
+	'.edit-site-template-part-converter__modal .components-text-control__input';
+
 describe( 'Template Part', () => {
 	beforeAll( async () => {
 		await activateTheme( 'tt1-blocks' );
@@ -142,6 +145,17 @@ describe( 'Template Part', () => {
 
 			// Convert block to a template part.
 			await triggerEllipsisMenuItem( 'Make template part' );
+			const nameInput = await page.waitForSelector(
+				templatePartNameInput
+			);
+			await nameInput.click();
+			await page.keyboard.type( 'My template part' );
+			await page.keyboard.press( 'Enter' );
+
+			// Wait for creation to finish
+			await page.waitForXPath(
+				'//*[contains(@class, "components-snackbar")]/*[text()="Template part created."]'
+			);
 
 			// Verify new template part is created with expected content.
 			await assertParagraphInTemplatePart( 'Some block...' );
@@ -180,6 +194,17 @@ describe( 'Template Part', () => {
 
 			// Convert block to a template part.
 			await triggerEllipsisMenuItem( 'Make template part' );
+			const nameInput = await page.waitForSelector(
+				templatePartNameInput
+			);
+			await nameInput.click();
+			await page.keyboard.type( 'My multi  template part' );
+			await page.keyboard.press( 'Enter' );
+
+			// Wait for creation to finish
+			await page.waitForXPath(
+				'//*[contains(@class, "components-snackbar")]/*[text()="Template part created."]'
+			);
 
 			// Verify new template part is created with expected content.
 			await assertParagraphInTemplatePart( 'Some block #1' );

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -7,7 +7,10 @@ import { kebabCase } from 'lodash';
  * WordPress dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { BlockSettingsMenuControls } from '@wordpress/block-editor';
+import {
+	BlockSettingsMenuControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import {
 	MenuItem,
 	TextControl,
@@ -25,7 +28,7 @@ import { store as noticesStore } from '@wordpress/notices';
 export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ title, setTitle ] = useState( '' );
-	const { replaceBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
@@ -87,7 +90,10 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 									value={ title }
 									onChange={ setTitle }
 								/>
-								<Flex justify="flex-end">
+								<Flex
+									className="edit-site-template-part-converter__convert-modal-actions"
+									justify="flex-end"
+								>
 									<FlexItem>
 										<Button
 											isSecondary

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -1,39 +1,114 @@
 /**
+ * External dependencies
+ */
+import { kebabCase } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useDispatch } from '@wordpress/data';
 import { BlockSettingsMenuControls } from '@wordpress/block-editor';
-import { MenuItem } from '@wordpress/components';
-import { createBlock } from '@wordpress/blocks';
+import {
+	MenuItem,
+	TextControl,
+	Flex,
+	FlexItem,
+	Button,
+	Modal,
+} from '@wordpress/components';
+import { createBlock, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 
 export default function ConvertToTemplatePart( { clientIds, blocks } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ title, setTitle ] = useState( '' );
 	const { replaceBlocks } = useDispatch( 'core/block-editor' );
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	const onConvert = async ( templatePartTitle ) => {
+		const defaultTitle = __( 'Untitled Template Part' );
+		const templatePart = await saveEntityRecord(
+			'postType',
+			'wp_template_part',
+			{
+				slug: kebabCase( templatePartTitle || defaultTitle ),
+				title: templatePartTitle || defaultTitle,
+				content: serialize( blocks ),
+			}
+		);
+		replaceBlocks(
+			clientIds,
+			createBlock( 'core/template-part', {
+				slug: templatePart.slug,
+				theme: templatePart.theme,
+			} )
+		);
+		createSuccessNotice( __( 'Template part created.' ), {
+			type: 'snackbar',
+		} );
+	};
 
 	return (
 		<BlockSettingsMenuControls>
 			{ ( { onClose } ) => (
-				<MenuItem
-					onClick={ () => {
-						replaceBlocks(
-							clientIds,
-							createBlock(
-								'core/template-part',
-								{},
-								blocks.map( ( block ) =>
-									createBlock(
-										block.name,
-										block.attributes,
-										block.innerBlocks
-									)
-								)
-							)
-						);
-						onClose();
-					} }
-				>
-					{ __( 'Make template part' ) }
-				</MenuItem>
+				<>
+					<MenuItem
+						onClick={ () => {
+							setIsModalOpen( true );
+						} }
+					>
+						{ __( 'Make template part' ) }
+					</MenuItem>
+					{ isModalOpen && (
+						<Modal
+							title={ __( 'Create a template part' ) }
+							closeLabel={ __( 'Close' ) }
+							onRequestClose={ () => {
+								setIsModalOpen( false );
+								setTitle( '' );
+							} }
+							overlayClassName="edit-site-template-part-converter__modal"
+						>
+							<form
+								onSubmit={ ( event ) => {
+									event.preventDefault();
+									onConvert( title );
+									setIsModalOpen( false );
+									setTitle( '' );
+									onClose();
+								} }
+							>
+								<TextControl
+									label={ __( 'Name' ) }
+									value={ title }
+									onChange={ setTitle }
+								/>
+								<Flex justify="flex-end">
+									<FlexItem>
+										<Button
+											isSecondary
+											onClick={ () => {
+												setIsModalOpen( false );
+												setTitle( '' );
+											} }
+										>
+											{ __( 'Cancel' ) }
+										</Button>
+									</FlexItem>
+									<FlexItem>
+										<Button isPrimary type="submit">
+											{ __( 'Create' ) }
+										</Button>
+									</FlexItem>
+								</Flex>
+							</form>
+						</Modal>
+					) }
+				</>
 			) }
 		</BlockSettingsMenuControls>
 	);

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -1,3 +1,8 @@
 .edit-site-template-part-converter__modal {
 	z-index: z-index(".edit-site-template-part-converter__modal");
 }
+
+
+.edit-site-template-part-converter__convert-modal-actions {
+	padding-top: $grid-unit-15;
+}

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -1,0 +1,3 @@
+.edit-site-template-part-converter__modal {
+	z-index: z-index(".edit-site-template-part-converter__modal");
+}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -12,6 +12,7 @@
 @import "./components/sidebar/template-card/style.scss";
 @import "./components/editor/style.scss";
 @import "./components/template-details/style.scss";
+@import "./components/template-part-converter/style.scss";
 
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color.
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations.

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -140,7 +140,10 @@ export default function ReusableBlockConvertButton( {
 									value={ title }
 									onChange={ setTitle }
 								/>
-								<Flex justify="flex-end">
+								<Flex
+									className="reusable-blocks-menu-items__convert-modal-actions"
+									justify="flex-end"
+								>
 									<FlexItem>
 										<Button
 											isSecondary

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/style.scss
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/style.scss
@@ -1,3 +1,7 @@
 .reusable-blocks-menu-items__convert-modal {
 	z-index: z-index(".reusable-blocks-menu-items__convert-modal");
 }
+
+.reusable-blocks-menu-items__convert-modal-actions {
+	padding-top: $grid-unit-15;
+}


### PR DESCRIPTION
Follow-up to #29040 

This PR uses the same flow for template part creation as the one used for reusable blocks.

This new reusable block creation flow has three advantages:

 - You can cancel the creation of the templates art
 - The generated slug  won't be the same untitled-template-part-xxx
 - It makes it easier to give a name for the template part since now the "title" is in the inspector controls.