### PR TITLE
Move the setting of the default attributes on new blocks to a single useEffect

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty, concat, some, find } from 'lodash';
+import { isEmpty, concat, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -23,7 +23,6 @@ import {
 	InspectorControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { store as coreStore } from '@wordpress/core-data';
 import { Platform, useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -52,6 +51,7 @@ import {
 import useImageSizes from './use-image-sizes';
 import useShortCodeTransform from './use-short-code-transform';
 import useGetNewImages from './use-get-new-images';
+import useGetMedia from './use-get-media';
 
 const MAX_COLUMNS = 8;
 const linkOptions = [
@@ -132,31 +132,7 @@ function GalleryEdit( props ) {
 		[ innerBlockImages ]
 	);
 
-	const imageData = useSelect(
-		( select ) => {
-			if (
-				! innerBlockImages?.length ||
-				some(
-					innerBlockImages,
-					( imageBlock ) => ! imageBlock.attributes.id
-				)
-			) {
-				return imageData;
-			}
-
-			const imageIds = innerBlockImages.map(
-				( imageBlock ) => imageBlock.attributes.id
-			);
-
-			const getMediaItems = select( coreStore ).getMediaItems;
-
-			return getMediaItems( {
-				include: imageIds,
-				per_page: imageIds.length,
-			} );
-		},
-		[ innerBlockImages ]
-	);
+	const imageData = useGetMedia( innerBlockImages );
 
 	const newImages = useGetNewImages( images, imageData );
 

--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -25,16 +25,13 @@ export default function useGetMedia( innerBlockImages ) {
 				return currentImageMedia;
 			}
 
-			const imageIds = innerBlockImages
-				.map( ( imageBlock ) => imageBlock.attributes.id )
-				.filter(
-					( id ) =>
-						! currentImageMedia.find( ( img ) => id === img.id )
-				);
+			const imageIds = innerBlockImages.map(
+				( imageBlock ) => imageBlock.attributes.id
+			);
+
 			if ( imageIds.length === 0 ) {
 				return currentImageMedia;
 			}
-
 			const getMedia = select( coreStore ).getMedia;
 			const newImageMedia = imageIds.map( ( img ) => {
 				return getMedia( img );
@@ -43,22 +40,15 @@ export default function useGetMedia( innerBlockImages ) {
 			if ( newImageMedia.some( ( img ) => ! img ) ) {
 				return currentImageMedia;
 			}
+
 			return newImageMedia;
 		},
 		[ innerBlockImages ]
 	);
 
-	const newData = imageMedia?.filter(
-		( img ) =>
-			! currentImageMedia.find(
-				( currentImg ) => currentImg.id === img.id
-			)
-	);
-
-	if ( newData?.length > 0 ) {
-		const newCurrentMedia = [ ...currentImageMedia, ...newData ];
-		setCurrentImageMedia( newCurrentMedia );
-		return newCurrentMedia;
+	if ( imageMedia?.length !== currentImageMedia.length ) {
+		setCurrentImageMedia( imageMedia );
+		return imageMedia;
 	}
 
 	return currentImageMedia;

--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -34,11 +34,16 @@ export default function useGetMedia( innerBlockImages ) {
 			if ( imageIds.length === 0 ) {
 				return currentImageMedia;
 			}
-			const getMediaItems = select( coreStore ).getMediaItems;
-			return getMediaItems( {
-				include: imageIds,
-				per_page: imageIds.length,
+
+			const getMedia = select( coreStore ).getMedia;
+			const newImageMedia = imageIds.map( ( img ) => {
+				return getMedia( img );
 			} );
+
+			if ( newImageMedia.some( ( img ) => ! img ) ) {
+				return currentImageMedia;
+			}
+			return newImageMedia;
 		},
 		[ innerBlockImages ]
 	);
@@ -55,5 +60,6 @@ export default function useGetMedia( innerBlockImages ) {
 		setCurrentImageMedia( newCurrentMedia );
 		return newCurrentMedia;
 	}
+
 	return currentImageMedia;
 }

--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+export default function useGetMedia( innerBlockImages ) {
+	const [ currentImageMedia, setCurrentImageMedia ] = useState( [] );
+
+	const imageMedia = useSelect(
+		( select ) => {
+			if (
+				! innerBlockImages?.length ||
+				some(
+					innerBlockImages,
+					( imageBlock ) => ! imageBlock.attributes.id
+				)
+			) {
+				return currentImageMedia;
+			}
+
+			const imageIds = innerBlockImages
+				.map( ( imageBlock ) => imageBlock.attributes.id )
+				.filter(
+					( id ) =>
+						! currentImageMedia.find( ( img ) => id === img.id )
+				);
+			if ( imageIds.length === 0 ) {
+				return currentImageMedia;
+			}
+			const getMediaItems = select( coreStore ).getMediaItems;
+			return getMediaItems( {
+				include: imageIds,
+				per_page: imageIds.length,
+			} );
+		},
+		[ innerBlockImages ]
+	);
+
+	const newData = imageMedia?.filter(
+		( img ) =>
+			! currentImageMedia.find(
+				( currentImg ) => currentImg.id === img.id
+			)
+	);
+
+	if ( newData?.length > 0 ) {
+		const newCurrentMedia = [ ...currentImageMedia, ...newData ];
+		setCurrentImageMedia( newCurrentMedia );
+		return newCurrentMedia;
+	}
+	return currentImageMedia;
+}

--- a/packages/block-library/src/gallery/use-get-new-images.js
+++ b/packages/block-library/src/gallery/use-get-new-images.js
@@ -23,7 +23,7 @@ export default function useGetNewImages( images, imageData ) {
 		}
 
 		// Now lets see if we have any images hydrated from saved content and if so
-		// add then to currentImages state.
+		// add them to currentImages state.
 		images.forEach( ( image ) => {
 			if (
 				image.fromSavedContent &&
@@ -36,7 +36,7 @@ export default function useGetNewImages( images, imageData ) {
 			}
 		} );
 
-		// Now check for any new images that have been added InnerBlocks and for which
+		// Now check for any new images that have been added to InnerBlocks and for which
 		// we have the imageData we need for setting default block attributes.
 		const newImages = images.filter(
 			( image ) =>

--- a/packages/block-library/src/gallery/use-get-new-images.js
+++ b/packages/block-library/src/gallery/use-get-new-images.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo, useState } from '@wordpress/element';
+
+export default function useGetNewImages( images, imageData ) {
+	const [ currentImages, setCurrentImages ] = useState( [] );
+
+	return useMemo( () => getNewImages(), [ images, imageData ] );
+
+	function getNewImages() {
+		let imagesUpdated = false;
+
+		// First lets check if any images have been deleted.
+		const newCurrentImages = currentImages.filter( ( currentImg ) =>
+			images.find( ( img ) => {
+				return currentImg.clientId === img.clientId;
+			} )
+		);
+
+		if ( newCurrentImages.length < currentImages.length ) {
+			imagesUpdated = true;
+		}
+
+		// Now lets see if we have any images hydrated from saved content and if so
+		// add then to currentImages state.
+		images.forEach( ( image ) => {
+			if (
+				image.fromSavedContent &&
+				! newCurrentImages.find(
+					( currentImage ) => currentImage.id === image.id
+				)
+			) {
+				imagesUpdated = true;
+				newCurrentImages.push( image );
+			}
+		} );
+
+		// Now check for any new images that have been added InnerBlocks and for which
+		// we have the imageData we need for setting default block attributes.
+		const newImages = images.filter(
+			( image ) =>
+				! newCurrentImages.find(
+					( currentImage ) => image.id && currentImage.id === image.id
+				) &&
+				imageData?.find( ( img ) => img.id === image.id ) &&
+				! image.fromSavedConent
+		);
+
+		if ( imagesUpdated || newImages?.length > 0 ) {
+			setCurrentImages( [ ...newCurrentImages, ...newImages ] );
+		}
+
+		return newImages.length > 0 ? newImages : null;
+	}
+}


### PR DESCRIPTION
## Description

Moves setting of default attribs to a single useEffect to enable setting for blocks added by drag and drop or via media placeholder in one place.

Related to: https://github.com/WordPress/gutenberg/pull/25940


## Testing

Check out PR and try adding and removing images in various ways and make sure the current gallery linkTO, etc. are applied to the new images.
