### PR TITLE
Try: Alternative button sizing fix.

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -6,13 +6,12 @@ $blocks-block__margin: 0.5em;
 .wp-block-button__link {
 	color: $white;
 	background-color: #32373c;
-	border: 2px solid #32373c;
 	border-radius: 9999px; // 100% causes an oval, but any explicit but really high value retains the pill shape.
 	box-shadow: none;
 	cursor: pointer;
 	display: inline-block;
 	font-size: 1.125em;
-	padding: 0.667em 1.333em;
+	padding: calc(0.667em + 2px) calc(1.333em + 2px); // The extra 2px are added to size solids the same as the outline versions.
 	text-align: center;
 	text-decoration: none;
 	overflow-wrap: break-word;
@@ -77,6 +76,7 @@ $blocks-block__margin: 0.5em;
 .is-style-outline > .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
 	border: 2px solid currentColor;
+	padding: 0.667em 1.333em;
 }
 
 .is-style-outline > .wp-block-button__link:not(.has-text-color),


### PR DESCRIPTION
## Description

Follow-up to #29206. Restores the size normalization so buttons are the sam height, whether solid or outline.

## How has this been tested?

Insert solid and outline style buttons in a buttons block and verify they are the same height.

## Screenshots <!-- if applicable -->

Before:

<img width="531" alt="before" src="https://user-images.githubusercontent.com/1204802/108692862-73022380-74fd-11eb-9019-9f3c5ee189b9.png">

After:

<img width="504" alt="after" src="https://user-images.githubusercontent.com/1204802/108692876-7695aa80-74fd-11eb-8cab-13ad0ea9e892.png">


## Types of changes

This uses padding instead of borders to size the buttons. 

To ensure we don't regress any themes here, I'd love a good sanity check before we land it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
