### PR TITLE
Blocks: preprocess validation log with util.format instead of sprintf

### DIFF
--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -19,6 +19,7 @@ import {
 	isValidBlockContent,
 	isClosedByToken,
 } from '../validation';
+import { createLogger } from '../validation/logger';
 import {
 	registerBlockType,
 	unregisterBlockType,
@@ -759,6 +760,14 @@ describe( 'validation', () => {
 			);
 
 			expect( isValid ).toBe( true );
+		} );
+	} );
+
+	describe( 'createLogger()', () => {
+		it( 'creates logger that pre-processes string substitutions', () => {
+			createLogger().warning( '%o', { foo: 'bar' } );
+
+			expect( console ).toHaveWarnedWith( "{ foo: 'bar' }" );
 		} );
 	} );
 } );

--- a/packages/blocks/src/api/validation/logger.js
+++ b/packages/blocks/src/api/validation/logger.js
@@ -10,14 +10,12 @@ export function createLogger() {
 		let log = ( message, ...args ) =>
 			logger( 'Block validation: ' + message, ...args );
 
-		// In test environments, pre-process the sprintf message to improve
+		// In test environments, pre-process string substitutions to improve
 		// readability of error messages. We'd prefer to avoid pulling in this
 		// dependency in runtime environments, and it can be dropped by a combo
 		// of Webpack env substitution + UglifyJS dead code elimination.
 		if ( process.env.NODE_ENV === 'test' ) {
-			log = ( ...args ) =>
-				// eslint-disable-next-line import/no-extraneous-dependencies
-				logger( require( 'sprintf-js' ).sprintf( ...args ) );
+			log = ( ...args ) => logger( require( 'util' ).format( ...args ) );
 		}
 
 		return log;


### PR DESCRIPTION
## Description
Replace usage of `sprintf` in block validation log message preprocessing with `util.format`. Fixes https://github.com/WordPress/gutenberg/issues/29291

## How has this been tested?

- Shows the expected output when applied to [this demo project](https://github.com/tmdk/gutenberg-block-validation-log-formatting-demo)
- Added a test to the block validation unit tests to verify `%o` substitution works as intended

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards. 
- [ ] I've tested my changes with keyboard and screen readers. 
- [x] My code has proper inline documentation. 
- [x] I've included developer documentation if appropriate. 
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.
