### PR TITLE
Add regression test for editor JS crash caused by rtlcss parsing exception

### DIFF
--- a/packages/e2e-tests/specs/editor/various/rtl.test.js
+++ b/packages/e2e-tests/specs/editor/various/rtl.test.js
@@ -43,7 +43,6 @@ describe( 'RTL', () => {
 			snippetScriptEl.text = 'document.dir = "rtl";';
 			newComponentsScriptEl.src = componentsScriptSrc;
 
-			//scripts.forEach( ( script ) => script.remove() );
 			head.appendChild( snippetScriptEl );
 			head.appendChild( newComponentsScriptEl );
 		} );

--- a/packages/e2e-tests/specs/editor/various/rtl.test.js
+++ b/packages/e2e-tests/specs/editor/various/rtl.test.js
@@ -21,6 +21,38 @@ describe( 'RTL', () => {
 		} );
 	} );
 
+	// Regression test for https://github.com/WordPress/gutenberg/issues/29250.
+	it( 'loads editor without errors when RTL is set at the WP admin level', async () => {
+		await page.evaluate( () => {
+			window._loadedWithoutErrors = true;
+
+			window.addEventListener( 'error', function ( event ) {
+				window._loadedWithoutErrors = false;
+				event.preventDefault();
+			} );
+
+			const scripts = Array.from( document.querySelectorAll( 'script' ) );
+			const snippetScriptEl = document.createElement( 'script' );
+			const newComponentsScriptEl = document.createElement( 'script' );
+			const head = document.head;
+
+			const componentsScriptSrc = scripts.find( ( s ) =>
+				s.src.match( 'components/index.js' )
+			).src;
+
+			snippetScriptEl.text = 'document.dir = "rtl";';
+			newComponentsScriptEl.src = componentsScriptSrc;
+
+			//scripts.forEach( ( script ) => script.remove() );
+			head.appendChild( snippetScriptEl );
+			head.appendChild( newComponentsScriptEl );
+		} );
+
+		expect(
+			await page.evaluate( () => window._loadedWithoutErrors )
+		).toBeTruthy();
+	} );
+
 	it( 'should arrow navigate', async () => {
 		await page.keyboard.press( 'Enter' );
 

--- a/packages/e2e-tests/specs/editor/various/rtl.test.js
+++ b/packages/e2e-tests/specs/editor/various/rtl.test.js
@@ -37,7 +37,7 @@ describe( 'RTL', () => {
 			const head = document.head;
 
 			const componentsScriptSrc = scripts.find( ( s ) =>
-				s.src.match( 'components/index.js' )
+				s.src.match( /components\/index\.js/ )
 			).src;
 
 			snippetScriptEl.text = 'document.dir = "rtl";';

--- a/packages/e2e-tests/specs/editor/various/rtl.test.js
+++ b/packages/e2e-tests/specs/editor/various/rtl.test.js
@@ -22,15 +22,8 @@ describe( 'RTL', () => {
 	} );
 
 	// Regression test for https://github.com/WordPress/gutenberg/issues/29250.
-	it( 'loads editor without errors when RTL is set at the WP admin level', async () => {
+	it( 'should load the editor without errors when RTL is set at the WP admin level', async () => {
 		await page.evaluate( () => {
-			window._loadedWithoutErrors = true;
-
-			window.addEventListener( 'error', function ( event ) {
-				window._loadedWithoutErrors = false;
-				event.preventDefault();
-			} );
-
 			const scripts = Array.from( document.querySelectorAll( 'script' ) );
 			const snippetScriptEl = document.createElement( 'script' );
 			const newComponentsScriptEl = document.createElement( 'script' );
@@ -47,9 +40,8 @@ describe( 'RTL', () => {
 			head.appendChild( newComponentsScriptEl );
 		} );
 
-		expect(
-			await page.evaluate( () => window._loadedWithoutErrors )
-		).toBeTruthy();
+		// No assertions are needed as the test will fail if an error is thrown
+		// during the evaluate call above, or pass if no errors are thrown.
 	} );
 
 	it( 'should arrow navigate', async () => {


### PR DESCRIPTION
## Description

Issue: https://github.com/WordPress/gutenberg/issues/29250.

Add regression test to prevent issues related to RTL being active at the WP-admin level.*

_*it seems you can activate RTL in two places: wp-admin and in the Gutenberg editor. The error we're trying to avoid a regression for only happens when RTL is active at the "WP admin level" (someone please correct me if this is the wrong mental model / I'm using the wrong term here)._

After investigating where `rtlcss` is parsing the CSS (see: https://github.com/ItsJonQ/g2/blob/main/packages/create-styles/src/create-compiler/plugins/rtl.js#L38), the challenge was then making sure that `document.dir = 'rtl'` ran before that. Played with several approaches, including using Puppeteer's `evaluateOnNewDocument` to execute the snippet, but none of them worked. 

Had to do some gymnastics to make sure the snippet ran before the corresponding js. With that test, I am able to reproduce the error in GB <= 10.0.0. Still need to clean it up, and it's less than perfect _(it effectively reloads the script after the page already loaded, while making sure the dir RTL property is set in the document)_ but it seems this approach is feasible. 

## How to test

1. Easiest way is to checkout `v10.0.0` (or revert commit `2f93c432a3`), then `npm ci && npm run build` and start a wp-env instance from there. Finally, in another Gutenberg copy, check out this branch (`add/regression-test-rtlcss-parser-comment-crash`) and run this test _(you might also call `only` in the `it` to restrict the run to the single test added in this PR, if you'd like)_. The `loads editor without errors when RTL is set at the WP admin level` test should fail 🔴:

![expect](https://user-images.githubusercontent.com/81248/109231946-01d89f80-778d-11eb-8064-68bd432c830e.png)


2. Now, where you had `v10.0.0` checkout, checkout `v10.0.2` (or `master`) instead, run `npm ci && npm run build` and go back to the other Gutenberg instance, and run the test again. It should pass 🟢:

![pass](https://user-images.githubusercontent.com/81248/109232624-33059f80-778e-11eb-8bfa-6efc4f828467.png)

## Types of changes

New E2E test.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->


