### PR TITLE
Fix legacy button center alignments inside the buttons block

### DIFF
--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -27,6 +27,13 @@ $blocks-block__margin: 0.5em;
 			box-shadow: none;
 		}
 	}
+
+	// Back compat: Inner button blocks previously had their own alignment
+	// options. Forcing them to 100% width in the flex container replicates
+	// that these were block level elements that took up the full width.
+	.wp-block[data-align] {
+		width: 100%;
+	}
 }
 
 .wp-block[data-align="center"] > .wp-block-buttons {

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -32,6 +32,9 @@ $blocks-block__margin: 0.5em;
 	// options. Forcing them to 100% width in the flex container replicates
 	// that these were block level elements that took up the full width.
 	//
+	// This back compat rule is ignored if the user decides to use the
+	// newer justification options on the button block, hence the :not.
+	//
 	// Disable the stylelint rule, otherwise this selector is ugly!
 	/* stylelint-disable indentation */
 	&:not(

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -31,10 +31,26 @@ $blocks-block__margin: 0.5em;
 	// Back compat: Inner button blocks previously had their own alignment
 	// options. Forcing them to 100% width in the flex container replicates
 	// that these were block level elements that took up the full width.
-	.wp-block[data-align="center"] {
-		margin-left: 0;
-		margin-right: 0;
+	//
+	// Disable the stylelint rule, otherwise this selector is ugly!
+	/* stylelint-disable indentation */
+	&:not(
+		.is-content-justification-space-between,
+		.is-content-justification-right,
+		.is-content-justification-left,
+		.is-content-justification-center
+	) .wp-block[data-align="center"] {
+	/* stylelint-enable indentation */
+		margin-left: auto;
+		margin-right: auto;
+		margin-top: 0;
 		width: 100%;
+
+		.wp-block-button {
+			// Some margin hacks are needed, since margin doesn't seem to
+			// collapse in the same way when a parent layout it flex.
+			margin-bottom: 0;
+		}
 	}
 }
 

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -31,7 +31,9 @@ $blocks-block__margin: 0.5em;
 	// Back compat: Inner button blocks previously had their own alignment
 	// options. Forcing them to 100% width in the flex container replicates
 	// that these were block level elements that took up the full width.
-	.wp-block[data-align] {
+	.wp-block[data-align="center"] {
+		margin-left: 0;
+		margin-right: 0;
 		width: 100%;
 	}
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -100,9 +100,19 @@ $blocks-block__margin: 0.5em;
 	// Back compat: Inner button blocks previously had their own alignment
 	// options. Forcing them to 100% width in the flex container replicates
 	// that these were block level elements that took up the full width.
-	.wp-block-button.aligncenter {
-		margin-left: 0;
-		margin-right: 0;
+	//
+	// Disable the stylelint rule, otherwise this selector is ugly!
+	/* stylelint-disable indentation */
+	&:not(
+		.is-content-justification-space-between,
+		.is-content-justification-right,
+		.is-content-justification-left,
+		.is-content-justification-center
+	) .wp-block-button.aligncenter {
+	/* stylelint-enable indentation */
+		margin-left: auto;
+		margin-right: auto;
+		margin-bottom: $blocks-block__margin;
 		width: 100%;
 	}
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -101,6 +101,9 @@ $blocks-block__margin: 0.5em;
 	// options. Forcing them to 100% width in the flex container replicates
 	// that these were block level elements that took up the full width.
 	//
+	// This back compat rule is ignored if the user decides to use the
+	// newer justification options on the button block, hence the :not.
+	//
 	// Disable the stylelint rule, otherwise this selector is ugly!
 	/* stylelint-disable indentation */
 	&:not(

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -70,7 +70,7 @@ $blocks-block__margin: 0.5em;
 		justify-content: space-between;
 	}
 
-	// Kept for backward compatibiity.
+	// Kept for backward compatibility.
 	&.aligncenter {
 		text-align: center;
 	}

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -66,6 +66,10 @@ $blocks-block__margin: 0.5em;
 		}
 	}
 
+	&.is-content-justification-space-between {
+		justify-content: space-between;
+	}
+
 	// Kept for backward compatibiity.
 	&.aligncenter {
 		text-align: center;
@@ -91,9 +95,5 @@ $blocks-block__margin: 0.5em;
 			/*rtl:ignore*/
 			margin-left: 0;
 		}
-	}
-
-	&.is-content-justification-space-between {
-		justify-content: space-between;
 	}
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -96,4 +96,13 @@ $blocks-block__margin: 0.5em;
 			margin-left: 0;
 		}
 	}
+
+	// Back compat: Inner button blocks previously had their own alignment
+	// options. Forcing them to 100% width in the flex container replicates
+	// that these were block level elements that took up the full width.
+	.wp-block-button.aligncenter {
+		margin-left: 0;
+		margin-right: 0;
+		width: 100%;
+	}
 }


### PR DESCRIPTION
## Description
Partly addresses #28957.

How this regression came about is a bit of a long story.

Before https://github.com/WordPress/gutenberg/pull/26380, users could set their own alignment on button blocks inside the buttons container. #26380 removed the alignment options, but blocks still kept their visual alignments.

At a similar time https://github.com/WordPress/gutenberg/pull/23168 made the buttons block a flex container. Individually aligned button blocks within buttons stopped working and there was no way to remove the alignments.

This change restores the visual appearance of center aligned button blocks within the buttons block.

I haven't been able to find a solution for left/right alignments (yet).

## How has this been tested?
E2E tests are hard to implement, so no automated testing. Visual regression testing would be ideal for this issue.

1. Paste the following markup in the code editor and switch back to visual:
```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"align":"center"} -->
<div class="wp-block-button aligncenter"><a class="wp-block-button__link">center aligned button (inside buttons)</a></div>
<!-- /wp:button -->

<!-- wp:button {"align":"center"} -->
<div class="wp-block-button aligncenter"><a class="wp-block-button__link">center aligned button (inside buttons)</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:button {"align":"center"} -->
<div class="wp-block-button aligncenter"><a class="wp-block-button__link">center aligned button (outside buttons)</a></div>
<!-- /wp:button -->

<!-- wp:button {"align":"center"} -->
<div class="wp-block-button aligncenter"><a class="wp-block-button__link">center aligned button (outside buttons)</a></div>
<!-- /wp:button -->

<!-- wp:buttons {"contentJustification":"center","orientation":"vertical"} -->
<div class="wp-block-buttons is-content-justification-center is-vertical"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link">Vertical centered buttons</a></div>
<!-- /wp:button -->

<!-- wp:button {"className":"is-style-fill"} -->
<div class="wp-block-button is-style-fill"><a class="wp-block-button__link">Vertical centered buttons</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```
2. It should look like the first screenshot (theme styles disabled)
3. Preview the post
4. It should look like the second screenshot, but may be theme dependent.
5. Try the justification options in the buttons block, it should override the legacy alignment.

## Screenshots <!-- if applicable -->
### Editor
<img width="563" alt="Screenshot 2021-02-24 at 2 20 41 pm" src="https://user-images.githubusercontent.com/677833/108957176-fe211c00-76ab-11eb-95e4-0f1642ef5077.png">

### Front end
<img width="833" alt="Screenshot 2021-02-24 at 2 23 51 pm" src="https://user-images.githubusercontent.com/677833/108957203-0aa57480-76ac-11eb-9148-3005270693ee.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
