### PR TITLE
Support skipping serialization in the color hook (block supports mechanism)

### DIFF
--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -62,10 +62,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( 'color' ), false );
 
 	if ( array_key_exists( 'skipSerialization', $color_support ) && $color_support['skipSerialization'] ) {
-		return array(
-			'class'  => '',
-			'styles' => '',
-		);
+		return array();
 	}
 
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'text' ), true ) );

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -60,6 +60,14 @@ function gutenberg_register_colors_support( $block_type ) {
  */
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( 'color' ), false );
+
+	if ( array_key_exists( 'skipSerialization', $color_support ) && $color_support['skipSerialization'] ) {
+		return array(
+			'class'  => '',
+			'styles' => '',
+		);
+	}
+
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'text' ), true ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'background' ), true ) );
 	$has_link_colors_support       = gutenberg_experimental_get( $color_support, array( 'link' ), false );

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -61,7 +61,7 @@ function gutenberg_register_colors_support( $block_type ) {
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( 'color' ), false );
 
-	if ( array_key_exists( 'skipSerialization', $color_support ) && $color_support['skipSerialization'] ) {
+	if ( array_key_exists( '__experimentalSkipSerialization', $color_support ) && $color_support['__experimentalSkipSerialization'] ) {
 		return array();
 	}
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -61,7 +61,11 @@ function gutenberg_register_colors_support( $block_type ) {
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( 'color' ), false );
 
-	if ( array_key_exists( '__experimentalSkipSerialization', $color_support ) && $color_support['__experimentalSkipSerialization'] ) {
+	if (
+		is_array( $color_support ) &&
+		array_key_exists( '__experimentalSkipSerialization', $color_support ) &&
+		$color_support['__experimentalSkipSerialization']
+	) {
 		return array();
 	}
 

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -47,7 +47,7 @@ const hasColorSupport = ( blockType ) => {
 const shouldSkipSerialization = ( blockType ) => {
 	const colorSupport = getBlockSupport( blockType, COLOR_SUPPORT_KEY );
 
-	return colorSupport?.skipSerialization;
+	return colorSupport?.__experimentalSkipSerialization;
 };
 
 const hasLinkColorSupport = ( blockType ) => {

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -44,6 +44,12 @@ const hasColorSupport = ( blockType ) => {
 	);
 };
 
+const shouldSkipSerialization = ( blockType ) => {
+	const colorSupport = getBlockSupport( blockType, COLOR_SUPPORT_KEY );
+
+	return colorSupport?.skipSerialization;
+};
+
 const hasLinkColorSupport = ( blockType ) => {
 	if ( Platform.OS !== 'web' ) {
 		return false;
@@ -124,7 +130,10 @@ function addAttributes( settings ) {
  * @return {Object}            Filtered props applied to save element
  */
 export function addSaveProps( props, blockType, attributes ) {
-	if ( ! hasColorSupport( blockType ) ) {
+	if (
+		! hasColorSupport( blockType ) ||
+		shouldSkipSerialization( blockType )
+	) {
 		return props;
 	}
 
@@ -169,7 +178,10 @@ export function addSaveProps( props, blockType, attributes ) {
  * @return {Object}          Filtered block settings
  */
 export function addEditProps( settings ) {
-	if ( ! hasColorSupport( settings ) ) {
+	if (
+		! hasColorSupport( settings ) ||
+		shouldSkipSerialization( settings )
+	) {
 		return settings;
 	}
 	const existingGetEditWrapperProps = settings.getEditWrapperProps;
@@ -375,7 +387,7 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 		const { name, attributes } = props;
 		const { backgroundColor, textColor } = attributes;
 		const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
-		if ( ! hasColorSupport( name ) ) {
+		if ( ! hasColorSupport( name ) || shouldSkipSerialization( name ) ) {
 			return <BlockListBlock { ...props } />;
 		}
 


### PR DESCRIPTION
This PR implements the first step in supporting a more fine-grained block supports mechanism as described at https://github.com/WordPress/gutenberg/issues/28913

Follow-up PRs should be created to migrate specific blocks to use this. The testing steps illustrate a use case for this: make the social links use the colors from the block support mechanism, so they are exposed from theme.json.

## How has this been tested?

Using the TT1-blocks:

1. Add this to the block supports of the social links:

```json
"color": {
  "__experimentalSkipSerialization": true
},
"__experimentalSelector": ".wp-social-link"
```

2. Compile this branch.

3. Go to the post editor and create a social links block with some icons:

  - Verify that it has a new "colors panel" in the post editor.
  - Select a text color and a background color. Block styles shouldn't be affected (no new classes on inline styles are added for text and background colors). A follow-up PR should update the block to use these instead of the existing custom controls.
  - Open the code editor and verify that the block has the `textColor` and `backgroundColor` attributes and they have the same value as the color you selected.

4. Go to the site editor and create a social links block with some icons:

  - Verify that the social links panel in the global styles sidebar has the color panel.
  - Select a text and background color. Nothing should happen due to block styles specificity that should be updated in a follow-up PR.
  - Go to the browser inspector and unselect the CSS rules that are affecting the icon color. You should see the new colors applied.

