### PR TITLE
Media Placeholder: Change media URL input type to allow a local URL path

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -36,7 +36,7 @@ const InsertFromURLPopover = ( { src, onChange, onSubmit, onClose } ) => (
 		>
 			<input
 				className="block-editor-media-placeholder__url-input-field"
-				type="url"
+				type="text"
 				aria-label={ __( 'URL' ) }
 				placeholder={ __( 'Paste or type URL' ) }
 				onChange={ onChange }


### PR DESCRIPTION
## Description
Change type of `block-editor-media-placeholder__url-input-field` from "url" to "text."

input type="url" makes the browser require a full URL of at least _urlscheme_:_restofurl_, which means you can't enter a local urlpath for an image like `/path/to/image.jpg` without scheme and host. With this change the media-placeholder URL input field matches the [url-input component](https://github.com/WordPress/gutenberg/blob/70b1cde3bcf186059f0e4ee7396717046b96569b/packages/block-editor/src/components/url-input/index.js#L422) which uses type="text".

## How has this been tested?
Making this change in Firefox's developer tools' HTML inspector fixes issue #20903, but I haven't tested the code change.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix, should fix #20903. 

## Checklist:
(I have never made a pull request to Gutenberg, I hope this proposed fix doesn't waste anyone's time.)
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. _It might be useful to mention why type="url" should not be used but I don't know if or how you can put a comment in a component definition._ <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
