### PR TITLE
Icons: Add custom post type icon

### DIFF
--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -51,6 +51,7 @@ export { default as crop } from './library/crop';
 export { default as currencyDollar } from './library/currency-dollar';
 export { default as currencyEuro } from './library/currency-euro';
 export { default as currencyPound } from './library/currency-pound';
+export { default as customPostType } from './library/custom-post-type';
 export { default as desktop } from './library/desktop';
 export { default as dragHandle } from './library/drag-handle';
 export { default as download } from './library/download';

--- a/packages/icons/src/library/custom-post-type.js
+++ b/packages/icons/src/library/custom-post-type.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const customPostType = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M4 20h9v-1.5H4V20zm0-5.5V16h16v-1.5H4zm.8-4l.7.7 2-2V12h1V9.2l2 2 .7-.7-2-2H12v-1H9.2l2-2-.7-.7-2 2V4h-1v2.8l-2-2-.7.7 2 2H4v1h2.8l-2 2z" />
+	</SVG>
+);
+
+export default customPostType;


### PR DESCRIPTION
This PR adds a `custom-post-type` icon. This will help differentiate navigation link variants as seen in #29095

| Design  | In Navigation Links |
| ------------- | ------------- |
| <img width="376" alt="screenshot_2021-02-22_at_10 02 50" src="https://user-images.githubusercontent.com/1270189/108745001-72629080-74ef-11eb-9feb-9c99e856d7f4.png">  | <img width="332" alt="Screen Shot 2021-02-22 at 8 53 14 AM" src="https://user-images.githubusercontent.com/1270189/108744786-329ba900-74ef-11eb-865f-7835c5298637.png"> |

### Testing Instructions
- Checkout this branch
- Run `npm run storybook:dev` (for more info see [docs](https://developer.wordpress.org/block-editor/contributors/develop/getting-started/#storybook))
- Allow the terminal to launch a browser
- Visit `?path=/story/icons-icon--library`
- Search for custom post type

<img width="888" alt="Screen Shot 2021-02-22 at 9 30 56 AM" src="https://user-images.githubusercontent.com/1270189/108746133-c621a980-74f0-11eb-9c01-b62462b45b85.png">

- Verify that the icon looks good at different sizes and that we like the name of this icon.  



