### PR TITLE
Post Featured Image: Add srcset and sizes attributes

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -51,42 +51,60 @@ function PostFeaturedImage( {
 		</p>
 	);
 
+	const mediaSourceSets = [];
 	let mediaWidth, mediaHeight, mediaSourceUrl;
+	let mediaSrcSetAttr = '';
+
+	// Use Sass medium breakpoint and image's width in sidebar for sizes attr.
+	const mediaSizesAttr = '(min-width: 782px) 248px, 100vw';
+
 	if ( media ) {
-		const mediaSize = applyFilters(
-			'editor.PostFeaturedImage.imageSize',
-			'post-thumbnail',
-			media.id,
-			currentPostId
-		);
-		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {
-			// use mediaSize when available
-			mediaWidth = media.media_details.sizes[ mediaSize ].width;
-			mediaHeight = media.media_details.sizes[ mediaSize ].height;
-			mediaSourceUrl = media.media_details.sizes[ mediaSize ].source_url;
-		} else {
-			// get fallbackMediaSize if mediaSize is not available
-			const fallbackMediaSize = applyFilters(
-				'editor.PostFeaturedImage.imageSize',
-				'thumbnail',
-				media.id,
-				currentPostId
-			);
-			if (
-				has( media, [ 'media_details', 'sizes', fallbackMediaSize ] )
-			) {
-				// use fallbackMediaSize when mediaSize is not available
-				mediaWidth =
-					media.media_details.sizes[ fallbackMediaSize ].width;
-				mediaHeight =
-					media.media_details.sizes[ fallbackMediaSize ].height;
-				mediaSourceUrl =
-					media.media_details.sizes[ fallbackMediaSize ].source_url;
-			} else {
-				// use full image size when mediaFallbackSize and mediaSize are not available
-				mediaWidth = media.media_details.width;
-				mediaHeight = media.media_details.height;
-				mediaSourceUrl = media.source_url;
+		mediaWidth = media.media_details.width;
+		mediaHeight = media.media_details.height;
+		mediaSourceUrl = media.source_url;
+
+		// Build srcset attribute from available image sizes.
+		if ( has( media, [ 'media_details', 'sizes' ] ) ) {
+			Object.keys( media.media_details.sizes ).forEach( ( key ) => {
+				const mediaSize = applyFilters(
+					'editor.PostFeaturedImage.imageSize',
+					key,
+					media.id,
+					currentPostId
+				);
+
+				/**
+				 * An individual image srcset entry.
+				 *
+				 * @typedef WPImageSourceSet
+				 *
+				 * @property {number} width      The width of the entry.
+				 * @property {string} source_url The URL of the entry.
+				 */
+
+				/** @type {WPImageSourceSet} */
+				const sourceSet = {
+					width: media.media_details.sizes[ mediaSize ].width,
+					source_url:
+						media.media_details.sizes[ mediaSize ].source_url,
+				};
+
+				mediaSourceSets.push( sourceSet );
+			} );
+
+			if ( mediaSourceSets.length > 0 ) {
+				mediaSrcSetAttr = mediaSourceSets.reduce(
+					( prevValue, curValue, i ) => {
+						const entry = `${ curValue.source_url } ${ curValue.width }w`;
+
+						if ( 0 !== i ) {
+							return `${ prevValue }, ${ entry }`;
+						}
+
+						return entry;
+					},
+					''
+				);
 			}
 		}
 	}
@@ -155,6 +173,10 @@ function PostFeaturedImage( {
 										>
 											<img
 												src={ mediaSourceUrl }
+												width={ mediaWidth }
+												height={ mediaHeight }
+												srcSet={ mediaSrcSetAttr }
+												sizes={ mediaSizesAttr }
 												alt=""
 											/>
 										</ResponsiveWrapper>


### PR DESCRIPTION
This change allows the browser to download a smaller thumbnail image in
the editor sidebar to save on bandwidth and rendering resources.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## How has this been tested?
Checked in latest Chrome and Firefox on Win 10 to ensure that appropriate thumbnail image was loaded based on viewport width.

## Types of changes
Bug fix: reimplemented feature that was present in the classic editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
