### PR TITLE
Global Styles: fix specificity conflict of blocks with single classes as selectors

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -785,22 +785,22 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Given a settings array, it extracts its presets
-	 * and adds them to the given input $stylesheet.
+	 * Given a settings array, it returns the generated rulesets
+	 * for the preset classes.
 	 *
-	 * @param string $stylesheet Input stylesheet to add the presets to.
 	 * @param array  $settings Settings to process.
 	 * @param string $selector Selector wrapping the classes.
 	 *
-	 * @return the modified $stylesheet.
+	 * @return string The result of processing the presets.
 	 */
-	private static function compute_preset_classes( $stylesheet, $settings, $selector ) {
+	private static function compute_preset_classes( $settings, $selector ) {
 		if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
 			// Classes at the global level do not need any CSS prefixed,
 			// and we don't want to increase its specificity.
 			$selector = '';
 		}
 
+		$stylesheet = '';
 		foreach ( self::PRESETS_METADATA as $preset ) {
 			$values = gutenberg_experimental_get( $settings, $preset['path'], array() );
 			foreach ( $values as $value ) {
@@ -1002,7 +1002,9 @@ class WP_Theme_JSON {
 			return $stylesheet;
 		}
 
-		$metadata = self::get_blocks_metadata();
+		$metadata     = self::get_blocks_metadata();
+		$block_rules  = '';
+		$preset_rules = '';
 		foreach ( $metadata as $block_selector => $metadata ) {
 			if ( empty( $metadata['selector'] ) ) {
 				continue;
@@ -1020,19 +1022,18 @@ class WP_Theme_JSON {
 				);
 			}
 
-			$stylesheet .= self::to_ruleset( $selector, $declarations );
+			$block_rules .= self::to_ruleset( $selector, $declarations );
 
 			// Attach the rulesets for the classes.
 			if ( isset( $this->theme_json['settings'][ $block_selector ] ) ) {
-				$stylesheet = self::compute_preset_classes(
-					$stylesheet,
+				$preset_rules .= self::compute_preset_classes(
 					$this->theme_json['settings'][ $block_selector ],
 					$selector
 				);
 			}
 		}
 
-		return $stylesheet;
+		return $block_rules . $preset_rules;
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -298,15 +298,15 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			array(
 				'settings' => array(
 					'core/group' => array(
-						'color'      => array(
+						'color' => array(
 							'palette' => array(
 								array(
 									'slug'  => 'grey',
 									'color' => 'grey',
 								),
 							),
-						)
-					)
+						),
+					),
 				),
 				'styles'   => array(
 					'core/group' => array(
@@ -314,7 +314,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 							'text' => 'red',
 						),
 					),
-				)
+				),
 			)
 		);
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -280,16 +280,51 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}',
+			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}',
 			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}',
+			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(
 			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}',
 			$theme_json->get_stylesheet( 'css_variables' )
+		);
+	}
+
+	function test_get_stylesheet_preset_rules_come_after_block_rules() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'settings' => array(
+					'core/group' => array(
+						'color'      => array(
+							'palette' => array(
+								array(
+									'slug'  => 'grey',
+									'color' => 'grey',
+								),
+							),
+						)
+					)
+				),
+				'styles'   => array(
+					'core/group' => array(
+						'color' => array(
+							'text' => 'red',
+						),
+					),
+				)
+			)
+		);
+
+		$this->assertEquals(
+			'.wp-block-group{--wp--preset--color--grey: grey;}.wp-block-group{color: red;}.wp-block-group.has-grey-color{color: grey;}.wp-block-group.has-grey-background-color{background-color: grey;}',
+			$theme_json->get_stylesheet()
+		);
+		$this->assertEquals(
+			'.wp-block-group{color: red;}.wp-block-group.has-grey-color{color: grey;}.wp-block-group.has-grey-background-color{background-color: grey;}',
+			$theme_json->get_stylesheet( 'block_styles' )
 		);
 	}
 


### PR DESCRIPTION
This PR fixes a bug in which the source order of blocks whose CSS selector is a class overrides user styles for preset values.

## How to reproduce

- Install and use a block that uses theme.json. For example, TT1-blocks.
- Style the background and foreground colors of the group block such as:

```json
"core/group": {
  "color": {
    "text": "red",
    "background": "black"
  }
}
```
- Go to the editor, add a group with a paragraph and set preset colors for them (not custom).
- Publish the post and go to the front end.

The expected result would be that the user colors were respected. Instead, what happens is that the theme's colors are applied.

## What's the fix

Load the preset classes after the block styles, so the last rule wins.

Note that there's a different issue with block selectors whose selector specificity is higher than the selector of user-selected styles (a class). https://github.com/WordPress/gutenberg/issues/29381 
