### PR TITLE
Fix navigation editor block selection clearing

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -208,8 +208,10 @@ describe( 'Navigation editor', () => {
 		} );
 		expect( submenuLinkVisible ).toBeDefined();
 
-		// Click the editor canvas.
-		await page.click( '.edit-navigation-layout__canvas' );
+		// click in the top left corner of the canvas.
+		const canvas = await page.$( '.edit-navigation-layout__canvas' );
+		const boundingBox = await canvas.boundingBox();
+		await page.mouse.click( boundingBox.x + 5, boundingBox.y + 5 );
 
 		// There should be a submenu in the DOM, but it should be hidden.
 		const submenuLinkHidden = await page.waitForXPath( submenuLinkXPath, {

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -19,7 +19,6 @@ import {
 	BlockInspector,
 	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 } from '@wordpress/block-editor';
-import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -37,8 +36,7 @@ import InspectorAdditions from '../inspector-additions';
 import { store as editNavigationStore } from '../../store';
 
 export default function Layout( { blockEditorSettings } ) {
-	const canvasRef = useRef();
-	useBlockSelectionClearer( canvasRef );
+	const canvasRef = useBlockSelectionClearer();
 
 	const { saveNavigationPost } = useDispatch( editNavigationStore );
 	const savePost = () => saveNavigationPost( navigationPost );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes the regression from #29114.

Improves the e2e test that was designed to catch the regression, but failed to do so after the screen was redesigned.

## How has this been tested?
1. Click a block
2. The block should be selected
3. Click the editor canvas
4. The block should be deselected

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
