### PR TITLE
Color controls: take labels from block supports

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -213,7 +213,7 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
  * @return {WPElement} Color edit element.
  */
 export function ColorEdit( props ) {
-	const { name: blockName, attributes } = props;
+	const { name: blockName, attributes, colorLabels } = props;
 	const isLinkColorEnabled = useEditorFeature( 'color.link' );
 	const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
 	const gradients = useEditorFeature( 'color.gradients' ) || EMPTY_ARRAY;
@@ -327,7 +327,7 @@ export function ColorEdit( props ) {
 				...( hasTextColorSupport( blockName )
 					? [
 							{
-								label: __( 'Text Color' ),
+								label: colorLabels?.textColorLabel || __( 'Text Color' ),
 								onColorChange: onChangeColor( 'text' ),
 								colorValue: getColorObjectByAttributeValues(
 									colors,
@@ -340,7 +340,7 @@ export function ColorEdit( props ) {
 				...( hasBackground || hasGradient
 					? [
 							{
-								label: __( 'Background Color' ),
+								label: colorLabels?.backgroundColorLabel || __( 'Background Color' ),
 								onColorChange: hasBackground
 									? onChangeColor( 'background' )
 									: undefined,
@@ -359,7 +359,7 @@ export function ColorEdit( props ) {
 				...( isLinkColorEnabled && hasLinkColorSupport( blockName )
 					? [
 							{
-								label: __( 'Link Color' ),
+								label: colorLabels?.linkColorLabel || __( 'Link Color' ),
 								onColorChange: onChangeLinkColor,
 								colorValue: getLinkColorFromAttributeValue(
 									colors,

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -327,7 +327,9 @@ export function ColorEdit( props ) {
 				...( hasTextColorSupport( blockName )
 					? [
 							{
-								label: colorLabels?.textColorLabel || __( 'Text Color' ),
+								label:
+									colorLabels?.textColorLabel ||
+									__( 'Text Color' ),
 								onColorChange: onChangeColor( 'text' ),
 								colorValue: getColorObjectByAttributeValues(
 									colors,
@@ -340,7 +342,9 @@ export function ColorEdit( props ) {
 				...( hasBackground || hasGradient
 					? [
 							{
-								label: colorLabels?.backgroundColorLabel || __( 'Background Color' ),
+								label:
+									colorLabels?.backgroundColorLabel ||
+									__( 'Background Color' ),
 								onColorChange: hasBackground
 									? onChangeColor( 'background' )
 									: undefined,
@@ -359,7 +363,9 @@ export function ColorEdit( props ) {
 				...( isLinkColorEnabled && hasLinkColorSupport( blockName )
 					? [
 							{
-								label: colorLabels?.linkColorLabel || __( 'Link Color' ),
+								label:
+									colorLabels?.linkColorLabel ||
+									__( 'Link Color' ),
 								onColorChange: onChangeLinkColor,
 								colorValue: getLinkColorFromAttributeValue(
 									colors,

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -159,10 +159,15 @@ export const withBlockControls = createHigherOrderComponent(
 			SPACING_SUPPORT_KEY
 		);
 
+		const colorLabels = {
+			backgroundColorLabel: 'Background Label',
+			linkColorLabel: 'Link Label',
+			textColorLabel: 'Text Label',
+		}
 		return [
 			<TypographyPanel key="typography" { ...props } />,
 			<BorderPanel key="border" { ...props } />,
-			<ColorEdit key="colors" { ...props } />,
+			<ColorEdit key="colors" { ...{ ...props, colorLabels } } />,
 			<BlockEdit key="edit" { ...props } />,
 			hasSpacingSupport && (
 				<SpacingPanelControl key="spacing">

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -8,6 +8,7 @@ import { capitalize, has, get, startsWith } from 'lodash';
  */
 import { addFilter } from '@wordpress/hooks';
 import {
+	getBlockSupport,
 	hasBlockSupport,
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 } from '@wordpress/blocks';
@@ -159,11 +160,14 @@ export const withBlockControls = createHigherOrderComponent(
 			SPACING_SUPPORT_KEY
 		);
 
+		const colorSupport = getBlockSupport( blockName, COLOR_SUPPORT_KEY );
 		const colorLabels = {
-			backgroundColorLabel: 'Background Label',
-			linkColorLabel: 'Link Label',
-			textColorLabel: 'Text Label',
-		}
+			backgroundColorLabel:
+				colorSupport?.__experimentalBackgroundColorLabel,
+			linkColorLabel: colorSupport?.__experimentalLinkColorLabel,
+			textColorLabel: colorSupport?.__experimentalTextColorLabel,
+		};
+
 		return [
 			<TypographyPanel key="typography" { ...props } />,
 			<BorderPanel key="border" { ...props } />,


### PR DESCRIPTION
This PR is part of https://github.com/WordPress/gutenberg/issues/28913 and follows-up to https://github.com/WordPress/gutenberg/pull/29142#issuecomment-782028538

It allows the blocks to set the labels they want to use in the UI components for the color hook: text, background (includes gradients), and link. If they're not present, it fallbacks to the current strings ("Text Color", "Background Color", "Link Color").

This is useful to support use cases such as the social links, in which the color and background properties want to be advertised as "Icon color" and "Icon background color".

## How has this been tested?

- Update the `color` section of the paragraph's block.json to be:

```json
  "color": {
    "link": true,
    "gradients": true,
    "__experimentalBackgroundColorLabel": "Background Label",
    "__experimentalLinkColorLabel": "Link Label",
    "__experimentalTextColorLabel": "Text Label"
  }
```

- Compile this branch and load the post editor.
- Add a paragraph and a heading.
- Select the paragraph and verify that the color panel has the three UI controls for text, background, and links and that their labels are the ones set by the block.json: "Background Label", "Link Label", "Text Label".
- Select the heading and verify that the color panel has the three UI controls as well and that their labels are the defaults: "Background Color", "Link Color", "Text Color".

Note that this only affects the block sidebar, but not the "global styles" sidebar. I'd like to address that in a follow-up PR.