### PR TITLE
Remove delete toolbar option from Site Logo

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -16,7 +16,6 @@ import {
 	RangeControl,
 	ResizableBox,
 	Spinner,
-	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -30,7 +29,6 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { trash } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -282,11 +280,6 @@ export default function LogoEdit( {
 		setLogo( media.id.toString() );
 	};
 
-	const deleteLogo = () => {
-		setLogo( '' );
-		setLogoUrl( '' );
-	};
-
 	const onUploadError = ( message ) => {
 		setError( message[ 2 ] ? message[ 2 ] : null );
 	};
@@ -301,13 +294,6 @@ export default function LogoEdit( {
 						accept={ ACCEPT_MEDIA_STRING }
 						onSelect={ onSelectLogo }
 						onError={ onUploadError }
-					/>
-				) }
-				{ !! logoUrl && (
-					<ToolbarButton
-						icon={ trash }
-						onClick={ () => deleteLogo() }
-						label={ __( 'Delete Site Logo' ) }
 					/>
 				) }
 			</ToolbarGroup>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/29234

`Site Logo` currently has a `delete` toolbar button that doesn't remove the block, but unsets the actual site logo. This seems to be confusing for many users and this PR removes that `delete` button.

Similar discussions were made about this option in `PostFeaturedImage` which was removed as well as it's confusing in the same way. https://github.com/WordPress/gutenberg/pull/27291
<!-- Please describe what you have changed or added -->
