### PR TITLE
Fix off-center appender in some themes.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -5,6 +5,11 @@
 	padding: 0;
 	list-style: none;
 
+	// Themes sometimes apply a max-width to all elements classed blocks.
+	&.wp-block {
+		max-width: none;
+	}
+
 	// Add a little left margin when used horizontally.
 	margin: 0 0 0 $grid-unit-10;
 


### PR DESCRIPTION
## Description

Some themes, like TT1, apply a max-width to the `wp-block` class, which is also applied to the appender. This doesn't work too well inside wide and fullwide group blocks, which has its own child block rules.

## How has this been tested?

Insert 3 empty group blocks, one unaligned, the other two wide and full wide.

Each block should be as wide as its container.

## Screenshots <!-- if applicable -->

Before:

<img width="1270" alt="before" src="https://user-images.githubusercontent.com/1204802/108979693-32d0ab80-768b-11eb-8802-b7864b64be2e.png">

After:

<img width="1270" alt="Screenshot 2021-02-24 at 10 26 55" src="https://user-images.githubusercontent.com/1204802/108979703-35cb9c00-768b-11eb-990a-26ad38b8c553.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
