### PR TITLE
Blocks: Ensure that metadata registered on the server for core block is preserved on the client

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -160,6 +160,10 @@ export const serverSideBlockDefinitions = {};
 // eslint-disable-next-line camelcase
 export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 	for ( const blockName of Object.keys( definitions ) ) {
+		// don't overwrite with block.json if we've already initialized from server
+		if ( serverSideBlockDefinitions[ blockName ] ) {
+			continue;
+		}
 		serverSideBlockDefinitions[ blockName ] = mapKeys(
 			pickBy( definitions[ blockName ], ( value ) => ! isNil( value ) ),
 			( value, key ) => camelCase( key )

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -160,7 +160,8 @@ export const serverSideBlockDefinitions = {};
 // eslint-disable-next-line camelcase
 export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 	for ( const blockName of Object.keys( definitions ) ) {
-		// don't overwrite with block.json if we've already initialized from server
+		// Don't overwrite if already set. It covers the case when metadata
+		// was initialized from the server.
 		if ( serverSideBlockDefinitions[ blockName ] ) {
 			continue;
 		}

--- a/packages/e2e-tests/plugins/register-block-type-hooks.php
+++ b/packages/e2e-tests/plugins/register-block-type-hooks.php
@@ -10,18 +10,18 @@
 /**
  * Changes the category for the paragraph block.
  *
- * @param array  $metadata Array of metadata for registering a block type.
+ * @param array $metadata Array of metadata for registering a block type.
  *
  * @return array Filtered metadata for registering a block type.
  */
 function gutenberg_test_block_type_metadata( $metadata ) {
-	if ( 'core/paragraph' !== $metadata[ 'name' ] ) {
+	if ( 'core/paragraph' !== $metadata['name'] ) {
 		return $metadata;
 	}
 
 	return array_merge(
 		$metadata,
-		array( 'category' => 'widgets' ),
+		array( 'category' => 'widgets' )
 	);
 }
 

--- a/packages/e2e-tests/plugins/register-block-type-hooks.php
+++ b/packages/e2e-tests/plugins/register-block-type-hooks.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Register Block Type Hooks
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-register-block-type-hooks
+ */
+
+/**
+ * Changes the category for the paragraph block.
+ *
+ * @param array  $metadata Array of metadata for registering a block type.
+ *
+ * @return array Filtered metadata for registering a block type.
+ */
+function gutenberg_test_block_type_metadata( $metadata ) {
+	if ( 'core/paragraph' !== $metadata[ 'name' ] ) {
+		return $metadata;
+	}
+
+	return array_merge(
+		$metadata,
+		array( 'category' => 'widgets' ),
+	);
+}
+
+add_filter( 'block_type_metadata', 'gutenberg_test_block_type_metadata' );

--- a/packages/e2e-tests/specs/editor/plugins/register-block-type-hooks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/register-block-type-hooks.test.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	openGlobalBlockInserter,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Register block type hooks', () => {
+	beforeEach( async () => {
+		await activatePlugin( 'gutenberg-test-register-block-type-hooks' );
+		await createNewPost();
+	} );
+
+	afterEach( async () => {
+		await deactivatePlugin( 'gutenberg-test-register-block-type-hooks' );
+	} );
+
+	it( 'has a custom category for Paragraph block', async () => {
+		await openGlobalBlockInserter();
+
+		const widgetsCategory = await page.$(
+			'.block-editor-block-types-list[aria-label="Widgets"]'
+		);
+
+		expect(
+			await widgetsCategory.$( '.editor-block-list-item-paragraph' )
+		).toBeDefined();
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Extracted from #29095.
Alternative to https://github.com/WordPress/gutenberg/pull/28829.

Props to @gwwar for the proposed solution.

This PR resolves the issue where metadata registered on the server from `block.json` would get overridden by the same data registered again on the client. The fix proposed ensures that for all blocks that have some metadata present, we skip all other attempts to pass the same metadata. `unstable__bootstrapServerSideBlockDefinitions` was never meant to stay for so long, but here we are. It isn't part of public API so we shouldn't be worried about backward compatibility that much.

It's a blocker for #29095.

It also was caught by @audrasjb when compiling the dev note for new filters added for `register_block_type_from_metadata`. I included e2e tests that ensure that one of the new filters is properly propagated to the client.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

There is a new e2e test added that ensures that the updated logic works correctly:

```bash
npm run test-e2e packages/e2e-tests/specs/editor/plugins/register-block-type-hooks.test.js
````

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue). Should be backported to WordPress 5.7. /cc @noisysocks.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
