### PR TITLE
Fix Cover block ref usage

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -362,7 +362,7 @@ function CoverEdit( {
 	const imperativeFocalPointPreview = ( value ) => {
 		const [ styleOfRef, property ] = isDarkElement.current
 			? [ isDarkElement.current.style, 'objectPosition' ]
-			: [ blockProps.ref.current.style, 'backgroundPosition' ];
+			: [ ref.current.style, 'backgroundPosition' ];
 		styleOfRef[ property ] = mediaPosition( value );
 	};
 
@@ -494,7 +494,8 @@ function CoverEdit( {
 		</>
 	);
 
-	const blockProps = useBlockProps();
+	const ref = useRef();
+	const blockProps = useBlockProps( { ref } );
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-cover__inner-container',


### PR DESCRIPTION
In the same vein as https://github.com/WordPress/gutenberg/pull/29288#issue-579083128
>The components receiving refs shouldn't be assuming the type of ref they receive, they should instead use their own local refs.

In this case, the ref assumption causes an error and breaks updating of the focal point in a cover block **with a repeated background** (other background types are fine).

This is a pretty obscure thing but I put this in the same milestone as #28917 which had the change that necessitates this.

## How has this been tested?
Putting a cover block in a post, adding a repeated background and verifying the focal point adjustment works and the console is free of errors.

## Screenshots <!-- if applicable -->
### Repeated background focal point adjustment 
Before | After
-------|-------
![cover-fail](https://user-images.githubusercontent.com/9000376/108893613-259db900-75c6-11eb-954f-324257562f5c.gif) | ![cover-expected](https://user-images.githubusercontent.com/9000376/108893661-33533e80-75c6-11eb-9add-aecde50a69d5.gif)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
