### PR TITLE
Use correct classname for nested Navigation Link container

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -311,7 +311,7 @@ export default function NavigationLinkEdit( {
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{
-			className: classnames( 'wp-block-navigation__container', {
+			className: classnames( 'wp-block-navigation-link__container', {
 				'is-parent-of-selected-block':
 					isParentOfSelectedBlock &&
 					// Don't select as parent of selected block while dragging.

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -214,9 +214,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 			$inner_blocks_html .= $inner_block->render();
 		}
 
-		// TODO - classname is wrong!
 		$html .= sprintf(
-			'<ul class="wp-block-navigation__container">%s</ul>',
+			'<ul class="wp-block-navigation-link__container">%s</ul>',
 			$inner_blocks_html
 		);
 	}

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -9,23 +9,6 @@
 	}
 }
 
-.wp-block-navigation__container {
-	// Reset the default list styles
-	list-style: none;
-	margin: 0;
-	padding-left: 0;
-
-	// Horizontal layout
-	display: flex;
-	flex-wrap: wrap;
-
-	// Vertical layout
-
-	.is-vertical & {
-		display: block;
-	}
-}
-
 // Styles for submenu flyout
 .has-child {
 	> .wp-block-navigation-link__content {
@@ -102,6 +85,19 @@
 		}
 	}
 }
+
+// Default background and font color
+.wp-block-navigation:not(.has-background) .wp-block-navigation__container {
+	.wp-block-navigation-link__container {
+		// Set a background color for submenus so that they're not transparent.
+		// NOTE TO DEVS - if refactoring this code, please double-check that
+		// submenus have a default background color, this feature has regressed
+		// several times, so care needs to be taken.
+		background-color: $white;
+		color: $gray-900;
+	}
+}
+
 
 // Force links to inherit text decoration applied to navigation block.
 .wp-block-navigation[style*="text-decoration"] {

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -4,7 +4,7 @@
 	position: relative;
 	margin: 0;
 
-	.wp-block-navigation__container:empty {
+	.wp-block-navigation-link__container:empty {
 		display: none;
 	}
 }
@@ -14,7 +14,7 @@
 	> .wp-block-navigation-link__content {
 		padding-right: 0.5em;
 	}
-	.wp-block-navigation__container {
+	.wp-block-navigation-link__container {
 		border: $border-width solid rgba(0, 0, 0, 0.15);
 		background-color: inherit;
 		color: inherit;
@@ -40,7 +40,7 @@
 			left: 1.5em;
 
 			// Nested submenus sit to the left on large breakpoints
-			.wp-block-navigation__container {
+			.wp-block-navigation-link__container {
 				left: 100%;
 				top: -1px;
 
@@ -66,7 +66,7 @@
 	&:hover {
 		cursor: pointer;
 
-		> .wp-block-navigation__container {
+		> .wp-block-navigation-link__container {
 			visibility: visible;
 			opacity: 1;
 			display: flex;
@@ -77,7 +77,7 @@
 	&:focus-within {
 		cursor: pointer;
 
-		> .wp-block-navigation__container {
+		> .wp-block-navigation-link__container {
 			visibility: visible;
 			opacity: 1;
 			display: flex;
@@ -101,7 +101,7 @@
 
 // Force links to inherit text decoration applied to navigation block.
 .wp-block-navigation[style*="text-decoration"] {
-	.wp-block-navigation__container,
+	.wp-block-navigation-link__container,
 	.wp-block-navigation-link {
 		text-decoration: inherit;
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,15 +1,3 @@
-// Default background and font color
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container {
-	.wp-block-navigation__container {
-		// Set a background color for submenus so that they're not transparent.
-		// NOTE TO DEVS - if refactoring this code, please double-check that
-		// submenus have a default background color, this feature has regressed
-		// several times, so care needs to be taken.
-		background-color: $white;
-		color: $gray-900;
-	}
-}
-
 .wp-block-navigation .wp-block-navigation__container {
 	.wp-block-navigation__container {
 		align-items: normal;
@@ -20,6 +8,22 @@
 .wp-block-navigation__container {
 	// Vertically align child blocks, like Social Links or Search.
 	align-items: center;
+
+	// Reset the default list styles
+	list-style: none;
+	margin: 0;
+	padding-left: 0;
+
+	// Horizontal layout
+	display: flex;
+	flex-wrap: wrap;
+
+	// Vertical layout
+
+	.is-vertical & {
+		display: block;
+	}
+
 }
 
 .items-justified-center > ul {


### PR DESCRIPTION
## Description
As described in https://github.com/WordPress/gutenberg/issues/21444, the container within Navigation Link inner block container was using the same class name as the parent Navigation Block. This sets the correct class, and updates the relevan style definitions to use that class as well.

This PR also moves some styles that are specific to Navigation Link, but were defined within the Navigation Block's styles.

## How has this been tested?
1. Create a nested navigation menu
2. Preview the post
3. Inspect elements and check that nested `ul` block lists have the class `wp-block-navigation-link__container` instead of `wp-block-navigation__container`.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/1157901/109322410-0a82b180-7831-11eb-9c6e-afa0df80bed3.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
