### PR TITLE
Do not render Sections in Preferences modal if children render nothing

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/section.js
+++ b/packages/edit-post/src/components/preferences-modal/section.js
@@ -1,15 +1,24 @@
-const Section = ( { description, title, children } ) => (
-	<section className="edit-post-preferences-modal__section">
-		<h2 className="edit-post-preferences-modal__section-title">
-			{ title }
-		</h2>
-		{ description && (
-			<p className="edit-post-preferences-modal__section-description">
-				{ description }
-			</p>
-		) }
-		{ children }
-	</section>
-);
+/**
+ * WordPress dependencies
+ */
+import { renderToString } from '@wordpress/element';
+
+const Section = ( { description, title, children } ) => {
+	const content = renderToString( children );
+	if ( ! content ) return null;
+	return (
+		<section className="edit-post-preferences-modal__section">
+			<h2 className="edit-post-preferences-modal__section-title">
+				{ title }
+			</h2>
+			{ description && (
+				<p className="edit-post-preferences-modal__section-description">
+					{ description }
+				</p>
+			) }
+			{ children }
+		</section>
+	);
+};
 
 export default Section;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/11923

When you remove all panels programmatically, the respective section (`Panels`->`Document settings`) in the Preferences dialog is still there but empty.
<!-- Please describe what you have changed or added -->

## Testing Instructions
1. Paste the following code and execute in JS console
2. Open `Preferences` modal
3. Go to `Panels` tab
4. Observe that `Document settings` section is not shown
```
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'post-link' ) ;
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'taxonomy-panel-category' ) ;
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'taxonomy-panel-post_tag' );
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'featured-image' );
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'post-excerpt' );
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'discussion-panel' );
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'page-attributes' );
```