### PR TITLE
Table of Contents block: fix links when in archive loop or when using "Plain" permalink structure.

### DIFF
--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -243,15 +243,21 @@ function block_core_table_of_contents_render_list(
 
 	$child_nodes = array_map(
 		function ( $child_node ) use ( $entry_class, $page_url ) {
+			global $multipage;
+
 			$id      = $child_node['heading']['id'];
 			$content = $child_node['heading']['content'];
 
 			if ( isset( $id ) ) {
-				$href = add_query_arg(
-					'page',
-					(string) $child_node['heading']['page'],
-					remove_query_arg( 'page', $page_url )
-				) . '#' . $id;
+				if ( $multipage ) {
+					$href = add_query_arg(
+						'page',
+						(string) $child_node['heading']['page'],
+						remove_query_arg( 'page', $page_url )
+					) . '#' . $id;
+				} else {
+					$href = $page_url . '#' . $id;
+				}
 
 				$entry = sprintf(
 					'<a class="%1$s" href="%2$s">%3$s</a>',


### PR DESCRIPTION
## Description
This PR fixes two bugs with the Table of Contents block:
1. Links in the block would not point to the right place when the contents were rendered in an archive loop. This is fixed by always using absolute URLs.
2. When using the default "Plain" permalink structure, the links would end up creating URLs like `https://example.com/?p=7/./2#id`, which isn't a valid URL. (The proper one would be `https://example.com/?p=7&page=2#id`.) This is fixed by switching over to using the `page` query param to choose which page to go to. This should work with any permalink structure, since on sites with slug-based permalink structures, `https://example.com/post-slug?page=2#id` will automatically redirect to `https://example.com/post-slug/2#id`.

Special thanks to @asafm7 for pointing out the first bug, which led me to discover the second while trying to fix it.

## Testing instructions
1. Go to `YOUR_SITE/wp-admin/options-permalink.php`.
2. Set your site's permalink structure to "Plain".
3. Use Twenty Fourteen theme with default posts feed on home page.
4. Create a post with a Table of Contents block as the first block.
5. Insert several Heading blocks and set custom anchor ids on all of them.
6. Insert some Page Break blocks between the Heading blocks.
7. Save the post.
8. Go to your site's home page and try using the links in the the Table of Contents block to ensure that they all take you to the right page of the paginated post.
9. Change your site's permalink structure to "Post name".
10. Go back to your site's home page.
11. Ensure that all the Table of Contents links still work.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
