### PR TITLE
Remove Font style, weight, decoration, and transform presets from the theme.json documentation

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -180,10 +180,6 @@ The settings section has the following structure and default values:
         "dropCap": true, /* false to opt-out */
         "fontFamilies": [ ... ], /* font family presets */
         "fontSizes": [ ... ], /* font size presets, as in add_theme_support('editor-font-sizes', ... ) */
-        "fontStyles": [ ... ], /* font style presets */
-        "fontWeights": [ ... ], /* font weight presets */
-        "textDecorations": [ ... ], /* text decoration presets */
-        "textTransforms": [ ... ] /* text transform presets */
       }
     }
   }


### PR DESCRIPTION
## Description

Removes fontStyles, fontWeights, textDecorations and textTransforms presets from the expiermental-theme.json documentation.
These presets were removed from the json file in #27555

Fixes #28197

## Types of changes
Documentation update
