### PR TITLE
Do not use __experimentalSelector to check the panel title 

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -107,7 +107,7 @@ function getPanelTitle( context ) {
 	}
 
 	let panelTitle = blockType.title;
-	if ( 'object' === typeof blockType?.supports?.__experimentalSelector ) {
+	if ( context?.title ) {
 		panelTitle += ` (${ context.title })`;
 	}
 	return panelTitle;


### PR DESCRIPTION
While working on https://github.com/WordPress/gutenberg/issues/28913 to add block selectors per property I've noticed we check whether `__experimentalSelector` is present to prepare the panel title.

We can simply check whether the `context.title` is present, which helps in refactoring / work with the experimental selector.

### How has this been tested?

- Go to the site editor.
- Open the Global Styles sidebar, go to the blocks tab.
- Verify that each heading (h1...h6) has a separate panel and it works.

![Captura de ecrã de 2021-02-23 18-54-04](https://user-images.githubusercontent.com/583546/108885855-95cd2e80-7608-11eb-97a0-3e9a8a7b9639.png)
