### PR TITLE
Button block: add color support via block.json

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -65,7 +65,7 @@
 			"__experimentalSkipSerialization": true
 		},
 		"reusable": false,
-		"__experimentalSelector": ".wp-block-button > a"
+		"__experimentalSelector": ".wp-block-button__link"
 	},
 	"editorStyle": "wp-block-button-editor",
 	"style": "wp-block-button"

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -61,6 +61,9 @@
 		"anchor": true,
 		"align": true,
 		"alignWide": false,
+		"color": {
+			"__experimentalSkipSerialization": true
+		},
 		"reusable": false,
 		"__experimentalSelector": ".wp-block-button > a"
 	},

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -35,7 +35,6 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import ColorEdit from './color-edit';
 import getColorAndStyleProps from './color-props';
 
 const NEW_TAB_REL = 'noreferrer noopener';
@@ -241,7 +240,6 @@ function ButtonEdit( props ) {
 
 	return (
 		<>
-			<ColorEdit { ...props } />
 			<div
 				{ ...blockProps }
 				className={ classnames( blockProps.className, {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/28913
Depends on https://github.com/WordPress/gutenberg/pull/29378

This PR removes the ad-hoc color support for the block and uses recently added features to the block support mechanism https://github.com/WordPress/gutenberg/issues/28913 that allows us to target elements other than the block wrapper.

## How has this been tested?

This PR depends on https://github.com/WordPress/gutenberg/pull/29378 so, you'd need to apply those changes to your local branch. For example, check out 29378 locally and then `git merge --squash <local-name-of-29378-branch>`.

- Use a theme with theme.json support, such as TT1-blocks.
- Via theme.json target the button color styles by adding the following within the styles section:

```json
"core/button": {
    "color": {
        "text": "green",
        "background": "yellow"
    }
}
```
- Go to the editor, add three buttons: one without user styles, one that uses preset colors, and one that uses custom colors.
- Publish the post and go to the front end.

The expected result is that the button without user styles has the colors declared via theme.json and the other button have the user style colors.
