### PR TITLE
Template part block: Add variations based on areas

### DIFF
--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -15,6 +15,7 @@ import { __, _x } from '@wordpress/i18n';
  */
 import metadata from './block.json';
 import edit from './edit';
+import variations from './variations';
 
 const { name } = metadata;
 export { metadata, name };
@@ -44,4 +45,5 @@ export const settings = {
 		return startCase( entity.title?.rendered || entity.slug );
 	},
 	edit,
+	variations,
 };

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -24,6 +24,8 @@ const variations = [
 	{
 		name: 'header',
 		title: __( 'Header' ),
+		description:
+			"The header template defines a page area that typically contains a title, logo, and main navigation. Since it's a global element it can be present across all pages and posts.",
 		icon: header,
 		isActive: createIsActiveBasedOnArea( 'header' ),
 		scope: [],
@@ -31,6 +33,8 @@ const variations = [
 	{
 		name: 'footer',
 		title: __( 'Footer' ),
+		description:
+			"The footer template defines a page area that typically contains site credits, social links, or any other combination of blocks. Since it's a global element it can be present across all pages and posts.",
 		icon: footer,
 		isActive: createIsActiveBasedOnArea( 'footer' ),
 		scope: [],

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { footer, header, sidebar } from '@wordpress/icons';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+const createIsActive = ( area ) => ( { theme, slug } ) => {
+	if ( ! slug ) {
+		return false;
+	}
+
+	const entity = select( coreDataStore ).getEntityRecord(
+		'postType',
+		'wp_template_part',
+		`${ theme }//${ slug }`
+	);
+
+	return entity?.area === area;
+};
+
+const variations = [
+	{
+		name: 'header',
+		title: __( 'Header' ),
+		icon: header,
+		isActive: createIsActive( 'header' ),
+		scope: [],
+	},
+	{
+		name: 'sidebar',
+		title: __( 'Sidebar' ),
+		icon: sidebar,
+		isActive: createIsActive( 'sidebar' ),
+		scope: [],
+	},
+	{
+		name: 'footer',
+		title: __( 'Footer' ),
+		icon: footer,
+		isActive: createIsActive( 'footer' ),
+		scope: [],
+	},
+];
+
+export default variations;

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -6,7 +6,7 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
-const createIsActive = ( area ) => ( { theme, slug } ) => {
+const createIsActiveBasedOnArea = ( area ) => ( { theme, slug } ) => {
 	if ( ! slug ) {
 		return false;
 	}
@@ -25,21 +25,21 @@ const variations = [
 		name: 'header',
 		title: __( 'Header' ),
 		icon: header,
-		isActive: createIsActive( 'header' ),
+		isActive: createIsActiveBasedOnArea( 'header' ),
 		scope: [],
 	},
 	{
 		name: 'sidebar',
 		title: __( 'Sidebar' ),
 		icon: sidebar,
-		isActive: createIsActive( 'sidebar' ),
+		isActive: createIsActiveBasedOnArea( 'sidebar' ),
 		scope: [],
 	},
 	{
 		name: 'footer',
 		title: __( 'Footer' ),
 		icon: footer,
-		isActive: createIsActive( 'footer' ),
+		isActive: createIsActiveBasedOnArea( 'footer' ),
 		scope: [],
 	},
 ];

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { footer, header, sidebar } from '@wordpress/icons';
+import { footer, header } from '@wordpress/icons';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -26,13 +26,6 @@ const variations = [
 		title: __( 'Header' ),
 		icon: header,
 		isActive: createIsActiveBasedOnArea( 'header' ),
-		scope: [],
-	},
-	{
-		name: 'sidebar',
-		title: __( 'Sidebar' ),
-		icon: sidebar,
-		isActive: createIsActiveBasedOnArea( 'sidebar' ),
 		scope: [],
 	},
 	{


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add 2 new template part variations:
- Header
- Footer
 
These variations are used to show a different title, icon, and description based on the assigned area of the template part.

## How has this been tested?
1. Specify template part areas in your theme if you don't have already. Open `theme-experiments.json` and add the following snippet:
```json
"templateParts": {
	"header": {
		"area": "header"
	},
	"footer": {
		"area": "footer"
	}
}
```
2. Open site editor
3. Make sure you have 2 template parts with the following slugs: `header` and `footer`.
4. Insert all 2 template parts mentioned above.
5. Select `header` template part block.
- Make sure it shows the `header` icon and Header title in the block inspector
6. Select `footer` template part block.
- Make sure it shows the `footer` icon and Footer title in the block inspector

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/108523529-4fa56180-72ce-11eb-8aea-d9c437a3e584.png)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
