### PR TITLE
Paragraph block: add test to ensure unwrapped editable paragraph

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/paragraph.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/paragraph.test.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { createNewPost, insertBlock } from '@wordpress/e2e-test-utils';
+
+describe( 'Paragraph', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'should output unwrapped editable paragraph', async () => {
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( '1' );
+
+		const firstBlockTagName = await page.evaluate( () => {
+			return document.querySelector( '.block-editor-block-list__layout' )
+				.firstChild.tagName;
+		} );
+
+		// The outer element should be a paragraph. Blocks should never have any
+		// additional div wrappers so the markup remains simple and easy to
+		// style.
+		expect( firstBlockTagName ).toBe( 'P' );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

See https://github.com/WordPress/gutenberg/pull/29213#issuecomment-785057482

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
