### PR TITLE
Fix typos in git workflow documentation

### DIFF
--- a/docs/contributors/git-workflow.md
+++ b/docs/contributors/git-workflow.md
@@ -60,7 +60,7 @@ git commit -m "Your Good Commit Message" path/to/FILE
 **Step 6**: Push your change up to GitHub. The change will be pushed to your fork of the repository on the GitHub
 
 ```bash
-git push -u origin upgrade/my-branch
+git push -u origin update/my-branch
 ```
 
 **Step 7**: Go to your forked repository on GitHub -- it will automatically detect the change and give you a link to create a pull request.

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,7 +80,7 @@ function render_block_core_search( $attributes ) {
 		}
 
 		$button_markup = sprintf(
-			'<button type="submit"class="wp-block-search__button ' . $button_classes . '">%s</button>',
+			'<button type="submit" class="wp-block-search__button ' . $button_classes . '">%s</button>',
 			$button_internal_markup
 		);
 	}


### PR DESCRIPTION
## Description
Fixes an error in the example code. Line 49 mentions 'update' instead of 'upgrade', which should be the same.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
