### PR TITLE
Fix Site Logo Styles

### DIFF
--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -1,11 +1,11 @@
-.wp-block-custom-logo {
+.wp-block-site-logo {
 	line-height: 0;
 
 	.aligncenter {
 		display: table;
 	}
 
-	// Variations
+	// Style variations
 	&.is-style-rounded img {
 		// We use an absolute pixel to prevent the oval shape that a value of 50% would give
 		// to rectangular images. A pill-shape is better than otherwise.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/29219

This PR fixes the bug for applying the `Site Logo` block's style variations.
<!-- Please describe what you have changed or added -->

## How to test
1. Insert `Site Logo` block
2. Change `Styles`
3. Observe that they are applied properly
