### PR TITLE
Fix footer icon

### DIFF
--- a/packages/icons/src/library/footer.js
+++ b/packages/icons/src/library/footer.js
@@ -6,9 +6,9 @@ import { SVG, Path } from '@wordpress/primitives';
 const footer = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
-			fill-rule="evenodd"
+			fillRule="evenodd"
 			d="M18 5.5h-8v8h8.5V6a.5.5 0 00-.5-.5zm-9.5 8h-3V6a.5.5 0 01.5-.5h2.5v8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z"
-			clip-rule="evenodd"
+			clipRule="evenodd"
 		/>
 	</SVG>
 );

--- a/packages/icons/src/library/footer.js
+++ b/packages/icons/src/library/footer.js
@@ -8,7 +8,6 @@ const footer = (
 		<Path
 			fillRule="evenodd"
 			d="M18 5.5h-8v8h8.5V6a.5.5 0 00-.5-.5zm-9.5 8h-3V6a.5.5 0 01.5-.5h2.5v8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z"
-			clipRule="evenodd"
 		/>
 	</SVG>
 );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
By testing this PR: https://github.com/WordPress/gutenberg/pull/29195, I saw that `footer` icon did not provide some props properly.
