### PR TITLE
Add Columns transform from Media & Text

### DIFF
--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -8,55 +8,8 @@ import {
 
 const MAXIMUM_SELECTED_BLOCKS = 6;
 
-function fromMediaText( attributes, innerBlocks ) {
-	const {
-		align,
-		backgroundColor,
-		mediaAlt: alt,
-		mediaId: id,
-		mediaPosition,
-		mediaSizeSlug: sizeSlug,
-		mediaType,
-		mediaUrl: url,
-		mediaWidth,
-		verticalAlignment,
-	} = attributes;
-	let media;
-	if ( mediaType === 'image' || ! mediaType ) {
-		const imageAttrs = { id, alt, url, sizeSlug };
-		const linkAttrs = {
-			href: attributes.href,
-			linkClass: attributes.linkClass,
-			linkDestination: attributes.linkDestination,
-			linkTarget: attributes.linkTarget,
-			rel: attributes.rel,
-		};
-		media = [ 'core/image', { ...imageAttrs, ...linkAttrs } ];
-	} else {
-		media = [ 'core/video', { id, src: url } ];
-	}
-	const innerBlocksTemplate = [
-		[ 'core/column', { width: `${ mediaWidth }%` }, [ media ] ],
-		[ 'core/column', { width: `${ 100 - mediaWidth }%` }, innerBlocks ],
-	];
-	if ( mediaPosition === 'right' ) {
-		innerBlocksTemplate.reverse();
-	}
-	return createBlock(
-		'core/columns',
-		{ align, backgroundColor, verticalAlignment },
-		createBlocksFromInnerBlocksTemplate( innerBlocksTemplate )
-	);
-}
-
 const transforms = {
 	from: [
-		{
-			type: 'block',
-			blocks: [ 'core/media-text' ],
-			isMatch: ( { mediaId } ) => !! mediaId,
-			transform: fromMediaText,
-		},
 		{
 			type: 'block',
 			isMultiBlock: true,
@@ -79,6 +32,55 @@ const transforms = {
 			isMatch: ( { length: selectedBlocksLength } ) =>
 				selectedBlocksLength &&
 				selectedBlocksLength <= MAXIMUM_SELECTED_BLOCKS,
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/media-text' ],
+			priority: 1,
+			transform: ( attributes, innerBlocks ) => {
+				const {
+					align,
+					backgroundColor,
+					mediaAlt: alt,
+					mediaId: id,
+					mediaPosition,
+					mediaSizeSlug: sizeSlug,
+					mediaType,
+					mediaUrl: url,
+					mediaWidth,
+					verticalAlignment,
+				} = attributes;
+				let media;
+				if ( mediaType === 'image' || ! mediaType ) {
+					const imageAttrs = { id, alt, url, sizeSlug };
+					const linkAttrs = {
+						href: attributes.href,
+						linkClass: attributes.linkClass,
+						linkDestination: attributes.linkDestination,
+						linkTarget: attributes.linkTarget,
+						rel: attributes.rel,
+					};
+					media = [ 'core/image', { ...imageAttrs, ...linkAttrs } ];
+				} else {
+					media = [ 'core/video', { id, src: url } ];
+				}
+				const innerBlocksTemplate = [
+					[ 'core/column', { width: `${ mediaWidth }%` }, [ media ] ],
+					[
+						'core/column',
+						{ width: `${ 100 - mediaWidth }%` },
+						innerBlocks,
+					],
+				];
+				if ( mediaPosition === 'right' ) {
+					innerBlocksTemplate.reverse();
+				}
+				return createBlock(
+					'core/columns',
+					{ align, backgroundColor, verticalAlignment },
+					createBlocksFromInnerBlocksTemplate( innerBlocksTemplate )
+				);
+			},
 		},
 	],
 };

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -8,8 +8,55 @@ import {
 
 const MAXIMUM_SELECTED_BLOCKS = 6;
 
+function fromMediaText( attributes, innerBlocks ) {
+	const {
+		align,
+		backgroundColor,
+		mediaAlt: alt,
+		mediaId: id,
+		mediaPosition,
+		mediaSizeSlug: sizeSlug,
+		mediaType,
+		mediaUrl: url,
+		mediaWidth,
+		verticalAlignment,
+	} = attributes;
+	let media;
+	if ( mediaType === 'image' || ! mediaType ) {
+		const imageAttrs = { id, alt, url, sizeSlug };
+		const linkAttrs = {
+			href: attributes.href,
+			linkClass: attributes.linkClass,
+			linkDestination: attributes.linkDestination,
+			linkTarget: attributes.linkTarget,
+			rel: attributes.rel,
+		};
+		media = [ 'core/image', { ...imageAttrs, ...linkAttrs } ];
+	} else {
+		media = [ 'core/video', { id, src: url } ];
+	}
+	const innerBlocksTemplate = [
+		[ 'core/column', { width: `${ mediaWidth }%` }, [ media ] ],
+		[ 'core/column', { width: `${ 100 - mediaWidth }%` }, innerBlocks ],
+	];
+	if ( mediaPosition === 'right' ) {
+		innerBlocksTemplate.reverse();
+	}
+	return createBlock(
+		'core/columns',
+		{ align, backgroundColor, verticalAlignment },
+		createBlocksFromInnerBlocksTemplate( innerBlocksTemplate )
+	);
+}
+
 const transforms = {
 	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/media-text' ],
+			isMatch: ( { mediaId } ) => !! mediaId,
+			transform: fromMediaText,
+		},
 		{
 			type: 'block',
 			isMultiBlock: true,

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -41,6 +41,8 @@ const transforms = {
 				const {
 					align,
 					backgroundColor,
+					textColor,
+					style,
 					mediaAlt: alt,
 					mediaId: id,
 					mediaPosition,
@@ -77,7 +79,13 @@ const transforms = {
 				}
 				return createBlock(
 					'core/columns',
-					{ align, backgroundColor, verticalAlignment },
+					{
+						align,
+						backgroundColor,
+						textColor,
+						style,
+						verticalAlignment,
+					},
 					createBlocksFromInnerBlocksTemplate( innerBlocksTemplate )
 				);
 			},


### PR DESCRIPTION
This PR adds the ability to transform a Media & Text block into a Columns block with two Columns and all the relevant fixings from the original block.

## Motivation
Since #26185 it has been possible to “transform” any single block into a Columns block. It's a generic operation that just wraps the block inside a single column Columns block. It seems unlikely to be the expected behavior when applied to a Media & Text block. 

## How has this been tested?
Manually transforming various Media & Text blocks and verifying any applicable attributes are transferred as expected.

## Screenshots
https://user-images.githubusercontent.com/9000376/109434800-d42d6980-79cb-11eb-8275-3e8960d03ee4.mp4

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
