### PR TITLE
Rich Text Docs: Add section for disabling specific format types

### DIFF
--- a/docs/reference-guides/richtext.md
+++ b/docs/reference-guides/richtext.md
@@ -122,3 +122,19 @@ If the HTML tags from text formatting such as `<strong>` or `<em>` are being esc
 Before moving forward, consider if using the RichText component makes sense at all. Would it be better to use a basic `input` or `textarea` element? If you don't think any formatting should be possible, these HTML tags may make more sense.
 
 If you'd still like to use RichText, you can eliminate all of the formatting options by specifying the `withoutInteractiveFormatting` property.
+
+### Disable Specific Format Types
+
+The RichText component uses formats to display inline elements, for example images within the paragraph block. There are two methods to limit formats:
+
+1. You can set a specific set of allowed formats. For example, only allowing bold and links, use:
+
+```
+wp.richText.allowedFormats( ['core/bold', 'core/link' ] );
+```
+
+2. If you just want to disable a single format use the `unregisterFormatType` function.  For example to disable inline images, use:
+
+```
+wp.richText.unregisterFormatType( 'core/image' );
+```

--- a/docs/reference-guides/richtext.md
+++ b/docs/reference-guides/richtext.md
@@ -123,18 +123,15 @@ Before moving forward, consider if using the RichText component makes sense at a
 
 If you'd still like to use RichText, you can eliminate all of the formatting options by specifying the `withoutInteractiveFormatting` property.
 
-### Disable Specific Format Types
+If you want to limit the formats allowed, you can specify using `allowedFormats` property in your code, [see component documentation](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md#allowedformats-array) for details.
 
-The RichText component uses formats to display inline elements, for example images within the paragraph block. There are two methods to limit formats:
+### Disable Specific Format Types in Editor
 
-1. You can set a specific set of allowed formats. For example, only allowing bold and links, use:
-
-```
-wp.richText.allowedFormats( ['core/bold', 'core/link' ] );
-```
-
-2. If you just want to disable a single format use the `unregisterFormatType` function.  For example to disable inline images, use:
+The RichText component uses formats to display inline elements, for example images within the paragraph block.  If you just want to disable a format from the editor, you can use the `unregisterFormatType` function.  For example to disable inline images, use:
 
 ```
 wp.richText.unregisterFormatType( 'core/image' );
 ```
+
+To apply, you would need to enqueue the above script in your plugin or theme. See the JavaScript tutorial for [how to load JavaScript in WordPress](https://developer.wordpress.org/block-editor/tutorials/javascript/loading-javascript/).
+

--- a/docs/reference-guides/richtext.md
+++ b/docs/reference-guides/richtext.md
@@ -123,7 +123,7 @@ Before moving forward, consider if using the RichText component makes sense at a
 
 If you'd still like to use RichText, you can eliminate all of the formatting options by specifying the `withoutInteractiveFormatting` property.
 
-If you want to limit the formats allowed, you can specify using `allowedFormats` property in your code, [see component documentation](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md#allowedformats-array) for details.
+If you want to limit the formats allowed, you can specify using `allowedFormats` property in your code, see the example above or [the component documentation](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md#allowedformats-array) for details.
 
 ### Disable Specific Format Types in Editor
 


### PR DESCRIPTION
Adds a new question/answer to rich text documentation for disabling a specific format type either by using allowedFormts or unregister a format.

Related: #12680

## Type of Change

Documentation.

You can test the documentation change by applying in the browser devtools console.

![inline-image](https://user-images.githubusercontent.com/45363/109368165-0e243180-784d-11eb-8de9-19886a21ae14.gif)

