### PR TITLE
Fix reusable block crash when converting a just created reusable block to blocks.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/reusable-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/reusable-blocks.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Reusable blocks allows conversion back to blocks when the reusable block has unsaved edits 1`] = `
+"<!-- wp:paragraph -->
+<p>12</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Reusable blocks can be created from multiselection and converted back to regular blocks 1`] = `
 "<!-- wp:paragraph -->
 <p>Hello there!</p>

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -297,4 +297,29 @@ describe( 'Reusable blocks', () => {
 			expect( content ).toEqual( 'Awesome Paragraph modified' );
 		} );
 	} );
+
+	// Check for regressions of https://github.com/WordPress/gutenberg/issues/26421.
+	it( 'allows conversion back to blocks when the reusable block has unsaved edits', async () => {
+		await createReusableBlock( '1', 'Edited block' );
+
+		// Make an edit to the reusable block and assert that there's only a
+		// paragraph in a reusable block.
+		await page.waitForSelector( 'p[aria-label="Paragraph block"]' );
+		await page.click( 'p[aria-label="Paragraph block"]' );
+		await page.keyboard.type( '2' );
+		const selector =
+			'//div[@aria-label="Block: Reusable block"]//p[@aria-label="Paragraph block"][.="12"]';
+		const reusableBlockWithParagraph = await page.$x( selector );
+		expect( reusableBlockWithParagraph ).toBeTruthy();
+
+		// Convert back to regular blocks.
+		await clickBlockToolbarButton( 'Select Reusable block' );
+		await clickBlockToolbarButton( 'Convert to regular blocks' );
+		await page.waitForXPath( selector, {
+			hidden: true,
+		} );
+
+		// Check that there's only a paragraph.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/reusable-blocks/src/store/controls.js
+++ b/packages/reusable-blocks/src/store/controls.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isFunction } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -70,7 +75,11 @@ const controls = {
 					oldBlock.attributes.ref
 				);
 
-			const newBlocks = parse( reusableBlock.content );
+			const newBlocks = parse(
+				isFunction( reusableBlock.content )
+					? reusableBlock.content( reusableBlock.blocks )
+					: reusableBlock.content
+			);
 			registry
 				.dispatch( 'core/block-editor' )
 				.replaceBlocks( oldBlock.clientId, newBlocks );

--- a/packages/reusable-blocks/src/store/controls.js
+++ b/packages/reusable-blocks/src/store/controls.js
@@ -77,7 +77,7 @@ const controls = {
 
 			const newBlocks = parse(
 				isFunction( reusableBlock.content )
-					? reusableBlock.content( reusableBlock.blocks )
+					? reusableBlock.content( reusableBlock )
 					: reusableBlock.content
 			);
 			registry


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #26421

Reusable blocks crash on conversion when they have unsaved edits.

This happens because the entity `content` prop is passed to the blocks `parse` function. Usually that's ok, because it'll be a string. But when a reusable block has unsaved edits, `content` is a function that `parse` doesn't know how to handle.

The content function is created here:
https://github.com/WordPress/gutenberg/blob/60314e8e879579058164e30514cf217a47a00dd5/packages/core-data/src/entity-provider.js#L183-L187

It looks like this function is called on `saveEntityRecord`, but is otherwise stored internally as a function:
https://github.com/WordPress/gutenberg/blob/5d3681a8af68c50da6921902284276838657f1ea/packages/core-data/src/actions.js#L386-L394

This became an issue in #25859, where reusable blocks were switched over to using the entity system. Before that they did a plain `apiFetch` and as far as I can tell always dealt with string `content`.

## How has this been tested?
1. Add a paragraph block and type the text '1' within it.
2. Convert the paragraph to reusable
3. Edit the reusable block, change the paragraph text to '12'.
4. Try converting the reusable block back to regular blocks.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
