### PR TITLE
Site Editor: Fix navigate-to-link error

### DIFF
--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -35,13 +35,17 @@ describe( 'Template Part', () => {
 			await siteEditor.visit();
 		} );
 
-		async function updateHeader( content ) {
+		async function navigateToHeader() {
 			// Switch to editing the header template part.
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
 			// TODO: Change General to Headers once TT1 blocks categorise the template parts
 			await navigationPanel.navigate( [ 'Template Parts', 'General' ] );
 			await navigationPanel.clickItemByText( 'header' );
+		}
+
+		async function updateHeader( content ) {
+			await navigateToHeader();
 
 			// Edit it.
 			await insertBlock( 'Paragraph' );
@@ -125,6 +129,36 @@ describe( 'Template Part', () => {
 			const [ expectedContent ] = await canvas().$x(
 				'//p[contains(text(), "Header Template Part 456")]'
 			);
+			expect( expectedContent ).not.toBeUndefined();
+		} );
+
+		it( 'Should load navigate-to-links properly', async () => {
+			await navigateToHeader();
+			await insertBlock( 'Paragraph' );
+			await page.keyboard.type( 'Header Template Part 789' );
+
+			// Select the paragraph block
+			const text = await canvas().waitForXPath(
+				'//p[contains(text(), "Header Template Part 789")]'
+			);
+
+			// Highlight all the text in the paragraph block
+			await text.click( { clickCount: 3 } );
+
+			// Click the convert to link toolbar button
+			await page.waitForSelector( 'button[aria-label="Link"]' );
+			await page.click( 'button[aria-label="Link"]' );
+
+			// Enter url for link
+			await page.keyboard.type( 'https://google.com' );
+			await page.keyboard.press( 'Enter' );
+
+			// Verify that there is no error
+			await canvas().click( 'p[data-type="core/paragraph"] a' );
+			const expectedContent = await canvas().$x(
+				'//p[contains(text(), "Header Template Part 789")]'
+			);
+
 			expect( expectedContent ).not.toBeUndefined();
 		} );
 

--- a/packages/edit-site/src/components/navigate-to-link/index.js
+++ b/packages/edit-site/src/components/navigate-to-link/index.js
@@ -26,7 +26,7 @@ export default function NavigateToLink( {
 	const onClick = useMemo( () => {
 		if ( ! post?.link ) return null;
 		const path = getPathAndQueryString( post.link );
-		if ( path === activePage.path ) return null;
+		if ( path === activePage?.path ) return null;
 		return () =>
 			onActivePageChange( {
 				type,
@@ -37,7 +37,7 @@ export default function NavigateToLink( {
 					postId: post.id,
 				},
 			} );
-	}, [ post, activePage.path, onActivePageChange ] );
+	}, [ post, activePage?.path, onActivePageChange ] );
 
 	return (
 		onClick && (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
In full site editing, after navigating to a template part from the navigation sidebar, adding and manipulating navigate-to-links errors out the block.

This happens because the navigate-to-link expects to be loaded within the context of a page or a template. The editor, however, may load blocks outside of this context. If, for example, a user opens the navigation sidebar and loads a template part, there will be no page entity and no page metadata.

The changes here allow navigate-to-links to be loaded in the context of template parts.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Spin up a local instance of Gutenberg
2. Enable full site editing by activating a block theme (Seedlet Blocks or TT1 Blocks)
3. Navigate to the full site editor
4. Open the navigation sidebar
5. Load a template part
6. Add a paragraph block with some text
7. Add a link to the text
8. Click on the link
9. Verify that the paragraph block errors

## Screenshots <!-- if applicable -->
### Before
![2021-02-22 16 07 44](https://user-images.githubusercontent.com/5414230/108786326-3566c000-7528-11eb-8dc6-2999752c3ca9.gif)

### After
![2021-02-22 16 50 50](https://user-images.githubusercontent.com/5414230/108789023-326ece00-752e-11eb-8fce-2182e9abb019.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix #29240

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
