### PR TITLE
Template Part: Update switching trigger

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -8,7 +8,12 @@ import {
 	Warning,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { Button, Dropdown, ToolbarGroup, Spinner } from '@wordpress/components';
+import {
+	Dropdown,
+	ToolbarGroup,
+	ToolbarButton,
+	Spinner,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -108,7 +113,7 @@ export default function TemplatePartEdit( {
 								contentClassName="wp-block-template-part__preview-dropdown-content"
 								position="bottom right left"
 								renderToggle={ ( { isOpen, onToggle } ) => (
-									<Button
+									<ToolbarButton
 										aria-expanded={ isOpen }
 										onClick={ onToggle }
 										// Disable when open to prevent odd FireFox bug causing reopening.
@@ -116,7 +121,7 @@ export default function TemplatePartEdit( {
 										disabled={ isOpen }
 									>
 										{ __( 'Replace' ) }
-									</Button>
+									</ToolbarButton>
 								) }
 								renderContent={ ( { onClose } ) => (
 									<TemplatePartSelection

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -8,14 +8,8 @@ import {
 	Warning,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	Dropdown,
-	ToolbarGroup,
-	ToolbarButton,
-	Spinner,
-} from '@wordpress/components';
+import { Button, Dropdown, ToolbarGroup, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { chevronUp, chevronDown } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -114,17 +108,15 @@ export default function TemplatePartEdit( {
 								contentClassName="wp-block-template-part__preview-dropdown-content"
 								position="bottom right left"
 								renderToggle={ ( { isOpen, onToggle } ) => (
-									<ToolbarButton
+									<Button
 										aria-expanded={ isOpen }
-										icon={
-											isOpen ? chevronUp : chevronDown
-										}
-										label={ __( 'Choose another' ) }
 										onClick={ onToggle }
 										// Disable when open to prevent odd FireFox bug causing reopening.
 										// As noted in https://github.com/WordPress/gutenberg/pull/24990#issuecomment-689094119 .
 										disabled={ isOpen }
-									/>
+									>
+										{ __( 'Replace' ) }
+									</Button>
 								) }
 								renderContent={ ( { onClose } ) => (
 									<TemplatePartSelection


### PR DESCRIPTION
It is currently possible to switch Template Parts by clicking the chevron icon in the Toolbar:

<img width="579" alt="Screenshot 2021-02-23 at 13 03 25" src="https://user-images.githubusercontent.com/846565/108851875-d6af4e00-75dc-11eb-978a-7b574a5e875f.png">

The icon used here is however a little ambiguous. 

In this PR I'm exploring alternatives that might better communicate what will happen when the button is clicked. My initial iteration takes inspiration from the Image block, and uses a simple text button with "Replace" as a label:

<img width="577" alt="Screenshot 2021-02-23 at 13 04 18" src="https://user-images.githubusercontent.com/846565/108852032-01010b80-75dd-11eb-8084-82258cf4e7c8.png">

Edit: It is worth noting that in the long term I suspect this affordance will move to the Transform menu. But that is not 100% clear yet. This is very much proposed as an interim step that improves the existing UX.