### PR TITLE
Table of contents: fix class attribute

### DIFF
--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -309,7 +309,7 @@ function render_block_core_table_of_contents( $attributes, $content, $block ) {
 	}
 
 	return sprintf(
-		'<nav class="%1$s">%2$s</nav>',
+		'<nav %1$s>%2$s</nav>',
 		get_block_wrapper_attributes(),
 		block_core_table_of_contents_render_list(
 			block_core_table_of_contents_linear_to_nested_heading_list( $headings )


### PR DESCRIPTION
## Description
[get_block_wrapper_attributes()](https://developer.wordpress.org/reference/functions/get_block_wrapper_attributes/) already adds the "class=" attribute. So we don't need this attribute here.

Before: `<nav class="class="wp-block-table-of-contents"">`
After: `<nav class="wp-block-table-of-contents">`
