### PR TITLE
Component Systems: Update references to external module

### DIFF
--- a/packages/components/src/ui/font-size-control/font-size-control.js
+++ b/packages/components/src/ui/font-size-control/font-size-control.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { contextConnect } from '@wp-g2/context';
-import { VisuallyHidden, VStack } from '@wp-g2/components';
 
 /**
  * WordPress dependencies
@@ -12,6 +11,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { VisuallyHidden } from '../visually-hidden';
+import { VStack } from '../v-stack';
 import FontSizeControlSelect from './select';
 import FontSizeControlSlider from './slider';
 import useFontSizeControl from './use-font-size-control';

--- a/packages/components/src/ui/font-size-control/slider.js
+++ b/packages/components/src/ui/font-size-control/slider.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { noop } from 'lodash';
-import { ControlLabel, Slider, TextInput, VStack } from '@wp-g2/components';
+import { ControlLabel, Slider, TextInput } from '@wp-g2/components';
 
 /**
  * WordPress dependencies
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { getSliderTemplateColumns } from './utils';
 import { Grid } from '../grid';
+import { VStack } from '../v-stack';
 
 function FontSizeControlSlider( props ) {
 	const {

--- a/packages/components/src/ui/form-group/stories/index.js
+++ b/packages/components/src/ui/form-group/stories/index.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { Text } from '@wp-g2/components';
-
-/**
  * Internal dependencies
  */
 import { FormGroup, useFormGroupContextId } from '../index';
+import { Text } from '../../text';
 
 // @todo: Refactor this after adding next TextInput component.
 const TextInput = ( { id: idProp, ...props } ) => {

--- a/packages/components/src/ui/h-stack/README.md
+++ b/packages/components/src/ui/h-stack/README.md
@@ -7,6 +7,8 @@
 `HStack` can render anything inside.
 
 ```jsx
+import { HStack, Text, View } from '@wordpress/components/ui';
+
 function Example() {
 	return (
 		<HStack>

--- a/packages/components/src/ui/visually-hidden/README.md
+++ b/packages/components/src/ui/visually-hidden/README.md
@@ -1,0 +1,17 @@
+# VisuallyHidden
+
+`VisuallyHidden` is a component used to render text intended to be visually hidden, but will show for alternate devices, for example a screen reader.
+
+## Usage
+
+```jsx
+import { View, VisuallyHidden } from '@wordpress/components/ui';
+
+function Example() {
+	return (
+		<VisuallyHidden>
+			<View as="label">Code is Poetry</View>
+		</VisuallyHidden>
+	);
+}
+```

--- a/packages/components/src/ui/visually-hidden/component.js
+++ b/packages/components/src/ui/visually-hidden/component.js
@@ -5,15 +5,23 @@ import { createComponent } from '../utils';
 import { useVisuallyHidden } from './hook';
 
 /**
- * `VisuallyHidden` is used hide content from the visual client, but keep it readable for screen readers.
+ * `VisuallyHidden` is a component used to render text intended to be visually
+ * hidden, but will show for alternate devices, for example a screen reader.
  *
  * @example
  * ```jsx
- * <VisuallyHidden>
- *  <Text>Hidding</Text>
- * </VisuallyHidden>
+ * import { View, VisuallyHidden } from `@wordpress/components/ui`;
+ *
+ * function Example() {
+ * 	return (
+ * 		<VisuallyHidden>
+ * 			<View as="label">Code is Poetry</View>
+ * 		</VisuallyHidden>
+ * 	);
+ * }
  * ```
  */
+
 const VisuallyHidden = createComponent( {
 	as: 'div',
 	useHook: useVisuallyHidden,


### PR DESCRIPTION
This update fixes some referneces to `@wp-g2/`. Documentation (README.md + JSDocs) have also been updated.

## Checklist:
- [x] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
