### PR TITLE
Fix server rendered widget not previewing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12883,6 +12883,7 @@
 			"requires": {
 				"@babel/runtime": "^7.12.5",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
+				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -720,20 +720,6 @@ _Parameters_
 -   _blockName_ `string`: Name of the block (example: “core/columns”).
 -   _variation_ `WPBlockVariation`: Object describing a block variation.
 
-<a name="sanitizeBlockAttributes" href="#sanitizeBlockAttributes">#</a> **sanitizeBlockAttributes**
-
-Ensure attributes contains only values defined by block type, and merge
-default values for missing attributes.
-
-_Parameters_
-
--   _name_ `string`: The block's name.
--   _attributes_ `Object`: The block's attributes.
-
-_Returns_
-
--   `Object`: The sanitized attributes.
-
 <a name="serialize" href="#serialize">#</a> **serialize**
 
 Takes a block or set of blocks and returns the serialized post content.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -720,6 +720,20 @@ _Parameters_
 -   _blockName_ `string`: Name of the block (example: “core/columns”).
 -   _variation_ `WPBlockVariation`: Object describing a block variation.
 
+<a name="sanitizeBlockAttributes" href="#sanitizeBlockAttributes">#</a> **sanitizeBlockAttributes**
+
+Ensure attributes contains only values defined by block type, and merge
+default values for missing attributes.
+
+_Parameters_
+
+-   _name_ `string`: The block's name.
+-   _attributes_ `Object`: The block's attributes.
+
+_Returns_
+
+-   `Object`: The sanitized attributes.
+
 <a name="serialize" href="#serialize">#</a> **serialize**
 
 Takes a block or set of blocks and returns the serialized post content.

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -30,7 +30,10 @@ import {
 	getBlockTypes,
 	getGroupingBlockName,
 } from './registration';
-import { normalizeBlockType, sanitizeBlockAttributes } from './utils';
+import {
+	normalizeBlockType,
+	__experimentalSanitizeBlockAttributes,
+} from './utils';
 
 /**
  * Returns a block object given its type and attributes.
@@ -42,7 +45,10 @@ import { normalizeBlockType, sanitizeBlockAttributes } from './utils';
  * @return {Object} Block object.
  */
 export function createBlock( name, attributes = {}, innerBlocks = [] ) {
-	const sanitizedAttributes = sanitizeBlockAttributes( name, attributes );
+	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+		name,
+		attributes
+	);
 
 	const clientId = uuid();
 
@@ -104,10 +110,13 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	const sanitizedAttributes = sanitizeBlockAttributes( block.name, {
-		...block.attributes,
-		...mergeAttributes,
-	} );
+	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+		block.name,
+		{
+			...block.attributes,
+			...mergeAttributes,
+		}
+	);
 
 	return {
 		...block,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -140,7 +140,7 @@ export {
 	isValidIcon,
 	getBlockLabel as __experimentalGetBlockLabel,
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
-	sanitizeBlockAttributes,
+	__experimentalSanitizeBlockAttributes,
 } from './utils';
 
 // Templates are, in a general sense, a basic collection of block nodes with any

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -140,6 +140,7 @@ export {
 	isValidIcon,
 	getBlockLabel as __experimentalGetBlockLabel,
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
+	sanitizeBlockAttributes,
 } from './utils';
 
 // Templates are, in a general sense, a basic collection of block nodes with any

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -17,7 +17,7 @@ import {
 	isUnmodifiedDefaultBlock,
 	getAccessibleBlockLabel,
 	getBlockLabel,
-	sanitizeBlockAttributes,
+	__experimentalSanitizeBlockAttributes,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -231,10 +231,13 @@ describe( 'sanitizeBlockAttributes', () => {
 			title: 'Test block',
 		} );
 
-		const attributes = sanitizeBlockAttributes( 'core/test-block', {
-			defined: 'defined-attribute',
-			notDefined: 'not-defined-attribute',
-		} );
+		const attributes = __experimentalSanitizeBlockAttributes(
+			'core/test-block',
+			{
+				defined: 'defined-attribute',
+				notDefined: 'not-defined-attribute',
+			}
+		);
 
 		expect( attributes ).toEqual( {
 			defined: 'defined-attribute',
@@ -243,7 +246,10 @@ describe( 'sanitizeBlockAttributes', () => {
 
 	it( 'throws error if the block is not registered', () => {
 		expect( () => {
-			sanitizeBlockAttributes( 'core/not-registered-test-block', {} );
+			__experimentalSanitizeBlockAttributes(
+				'core/not-registered-test-block',
+				{}
+			);
 		} ).toThrowErrorMatchingInlineSnapshot(
 			`"Block type 'core/not-registered-test-block' is not registered."`
 		);
@@ -263,7 +269,10 @@ describe( 'sanitizeBlockAttributes', () => {
 			title: 'Test block',
 		} );
 
-		const attributes = sanitizeBlockAttributes( 'core/test-block', {} );
+		const attributes = __experimentalSanitizeBlockAttributes(
+			'core/test-block',
+			{}
+		);
 
 		expect( attributes ).toEqual( {
 			hasDefaultValue: 'default-value',
@@ -287,9 +296,12 @@ describe( 'sanitizeBlockAttributes', () => {
 			title: 'Test block',
 		} );
 
-		const attributes = sanitizeBlockAttributes( 'core/test-block', {
-			nodeContent: [ 'test-1', 'test-2' ],
-		} );
+		const attributes = __experimentalSanitizeBlockAttributes(
+			'core/test-block',
+			{
+				nodeContent: [ 'test-1', 'test-2' ],
+			}
+		);
 
 		expect( attributes ).toEqual( {
 			nodeContent: [ 'test-1', 'test-2' ],

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -241,7 +241,7 @@ export function getAccessibleBlockLabel(
  * @param {Object} attributes The block's attributes.
  * @return {Object} The sanitized attributes.
  */
-export function sanitizeBlockAttributes( name, attributes ) {
+export function __experimentalSanitizeBlockAttributes( name, attributes ) {
 	// Get the type definition associated with a registered block.
 	const blockType = getBlockType( name );
 

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.12.5",
 		"@wordpress/api-fetch": "file:../api-fetch",
+		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -11,7 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Placeholder, Spinner } from '@wordpress/components';
-import { sanitizeBlockAttributes } from '@wordpress/blocks';
+import { __experimentalSanitizeBlockAttributes } from '@wordpress/blocks';
 
 export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
 	return addQueryArgs( `/wp/v2/block-renderer/${ block }`, {
@@ -62,7 +62,8 @@ export class ServerSideRender extends Component {
 		} = props;
 
 		const sanitizedAttributes =
-			attributes && sanitizeBlockAttributes( block, attributes );
+			attributes &&
+			__experimentalSanitizeBlockAttributes( block, attributes );
 
 		// If httpMethod is 'POST', send the attributes in the request body instead of the URL.
 		// This allows sending a larger attributes object than in a GET request, where the attributes are in the URL.

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Placeholder, Spinner } from '@wordpress/components';
+import { sanitizeBlockAttributes } from '@wordpress/blocks';
 
 export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
 	return addQueryArgs( `/wp/v2/block-renderer/${ block }`, {
@@ -60,12 +61,15 @@ export class ServerSideRender extends Component {
 			urlQueryArgs = {},
 		} = props;
 
+		const sanitizedAttributes =
+			attributes && sanitizeBlockAttributes( block, attributes );
+
 		// If httpMethod is 'POST', send the attributes in the request body instead of the URL.
 		// This allows sending a larger attributes object than in a GET request, where the attributes are in the URL.
 		const isPostRequest = 'POST' === httpMethod;
-		const urlAttributes = isPostRequest ? null : attributes;
+		const urlAttributes = isPostRequest ? null : sanitizedAttributes;
 		const path = rendererPath( block, urlAttributes, urlQueryArgs );
-		const data = isPostRequest ? { attributes } : null;
+		const data = isPostRequest ? { attributes: sanitizedAttributes } : null;
 
 		// Store the latest fetch request so that when we process it, we can
 		// check if it is the current request, to avoid race conditions on slow networks.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Originally raised in https://github.com/WordPress/gutenberg/pull/29111#issuecomment-782100829.

The problem is that the endpoint `<ServerSideRender>` is using will try to [validate](https://core.trac.wordpress.org/browser/tags/5.6.1/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php#L87) the `attributes`. Since we're passing `__internalWidgetId` now (#29111) to every blocks in the widgets screen, this breaks on the server side.

The solution is to sanitize the attributes before sending them to the server. It should be backward-compatible if the client and the server are using the same logic to sanitize/validate the attributes. This PR leverages the `sanitizeBlockAttributes` API to achieve this, not sure if we should mark it as experimental at this stage though.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the new widgets screen
2. Add an archive block
3. Save and reload
4. Check that the archive block is correctly previewed

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/108673414-94273c00-751e-11eb-897d-4e215970cfb8.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
