### PR TITLE
Run CI jobs on wp prefix branches

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -5,7 +5,9 @@ on:
     paths-ignore:
     - '**.md'
   push:
-    branches: [master]
+    branches:
+      - master
+      - 'wp/**'
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -3,7 +3,9 @@ name: Static Analysis (Linting, License, Type checks...)
 on:
   pull_request:
   push:
-    branches: [master]
+    branches:
+      - master
+      - 'wp/**'
 
 jobs:
   check:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,9 @@ name: Unit Tests
 on:
   pull_request:
   push:
-    branches: [master, wp-trunk]
+    branches:
+      - master
+      - 'wp/**'
 
 jobs:
   unit-js:


### PR DESCRIPTION
## Description
Branches with the prefix `wp/<version>` act a bit like a release branch for WordPress releases, but tend to stay open. 

They're used for cutting a release of Gutenberg for a WordPress release and backporting bug fixes once the beta/rc process is underway.

It'd be nice to have a bit more confidence in the stability of the `wp/<version>` branches by running the test suite on commits to them. This is mainly so that anyone creating a new backport PR can tell whether the branch was already stable, or if there were test failures. It should also help anyone working on backports become aware of any problems earlier.