### PR TITLE
Add `full and wide` align controls to Query and Query Pagination blocks

### DIFF
--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -7,7 +7,8 @@
 		"query",
 		"queryContext",
 		"layout",
-		"templateSlug"
+		"templateSlug",
+		"align"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -2,13 +2,17 @@
 	"apiVersion": 2,
 	"name": "core/query-loop",
 	"category": "design",
+	"attributes": {
+		"align": {
+			"type": "string"
+		}
+	},
 	"usesContext": [
 		"queryId",
 		"query",
 		"queryContext",
 		"layout",
-		"templateSlug",
-		"align"
+		"templateSlug"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -47,7 +47,13 @@ export default function QueryLoopEdit( {
 		} = {},
 		queryContext = [ {} ],
 		templateSlug,
+		// `layout` and `align` context come from `Query` block
+		// and is a UI choice to make the handling of the block more
+		// user friendly. The plan is to find a way to make these two
+		// attributes of `QueryLoop`, but keep them in `Query` toolbar
+		// and later absorb the `QueryLoop` toolbar from its parent.
 		layout: { type: layoutType = 'flex', columns = 1 } = {},
+		align,
 	},
 } ) {
 	const [ { page } ] = useQueryContext() || queryContext;
@@ -123,12 +129,14 @@ export default function QueryLoopEdit( {
 		[ posts ]
 	);
 	const hasLayoutFlex = layoutType === 'flex' && columns > 1;
-	const blockProps = useBlockProps( {
+	const extraBlockProps = {
 		className: classnames( {
 			'is-flex-container': hasLayoutFlex,
 			[ `columns-${ columns }` ]: hasLayoutFlex,
 		} ),
-	} );
+	};
+	if ( align ) extraBlockProps[ 'data-align' ] = align;
+	const blockProps = useBlockProps( extraBlockProps );
 	const innerBlocksProps = useInnerBlocksProps( {}, { template: TEMPLATE } );
 
 	if ( ! posts ) {

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -30,6 +30,7 @@ const TEMPLATE = [
 ];
 export default function QueryLoopEdit( {
 	clientId,
+	attributes: { align },
 	context: {
 		query: {
 			perPage,
@@ -53,7 +54,6 @@ export default function QueryLoopEdit( {
 		// attributes of `QueryLoop`, but keep them in `Query` toolbar
 		// and later absorb the `QueryLoop` toolbar from its parent.
 		layout: { type: layoutType = 'flex', columns = 1 } = {},
-		align,
 	},
 } ) {
 	const [ { page } ] = useQueryContext() || queryContext;
@@ -135,6 +135,9 @@ export default function QueryLoopEdit( {
 			[ `columns-${ columns }` ]: hasLayoutFlex,
 		} ),
 	};
+	// We haven't used the `supports.align` here because first we
+	// need to find a way to absorb toolbars for nested block
+	// wrappers (https://github.com/WordPress/gutenberg/issues/7694).
 	if ( align ) extraBlockProps[ 'data-align' ] = align;
 	const blockProps = useBlockProps( extraBlockProps );
 	const innerBlocksProps = useInnerBlocksProps( {}, { template: TEMPLATE } );

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -48,11 +48,6 @@ export default function QueryLoopEdit( {
 		} = {},
 		queryContext = [ {} ],
 		templateSlug,
-		// `layout` and `align` context come from `Query` block
-		// and is a UI choice to make the handling of the block more
-		// user friendly. The plan is to find a way to make these two
-		// attributes of `QueryLoop`, but keep them in `Query` toolbar
-		// and later absorb the `QueryLoop` toolbar from its parent.
 		layout: { type: layoutType = 'flex', columns = 1 } = {},
 	},
 } ) {

--- a/packages/block-library/src/query-loop/editor.scss
+++ b/packages/block-library/src/query-loop/editor.scss
@@ -1,5 +1,4 @@
 .wp-block.wp-block-query-loop {
-	max-width: 100%;
 	padding-left: 0;
 	list-style: none;
 }

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -36,10 +36,18 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 
 	$posts      = get_posts( $query );
 	$classnames = '';
+	// `layout` and `align` context come from `Query` block
+	// and is a UI choice to make the handling of the block more
+	// user friendly. The plan is to find a way to make these two
+	// attributes of `QueryLoop`, but keep them in `Query` toolbar
+	// and later absorb the `QueryLoop` toolbar from its parent.
 	if ( isset( $block->context['layout'] ) && isset( $block->context['query'] ) ) {
 		if ( isset( $block->context['layout']['type'] ) && 'flex' === $block->context['layout']['type'] ) {
 			$classnames = "is-flex-container columns-{$block->context['layout']['columns']}";
 		}
+	}
+	if ( isset( $block->context['align'] ) ) {
+		$classnames .= " align{$block->context['align']}";
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -36,18 +36,17 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 
 	$posts      = get_posts( $query );
 	$classnames = '';
-	// `layout` and `align` context come from `Query` block
-	// and is a UI choice to make the handling of the block more
-	// user friendly. The plan is to find a way to make these two
-	// attributes of `QueryLoop`, but keep them in `Query` toolbar
-	// and later absorb the `QueryLoop` toolbar from its parent.
 	if ( isset( $block->context['layout'] ) && isset( $block->context['query'] ) ) {
 		if ( isset( $block->context['layout']['type'] ) && 'flex' === $block->context['layout']['type'] ) {
 			$classnames = "is-flex-container columns-{$block->context['layout']['columns']}";
 		}
 	}
-	if ( isset( $block->context['align'] ) ) {
-		$classnames .= " align{$block->context['align']}";
+
+	// We haven't used the `supports.align` here because first we
+	// need to find a way to absorb toolbars for nested block
+	// wrappers (https://github.com/WordPress/gutenberg/issues/7694).
+	if ( isset( $attributes['align'] ) ) {
+		$classnames .= " align{$attributes['align']}";
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -9,7 +9,8 @@
 	],
 	"supports": {
 		"reusable": false,
-		"html": false
+		"html": false,
+		"align": [ "wide", "full" ]
 	},
 	"editorStyle": "wp-block-query-pagination-editor",
 	"style": "wp-block-query-pagination"

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -34,13 +34,15 @@
 	"providesContext": {
 		"queryId": "queryId",
 		"query": "query",
-		"layout": "layout"
+		"layout": "layout",
+		"align": "align"
 	},
 	"usesContext": [
 		"postId"
 	],
 	"supports": {
-		"html": false
+		"html": false,
+		"align": [ "wide", "full" ]
 	},
 	"editorStyle": "wp-block-query-editor"
 }

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -34,15 +34,13 @@
 	"providesContext": {
 		"queryId": "queryId",
 		"query": "query",
-		"layout": "layout",
-		"align": "align"
+		"layout": "layout"
 	},
 	"usesContext": [
 		"postId"
 	],
 	"supports": {
-		"html": false,
-		"align": [ "wide", "full" ]
+		"html": false
 	},
 	"editorStyle": "wp-block-query-editor"
 }

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -25,6 +25,7 @@ export function QueryContent( {
 	attributes,
 	context: { postId },
 	setAttributes,
+	clientId,
 } ) {
 	const { queryId, query, layout } = attributes;
 	const instanceId = useInstanceId( QueryContent );
@@ -72,6 +73,7 @@ export function QueryContent( {
 			/>
 			<BlockControls>
 				<QueryToolbar
+					clientId={ clientId }
 					attributes={ attributes }
 					setQuery={ updateQuery }
 					setLayout={ updateLayout }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related: https://github.com/WordPress/gutenberg/issues/27589

This PR adds `full and wide` align support to `Query/QueryLoop` and `Query Pagination` blocks.

Ideally we would want to handle this with a mechanism for `absorbing` the toolbar of nested block wrappers as described in this issue: https://github.com/WordPress/gutenberg/issues/7694.

That's why I haven't used the `supports.align` in `QueryLoop` and created an adhoc toolbar control for `align` in `Query` block. This is a UI choice for better user experience.


<!-- Please describe what you have changed or added -->

## How has this been tested?
Manually by adding `Query` and `Query Pagination` blocks and try different combinations of `align` options.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
