### PR TITLE
Register style attribute when any color property is supported

### DIFF
--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -18,12 +18,17 @@ function gutenberg_register_colors_support( $block_type ) {
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'text' ), true ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'background' ), true ) );
 	$has_gradients_support         = gutenberg_experimental_get( $color_support, array( 'gradients' ), false );
+	$has_link_colors_support       = gutenberg_experimental_get( $color_support, array( 'link' ), false );
+	$has_color_support             = $has_text_colors_support ||
+		$has_background_colors_support ||
+		$has_gradients_support ||
+		$has_link_colors_support;
 
 	if ( ! $block_type->attributes ) {
 		$block_type->attributes = array();
 	}
 
-	if ( $has_text_colors_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+	if ( $has_color_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
 		$block_type->attributes['style'] = array(
 			'type' => 'object',
 		);
@@ -59,7 +64,7 @@ function gutenberg_register_colors_support( $block_type ) {
  * @return array Colors CSS classes and inline styles.
  */
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
-	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( 'color' ), false );
+	$color_support = gutenberg_experimental_get( $block_type->supports, array( 'color' ), false );
 
 	if (
 		is_array( $color_support ) &&


### PR DESCRIPTION
While reading some code, I've noticed we only registered the style attribute if the block supported text color. This makes it so that is registered when any color property is supported.

## How to test

I'm not sure.

The fact that the client logic registers the style att properly covers for the server, so I'm not sure under which circumstances this would ever be a bug. I think it should be fixed anyway.