### PR TITLE
Integrate AztecEditor-iOS 1.19.4

### DIFF
--- a/packages/react-native-aztec/RNTAztecView.podspec
+++ b/packages/react-native-aztec/RNTAztecView.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.xcconfig         = {'OTHER_LDFLAGS' => '-lxml2',
                         'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
   s.dependency         'React-Core'
-  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.3'
+  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.4'
 
 end

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -255,8 +255,8 @@ PODS:
     - React-Core
   - RNTAztecView (1.47.0):
     - React-Core
-    - WordPress-Aztec-iOS (~> 1.19.3)
-  - WordPress-Aztec-iOS (1.19.3)
+    - WordPress-Aztec-iOS (~> 1.19.4)
+  - WordPress-Aztec-iOS (1.19.4)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -435,8 +435,8 @@ SPEC CHECKSUMS:
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b
   RNSVG: 46c4b680fe18237fa01eb7d7b311d77618fde31f
-  RNTAztecView: 9c5552d00636833f452d88509421697869b1d13a
-  WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
+  RNTAztecView: b1dfb9116d5947d9740145d3620cec703b529203
+  WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
 PODFILE CHECKSUM: fb5a2c8eab8e33d063643370988400ebad0a71d2


### PR DESCRIPTION
## Description
Integrate latest AztecEditor-iOS 1.19.4 release.

* **WordPress-iOS:** wordpress-mobile/WordPress-iOS#15978
* **Gutenberg Mobile:** wordpress-mobile/gutenberg-mobile#3187

## How has this been tested?
* Verify iOS Demo app runs without error.
* Verify rich text blocks allow add, edit, and removal of text.
* Verify CI checks pass.

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
