### PR TITLE
E2E Tests: Add basic block preview coverage for inserter

### DIFF
--- a/packages/e2e-tests/specs/editor/various/inserter.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserter.test.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createNewPost,
+	openGlobalBlockInserter,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Inserter', () => {
+	it( 'shows block preview when hovering over block in inserter', async () => {
+		await createNewPost();
+		await openGlobalBlockInserter();
+		await page.focus( '.editor-block-list-item-paragraph' );
+		await page.waitForSelector( '.block-editor-inserter__preview', {
+			visible: true,
+		} );
+		const preview = await page.$( '.block-editor-inserter__preview' );
+		const isPreviewVisible = await preview.isIntersectingViewport();
+		expect( isPreviewVisible ).toBe( true );
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/various/inserter.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserter.test.js
@@ -11,10 +11,12 @@ describe( 'Inserter', () => {
 		await createNewPost();
 		await openGlobalBlockInserter();
 		await page.focus( '.editor-block-list-item-paragraph' );
-		await page.waitForSelector( '.block-editor-inserter__preview', {
-			visible: true,
-		} );
-		const preview = await page.$( '.block-editor-inserter__preview' );
+		const preview = await page.waitForSelector(
+			'.block-editor-inserter__preview',
+			{
+				visible: true,
+			}
+		);
 		const isPreviewVisible = await preview.isIntersectingViewport();
 		expect( isPreviewVisible ).toBe( true );
 	} );


### PR DESCRIPTION
## Description
Add a basic e2e test for the block inserter, to make sure block preview is visible when a block in the inserter is focused.

Fixes #29073.

## How has this been tested?

- Verify that e2e tests pass in CI.
- To run locally: `npm run test-e2e -- packages/e2e-tests/specs/editor/various/inserter.test.js`
- Revert the commit (a224cbf) that fixed block preview visibilty, rebuild Gutenberg, and re-run the test to make sure it will fail in that case:
```
git revert a224cbf
npm run build
npm run test-e2e -- packages/e2e-tests/specs/editor/various/inserter.test.js
```

