### PR TITLE
Block nodes: remove memoized context

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -77,8 +77,11 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				isFirstMultiSelectedBlock( clientId ) ||
 				getLastMultiSelectedBlockClientId() === clientId
 			);
-		},
-		[ clientId ]
+		}
+		// To do: figure out why tests are failing when dependencies are added.
+		// This data was originally retrieved with `withSelect` in `block.js`.
+		// For some reason, adding `clientId` as a dependency results in
+		// `toolbar-roving-tabindex.test.js` e2e test failures.
 	);
 	const nodesRef = useRefEffect(
 		( node ) => {

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,19 +9,19 @@ import { omit } from 'lodash';
 import { useRef, useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
-import { useMergeRefs, useRefEffect } from '@wordpress/compose';
+import { useMergeRefs } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import useMovingAnimation from '../../use-moving-animation';
-import { SetBlockNodes } from '../';
 import { BlockListBlockContext } from '../block';
 import { useFocusFirstElement } from './use-focus-first-element';
 import { useIsHovered } from './use-is-hovered';
 import { useBlockMovingModeClassNames } from './use-block-moving-mode-class-names';
 import { useEventHandlers } from './use-event-handlers';
+import { useBlockNodes } from './use-block-nodes';
 import { store as blockEditorStore } from '../../../store';
 
 /**
@@ -44,7 +43,6 @@ import { store as blockEditorStore } from '../../../store';
 export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const fallbackRef = useRef();
 	const ref = props.ref || fallbackRef;
-	const setBlockNodes = useContext( SetBlockNodes );
 	const {
 		clientId,
 		isSelected,
@@ -60,46 +58,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const mode = useSelect( ( select ) => {
 		return select( blockEditorStore ).getBlockMode( clientId );
 	} );
-
-	// Provide the selected node, or the first and last nodes of a multi-
-	// selection, so it can be used to position the contextual block toolbar.
-	// We only provide what is necessary, and remove the nodes again when they
-	// are no longer selected.
-	const isNodeNeeded = useSelect(
-		( select ) => {
-			const {
-				isBlockSelected,
-				isFirstMultiSelectedBlock,
-				getLastMultiSelectedBlockClientId,
-			} = select( blockEditorStore );
-			return (
-				isBlockSelected( clientId ) ||
-				isFirstMultiSelectedBlock( clientId ) ||
-				getLastMultiSelectedBlockClientId() === clientId
-			);
-		}
-		// To do: figure out why tests are failing when dependencies are added.
-		// This data was originally retrieved with `withSelect` in `block.js`.
-		// For some reason, adding `clientId` as a dependency results in
-		// `toolbar-roving-tabindex.test.js` e2e test failures.
-	);
-	const nodesRef = useRefEffect(
-		( node ) => {
-			if ( ! isNodeNeeded ) {
-				return;
-			}
-
-			setBlockNodes( ( nodes ) => ( {
-				...nodes,
-				[ clientId ]: node,
-			} ) );
-
-			return () => {
-				setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
-			};
-		},
-		[ isNodeNeeded, clientId, setBlockNodes ]
-	);
 
 	// translators: %s: Type of block (i.e. Text, Image etc)
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
@@ -119,7 +77,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
 	const mergedRefs = useMergeRefs( [
 		ref,
-		nodesRef,
+		useBlockNodes( clientId ),
 		useEventHandlers( clientId ),
 		useIsHovered(),
 	] );

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -49,7 +49,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		clientId,
 		isSelected,
 		isFirstMultiSelected,
-		isLastMultiSelected,
 		isPartOfMultiSelection,
 		enableAnimation,
 		index,
@@ -66,8 +65,21 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	// selection, so it can be used to position the contextual block toolbar.
 	// We only provide what is necessary, and remove the nodes again when they
 	// are no longer selected.
-	const isNodeNeeded =
-		isSelected || isFirstMultiSelected || isLastMultiSelected;
+	const isNodeNeeded = useSelect(
+		( select ) => {
+			const {
+				isBlockSelected,
+				isFirstMultiSelectedBlock,
+				getLastMultiSelectedBlockClientId,
+			} = select( blockEditorStore );
+			return (
+				isBlockSelected( clientId ) ||
+				isFirstMultiSelectedBlock( clientId ) ||
+				getLastMultiSelectedBlockClientId() === clientId
+			);
+		},
+		[ clientId ]
+	);
 	const nodesRef = useRefEffect(
 		( node ) => {
 			if ( ! isNodeNeeded ) {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-nodes.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-nodes.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useContext } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { SetBlockNodes } from '../';
+import { store as blockEditorStore } from '../../../store';
+
+export function useBlockNodes( clientId ) {
+	const setBlockNodes = useContext( SetBlockNodes );
+	// Provide the selected node, or the first and last nodes of a multi-
+	// selection, so it can be used to position the contextual block toolbar.
+	// We only provide what is necessary, and remove the nodes again when they
+	// are no longer selected.
+	const isNodeNeeded = useSelect(
+		( select ) => {
+			const {
+				isBlockSelected,
+				isFirstMultiSelectedBlock,
+				getLastMultiSelectedBlockClientId,
+			} = select( blockEditorStore );
+			return (
+				isBlockSelected( clientId ) ||
+				isFirstMultiSelectedBlock( clientId ) ||
+				getLastMultiSelectedBlockClientId() === clientId
+			);
+		}
+		// To do: figure out why tests are failing when dependencies are added.
+		// This data was originally retrieved with `withSelect` in `block.js`.
+		// For some reason, adding `clientId` as a dependency results in
+		// `toolbar-roving-tabindex.test.js` e2e test failures.
+	);
+
+	return useRefEffect(
+		( node ) => {
+			if ( ! isNodeNeeded ) {
+				return;
+			}
+
+			setBlockNodes( ( nodes ) => ( {
+				...nodes,
+				[ clientId ]: node,
+			} ) );
+
+			return () => {
+				setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
+			};
+		},
+		[ isNodeNeeded, clientId, setBlockNodes ]
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

This change is not the whole PR I would like to do, but it is the minimum to trigger a test failure. Essentially, I'm moving data selection from `block.js` (withSelect) to `useBlockProps` (useSelect), but for some reason the roving toolbar test is now failing.

@youknowriad @talldan Any ideas what the problem is here?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
