### PR TITLE
Fix mobile issue template label

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report_mobile.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report_mobile.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report (Mobile)
 about: Report a bug with the mobile app version of Gutenberg
-labels: Mobile App Android/iOS
+labels: Mobile App - i.e. Android or iOS
 
 ---
 


### PR DESCRIPTION
## Description
The label for mobile Gutenberg was renamed. So, in order for this
template to apply the correct label, we need to update its name here.

## How has this been tested?
Visually verified the label name matched between this template and in the
[GitHub UI](https://github.com/WordPress/gutenberg/labels?q=mobile).

## Screenshots
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
