### PR TITLE
Block Supports: Use empty initial value for border-radius

### DIFF
--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -4,11 +4,6 @@
 import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { cleanEmptyObject } from './utils';
-
 const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUE = 50;
 
@@ -25,19 +20,15 @@ export function BorderRadiusEdit( props ) {
 	} = props;
 
 	const onChange = ( newRadius ) => {
-		let newStyle = {
-			...style,
-			border: {
-				...style?.border,
-				radius: newRadius,
+		setAttributes( {
+			style: {
+				...style,
+				border: {
+					...style?.border,
+					radius: newRadius,
+				},
 			},
-		};
-
-		if ( newRadius === undefined ) {
-			newStyle = cleanEmptyObject( newStyle );
-		}
-
-		setAttributes( { style: newStyle } );
+		} );
 	};
 
 	return (
@@ -46,7 +37,7 @@ export function BorderRadiusEdit( props ) {
 			label={ __( 'Border radius' ) }
 			min={ MIN_BORDER_RADIUS_VALUE }
 			max={ MAX_BORDER_RADIUS_VALUE }
-			initialPosition={ 0 }
+			initialPosition=""
 			allowReset
 			onChange={ onChange }
 		/>


### PR DESCRIPTION
As suggested in #29210. Initially, this was a PR for just the Button block. When #30194 landed it made the initial version of this PR not applicable and this PR has been rebased to instead change the block supports hook/UI. As I understand there would still be a way to make this apply only to the Button block but it seems like the saner default for the hook in general.

## How has this been tested?
Putting buttons of various styles in a post and verifying their border-radius setting starts out empty. Then applying a border-radius and verifying that it resets to empty when reset. 

## Types of changes
Bug fix #29210

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
