### PR TITLE
Focus input when InputControl spinner arrows are pressed

### DIFF
--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -191,6 +191,7 @@ function InputField(
 	let handleOnMouseDown;
 	if ( type === 'number' ) {
 		handleOnMouseDown = ( event ) => {
+			props.onMouseDown?.( event );
 			if ( event.target !== event.target.ownerDocument.activeElement ) {
 				event.target.focus();
 			}

--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -183,21 +183,16 @@ function InputField(
 		}
 	);
 
-	const { onMouseDown, ...dragProps } = isDragEnabled
-		? dragGestureProps()
-		: {};
+	const dragProps = isDragEnabled ? dragGestureProps() : {};
 	/*
 	 * Works around the odd UA (e.g. Firefox) that does not focus inputs of
 	 * type=number when their spinner arrows are pressed.
 	 */
-	let handleOnMouseDown = onMouseDown;
+	let handleOnMouseDown;
 	if ( type === 'number' ) {
 		handleOnMouseDown = ( event ) => {
 			if ( event.target !== event.target.ownerDocument.activeElement ) {
 				event.target.focus();
-			}
-			if ( isDragEnabled ) {
-				onMouseDown( event );
 			}
 		};
 	}

--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -183,7 +183,24 @@ function InputField(
 		}
 	);
 
-	const dragProps = isDragEnabled ? dragGestureProps() : {};
+	const { onMouseDown, ...dragProps } = isDragEnabled
+		? dragGestureProps()
+		: {};
+	/*
+	 * Works around the odd UA (e.g. Firefox) that does not focus inputs of
+	 * type=number when their spinner arrows are pressed.
+	 */
+	let handleOnMouseDown = onMouseDown;
+	if ( type === 'number' ) {
+		handleOnMouseDown = ( event ) => {
+			if ( event.target !== event.target.ownerDocument.activeElement ) {
+				event.target.focus();
+			}
+			if ( isDragEnabled ) {
+				onMouseDown( event );
+			}
+		};
+	}
 
 	return (
 		<Input
@@ -198,6 +215,7 @@ function InputField(
 			onChange={ handleOnChange }
 			onFocus={ handleOnFocus }
 			onKeyDown={ handleOnKeyDown }
+			onMouseDown={ handleOnMouseDown }
 			ref={ ref }
 			size={ size }
 			value={ value }

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -31,15 +31,25 @@ describe( 'InputControl', () => {
 
 			expect( input.getAttribute( 'type' ) ).toBe( 'number' );
 		} );
-	} );
 
-	describe( 'Label', () => {
 		it( 'should render label', () => {
 			render( <InputControl label="Hello" value="There" /> );
 
 			const input = screen.getByText( 'Hello' );
 
 			expect( input ).toBeTruthy();
+		} );
+	} );
+
+	describe( 'Ensurance of focus for number inputs', () => {
+		it( 'should focus its input on mousedown events', () => {
+			const spy = jest.fn();
+			render( <InputControl type="number" onFocus={ spy } /> );
+
+			const input = getInput();
+			fireEvent.mouseDown( input );
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 


### PR DESCRIPTION
Fix #29271

This has been done before 4e7c772014478cf0aec58cb1da6cc42fe17710f8. It was removed in bf9f9e572138ab28814c1b113a6d9b5fbbfaea8c. This brings it back (and makes sure the drag-to-adjust feature still works).

UPDATE: The drag-to-adjust feature is not working in Safari (versions <= 12) but is unrelated to this PR. Also with regards to Safari support:
>According to this doc, [we support the last two versions ](https://developer.wordpress.org/block-editor/handbook/faq/#what-browsers-does-gutenberg-support)

Thanks @jeyip! 

## How has this been tested?
In Firefox, Chrome, and Safari, in the post editor, with a range control, clicking the up/down arrows of the number input before having focused the input. Also dragging the input field to adjust to ensure that still works.

## Screenshots 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
