### PR TITLE
Update text color icon.

### DIFF
--- a/packages/icons/src/library/text-color.js
+++ b/packages/icons/src/library/text-color.js
@@ -4,8 +4,8 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const textColor = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
-		<Path d="M13.23 15h1.9L11 4H9L5 15h1.88l1.07-3h4.18zm-1.53-4.54H8.51L10 5.6z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M12.9 6h-2l-4 11h1.9l1.1-3h4.2l1.1 3h1.9L12.9 6zm-2.5 6.5l1.5-4.9 1.7 4.9h-3.2z" />
 	</SVG>
 );
 


### PR DESCRIPTION
## Description

The "text color" icon is an older smaller icon:

<img width="601" alt="Screenshot 2021-02-22 at 12 21 38" src="https://user-images.githubusercontent.com/1204802/108701921-dd6c9100-7508-11eb-8c70-d05c7d50f59b.png">

This PR updates it:

<img width="626" alt="Screenshot 2021-02-22 at 12 22 39" src="https://user-images.githubusercontent.com/1204802/108701933-e0678180-7508-11eb-9277-87f7147b0e6d.png">

Yes, the difference is barely perceptible, but the new version is slightly better balanced, centered, and is based on the same font that the Bold and Italic icons are based on. 

Why isn't it larger, you ask? Because it has to be balanced for the colored bar below when used for text color:

<img width="1133" alt="Screenshot 2021-02-22 at 12 22 51" src="https://user-images.githubusercontent.com/1204802/108702020-fc6b2300-7508-11eb-813b-ca910a20f32f.png">

There's a separate conversation to be had on whether we might want to explore a larger A for the Cover block transform action. Happy to follow up.

## How has this been tested?

Test inserting an Image and observing the A icon. Test setting inline text color in a paragraph.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
