### PR TITLE
Block edit: avoid memoized block context in favour of useSelect

### DIFF
--- a/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
@@ -1,15 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BlockControls should render a dynamic toolbar of controls 1`] = `
-<ContextProvider
-  value={
-    Object {
-      "clientId": undefined,
-      "isSelected": true,
-      "name": undefined,
-    }
-  }
->
+<ContextProvider>
   <WithFilters(Edit)
     isSelected={true}
   >

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -2,21 +2,36 @@
  * WordPress dependencies
  */
 import { createContext, useContext } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
-const Context = createContext( {
-	name: '',
-	isSelected: false,
-	clientId: null,
-} );
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+const Context = createContext();
 const { Provider } = Context;
 
 export { Provider as BlockEditContextProvider };
 
 /**
- * A hook that returns the block edit context.
+ * A hook that returns the block client ID, name and selected status.
  *
- * @return {Object} Block edit context
+ * @return {Object} Block client ID, name and selected status.
  */
 export function useBlockEditContext() {
-	return useContext( Context );
+	const clientId = useContext( Context );
+	return useSelect(
+		( select ) => {
+			const { getBlockName, isBlockSelected } = select(
+				blockEditorStore
+			);
+			return {
+				clientId,
+				name: getBlockName( clientId ),
+				isSelected: isBlockSelected( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 }

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -23,9 +23,14 @@ export function useBlockEditContext() {
 	const clientId = useContext( Context );
 	return useSelect(
 		( select ) => {
+			if ( ! clientId ) {
+				return {};
+			}
+
 			const { getBlockName, isBlockSelected } = select(
 				blockEditorStore
 			);
+
 			return {
 				clientId,
 				name: getBlockName( clientId ),

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useMemo } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import Edit from './edit';
@@ -12,19 +7,8 @@ import { BlockEditContextProvider, useBlockEditContext } from './context';
 export { useBlockEditContext };
 
 export default function BlockEdit( props ) {
-	const { name, isSelected, clientId } = props;
-	const context = {
-		name,
-		isSelected,
-		clientId,
-	};
 	return (
-		<BlockEditContextProvider
-			// It is important to return the same object if props haven't
-			// changed to avoid  unnecessary rerenders.
-			// See https://reactjs.org/docs/context.html#caveats.
-			value={ useMemo( () => context, Object.values( context ) ) }
-		>
+		<BlockEditContextProvider value={ props.clientId }>
 			<Edit { ...props } />
 		</BlockEditContextProvider>
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Ideally the only piece of context is the block client ID and everything else is derived from that. Unfortunately `useBlockEditContext` is exported at the package level (not sure why because it's only used within the package), but it can be rewritten with `useSelect`.

After this we should create a new hook to only return the client ID, but I ran into some errors there which I'm trying to pinpoint. Doing this step by step instead.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
