### PR TITLE
Add enableCustomSpacing to block editor settings

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -127,7 +127,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 
 		return {
 			canUseUnfilteredHTML: canUserUseUnfilteredHTML(),
-			reusableBlocks: select( 'core' ).getEntityRecords(
+			reusableBlocks: select( coreStore ).getEntityRecords(
 				'postType',
 				'wp_block',
 				/**
@@ -151,11 +151,11 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		() => ( {
 			...pick( settings, [
 				'__experimentalBlockDirectory',
-				'__experimentalBlockPatterns',
 				'__experimentalBlockPatternCategories',
+				'__experimentalBlockPatterns',
 				'__experimentalFeatures',
-				'__experimentalGlobalStylesUserEntityId',
 				'__experimentalGlobalStylesBaseStyles',
+				'__experimentalGlobalStylesUserEntityId',
 				'__experimentalPreferredStyleVariations',
 				'__experimentalSetIsInserterOpened',
 				'alignWide',
@@ -167,16 +167,17 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'disableCustomColors',
 				'disableCustomFontSizes',
 				'disableCustomGradients',
-				'enableCustomUnits',
 				'enableCustomLineHeight',
+				'enableCustomSpacing',
+				'enableCustomUnits',
 				'focusMode',
 				'fontSizes',
 				'gradients',
 				'hasFixedToolbar',
 				'hasReducedUI',
+				'imageDimensions',
 				'imageEditing',
 				'imageSizes',
-				'imageDimensions',
 				'isRTL',
 				'keepCaretInsideBlock',
 				'maxWidth',


### PR DESCRIPTION
## Description

Fixes https://core.trac.wordpress.org/ticket/52619.

This fixes the Spacing control not appearing when global styles are disabled and `enableCustomSpacing` is set to `true` in the post editor settings. This means that the Spacing control will appear in Core when the theme has `add_theme_support( 'custom-spacing' );`.

## How has this been tested?

1. Ensure that you are testing Gutenberg against WordPress 5.7 RC 1 or against the latest Core `trunk`. This is the default Gutenberg dev environment setup.

1. Ensure that you are using a theme with `add_theme_support( 'custom-spacing' );` e.g. Twenty Twenty-one.

1. Simulate Core and disable global styles by commenting out this line in `lib/global-styles.php`:

   ```diff
   -add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
   +// add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
   ```

1. Insert a Cover block.

1. The Spacing panel should appear in the block inspector.