### PR TITLE
Social Links: Replace CSS variables with block context approach

### DIFF
--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -17,7 +17,9 @@
 		}
 	},
 	"usesContext": [
-		"openInNewTab"
+		"openInNewTab",
+		"iconColorValue",
+		"iconBackgroundColorValue"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -27,8 +27,14 @@ import { keyboardReturn } from '@wordpress/icons';
  */
 import { getIconBySite, getNameBySite } from './social-list';
 
-const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
+const SocialLinkEdit = ( {
+	attributes,
+	context,
+	isSelected,
+	setAttributes,
+} ) => {
 	const { url, service, label } = attributes;
+	const { iconColorValue, iconBackgroundColorValue } = context;
 	const [ showURLPopover, setPopover ] = useState( false );
 	const classes = classNames( 'wp-social-link', 'wp-social-link-' + service, {
 		'wp-social-link__is-incomplete': ! url,
@@ -36,7 +42,13 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
-	const blockProps = useBlockProps( { className: classes } );
+	const blockProps = useBlockProps( {
+		className: classes,
+		style: {
+			color: iconColorValue,
+			backgroundColor: iconBackgroundColorValue,
+		},
+	} );
 
 	return (
 		<Fragment>

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -33,7 +33,12 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	}
 
 	$icon               = block_core_social_link_get_icon( $service );
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wp-social-link wp-social-link-' . $service . $class_name ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class' => 'wp-social-link wp-social-link-' . $service . $class_name,
+			'style' => block_core_social_link_get_color_styles( $block->context ),
+		)
+	);
 
 	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $attribute . ' class="wp-block-social-link-anchor"> ' . $icon . '</a></li>';
 }
@@ -279,4 +284,25 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 	}
 
 	return $services_data;
+}
+
+/**
+ * Returns CSS styles for icon and icon background colors.
+ *
+ * @param array $context Block context passed to Social Link.
+ *
+ * @return string Inline CSS styles for link's icon and background colors.
+ */
+function block_core_social_link_get_color_styles( $context ) {
+	$styles = array();
+
+	if ( array_key_exists( 'iconColorValue', $context ) ) {
+		$styles[] = 'color: ' . $context['iconColorValue'] . '; ';
+	}
+
+	if ( array_key_exists( 'iconBackgroundColorValue', $context ) ) {
+		$styles[] = 'background-color: ' . $context['iconBackgroundColorValue'] . '; ';
+	}
+
+	return implode( '', $styles );
 }

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -30,7 +30,9 @@
 		}
 	},
 	"providesContext": {
-		"openInNewTab": "openInNewTab"
+		"openInNewTab": "openInNewTab",
+		"iconColorValue": "iconColorValue",
+		"iconBackgroundColorValue": "iconBackgroundColorValue"
 	},
 	"supports": {
 		"align": [

--- a/packages/block-library/src/social-links/deprecated.js
+++ b/packages/block-library/src/social-links/deprecated.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+// Social Links block deprecations.
+const deprecated = [
+	// V1. Remove CSS variable use for colors.
+	{
+		attributes: {
+			iconColor: {
+				type: 'string',
+			},
+			customIconColor: {
+				type: 'string',
+			},
+			iconColorValue: {
+				type: 'string',
+			},
+			iconBackgroundColor: {
+				type: 'string',
+			},
+			customIconBackgroundColor: {
+				type: 'string',
+			},
+			iconBackgroundColorValue: {
+				type: 'string',
+			},
+			openInNewTab: {
+				type: 'boolean',
+				default: false,
+			},
+			size: {
+				type: 'string',
+			},
+		},
+		providesContext: {
+			openInNewTab: 'openInNewTab',
+		},
+		supports: {
+			align: [ 'left', 'center', 'right' ],
+			anchor: true,
+		},
+		save: ( props ) => {
+			const {
+				attributes: {
+					iconBackgroundColorValue,
+					iconColorValue,
+					itemsJustification,
+					size,
+				},
+			} = props;
+
+			const className = classNames( size, {
+				'has-icon-color': iconColorValue,
+				'has-icon-background-color': iconBackgroundColorValue,
+				[ `items-justified-${ itemsJustification }` ]: itemsJustification,
+			} );
+
+			const style = {
+				'--wp--social-links--icon-color': iconColorValue,
+				'--wp--social-links--icon-background-color': iconBackgroundColorValue,
+			};
+
+			return (
+				<ul { ...useBlockProps.save( { className, style } ) }>
+					<InnerBlocks.Content />
+				</ul>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -91,13 +91,7 @@ export function SocialLinksEdit( props ) {
 		[ `items-justified-${ itemsJustification }` ]: itemsJustification,
 	} );
 
-	const style = {
-		'--wp--social-links--icon-color': iconColor.color || iconColorValue,
-		'--wp--social-links--icon-background-color':
-			iconBackgroundColor.color || iconBackgroundColorValue,
-	};
-
-	const blockProps = useBlockProps( { className, style } );
+	const blockProps = useBlockProps( { className } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
@@ -195,7 +189,6 @@ export function SocialLinksEdit( props ) {
 							value: iconColor.color || iconColorValue,
 							onChange: ( colorValue ) => {
 								setIconColor( colorValue );
-								// Set explicit color value used to add CSS variable in save.js
 								setAttributes( { iconColorValue: colorValue } );
 							},
 							label: __( 'Icon color' ),
@@ -208,7 +201,6 @@ export function SocialLinksEdit( props ) {
 								iconBackgroundColorValue,
 							onChange: ( colorValue ) => {
 								setIconBackgroundColor( colorValue );
-								// Set explicit color value used to add CSS variable in save.js
 								setAttributes( {
 									iconBackgroundColorValue: colorValue,
 								} );

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -7,6 +7,7 @@ import { share as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
@@ -54,4 +55,5 @@ export const settings = {
 	icon,
 	edit,
 	save,
+	deprecated,
 };

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -24,13 +24,8 @@ export default function save( props ) {
 		[ `items-justified-${ itemsJustification }` ]: itemsJustification,
 	} );
 
-	const style = {
-		'--wp--social-links--icon-color': iconColorValue,
-		'--wp--social-links--icon-background-color': iconBackgroundColorValue,
-	};
-
 	return (
-		<ul { ...useBlockProps.save( { className, style } ) }>
+		<ul { ...useBlockProps.save( { className } ) }>
 			<InnerBlocks.Content />
 		</ul>
 	);

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -67,19 +67,6 @@
 	&.alignright {
 		justify-content: flex-end;
 	}
-
-	// Ensure user color selections are applied to inner Social Link blocks.
-	// Double selectors to increase specificity to avoid themes overwriting user selection.
-	&.has-icon-color.has-icon-color {
-		> .wp-social-link {
-			color: var(--wp--social-links--icon-color);
-		}
-	}
-	&.has-icon-background-color.has-icon-background-color {
-		> .wp-social-link {
-			background-color: var(--wp--social-links--icon-background-color);
-		}
-	}
 }
 
 .wp-social-link {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/29297

## Description
The approach taken in https://github.com/WordPress/gutenberg/pull/28084 to provide the ability to set colors on the parent social link block and have these applied to inner blocks involved CSS custom properties. This has resulted in a problem where kses strip out the CSS custom property styles resulting in invalid blocks in the editor.

This PR alters the approach to pass the current icon color values via block context down to the individual social links so they can be applied as simple `color` and `background-color` inline styles. A deprecation has been included to handle updating the saved content for the main social links block.

## How has this been tested?

Manually.

#### Testing Instructions
1. On master, create a post, add a social links block, select icon and background colors for it, then save the post
2. Inspect the social links block in both the editor and frontend and notice the CSS custom properties in inline styles
3. Apply this PR branch and reload the editor
5. Confirm the social links block was deprecated and the block no longer contains CSS custom properties in its styles
6. Save the post, refresh the frontend and confirm the styles are correct there as well
7. Reload the editor and ensure there are no block validation errors
8. Tweak the colors and re-save, confirming block behaves as expected

## Screenshots <!-- if applicable -->

| Before | After |
|--------|------|
| ![SocialLinks-Before](https://user-images.githubusercontent.com/60436221/109115885-6a268180-778b-11eb-8d13-b6262426c395.gif) | ![SocialLinks-After](https://user-images.githubusercontent.com/60436221/109115897-6e529f00-778b-11eb-9723-9df2da242669.gif) |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
