### PR TITLE
E2E Tests: Add gallery caption coverage

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -61,6 +61,22 @@ describe( 'Gallery', () => {
 		expect( await getEditedPostContent() ).toMatch( regex );
 	} );
 
+	it( 'gallery caption can be edited', async () => {
+		const galleryCaption = 'Tested gallery caption';
+
+		await insertBlock( 'Gallery' );
+		const filename = await upload( '.wp-block-gallery input[type="file"]' );
+
+		await getUploadedFileFigure( filename );
+
+		await page.click( '.wp-block-gallery>.blocks-gallery-caption' );
+		await page.keyboard.type( galleryCaption );
+
+		expect( await getEditedPostContent() ).toMatch(
+			new RegExp( `<figcaption.*?>${ galleryCaption }</figcaption>` )
+		);
+	} );
+
 	it( "uploaded images' captions can be edited", async () => {
 		await insertBlock( 'Gallery' );
 		const filename = await upload( '.wp-block-gallery input[type="file"]' );

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -37,15 +37,6 @@ async function upload( selector ) {
 	return filename;
 }
 
-async function getUploadedFileFigure( filename ) {
-	const image = await page.waitForSelector(
-		`.wp-block-gallery img[src$="${ filename }.png"]`
-	);
-
-	const figureElement = await image.getProperty( 'parentElement' );
-	return await figureElement.asElement();
-}
-
 describe( 'Gallery', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -65,9 +56,7 @@ describe( 'Gallery', () => {
 		const galleryCaption = 'Tested gallery caption';
 
 		await insertBlock( 'Gallery' );
-		const filename = await upload( '.wp-block-gallery input[type="file"]' );
-
-		await getUploadedFileFigure( filename );
+		await upload( '.wp-block-gallery input[type="file"]' );
 
 		await page.click( '.wp-block-gallery>.blocks-gallery-caption' );
 		await page.keyboard.type( galleryCaption );
@@ -79,17 +68,13 @@ describe( 'Gallery', () => {
 
 	it( "uploaded images' captions can be edited", async () => {
 		await insertBlock( 'Gallery' );
-		const filename = await upload( '.wp-block-gallery input[type="file"]' );
+		await upload( '.wp-block-gallery input[type="file"]' );
 
-		const figureElement = await getUploadedFileFigure( filename );
+		const figureElement = await page.waitForSelector(
+			'.blocks-gallery-item figure'
+		);
 
 		await figureElement.click();
-
-		expect(
-			await figureElement.evaluate( ( element ) =>
-				element.classList.contains( 'is-selected' )
-			)
-		).toBeTruthy();
 
 		const captionElement = await figureElement.$(
 			'.block-editor-rich-text__editable'


### PR DESCRIPTION
## Description
Add an E2E test for the gallery's figure caption, making sure it's clickable and editable. I also included a test for the gallery caption.

Fixes #29001.

## How has this been tested?

- Verifying that the added tests passed running `npm run test-e2e "packages/e2e-tests/specs/editor/blocks/gallery.test.js"`
- Rerunning the tests after reverting the commit that fixed it (eabd210), making sure they will fail:
```shell
git revert eabd210
npm run build
npm run test-e2e "packages/e2e-tests/specs/editor/blocks/gallery.test.js"
```
Since eabd210 fixed the gallery's figure caption, only the test for the figures' caption will fail, and not the one for the gallery's.