### PR TITLE
Inserter: Add e2e test to make sure last inserted block is being focused

### DIFF
--- a/packages/e2e-tests/specs/editor/various/inserter.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserter.test.js
@@ -4,7 +4,7 @@
 import {
 	createNewPost,
 	openGlobalBlockInserter,
-	getAllBlocks,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Inserter', () => {
@@ -26,25 +26,19 @@ describe( 'Inserter', () => {
 	} );
 
 	it( 'last-inserted block should be given and keep the focus', async () => {
-		await page.focus( '.block-editor-default-block-appender__content' );
-		await page.keyboard.type( 'Testing inserted block focus' );
+		await page.type(
+			'.block-editor-default-block-appender__content',
+			'Testing inserted block focus'
+		);
 
-		await openGlobalBlockInserter();
-
-		await page.keyboard.down( 'Control' );
-		await page.click( '.editor-block-list-item-image' );
-		await page.keyboard.up( 'Control' );
+		await insertBlock( 'Image' );
 
 		await page.waitForSelector( 'figure[data-type="core/image"]' );
-
-		const imageBlock = ( await getAllBlocks() ).find(
-			( block ) => block.name === 'core/image'
-		);
 
 		const selectedBlock = await page.evaluate( () => {
 			return wp.data.select( 'core/block-editor' ).getSelectedBlock();
 		} );
 
-		expect( selectedBlock.clientId ).toBe( imageBlock.clientId );
+		expect( selectedBlock.name ).toBe( 'core/image' );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/inserter.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserter.test.js
@@ -4,11 +4,15 @@
 import {
 	createNewPost,
 	openGlobalBlockInserter,
+	getAllBlocks,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Inserter', () => {
-	it( 'shows block preview when hovering over block in inserter', async () => {
+	beforeEach( async () => {
 		await createNewPost();
+	} );
+
+	it( 'shows block preview when hovering over block in inserter', async () => {
 		await openGlobalBlockInserter();
 		await page.focus( '.editor-block-list-item-paragraph' );
 		const preview = await page.waitForSelector(
@@ -19,5 +23,28 @@ describe( 'Inserter', () => {
 		);
 		const isPreviewVisible = await preview.isIntersectingViewport();
 		expect( isPreviewVisible ).toBe( true );
+	} );
+
+	it( 'last-inserted block should be given and keep the focus', async () => {
+		await page.focus( '.block-editor-default-block-appender__content' );
+		await page.keyboard.type( 'Testing inserted block focus' );
+
+		await openGlobalBlockInserter();
+
+		await page.keyboard.down( 'Control' );
+		await page.click( '.editor-block-list-item-image' );
+		await page.keyboard.up( 'Control' );
+
+		await page.waitForSelector( 'figure[data-type="core/image"]' );
+
+		const imageBlock = ( await getAllBlocks() ).find(
+			( block ) => block.name === 'core/image'
+		);
+
+		const selectedBlock = await page.evaluate( () => {
+			return wp.data.select( 'core/block-editor' ).getSelectedBlock();
+		} );
+
+		expect( selectedBlock.clientId ).toBe( imageBlock.clientId );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #29003.
Asserts that the last inserted block has the focus when inserting with `Ctrl+click`. 

## How has this been tested?
- Checked that tests are passing running `npm run test-e2e "packages/e2e-tests/specs/editor/various/inserter.test.js"`. 
- Reverted 4bcb71f, the commit that fixed the focus on the last inserted block, rebuild Gutenberg (`npm run build`) and 
confirmed that the tests failed. 
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
### Test failing after reverting 4bcb71f
<img src="https://user-images.githubusercontent.com/18705930/108634215-590e0580-7457-11eb-8dbd-a4bce2213403.png" width="450"/>

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
