### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,7 +107,7 @@
 /packages/block-editor/src/components/rich-text @ellatrix @cameronvoell @guarani
 
 # Project Management
-/.github                                        @mapk @karmatosed
+/.github
 /packages/project-management-automation
 
 # wp-env


### PR DESCRIPTION
## Description
On a recent PR I noticed Mark and Tammie (who're no longer contributing as regularly to the project) are still listed as code owners. I asked them and they said they'd both like to be removed.