### PR TITLE
RN: Button Block set the width to fixed when width is set

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -398,6 +398,7 @@ class ButtonEdit extends Component {
 
 		const backgroundColor = this.getBackgroundColor();
 		const textColor = this.getTextColor();
+		const isFixedWidth = !! width;
 
 		return (
 			<View onLayout={ this.onLayout }>
@@ -426,6 +427,12 @@ class ButtonEdit extends Component {
 						onChange={ this.onChangeText }
 						style={ {
 							...richTextStyle.richText,
+							paddingLeft: isFixedWidth
+								? 0
+								: richTextStyle.richText.paddingLeft,
+							paddingRight: isFixedWidth
+								? 0
+								: richTextStyle.richText.paddingRight,
 							color: textColor,
 						} }
 						textAlign={ align }
@@ -435,7 +442,7 @@ class ButtonEdit extends Component {
 						identifier="text"
 						tagName="p"
 						minWidth={ minWidth } // The minimum Button size.
-						maxWidth={ width ? minWidth : maxWidth } // The width of the screen.
+						maxWidth={ isFixedWidth ? minWidth : maxWidth } // The width of the screen.
 						id={ clientId }
 						isSelected={ isButtonFocused }
 						withoutInteractiveFormatting

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -435,7 +435,7 @@ class ButtonEdit extends Component {
 						identifier="text"
 						tagName="p"
 						minWidth={ minWidth } // The minimum Button size.
-						maxWidth={ maxWidth } // The width of the screen.
+						maxWidth={ width ? minWidth : maxWidth } // The width of the screen.
 						id={ clientId }
 						isSelected={ isButtonFocused }
 						withoutInteractiveFormatting

--- a/packages/block-library/src/button/rich-text.ios.scss
+++ b/packages/block-library/src/button/rich-text.ios.scss
@@ -1,4 +1,6 @@
 .richText {
 	margin: 10px $grid-unit-20;
+	padding-left: 0;
+	padding-right: 0;
 	background-color: transparent;
 }


### PR DESCRIPTION
## Description
In https://github.com/WordPress/gutenberg/pull/28543 we shipped a new button width setting. 
However it doesn't quite work as expected. Since if you type too many characters the buttons width expands and takes the buttons don't fit on the row as expected any more. 

This PR tried to fix that by setting the maxWidth to the minWidth if a width is set and not null. (Auto) 

Before:
![image (3)](https://user-images.githubusercontent.com/115071/109239125-9c36e400-7789-11eb-8e7d-862af94ae40c.png)

After:
<img width="400" alt="Screen Shot 2021-02-25 at 12 46 58 PM" src="https://user-images.githubusercontent.com/115071/109239166-b4a6fe80-7789-11eb-9906-5bcde1b7c777.png">


## How has this been tested?
Add 4 different 25% width Button blocks. Notice that they all fall in the same line. Take up the whole editor. 
Set up different width buttons do things work out as expected? 

## Screenshots <!-- if applicable -->


25%
iOS | Android
--- | ---
<kbd>![Screenshot_1616539291](https://user-images.githubusercontent.com/115071/112228277-4e799400-8bee-11eb-9dc1-a16a6905f5ab.png)</kbd>|<kbd>![simulator_screenshot_297D273D-E881-46FA-84D0-A117FC9AF665](https://user-images.githubusercontent.com/115071/112228219-3275f280-8bee-11eb-8cf9-817b54477095.png)</kbd>


50% and 75%
iOS | Android
--- | ---
<kbd>![simulator_screenshot_4BE51D1F-27D5-4495-A91C-F30B3ED98AD2](https://user-images.githubusercontent.com/115071/112229610-884b9a00-8bf0-11eb-87a1-288a027dd65b.png)</kbd>|<kbd>![Screenshot_1616540199](https://user-images.githubusercontent.com/115071/112229538-618d6380-8bf0-11eb-9385-56838c637973.png)

</kbd>


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
