### PR TITLE
Fix Slash Inserter position

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch, useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { getBlockType, withBlockContentContext } from '@wordpress/blocks';
@@ -159,7 +159,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		[ clientId, isSmallScreen ]
 	);
 
-	const ref = props.ref || fallbackRef;
+	const ref = useMergeRefs( [ props.ref, fallbackRef ] );
 	const InnerBlocks =
 		options.value && options.onChange
 			? ControlledInnerBlocks
@@ -179,7 +179,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			<InnerBlocks
 				{ ...options }
 				clientId={ clientId }
-				wrapperRef={ ref }
+				wrapperRef={ fallbackRef }
 			/>
 		),
 	};

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -22,7 +22,7 @@ import {
 	findTransform,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, useMergeRefs } from '@wordpress/compose';
 import {
 	__experimentalRichText as RichText,
 	__unstableCreateElement,
@@ -154,7 +154,6 @@ function RichTextWrapper(
 	identifier = identifier || instanceId;
 
 	const fallbackRef = useRef();
-	const ref = forwardedRef || fallbackRef;
 	const {
 		clientId,
 		onCaretVerticalPositionChange,
@@ -558,11 +557,13 @@ function RichTextWrapper(
 		[ onReplace, __unstableMarkAutomaticChange ]
 	);
 
+	const mergedRef = useMergeRefs( [ forwardedRef, fallbackRef ] );
+
 	const content = (
 		<RichText
 			clientId={ clientId }
 			identifier={ identifier }
-			ref={ ref }
+			ref={ mergedRef }
 			value={ adjustedValue }
 			onChange={ adjustedOnChange }
 			selectionStart={ selectionStart }
@@ -636,7 +637,7 @@ function RichTextWrapper(
 					{ nestedIsSelected && hasFormats && (
 						<FormatToolbarContainer
 							inline={ inlineToolbar }
-							anchorRef={ ref.current }
+							anchorRef={ fallbackRef.current }
 						/>
 					) }
 					{ nestedIsSelected && <RemoveBrowserShortcuts /> }
@@ -646,7 +647,7 @@ function RichTextWrapper(
 						record={ value }
 						onChange={ onChange }
 						isSelected={ nestedIsSelected }
-						contentRef={ ref }
+						contentRef={ fallbackRef }
 					>
 						{ ( { listBoxId, activeId, onKeyDown } ) => (
 							<TagName

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useRef } from '@wordpress/element';
 import {
 	Button,
 	ButtonGroup,
@@ -231,7 +231,8 @@ function ButtonEdit( props ) {
 	);
 
 	const colorProps = getColorAndStyleProps( attributes, colors, true );
-	const blockProps = useBlockProps();
+	const ref = useRef();
+	const blockProps = useBlockProps( { ref } );
 
 	return (
 		<>
@@ -279,7 +280,7 @@ function ButtonEdit( props ) {
 				isSelected={ isSelected }
 				opensInNewTab={ linkTarget === '_blank' }
 				onToggleOpenInNewTab={ onToggleOpenInNewTab }
-				anchorRef={ blockProps.ref }
+				anchorRef={ ref }
 			/>
 			<InspectorControls>
 				<BorderPanel

--- a/packages/components/src/focusable-iframe/index.js
+++ b/packages/components/src/focusable-iframe/index.js
@@ -2,13 +2,14 @@
  * WordPress dependencies
  */
 import { useEffect, useRef } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
 
 export default function FocusableIframe( { iframeRef, onFocus, ...props } ) {
 	const fallbackRef = useRef();
-	const ref = iframeRef || fallbackRef;
+	const ref = useMergeRefs( [ iframeRef, fallbackRef ] );
 
 	useEffect( () => {
-		const iframe = ref.current;
+		const iframe = fallbackRef.current;
 		const { ownerDocument } = iframe;
 		const { defaultView } = ownerDocument;
 		const { FocusEvent } = defaultView;

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -11,6 +11,7 @@ export { default as withGlobalEvents } from './higher-order/with-global-events';
 export { default as withInstanceId } from './higher-order/with-instance-id';
 export { default as withSafeTimeout } from './higher-order/with-safe-timeout';
 export { default as withState } from './higher-order/with-state';
+export { default as withPreferredColorScheme } from './higher-order/with-preferred-color-scheme';
 
 // Hooks
 export { default as useConstrainedTabbing } from './hooks/use-constrained-tabbing';
@@ -23,12 +24,8 @@ export { default as useMediaQuery } from './hooks/use-media-query';
 export { default as useReducedMotion } from './hooks/use-reduced-motion';
 export { default as useViewportMatch } from './hooks/use-viewport-match';
 export { default as useAsyncList } from './hooks/use-async-list';
-
-// Higher-order components
-export { default as withPreferredColorScheme } from './higher-order/with-preferred-color-scheme';
-
-// Hooks
 export { default as usePreferredColorScheme } from './hooks/use-preferred-color-scheme';
 export { default as usePreferredColorSchemeStyle } from './hooks/use-preferred-color-scheme-style';
 export { default as useResizeObserver } from './hooks/use-resize-observer';
 export { default as useDebounce } from './hooks/use-debounce';
+export { default as useMergeRefs } from './hooks/use-merge-refs';


### PR DESCRIPTION
closes #29262 
Fix regression introduce in https://github.com/WordPress/gutenberg/pull/28917#issuecomment-781996219
Alternative to #29188 

The components receiving refs shouldn't be assuming the type of ref they receive, they should instead use their own local refs. This is an error that existed in the components for some time now, but I believe it's the right fix for these issues.

**Testing instructions**

 - Test that the slash inserter shows up at the right position. 