### PR TITLE
Blocks: Ensure that metadata registered on the server for core block is preserved on the client (try 2)

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -160,6 +160,11 @@ export const serverSideBlockDefinitions = {};
 // eslint-disable-next-line camelcase
 export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 	for ( const blockName of Object.keys( definitions ) ) {
+		// Don't overwrite if already set. It covers the case when metadata
+		// was initialized from the server.
+		if ( serverSideBlockDefinitions[ blockName ] ) {
+			continue;
+		}
 		serverSideBlockDefinitions[ blockName ] = mapKeys(
 			pickBy( definitions[ blockName ], ( value ) => ! isNil( value ) ),
 			( value, key ) => camelCase( key )

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -163,6 +163,18 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 		// Don't overwrite if already set. It covers the case when metadata
 		// was initialized from the server.
 		if ( serverSideBlockDefinitions[ blockName ] ) {
+			// We still need to polyfill `apiVersion` for WordPress version
+			// lower than 5.7. If it isn't present in the definition shared
+			// from the server, we try to fallback to the definition passed.
+			// @see https://github.com/WordPress/gutenberg/pull/29279
+			if (
+				serverSideBlockDefinitions[ blockName ].apiVersion ===
+					undefined &&
+				definitions[ blockName ].apiVersion
+			) {
+				serverSideBlockDefinitions[ blockName ].apiVersion =
+					definitions[ blockName ].apiVersion;
+			}
 			continue;
 		}
 		serverSideBlockDefinitions[ blockName ] = mapKeys(

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -385,6 +385,43 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		// This test can be removed once the polyfill for apiVersion gets removed.
+		it( 'should apply apiVersion on the client when not set on the server', () => {
+			const blockName = 'core/test-block-back-compat';
+			unstable__bootstrapServerSideBlockDefinitions( {
+				[ blockName ]: {
+					category: 'widgets',
+				},
+			} );
+			unstable__bootstrapServerSideBlockDefinitions( {
+				[ blockName ]: {
+					apiVersion: 2,
+					category: 'ignored',
+				},
+			} );
+
+			const blockType = {
+				title: 'block title',
+			};
+			registerBlockType( blockName, blockType );
+			expect( getBlockType( blockName ) ).toEqual( {
+				apiVersion: 2,
+				name: blockName,
+				save: expect.any( Function ),
+				title: 'block title',
+				category: 'widgets',
+				icon: {
+					src: blockIcon,
+				},
+				attributes: {},
+				providesContext: {},
+				usesContext: [],
+				keywords: [],
+				supports: {},
+				styles: [],
+			} );
+		} );
+
 		it( 'should validate the icon', () => {
 			const blockType = {
 				save: noop,

--- a/packages/e2e-tests/plugins/register-block-type-hooks.php
+++ b/packages/e2e-tests/plugins/register-block-type-hooks.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Register Block Type Hooks
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-register-block-type-hooks
+ */
+
+/**
+ * Changes the category for the paragraph block.
+ *
+ * @param array $metadata Array of metadata for registering a block type.
+ *
+ * @return array Filtered metadata for registering a block type.
+ */
+function gutenberg_test_block_type_metadata( $metadata ) {
+	if ( 'core/paragraph' !== $metadata['name'] ) {
+		return $metadata;
+	}
+
+	return array_merge(
+		$metadata,
+		array( 'category' => 'widgets' )
+	);
+}
+
+add_filter( 'block_type_metadata', 'gutenberg_test_block_type_metadata' );

--- a/packages/e2e-tests/specs/editor/plugins/register-block-type-hooks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/register-block-type-hooks.test.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	openGlobalBlockInserter,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Register block type hooks', () => {
+	beforeEach( async () => {
+		await activatePlugin( 'gutenberg-test-register-block-type-hooks' );
+		await createNewPost();
+	} );
+
+	afterEach( async () => {
+		await deactivatePlugin( 'gutenberg-test-register-block-type-hooks' );
+	} );
+
+	it( 'has a custom category for Paragraph block', async () => {
+		await openGlobalBlockInserter();
+
+		const widgetsCategory = await page.$(
+			'.block-editor-block-types-list[aria-label="Widgets"]'
+		);
+
+		expect(
+			await widgetsCategory.$( '.editor-block-list-item-paragraph' )
+		).toBeDefined();
+	} );
+} );


### PR DESCRIPTION
## Description

2nd attempt to land #29213 that revert the revert from #29279. This time it should cover the following issue when using WordPress 5.6:

> There seems to have been a pretty huge regression merged at some point into master, many blocks are now missing their default class names in the editor: e.g. `wp-block-cover`, `wp-block-buttons`, `wp-block-navigation-link`
Trying to track it down, if anyone is able to lend a hand, that would be appreciated. 

New changes include the polyfill logic when `apiVersion` is present in `block.json` but it isn't exposed from the server.

This PR resolves the issue where metadata registered on the server from `block.json` would get overridden by the same data registered again on the client. The fix proposed ensures that for all blocks that have some metadata present, we skip all other attempts to pass the same metadata. `unstable__bootstrapServerSideBlockDefinitions` was never meant to stay for so long, but here we are. It isn't part of public API so we shouldn't be worried about backward compatibility that much.

It's a blocker for #29095.

It also was caught by @audrasjb when compiling the dev note for new filters added for `register_block_type_from_metadata`. I included e2e tests that ensure that one of the new filters is properly propagated to the client.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

There is a new e2e test added that ensures that the updated logic works correctly:

```bash
npm run test-e2e packages/e2e-tests/specs/editor/plugins/register-block-type-hooks.test.js
````

There is a new unit test added that ensures that polyfilling works as expected.
```bash
npm run test-unit packages/blocks/src/api/test/registration.js
````

Use WordPress 5.6 and make sure that all blocks have the same class names applied as in WordPress 5.7. It's related to the `apiVersion` presence during block registration.

For example, as reported by @glendaviesnz:

> Image block div `figure` is at top level of root container:
> <img width="681" alt="Screen Shot 2021-02-24 at 3 56 17 PM" src="https://user-images.githubusercontent.com/3629020/108940954-18152b80-76b9-11eb-8605-7c24ade47e0a.png">

I tested with WordPress 5.6 and the Gutenberg demo page:

Block wrapper is correctly applied:
<img width="1417" alt="Screen Shot 2021-02-24 at 17 23 50" src="https://user-images.githubusercontent.com/699132/109032348-db036600-76c5-11eb-87e6-02d616f49ed1.png">

No `apiVersion in the response from the server:
<img width="896" alt="Screen Shot 2021-02-24 at 17 28 56" src="https://user-images.githubusercontent.com/699132/109032363-df2f8380-76c5-11eb-8609-f41f80dcac61.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue). 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->