### PR TITLE
Fix shortcode not showing in the widgets screen

### DIFF
--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -64,7 +64,10 @@ class WP_Widget_Block extends WP_Widget {
 		$content = $wp_embed->run_shortcode( $instance['content'] );
 		$content = $wp_embed->autoembed( $content );
 
-		echo do_blocks( $content );
+		$content = do_blocks( $content );
+		$content = do_shortcode( $content );
+
+		echo $content;
 
 		echo $args['after_widget'];
 	}

--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -45,7 +45,7 @@ describe( 'Widgets screen', () => {
 		await activateTheme( 'twentytwentyone' );
 	} );
 
-	async function getParagraphBlockInGlobalInserter() {
+	async function getBlockInGlobalInserter( blockName ) {
 		await page.click(
 			'button[aria-pressed="false"][aria-label="Add block"]'
 		);
@@ -58,11 +58,11 @@ describe( 'Widgets screen', () => {
 		const categoryHeader = await blockLibrary.$$( 'h2' );
 		expect( categoryHeader.length > 0 ).toBe( true );
 
-		const [ addParagraphBlock ] = await blockLibrary.$x(
-			'//*[@role="option"][*[text()="Paragraph"]]'
+		const [ addBlock ] = await blockLibrary.$x(
+			`//*[@role="option"][*[text()="${ blockName }"]]`
 		);
 
-		return addParagraphBlock;
+		return addBlock;
 	}
 
 	async function expectInsertionPointIndicatorToBeBelowLastBlock(
@@ -98,7 +98,7 @@ describe( 'Widgets screen', () => {
 		);
 		const [ firstWidgetArea ] = widgetAreas;
 
-		let addParagraphBlock = await getParagraphBlockInGlobalInserter();
+		let addParagraphBlock = await getBlockInGlobalInserter( 'Paragraph' );
 		await addParagraphBlock.hover();
 
 		// FIXME: The insertion point indicator is not showing when the widget area has no blocks.
@@ -106,31 +106,41 @@ describe( 'Widgets screen', () => {
 		// 	firstWidgetArea
 		// );
 
-		await addParagraphBlock.focus();
-		await pressKeyWithModifier( 'primary', 'Enter' );
+		await addParagraphBlock.click();
 
-		const addedParagraphBlockInFirstWidgetArea = await firstWidgetArea.$(
+		let addedParagraphBlockInFirstWidgetArea = await firstWidgetArea.$(
 			'[data-block][data-type="core/paragraph"][aria-label^="Empty block"]'
 		);
-
-		expect(
-			await addedParagraphBlockInFirstWidgetArea.evaluate(
-				( node ) => node === document.activeElement
-			)
-		).toBe( true );
+		await addedParagraphBlockInFirstWidgetArea.focus();
 
 		await page.keyboard.type( 'First Paragraph' );
 
-		addParagraphBlock = await getParagraphBlockInGlobalInserter();
+		addParagraphBlock = await getBlockInGlobalInserter( 'Paragraph' );
 		await addParagraphBlock.hover();
 
 		await expectInsertionPointIndicatorToBeBelowLastBlock(
 			firstWidgetArea
 		);
 		await addParagraphBlock.focus();
-		await pressKeyWithModifier( 'primary', 'Enter' );
+		await addParagraphBlock.click();
 
+		addedParagraphBlockInFirstWidgetArea = await firstWidgetArea.$(
+			'[data-block][data-type="core/paragraph"][aria-label^="Empty block"]'
+		);
+		await addedParagraphBlockInFirstWidgetArea.focus();
 		await page.keyboard.type( 'Second Paragraph' );
+
+		const addShortCodeBlock = await getBlockInGlobalInserter( 'Shortcode' );
+		await addShortCodeBlock.click();
+
+		const shortCodeInput = await page.waitForSelector(
+			'textarea[aria-label="Shortcode text"]'
+		);
+		await shortCodeInput.focus();
+		// The famous Big Buck Bunny video.
+		await shortCodeInput.type(
+			'[video src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"]'
+		);
 
 		/**
 		 * FIXME: There seems to have a bug when saving the widgets
@@ -214,12 +224,7 @@ describe( 'Widgets screen', () => {
 			firstWidgetArea
 		);
 
-		expect(
-			await firstParagraphBlock.evaluate(
-				( node ) => node === document.activeElement
-			)
-		).toBe( true );
-
+		await firstParagraphBlock.focus();
 		await page.keyboard.type( 'First Paragraph' );
 
 		await page.keyboard.press( 'Enter' );
@@ -313,13 +318,13 @@ describe( 'Widgets screen', () => {
 			'[aria-label="Block: Widget Area"][role="group"]'
 		);
 
-		const addParagraphBlock = await getParagraphBlockInGlobalInserter();
-		await addParagraphBlock.focus();
-		await pressKeyWithModifier( 'primary', 'Enter' );
+		const addParagraphBlock = await getBlockInGlobalInserter( 'Paragraph' );
+		await addParagraphBlock.click();
 
 		let firstParagraphBlock = await firstWidgetArea.$(
 			'[data-block][data-type="core/paragraph"][aria-label^="Empty block"]'
 		);
+		await firstParagraphBlock.focus();
 		await page.keyboard.type( 'First Paragraph' );
 
 		await saveWidgets();

--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -178,6 +178,9 @@ describe( 'Widgets screen', () => {
 		</div></div>
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
+		</div></div>
+		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\"><p><div style=\\"width: 580px;\\" class=\\"wp-video\\"><!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->
+		<video class=\\"wp-video-shortcode\\" id=\\"video-0-1\\" width=\\"580\\" height=\\"326\\" preload=\\"metadata\\" controls=\\"controls\\"><source type=\\"video/mp4\\" src=\\"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4?_=1\\" /><a href=\\"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4\\">http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4</a></video></div></p>
 		</div></div>",
 		}
 	` );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #27793.

Add `do_shortcode()` to the widgets screen.

Also fixed flaky widgets e2e tests, as it turns out it's no longer expected to move focus to the newly added blocks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Added e2e test, or:
1. Go to the widgets screen
2. Add a shortcode block
3. Add a video shortcode like: `[video src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"]`
4. Save
5. Go to the site's frontend
6. Observe that the video is showing correctly on screen

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
