### PR TITLE
Add a link completer for inline links to posts

### DIFF
--- a/packages/block-editor/src/autocompleters/link.js
+++ b/packages/block-editor/src/autocompleters/link.js
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { Icon, page, customPostType as post } from '@wordpress/icons';
 
 const SHOWN_SUGGESTIONS = 10;
 
@@ -18,8 +19,8 @@ function createLinkCompleter() {
 		name: 'links',
 		className: 'block-editor-autocompleters__link',
 		triggerPrefix: '[[',
-		options( letters ) {
-			return apiFetch( {
+		options: async ( letters ) => {
+			let options = await apiFetch( {
 				path: addQueryArgs( '/wp/v2/search', {
 					per_page: SHOWN_SUGGESTIONS,
 					search: letters,
@@ -27,13 +28,25 @@ function createLinkCompleter() {
 					order_by: 'menu_order',
 				} ),
 			} );
+
+			options = options.filter( ( option ) => option.title !== '' );
+
+			return options;
 		},
 		getOptionKeywords( item ) {
 			const expansionWords = item.title.split( /\s+/ );
 			return [ ...expansionWords ];
 		},
 		getOptionLabel( item ) {
-			return item.title;
+			return (
+				<>
+					<Icon
+						key="icon"
+						icon={ item.subtype === 'page' ? page : post }
+					/>
+					{ item.title }
+				</>
+			);
 		},
 		getOptionCompletion( item ) {
 			return <a href={ item.url }>{ item.title }</a>;

--- a/packages/block-editor/src/autocompleters/link.js
+++ b/packages/block-editor/src/autocompleters/link.js
@@ -3,7 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import { Icon, page, customPostType as post } from '@wordpress/icons';
+import { Icon, page, post } from '@wordpress/icons';
 
 const SHOWN_SUGGESTIONS = 10;
 

--- a/packages/block-editor/src/autocompleters/link.js
+++ b/packages/block-editor/src/autocompleters/link.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const SHOWN_SUGGESTIONS = 10;
+
+/** @typedef {import('@wordpress/components').WPCompleter} WPCompleter */
+
+/**
+ * Creates a suggestion list for links to posts or pages.
+ *
+ * @return {WPCompleter} A links completer.
+ */
+function createLinkCompleter() {
+	return {
+		name: 'links',
+		className: 'block-editor-autocompleters__link',
+		triggerPrefix: '[[',
+		options( letters ) {
+			return apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					per_page: SHOWN_SUGGESTIONS,
+					search: letters,
+					type: 'post',
+					order_by: 'menu_order',
+				} ),
+			} );
+		},
+		getOptionKeywords( item ) {
+			const expansionWords = item.title.split( /\s+/ );
+			return [ ...expansionWords ];
+		},
+		getOptionLabel( item ) {
+			return item.title;
+		},
+		getOptionCompletion( item ) {
+			return <a href={ item.url }>{ item.title }</a>;
+		},
+	};
+}
+
+/**
+ * Creates a suggestion list for links to posts or pages..
+ *
+ * @return {WPCompleter} A link completer.
+ */
+export default createLinkCompleter();

--- a/packages/block-editor/src/autocompleters/style.scss
+++ b/packages/block-editor/src/autocompleters/style.scss
@@ -5,3 +5,11 @@
 		margin-right: $grid-unit-10;
 	}
 }
+
+.block-editor-autocompleters__link {
+	white-space: nowrap;
+
+	.block-editor-block-icon {
+		margin-right: $grid-unit-10;
+	}
+}

--- a/packages/block-editor/src/components/autocomplete/index.js
+++ b/packages/block-editor/src/components/autocomplete/index.js
@@ -19,6 +19,7 @@ import { getDefaultBlockName, getBlockSupport } from '@wordpress/blocks';
  */
 import { useBlockEditContext } from '../block-edit/context';
 import blockAutocompleter from '../../autocompleters/block';
+import linkAutocompleter from '../../autocompleters/link';
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -39,6 +40,7 @@ function useCompleters( { completers = EMPTY_ARRAY } ) {
 		) {
 			filteredCompleters = filteredCompleters.concat( [
 				blockAutocompleter,
+				linkAutocompleter,
 			] );
 		}
 

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -24,4 +24,8 @@ export const textFormattingShortcuts = [
 		keyCombination: { modifier: 'primary', character: 'u' },
 		description: __( 'Underline the selected text.' ),
 	},
+	{
+		keyCombination: { character: '[[' },
+		description: __( 'Insert a link to a post or page' ),
+	},
 ];

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -21,11 +21,11 @@ export const textFormattingShortcuts = [
 		description: __( 'Remove a link.' ),
 	},
 	{
-		keyCombination: { modifier: 'primary', character: 'u' },
-		description: __( 'Underline the selected text.' ),
-	},
-	{
 		keyCombination: { character: '[[' },
 		description: __( 'Insert a link to a post or page' ),
+	},
+	{
+		keyCombination: { modifier: 'primary', character: 'u' },
+		description: __( 'Underline the selected text.' ),
 	},
 ];

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -70,6 +70,12 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
           },
         },
         Object {
+          "description": "Insert a link to a post or page",
+          "keyCombination": Object {
+            "character": "[[",
+          },
+        },
+        Object {
           "description": "Underline the selected text.",
           "keyCombination": Object {
             "character": "u",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
In the block editor we currently have the `/` inserter which is an autocompleter for blocks. This PR adds a new autcompleter triggered by `[[` with links to existing posts and pages.

## How has this been tested?
For now tested manually.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/107534/154686186-ad46a3f5-f94d-4c7b-ac88-39f9b2a2cf8c.mp4


## Types of changes
Non breaking change. Adds a new autocompleter to the `block-editor` package.


## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
