### PR TITLE
Buttons border hotfix.

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -6,7 +6,6 @@ $blocks-block__margin: 0.5em;
 .wp-block-button__link {
 	color: $white;
 	background-color: #32373c;
-	border: 2px solid #32373c;
 	border-radius: 9999px; // 100% causes an oval, but any explicit but really high value retains the pill shape.
 	box-shadow: none;
 	cursor: pointer;


### PR DESCRIPTION
## Description
Hotfix for solid buttons having borders. Fixes #29149. 

## How has this been tested?

Insert outline and solid buttons. Change the background color of the solid button. It should not have a border.

## Screenshots <!-- if applicable -->

Before:

<img width="510" alt="before" src="https://user-images.githubusercontent.com/1204802/108690368-92e41800-74fa-11eb-9dfa-415d1c66a84c.png">

After:

<img width="531" alt="Screenshot 2021-02-22 at 10 39 36" src="https://user-images.githubusercontent.com/1204802/108690366-911a5480-74fa-11eb-8f1c-dba616c26fe2.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
