### PR TITLE
Add Widgets REST API changes from Core-51460

### DIFF
--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -290,7 +290,10 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			$sidebar['before_title']  = isset( $registered_sidebar['before_title'] ) ? $registered_sidebar['before_title'] : '';
 			$sidebar['after_title']   = isset( $registered_sidebar['after_title'] ) ? $registered_sidebar['after_title'] : '';
 		} else {
-			$sidebar['status'] = 'inactive';
+			$sidebar['status']      = 'inactive';
+			$sidebar['name']        = $raw_sidebar['name'];
+			$sidebar['description'] = '';
+			$sidebar['class']       = '';
 		}
 
 		$fields = $this->get_fields_for_response( $request );

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -100,9 +100,10 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check() {
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->do_permissions_check();
 	}
 
@@ -136,9 +137,10 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_item_permissions_check() {
+	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->do_permissions_check();
 	}
 
@@ -165,9 +167,10 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function update_item_permissions_check() {
+	public function update_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->do_permissions_check();
 	}
 

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * An extension for the WP REST API that exposes endpoints for sidebars and widgets.
+ * REST API: WP_REST_Sidebars_Controller class
  *
- * PHP version 5.4.0
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 5.6.0
  *
  * Copyright (C) 2015  Martin Pettersson
  *
@@ -23,20 +25,21 @@
  * @copyright 2015 Martin Pettersson
  * @license   GPLv2
  * @link      https://github.com/martin-pettersson/wp-rest-api-sidebars
- * @package   gutenberg
  */
 
 /**
- * Class Sidebars_Controller
+ * Core class used to manage a site's sidebars.
  *
- * @package WP_API_Sidebars\Controllers
+ * @since 5.6.0
+ *
+ * @see WP_REST_Controller
  */
 class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 	/**
 	 * Sidebars controller constructor.
 	 *
-	 * @since 5.5.0
+	 * @since 5.6.0
 	 */
 	public function __construct() {
 		$this->namespace = 'wp/v2';
@@ -49,7 +52,6 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * @return void
 	 */
 	public function register_routes() {
-		// Lists all sidebars.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
@@ -57,7 +59,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'permissions_check' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => array(
 						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 					),
@@ -66,7 +68,6 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			)
 		);
 
-		// Lists/updates a single sidebar based on the given id.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<id>[\w-]+)',
@@ -74,7 +75,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'permissions_check' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
 						'id'      => array(
 							'description' => __( 'The id of a registered sidebar', 'gutenberg' ),
@@ -86,7 +87,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_item' ),
-					'permission_callback' => array( $this, 'permissions_check' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
@@ -95,41 +96,30 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Checks if the user has permissions to make the request.
+	 * Checks if a given request has access to get sidebars.
+	 *
+	 * @since 5.6.0
 	 *
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
-	 * @since  5.6.0
-	 * @access public
 	 */
-	public function permissions_check() {
-		// Verify if the current user has edit_theme_options capability.
-		// This capability is required to access the widgets screen.
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			return new WP_Error(
-				'widgets_cannot_access',
-				__( 'Sorry, you are not allowed to access widgets on this site.', 'gutenberg' ),
-				array(
-					'status' => rest_authorization_required_code(),
-				)
-			);
-		}
-
-		return true;
+	public function get_items_permissions_check() {
+		return $this->do_permissions_check();
 	}
 
 	/**
-	 * Returns a list of sidebars (active or inactive)
+	 * Retrieves the list of sidebars (active or inactive).
 	 *
-	 * @param WP_REST_Request $request The request instance.
+	 * @since 5.6.0
 	 *
-	 * @return WP_REST_Response
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
 		$data = array();
 		foreach ( (array) wp_get_sidebars_widgets() as $id => $widgets ) {
-			list( $exists, $sidebar ) = $this->get_sidebar( $id );
+			$sidebar = $this->get_sidebar( $id );
 
-			if ( ! $exists && 'wp_inactive_widgets' !== $id ) {
+			if ( ! $sidebar ) {
 				continue;
 			}
 
@@ -142,16 +132,28 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Returns the given sidebar
+	 * Checks if a given request has access to get a single sidebar.
 	 *
-	 * @param WP_REST_Request $request The request instance.
+	 * @since 5.6.0
 	 *
-	 * @return WP_REST_Response|WP_Error
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check() {
+		return $this->do_permissions_check();
+	}
+
+	/**
+	 * Retrieves one sidebar from the collection.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
-		list( $exists, $sidebar ) = $this->get_sidebar( $request['id'] );
+		$sidebar = $this->get_sidebar( $request['id'] );
 
-		if ( ! $exists && 'wp_inactive_widgets' !== $request['id'] ) {
+		if ( ! $sidebar ) {
 			return new WP_Error( 'rest_sidebar_not_found', __( 'No sidebar exists with that id.', 'gutenberg' ), array( 'status' => 404 ) );
 		}
 
@@ -159,11 +161,23 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Updates the sidebar.
+	 * Checks if a given request has access to update sidebars.
 	 *
-	 * @param WP_REST_Request $request The request instance.
+	 * @since 5.6.0
 	 *
-	 * @return WP_REST_Response
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function update_item_permissions_check() {
+		return $this->do_permissions_check();
+	}
+
+	/**
+	 * Updates a sidebar.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function update_item( $request ) {
 		if ( isset( $request['widgets'] ) ) {
@@ -190,52 +204,73 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 		$request['context'] = 'edit';
 
-		list( , $sidebar ) = $this->get_sidebar( $request['id'] );
+		$sidebar = $this->get_sidebar( $request['id'] );
 
 		return $this->prepare_item_for_response( $sidebar, $request );
 	}
 
 	/**
-	 * Returns a sidebar for the given id or null if not found
+	 * Checks if the user has permissions to make the request.
 	 *
-	 * Note: The id can be either an index, the id or the name of a sidebar
+	 * @since 5.6.0
+	 *
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	protected function do_permissions_check() {
+		// Verify if the current user has edit_theme_options capability.
+		// This capability is required to access the widgets screen.
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_cannot_manage_widgets',
+				__( 'Sorry, you are not allowed to manage widgets on this site.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the registered sidebar with the given id.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @global array $wp_registered_sidebars The registered sidebars.
 	 *
 	 * @param string|int $id ID of the sidebar.
-	 *
-	 * @return array|null
-	 * @global array     $wp_registered_sidebars
+	 * @return array|null The discovered sidebar, or null if it is not registered.
 	 */
 	protected function get_sidebar( $id ) {
 		global $wp_registered_sidebars;
 
-		if ( is_int( $id ) ) {
-			$id = 'sidebar-' . $id;
-		} else {
-			$id = sanitize_title( $id );
-
-			foreach ( (array) $wp_registered_sidebars as $key => $sidebar ) {
-				if ( sanitize_title( $sidebar['name'] ) === $id ) {
-					return array( true, $sidebar );
-				}
+		foreach ( (array) $wp_registered_sidebars as $sidebar ) {
+			if ( $sidebar['id'] === $id ) {
+				return $sidebar;
 			}
 		}
 
-		foreach ( (array) $wp_registered_sidebars as $key => $sidebar ) {
-			if ( $key === $id ) {
-				return array( true, $sidebar );
-			}
+		if ( 'wp_inactive_widgets' === $id ) {
+			return array(
+				'id'   => 'wp_inactive_widgets',
+				'name' => __( 'Inactive widgets', 'gutenberg' ),
+			);
 		}
 
-		return array( false, array( 'id' => $id ) );
+		return null;
 	}
 
 	/**
-	 * Prepare a single sidebar output for response
+	 * Prepares a single sidebar output for response.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @global array $wp_registered_sidebars The registered sidebars.
+	 * @global array $wp_registered_widgets  The registered widgets.
 	 *
 	 * @param array           $raw_sidebar Sidebar instance.
-	 * @param WP_REST_Request $request     Request object.
+	 * @param WP_REST_Request $request     Full details about the request.
 	 *
-	 * @return WP_REST_Response $data
+	 * @return WP_REST_Response Prepared response object.
 	 */
 	public function prepare_item_for_response( $raw_sidebar, $request ) {
 		global $wp_registered_sidebars, $wp_registered_widgets;
@@ -258,16 +293,12 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			$sidebar['status'] = 'inactive';
 		}
 
-		if ( 'wp_inactive_widgets' === $sidebar['id'] && empty( $sidebar['name'] ) ) {
-			$sidebar['name'] = __( 'Inactive widgets', 'gutenberg' );
-		}
-
 		$fields = $this->get_fields_for_response( $request );
 		if ( rest_is_field_included( 'widgets', $fields ) ) {
 			$sidebars = wp_get_sidebars_widgets();
 			$widgets  = array_filter(
 				isset( $sidebars[ $sidebar['id'] ] ) ? $sidebars[ $sidebar['id'] ] : array(),
-				function ( $widget_id ) use ( $wp_registered_widgets ) {
+				static function ( $widget_id ) use ( $wp_registered_widgets ) {
 					return isset( $wp_registered_widgets[ $widget_id ] );
 				}
 			);
@@ -294,20 +325,21 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 		$response->add_links( $this->prepare_links( $sidebar ) );
 
 		/**
-		 * Filters a sidebar location returned from the REST API.
+		 * Filters the REST API response for a sidebar.
 		 *
-		 * Allows modification of the menu location data right before it is
-		 * returned.
+		 * @since 5.6.0
 		 *
-		 * @param WP_REST_Response $response The response object.
-		 * @param object           $sidebar  The original status object.
-		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 * @param WP_REST_Response $response    The response object.
+		 * @param array            $raw_sidebar The raw sidebar data.
+		 * @param WP_REST_Request  $request     The request object.
 		 */
-		return apply_filters( 'rest_prepare_sidebar', $response, $sidebar, $request );
+		return apply_filters( 'rest_prepare_sidebar', $response, $raw_sidebar, $request );
 	}
 
 	/**
-	 * Prepares links for the request.
+	 * Prepares links for the sidebar.
+	 *
+	 * @since 5.6.0
 	 *
 	 * @param array $sidebar Sidebar.
 	 *
@@ -322,7 +354,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $sidebar['id'] ) ),
 			),
 			'https://api.w.org/widget' => array(
-				'href'       => add_query_arg( 'sidebar', $sidebar['id'], rest_url( sprintf( '%s/%s', 'wp/v2', 'widgets' ) ) ),
+				'href'       => add_query_arg( 'sidebar', $sidebar['id'], rest_url( '/wp/v2/widgets' ) ),
 				'embeddable' => true,
 			),
 		);
@@ -346,28 +378,24 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 				'id'            => array(
 					'description' => __( 'ID of sidebar.', 'gutenberg' ),
 					'type'        => 'string',
-					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'name'          => array(
 					'description' => __( 'Unique name identifying the sidebar.', 'gutenberg' ),
 					'type'        => 'string',
-					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'description'   => array(
 					'description' => __( 'Description of sidebar.', 'gutenberg' ),
 					'type'        => 'string',
-					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'class'         => array(
 					'description' => __( 'Extra CSS class to assign to the sidebar in the Widgets interface.', 'gutenberg' ),
 					'type'        => 'string',
-					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
@@ -403,7 +431,6 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 					'description' => __( 'Status of sidebar.', 'gutenberg' ),
 					'type'        => 'string',
 					'enum'        => array( 'active', 'inactive' ),
-					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -4,13 +4,13 @@
  *
  * @package WordPress
  * @subpackage REST_API
- * @since x.x.0
+ * @since 5.6.0
  */
 
 /**
- * Core class used to access widget types via the REST API.
+ * Core class to access widget types via the REST API.
  *
- * @since x.x.0
+ * @since 5.6.0
  *
  * @see WP_REST_Controller
  */
@@ -19,7 +19,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	/**
 	 * Constructor.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 */
 	public function __construct() {
 		$this->namespace = 'wp/v2';
@@ -27,14 +27,13 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Registers the routes for the objects of the controller.
+	 * Registers the widget type routes.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @see register_rest_route()
 	 */
 	public function register_routes() {
-
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
@@ -51,11 +50,31 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<name>[a-zA-Z0-9_-]+)/form-renderer',
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'The widget type id.', 'gutenberg' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)/form-renderer',
 			array(
 				'args' => array(
-					'name'     => array(
-						'description' => __( 'Name of the widget.', 'gutenberg' ),
+					'id'       => array(
+						'description' => __( 'The widget type id.', 'gutenberg' ),
 						'type'        => 'string',
 						'required'    => true,
 					),
@@ -75,44 +94,23 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 				),
 			)
 		);
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/(?P<name>[a-zA-Z0-9_-]+)',
-			array(
-				'args'   => array(
-					'name' => array(
-						'description' => __( 'Widget name.', 'gutenberg' ),
-						'type'        => 'string',
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'get_item_permissions_check' ),
-					'args'                => $this->get_collection_params(),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
 	}
 
 	/**
-	 * Checks whether a given request has permission to read post widget types.
+	 * Checks whether a given request has permission to read widget types.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function get_items_permissions_check() {
 		return $this->check_read_permission();
 	}
 
 	/**
-	 * Retrieves all post widget types, depending on user context.
+	 * Retrieves the list of all widget types.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
@@ -130,7 +128,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	/**
 	 * Checks if a given request has access to read a widget type.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has read access for the item, WP_Error object otherwise.
@@ -140,8 +138,8 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $check ) ) {
 			return $check;
 		}
-		$widget_name = $request['name'];
-		$widget_type = $this->get_widget( $widget_name );
+		$widget_id   = $request['id'];
+		$widget_type = $this->get_widget( $widget_id );
 		if ( is_wp_error( $widget_type ) ) {
 			return $widget_type;
 		}
@@ -150,17 +148,17 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Checks whether a given widget type should be visible.
+	 * Checks whether the user can read widget types.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @return WP_Error|bool True if the widget type is visible, WP_Error otherwise.
 	 */
 	protected function check_read_permission() {
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
 			return new WP_Error(
-				'widgets_cannot_access',
-				__( 'Sorry, you are not allowed to access widgets on this site.', 'gutenberg' ),
+				'rest_cannot_manage_widgets',
+				__( 'Sorry, you are not allowed to manage widgets on this site.', 'gutenberg' ),
 				array(
 					'status' => rest_authorization_required_code(),
 				)
@@ -171,16 +169,16 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get the widget, if the name is valid.
+	 * Gets the details about the requested widget.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
-	 * @param string $name Widget name.
-	 * @return WP_Widget|WP_Error Widget type object if name is valid, WP_Error otherwise.
+	 * @param string $id The widget type id.
+	 * @return array|WP_Error The array of widget data if the name is valid, WP_Error otherwise.
 	 */
-	public function get_widget( $name ) {
+	public function get_widget( $id ) {
 		foreach ( $this->get_widgets() as $widget ) {
-			if ( $name === $widget['id'] ) {
+			if ( $id === $widget['id'] ) {
 				return $widget;
 			}
 		}
@@ -191,13 +189,17 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	/**
 	 * Normalize array of widgets.
 	 *
+	 * @since 5.6.0
+	 *
+	 * @global array $wp_registered_widgets The list of registered widgets.
+	 *
 	 * @return array Array of widgets.
 	 */
 	protected function get_widgets() {
 		global $wp_registered_widgets;
 
 		$widgets = array();
-		foreach ( $wp_registered_widgets as $widget ) {
+		foreach ( $wp_registered_widgets as  $widget ) {
 			$widget_callback = $widget['callback'];
 			unset( $widget['callback'] );
 
@@ -217,16 +219,16 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Retrieves a specific widget type.
+	 * Retrieves a single widget type from the collection.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
-		$widget_name = $request['name'];
-		$widget_type = $this->get_widget( $widget_name );
+		$widget_id   = $request['id'];
+		$widget_type = $this->get_widget( $widget_id );
 		if ( is_wp_error( $widget_type ) ) {
 			return $widget_type;
 		}
@@ -238,21 +240,21 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	/**
 	 * Prepares a widget type object for serialization.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @param array           $widget_type Widget type data.
 	 * @param WP_REST_Request $request    Full details about the request.
 	 * @return WP_REST_Response Widget type data.
 	 */
 	public function prepare_item_for_response( $widget_type, $request ) {
-
 		$fields = $this->get_fields_for_response( $request );
-		$data   = array();
+		$data   = array(
+			'id' => $widget_type['id'],
+		);
 
 		$schema       = $this->get_item_schema();
 		$extra_fields = array(
 			'name',
-			'id',
 			'description',
 			'classname',
 			'widget_class',
@@ -261,17 +263,19 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		);
 
 		foreach ( $extra_fields as $extra_field ) {
-			if ( rest_is_field_included( $extra_field, $fields ) ) {
-				if ( isset( $widget_type[ $extra_field ] ) ) {
-					$field = $widget_type[ $extra_field ];
-				} elseif ( array_key_exists( 'default', $schema['properties'][ $extra_field ] ) ) {
-					$field = $schema['properties'][ $extra_field ]['default'];
-				} else {
-					$field = '';
-				}
-
-				$data[ $extra_field ] = rest_sanitize_value_from_schema( $field, $schema['properties'][ $extra_field ] );
+			if ( ! rest_is_field_included( $extra_field, $fields ) ) {
+				continue;
 			}
+
+			if ( isset( $widget_type[ $extra_field ] ) ) {
+				$field = $widget_type[ $extra_field ];
+			} elseif ( array_key_exists( 'default', $schema['properties'][ $extra_field ] ) ) {
+				$field = $schema['properties'][ $extra_field ]['default'];
+			} else {
+				$field = '';
+			}
+
+			$data[ $extra_field ] = rest_sanitize_value_from_schema( $field, $schema['properties'][ $extra_field ] );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -283,29 +287,27 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		$response->add_links( $this->prepare_links( $widget_type ) );
 
 		/**
-		 * Filters a widget type returned from the REST API.
+		 * Filters the REST API response for a widget type.
 		 *
-		 * Allows modification of the widget type data right before it is returned.
+		 * @since 5.6.0
 		 *
-		 * @since x.x.0
-		 *
-		 * @param WP_REST_Response $response   The response object.
-		 * @param WP_Widget    $widget_type The original widget type object.
-		 * @param WP_REST_Request  $request    Request used to generate the response.
+		 * @param WP_REST_Response $response    The response object.
+		 * @param array            $widget_type The array of widget data.
+		 * @param WP_REST_Request  $request     The request object.
 		 */
 		return apply_filters( 'rest_prepare_widget_type', $response, $widget_type, $request );
 	}
 
 	/**
-	 * Prepares links for the request.
+	 * Prepares links for the widget type.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
-	 * @param WP_Widget $widget_type Widget type data.
+	 * @param array $widget_type Widget type data.
 	 * @return array Links for the given widget type.
 	 */
 	protected function prepare_links( $widget_type ) {
-		$links = array(
+		return array(
 			'collection' => array(
 				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
 			),
@@ -313,14 +315,12 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $widget_type['id'] ) ),
 			),
 		);
-
-		return $links;
 	}
 
 	/**
-	 * Retrieves the widget type' schema, conforming to JSON Schema.
+	 * Retrieves the widget type's schema, conforming to JSON Schema.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @return array Item schema data.
 	 */
@@ -334,15 +334,14 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			'title'      => 'widget-type',
 			'type'       => 'object',
 			'properties' => array(
-				'name'                        => array(
-					'description' => __( 'Unique name identifying the widget type.', 'gutenberg' ),
+				'id'                          => array(
+					'description' => __( 'Unique slug identifying the widget type.', 'gutenberg' ),
 					'type'        => 'string',
-					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'id'                          => array(
-					'description' => __( 'Unique name identifying the widget type.', 'gutenberg' ),
+				'name'                        => array(
+					'description' => __( 'Human-readable name identifying the widget type.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
@@ -393,43 +392,28 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	/**
 	 * Returns the new widget instance and the form that represents it.
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 * @since 5.7.0
-	 * @access public
 	 */
 	public function get_widget_form( $request ) {
 		$instance = $request->get_param( 'instance' );
 
-		$widget_name = $request['name'];
+		$widget_name = $request['id'];
 		$widget      = $this->get_widget( $widget_name );
 		$widget_obj  = new $widget['widget_class'];
 		$widget_obj->_set( -1 );
 		ob_start();
 
+		/** This filter is documented in wp-includes/class-wp-widget.php */
 		$instance = apply_filters( 'widget_form_callback', $instance, $widget_obj );
 
 		$return = null;
 		if ( false !== $instance ) {
 			$return = $widget_obj->form( $instance );
 
-			/**
-			 * Fires at the end of the widget control form.
-			 *
-			 * Use this hook to add extra fields to the widget form. The hook
-			 * is only fired if the value passed to the 'widget_form_callback'
-			 * hook is not false.
-			 *
-			 * Note: If the widget has no form, the text echoed from the default
-			 * form method can be hidden using CSS.
-			 *
-			 * @param WP_Widget $widget_obj The widget instance (passed by reference).
-			 * @param null $return Return null if new fields are added.
-			 * @param array $instance An array of the widget's settings.
-			 *
-			 * @since 5.2.0
-			 */
+			/** This filter is documented in wp-includes/class-wp-widget.php */
 			do_action_ref_array( 'in_widget_form', array( &$widget_obj, &$return, $instance ) );
 		}
 		$form = ob_get_clean();
@@ -445,7 +429,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves the query params for collections.
 	 *
-	 * @since 5.5.0
+	 * @since 5.6.0
 	 *
 	 * @return array Collection parameters.
 	 */
@@ -454,5 +438,4 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 		);
 	}
-
 }

--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -101,9 +101,10 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check() {
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->check_read_permission();
 	}
 

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -2,16 +2,24 @@
 /**
  * REST API: WP_REST_Widgets_Controller class
  *
- * @package Gutenberg
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 5.6.0
  */
 
 /**
- * Core class representing a controller for widgets.
+ * Core class to access widgets via the REST API.
+ *
+ * @since 5.6.0
+ *
+ * @see WP_REST_Controller
  */
 class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
 	/**
 	 * Widgets controller constructor.
+	 *
+	 * @since 5.6.0
 	 */
 	public function __construct() {
 		$this->namespace = 'wp/v2';
@@ -20,6 +28,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
 	/**
 	 * Registers the widget routes for the controller.
+	 *
+	 * @since 5.6.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -83,10 +93,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function get_items_permissions_check() {
 		return $this->permissions_check();
 	}
 
@@ -123,10 +132,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function get_item_permissions_check() {
 		return $this->permissions_check();
 	}
 
@@ -154,10 +162,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function create_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function create_item_permissions_check() {
 		return $this->permissions_check();
 	}
 
@@ -196,10 +203,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function update_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function update_item_permissions_check() {
 		return $this->permissions_check();
 	}
 
@@ -225,13 +231,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$backup_post = $_POST;
-
 		if ( isset( $request['settings'] ) ) {
+			$backup_post = $_POST;
 			$this->save_widget( $request );
+			$_POST = $backup_post;
 		}
-
-		$_POST = $backup_post;
 
 		if ( isset( $request['sidebar'] ) && $request['sidebar'] !== $sidebar_id ) {
 			$sidebar_id = $request['sidebar'];
@@ -248,10 +252,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function delete_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function delete_item_permissions_check() {
 		return $this->permissions_check();
 	}
 
@@ -275,7 +278,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
 		if ( $request['force'] ) {
 			$prepared = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
-			$this->assign_to_sidebar( $widget_id, null );
+			$this->assign_to_sidebar( $widget_id, '' );
 			$prepared->set_data(
 				array(
 					'deleted'  => true,
@@ -299,8 +302,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	/**
 	 * Assigns a widget to the given sidebar.
 	 *
+	 * @since 5.6.0
+	 *
 	 * @param string $widget_id  The widget id to assign.
-	 * @param string $sidebar_id The sidebar id to assign to.
+	 * @param string $sidebar_id The sidebar id to assign to. If empty, the widget won't be added to any sidebar.
 	 */
 	protected function assign_to_sidebar( $widget_id, $sidebar_id ) {
 		$sidebars = wp_get_sidebars_widgets();
@@ -325,6 +330,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	/**
 	 * Performs a permissions check for managing widgets.
 	 *
+	 * @since 5.6.0
+	 *
 	 * @return true|WP_Error
 	 */
 	protected function permissions_check() {
@@ -344,6 +351,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	/**
 	 * Finds the sidebar a widget belongs to.
 	 *
+	 * @since 5.6.0
+	 *
 	 * @param string $widget_id The widget id to search for.
 	 * @return string|WP_Error The found sidebar id, or a WP_Error instance if it does not exist.
 	 */
@@ -362,9 +371,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	/**
 	 * Saves the widget in the request object.
 	 *
+	 * @since 5.6.0
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
-	 * @return string
+	 * @return string The saved widget ID.
 	 */
 	protected function save_widget( $request ) {
 		global $wp_registered_widget_updates, $wp_registered_widgets;
@@ -434,6 +445,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	/**
 	 * Gets the last number used by the given widget.
 	 *
+	 * @since 5.6.0
+	 *
+	 * @global array $wp_registered_widget_updates List of widget update callbacks.
+	 *
 	 * @param string $id_base The widget id base.
 	 * @return int The last number, or zero if the widget has not been used.
 	 */
@@ -462,6 +477,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 * Prepares the widget for the REST response.
 	 *
 	 * @since 5.6.0
+	 *
+	 * @global array $wp_registered_sidebars        The registered sidebars.
+	 * @global array $wp_registered_widgets         The registered widgets.
+	 * @global array $wp_registered_widget_controls The registered widget controls.
 	 *
 	 * @param array           $item    An array containing a widget_id and sidebar_id.
 	 * @param WP_REST_Request $request Request object.
@@ -573,30 +592,34 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		$response->add_links( $this->prepare_links( $prepared ) );
 
 		/**
-		 * Filter widget REST API response.
+		 * Filters the REST API response for a widget.
+		 *
+		 * @since 5.6.0
 		 *
 		 * @param WP_REST_Response $response The response object.
-		 * @param array            $prepared Widget data.
+		 * @param array            $widget   The registered widget data.
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
-		return apply_filters( 'rest_prepare_widget', $response, $prepared, $request );
+		return apply_filters( 'rest_prepare_widget', $response, $widget, $request );
 	}
 
 	/**
-	 * Prepares links for the request.
+	 * Prepares links for the widget.
+	 *
+	 * @since 5.6.0
 	 *
 	 * @param array $prepared Widget.
 	 * @return array Links for the given widget.
 	 */
 	protected function prepare_links( $prepared ) {
-		$id_base = ( ! empty( $prepared['id_base'] ) ) ? $prepared['id_base'] : $prepared['id'];
+		$id_base = ! empty( $prepared['id_base'] ) ? $prepared['id_base'] : $prepared['id'];
 
 		return array(
-			'collection'                => array(
-				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
-			),
 			'self'                      => array(
 				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $prepared['id'] ) ),
+			),
+			'collection'                => array(
+				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
 			),
 			'about'                     => array(
 				'href'       => rest_url( sprintf( 'wp/v2/widget-types/%s', $id_base ) ),
@@ -611,9 +634,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves a widget instance.
 	 *
-	 * @param array  $sidebar sidebar data available at $wp_registered_sidebars.
-	 * @param string $id      Identifier of the widget instance.
+	 * @since 5.6.0
 	 *
+	 * @param array  $sidebar The sidebar data registered with {@see register_sidebar()}.
+	 * @param string $id      Identifier of the widget instance.
 	 * @return array Array containing the widget instance.
 	 */
 	protected function get_sidebar_widget_instance( $sidebar, $id ) {
@@ -646,10 +670,13 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Given a widget id returns an array containing information about the widget.
+	 * Returns an array containing information about the requested widget.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @global array $wp_registered_widgets The list of reigstered widgets.
 	 *
 	 * @param string $widget_id Identifier of the widget.
-	 *
 	 * @return array Array containing the the widget object, the number, and the name.
 	 */
 	protected function get_widget_info( $widget_id ) {

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -93,9 +93,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check() {
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
@@ -132,9 +133,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_item_permissions_check() {
+	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
@@ -162,9 +164,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function create_item_permissions_check() {
+	public function create_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
@@ -203,9 +206,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function update_item_permissions_check() {
+	public function update_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
@@ -252,9 +256,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function delete_item_permissions_check() {
+	public function delete_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -56,10 +56,11 @@ function gutenberg_register_sidebars_and_widgets_endpoint() {
 	$sidebars = new WP_REST_Sidebars_Controller();
 	$sidebars->register_routes();
 
-	$widget_types = new WP_REST_Widget_Types_Controller();
-	$widget_types->register_routes();
 	$widgets = new WP_REST_Widgets_Controller();
 	$widgets->register_routes();
+
+	$widget_types = new WP_REST_Widget_Types_Controller();
+	$widget_types->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_sidebars_and_widgets_endpoint' );
 

--- a/phpunit/class-rest-widget-types-controller-test.php
+++ b/phpunit/class-rest-widget-types-controller-test.php
@@ -68,10 +68,10 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey( '/wp/v2/widget-types', $routes );
 		$this->assertCount( 1, $routes['/wp/v2/widget-types'] );
-		$this->assertArrayHasKey( '/wp/v2/widget-types/(?P<name>[a-zA-Z0-9_-]+)', $routes );
-		$this->assertCount( 1, $routes['/wp/v2/widget-types/(?P<name>[a-zA-Z0-9_-]+)'] );
-		$this->assertArrayHasKey( '/wp/v2/widget-types/(?P<name>[a-zA-Z0-9_-]+)/form-renderer', $routes );
-		$this->assertCount( 1, $routes['/wp/v2/widget-types/(?P<name>[a-zA-Z0-9_-]+)/form-renderer'] );
+		$this->assertArrayHasKey( '/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)', $routes );
+		$this->assertCount( 1, $routes['/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)'] );
+		$this->assertArrayHasKey( '/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)/form-renderer', $routes );
+		$this->assertCount( 1, $routes['/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)/form-renderer'] );
 	}
 
 	/**
@@ -179,7 +179,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( self::$subscriber_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/widget-types' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
 	}
 
 	/**
@@ -189,7 +189,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( self::$subscriber_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/widget-types/calendar' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
 	}
 
 	/**
@@ -199,7 +199,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( 0 );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/widget-types' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
 	}
 
 	/**
@@ -209,7 +209,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( 0 );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/widget-types/calendar' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
 	}
 
 	/**

--- a/phpunit/class-rest-widget-types-controller-test.php
+++ b/phpunit/class-rest-widget-types-controller-test.php
@@ -1,28 +1,27 @@
 <?php
 /**
- * WP_REST_Widget_Types_Controller tests.
+ * WP_Test_REST_Widget_Types_Controller tests.
  *
  * @package WordPress
  * @subpackage REST_API
- * @since x.x.0
+ * @since 5.6.0
  */
 
 /**
  * Tests for WP_REST_Widget_Types_Controller.
  *
- * @since x.x.0
+ * @since 5.6.0
  *
  * @covers WP_REST_Widget_Types_Controller
  *
- * @group restapi-widgets
  * @group restapi
  */
-class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase {
+class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testcase {
 
 	/**
 	 * Admin user ID.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @var int $subscriber_id
 	 */
@@ -31,7 +30,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	/**
 	 * Subscriber user ID.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @var int $subscriber_id
 	 */
@@ -40,7 +39,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	/**
 	 * Create fake data before our tests run.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
@@ -63,7 +62,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
@@ -76,7 +75,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_context_param() {
 		// Collection.
@@ -94,7 +93,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_items() {
 		wp_set_current_user( self::$admin_id );
@@ -111,7 +110,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_item() {
 		$widget_name = 'calendar';
@@ -124,7 +123,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_widget_legacy() {
 		$widget_id = 'legacy';
@@ -142,7 +141,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_widget_invalid_name() {
 		$widget_type = 'fake';
@@ -154,7 +153,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_item_schema() {
 		wp_set_current_user( self::$admin_id );
@@ -174,7 +173,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_items_wrong_permission() {
 		wp_set_current_user( self::$subscriber_id );
@@ -184,7 +183,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_item_wrong_permission() {
 		wp_set_current_user( self::$subscriber_id );
@@ -194,7 +193,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
@@ -204,7 +203,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_item_no_permission() {
 		wp_set_current_user( 0 );
@@ -214,7 +213,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_prepare_item() {
 		$endpoint    = new WP_REST_Widget_Types_Controller;
@@ -228,7 +227,7 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 	/**
 	 * Util check widget type object against.
 	 *
-	 * @since x.x.0
+	 * @since 5.6.0
 	 *
 	 * @param WP_Widget_Type $widget_type Sample widget type.
 	 * @param array          $data Data to compare against.
@@ -243,7 +242,6 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 			'control_options',
 			'widget_options',
 			'widget_class',
-
 		);
 
 		foreach ( $extra_fields as $extra_field ) {
@@ -254,7 +252,6 @@ class REST_Widget_Types_Controller_Test extends WP_Test_REST_Controller_Testcase
 
 		// Test links.
 		$this->assertSame( rest_url( 'wp/v2/widget-types' ), $links['collection'][0]['href'] );
-		// $this->assertSame( rest_url( 'wp/v2/widget-types/' . $widget_type->id_base ), $links['self'][0]['href'] );
 	}
 
 	public function test_get_widget_form() {

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -923,7 +923,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
 	}
 
 	/**
@@ -939,7 +939,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
 	}
 
 	/**

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -89,9 +89,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		);
 	}
 
-	/**
-	 *
-	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -144,7 +141,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
@@ -153,13 +150,13 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_context_param() {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_items_no_widgets() {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets' );
@@ -170,7 +167,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
@@ -180,7 +177,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_items_wrong_permission_author() {
 		wp_set_current_user( self::$author_id );
@@ -190,7 +187,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_items() {
 		$this->setup_widget(
@@ -301,7 +298,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_item() {
 		$this->setup_widget(
@@ -341,7 +338,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_item_no_permission() {
 		wp_set_current_user( 0 );
@@ -367,7 +364,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_item_wrong_permission_author() {
 		wp_set_current_user( self::$author_id );
@@ -391,7 +388,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_create_item() {
 		$this->setup_sidebar(
@@ -427,7 +424,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_create_item_multiple_in_a_row() {
 		$this->setup_sidebar(
@@ -487,7 +484,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_create_item_second_instance() {
 		$this->setup_widget(
@@ -530,7 +527,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_update_item() {
 		$this->setup_widget(
@@ -580,7 +577,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_update_item_reassign_sidebar() {
 		$this->setup_widget(
@@ -624,7 +621,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_update_item_shouldnt_require_id_base() {
 		$this->setup_widget(
@@ -739,21 +736,21 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_update_item_legacy_widget_1() {
 		$this->do_test_update_item_legacy_widget( 'testwidget-1' );
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_update_item_legacy_widget_2() {
 		$this->do_test_update_item_legacy_widget( 'testwidget' );
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function do_test_update_item_legacy_widget( $widget_id ) {
 		// @TODO: Use @dataProvider instead (it doesn't work with custom constructors like the one we have in this class)
@@ -826,21 +823,21 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_create_item_legacy_widget_1() {
 		$this->do_test_create_item_legacy_widget( 'testwidget-1' );
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_create_item_legacy_widget_2() {
 		$this->do_test_create_item_legacy_widget( 'testwidget' );
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function do_test_create_item_legacy_widget( $widget_id ) {
 		// @TODO: Use @dataProvider instead (it doesn't work with custom constructors like the one we have in this class)
@@ -914,7 +911,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_update_item_no_permission() {
 		wp_set_current_user( 0 );
@@ -930,7 +927,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_update_item_wrong_permission_author() {
 		wp_set_current_user( self::$author_id );
@@ -986,7 +983,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_delete_item() {
 		$this->setup_widget(
@@ -1030,7 +1027,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_delete_item_force() {
 		$this->setup_widget(
@@ -1083,7 +1080,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_delete_item_logged_out() {
 		wp_set_current_user( 0 );
@@ -1110,7 +1107,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_delete_item_author() {
 		wp_set_current_user( self::$author_id );
@@ -1143,7 +1140,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * @ticket 51460
 	 */
 	public function test_get_item_schema() {
 		wp_set_current_user( self::$admin_id );


### PR DESCRIPTION
Various bug fixes and code quality improvements were made by @TimothyBJacobs to the Widget REST API endpoints while they were being prepared to be merged into Core for WP 5.6 in https://core.trac.wordpress.org/ticket/51460.

This pulls those changes (https://github.com/TimothyBJacobs/wordpress-develop/commit/bf4845d70b7a38a8b66527b985dc097e614d97dd) into the Gutenberg plugin.