### PR TITLE
Do not automatically close message, update stale message

### DIFF
--- a/.github/workflows/stale-issue-needs-info.yml
+++ b/.github/workflows/stale-issue-needs-info.yml
@@ -1,4 +1,4 @@
-name: "Mark issues stale that requires info"
+name: "Mark issues stale that require info"
 on:
   schedule:
   - cron: "30 1 * * *"
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Help us help you. This issue is being marked stale since it has no activity after 15 days of requesting more information. Please add info requested so we can help move the issue forward. Note: The triage policy is to close stale issues that need more info and no response after 2 weeks.'
+        stale-issue-message: 'Help us move this issue forward. This issue is being marked stale since it has no activity after 15 days of requesting more information. Please add info requested so we can help move the issue forward. Note: The triage policy is to close stale issues that need more info and no response after 2 weeks.'
         days-before-stale: 15
         days-before-close: -1
         only-labels: '[Status] Needs More Info'

--- a/.github/workflows/stale-issue-needs-info.yml
+++ b/.github/workflows/stale-issue-needs-info.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues that requires info"
+name: "Mark issues stale that requires info"
 on:
   schedule:
   - cron: "30 1 * * *"
@@ -10,9 +10,8 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Help us move this issue forward. Since it has no activity after 15 days of requesting more information, a bot is marking the issue as stale. Please add additional information as a comment or this issued will be closed in 5 days.'
-        close-issue-message: 'This issue was closed because more information was requested and there was no activity. If this is a bug report and still a problem, please supply the additional information requested and reopen the issue.'
+        stale-issue-message: 'Help us help you. This issue is being marked stale since it has no activity after 15 days of requesting more information. Please add info requested so we can help move the issue forward. Note: The triage policy is to close stale issues that need more info and no response after 2 weeks.'
         days-before-stale: 15
-        days-before-close: 5
+        days-before-close: -1
         only-labels: '[Status] Needs More Info'
         stale-issue-label: '[Status] Stale'


### PR DESCRIPTION

## Description

The Needs Info / Stale bot previously closed messages after 5 days of no response after a ping for more info. This removes the auto closing and updates the message to clarify the policy, but leaves it for a triage human to do the actual closing

Related to #28900

See [Triage policies here](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/triage.md#general-triage-process)

## How has this been tested?

- Tricky to test but reading the docs and [issue here](https://github.com/actions/stale/issues/74) says setting to -1 will not close.

The new message is:

> Help us help you. This issue is being marked stale since it has no activity after 15 days of requesting more information. Please add info requested so we can help move the issue forward. Note: The triage policy is to close stale issues that need more info and no response after 2 weeks.

## Types of changes

Alters the GitHub workflow that marks issue stale and previously closed when more information was requested and not updated after 15 days. Now it will only mark as stale and not close, allowing a triage human to review and close manually.
