### PR TITLE
env: Do not support newer PHPunit versions

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -150,13 +150,8 @@ module.exports = function buildDockerComposeConfig( config ) {
 		phpunitTag = '5' + phpunitPhpVersion;
 	} else if ( testsPhpVersion === '7.0' ) {
 		phpunitTag = '6' + phpunitPhpVersion;
-	} else if ( testsPhpVersion === '7.1' ) {
-		phpunitTag = '7' + phpunitPhpVersion;
-	} else if ( [ '7.2', '7.3', '7.4' ].indexOf( testsPhpVersion ) >= 0 ) {
-		phpunitTag = '8' + phpunitPhpVersion;
-	} else if ( testsPhpVersion === '8.0' ) {
-		phpunitTag = '9' + phpunitPhpVersion;
 	}
+	// Note: the WP tests lib does not yet support PHPunit above 7, so we keep it at "latest" in that case.
 	const phpunitImage = `wordpressdevelop/phpunit:${ phpunitTag }`;
 
 	// The www-data user in wordpress:cli has a different UID (82) to the


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
The WP test library does not support newer PHPunit versions. This means that one cannot simultaneously set a "php version" and also use the recommended WP test library.

My proposal is to just support up to the "latest" tagged image, which is currently 7. However, this would obviously break things if you're trying to work with PHP 8.... Then again, you wouldn't be able to use the WP tests lib with that anyways. 🤔 Not sure what the best path forward is in that scenario.

What do folks think?
 
## How has this been tested?
1. Run npm build.
1. Add "phpVersion": "7.2" to Gutenberg's .wp-env.json file.
2. Rebuild the containers with npm run wp-env start.
3. Run npm run test-php.
4. Tests should pass.

Also, GH actions phpunit step should pass.

## Types of changes
bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
