### PR TITLE
Packages: Update the publishing command for npm with next dist tag

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -275,14 +275,23 @@ async function publishPackagesToNpm(
 	} );
 
 	if ( isPrerelease ) {
-		log( '>> Publishing modified packages to npm.' );
+		log(
+			'>> Bumping version of public packages changed since the last release.'
+		);
+		const { stdout: sha } = await command( 'git rev-parse --short HEAD' );
 		await command(
-			`npx lerna publish --canary ${ minimumVersionBump } --preid next`,
+			`npx lerna version pre${ minimumVersionBump } --preid next.${ sha } --no-private`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',
 			}
 		);
+
+		log( '>> Publishing modified packages to npm.' );
+		await command( 'npx lerna publish from-package --dist-tag next', {
+			cwd: gitWorkingDirectoryPath,
+			stdio: 'inherit',
+		} );
 	} else {
 		log(
 			'>> Bumping version of public packages changed since the last release.'


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

I tried publishing to npm with the `next` dist tag earlier today as documented on WordPress Slack:
https://wordpress.slack.com/archives/C5UNMSU4R/p1614334180022200

```
Successfully published npm packages with the `canary` (development) dist tag based on Gutenberg `10.1.0-rc.1`:
 - @wordpress/a11y@2.14.1-next.1+c95ee08bb
 - @wordpress/annotations@1.24.2-next.1+c95ee08bb
 - @wordpress/api-fetch@3.21.2-next.1+c95ee08bb
 - @wordpress/babel-preset-default@5.0.0-next.1+c95ee08bb
 - @wordpress/block-directory@1.18.2-next.1+c95ee08bb
 - @wordpress/block-editor@5.2.2-next.1+c95ee08bb
... and so on
```

However, there were two issues discovered:
- publishing was done with the `canary` dist tag rather than `next`
- `--canary` in Lerna is buggy, it doesn’t take into account the most recen version in `package.json`, so versions might be outdated when they change in the release branch, related Lerna issue: https://github.com/lerna/lerna/issues/2622

The revised approach takes a bit different approach:
- it ensures the `next` tag is used for publishing
- rather than using `--canary` flag it runs `lerna version` with the dist id composed of the word `next` and the "sha" of the latest commit

Example versions published:
```
- @wordpress/block-directory@1.18.9-next.645224df70.0
 - @wordpress/block-editor@5.2.10-next.645224df70.0
 - @wordpress/block-library@2.28.6-next.645224df70.0
 - @wordpress/edit-post@3.27.1-next.645224df70.0
 - @wordpress/edit-site@1.16.9-next.645224df70.0
 - @wordpress/edit-widgets@1.2.9-next.645224df70.0
 - @wordpress/editor@9.25.9-next.645224df70.0
 - @wordpress/format-library@1.26.9-next.645224df70.0
 - @wordpress/interface@1.0.6-next.645224df70.0
 - @wordpress/list-reusable-blocks@1.25.8-next.645224df70.0
 - @wordpress/nux@3.24.8-next.645224df70.0
 - @wordpress/reusable-blocks@1.1.9-next.645224df70.0
 - @wordpress/server-side-render@1.20.8-next.645224df70.0
... and so on
```

Online Semver checker seems to be mildly satisfied:

<img width="1155" alt="Screen Shot 2021-02-26 at 16 59 55" src="https://user-images.githubusercontent.com/699132/109323820-2b103300-7854-11eb-9ee0-a9525890f5ca.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I executed:
`./bin/commander.js npm-next`

In theory, it should be possible to run this command again since it syncs `wp/next` with `release/10.1` and adds two commits so there always is a new "sha" created. It's a bit impractical though as it will update over 40 `package.json` files that changed between releases, so it will trigger publishing for all those packages creating git tag for each of them.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
