### PR TITLE
Scripts: coerce live reload port to integer

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -76,10 +76,10 @@ const getJsonpFunctionIdentifier = () => {
 	);
 };
 
-const getLiveReloadPort = ( inputPort, defaultPort = 35729 ) => {
+const getLiveReloadPort = ( inputPort ) => {
 	const parsedPort = parseInt( inputPort, 10 );
 
-	return Number.isInteger( parsedPort ) ? parsedPort : defaultPort;
+	return Number.isInteger( parsedPort ) ? parsedPort : 35729;
 };
 
 const config = {

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -76,6 +76,12 @@ const getJsonpFunctionIdentifier = () => {
 	);
 };
 
+const getLiveReloadPort = ( inputPort, defaultPort = 35729 ) => {
+	const parsedPort = parseInt( inputPort, 10 );
+
+	return Number.isInteger( parsedPort ) ? parsedPort : defaultPort;
+};
+
 const config = {
 	mode,
 	entry: {
@@ -221,7 +227,7 @@ const config = {
 		// works when running watch mode.
 		! isProduction &&
 			new LiveReloadPlugin( {
-				port: process.env.WP_LIVE_RELOAD_PORT || 35729,
+				port: getLiveReloadPort( process.env.WP_LIVE_RELOAD_PORT ),
 			} ),
 		// WP_NO_EXTERNALS global variable controls whether scripts' assets get
 		// generated, and the default externals set.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Attempting to use `process.env.WP_LIVE_RELOAD_PORT` was not working for me. After some debugging, I realized `webpack-livereload-plugin` must not expect to receive a port argument of a `string` type, failing silently to take the desired port, and per [`process.env`](https://nodejs.org/docs/latest-v14.x/api/process.html#process_process_env) docs:

> Assigning a property on process.env will implicitly convert the value to a string.

Additionally, the use of the logical OR operator would prevent passing a `0` value, precluding the use of the following `webpack-livereload-plugin` functionality:

> If you define port 0, an available port will be searched for, starting from 35729.

This PR aims to remedy this by parsing `process.env.WP_LIVE_RELOAD_PORT` before passing the value to `webpack-livereload-plugin`.

## How has this been tested?

Validated by running these changes against a local project. Before the change, running `wp-scripts start` would always log one of the two below:

- `Live Reload listening on port 35729`
- `Live Reload disabled: listen EADDRINUSE: address already in use :::35729` (for parallel processes run)

After the changes in this PR, the appropriate port will be used — including the use of a `0` value.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
