### PR TITLE
Correct border radius value in settings of Button block

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -239,13 +239,13 @@ function ButtonEdit( props ) {
 				ownValue = current.element.style.borderRadius;
 				current.element.style.borderRadius = '';
 			}
-			setComputedBorderRadius(
-				parseFloat(
-					current.element.ownerDocument.defaultView
-						.getComputedStyle( current.element )
-						.getPropertyValue( 'border-radius' )
-				)
-			);
+			let value = current.element.ownerDocument.defaultView
+				.getComputedStyle( current.element )
+				.getPropertyValue( 'border-radius' );
+			// if it's a compound value (has a space) it's not suitable for the
+			// single input of the UI so an empty string is preferable
+			value = value.indexOf( ' ' ) !== -1 ? '' : parseFloat( value );
+			setComputedBorderRadius( value );
 			if ( hasOwnValue ) {
 				current.element.style.borderRadius = ownValue;
 			}

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -41,22 +41,29 @@ import getColorAndStyleProps from './color-props';
 const NEW_TAB_REL = 'noreferrer noopener';
 const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUE = 50;
-const INITIAL_BORDER_RADIUS_POSITION = 5;
 
 const EMPTY_ARRAY = [];
 
-function BorderPanel( { borderRadius = '', setAttributes } ) {
-	const initialBorderRadius = borderRadius;
-	const setBorderRadius = useCallback(
-		( newBorderRadius ) => {
-			if ( newBorderRadius === undefined )
-				setAttributes( {
-					borderRadius: initialBorderRadius,
-				} );
-			else setAttributes( { borderRadius: newBorderRadius } );
-		},
-		[ setAttributes ]
+let computedBorderRadius;
+document.addEventListener( 'readystatechange', () => {
+	// returns early until styles are loaded
+	if ( document.readyState !== 'complete' ) return;
+	const sample = document.createElement( 'a' );
+	sample.className = 'wp-block-button__link';
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = 'editor-styles-wrapper';
+	wrapper.hidden = true;
+	wrapper.appendChild( sample );
+	document.body.appendChild( wrapper );
+	computedBorderRadius = parseFloat(
+		window.getComputedStyle( sample ).getPropertyValue( 'border-radius' )
 	);
+	document.body.removeChild( wrapper );
+} );
+
+function BorderPanel( { borderRadius = '', setAttributes } ) {
+	const setBorderRadius = ( value ) =>
+		setAttributes( { borderRadius: value } );
 	return (
 		<PanelBody title={ __( 'Border settings' ) }>
 			<RangeControl
@@ -64,7 +71,7 @@ function BorderPanel( { borderRadius = '', setAttributes } ) {
 				label={ __( 'Border radius' ) }
 				min={ MIN_BORDER_RADIUS_VALUE }
 				max={ MAX_BORDER_RADIUS_VALUE }
-				initialPosition={ INITIAL_BORDER_RADIUS_POSITION }
+				initialPosition={ computedBorderRadius }
 				allowReset
 				onChange={ setBorderRadius }
 			/>


### PR DESCRIPTION
To fix #17596.

TODO: Maybe support the resize edge cases (which are mentioned below).

## How has this been tested?
In the visual editor adding buttons with various style variations and changing their radii, then resetting their radii. Also by creating button style variations to confirm expected limitations of the implementation at present. Specifically buttons with a radius that changes depending on viewport size (See the second video).

## Screenshots

### Cases it aces
https://user-images.githubusercontent.com/9000376/108656674-e31d9480-747e-11eb-9886-a445a53226c1.mp4

The asymmetric case is maybe not aced, but not showing a value there seemed the most sensible thing to do given the current UI.

### Known Limitations
After the window resizes, buttons with a radius that varies depending on viewport size won't show the true radius in the settings.

https://user-images.githubusercontent.com/9000376/108659629-a1d9b480-747f-11eb-9a52-b76732bd411c.mp4

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
