### PR TITLE
WP Block Styles: Only load in the editor if a theme opts in

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -376,7 +376,7 @@ function gutenberg_register_packages_styles( $styles ) {
 	);
 
 	global $editor_styles;
-	if ( count( $editor_styles ) === 0 ) {
+	if ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 ) {
 		// Always include visual styles is no $editor_styles are declared, so the editor never appears broken.
 		$wp_edit_blocks_dependencies[] = 'wp-block-library-theme';
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -377,7 +377,7 @@ function gutenberg_register_packages_styles( $styles ) {
 
 	global $editor_styles;
 	if ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 ) {
-		// Always include visual styles is no $editor_styles are declared, so the editor never appears broken.
+		// Include opinionated block styles if no $editor_styles are declared, so the editor never appears broken.
 		$wp_edit_blocks_dependencies[] = 'wp-block-library-theme';
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -368,18 +368,24 @@ function gutenberg_register_packages_styles( $styles ) {
 	);
 	$styles->add_data( 'wp-format-library', 'rtl', 'replace' );
 
+	$wp_edit_blocks_dependencies = array(
+		'wp-components',
+		'wp-editor',
+		'wp-block-library',
+		'wp-reusable-blocks',
+	);
+
+	global $editor_styles;
+	if ( count( $editor_styles ) === 0 ) {
+		// Always include visual styles is no $editor_styles are declared, so the editor never appears broken.
+		$wp_edit_blocks_dependencies[] = 'wp-block-library-theme';
+	}
+
 	gutenberg_override_style(
 		$styles,
 		'wp-edit-blocks',
 		gutenberg_url( 'build/block-library/editor.css' ),
-		array(
-			'wp-components',
-			'wp-editor',
-			'wp-block-library',
-			'wp-reusable-blocks',
-			// Always include visual styles so the editor never appears broken.
-			'wp-block-library-theme',
-		),
+		$wp_edit_blocks_dependencies,
 		filemtime( gutenberg_dir_path() . 'build/block-library/editor.css' )
 	);
 	$styles->add_data( 'wp-edit-blocks', 'rtl', 'replace' );


### PR DESCRIPTION
## Description
The current behaviour is to always load opinionated block styles regardless of whether the theme uses them. This is a safe fall back for cases where a theme doesn't have any editor styles - so that the blocks in the editor don't look totally broken. However it has the drawback of overriding editor styles provided by the theme, meaning that theme editor styles end up becoming larger and more complex than necessary, to override these rules.

This PR changes that behaviour so that:
- For themes that opt into wp-block-styles, we always load the opinionated block styles (Independent Publisher 2)
- For themes that don't opt into wp-block-styles and don't provide editor styles, we always load the opinionated block styles (Kaura)
- For themes that don't opt into wp-block-styles and provide editor styles we don't load the opinionated block styles (Libre 2)

## How has this been tested?
With Independent Publisher 2, Karuna Libre 2

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
