### PR TITLE
Run phpcbf to fix PHP CS issues

### DIFF
--- a/phpunit/class-gutenberg-utils-test.php
+++ b/phpunit/class-gutenberg-utils-test.php
@@ -134,7 +134,7 @@ class Gutenberg_Utils_Test extends WP_UnitTestCase {
 	public function test_gutenberg_get_minified_styles() {
 		$cases = array(
 			array(
-				'in' => '
+				'in'  => '
 /**
  * Comment
  */
@@ -145,7 +145,7 @@ class Gutenberg_Utils_Test extends WP_UnitTestCase {
 				'out' => '.foo{bar:1}',
 			),
 			array(
-				'in' => '/* Comment */#foo{content:" ";  bar:   0;
+				'in'  => '/* Comment */#foo{content:" ";  bar:   0;
 				  }',
 				'out' => '#foo{content:" ";bar:0}',
 			),


### PR DESCRIPTION
## Description
Simple PR, I ran `vendor/bin/phpcbf` to fix some phpcs issues.

## How has this been tested?
Running `vendor/bin/phpcs` no longer fails.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
