### PR TITLE
Site Editor: Show contextual icon in the Inspector's template tab

### DIFF
--- a/packages/edit-site/src/components/sidebar/template-card/index.js
+++ b/packages/edit-site/src/components/sidebar/template-card/index.js
@@ -3,7 +3,6 @@
  */
 import { useSelect } from '@wordpress/data';
 import { Icon } from '@wordpress/components';
-import { layout } from '@wordpress/icons';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -13,7 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editSiteStore } from '../../../store';
 
 export default function TemplateCard() {
-	const { title, description } = useSelect( ( select ) => {
+	const { title, description, icon } = useSelect( ( select ) => {
 		const { getEditedPostType, getEditedPostId } = select( editSiteStore );
 		const { getEntityRecord } = select( coreStore );
 		const { __experimentalGetTemplateInfo: getTemplateInfo } = select(
@@ -34,7 +33,7 @@ export default function TemplateCard() {
 
 	return (
 		<div className="edit-site-template-card">
-			<Icon className="edit-site-template-card__icon" icon={ layout } />
+			<Icon className="edit-site-template-card__icon" icon={ icon } />
 			<div className="edit-site-template-card__content">
 				<h2 className="edit-site-template-card__title">{ title }</h2>
 				<span className="edit-site-template-card__description">

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -27,6 +27,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { createRegistrySelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { Platform } from '@wordpress/element';
+import { layout, header, footer } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -1678,18 +1679,18 @@ export const __experimentalGetDefaultTemplateType = createSelector(
 
 /**
  * Given a template entity, return information about it which is ready to be
- * rendered, such as the title and description.
+ * rendered, such as the title, description, and icon.
  *
  * @param {Object} state Global application state.
  * @param {Object} template The template for which we need information.
- * @return {Object} Information about the template, including title and description.
+ * @return {Object} Information about the template, including title, description, and icon.
  */
 export function __experimentalGetTemplateInfo( state, template ) {
 	if ( ! template ) {
 		return {};
 	}
 
-	const { excerpt, slug, title } = template;
+	const { excerpt, slug, title, area } = template;
 	const {
 		title: defaultTitle,
 		description: defaultDescription,
@@ -1697,6 +1698,11 @@ export function __experimentalGetTemplateInfo( state, template ) {
 
 	const templateTitle = isString( title ) ? title : title?.rendered;
 	const templateDescription = isString( excerpt ) ? excerpt : excerpt?.raw;
+	const iconsByArea = {
+		footer,
+		header,
+	};
+	const templateIcon = iconsByArea[ area ] || layout;
 
 	return {
 		title:
@@ -1704,5 +1710,6 @@ export function __experimentalGetTemplateInfo( state, template ) {
 				? templateTitle
 				: defaultTitle || slug,
 		description: templateDescription || defaultDescription,
+		icon: templateIcon,
 	};
 }

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -16,6 +16,7 @@ import {
 	getBlockTypes,
 } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
+import { layout, footer, header } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -2894,12 +2895,13 @@ describe( 'selectors', () => {
 			).toEqual( 'test description' );
 		} );
 
-		it( 'should return both a title and a description', () => {
+		it( 'should return a title, description, and icon', () => {
 			expect(
 				__experimentalGetTemplateInfo( state, { slug: 'index' } )
 			).toEqual( {
 				title: 'Default (Index)',
 				description: 'Main template',
+				icon: layout,
 			} );
 
 			expect(
@@ -2910,6 +2912,7 @@ describe( 'selectors', () => {
 			).toEqual( {
 				title: 'test title',
 				description: 'Main template',
+				icon: layout,
 			} );
 
 			expect(
@@ -2920,6 +2923,7 @@ describe( 'selectors', () => {
 			).toEqual( {
 				title: 'Default (Index)',
 				description: 'test description',
+				icon: layout,
 			} );
 
 			expect(
@@ -2931,6 +2935,49 @@ describe( 'selectors', () => {
 			).toEqual( {
 				title: 'test title',
 				description: 'test description',
+				icon: layout,
+			} );
+		} );
+
+		it( 'should return correct icon based on area', () => {
+			expect(
+				__experimentalGetTemplateInfo( state, {
+					slug: 'template part, area = uncategorized',
+					area: 'uncategorized',
+				} )
+			).toEqual( {
+				title: 'template part, area = uncategorized',
+				icon: layout,
+			} );
+
+			expect(
+				__experimentalGetTemplateInfo( state, {
+					slug: 'template part, area = invalid',
+					area: 'invalid',
+				} )
+			).toEqual( {
+				title: 'template part, area = invalid',
+				icon: layout,
+			} );
+
+			expect(
+				__experimentalGetTemplateInfo( state, {
+					slug: 'template part, area = header',
+					area: 'header',
+				} )
+			).toEqual( {
+				title: 'template part, area = header',
+				icon: header,
+			} );
+
+			expect(
+				__experimentalGetTemplateInfo( state, {
+					slug: 'template part, area = footer',
+					area: 'footer',
+				} )
+			).toEqual( {
+				title: 'template part, area = footer',
+				icon: footer,
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Show contextual icon in the Inspector's template tab.

## How has this been tested?
1. Open Site Editor
2. Open Browsing sidebar -> Template Parts
3. First, Open Headers -> header and make sure the `header` icon is showing up in the inspector
4. Go back to template parts and open Footers -> Footer, make sure the `footer` icon is showing up in the inspector
5. Go back to template parts and open any template parts under General. Make sure the generic, `layout` icon is shown.

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/2256104/108671421-b601ce00-74e0-11eb-859a-fb59b85ac239.mov



## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
