### PR TITLE
Fix: Invert gallery gravity.

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -16,6 +16,7 @@
 		flex-direction: column;
 		justify-content: center;
 		position: relative;
+		align-self: flex-start;
 
 		// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
 		width: calc(50% - 1em);


### PR DESCRIPTION
## Description

Fixes #29316. Uncropped images fell to the floor. This PR let's them reach for the stars. They may not catch any, but they won't end up with a handful of mud either.

## How has this been tested?

Insert a gallery with varying image sizes, then untoggle the crop feature.

## Screenshots <!-- if applicable -->

Before:

<img width="1099" alt="Screenshot 2021-02-26 at 10 06 11" src="https://user-images.githubusercontent.com/1204802/109279802-7c9bcc00-781a-11eb-8710-afa89fdbfea4.png">

After:

<img width="1145" alt="Screenshot 2021-02-26 at 10 06 02" src="https://user-images.githubusercontent.com/1204802/109279810-7efe2600-781a-11eb-91ec-bf8673612553.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
