### PR TITLE
Include PHP: Replace `dirname( __FILE__ )` with `__DIR__`

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -41,7 +41,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		require_once __DIR__ . '/class-wp-rest-widgets-controller.php';
 	}
 	if ( ! class_exists( 'WP_REST_Pattern_Directory_Controller' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-pattern-directory-controller.php';
+		require_once __DIR__ . '/class-wp-rest-pattern-directory-controller.php';
 	}
 	if ( ! class_exists( 'WP_REST_Menus_Controller' ) ) {
 		require_once __DIR__ . '/class-wp-rest-menus-controller.php';


### PR DESCRIPTION
## Description
To make the code more consistent, we should use `require_once __DIR__` instead of `require dirname( __FILE__ )` to include PHP files.