### PR TITLE
Compose: Add partial type support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10783,6 +10783,11 @@
 			"integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==",
 			"dev": true
 		},
+		"@types/clipboard": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/clipboard/-/clipboard-2.0.1.tgz",
+			"integrity": "sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA=="
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -12132,6 +12137,7 @@
 			"version": "file:packages/compose",
 			"requires": {
 				"@babel/runtime": "^7.12.5",
+				"@types/clipboard": "^2.0.1",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -85,12 +85,12 @@ name, returns the enhanced component augmented with a generated displayName.
 
 _Parameters_
 
--   _mapComponentToEnhancedComponent_ `Function`: Function mapping component to enhanced component.
+-   _mapComponentToEnhancedComponent_ `(OriginalComponent: import('react').ComponentType<T>) => import('react').ComponentType<T>`: Function mapping component to enhanced component.
 -   _modifierName_ `string`: Seed name from which to generated display name.
 
 _Returns_
 
--   `WPComponent`: Component class with generated display name assigned.
+-   `(OriginalComponent: import('react').ComponentType<T>) => import('react').ComponentType<T>`: Component class with generated display name assigned.
 
 <a name="ifCondition" href="#ifCondition">#</a> **ifCondition**
 
@@ -99,11 +99,11 @@ the given condition is satisfied or with the given optional prop name.
 
 _Parameters_
 
--   _predicate_ `Function`: Function to test condition.
+-   _predicate_ `(props: T) => boolean`: Function to test condition.
 
 _Returns_
 
--   `Function`: Higher-order component.
+-   `(Component: import('react').ComponentType<T>) => import('react').ComponentType<T>`: Higher-order component.
 
 <a name="pure" href="#pure">#</a> **pure**
 
@@ -126,11 +126,11 @@ This behavior is useful if we want to render a list of items asynchronously for 
 
 _Parameters_
 
--   _list_ `Array`: Source array.
+-   _list_ `T[]`: Source array.
 
 _Returns_
 
--   `Array`: Async array.
+-   `T[]`: Async array.
 
 <a name="useConstrainedTabbing" href="#useConstrainedTabbing">#</a> **useConstrainedTabbing**
 
@@ -163,8 +163,8 @@ Copies the text to the clipboard when the element is clicked.
 
 _Parameters_
 
--   _ref_ `Object`: Reference with the element.
--   _text_ `string|Function`: The text to copy.
+-   _ref_ `import('react').RefObject<TElement>`: Reference with the element.
+-   _text_ `string| ( () => string )`: The text to copy.
 -   _timeout_ `number`: Optional timeout to reset the returned state. 4 seconds by default.
 
 _Returns_

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -26,6 +26,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.12.5",
+		"@types/clipboard": "^2.0.1",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",

--- a/packages/compose/src/higher-order/if-condition/index.js
+++ b/packages/compose/src/higher-order/if-condition/index.js
@@ -7,9 +7,10 @@ import createHigherOrderComponent from '../../utils/create-higher-order-componen
  * Higher-order component creator, creating a new component which renders if
  * the given condition is satisfied or with the given optional prop name.
  *
- * @param {Function} predicate Function to test condition.
+ * @template {{}} T
+ * @param {(props: T) => boolean} predicate Function to test condition.
  *
- * @return {Function} Higher-order component.
+ * @return {(Component: import('react').ComponentType<T>) => import('react').ComponentType<T>} Higher-order component.
  */
 const ifCondition = ( predicate ) =>
 	createHigherOrderComponent(

--- a/packages/compose/src/hooks/use-async-list/index.js
+++ b/packages/compose/src/hooks/use-async-list/index.js
@@ -7,9 +7,10 @@ import { createQueue } from '@wordpress/priority-queue';
 /**
  * Returns the first items from list that are present on state.
  *
- * @param {Array} list  New array.
- * @param {Array} state Current state.
- * @return {Array} First items present iin state.
+ * @template T
+ * @param {T[]} list  New array.
+ * @param {T[]} state Current state.
+ * @return {T[]} First items present in state.
  */
 function getFirstItemsPresentInState( list, state ) {
 	const firstItems = [];
@@ -29,10 +30,11 @@ function getFirstItemsPresentInState( list, state ) {
 /**
  * Reducer keeping track of a list of appended items.
  *
- * @param {Array}  state  Current state
- * @param {Object} action Action
+ * @template T
+ * @param {T[]}  state  Current state
+ * @param {{ type: 'reset', list: T[] } | { type: 'append', item: T }} action Action
  *
- * @return {Array} update state.
+ * @return {T[]} update state.
  */
 function listReducer( state, action ) {
 	if ( action.type === 'reset' ) {
@@ -50,8 +52,9 @@ function listReducer( state, action ) {
  * React hook returns an array which items get asynchronously appended from a source array.
  * This behavior is useful if we want to render a list of items asynchronously for performance reasons.
  *
- * @param {Array} list Source array.
- * @return {Array} Async array.
+ * @template T
+ * @param {T[]} list Source array.
+ * @return {T[]} Async array.
  */
 function useAsyncList( list ) {
 	const [ current, dispatch ] = useReducer( listReducer, [] );
@@ -64,7 +67,7 @@ function useAsyncList( list ) {
 			list: firstItems,
 		} );
 		const asyncQueue = createQueue();
-		const append = ( index ) => () => {
+		const append = ( /** @type {number} */ index ) => () => {
 			if ( list.length <= index ) {
 				return;
 			}
@@ -76,7 +79,9 @@ function useAsyncList( list ) {
 		return () => asyncQueue.reset();
 	}, [ list ] );
 
-	return current;
+	/* eslint-disable jsdoc/no-undefined-types */
+	return /** @type {T[]} */ ( current );
+	/* eslint-enable jsdoc/no-undefined-types */
 }
 
 export default useAsyncList;

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -11,8 +11,9 @@ import { useRef, useEffect, useState } from '@wordpress/element';
 /**
  * Copies the text to the clipboard when the element is clicked.
  *
- * @param {Object}          ref     Reference with the element.
- * @param {string|Function} text    The text to copy.
+ * @template {HTMLElement} TElement
+ * @param {import('react').RefObject<TElement>}          ref     Reference with the element.
+ * @param {string| ( () => string )} text    The text to copy.
  * @param {number}          timeout Optional timeout to reset the returned
  *                                  state. 4 seconds by default.
  *
@@ -20,10 +21,16 @@ import { useRef, useEffect, useState } from '@wordpress/element';
  *                   timeout.
  */
 export default function useCopyOnClick( ref, text, timeout = 4000 ) {
+	/** @type {import('react').MutableRefObject<Clipboard | undefined>} */
 	const clipboard = useRef();
 	const [ hasCopied, setHasCopied ] = useState( false );
 
 	useEffect( () => {
+		if ( ! ref.current ) {
+			return;
+		}
+
+		/** @type {number} */
 		let timeoutId;
 
 		// Clipboard listens to click events.
@@ -39,7 +46,7 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 
 			// Handle ClipboardJS focus bug, see https://github.com/zenorocha/clipboard.js/issues/680
 			if ( trigger ) {
-				trigger.focus();
+				/** @type {HTMLElement} */ ( trigger ).focus();
 			}
 
 			if ( timeout ) {
@@ -50,7 +57,9 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 		} );
 
 		return () => {
-			clipboard.current.destroy();
+			if ( clipboard.current ) {
+				clipboard.current.destroy();
+			}
 			clearTimeout( timeoutId );
 		};
 	}, [ text, timeout, setHasCopied ] );

--- a/packages/compose/src/utils/create-higher-order-component/index.js
+++ b/packages/compose/src/utils/create-higher-order-component/index.js
@@ -7,12 +7,13 @@ import { camelCase, upperFirst } from 'lodash';
  * Given a function mapping a component to an enhanced component and modifier
  * name, returns the enhanced component augmented with a generated displayName.
  *
- * @param {Function} mapComponentToEnhancedComponent Function mapping component
+ * @template {{}} T
+ * @param {(OriginalComponent: import('react').ComponentType<T>) => import('react').ComponentType<T>} mapComponentToEnhancedComponent Function mapping component
  *                                                   to enhanced component.
  * @param {string}   modifierName                    Seed name from which to
  *                                                   generated display name.
  *
- * @return {WPComponent} Component class with generated display name assigned.
+ * @return {(OriginalComponent: import('react').ComponentType<T>) => import('react').ComponentType<T>} Component class with generated display name assigned.
  */
 function createHigherOrderComponent(
 	mapComponentToEnhancedComponent,

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types",
+		"types": [ "gutenberg-env" ]
+	},
+	"references": [
+		{ "path": "../element" },
+		{ "path": "../is-shallow-equal" },
+		{ "path": "../priority-queue" }
+	],
+	"include": [
+		"src/higher-order/if-condition/**/*",
+		"src/hooks/use-async-list/**/*",
+		"src/hooks/use-copy-on-click/**/*",
+		"src/utils/**/*"
+	],
+	"exclude": [
+		"src/**/test",
+	]
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds partial type support for `@wordpress/compose` in the same way we've done for `@wordpress/components`. We'll type if file by file as each file allows (provided it has no dependencies on untyped packages like `@wordpress/dom` for example).

I only typed a few files to make this easier to review and just to illustrate the point of how this can be done, just as it is being done for `@wordpress/components`.

## How has this been tested?
Build/type-check passes.

## Types of changes
Non-breaking changes to documentation (and some minor runtime changes for null-safety).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
