### PR TITLE
Show Site Logo's block toolbar when selected, after the editor loads

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -350,12 +350,9 @@ export default function LogoEdit( {
 		'is-focused': isSelected,
 	} );
 
-	const key = !! logoUrl;
-
 	const blockProps = useBlockProps( {
 		ref,
 		className: classes,
-		key,
 	} );
 
 	return (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/29218

If the site has a logo, the Site Logo block's `toolbar` is not shown after loading a post containing it. The block is still selected as you can see from the `Insperctor controls` and the `resize` handler.

This PR fixes that by removing the unnecessary (IMO) `key` prop from the block, which causes some issues with the toolbar positioning probably.

@scruffian do you remember why you added this in the original PR: https://github.com/WordPress/gutenberg/pull/18811?

