### PR TITLE
Refactored Gallery: Tidy up gallery attribute snackbar notices

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -292,6 +292,7 @@ function GalleryEdit( props ) {
 				linkToText.label
 			),
 			{
+				id: 'gallery-attributes-linkTo',
 				type: 'snackbar',
 			}
 		);
@@ -328,6 +329,7 @@ function GalleryEdit( props ) {
 			? __( 'All gallery images updated to open in new tab' )
 			: __( 'All gallery images updated to not open in new tab' );
 		createSuccessNotice( noticeText, {
+			id: 'gallery-attributes-openInNewTab',
 			type: 'snackbar',
 		} );
 	}
@@ -358,6 +360,7 @@ function GalleryEdit( props ) {
 				imageSize.label
 			),
 			{
+				id: 'gallery-attributes-sizeSlug',
 				type: 'snackbar',
 			}
 		);


### PR DESCRIPTION
## Description
Tidies up snackbar notifications when gallery attributes are repeatedly changed.

## How has this been tested?
Manually.

#### Testing Instructions
1. With the refactored gallery Gutenberg experiment turned on, add a gallery to a post along with images
2. Toggle gallery level link to, open in new tab and image size attributes repeatedly. Notice the large stack of notices.
3. Apply this PR branch
4. Reload the editor and repeat the process of toggling gallery level attributes. There should only be one notice for each gallery level attribute being toggled.

## Screenshots <!-- if applicable -->
| Before | After | 
|----|----|
| ![GallerySnackbarNotice](https://user-images.githubusercontent.com/60436221/109270939-85ac8d80-785a-11eb-8b87-a26e43a3ffe0.gif) | ![GallerySnackbarNotice-After](https://user-images.githubusercontent.com/60436221/109270954-8b09d800-785a-11eb-9526-33196ef569e5.gif) |

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
