### PR TITLE
Components: Try to make the order of fills stable in regular slots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13220,7 +13220,8 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/icons": "file:packages/icons",
-				"lodash": "^4.17.19"
+				"lodash": "^4.17.19",
+				"memize": "^1.1.0"
 			}
 		},
 		"@wordpress/postcss-plugins-preset": {

--- a/packages/components/src/slot-fill/context.js
+++ b/packages/components/src/slot-fill/context.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { sortBy, forEach, without } from 'lodash';
+import { without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -95,7 +95,6 @@ class SlotFillProvider extends Component {
 
 	unregisterFill( name, instance ) {
 		this.fills[ name ] = without( this.fills[ name ], instance );
-		this.resetFillOccurrence( name );
 		this.forceUpdateSlot( name );
 	}
 
@@ -109,17 +108,11 @@ class SlotFillProvider extends Component {
 		if ( this.slots[ name ] !== slotInstance ) {
 			return [];
 		}
-		return sortBy( this.fills[ name ], 'occurrence' );
+		return this.fills[ name ];
 	}
 
 	hasFills( name ) {
 		return this.fills[ name ] && !! this.fills[ name ].length;
-	}
-
-	resetFillOccurrence( name ) {
-		forEach( this.fills[ name ], ( instance ) => {
-			instance.occurrence = undefined;
-		} );
 	}
 
 	forceUpdateSlot( name ) {

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -13,8 +13,6 @@ import { createPortal, useLayoutEffect, useRef } from '@wordpress/element';
  */
 import { Consumer, useSlot } from './context';
 
-let occurrences = 0;
-
 function FillComponent( { name, children, registerFill, unregisterFill } ) {
 	const slot = useSlot( name );
 
@@ -22,10 +20,6 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 		name,
 		children,
 	} );
-
-	if ( ! ref.current.occurrence ) {
-		ref.current.occurrence = ++occurrences;
-	}
 
 	useLayoutEffect( () => {
 		registerFill( name, ref.current );

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -62,7 +62,6 @@ class SlotComponent extends Component {
 		const { children, name, fillProps = {}, getFills } = this.props;
 
 		const fills = map( getFills( name, this ), ( fill ) => {
-			const fillKey = fill.occurrence;
 			const fillChildren = isFunction( fill.children )
 				? fill.children( fillProps )
 				: fill.children;
@@ -72,7 +71,7 @@ class SlotComponent extends Component {
 					return child;
 				}
 
-				const childKey = `${ fillKey }---${ child.key || childIndex }`;
+				const childKey = child.key || childIndex;
 				return cloneElement( child, { key: childKey } );
 			} );
 		} ).filter(

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -155,7 +155,15 @@ exports[`Slot should render in expected order 1`] = `
   <div>
     first
     second
+    third
+    fourth
   </div>
+  <button
+    type="button"
+  />
+  <button
+    type="button"
+  />
   <button
     type="button"
   />

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -150,13 +150,24 @@ exports[`Slot should render empty Fills without HTML wrapper when render props u
 </div>
 `;
 
-exports[`Slot should render in expected order 1`] = `
+exports[`Slot should render in expected order when fills always mounted 1`] = `
 <div>
   <div>
-    first
+    first (rerendered)
     second
     third
-    fourth
+    fourth (new)
+  </div>
+</div>
+`;
+
+exports[`Slot should render in expected order when fills unmounted 1`] = `
+<div>
+  <div>
+    second
+    third
+    first (rerendered)
+    fourth (new)
   </div>
   <button
     type="button"

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -192,6 +192,7 @@ describe( 'Slot', () => {
 					<Slot name="egg" />
 				</div>
 				<Filler name="egg" key="second" text="second" />
+				<Filler name="egg" key="third" text="third" />
 			</Provider>
 		);
 
@@ -202,6 +203,8 @@ describe( 'Slot', () => {
 				</div>
 				<Filler name="egg" key="first" text="first" />
 				<Filler name="egg" key="second" text="second" />
+				<Filler name="egg" key="third" text="third" />
+				<Filler name="egg" key="fourth" text="fourth" />
 			</Provider>
 		);
 

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -167,7 +167,68 @@ describe( 'Slot', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'should render in expected order', () => {
+	it( 'should render in expected order when fills always mounted', () => {
+		const { container, rerender } = render(
+			<Provider>
+				<div key="slot">
+					<Slot name="egg" />
+				</div>
+			</Provider>
+		);
+
+		rerender(
+			<Provider>
+				<div key="slot">
+					<Slot name="egg" />
+				</div>
+				<Fill name="egg" key="first">
+					first
+				</Fill>
+				<Fill name="egg" key="second">
+					second
+				</Fill>
+			</Provider>
+		);
+
+		rerender(
+			<Provider>
+				<div key="slot">
+					<Slot name="egg" />
+				</div>
+				<Fill name="egg" key="first" />
+				<Fill name="egg" key="second">
+					second
+				</Fill>
+				<Fill name="egg" key="third">
+					third
+				</Fill>
+			</Provider>
+		);
+
+		rerender(
+			<Provider>
+				<div key="slot">
+					<Slot name="egg" />
+				</div>
+				<Fill name="egg" key="first">
+					first (rerendered)
+				</Fill>
+				<Fill name="egg" key="second">
+					second
+				</Fill>
+				<Fill name="egg" key="third">
+					third
+				</Fill>
+				<Fill name="egg" key="fourth">
+					fourth (new)
+				</Fill>
+			</Provider>
+		);
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'should render in expected order when fills unmounted', () => {
 		const { container, rerender } = render(
 			<Provider>
 				<div key="slot">
@@ -201,10 +262,10 @@ describe( 'Slot', () => {
 				<div key="slot">
 					<Slot name="egg" />
 				</div>
-				<Filler name="egg" key="first" text="first" />
+				<Filler name="egg" key="first" text="first (rerendered)" />
 				<Filler name="egg" key="second" text="second" />
 				<Filler name="egg" key="third" text="third" />
-				<Filler name="egg" key="fourth" text="fourth" />
+				<Filler name="egg" key="fourth" text="fourth (new)" />
 			</Provider>
 		);
 

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -27,7 +27,8 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/icons": "file:../icons",
-		"lodash": "^4.17.19"
+		"lodash": "^4.17.19",
+		"memize": "^1.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { map } from 'lodash';
+import memoize from 'memize';
 
 /**
  * WordPress dependencies
@@ -54,6 +55,12 @@ class PluginArea extends Component {
 		super( ...arguments );
 
 		this.setPlugins = this.setPlugins.bind( this );
+		this.memoizedContext = memoize( ( name, icon ) => {
+			return {
+				name,
+				icon,
+			};
+		} );
 		this.state = this.getCurrentPluginsState();
 	}
 
@@ -64,10 +71,7 @@ class PluginArea extends Component {
 				( { icon, name, render } ) => {
 					return {
 						Plugin: render,
-						context: {
-							name,
-							icon,
-						},
+						context: this.memoizedContext( name, icon ),
 					};
 				}
 			),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR tries to resolve #28546.


> If you unpin a plugin sidebar, then pin it again, it's now the first pinned item, which is problematic as the Settings cog should always be the first icon:
> 
> ![106005578-a4c9cb00-60b4-11eb-98c6-bd731ce38582](https://user-images.githubusercontent.com/1204802/106115601-3b4bca00-6151-11eb-9221-52d23e29e22c.gif)
> 
> The fact that upon a page reload, the pinned item is back where it "should" be, suggests it's a bug.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Register a few sidebar plugins that are pinnable, for example, plugins that offer integration: Yoast, Jetpack. Make sure that the order of pinned items remains the same when you pin and unpin them several times.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/699132/108962719-70c4d400-7679-11eb-83ec-8148d690550a.mov

![bug](https://user-images.githubusercontent.com/1204802/108978240-b12c4e00-7689-11eb-8de4-6991a51e61bc.gif)

## Types of changes
Enhancement.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
