### PR TITLE
Fix legacy widgets not previewing and widgets saving issue

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -8,7 +8,7 @@ import { last, noop } from 'lodash';
  */
 import { useEffect, useRef } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
-import { cloneBlock } from '@wordpress/blocks';
+import { duplicateBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -100,7 +100,7 @@ export default function useBlockSync( {
 			setHasControlledInnerBlocks( clientId, true );
 			__unstableMarkNextChangeAsNotPersistent();
 			const storeBlocks = controlledBlocks.map( ( block ) =>
-				cloneBlock( block )
+				duplicateBlock( block )
 			);
 			if ( subscribed.current ) {
 				pendingChanges.current.incoming = storeBlocks;

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -8,7 +8,7 @@ import { last, noop } from 'lodash';
  */
 import { useEffect, useRef } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
-import { duplicateBlock } from '@wordpress/blocks';
+import { cloneBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -100,7 +100,7 @@ export default function useBlockSync( {
 			setHasControlledInnerBlocks( clientId, true );
 			__unstableMarkNextChangeAsNotPersistent();
 			const storeBlocks = controlledBlocks.map( ( block ) =>
-				duplicateBlock( block )
+				cloneBlock( block )
 			);
 			if ( subscribed.current ) {
 				pendingChanges.current.incoming = storeBlocks;

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -8,6 +8,7 @@ import { castArray, findKey, first, isObject, last, some } from 'lodash';
  */
 import {
 	cloneBlock,
+	__experimentalCloneSanitizedBlock,
 	createBlock,
 	doBlocksMatchTemplate,
 	getBlockType,
@@ -1246,7 +1247,9 @@ export function* duplicateBlocks( clientIds, updateSelection = true ) {
 		last( castArray( clientIds ) ),
 		rootClientId
 	);
-	const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
+	const clonedBlocks = blocks.map( ( block ) =>
+		__experimentalCloneSanitizedBlock( block )
+	);
 	yield insertBlocks(
 		clonedBlocks,
 		lastSelectedIndex + 1,

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   Reverted `cloneBlock` back to its original logic that doesn't sanitize block's attributes. [#28379](https://github.com/WordPress/gutenberg/pull/29111)
+
 ## 7.0.0 (2021-02-01)
 
 ### Breaking Change

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -183,8 +183,8 @@ In the random image block above, we've given the `alt` attribute of the image a 
 
 <a name="cloneBlock" href="#cloneBlock">#</a> **cloneBlock**
 
-Given a block object, returns a copy of the block object, optionally merging
-new attributes and/or replacing its inner blocks.
+Given a block object, returns a copy of the block object while sanitizing its attributes,
+optionally merging new attributes and/or replacing its inner blocks.
 
 _Parameters_
 
@@ -237,6 +237,21 @@ _Parameters_
 _Returns_
 
 -   `boolean`: Whether the list of blocks matches a templates
+
+<a name="duplicateBlock" href="#duplicateBlock">#</a> **duplicateBlock**
+
+Given a block object, returns a copy of the block object without sanitizing its attributes,
+optionally merging new attributes and/or replacing its inner blocks.
+
+_Parameters_
+
+-   _block_ `Object`: Block instance.
+-   _mergeAttributes_ `Object`: Block attributes.
+-   _newInnerBlocks_ `?Array`: Nested blocks.
+
+_Returns_
+
+-   `Object`: A cloned block.
 
 <a name="findTransform" href="#findTransform">#</a> **findTransform**
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -183,7 +183,7 @@ In the random image block above, we've given the `alt` attribute of the image a 
 
 <a name="cloneBlock" href="#cloneBlock">#</a> **cloneBlock**
 
-Given a block object, returns a copy of the block object while sanitizing its attributes,
+Given a block object, returns a copy of the block object,
 optionally merging new attributes and/or replacing its inner blocks.
 
 _Parameters_
@@ -237,21 +237,6 @@ _Parameters_
 _Returns_
 
 -   `boolean`: Whether the list of blocks matches a templates
-
-<a name="duplicateBlock" href="#duplicateBlock">#</a> **duplicateBlock**
-
-Given a block object, returns a copy of the block object without sanitizing its attributes,
-optionally merging new attributes and/or replacing its inner blocks.
-
-_Parameters_
-
--   _block_ `Object`: Block instance.
--   _mergeAttributes_ `Object`: Block attributes.
--   _newInnerBlocks_ `?Array`: Nested blocks.
-
-_Returns_
-
--   `Object`: A cloned block.
 
 <a name="findTransform" href="#findTransform">#</a> **findTransform**
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -88,36 +88,6 @@ export function createBlocksFromInnerBlocksTemplate(
 }
 
 /**
- * Given a block object, returns a copy of the block object without sanitizing its attributes,
- * optionally merging new attributes and/or replacing its inner blocks.
- *
- * @param {Object} block              Block instance.
- * @param {Object} mergeAttributes    Block attributes.
- * @param {?Array} newInnerBlocks     Nested blocks.
- *
- * @return {Object} A cloned block.
- */
-export function duplicateBlock( block, mergeAttributes = {}, newInnerBlocks ) {
-	const clientId = uuid();
-
-	const attributes = {
-		...block.attributes,
-		...mergeAttributes,
-	};
-
-	return {
-		...block,
-		clientId,
-		attributes,
-		innerBlocks:
-			newInnerBlocks ||
-			block.innerBlocks.map( ( innerBlock ) =>
-				duplicateBlock( innerBlock )
-			),
-	};
-}
-
-/**
  * Given a block object, returns a copy of the block object while sanitizing its attributes,
  * optionally merging new attributes and/or replacing its inner blocks.
  *
@@ -127,7 +97,11 @@ export function duplicateBlock( block, mergeAttributes = {}, newInnerBlocks ) {
  *
  * @return {Object} A cloned block.
  */
-export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
+export function __experimentalCloneSanitizedBlock(
+	block,
+	mergeAttributes = {},
+	newInnerBlocks
+) {
 	const clientId = uuid();
 
 	const sanitizedAttributes = sanitizeBlockAttributes( block.name, {
@@ -139,6 +113,34 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 		...block,
 		clientId,
 		attributes: sanitizedAttributes,
+		innerBlocks:
+			newInnerBlocks ||
+			block.innerBlocks.map( ( innerBlock ) =>
+				__experimentalCloneSanitizedBlock( innerBlock )
+			),
+	};
+}
+
+/**
+ * Given a block object, returns a copy of the block object,
+ * optionally merging new attributes and/or replacing its inner blocks.
+ *
+ * @param {Object} block              Block instance.
+ * @param {Object} mergeAttributes    Block attributes.
+ * @param {?Array} newInnerBlocks     Nested blocks.
+ *
+ * @return {Object} A cloned block.
+ */
+export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
+	const clientId = uuid();
+
+	return {
+		...block,
+		clientId,
+		attributes: {
+			...block.attributes,
+			...mergeAttributes,
+		},
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) => cloneBlock( innerBlock ) ),

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -88,8 +88,38 @@ export function createBlocksFromInnerBlocksTemplate(
 }
 
 /**
- * Given a block object, returns a copy of the block object, optionally merging
- * new attributes and/or replacing its inner blocks.
+ * Given a block object, returns a copy of the block object without sanitizing its attributes,
+ * optionally merging new attributes and/or replacing its inner blocks.
+ *
+ * @param {Object} block              Block instance.
+ * @param {Object} mergeAttributes    Block attributes.
+ * @param {?Array} newInnerBlocks     Nested blocks.
+ *
+ * @return {Object} A cloned block.
+ */
+export function duplicateBlock( block, mergeAttributes = {}, newInnerBlocks ) {
+	const clientId = uuid();
+
+	const attributes = {
+		...block.attributes,
+		...mergeAttributes,
+	};
+
+	return {
+		...block,
+		clientId,
+		attributes,
+		innerBlocks:
+			newInnerBlocks ||
+			block.innerBlocks.map( ( innerBlock ) =>
+				duplicateBlock( innerBlock )
+			),
+	};
+}
+
+/**
+ * Given a block object, returns a copy of the block object while sanitizing its attributes,
+ * optionally merging new attributes and/or replacing its inner blocks.
  *
  * @param {Object} block              Block instance.
  * @param {Object} mergeAttributes    Block attributes.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -7,8 +7,8 @@
 export {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
-	duplicateBlock,
 	cloneBlock,
+	__experimentalCloneSanitizedBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,
 	getBlockTransforms,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -7,6 +7,7 @@
 export {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
+	duplicateBlock,
 	cloneBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -11,6 +11,7 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	cloneBlock,
+	__experimentalCloneSanitizedBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,
 	getBlockTransforms,
@@ -424,7 +425,9 @@ describe( 'block factory', () => {
 				block.innerBlocks[ 1 ].attributes
 			);
 		} );
+	} );
 
+	describe( '__experimentalCloneSanitizedBlock', () => {
 		it( 'should sanitize attributes not defined in the block type', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
@@ -439,7 +442,7 @@ describe( 'block factory', () => {
 				notDefined: 'not-defined',
 			} );
 
-			const clonedBlock = cloneBlock( block, {
+			const clonedBlock = __experimentalCloneSanitizedBlock( block, {
 				notDefined2: 'not-defined-2',
 			} );
 

--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -338,15 +338,7 @@ describe( 'Widgets screen', () => {
 		}
 	` );
 		const initialWidgets = await getWidgetAreaWidgets();
-		expect( initialWidgets ).toMatchInlineSnapshot( `
-		Object {
-		  "sidebar-1": Array [
-		    "block-2",
-		  ],
-		  "sidebar-2": Array [],
-		  "wp_inactive_widgets": Array [],
-		}
-	` );
+		expect( initialWidgets[ 'sidebar-1' ].length ).toBe( 1 );
 
 		firstParagraphBlock = await firstWidgetArea.$(
 			'[data-block][data-type="core/paragraph"]'
@@ -417,16 +409,10 @@ describe( 'Widgets screen', () => {
 		}
 	` );
 		const editedWidgets = await getWidgetAreaWidgets();
-		expect( editedWidgets ).toMatchInlineSnapshot( `
-		Object {
-		  "sidebar-1": Array [
-		    "block-2",
-		    "block-3",
-		  ],
-		  "sidebar-2": Array [],
-		  "wp_inactive_widgets": Array [],
-		}
-	` );
+		expect( editedWidgets[ 'sidebar-1' ].length ).toBe( 2 );
+		expect( editedWidgets[ 'sidebar-1' ][ 0 ] ).toBe(
+			initialWidgets[ 'sidebar-1' ][ 0 ]
+		);
 	} );
 
 	it( 'Should display legacy widgets', async () => {

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -75,12 +75,10 @@ export function* getWidgets() {
 		query
 	);
 
-	const widgetIdToClientId = {};
 	const groupedBySidebar = {};
 
 	for ( const widget of widgets ) {
 		const block = transformWidgetToBlock( widget );
-		widgetIdToClientId[ widget.id ] = block.clientId;
 		groupedBySidebar[ widget.sidebar ] =
 			groupedBySidebar[ widget.sidebar ] || [];
 		groupedBySidebar[ widget.sidebar ].push( block );
@@ -95,9 +93,4 @@ export function* getWidgets() {
 			);
 		}
 	}
-
-	yield {
-		type: 'SET_WIDGET_TO_CLIENT_ID_MAPPING',
-		mapping: widgetIdToClientId,
-	};
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Continued and fix #28379.

<!-- Please describe what you have changed or added -->
`useBlockSync` internally uses `cloneBlock` to sync external changes. However, in a recent change in #28379, `cloneBlock` now will sanitize the attributes, which makes `__internalWidgetId` to be dropped off whenever the user is making any changes.

This PR renames `cloneBlock` to `__experimentalCloneSanitizedBlock` (naming TBD) and uses it when duplicating blocks. Then, creates a new method `cloneBlock` that doesn't sanitize attributes, which is essentially the same as the original `cloneBlock` before #28379. This means that the exported `cloneBlock` doesn't have to be breaking anymore.

This also fixes an issue where legacy widgets' previews are not being shown correctly, as `__internalWidgetId` was not being passed to the block before.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Updated e2e test for duplicating blocks, and added e2e test for displaying legacy widgets' previews.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
