### PR TITLE
Update the package-lock.json with --package-lock-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11970,137 +11970,6 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.2",
 				"uuid": "^8.3.0"
-			},
-			"dependencies": {
-				"@emotion/is-prop-valid": {
-					"version": "0.8.8",
-					"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-					"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-					"requires": {
-						"@emotion/memoize": "0.7.4"
-					}
-				},
-				"@emotion/memoize": {
-					"version": "0.7.4",
-					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-					"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
-				},
-				"@wp-g2/components": {
-					"version": "0.0.150",
-					"resolved": "https://registry.npmjs.org/@wp-g2/components/-/components-0.0.150.tgz",
-					"integrity": "sha512-wolFRz5X53jFTgnqLfZlJue7xs3ucGHksR9zBsONKXwolDvING0cJLn9U17vuU7dB7WFzf8lLxKxPvdFyYMcoQ==",
-					"requires": {
-						"@popperjs/core": "^2.5.4",
-						"@wp-g2/context": "^0.0.150",
-						"@wp-g2/styles": "^0.0.150",
-						"@wp-g2/utils": "^0.0.150",
-						"csstype": "^3.0.3",
-						"downshift": "^6.0.15",
-						"framer-motion": "^2.1.0",
-						"highlight-words-core": "^1.2.2",
-						"history": "^4.9.0",
-						"lodash": "^4.17.19",
-						"path-to-regexp": "^1.7.0",
-						"react-colorful": "4.4.4",
-						"react-textarea-autosize": "^8.2.0",
-						"react-use-gesture": "^9.0.0",
-						"reakit": "^1.3.4"
-					}
-				},
-				"@wp-g2/context": {
-					"version": "0.0.150",
-					"resolved": "https://registry.npmjs.org/@wp-g2/context/-/context-0.0.150.tgz",
-					"integrity": "sha512-VaC79oGUhJ/4THEW0XupIhunovV0u5IMLZfIrDAs5k0eqp45CO30zghMv2DQBQnuSzI1PH6DJCoHGkn4DTBDfw==",
-					"requires": {
-						"@wp-g2/styles": "^0.0.150",
-						"@wp-g2/utils": "^0.0.150",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@wp-g2/create-styles": {
-					"version": "0.0.150",
-					"resolved": "https://registry.npmjs.org/@wp-g2/create-styles/-/create-styles-0.0.150.tgz",
-					"integrity": "sha512-Dl2k/s9qtcJ86v2eTGfX/NdS9mjnCk1zWj0fEbCxKxdDCBEoGmYeFsBq16+ZEEA0YgyTzq8QmYjLhhSNGHwptQ==",
-					"requires": {
-						"@emotion/core": "^10.1.1",
-						"@emotion/is-prop-valid": "^0.8.8",
-						"@wp-g2/utils": "^0.0.150",
-						"create-emotion": "^10.0.27",
-						"emotion": "^10.0.27",
-						"emotion-theming": "^10.0.27",
-						"lodash": "^4.17.19",
-						"mitt": "^2.1.0",
-						"rtlcss": "^2.6.2",
-						"styled-griddie": "^0.1.3"
-					}
-				},
-				"@wp-g2/styles": {
-					"version": "0.0.150",
-					"resolved": "https://registry.npmjs.org/@wp-g2/styles/-/styles-0.0.150.tgz",
-					"integrity": "sha512-5CewOL0Ts5IdQIrW7d7Oa5joU1SWsVVBx9q+7rXfaXjFyeGliLrpRPchBk3OBPCQmw938kcexsa7eySlKFT67Q==",
-					"requires": {
-						"@wp-g2/create-styles": "^0.0.150",
-						"@wp-g2/utils": "^0.0.150"
-					}
-				},
-				"@wp-g2/utils": {
-					"version": "0.0.150",
-					"resolved": "https://registry.npmjs.org/@wp-g2/utils/-/utils-0.0.150.tgz",
-					"integrity": "sha512-CXJEZvwZwlLJfvsfWyxzAxd8qCVzZp9kK7w+GJ883K6NythPymOVJwECUEv2PG3xTUo5qwX4mAwePhA8ZPTHfQ==",
-					"requires": {
-						"copy-to-clipboard": "^3.3.1",
-						"create-emotion": "^10.0.27",
-						"deepmerge": "^4.2.2",
-						"fast-deep-equal": "^3.1.3",
-						"hoist-non-react-statics": "^3.3.2",
-						"json2mq": "^0.2.0",
-						"lodash": "^4.17.19",
-						"memize": "^1.1.0",
-						"react-merge-refs": "^1.1.0",
-						"react-resize-aware": "^3.1.0",
-						"tinycolor2": "^1.4.2",
-						"use-enhanced-state": "^0.0.13",
-						"use-isomorphic-layout-effect": "^1.0.0"
-					},
-					"dependencies": {
-						"react-merge-refs": {
-							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
-							"integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
-						}
-					}
-				},
-				"csstype": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-					"integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
-				},
-				"fast-deep-equal": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-				},
-				"hoist-non-react-statics": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-					"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-					"requires": {
-						"react-is": "^16.7.0"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"path-to-regexp": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-					"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-					"requires": {
-						"isarray": "0.0.1"
-					}
-				}
 			}
 		},
 		"@wordpress/compose": {
@@ -12995,6 +12864,134 @@
 			"requires": {
 				"@babel/runtime": "^7.12.5",
 				"lodash": "^4.17.19"
+			}
+		},
+		"@wp-g2/components": {
+			"version": "0.0.156",
+			"resolved": "https://registry.npmjs.org/@wp-g2/components/-/components-0.0.156.tgz",
+			"integrity": "sha512-PLu1jgQ2LRV2gcnvWrC4QM0bpfxzC1N2f6e4dpvueawuXs2avq2GJKol9vDKT2AKsmuQt+GhreTkyGHR4HO0fA==",
+			"requires": {
+				"@popperjs/core": "^2.5.4",
+				"@wp-g2/context": "^0.0.156",
+				"@wp-g2/styles": "^0.0.156",
+				"@wp-g2/utils": "^0.0.156",
+				"csstype": "^3.0.3",
+				"downshift": "^6.0.15",
+				"framer-motion": "^2.1.0",
+				"highlight-words-core": "^1.2.2",
+				"history": "^4.9.0",
+				"lodash": "^4.17.19",
+				"path-to-regexp": "^1.7.0",
+				"react-colorful": "4.4.4",
+				"react-textarea-autosize": "^8.2.0",
+				"react-use-gesture": "^9.0.0",
+				"reakit": "^1.3.4"
+			},
+			"dependencies": {
+				"csstype": {
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+					"integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"path-to-regexp": {
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+					"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+					"requires": {
+						"isarray": "0.0.1"
+					}
+				}
+			}
+		},
+		"@wp-g2/context": {
+			"version": "0.0.156",
+			"resolved": "https://registry.npmjs.org/@wp-g2/context/-/context-0.0.156.tgz",
+			"integrity": "sha512-T7Sy0Ti9W6I6+VpZJNlnseSuKXk0Q/UqJHsA3jO0wI3zWL/Vj3xl7ZEHFt1Hyae3gIqWKd84REkRK667274pXw==",
+			"requires": {
+				"@wp-g2/styles": "^0.0.156",
+				"@wp-g2/utils": "^0.0.156",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@wp-g2/create-styles": {
+			"version": "0.0.156",
+			"resolved": "https://registry.npmjs.org/@wp-g2/create-styles/-/create-styles-0.0.156.tgz",
+			"integrity": "sha512-wbMIfgUSnQKOsK+z0HVQDEntzZeltuN1ZePYn7o/eNbhDaA3nKKVQ9GhHcjPbNQxZlmPRKy4wPeQntWSOVGipA==",
+			"requires": {
+				"@emotion/core": "^10.1.1",
+				"@emotion/is-prop-valid": "^0.8.8",
+				"@wp-g2/utils": "^0.0.156",
+				"create-emotion": "^10.0.27",
+				"emotion": "^10.0.27",
+				"emotion-theming": "^10.0.27",
+				"lodash": "^4.17.19",
+				"mitt": "^2.1.0",
+				"rtlcss": "^2.6.2",
+				"styled-griddie": "^0.1.3"
+			},
+			"dependencies": {
+				"@emotion/is-prop-valid": {
+					"version": "0.8.8",
+					"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+					"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+					"requires": {
+						"@emotion/memoize": "0.7.4"
+					}
+				},
+				"@emotion/memoize": {
+					"version": "0.7.4",
+					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+					"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+				}
+			}
+		},
+		"@wp-g2/styles": {
+			"version": "0.0.156",
+			"resolved": "https://registry.npmjs.org/@wp-g2/styles/-/styles-0.0.156.tgz",
+			"integrity": "sha512-KZfBEfgFhKbAsNqcYyrdG5uyk7BZ7jVcZ0HPC9iUFi58c7/+v+1qN5EkGxVwTg3F2iDR8J0iTbhrwKtckgcaTA==",
+			"requires": {
+				"@wp-g2/create-styles": "^0.0.156",
+				"@wp-g2/utils": "^0.0.156"
+			}
+		},
+		"@wp-g2/utils": {
+			"version": "0.0.156",
+			"resolved": "https://registry.npmjs.org/@wp-g2/utils/-/utils-0.0.156.tgz",
+			"integrity": "sha512-iBxzoecGlpPnX8pv6f4MfUulGf/cyYlsff8Vl4BHI6sU8kQc4lLDo2qyQ/723bqFPiVgAE5fDanyqKoVywxO3Q==",
+			"requires": {
+				"copy-to-clipboard": "^3.3.1",
+				"create-emotion": "^10.0.27",
+				"deepmerge": "^4.2.2",
+				"fast-deep-equal": "^3.1.3",
+				"hoist-non-react-statics": "^3.3.2",
+				"json2mq": "^0.2.0",
+				"lodash": "^4.17.19",
+				"memize": "^1.1.0",
+				"react-merge-refs": "^1.1.0",
+				"react-resize-aware": "^3.1.0",
+				"tinycolor2": "^1.4.2",
+				"use-enhanced-state": "^0.0.13",
+				"use-isomorphic-layout-effect": "^1.0.0"
+			},
+			"dependencies": {
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+				},
+				"hoist-non-react-statics": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+					"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+					"requires": {
+						"react-is": "^16.7.0"
+					}
+				}
 			}
 		},
 		"@xtuc/ieee754": {
@@ -47133,6 +47130,11 @@
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
 			"dev": true
+		},
+		"react-merge-refs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+			"integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
 		},
 		"react-moment-proptypes": {
 			"version": "1.7.0",


### PR DESCRIPTION
Attempt at fixing issue where the GB build still generates an `components` bundle that includes code from `wp/g2` that's pre `v0.156` (before the fix that removes the invalid comment in CSS).

Related PRs:
* https://github.com/ItsJonQ/g2/pull/267
* https://github.com/WordPress/gutenberg/pull/29224