### PR TITLE
Fix typos in PHP comments

### DIFF
--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -49,7 +49,7 @@ class WP_Block_Supports {
 	}
 
 	/**
-	 * Initializes the block supports. It registes the block supports block attributes.
+	 * Initializes the block supports. It registers the block supports block attributes.
 	 */
 	public static function init() {
 		$instance = self::get_instance();

--- a/lib/class-wp-rest-batch-controller.php
+++ b/lib/class-wp-rest-batch-controller.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Core class used to perform abtch requests.
+ * Core class used to perform batch requests.
  *
  * @see WP_REST_Controller
  */

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -710,7 +710,7 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Whether the medatata contains a key named properties.
+	 * Whether the metadata contains a key named properties.
 	 *
 	 * @param array $metadata Description of the style property.
 	 *
@@ -1238,7 +1238,7 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Retuns the raw data.
+	 * Returns the raw data.
 	 *
 	 * @return array Raw data.
 	 */

--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -74,9 +74,9 @@ class WP_Widget_Block extends WP_Widget {
 	 *
 	 * Usually this is set to $this->widget_options['classname'] by
 	 * dynamic_sidebar(). In this case, however, we want to set the classname
-	 * dynamically depending on the block conatined by this block widget.
+	 * dynamically depending on the block contained by this block widget.
 	 *
-	 * If a block widget contains a block that has an equivelant legacy widget,
+	 * If a block widget contains a block that has an equivalent legacy widget,
 	 * we display that legacy widget's class name. This helps with theme
 	 * backwards compatibility.
 	 *

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Bootstraping the Gutenberg experiments page.
+ * Bootstrapping the Gutenberg experiments page.
  *
  * @package gutenberg
  */

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -266,7 +266,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 * Checks if a given request has access to delete a single template.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return true|WP_Error True if the request has dedlete access for the item, WP_Error object otherwise.
+	 * @return true|WP_Error True if the request has delete access for the item, WP_Error object otherwise.
 	 */
 	public function delete_item_permissions_check( $request ) {
 		return $this->permissions_check( $request );

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Bootstraping the Gutenberg Edit Site Page.
+ * Bootstrapping the Gutenberg Edit Site Page.
  *
  * @package gutenberg
  */

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -106,7 +106,7 @@ function gutenberg_menu_order( $menu_order ) {
 	}
 
 	$new_positions = array(
-		// Position the site editor before the appearnce menu.
+		// Position the site editor before the appearance menu.
 		'gutenberg-edit-site' => array_search( 'themes.php', $menu_order, true ),
 	);
 

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -89,7 +89,7 @@ function gutenberg_register_wp_template_part_area_taxonomy() {
 }
 add_action( 'init', 'gutenberg_register_wp_template_part_area_taxonomy' );
 
-// Definte constants for supported wp_template_part_area taxonomy.
+// Define constants for supported wp_template_part_area taxonomy.
 if ( ! defined( 'WP_TEMPLATE_PART_AREA_HEADER' ) ) {
 	define( 'WP_TEMPLATE_PART_AREA_HEADER', 'header' );
 }

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Bootstraping the Gutenberg Navigation page.
+ * Bootstrapping the Gutenberg Navigation page.
  *
  * @package gutenberg
  */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix typos in comments.

## How has this been tested?
Smoke test? Only comments have been changed so it shouldn't affect the code in any way.

## Types of changes
Code quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
