### PR TITLE
Add expandOnFocus, showHowTo and validateInput experimental props to FormTokenField

### DIFF
--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -14,7 +14,7 @@ const countries = [
 	{ name: 'Albania', code: 'AL' },
 	{ name: 'Algeria', code: 'DZ' },
 	{ name: 'American Samoa', code: 'AS' },
-	{ name: 'AndorrA', code: 'AD' },
+	{ name: 'Andorra', code: 'AD' },
 	{ name: 'Angola', code: 'AO' },
 	{ name: 'Anguilla', code: 'AI' },
 	{ name: 'Antarctica', code: 'AQ' },

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -50,6 +50,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `maxLength` - If passed, `TokenField` will disable ability to add new tokens once number of tokens is greater than or equal to `maxLength`.
 - `disabled` - When true, tokens are not able to be added or removed.
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
+- `showHowTo` - If false, the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
 
 ## Usage
 

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -52,7 +52,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
 - `expandOnFocus` - If true, the suggestions list will be always expanded when the input field has the focus.
 - `showHowTo` - If false, the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
-- `validateInput` - If passed, all introduced values will be validated before the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
+- `validateInput` - If passed, all introduced values will be validated before being added as tokens.
 
 ## Usage
 

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -52,6 +52,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
 - `expandOnFocus` - If true, the suggestions list will be always expanded when the input field has the focus.
 - `showHowTo` - If false, the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
+- `validateInput` - If passed, all introduced values will be validated before the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
 
 ## Usage
 

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -50,6 +50,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `maxLength` - If passed, `TokenField` will disable ability to add new tokens once number of tokens is greater than or equal to `maxLength`.
 - `disabled` - When true, tokens are not able to be added or removed.
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
+- `expandOnFocus` - If true, the suggestions list will be always expanded when the input field has the focus.
 - `showHowTo` - If false, the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
 
 ## Usage

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -50,6 +50,11 @@ The `value` property is handled in a manner similar to controlled form component
 - `maxLength` - If passed, `TokenField` will disable ability to add new tokens once number of tokens is greater than or equal to `maxLength`.
 - `disabled` - When true, tokens are not able to be added or removed.
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
+- `messages` - Allows customizing the messages presented by screen readers in different occasions:
+  - `added` - The user added a new token.
+  - `removed` - The user removed an existing token.
+  - `remove` - The user focused the button to remove the token.
+  - `__experimentalInvalid` - The user tried to add a token that didn't pass the validation.
 - `__experimentalExpandOnFocus` - If true, the suggestions list will be always expanded when the input field has the focus.
 - `__experimentalShowHowTo` - If false, the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
 - `__experimentalValidateInput` - If passed, all introduced values will be validated before being added as tokens.

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -50,9 +50,9 @@ The `value` property is handled in a manner similar to controlled form component
 - `maxLength` - If passed, `TokenField` will disable ability to add new tokens once number of tokens is greater than or equal to `maxLength`.
 - `disabled` - When true, tokens are not able to be added or removed.
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
-- `expandOnFocus` - If true, the suggestions list will be always expanded when the input field has the focus.
-- `showHowTo` - If false, the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
-- `validateInput` - If passed, all introduced values will be validated before being added as tokens.
+- `__experimentalExpandOnFocus` - If true, the suggestions list will be always expanded when the input field has the focus.
+- `__experimentalShowHowTo` - If false, the text on how to use the select (ie: _Separate with commas or the Enter key._) will be hidden.
+- `__experimentalValidateInput` - If passed, all introduced values will be validated before being added as tokens.
 
 ## Usage
 

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -595,6 +595,7 @@ class FormTokenField extends Component {
 			label = __( 'Add item' ),
 			instanceId,
 			className,
+			showHowTo,
 		} = this.props;
 		const { isExpanded } = this.state;
 		const classes = classnames(
@@ -657,16 +658,18 @@ class FormTokenField extends Component {
 						/>
 					) }
 				</div>
-				<p
-					id={ `components-form-token-suggestions-howto-${ instanceId }` }
-					className="components-form-token-field__help"
-				>
-					{ this.props.tokenizeOnSpace
-						? __(
-								'Separate with commas, spaces, or the Enter key.'
-						  )
-						: __( 'Separate with commas or the Enter key.' ) }
-				</p>
+				{ showHowTo && (
+					<p
+						id={ `components-form-token-suggestions-howto-${ instanceId }` }
+						className="components-form-token-field__help"
+					>
+						{ this.props.tokenizeOnSpace
+							? __(
+									'Separate with commas, spaces, or the Enter key.'
+							  )
+							: __( 'Separate with commas or the Enter key.' ) }
+					</p>
+				) }
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions */
@@ -689,6 +692,7 @@ FormTokenField.defaultProps = {
 		removed: __( 'Item removed.' ),
 		remove: __( 'Remove item' ),
 	},
+	showHowTo: true,
 };
 
 export default withSpokenMessages( withInstanceId( FormTokenField ) );

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -708,6 +708,7 @@ FormTokenField.defaultProps = {
 		remove: __( 'Remove item' ),
 		invalid: __( 'Invalid item' ),
 	},
+	expandOnFocus: false,
 	validateInput: () => true,
 	showHowTo: true,
 };

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -574,6 +574,7 @@ class FormTokenField extends Component {
 			autoCapitalize,
 			autoComplete,
 			maxLength,
+			placeholder,
 			value,
 			instanceId,
 		} = this.props;
@@ -582,6 +583,7 @@ class FormTokenField extends Component {
 			instanceId,
 			autoCapitalize,
 			autoComplete,
+			placeholder: value.length === 0 ? placeholder : '',
 			ref: this.bindInput,
 			key: 'input',
 			disabled: this.props.disabled,

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -108,9 +108,14 @@ class FormTokenField extends Component {
 	}
 
 	onFocus( event ) {
+		const { expandOnFocus } = this.props;
 		// If focus is on the input or on the container, set the isActive state to true.
 		if ( this.input.hasFocus() || event.target === this.tokensAndInput ) {
-			this.setState( { isActive: true } );
+			const newState = { isActive: true };
+			if ( expandOnFocus ) {
+				newState.isExpanded = true;
+			}
+			this.setState( newState );
 		} else {
 			/*
 			 * Otherwise, focus is on one of the token "remove" buttons and we
@@ -397,6 +402,7 @@ class FormTokenField extends Component {
 	}
 
 	addNewToken( token ) {
+		const { expandOnFocus } = this.props;
 		this.addNewTokens( [ token ] );
 		this.props.speak( this.props.messages.added, 'assertive' );
 
@@ -404,7 +410,7 @@ class FormTokenField extends Component {
 			incompleteTokenValue: '',
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
-			isExpanded: false,
+			isExpanded: ! expandOnFocus,
 		} );
 
 		if ( this.state.isActive ) {
@@ -491,6 +497,7 @@ class FormTokenField extends Component {
 	}
 
 	updateSuggestions( resetSelectedSuggestion = true ) {
+		const { expandOnFocus } = this.props;
 		const { incompleteTokenValue } = this.state;
 
 		const inputHasMinimumChars = incompleteTokenValue.trim().length > 1;
@@ -500,7 +507,9 @@ class FormTokenField extends Component {
 		const hasMatchingSuggestions = matchingSuggestions.length > 0;
 
 		const newState = {
-			isExpanded: inputHasMinimumChars && hasMatchingSuggestions,
+			isExpanded:
+				expandOnFocus ||
+				( inputHasMinimumChars && hasMatchingSuggestions ),
 		};
 		if ( resetSelectedSuggestion ) {
 			newState.selectedSuggestionIndex = -1;

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -402,7 +402,11 @@ class FormTokenField extends Component {
 	}
 
 	addNewToken( token ) {
-		const { expandOnFocus } = this.props;
+		const { expandOnFocus, validateInput } = this.props;
+		if ( ! validateInput( token ) ) {
+			this.props.speak( this.props.messages.invalid, 'assertive' );
+			return;
+		}
 		this.addNewTokens( [ token ] );
 		this.props.speak( this.props.messages.added, 'assertive' );
 
@@ -702,7 +706,9 @@ FormTokenField.defaultProps = {
 		added: __( 'Item added.' ),
 		removed: __( 'Item removed.' ),
 		remove: __( 'Remove item' ),
+		invalid: __( 'Invalid item' ),
 	},
+	validateInput: () => true,
 	showHowTo: true,
 };
 

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -111,11 +111,11 @@ class FormTokenField extends Component {
 		const { __experimentalExpandOnFocus } = this.props;
 		// If focus is on the input or on the container, set the isActive state to true.
 		if ( this.input.hasFocus() || event.target === this.tokensAndInput ) {
-			const newState = { isActive: true };
-			if ( __experimentalExpandOnFocus ) {
-				newState.isExpanded = true;
-			}
-			this.setState( newState );
+			this.setState( {
+				isActive: true,
+				isExpanded:
+					!! __experimentalExpandOnFocus || this.state.isExpanded,
+			} );
 		} else {
 			/*
 			 * Otherwise, focus is on one of the token "remove" buttons and we

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -108,11 +108,11 @@ class FormTokenField extends Component {
 	}
 
 	onFocus( event ) {
-		const { expandOnFocus } = this.props;
+		const { __experimentalExpandOnFocus } = this.props;
 		// If focus is on the input or on the container, set the isActive state to true.
 		if ( this.input.hasFocus() || event.target === this.tokensAndInput ) {
 			const newState = { isActive: true };
-			if ( expandOnFocus ) {
+			if ( __experimentalExpandOnFocus ) {
 				newState.isExpanded = true;
 			}
 			this.setState( newState );
@@ -402,9 +402,15 @@ class FormTokenField extends Component {
 	}
 
 	addNewToken( token ) {
-		const { expandOnFocus, validateInput } = this.props;
-		if ( ! validateInput( token ) ) {
-			this.props.speak( this.props.messages.invalid, 'assertive' );
+		const {
+			__experimentalExpandOnFocus,
+			__experimentalValidateInput,
+		} = this.props;
+		if ( ! __experimentalValidateInput( token ) ) {
+			this.props.speak(
+				this.props.messages.__experimentalInvalid,
+				'assertive'
+			);
 			return;
 		}
 		this.addNewTokens( [ token ] );
@@ -414,7 +420,7 @@ class FormTokenField extends Component {
 			incompleteTokenValue: '',
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
-			isExpanded: ! expandOnFocus,
+			isExpanded: ! __experimentalExpandOnFocus,
 		} );
 
 		if ( this.state.isActive ) {
@@ -501,7 +507,7 @@ class FormTokenField extends Component {
 	}
 
 	updateSuggestions( resetSelectedSuggestion = true ) {
-		const { expandOnFocus } = this.props;
+		const { __experimentalExpandOnFocus } = this.props;
 		const { incompleteTokenValue } = this.state;
 
 		const inputHasMinimumChars = incompleteTokenValue.trim().length > 1;
@@ -512,7 +518,7 @@ class FormTokenField extends Component {
 
 		const newState = {
 			isExpanded:
-				expandOnFocus ||
+				__experimentalExpandOnFocus ||
 				( inputHasMinimumChars && hasMatchingSuggestions ),
 		};
 		if ( resetSelectedSuggestion ) {
@@ -610,7 +616,7 @@ class FormTokenField extends Component {
 			label = __( 'Add item' ),
 			instanceId,
 			className,
-			showHowTo,
+			__experimentalShowHowTo,
 		} = this.props;
 		const { isExpanded } = this.state;
 		const classes = classnames(
@@ -673,7 +679,7 @@ class FormTokenField extends Component {
 						/>
 					) }
 				</div>
-				{ showHowTo && (
+				{ __experimentalShowHowTo && (
 					<p
 						id={ `components-form-token-suggestions-howto-${ instanceId }` }
 						className="components-form-token-field__help"
@@ -706,11 +712,11 @@ FormTokenField.defaultProps = {
 		added: __( 'Item added.' ),
 		removed: __( 'Item removed.' ),
 		remove: __( 'Remove item' ),
-		invalid: __( 'Invalid item' ),
+		__experimentalInvalid: __( 'Invalid item' ),
 	},
-	expandOnFocus: false,
-	validateInput: () => true,
-	showHowTo: true,
+	__experimentalExpandOnFocus: false,
+	__experimentalValidateInput: () => true,
+	__experimentalShowHowTo: true,
 };
 
 export default withSpokenMessages( withInstanceId( FormTokenField ) );

--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { boolean } from '@storybook/addon-knobs';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -23,6 +28,7 @@ const continents = [
 ];
 
 const FormTokenFieldExample = () => {
+	const showHowTo = boolean( 'Show how to instructions', true );
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 
 	return (
@@ -31,6 +37,7 @@ const FormTokenFieldExample = () => {
 			suggestions={ continents }
 			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
 			label="Type a continent"
+			showHowTo={ showHowTo }
 		/>
 	);
 };
@@ -40,6 +47,7 @@ export const _default = () => {
 };
 
 const FormTokenFieldAsyncExample = () => {
+	const showHowTo = boolean( 'Show how to instructions', true );
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 	const [ availableContinents, setAvailableContinents ] = useState( [] );
 	const searchContinents = ( input ) => {
@@ -60,6 +68,7 @@ const FormTokenFieldAsyncExample = () => {
 			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
 			onInputChange={ searchContinents }
 			label="Type a continent"
+			showHowTo={ showHowTo }
 		/>
 	);
 };

--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -29,6 +29,7 @@ const continents = [
 
 const FormTokenFieldExample = () => {
 	const showHowTo = boolean( 'Show how to instructions', true );
+	const expandOnFocus = boolean( 'Expand on focus', false );
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 
 	return (
@@ -37,6 +38,7 @@ const FormTokenFieldExample = () => {
 			suggestions={ continents }
 			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
 			label="Type a continent"
+			expandOnFocus={ expandOnFocus }
 			showHowTo={ showHowTo }
 		/>
 	);
@@ -48,6 +50,7 @@ export const _default = () => {
 
 const FormTokenFieldAsyncExample = () => {
 	const showHowTo = boolean( 'Show how to instructions', true );
+	const expandOnFocus = boolean( 'Expand on focus', false );
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 	const [ availableContinents, setAvailableContinents ] = useState( [] );
 	const searchContinents = ( input ) => {
@@ -68,6 +71,7 @@ const FormTokenFieldAsyncExample = () => {
 			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
 			onInputChange={ searchContinents }
 			label="Type a continent"
+			expandOnFocus={ expandOnFocus }
 			showHowTo={ showHowTo }
 		/>
 	);

--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 
 /**
  * WordPress dependencies
@@ -30,6 +30,7 @@ const continents = [
 const FormTokenFieldExample = () => {
 	const showHowTo = boolean( 'Show how to instructions', true );
 	const expandOnFocus = boolean( 'Expand on focus', false );
+	const placeholder = text( 'Placeholder', '' );
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 
 	return (
@@ -40,6 +41,7 @@ const FormTokenFieldExample = () => {
 			label="Type a continent"
 			expandOnFocus={ expandOnFocus }
 			showHowTo={ showHowTo }
+			placeholder={ placeholder }
 		/>
 	);
 };
@@ -51,6 +53,7 @@ export const _default = () => {
 const FormTokenFieldAsyncExample = () => {
 	const showHowTo = boolean( 'Show how to instructions', true );
 	const expandOnFocus = boolean( 'Expand on focus', false );
+	const placeholder = text( 'Placeholder', '' );
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 	const [ availableContinents, setAvailableContinents ] = useState( [] );
 	const searchContinents = ( input ) => {
@@ -73,6 +76,7 @@ const FormTokenFieldAsyncExample = () => {
 			label="Type a continent"
 			expandOnFocus={ expandOnFocus }
 			showHowTo={ showHowTo }
+			placeholder={ placeholder }
 		/>
 	);
 };

--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -27,14 +27,15 @@ const continents = [
 	'Oceania',
 ];
 
+const getKnobs = () => ( {
+	showHowTo: boolean( 'Show how to instructions', true ),
+	expandOnFocus: boolean( 'Expand on focus', false ),
+	placeholder: text( 'Placeholder', '' ),
+	enableValidation: boolean( 'Validate that value is in suggestions', false ),
+} );
+
 const FormTokenFieldExample = () => {
-	const showHowTo = boolean( 'Show how to instructions', true );
-	const expandOnFocus = boolean( 'Expand on focus', false );
-	const placeholder = text( 'Placeholder', '' );
-	const enableValidation = boolean(
-		'Validate that value is in suggestions',
-		false
-	);
+	const knobs = getKnobs();
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 
 	return (
@@ -43,11 +44,11 @@ const FormTokenFieldExample = () => {
 			suggestions={ continents }
 			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
 			label="Type a continent"
-			placeholder={ placeholder }
-			__experimentalExpandOnFocus={ expandOnFocus }
-			__experimentalShowHowTo={ showHowTo }
+			placeholder={ knobs.placeholder }
+			__experimentalExpandOnFocus={ knobs.expandOnFocus }
+			__experimentalShowHowTo={ knobs.showHowTo }
 			__experimentalValidateInput={
-				enableValidation
+				knobs.enableValidation
 					? ( newValue ) => continents.includes( newValue )
 					: () => true
 			}
@@ -60,13 +61,7 @@ export const _default = () => {
 };
 
 const FormTokenFieldAsyncExample = () => {
-	const showHowTo = boolean( 'Show how to instructions', true );
-	const expandOnFocus = boolean( 'Expand on focus', false );
-	const placeholder = text( 'Placeholder', '' );
-	const enableValidation = boolean(
-		'Validate that value is in suggestions',
-		false
-	);
+	const knobs = getKnobs();
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 	const [ availableContinents, setAvailableContinents ] = useState( [] );
 	const searchContinents = ( input ) => {
@@ -87,11 +82,11 @@ const FormTokenFieldAsyncExample = () => {
 			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
 			onInputChange={ searchContinents }
 			label="Type a continent"
-			placeholder={ placeholder }
-			__experimentalExpandOnFocus={ expandOnFocus }
-			__experimentalShowHowTo={ showHowTo }
+			placeholder={ knobs.placeholder }
+			__experimentalExpandOnFocus={ knobs.expandOnFocus }
+			__experimentalShowHowTo={ knobs.showHowTo }
 			__experimentalValidateInput={
-				enableValidation
+				knobs.enableValidation
 					? ( newValue ) => continents.includes( newValue )
 					: () => true
 			}

--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -39,9 +39,9 @@ const FormTokenFieldExample = () => {
 			suggestions={ continents }
 			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
 			label="Type a continent"
-			expandOnFocus={ expandOnFocus }
-			showHowTo={ showHowTo }
 			placeholder={ placeholder }
+			__experimentalExpandOnFocus={ expandOnFocus }
+			__experimentalShowHowTo={ showHowTo }
 		/>
 	);
 };
@@ -74,9 +74,9 @@ const FormTokenFieldAsyncExample = () => {
 			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
 			onInputChange={ searchContinents }
 			label="Type a continent"
-			expandOnFocus={ expandOnFocus }
-			showHowTo={ showHowTo }
 			placeholder={ placeholder }
+			__experimentalExpandOnFocus={ expandOnFocus }
+			__experimentalShowHowTo={ showHowTo }
 		/>
 	);
 };

--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -31,6 +31,10 @@ const FormTokenFieldExample = () => {
 	const showHowTo = boolean( 'Show how to instructions', true );
 	const expandOnFocus = boolean( 'Expand on focus', false );
 	const placeholder = text( 'Placeholder', '' );
+	const enableValidation = boolean(
+		'Validate that value is in suggestions',
+		false
+	);
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 
 	return (
@@ -42,6 +46,11 @@ const FormTokenFieldExample = () => {
 			placeholder={ placeholder }
 			__experimentalExpandOnFocus={ expandOnFocus }
 			__experimentalShowHowTo={ showHowTo }
+			__experimentalValidateInput={
+				enableValidation
+					? ( newValue ) => continents.includes( newValue )
+					: () => true
+			}
 		/>
 	);
 };
@@ -54,6 +63,10 @@ const FormTokenFieldAsyncExample = () => {
 	const showHowTo = boolean( 'Show how to instructions', true );
 	const expandOnFocus = boolean( 'Expand on focus', false );
 	const placeholder = text( 'Placeholder', '' );
+	const enableValidation = boolean(
+		'Validate that value is in suggestions',
+		false
+	);
 	const [ selectedContinents, setSelectedContinents ] = useState( [] );
 	const [ availableContinents, setAvailableContinents ] = useState( [] );
 	const searchContinents = ( input ) => {
@@ -77,6 +90,11 @@ const FormTokenFieldAsyncExample = () => {
 			placeholder={ placeholder }
 			__experimentalExpandOnFocus={ expandOnFocus }
 			__experimentalShowHowTo={ showHowTo }
+			__experimentalValidateInput={
+				enableValidation
+					? ( newValue ) => continents.includes( newValue )
+					: () => true
+			}
 		/>
 	);
 };

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -2,7 +2,7 @@
 	@include input-control();
 	display: flex;
 	flex-wrap: wrap;
-	align-items: flex-start;
+	align-items: center;
 	width: 100%;
 	margin: 0 0 $grid-unit-10 0;
 	padding: $grid-unit-05/2 $grid-unit-05;

--- a/packages/components/src/form-token-field/test/index.js
+++ b/packages/components/src/form-token-field/test/index.js
@@ -95,8 +95,10 @@ describe( 'FormTokenField', () => {
 		return selectedSuggestions[ 0 ] || null;
 	}
 
-	beforeEach( () => {
-		wrapper = TestUtils.renderIntoDocument( <TokenFieldWrapper /> );
+	function setUp( props ) {
+		wrapper = TestUtils.renderIntoDocument(
+			<TokenFieldWrapper { ...props } />
+		);
 		/* eslint-disable react/no-find-dom-node */
 		wrapperElement = () => ReactDOM.findDOMNode( wrapper );
 		textInputElement = () =>
@@ -108,10 +110,11 @@ describe( 'FormTokenField', () => {
 			TestUtils.findRenderedComponentWithType( wrapper, TokenInput );
 		/* eslint-enable react/no-find-dom-node */
 		TestUtils.Simulate.focus( textInputElement() );
-	} );
+	}
 
 	describe( 'displaying tokens', () => {
 		it( 'should render default tokens', () => {
+			setUp();
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -119,6 +122,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should display tokens with escaped special characters properly', () => {
+			setUp();
 			wrapper.setState( {
 				tokens: fixtures.specialTokens.textEscaped,
 				isExpanded: true,
@@ -129,6 +133,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should display tokens with special characters properly', () => {
+			setUp();
 			// This test is not as realistic as the previous one: if a WP site
 			// contains tag names with special characters, the API will always
 			// return the tag names already escaped.  However, this is still
@@ -147,6 +152,7 @@ describe( 'FormTokenField', () => {
 
 	describe( 'suggestions', () => {
 		it( 'should not render suggestions unless we type at least two characters', () => {
+			setUp();
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -157,7 +163,16 @@ describe( 'FormTokenField', () => {
 			);
 		} );
 
+		it( 'should show suggestions when when input is empty if expandOnFocus is set to true', () => {
+			setUp( { expandOnFocus: true } );
+			wrapper.setState( {
+				isExpanded: true,
+			} );
+			expect( getSuggestionsText() ).not.toEqual( [] );
+		} );
+
 		it( 'should remove already added tags from suggestions', () => {
+			setUp();
 			wrapper.setState( {
 				tokens: Object.freeze( [ 'of', 'and' ] ),
 			} );
@@ -165,6 +180,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'suggestions that begin with match are boosted', () => {
+			setUp();
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -175,6 +191,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should match against the unescaped values of suggestions with special characters', () => {
+			setUp();
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
 				isExpanded: true,
@@ -186,6 +203,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should match against the unescaped values of suggestions with special characters (including spaces)', () => {
+			setUp();
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
 				isExpanded: true,
@@ -197,6 +215,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should not match against the escaped values of suggestions with special characters', () => {
+			setUp();
 			setText( 'amp' );
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
@@ -208,6 +227,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should match suggestions even with trailing spaces', () => {
+			setUp();
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -218,6 +238,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should manage the selected suggestion based on both keyboard and mouse events', () => {
+			setUp();
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -255,6 +276,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should re-render when suggestions prop has changed', () => {
+			setUp();
 			wrapper.setState( {
 				tokenSuggestions: [],
 				isExpanded: true,
@@ -279,17 +301,20 @@ describe( 'FormTokenField', () => {
 
 	describe( 'adding tokens', () => {
 		it( 'should not allow adding blank tokens with Tab', () => {
+			setUp();
 			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should not allow adding whitespace tokens with Tab', () => {
+			setUp();
 			setText( '   ' );
 			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should add a token when Enter pressed', () => {
+			setUp();
 			setText( 'baz' );
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar', 'baz' ] );
@@ -298,37 +323,52 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should not allow adding blank tokens with Enter', () => {
+			setUp();
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should not allow adding whitespace tokens with Enter', () => {
+			setUp();
 			setText( '   ' );
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should not allow adding whitespace tokens with comma', () => {
+			setUp();
 			setText( '   ' );
 			sendKeyPress( charCodes.comma );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should add a token when comma pressed', () => {
+			setUp();
 			setText( 'baz' );
 			sendKeyPress( charCodes.comma );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar', 'baz' ] );
 		} );
 
 		it( 'should trim token values when adding', () => {
+			setUp();
 			setText( '  baz  ' );
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar', 'baz' ] );
+		} );
+
+		it( "should not add values that don't pass the validation", () => {
+			setUp( {
+				validateInput: ( newValue ) => newValue !== 'baz',
+			} );
+			setText( 'baz' );
+			sendKeyDown( keyCodes.enter );
+			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 	} );
 
 	describe( 'removing tokens', () => {
 		it( 'should remove tokens when X icon clicked', () => {
+			setUp();
 			const forClickNode = wrapperElement().querySelector(
 				'.components-form-token-field__remove-token'
 			).firstChild;

--- a/packages/components/src/form-token-field/test/index.js
+++ b/packages/components/src/form-token-field/test/index.js
@@ -164,7 +164,7 @@ describe( 'FormTokenField', () => {
 		} );
 
 		it( 'should show suggestions when when input is empty if expandOnFocus is set to true', () => {
-			setUp( { expandOnFocus: true } );
+			setUp( { __experimentalExpandOnFocus: true } );
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -358,7 +358,7 @@ describe( 'FormTokenField', () => {
 
 		it( "should not add values that don't pass the validation", () => {
 			setUp( {
-				validateInput: ( newValue ) => newValue !== 'baz',
+				__experimentalValidateInput: ( newValue ) => newValue !== 'baz',
 			} );
 			setText( 'baz' );
 			sendKeyDown( keyCodes.enter );

--- a/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
+++ b/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
@@ -43,6 +43,7 @@ class TokenFieldWrapper extends Component {
 				value={ this.state.tokens }
 				displayTransform={ unescapeAndFormatSpaces }
 				onChange={ this.onTokensChange }
+				{ ...this.props }
 			/>
 		);
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds three new props to `FormTokenField`:
* `expandOnFocus`: allows keeping the suggestion list expanded every time the input field has the focus.
* `showHowTo`: allows hiding the _How to use_ text when set to false.
* `validateInput`: allows validating the input before it's accepted and converted to a token. That will be useful in use-cases where only inputs which match one of the suggestions is accepted.

It also fixes the `placeholder` prop, which seemed not to be honored.

## How has this been tested?
* All changes are behind new props (except the placeholder fix), so it shouldn't affect current uses of `FormTokenField`.
* Tested the `FormTokenField` in Storybook and added new knobs for the new props.
* Tested there are no regressions in the Tags input field when editing a post.
* Tested with screen reader (Orca) and using only the keyboard.
* Added some unit tests.

## Screenshots
* `expandOnFocus` set to true
* `showHowTo` set to false
* `placeholder` set to `Africa, America, Asia...`

https://user-images.githubusercontent.com/3616980/108348391-0546b680-71e2-11eb-9143-017c409e3309.mp4

## Types of changes
New feature which adds new props to `FormTokenField`.
Bug fix that makes the `placeholder` prop in `FormTokenField` to be honored.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
