### PR TITLE
Make navigation placeholder state visible in dark themes.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -243,6 +243,10 @@ $color-control-label-height: 20px;
 	.is-selected & {
 		opacity: 0.2;
 	}
+
+	.is-dark-theme .is-selected & {
+		opacity: 0.4;
+	}
 }
 
 // Selected state.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -200,6 +200,7 @@ $color-control-label-height: 20px;
 
 // Ensure that an empty block has space around the appender.
 .wp-block-navigation-placeholder,
+.wp-block-navigation-placeholder__preview,
 .is-selected .wp-block-navigation__container {
 	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
 }
@@ -214,11 +215,6 @@ $color-control-label-height: 20px;
 
 // Unselected state.
 .wp-block-navigation-placeholder__preview {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -235,17 +231,25 @@ $color-control-label-height: 20px;
 		margin: $grid-unit-15 $grid-unit-30 $grid-unit-15 0;
 	}
 
+	svg {
+		fill: currentColor;
+	}
+
 	.wp-block-navigation-link.wp-block-navigation-link,
 	svg {
 		opacity: 0.3;
 	}
 
 	.is-selected & {
-		opacity: 0.2;
-	}
+		// Don't show the preview boxes for an empty nav block.
+		opacity: 0;
 
-	.is-dark-theme .is-selected & {
-		opacity: 0.4;
+		// Need to show the placeholder box above the preview boxes.
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #29235.

This makes the setup state slightly more opaque in dark themes, when selected.

## How has this been tested?

Use TT1 blocks, set the background color to black in the site editor, text to white, then insert a navigation block and start empty. Then select and unselect to see the difference.

## Screenshots <!-- if applicable -->

![state](https://user-images.githubusercontent.com/1204802/109277399-91c32b80-7817-11eb-8a88-da07b2029521.gif)


## Types of changes

The setup state is meant to be purely decorative, so there isn't a contrast ratio to meet. What's important is that the plus button is visible against a dark background.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
