### PR TITLE
Server side renderer: Fix errors in template part editor context

### DIFF
--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -18,15 +18,14 @@ const EMPTY_OBJECT = {};
 const ExportedServerSideRender = withSelect( ( select ) => {
 	const coreEditorSelect = select( 'core/editor' );
 	if ( coreEditorSelect ) {
-		const currentPost = coreEditorSelect.getCurrentPost();
-		if ( currentPost ) {
+		const currentPostId = coreEditorSelect.getCurrentPostId();
+		// For templates and template parts we use a custom ID format.
+		// Since they aren't real posts, we don't want to use their ID
+		// for server-side rendering. Since they use a string based ID,
+		// we can assume real post IDs are numbers.
+		if ( currentPostId && typeof currentPostId.id === 'number' ) {
 			return {
-				// For templates and template parts we use a custom ID format.
-				// To preserve the original ID that WordPress assigns to the post
-				// we save it to `wp_id` field. We want to make sure that we
-				// always use the original ID in this case. Since we
-				// expect a post database ID here.
-				currentPostId: currentPost.wp_id || currentPost.id,
+				currentPostId,
 			};
 		}
 	}

--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -21,6 +21,11 @@ const ExportedServerSideRender = withSelect( ( select ) => {
 		const currentPost = coreEditorSelect.getCurrentPost();
 		if ( currentPost ) {
 			return {
+				// For templates and template parts we use a custom ID format.
+				// To preserve the original ID that WordPress assigns to the post
+				// we save it to `wp_id` field. We want to make sure that we
+				// always use the original ID in this case. Since we
+				// expect a post database ID here.
 				currentPostId: currentPost.wp_id || currentPost.id,
 			};
 		}

--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -18,10 +18,10 @@ const EMPTY_OBJECT = {};
 const ExportedServerSideRender = withSelect( ( select ) => {
 	const coreEditorSelect = select( 'core/editor' );
 	if ( coreEditorSelect ) {
-		const currentPostId = coreEditorSelect.getCurrentPostId();
-		if ( currentPostId ) {
+		const currentPost = coreEditorSelect.getCurrentPost();
+		if ( currentPost ) {
 			return {
-				currentPostId,
+				currentPostId: currentPost.wp_id || currentPost.id,
 			};
 		}
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes https://github.com/WordPress/gutenberg/issues/29237 
Fixes https://github.com/WordPress/gutenberg/issues/29236
In https://github.com/WordPress/gutenberg/pull/27910 we introduced a custom ID for template and template parts. Server side renderer tried to use these IDs but failed since they aren't real post IDs. To fix this, this PR tries to use `wp_id` if possible, otherwise fallback to `id`.

## How has this been tested?
1. Open wp-admin
2. Go to Themes -> Template Parts
3. Edit a template part
4. Insert any of these blocks:
    - Page List
    - RSS
    - Archives
    - Calendar
    - Latest Comments 
    - Post Comments Count
5. See error: "Error loading block: Invalid parameter(s): post_id"

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
