### PR TITLE
Update docs for social links & theme.json

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -433,7 +433,6 @@ These are the current color properties supported by blocks:
 | Post Title | Yes | Yes | - | Yes |
 | Site Tagline | Yes | Yes | - | Yes |
 | Site Title | Yes | Yes | - | Yes |
-| Social Links | Yes | - | - | Yes |
 | Template Part | Yes | Yes | Yes | Yes |
 
 [1] The heading block represents 6 distinct HTML elements: H1-H6. It comes with selectors to target each individual element (ex: core/heading/h1 for H1, etc).


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/28084 added support for tweaking the icon color and background for social links. However, it didn't use the block support mechanism, hence those properties can't be targeted via the theme.json. This PR fixes the docs.

