### PR TITLE
Implement skip serialization for color key in style att

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { capitalize, has, get, startsWith } from 'lodash';
+import { capitalize, get, has, omitBy, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
 import {
+	getBlockSupport,
 	hasBlockSupport,
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 } from '@wordpress/blocks';
@@ -97,6 +98,22 @@ function addAttribute( settings ) {
 }
 
 /**
+ * Filters a style object returning only the keys
+ * that are serializable for a given block.
+ *
+ * @param {Object} style Input style object to filter.
+ * @param {Object} blockSupports Info about block supports.
+ * @return {Object} Filtered style.
+ */
+export function omitNonSerializableKeys( style, blockSupports ) {
+	return omitBy(
+		style,
+		( value, key ) =>
+			!! blockSupports[ key ]?.__experimentalSkipSerialization
+	);
+}
+
+/**
  * Override props assigned to save component to inject the CSS variables definition.
  *
  * @param  {Object} props      Additional props applied to save element
@@ -110,8 +127,11 @@ export function addSaveProps( props, blockType, attributes ) {
 	}
 
 	const { style } = attributes;
+	const filteredStyle = omitNonSerializableKeys( style, {
+		[ COLOR_SUPPORT_KEY ]: getBlockSupport( blockType, COLOR_SUPPORT_KEY ),
+	} );
 	props.style = {
-		...getInlineStyles( style ),
+		...getInlineStyles( filteredStyle ),
 		...props.style,
 	};
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -105,7 +105,7 @@ function addAttribute( settings ) {
  * @param {Object} blockSupports Info about block supports.
  * @return {Object} Filtered style.
  */
-export function omitNonSerializableKeys( style, blockSupports ) {
+export function omitKeysNotToSerialize( style, blockSupports ) {
 	return omitBy(
 		style,
 		( value, key ) =>
@@ -127,7 +127,7 @@ export function addSaveProps( props, blockType, attributes ) {
 	}
 
 	const { style } = attributes;
-	const filteredStyle = omitNonSerializableKeys( style, {
+	const filteredStyle = omitKeysNotToSerialize( style, {
 		[ COLOR_SUPPORT_KEY ]: getBlockSupport( blockType, COLOR_SUPPORT_KEY ),
 	} );
 	props.style = {

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getInlineStyles } from '../style';
+import { getInlineStyles, omitNonSerializableKeys } from '../style';
 
 describe( 'getInlineStyles', () => {
 	it( 'should return an empty object when called with undefined', () => {
@@ -25,6 +25,34 @@ describe( 'getInlineStyles', () => {
 			color: 'red',
 			lineHeight: 1.5,
 			fontSize: 10,
+		} );
+	} );
+} );
+
+describe( 'omitNonSerializableKeys', () => {
+	it( 'should return the same style if no keys are skipped from serialization', () => {
+		const style = {
+			color: { text: 'red' },
+			lineHeigh: 2,
+		};
+		expect( omitNonSerializableKeys( style, {} ) ).toEqual( {
+			color: { text: 'red' },
+			lineHeigh: 2,
+		} );
+	} );
+
+	it( 'should omit the color key if it is skipped for serialization', () => {
+		const style = {
+			color: { text: 'red' },
+			lineHeigh: 2,
+		};
+		const blockSupports = {
+			color: {
+				__experimentalSkipSerialization: true,
+			},
+		};
+		expect( omitNonSerializableKeys( style, blockSupports ) ).toEqual( {
+			lineHeigh: 2,
 		} );
 	} );
 } );

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getInlineStyles, omitNonSerializableKeys } from '../style';
+import { getInlineStyles, omitKeysNotToSerialize } from '../style';
 
 describe( 'getInlineStyles', () => {
 	it( 'should return an empty object when called with undefined', () => {
@@ -29,13 +29,13 @@ describe( 'getInlineStyles', () => {
 	} );
 } );
 
-describe( 'omitNonSerializableKeys', () => {
+describe( 'omitKeysNotToSerialize', () => {
 	it( 'should return the same style if no keys are skipped from serialization', () => {
 		const style = {
 			color: { text: 'red' },
 			lineHeight: 2,
 		};
-		expect( omitNonSerializableKeys( style, {} ) ).toEqual( {
+		expect( omitKeysNotToSerialize( style, {} ) ).toEqual( {
 			color: { text: 'red' },
 			lineHeight: 2,
 		} );
@@ -51,7 +51,7 @@ describe( 'omitNonSerializableKeys', () => {
 				__experimentalSkipSerialization: true,
 			},
 		};
-		expect( omitNonSerializableKeys( style, blockSupports ) ).toEqual( {
+		expect( omitKeysNotToSerialize( style, blockSupports ) ).toEqual( {
 			lineHeight: 2,
 		} );
 	} );

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -33,18 +33,18 @@ describe( 'omitNonSerializableKeys', () => {
 	it( 'should return the same style if no keys are skipped from serialization', () => {
 		const style = {
 			color: { text: 'red' },
-			lineHeigh: 2,
+			lineHeight: 2,
 		};
 		expect( omitNonSerializableKeys( style, {} ) ).toEqual( {
 			color: { text: 'red' },
-			lineHeigh: 2,
+			lineHeight: 2,
 		} );
 	} );
 
 	it( 'should omit the color key if it is skipped for serialization', () => {
 		const style = {
 			color: { text: 'red' },
-			lineHeigh: 2,
+			lineHeight: 2,
 		};
 		const blockSupports = {
 			color: {
@@ -52,7 +52,7 @@ describe( 'omitNonSerializableKeys', () => {
 			},
 		};
 		expect( omitNonSerializableKeys( style, blockSupports ) ).toEqual( {
-			lineHeigh: 2,
+			lineHeight: 2,
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/28913

In https://github.com/WordPress/gutenberg/pull/29142 we added a mechanism for the color hook to skip serialization for preset colors. This adds the same logic for custom colors, that are serialized as inline CSS.

## How to test

- Add this to the block supports object of the social links block:

```
 "color": {
    "__experimentalSkipSerialization": true
},
"__experimentalSelector": ".wp-social-link"
```

- Compile this branch, go to the post editor, and add a social links block.
- Verify that there's an additional color panel with labels "Text color" and "Background color".

![Captura de ecrã de 2021-02-23 12-25-17](https://user-images.githubusercontent.com/583546/108837253-41a75780-75d2-11eb-9e55-58249f8f009c.png)

- Select a custom color for the text and a custom color for the background. This shouldn't have any visual effect on the block.
- Open the code editor and verify that the block attributes have the values you picked but there's no style DOM attribute. It should look like this:

```
<!-- wp:social-links {"style":{"color":{"text":"#157ba6","background":"#c31633"}}} -->
<ul class="wp-block-social-links"> ... </ul>
<!-- /wp:social-links -->
```

