### PR TITLE
Interface: Fix React warnings triggered in ActionItem component

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -2,6 +2,10 @@
 
 For features included in the Gutenberg plugin, the deprecation policy is intended to support backward compatibility for two minor plugin releases, when possible. Features and code included in a stable release of WordPress are not included in this deprecation timeline, and are instead subject to the [versioning policies of the WordPress project](https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/). The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 10.3.0
+
+-   Passing a tuple of components with `as` prop to `ActionItem.Slot` component is no longer supported. Please pass a component with `as` prop instead.
+
 ## 9.7.0
 
 -   `leftSidebar` prop in `InterfaceSkeleton` component has been removed. Use `secondarySidebar` prop instead.

--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -6,12 +6,12 @@ For features included in the Gutenberg plugin, the deprecation policy is intende
 
 -   Passing a tuple of components with `as` prop to `ActionItem.Slot` component is no longer supported. Please pass a component with `as` prop instead. Example:
     ```diff
-		<ActionItem.Slot
- 						name="core/edit-post/plugin-more-menu"
- 						label={ __( 'Plugins' ) }
- 		- 				as={ [ MenuGroup, MenuItem ] }
- 		+ 				as={ MenuGroup }
-		/>
+    <ActionItem.Slot
+    	name="my/slot"
+    	label={ __( 'My slot' ) }
+    - 	as={ [ MenuGroup, MenuItem ] }
+    + 	as={ MenuGroup }
+    />
     ```
 
 ## 9.7.0

--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -4,7 +4,15 @@ For features included in the Gutenberg plugin, the deprecation policy is intende
 
 ## 10.3.0
 
--   Passing a tuple of components with `as` prop to `ActionItem.Slot` component is no longer supported. Please pass a component with `as` prop instead.
+-   Passing a tuple of components with `as` prop to `ActionItem.Slot` component is no longer supported. Please pass a component with `as` prop instead. Example:
+    ```diff
+		<ActionItem.Slot
+ 						name="core/edit-post/plugin-more-menu"
+ 						label={ __( 'Plugins' ) }
+ 		- 				as={ [ MenuGroup, MenuItem ] }
+ 		+ 				as={ MenuGroup }
+		/>
+    ```
 
 ## 9.7.0
 

--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { ActionItem, PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
@@ -52,7 +52,7 @@ const MoreMenu = ( { showIconLabels } ) => {
 					<ActionItem.Slot
 						name="core/edit-post/plugin-more-menu"
 						label={ __( 'Plugins' ) }
-						as={ [ MenuGroup, MenuItem ] }
+						as={ MenuGroup }
 						fillProps={ { onClick: onClose } }
 					/>
 					<ToolsMoreMenuGroup.Slot fillProps={ { onClose } } />

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -3,7 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup } from '@wordpress/components';
 import { ActionItem } from '@wordpress/interface';
 
 /**
@@ -61,7 +61,7 @@ const MoreMenu = () => (
 					<ActionItem.Slot
 						name="core/edit-site/plugin-more-menu"
 						label={ __( 'Plugins' ) }
-						as={ [ MenuGroup, MenuItem ] }
+						as={ MenuGroup }
 						fillProps={ { onClick: onClose } }
 					/>
 				</MenuGroup>

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Passing a tuple of components with `as` prop to `ActionItem.Slot` component is deprecated. Please pass a component with `as` prop instead ([#29340](https://github.com/WordPress/gutenberg/pull/29340)).
+
 ## 1.0.0 (2021-01-21)
 
 ### Breaking Changes

--- a/packages/interface/src/components/action-item/README.md
+++ b/packages/interface/src/components/action-item/README.md
@@ -1,5 +1,4 @@
-ActionItem
-=============================
+# ActionItem
 
 `ActionItem` is a component that implements a slot & fill pair used in situations where we have a container that will contain several possible actions e.g: a button group that will contain several buttons or a menu that will contain several menu items.
 
@@ -13,23 +12,23 @@ The props not referred below are passed to the container component.
 
 The name of the slot and fill pair passed to the `Slot` component.
 
-- Type: `String`
-- Required: Yes
+-   Type: `String`
+-   Required: Yes
 
 ### bubblesVirtually
 
 Property used to change the event bubbling behavior, passed to the `Slot` component.
 
-- Type: `boolean`
-- Required: no
+-   Type: `boolean`
+-   Required: no
 
 ### as
 
-An array of two components the first is the component used on the container of the fills and the second is the component used to render each fill.
-Defaults to `ButtonGroup` and `Button`can be changed to `MenuGroup` and `MenuItem`for example.
+The component used as the container of the fills. Defaults to the `ButtonGroup` component.
 
-- Type: `Array`
-- Required: no
+-   Type: `Component`
+-   Required: no
+-   Default: `ButtonGroup`
 
 ## ActionItem
 
@@ -39,20 +38,20 @@ The props not referred below are passed to the item component.
 
 The name of the slot and fill pair passed to the `Fill` component.
 
-- Type: `String`
-- Required: Yes
+-   Type: `String`
+-   Required: Yes
 
 ### onClick
 
 Callback function executed when a click on the item happens.
 
-- Type: `Function`
-- Required: no
+-   Type: `Function`
+-   Required: no
 
 ### as
 
-The component that is going to be used to render a the action item. If the component is not passed it defaults to the component specified on the slot.
+The component that is going to be used to render an action item. Defaults to the `Button` component.
 
-- Type: `Array`
-- Required: no
-
+-   Type: `Component`
+-   Required: no
+-   Default: `Button`

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -11,17 +11,16 @@ import { Children } from '@wordpress/element';
 
 function ActionItemSlot( {
 	name,
-	as = [ ButtonGroup, Button ],
+	as: Component = ButtonGroup,
 	fillProps = {},
 	bubblesVirtually,
 	...props
 } ) {
-	const [ Container, Item ] = as;
 	return (
 		<Slot
 			name={ name }
 			bubblesVirtually={ bubblesVirtually }
-			fillProps={ { as: Item, ...fillProps } }
+			fillProps={ fillProps }
 		>
 			{ ( fills ) => {
 				if ( isEmpty( Children.toArray( fills ) ) ) {
@@ -56,20 +55,18 @@ function ActionItemSlot( {
 					return child;
 				} );
 
-				return <Container { ...props }>{ children }</Container>;
+				return <Component { ...props }>{ children }</Component>;
 			} }
 		</Slot>
 	);
 }
 
-function ActionItem( { name, as, onClick, ...props } ) {
+function ActionItem( { name, as: Component = Button, onClick, ...props } ) {
 	return (
 		<Fill name={ name }>
-			{ ( fillProps ) => {
-				const { onClick: fpOnClick, as: fpAs } = fillProps;
-				const Item = as || fpAs || Button;
+			{ ( { onClick: fpOnClick } ) => {
 				return (
-					<Item
+					<Component
 						onClick={
 							onClick || fpOnClick
 								? ( ...args ) => {

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop } from 'lodash';
+import { isArray, isEmpty, noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { ButtonGroup, Button, Slot, Fill } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 import { Children } from '@wordpress/element';
 
 function ActionItemSlot( {
@@ -16,6 +17,16 @@ function ActionItemSlot( {
 	bubblesVirtually,
 	...props
 } ) {
+	if ( isArray( Component ) ) {
+		deprecated(
+			'Passing a tuple of components with `as` prop to `ActionItem.Slot` component',
+			{
+				alternative: 'a component with `as` prop',
+				version: '10.3',
+			}
+		);
+		Component = Component[ 0 ];
+	}
 	return (
 		<Slot
 			name={ name }

--- a/packages/interface/src/components/complementary-area-more-menu-item/index.js
+++ b/packages/interface/src/components/complementary-area-more-menu-item/index.js
@@ -1,12 +1,31 @@
 /**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { check } from '@wordpress/icons';
+import { MenuItem } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
 import ComplementaryAreaToggle from '../complementary-area-toggle';
 import ActionItem from '../action-item';
+
+const PluginsMenuItem = ( props ) => (
+	// Menu item is marked with unstable prop for backward compatibility.
+	// They are removed so they don't leak to DOM elements.
+	// @see https://github.com/WordPress/gutenberg/issues/14457
+	<MenuItem
+		{ ...omit( props, [
+			'__unstableExplicitMenuItem',
+			'__unstableTarget',
+		] ) }
+	/>
+);
 
 export default function ComplementaryAreaMoreMenuItem( {
 	scope,
@@ -23,6 +42,7 @@ export default function ComplementaryAreaMoreMenuItem( {
 							__unstableExplicitMenuItem
 						}
 						__unstableTarget={ `${ scope }/${ target }` }
+						as={ PluginsMenuItem }
 						name={ `${ scope }/plugin-more-menu` }
 						{ ...toggleProps }
 					/>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up for #29081.

This PR fixes the following warnings from React:

> The last remaining thing I discovered now are two warnings that need to be fixed:
> > Warning: React does not recognize the `__unstableExplicitMenuItem` prop on a DOM element.
> > Warning: React does not recognize the `__unstableTarget` prop on a DOM element.

I added a wrapper component for `MenuItem` that removes props that are added to detect duplicated menu items.

As part of the efforts, I simplified the API for `ActionItem.Slot` component to make it simpler to override the fill. I added a corresponding deprecation:

>  Passing a tuple of components with `as` prop to `ActionItem.Slot` component is deprecated. Please pass a component with `as` prop instead.

I tried different approaches with using `cloneElement` from React, but it isn't possible to remove existing props. You can only override them. See relates issue in React: https://github.com/facebook/react/issues/13381.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Open an edit post page.
2. Paste the following snippet in the Browser Console:
  ```js
wp.plugins.registerPlugin( 'my-custom-plugin', {
	render: function() {
		const el = wp.element.createElement;
 	
		function MyPluginSidebar() {
 			return el(
				wp.editPost.PluginSidebar,
				{
					name: 'my-custom-sidebar',
					title: 'My sidebar title',
					icon: 'palmtree',
				},
				el(
					wp.components.PanelBody,
					{},
					'My custom content'
				)
			);
		}

		function MyPluginSidebarMoreMenuItem() {
 			return el(
				wp.editPost.PluginSidebarMoreMenuItem,
				{
					target: 'my-custom-sidebar',
					icon: 'menu'
				},
				'My custom title'
			);
		}

 		return el( wp.element.Fragment, {}, el( MyPluginSidebar ), el( MyPluginSidebarMoreMenuItem ) );
	}
} );
  ```
3. Ensure there are no React warnings when opening More Menu.

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/699132/109163541-bbc61080-7779-11eb-96a2-f9ad9322172b.mov

Note: There is also PR https://github.com/WordPress/gutenberg/pull/29287 that ensures the order of pinned items doesn't change.

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
