### PR TITLE
Make RNMobile Appium logs available

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -50,3 +50,9 @@ jobs:
       with:
         name: android-screen-recordings
         path: packages/react-native-editor/android-screen-recordings
+
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: appium-logs
+        path: packages/react-native-editor/appium-out.log

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -75,3 +75,9 @@ jobs:
       with:
         name: ios-screen-recordings
         path: packages/react-native-editor/ios-screen-recordings
+
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: appium-logs
+        path: packages/react-native-editor/appium-out.log


### PR DESCRIPTION
## Description
When a RN Mobile E2E test fails (e.g. `gutenberg-editor-gallery`), the cause of the error is sometimes unclear and access to the `appium-out.log` is needed. This PR uploads that log as a workflow artifact (similar to how screen recordings are uploaded currently), so they can be downloaded and viewed if needed.

## How has this been tested?

By verifying that the `appium-log.out` file is now downloadable on both React Native E2E Tests (iOS) and React Native E2E Tests (Android) tests.

## Screenshots <!-- if applicable -->

<img width="1261" alt="Screenshot showing option to download appium log artifact" src="https://user-images.githubusercontent.com/1898325/108420332-6b4b3200-7212-11eb-87fc-2d37fe23995f.png">


## Types of changes

Improvement to RNMobile E2E tests to allow for easier debugging when tests fail.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
