### PR TITLE
Added better kses handling to copypasta text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12870,6 +12870,7 @@
 				"@wordpress/data-controls": "file:packages/data-controls",
 				"@wordpress/date": "file:packages/date",
 				"@wordpress/deprecated": "file:packages/deprecated",
+				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -630,6 +630,10 @@ _Returns_
 
 -   `Object`: Props to pass to the element to mark as a block.
 
+<a name="useKsesSanitization" href="#useKsesSanitization">#</a> **useKsesSanitization**
+
+Undocumented declaration.
+
 <a name="validateThemeColors" href="#validateThemeColors">#</a> **validateThemeColors**
 
 Given an array of theme colors checks colors for validity

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -35,19 +35,19 @@ function BlockHTML( { clientId } ) {
 	);
 	const { updateBlock } = useDispatch( blockEditorStore );
 	const onChange = () => {
-		const sanitizedHtml = sanitizeHTML( html );
+		const maybeSanitizedHtml = sanitizeHTML( html );
 		const blockType = getBlockType( block.name );
 		const attributes = getBlockAttributes(
 			blockType,
-			sanitizedHtml,
+			maybeSanitizedHtml,
 			block.attributes
 		);
 
 		// If html is empty  we reset the block to the default HTML and mark it as valid to avoid triggering an error
-		const content = sanitizedHtml
-			? sanitizedHtml
+		const content = maybeSanitizedHtml
+			? maybeSanitizedHtml
 			: getSaveContent( blockType, attributes );
-		const isValid = sanitizedHtml
+		const isValid = maybeSanitizedHtml
 			? isValidBlockContent( blockType, attributes, content )
 			: true;
 		updateBlock( clientId, {

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -23,7 +23,11 @@ import { store as blockEditorStore } from '../../store';
 import { useKsesSanitization } from '../../hooks/utils';
 
 function BlockHTML( { clientId } ) {
-	const sanitizeHTML = useKsesSanitization();
+	const allowedHtmlTags = useSelect(
+		( select ) => select( blockEditorStore ).getSettings().allowedHtmlTags
+	);
+	const sanitizeHTML = useKsesSanitization( allowedHtmlTags );
+
 	const [ html, setHtml ] = useState( '' );
 	const block = useSelect(
 		( select ) => select( blockEditorStore ).getBlock( clientId ),

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -35,7 +35,7 @@ function BlockHTML( { clientId } ) {
 		const blockType = getBlockType( block.name );
 		const attributes = getBlockAttributes(
 			blockType,
-			html,
+			sanitizedHtml,
 			block.attributes
 		);
 
@@ -43,16 +43,12 @@ function BlockHTML( { clientId } ) {
 		const content = sanitizedHtml
 			? sanitizedHtml
 			: getSaveContent( blockType, attributes );
-		const originalContent = html
-			? html
-			: getSaveContent( blockType, attributes );
 		const isValid = sanitizedHtml
 			? isValidBlockContent( blockType, attributes, content )
 			: true;
-
 		updateBlock( clientId, {
 			attributes,
-			originalContent,
+			originalContent: content,
 			isValid,
 		} );
 

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -20,8 +20,10 @@ import {
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { useKsesSanitization } from '../../hooks/utils';
 
 function BlockHTML( { clientId } ) {
+	const sanitizeHTML = useKsesSanitization();
 	const [ html, setHtml ] = useState( '' );
 	const block = useSelect(
 		( select ) => select( blockEditorStore ).getBlock( clientId ),
@@ -29,6 +31,7 @@ function BlockHTML( { clientId } ) {
 	);
 	const { updateBlock } = useDispatch( blockEditorStore );
 	const onChange = () => {
+		const sanitizedHtml = sanitizeHTML( html );
 		const blockType = getBlockType( block.name );
 		const attributes = getBlockAttributes(
 			blockType,
@@ -37,14 +40,19 @@ function BlockHTML( { clientId } ) {
 		);
 
 		// If html is empty  we reset the block to the default HTML and mark it as valid to avoid triggering an error
-		const content = html ? html : getSaveContent( blockType, attributes );
-		const isValid = html
+		const content = sanitizedHtml
+			? sanitizedHtml
+			: getSaveContent( blockType, attributes );
+		const originalContent = html
+			? html
+			: getSaveContent( blockType, attributes );
+		const isValid = sanitizedHtml
 			? isValidBlockContent( blockType, attributes, content )
 			: true;
 
 		updateBlock( clientId, {
 			attributes,
-			originalContent: content,
+			originalContent,
 			isValid,
 		} );
 

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -60,14 +60,14 @@ export const useKsesSanitization = ( allowedHtmlTags ) => {
 /**
  * Returns all the available block types.
  *
- * @param {string} allowedHtmlTags Allowed HTML Tags.
+ * @param {Object} allowedHtmlTags Allowed HTML Tags.
  * @return {Array} Block Types.
  */
 export const allowedTagsToKsesSchema = ( allowedHtmlTags ) => {
 	const schema = {
 		'#text': {},
 	};
-	for ( const tagName of Object.keys( allowedHtmlTags ) ) {
+	for ( const tagName of Object.keys( allowedHtmlTags || {} ) ) {
 		schema[ tagName ] = {
 			attributes: map( allowedHtmlTags[ tagName ], ( enabled, attr ) => [
 				attr,

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -7,6 +7,7 @@ import '@wordpress/rich-text';
  * Internal dependencies
  */
 import './hooks';
+export { useKsesSanitization } from './hooks/utils';
 export * from './components';
 export * from './utils';
 export { storeConfig, store } from './store';

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2131,35 +2131,3 @@ export const __experimentalGetActiveBlockIdByBlockNames = createSelector(
 		validBlockNames,
 	]
 );
-
-/**
- * Returns all the available block types.
- *
- * @param {Object} state Data state.
- *
- * @return {Array} Block Types.
- */
-export const getKsesSchema = createSelector(
-	( state ) => {
-		const allowedHtmlTags = getSettings( state ).allowedHtmlTags;
-		const schema = {
-			'#text': {},
-		};
-		for ( const tagName of Object.keys( allowedHtmlTags ) ) {
-			schema[ tagName ] = {
-				attributes: map(
-					allowedHtmlTags[ tagName ],
-					( enabled, attr ) => [ attr, enabled ]
-				)
-					.filter( ( [ , enabled ] ) => enabled )
-					.map( ( [ attr ] ) => attr ),
-			};
-			if ( ! [ '#text', 'br' ].includes( tagName ) ) {
-				schema[ tagName ].children = schema;
-			}
-		}
-
-		return schema;
-	},
-	( state ) => [ getSettings( state ).allowedHtmlTags ]
-);

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2141,7 +2141,7 @@ export const __experimentalGetActiveBlockIdByBlockNames = createSelector(
  */
 export const getKsesSchema = createSelector(
 	( state ) => {
-		const allowedHtmlTags = getSettings( state ).allowedHtmlTags;
+		const allowedHtmlTags = getSettings( state ).allowedHtmlTags || {};
 		const schema = {
 			'#text': {},
 		};

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2131,3 +2131,35 @@ export const __experimentalGetActiveBlockIdByBlockNames = createSelector(
 		validBlockNames,
 	]
 );
+
+/**
+ * Returns all the available block types.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Array} Block Types.
+ */
+export const getKsesSchema = createSelector(
+	( state ) => {
+		const allowedHtmlTags = getSettings( state ).allowedHtmlTags;
+		const schema = {
+			'#text': {},
+		};
+		for ( const tagName of Object.keys( allowedHtmlTags ) ) {
+			schema[ tagName ] = {
+				attributes: map(
+					allowedHtmlTags[ tagName ],
+					( enabled, attr ) => [ attr, enabled ]
+				)
+					.filter( ( [ , enabled ] ) => enabled )
+					.map( ( [ attr ] ) => attr ),
+			};
+			if ( ! [ '#text', 'br' ].includes( tagName ) ) {
+				schema[ tagName ].children = schema;
+			}
+		}
+
+		return schema;
+	},
+	( state ) => [ getSettings( state ).allowedHtmlTags ]
+);

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -40,6 +40,7 @@
 		"@wordpress/data-controls": "file:../data-controls",
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
+		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -74,6 +74,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'__experimentalSetIsInserterOpened',
 				'alignWide',
 				'allowedBlockTypes',
+				'allowedHtmlTags',
 				'bodyPlaceholder',
 				'codeEditingEnabled',
 				'colors',


### PR DESCRIPTION
## Description
Pasting text sometimes breaks related CSS, this refactor fixes that. https://github.com/WordPress/wordpress-develop/pull/1178 is a pre-requisite

## Test plan
* Apply https://github.com/WordPress/wordpress-develop/pull/1178
* Create a new HTML block
* Paste `<p>This is a <em>test</em></p>` in the editor
* Confirm there were no errors and that visually everything looks correctly

## Types of changes
Bug fix (non-breaking change which fixes an issue)
