### PR TITLE
Reduce memoized block context: class names

### DIFF
--- a/packages/block-editor/src/components/block-list/block-crash-boundary.js
+++ b/packages/block-editor/src/components/block-list/block-crash-boundary.js
@@ -12,9 +12,7 @@ class BlockCrashBoundary extends Component {
 		};
 	}
 
-	componentDidCatch( error ) {
-		this.props.onError( error );
-
+	componentDidCatch() {
 		this.setState( {
 			hasError: true,
 		} );
@@ -22,7 +20,7 @@ class BlockCrashBoundary extends Component {
 
 	render() {
 		if ( this.state.hasError ) {
-			return null;
+			return this.props.fallback;
 		}
 
 		return this.props.children;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -17,9 +17,7 @@ import {
 	getBlockType,
 	getSaveElement,
 	isUnmodifiedDefaultBlock,
-	getUnregisteredTypeHandlerName,
 	hasBlockSupport,
-	getBlockDefaultClassName,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import { withDispatch, withSelect, useDispatch } from '@wordpress/data';
@@ -99,7 +97,6 @@ function BlockListBlock( {
 	const lightBlockWrapper =
 		blockType.apiVersion > 1 ||
 		hasBlockSupport( blockType, 'lightBlockWrapper', false );
-	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 
 	// Determine whether the block has props to apply to the wrapper.
 	if ( blockType.getEditWrapperProps ) {
@@ -108,26 +105,12 @@ function BlockListBlock( {
 			blockType.getEditWrapperProps( attributes )
 		);
 	}
-
-	const generatedClassName =
-		lightBlockWrapper && hasBlockSupport( blockType, 'className', true )
-			? getBlockDefaultClassName( name )
-			: null;
-	const customClassName = lightBlockWrapper ? attributes.className : null;
 	const isAligned = wrapperProps && !! wrapperProps[ 'data-align' ];
 
 	// The wp-block className is important for editor styles.
-	// Generate the wrapper class names handling the different states of the
-	// block.
-	const wrapperClassName = classnames(
-		generatedClassName,
-		customClassName,
-		{
-			'wp-block': ! isAligned,
-			'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
-		},
-		className
-	);
+	const wrapperClassName = classnames( className, {
+		'wp-block': ! isAligned,
+	} );
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces
@@ -175,7 +158,7 @@ function BlockListBlock( {
 
 	if ( ! isValid ) {
 		block = (
-			<Block>
+			<Block className="has-warning">
 				<BlockInvalidWarning clientId={ clientId } />
 				<div>{ getSaveElement( blockType, attributes ) }</div>
 			</Block>
@@ -203,7 +186,7 @@ function BlockListBlock( {
 				{ block }
 			</BlockCrashBoundary>
 			{ !! hasError && (
-				<Block>
+				<Block className="has-warning">
 					<BlockCrashWarning />
 				</Block>
 			) }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -59,25 +59,16 @@ function Items( {
 		const {
 			getBlockOrder,
 			getBlockListSettings,
-			getSettings,
 			getSelectedBlockClientId,
 			getMultiSelectedBlockClientIds,
 			hasMultiSelection,
-			__experimentalGetActiveBlockIdByBlockNames,
 		} = select( blockEditorStore );
-
-		// Determine if there is an active entity area to spotlight.
-		const activeEntityBlockId = __experimentalGetActiveBlockIdByBlockNames(
-			getSettings().__experimentalSpotlightEntityBlocks
-		);
-
 		return {
 			blockClientIds: getBlockOrder( rootClientId ),
 			selectedBlockClientId: getSelectedBlockClientId(),
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
 			orientation: getBlockListSettings( rootClientId )?.orientation,
 			hasMultiSelection: hasMultiSelection(),
-			activeEntityBlockId,
 		};
 	}
 
@@ -87,7 +78,6 @@ function Items( {
 		multiSelectedBlockClientIds,
 		orientation,
 		hasMultiSelection,
-		activeEntityBlockId,
 	} = useSelect( selector, [ rootClientId ] );
 
 	const dropTargetIndex = useBlockDropZone( {
@@ -123,9 +113,7 @@ function Items( {
 								'is-dropping-horizontally':
 									isDropTarget &&
 									orientation === 'horizontal',
-								'has-active-entity': activeEntityBlockId,
 							} ) }
-							activeEntityBlockId={ activeEntityBlockId }
 						/>
 					</AsyncModeProvider>
 				);

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -22,6 +22,7 @@ import useMovingAnimation from '../../use-moving-animation';
 import { BlockListBlockContext } from '../block';
 import { useFocusFirstElement } from './use-focus-first-element';
 import { useIsHovered } from './use-is-hovered';
+import { useBlockClassNames } from './use-block-class-names';
 import { useBlockMovingModeClassNames } from './use-block-moving-mode-class-names';
 import { useEventHandlers } from './use-event-handlers';
 import { useBlockNodes } from './use-block-nodes';
@@ -99,7 +100,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	useFocusFirstElement( ref, clientId );
 
-	const blockMovingModeClassNames = useBlockMovingModeClassNames( clientId );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
 	const mergedRefs = useMergeRefs( [
 		ref,
@@ -129,7 +129,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			className,
 			props.className,
 			wrapperProps.className,
-			blockMovingModeClassNames
+			useBlockClassNames( clientId ),
+			useBlockMovingModeClassNames( clientId )
 		),
 		style: { ...wrapperProps.style, ...props.style },
 	};

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -23,6 +23,8 @@ import { BlockListBlockContext } from '../block';
 import { useFocusFirstElement } from './use-focus-first-element';
 import { useIsHovered } from './use-is-hovered';
 import { useBlockClassNames } from './use-block-class-names';
+import { useBlockDefaultClassName } from './use-block-default-class-name';
+import { useBlockCustomClassName } from './use-block-custom-class-name';
 import { useBlockMovingModeClassNames } from './use-block-moving-mode-class-names';
 import { useEventHandlers } from './use-event-handlers';
 import { useBlockNodes } from './use-block-nodes';
@@ -130,6 +132,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			props.className,
 			wrapperProps.className,
 			useBlockClassNames( clientId ),
+			useBlockDefaultClassName( clientId ),
+			useBlockCustomClassName( clientId ),
 			useBlockMovingModeClassNames( clientId )
 		),
 		style: { ...wrapperProps.style, ...props.style },

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
+import { isReusableBlock, getBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+/**
+ * Returns the class names used for the different states of the block.
+ *
+ * @param {string} clientId The block client ID.
+ *
+ * @return {string} The class names.
+ */
+export function useBlockClassNames( clientId ) {
+	const isLargeViewport = useViewportMatch( 'medium' );
+	return useSelect(
+		( select ) => {
+			const {
+				isTyping,
+				isBlockBeingDragged,
+				isBlockHighlighted,
+				isBlockSelected,
+				isBlockMultiSelected,
+				getBlockName,
+				getSettings,
+				hasSelectedInnerBlock,
+				__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
+			} = select( blockEditorStore );
+			const {
+				focusMode,
+				outlineMode,
+				__experimentalSpotlightEntityBlocks: spotlightEntityBlocks,
+			} = getSettings();
+			const isDragging = isBlockBeingDragged( clientId );
+			const isSelected = isBlockSelected( clientId );
+			const name = getBlockName( clientId );
+			const checkDeep = true;
+			// "ancestor" is the more appropriate label due to "deep" check
+			const isAncestorOfSelectedBlock = hasSelectedInnerBlock(
+				clientId,
+				checkDeep
+			);
+			const activeEntityBlockId = getActiveBlockIdByBlockNames(
+				spotlightEntityBlocks
+			);
+			return classnames( 'block-editor-block-list__block', {
+				'is-selected': isSelected && ! isDragging,
+				'is-highlighted': isBlockHighlighted( clientId ),
+				'is-multi-selected': isBlockMultiSelected( clientId ),
+				'is-reusable': isReusableBlock( getBlockType( name ) ),
+				'is-dragging': isDragging,
+				// We only care about this prop when the block is selected
+				// Thus to avoid unnecessary rerenders we avoid updating the prop if
+				// the block is not selected.
+				'is-typing':
+					( isSelected || isAncestorOfSelectedBlock ) && isTyping(),
+				'is-focused':
+					focusMode &&
+					isLargeViewport &&
+					( isSelected || isAncestorOfSelectedBlock ),
+				'is-focus-mode': focusMode && isLargeViewport,
+				'is-outline-mode': outlineMode,
+				'has-child-selected': isAncestorOfSelectedBlock && ! isDragging,
+				'has-active-entity': activeEntityBlockId,
+				// Determine if there is an active entity area to spotlight.
+				'is-active-entity': activeEntityBlockId === clientId,
+			} );
+		},
+		[ clientId, isLargeViewport ]
+	);
+}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-custom-class-name.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-custom-class-name.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { hasBlockSupport, getBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+/**
+ * Returns the custom class name if the block is a light block.
+ *
+ * @param {string} clientId The block client ID.
+ *
+ * @return {string} The custom class name.
+ */
+export function useBlockCustomClassName( clientId ) {
+	// It's good for this to be a separate selector because it will be executed
+	// on every attribute change, while the other selectors are not re-evaluated
+	// as much.
+	return useSelect(
+		( select ) => {
+			const { getBlockName, getBlockAttributes } = select(
+				blockEditorStore
+			);
+			const { className } = getBlockAttributes( clientId );
+
+			if ( ! className ) {
+				return;
+			}
+
+			const blockType = getBlockType( getBlockName( clientId ) );
+			const hasLightBlockWrapper =
+				blockType.apiVersion > 1 ||
+				hasBlockSupport( blockType, 'lightBlockWrapper', false );
+
+			if ( ! hasLightBlockWrapper ) {
+				return;
+			}
+
+			return className;
+		},
+		[ clientId ]
+	);
+}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-default-class-name.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-default-class-name.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import {
+	hasBlockSupport,
+	getBlockType,
+	getBlockDefaultClassName,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+/**
+ * Returns the default class name if the block is a light block and it supports
+ * `className`.
+ *
+ * @param {string} clientId The block client ID.
+ *
+ * @return {string} The class name, e.g. `wp-block-paragraph`.
+ */
+export function useBlockDefaultClassName( clientId ) {
+	return useSelect(
+		( select ) => {
+			const name = select( blockEditorStore ).getBlockName( clientId );
+			const blockType = getBlockType( name );
+			const hasLightBlockWrapper =
+				blockType.apiVersion > 1 ||
+				hasBlockSupport( blockType, 'lightBlockWrapper', false );
+
+			if ( ! hasLightBlockWrapper ) {
+				return;
+			}
+
+			return getBlockDefaultClassName( name );
+		},
+		[ clientId ]
+	);
+}

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -43,7 +43,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 	}
 
 	return (
-		<div { ...useBlockProps() }>
+		<div { ...useBlockProps( { className: 'has-warning' } ) }>
 			<Warning actions={ actions }>{ messageHTML }</Warning>
 			<RawHTML>{ originalUndelimitedContent }</RawHTML>
 		</div>

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -254,6 +254,8 @@ describe( 'Multi-block selection', () => {
 
 		await page.keyboard.press( 'Escape' );
 
+		// Wait for blocks to have updated asynchronously.
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		expect( await getSelectedFlatIndices() ).toEqual( [] );
 	} );
 
@@ -504,6 +506,8 @@ describe( 'Multi-block selection', () => {
 
 		await page.mouse.click( coord.x, coord.y );
 
+		// Wait for blocks to have updated asynchronously.
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		await testNativeSelection();
 		expect( await getSelectedFlatIndices() ).toEqual( [] );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Moves selectors closer to the place where it's needed (`useBlockProps`).
The goal is to eventually get rid of all all the contextual data being passed down and only depend on the client ID.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
