### PR TITLE
Component System: Add tests for color utils

### DIFF
--- a/packages/components/src/ui/utils/colors.js
+++ b/packages/components/src/ui/utils/colors.js
@@ -75,7 +75,7 @@ const getComputedBackgroundColor = memoize( _getComputedBackgroundColor );
  *
  * @return {string} The optimized text color (black or white).
  */
-function getOptimalTextColor( backgroundColor ) {
+export function getOptimalTextColor( backgroundColor ) {
 	const background = getComputedBackgroundColor( backgroundColor );
 	const isReadableWithBlackText = tinycolor.isReadable(
 		background,

--- a/packages/components/src/ui/utils/test/colors.js
+++ b/packages/components/src/ui/utils/test/colors.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import { getOptimalTextColor, getOptimalTextShade } from '../colors';
+
+describe( 'getOptimalTextColor', () => {
+	test( 'should be white for dark backgrounds', () => {
+		expect( getOptimalTextColor( 'black' ) ).toBe( '#ffffff' );
+		expect( getOptimalTextColor( '#000' ) ).toBe( '#ffffff' );
+		expect( getOptimalTextColor( '#111' ) ).toBe( '#ffffff' );
+		expect( getOptimalTextColor( '#123' ) ).toBe( '#ffffff' );
+		expect( getOptimalTextColor( '#555' ) ).toBe( '#ffffff' );
+		expect( getOptimalTextColor( '#05f' ) ).toBe( '#ffffff' );
+	} );
+
+	test( 'should be black for light backgrounds', () => {
+		expect( getOptimalTextColor( 'white' ) ).toBe( '#000000' );
+		expect( getOptimalTextColor( '#fff' ) ).toBe( '#000000' );
+		expect( getOptimalTextColor( '#def' ) ).toBe( '#000000' );
+		expect( getOptimalTextColor( '#c3c3c3' ) ).toBe( '#000000' );
+		expect( getOptimalTextColor( '#0ff' ) ).toBe( '#000000' );
+	} );
+} );
+
+describe( 'getOptimalTextShade', () => {
+	test( 'should be "light" for dark backgrounds', () => {
+		expect( getOptimalTextShade( 'black' ) ).toBe( 'light' );
+		expect( getOptimalTextShade( '#000' ) ).toBe( 'light' );
+		expect( getOptimalTextShade( '#111' ) ).toBe( 'light' );
+		expect( getOptimalTextShade( '#123' ) ).toBe( 'light' );
+		expect( getOptimalTextShade( '#555' ) ).toBe( 'light' );
+		expect( getOptimalTextShade( '#05f' ) ).toBe( 'light' );
+	} );
+
+	test( 'should be "dark" for light backgrounds', () => {
+		expect( getOptimalTextShade( 'white' ) ).toBe( 'dark' );
+		expect( getOptimalTextShade( '#fff' ) ).toBe( 'dark' );
+		expect( getOptimalTextShade( '#def' ) ).toBe( 'dark' );
+		expect( getOptimalTextShade( '#c3c3c3' ) ).toBe( 'dark' );
+		expect( getOptimalTextShade( '#0ff' ) ).toBe( 'dark' );
+	} );
+} );


### PR DESCRIPTION
This update adds a couple of unit tests for the color utilities in `components/src/ui/`.

Resolves a concern brought up by @gziolo 
https://github.com/WordPress/gutenberg/issues/28399#issuecomment-771579755

## How has this been tested?
Tested locally in Jest.

For testing, run:
* `npm run test-unit`



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
