### PR TITLE
Browsing sidebar: Add content menu items preview

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
@@ -67,7 +67,10 @@ export default function ContentNavigationItem( { item } ) {
 				<NavigationPanelPreviewFill>
 					<TemplatePreview
 						rawContent={ previewContent }
-						provideEntity={ item }
+						blockContext={ {
+							postType: item.type,
+							postId: item.id,
+						} }
 					/>
 				</NavigationPanelPreviewFill>
 			) }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
@@ -2,16 +2,38 @@
  * WordPress dependencies
  */
 import { __experimentalNavigationItem as NavigationItem } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getPathAndQueryString } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { NavigationPanelPreviewFill } from '..';
+import TemplatePreview from './template-preview';
+import { store as editSiteStore } from '../../../store';
 
 const getTitle = ( entity ) =>
 	entity.taxonomy ? entity.name : entity?.title?.rendered;
 
 export default function ContentNavigationItem( { item } ) {
-	const { setPage } = useDispatch( 'core/edit-site' );
+	const [ isPreviewVisible, setIsPreviewVisible ] = useState( false );
+	const previewContent = useSelect(
+		( select ) => {
+			if ( ! isPreviewVisible ) {
+				return null;
+			}
+
+			const template = select(
+				coreStore
+			).__experimentalGetTemplateForLink( item.link );
+			return template?.content?.raw;
+		},
+		[ isPreviewVisible ]
+	);
+	const { setPage } = useDispatch( editSiteStore );
 
 	const onActivateItem = useCallback( () => {
 		const { type, slug, link, id } = item;
@@ -31,11 +53,24 @@ export default function ContentNavigationItem( { item } ) {
 	}
 
 	return (
-		<NavigationItem
-			className="edit-site-navigation-panel__content-item"
-			item={ `${ item.taxonomy || item.type }-${ item.id }` }
-			title={ getTitle( item ) || __( '(no title)' ) }
-			onClick={ onActivateItem }
-		/>
+		<>
+			<NavigationItem
+				className="edit-site-navigation-panel__content-item"
+				item={ `${ item.taxonomy || item.type }-${ item.id }` }
+				title={ getTitle( item ) || __( '(no title)' ) }
+				onClick={ onActivateItem }
+				onMouseEnter={ () => setIsPreviewVisible( true ) }
+				onMouseLeave={ () => setIsPreviewVisible( false ) }
+			/>
+
+			{ isPreviewVisible && previewContent && (
+				<NavigationPanelPreviewFill>
+					<TemplatePreview
+						rawContent={ previewContent }
+						provideEntity={ item }
+					/>
+				</NavigationPanelPreviewFill>
+			) }
+		</>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
@@ -5,7 +5,7 @@ import { parse } from '@wordpress/blocks';
 import { BlockPreview, BlockContextProvider } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 
-export default function TemplatePreview( { rawContent, provideEntity } ) {
+export default function TemplatePreview( { rawContent, blockContext } ) {
 	const blocks = useMemo( () => ( rawContent ? parse( rawContent ) : [] ), [
 		rawContent,
 	] );
@@ -14,15 +14,10 @@ export default function TemplatePreview( { rawContent, provideEntity } ) {
 		return null;
 	}
 
-	if ( provideEntity ) {
+	if ( blockContext ) {
 		return (
 			<div className="edit-site-navigation-panel__preview">
-				<BlockContextProvider
-					value={ {
-						postId: provideEntity.id,
-						postType: provideEntity.type,
-					} }
-				>
+				<BlockContextProvider value={ blockContext }>
 					<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
 				</BlockContextProvider>
 			</div>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
@@ -4,14 +4,29 @@
 import { parse } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
+import { EntityProvider } from '@wordpress/core-data';
 
-export default function TemplatePreview( { rawContent } ) {
+export default function TemplatePreview( { rawContent, provideEntity } ) {
 	const blocks = useMemo( () => ( rawContent ? parse( rawContent ) : [] ), [
 		rawContent,
 	] );
 
 	if ( ! blocks || blocks.length === 0 ) {
 		return null;
+	}
+
+	if ( provideEntity ) {
+		return (
+			<div className="edit-site-navigation-panel__preview">
+				<EntityProvider
+					kind="postType"
+					type={ provideEntity.type }
+					id={ provideEntity.id }
+				>
+					<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
+				</EntityProvider>
+			</div>
+		);
 	}
 
 	return (

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
@@ -2,9 +2,8 @@
  * WordPress dependencies
  */
 import { parse } from '@wordpress/blocks';
-import { BlockPreview } from '@wordpress/block-editor';
+import { BlockPreview, BlockContextProvider } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
-import { EntityProvider } from '@wordpress/core-data';
 
 export default function TemplatePreview( { rawContent, provideEntity } ) {
 	const blocks = useMemo( () => ( rawContent ? parse( rawContent ) : [] ), [
@@ -18,13 +17,14 @@ export default function TemplatePreview( { rawContent, provideEntity } ) {
 	if ( provideEntity ) {
 		return (
 			<div className="edit-site-navigation-panel__preview">
-				<EntityProvider
-					kind="postType"
-					type={ provideEntity.type }
-					id={ provideEntity.id }
+				<BlockContextProvider
+					value={ {
+						postId: provideEntity.id,
+						postType: provideEntity.type,
+					} }
 				>
 					<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
-				</EntityProvider>
+				</BlockContextProvider>
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/29164
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add previews for content menu items.

## How has this been tested?
1. Open site editor
2. Open browsing sidebar
3. Navigate to any Content submenus and move your mouse over the item
4. Make sure a preview appears and it shows the correct content

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/108870848-d0c76600-75f8-11eb-9808-ae302ed72d7f.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
