### PR TITLE
Components: Remove references to __experimental* in the DateTimePicker component docs

### DIFF
--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -16,28 +16,16 @@ Render a DateTimePicker.
 
 ```jsx
 import { DateTimePicker } from '@wordpress/components';
-import { __experimentalGetSettings } from '@wordpress/date';
 import { withState } from '@wordpress/compose';
 
 const MyDateTimePicker = withState( {
 	date: new Date(),
 } )( ( { date, setState } ) => {
-	const settings = __experimentalGetSettings();
-
-	// To know if the current timezone is a 12 hour time with look for an "a" in the time format.
-	// We also make sure this a is not escaped by a "/".
-	const is12HourTime = /a(?!\\)/i.test(
-		settings.formats.time
-			.toLowerCase() // Test only the lower case a
-			.replace( /\\\\/g, '' ) // Replace "//" with empty strings
-			.split( '' ).reverse().join( '' ) // Reverse the string and test for "a" not followed by a slash
-	);
-
 	return (
 		<DateTimePicker
 			currentDate={ date }
 			onChange={ ( date ) => setState( { date } ) }
-			is12Hour={ is12HourTime }
+			is12Hour={ true }
 		/>
 	);
 } );
@@ -68,6 +56,7 @@ Whether we use a 12-hour clock. With a 12-hour clock, an AM/PM widget is display
 
 - Type: `bool`
 - Required: No
+- Default: false
 
 ### isInvalidDate
 


### PR DESCRIPTION

## Description
Remove documented code using `__experimentalGetSettings` as per https://developer.wordpress.org/block-editor/contributors/develop/coding-guidelines/#experimental-and-unstable-apis

In place of the value set by that code, I added an example value and indicated the default value below.

## How has this been tested?
Documentation change only

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
