### PR TITLE
Buttons: Add space-between justification controls

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -42,10 +42,16 @@ function ButtonsEdit( {
 		templateInsertUpdatesSelection: true,
 	} );
 
+	const justifyControls =
+		orientation === 'vertical'
+			? [ 'left', 'center', 'right' ]
+			: [ 'left', 'center', 'right', 'space-between' ];
+
 	return (
 		<>
 			<BlockControls>
 				<JustifyToolbar
+					allowedControls={ justifyControls }
 					value={ contentJustification }
 					onChange={ ( value ) =>
 						setAttributes( { contentJustification: value } )

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -46,7 +46,6 @@ function ButtonsEdit( {
 		<>
 			<BlockControls>
 				<JustifyToolbar
-					allowedControls={ [ 'left', 'center', 'right' ] }
 					value={ contentJustification }
 					onChange={ ( value ) =>
 						setAttributes( { contentJustification: value } )

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -121,7 +121,6 @@ export default function ButtonsEdit( {
 			{ isSelected && (
 				<BlockControls>
 					<JustifyToolbar
-						allowedControls={ [ 'left', 'center', 'right' ] }
 						value={ contentJustification }
 						onChange={ ( value ) =>
 							setAttributes( { contentJustification: value } )

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -31,7 +31,7 @@ const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
 const layoutProp = { type: 'default', alignments: [] };
 
 export default function ButtonsEdit( {
-	attributes: { contentJustification, align },
+	attributes: { contentJustification, align, orientation },
 	clientId,
 	isSelected,
 	setAttributes,
@@ -114,6 +114,11 @@ export default function ButtonsEdit( {
 		</View>
 	) );
 
+	const justifyControls =
+		orientation === 'vertical'
+			? [ 'left', 'center', 'right' ]
+			: [ 'left', 'center', 'right', 'space-between' ];
+
 	const remove = useCallback( () => removeBlock( clientId ), [ clientId ] );
 	const shouldRenderFooterAppender = isSelected || isInnerButtonSelected;
 	return (
@@ -121,6 +126,7 @@ export default function ButtonsEdit( {
 			{ isSelected && (
 				<BlockControls>
 					<JustifyToolbar
+						allowedControls={ justifyControls }
 						value={ contentJustification }
 						onChange={ ( value ) =>
 							setAttributes( { contentJustification: value } )

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -92,4 +92,8 @@ $blocks-block__margin: 0.5em;
 			margin-left: 0;
 		}
 	}
+
+	&.is-content-justification-space-between {
+		justify-content: space-between;
+	}
 }


### PR DESCRIPTION
## Description

In #28768 the justificatoon toolbar was added, however the space-between option was purposely left out to match previous functionality. Well, turns out there was no real reason and buttons get space-between too. 


## How has this been tested?

- Add buttons blocks
- Select space-between item justification
- Confirm in editor and published view items are spaced properly

## Screenshots 

![buttons-justify](https://user-images.githubusercontent.com/45363/108549574-2b339000-72a2-11eb-8290-7b9838f5cc6a.gif)

## Types of changes

- Adds CSS to support space-between
- Removes limiting controls, thus defaulting to all


## Open Question

@jasmussen what should we do about `is-vertical`? This might be why it was left off previously.
After recording the screenshot, it seems rather obvious that it doesn't quite make sense for vertical, so I pushed up a change to remove the option if vertical orientation. So if/when you test that will be different than screenshot.
