### PR TITLE
InputControl: Fix labelPosition rendering with new ui/flex component

### DIFF
--- a/packages/components/src/input-control/input-base.js
+++ b/packages/components/src/input-control/input-base.js
@@ -24,6 +24,26 @@ function useUniqueId( idProp ) {
 	return idProp || id;
 }
 
+// Adapter to map props for the new ui/flex compopnent.
+function getUIFlexProps( { labelPosition } ) {
+	const props = {};
+	switch ( labelPosition ) {
+		case 'top':
+			props.direction = 'column';
+			props.gap = 0;
+			break;
+		case 'bottom':
+			props.direction = 'column-reverse';
+			props.gap = 0;
+			break;
+		case 'edge':
+			props.justify = 'space-between';
+			break;
+	}
+
+	return props;
+}
+
 export function InputBase(
 	{
 		__unstableInputWidth,
@@ -48,6 +68,7 @@ export function InputBase(
 	return (
 		<Root
 			{ ...props }
+			{ ...getUIFlexProps( { labelPosition } ) }
 			className={ className }
 			isFocused={ isFocused }
 			labelPosition={ labelPosition }

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -25,9 +25,9 @@ module.exports = {
 	// https://github.com/storybookjs/storybook/issues/12270
 	webpackFinal: async ( config ) => {
 		// Find the DefinePlugin
-		const plugin = config.plugins.find(
-			( p ) => p.definitions?.[ 'process.env' ]
-		);
+		const plugin = config.plugins.find( ( p ) => {
+			return p.definitions && p.definitions[ 'process.env' ];
+		} );
 		// Add custom env variables
 		Object.keys( customEnvVariables ).forEach( ( key ) => {
 			plugin.definitions[ 'process.env' ][ key ] = JSON.stringify(

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -5,6 +5,10 @@ const stories = [
 	'../packages/icons/src/**/stories/*.js',
 ].filter( Boolean );
 
+const customEnvVariables = {
+	COMPONENT_SYSTEM_PHASE: 1,
+};
+
 module.exports = {
 	stories,
 	addons: [
@@ -17,4 +21,20 @@ module.exports = {
 		'@storybook/addon-viewport',
 		'@storybook/addon-a11y',
 	],
+	// Workaround:
+	// https://github.com/storybookjs/storybook/issues/12270
+	webpackFinal: async ( config ) => {
+		// Find the DefinePlugin
+		const plugin = config.plugins.find(
+			( p ) => p.definitions?.[ 'process.env' ]
+		);
+		// Add custom env variables
+		Object.keys( customEnvVariables ).forEach( ( key ) => {
+			plugin.definitions[ 'process.env' ][ key ] = JSON.stringify(
+				customEnvVariables[ key ]
+			);
+		} );
+
+		return config;
+	},
 };


### PR DESCRIPTION
In this update, the `InputControl` component was updated to fix the `labelPosition` rendering.
The issue was caused by how the previous vs. new ui/flex component rendered styles.

During the `ui/flex` integration, the `input-control/input-base` was flipped to use the `__unstableVersion` of `next` for Flex.

Below is a screenshot of this working for the `SelectControl` component (from Storybook)

<img width="528" alt="Screen Shot 2021-02-22 at 10 40 22 AM" src="https://user-images.githubusercontent.com/2322354/108731813-efdfce00-74fa-11eb-9668-7f64c023465b.png">

Another adjustment was to Storybook itself. The webpack config was modified so that Storybook can correctly render components targeted/wrapped with "next" components.

This issue was recently discovered here:
https://github.com/WordPress/gutenberg/pull/29159#pullrequestreview-594457157

## How has this been tested?

Tested in local Storybook and in Gutenberg

* npm run storybook:dev
* View the SelectControl story
* Adjust the `labelPosition` knob to another value
* The position should change



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
