### PR TITLE
Components: Do not use ViewOwnProps for Portal

### DIFF
--- a/packages/components/src/ui/portal/component.js
+++ b/packages/components/src/ui/portal/component.js
@@ -22,7 +22,7 @@ import { Portal as BasePortal } from 'reakit';
  * }
  * ```
  *
- * @param {import('@wp-g2/create-styles').ViewOwnProps<{}, never>} props
+ * @param {{ children: import('react').ReactNode }} props
  */
 /* eslint-enable jsdoc/valid-types */
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Remove `ViewOwnProps` from `Portal` and explicitly document `children`.

## How has this been tested?
Typechecks pass.

## Types of changes
Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
