### PR TITLE
Have useMergeRefs return a callback that mimics a ref

### DIFF
--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -52,7 +52,7 @@ export default function useMergeRefs( refs ) {
 
 	// There should be no dependencies so that `callback` is only called when
 	// the node changes.
-	return useCallback( ( value ) => {
+	const rootCallback = useCallback( ( value ) => {
 		// Update the element so it can be used when calling ref callbacks on a
 		// dependency change.
 		element.current = value;
@@ -60,7 +60,14 @@ export default function useMergeRefs( refs ) {
 
 		// When an element changes, the current ref callback should be called
 		// with the new element and the previous one with `null`.
-		const refsToUpdate = value ? currentRefs.current : previousRefs.current;
+		let refsToUpdate;
+		if ( value ) {
+			refsToUpdate = currentRefs.current;
+			// Makes this callback mimic a ref
+			rootCallback.current = value;
+		} else {
+			refsToUpdate = previousRefs.current;
+		}
 
 		// Update the latest refs.
 		refsToUpdate.forEach( ( ref ) => {
@@ -71,4 +78,5 @@ export default function useMergeRefs( refs ) {
 			}
 		} );
 	}, [] );
+	return rootCallback;
 }


### PR DESCRIPTION
Since #28917 was merged, the `ref` property of the object returned by `useBlockProps` is a function instead of a ref. This PR lets the function returned from `useMergeRefs` mimic a ref by having a `current` property referencing the `current` property of the appropriate ref.

This seems to work well enough and tests aren't failing but it looks possible and may be preferable to do this in `useBlockProps` instead of `useMergeRefs`.

## How has this been tested?
Verifying instances of breakage are fixed ;P

## Screenshots detailing some breakage/fixage
I've posted three examples but there could be more. 

### Popover for slash inserter (first reported https://github.com/WordPress/gutenberg/pull/28917#issuecomment-781996219)
Before | After
-------|-------
![slash-inserter-popover-fail](https://user-images.githubusercontent.com/9000376/108892904-487b9d80-75c5-11eb-95ec-99ab260c7d7e.gif) | ![slash-inserter-popover-expected](https://user-images.githubusercontent.com/9000376/108892951-5af5d700-75c5-11eb-8b9e-eccb28fd47b4.gif)

### Cover block focal point adjustment (only on repeated backgrounds)
Before | After
-------|-------
![cover-fail](https://user-images.githubusercontent.com/9000376/108893613-259db900-75c6-11eb-954f-324257562f5c.gif) | ![cover-expected](https://user-images.githubusercontent.com/9000376/108893661-33533e80-75c6-11eb-9add-aecde50a69d5.gif)

### Popover for Button block link
Before | After
-------|-------
![button-link-popover-fail](https://user-images.githubusercontent.com/9000376/108893838-65fd3700-75c6-11eb-8c45-6a8e30a4b470.gif) | ![button-link-popover-expected](https://user-images.githubusercontent.com/9000376/108893892-72818f80-75c6-11eb-8699-74217ca4c791.gif)

## Types of changes
Bug fix #29262

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
