### PR TITLE
Add backports for 5.7 RC 2

### DIFF
--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -27,6 +27,34 @@ $blocks-block__margin: 0.5em;
 			box-shadow: none;
 		}
 	}
+
+	// Back compat: Inner button blocks previously had their own alignment
+	// options. Forcing them to 100% width in the flex container replicates
+	// that these were block level elements that took up the full width.
+	//
+	// This back compat rule is ignored if the user decides to use the
+	// newer justification options on the button block, hence the :not.
+	//
+	// Disable the stylelint rule, otherwise this selector is ugly!
+	/* stylelint-disable indentation */
+	&:not(
+		.is-content-justification-space-between,
+		.is-content-justification-right,
+		.is-content-justification-left,
+		.is-content-justification-center
+	) .wp-block[data-align="center"] {
+	/* stylelint-enable indentation */
+		margin-left: auto;
+		margin-right: auto;
+		margin-top: 0;
+		width: 100%;
+
+		.wp-block-button {
+			// Some margin hacks are needed, since margin doesn't seem to
+			// collapse in the same way when a parent layout it flex.
+			margin-bottom: 0;
+		}
+	}
 }
 
 .wp-block[data-align="center"] > .wp-block-buttons {

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -66,7 +66,11 @@ $blocks-block__margin: 0.5em;
 		}
 	}
 
-	// Kept for backward compatibiity.
+	&.is-content-justification-space-between {
+		justify-content: space-between;
+	}
+
+	// Kept for backward compatibility.
 	&.aligncenter {
 		text-align: center;
 	}
@@ -91,5 +95,27 @@ $blocks-block__margin: 0.5em;
 			/*rtl:ignore*/
 			margin-left: 0;
 		}
+	}
+
+	// Back compat: Inner button blocks previously had their own alignment
+	// options. Forcing them to 100% width in the flex container replicates
+	// that these were block level elements that took up the full width.
+	//
+	// This back compat rule is ignored if the user decides to use the
+	// newer justification options on the button block, hence the :not.
+	//
+	// Disable the stylelint rule, otherwise this selector is ugly!
+	/* stylelint-disable indentation */
+	&:not(
+		.is-content-justification-space-between,
+		.is-content-justification-right,
+		.is-content-justification-left,
+		.is-content-justification-center
+	) .wp-block-button.aligncenter {
+	/* stylelint-enable indentation */
+		margin-left: auto;
+		margin-right: auto;
+		margin-bottom: $blocks-block__margin;
+		width: 100%;
 	}
 }

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -17,7 +17,9 @@
 		}
 	},
 	"usesContext": [
-		"openInNewTab"
+		"openInNewTab",
+		"iconColorValue",
+		"iconBackgroundColorValue"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -27,8 +27,14 @@ import { keyboardReturn } from '@wordpress/icons';
  */
 import { getIconBySite, getNameBySite } from './social-list';
 
-const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
+const SocialLinkEdit = ( {
+	attributes,
+	context,
+	isSelected,
+	setAttributes,
+} ) => {
 	const { url, service, label } = attributes;
+	const { iconColorValue, iconBackgroundColorValue } = context;
 	const [ showURLPopover, setPopover ] = useState( false );
 	const classes = classNames( 'wp-social-link', 'wp-social-link-' + service, {
 		'wp-social-link__is-incomplete': ! url,
@@ -36,7 +42,13 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
-	const blockProps = useBlockProps( { className: classes } );
+	const blockProps = useBlockProps( {
+		className: classes,
+		style: {
+			color: iconColorValue,
+			backgroundColor: iconBackgroundColorValue,
+		},
+	} );
 
 	return (
 		<Fragment>

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -33,7 +33,12 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	}
 
 	$icon               = block_core_social_link_get_icon( $service );
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wp-social-link wp-social-link-' . $service . $class_name ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class' => 'wp-social-link wp-social-link-' . $service . $class_name,
+			'style' => block_core_social_link_get_color_styles( $block->context ),
+		)
+	);
 
 	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $attribute . ' class="wp-block-social-link-anchor"> ' . $icon . '</a></li>';
 }
@@ -279,4 +284,25 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 	}
 
 	return $services_data;
+}
+
+/**
+ * Returns CSS styles for icon and icon background colors.
+ *
+ * @param array $context Block context passed to Social Link.
+ *
+ * @return string Inline CSS styles for link's icon and background colors.
+ */
+function block_core_social_link_get_color_styles( $context ) {
+	$styles = array();
+
+	if ( array_key_exists( 'iconColorValue', $context ) ) {
+		$styles[] = 'color: ' . $context['iconColorValue'] . '; ';
+	}
+
+	if ( array_key_exists( 'iconBackgroundColorValue', $context ) ) {
+		$styles[] = 'background-color: ' . $context['iconBackgroundColorValue'] . '; ';
+	}
+
+	return implode( '', $styles );
 }

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -30,7 +30,9 @@
 		}
 	},
 	"providesContext": {
-		"openInNewTab": "openInNewTab"
+		"openInNewTab": "openInNewTab",
+		"iconColorValue": "iconColorValue",
+		"iconBackgroundColorValue": "iconBackgroundColorValue"
 	},
 	"supports": {
 		"align": [

--- a/packages/block-library/src/social-links/deprecated.js
+++ b/packages/block-library/src/social-links/deprecated.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+// Social Links block deprecations.
+const deprecated = [
+	// V1. Remove CSS variable use for colors.
+	{
+		attributes: {
+			iconColor: {
+				type: 'string',
+			},
+			customIconColor: {
+				type: 'string',
+			},
+			iconColorValue: {
+				type: 'string',
+			},
+			iconBackgroundColor: {
+				type: 'string',
+			},
+			customIconBackgroundColor: {
+				type: 'string',
+			},
+			iconBackgroundColorValue: {
+				type: 'string',
+			},
+			openInNewTab: {
+				type: 'boolean',
+				default: false,
+			},
+			size: {
+				type: 'string',
+			},
+		},
+		providesContext: {
+			openInNewTab: 'openInNewTab',
+		},
+		supports: {
+			align: [ 'left', 'center', 'right' ],
+			anchor: true,
+		},
+		save: ( props ) => {
+			const {
+				attributes: {
+					iconBackgroundColorValue,
+					iconColorValue,
+					itemsJustification,
+					size,
+				},
+			} = props;
+
+			const className = classNames( size, {
+				'has-icon-color': iconColorValue,
+				'has-icon-background-color': iconBackgroundColorValue,
+				[ `items-justified-${ itemsJustification }` ]: itemsJustification,
+			} );
+
+			const style = {
+				'--wp--social-links--icon-color': iconColorValue,
+				'--wp--social-links--icon-background-color': iconBackgroundColorValue,
+			};
+
+			return (
+				<ul { ...useBlockProps.save( { className, style } ) }>
+					<InnerBlocks.Content />
+				</ul>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -88,13 +88,7 @@ export function SocialLinksEdit( props ) {
 			iconBackgroundColor.color || iconBackgroundColorValue,
 	} );
 
-	const style = {
-		'--wp--social-links--icon-color': iconColor.color || iconColorValue,
-		'--wp--social-links--icon-background-color':
-			iconBackgroundColor.color || iconBackgroundColorValue,
-	};
-
-	const blockProps = useBlockProps( { className, style } );
+	const blockProps = useBlockProps( { className } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
@@ -176,7 +170,6 @@ export function SocialLinksEdit( props ) {
 							value: iconColor.color || iconColorValue,
 							onChange: ( colorValue ) => {
 								setIconColor( colorValue );
-								// Set explicit color value used to add CSS variable in save.js
 								setAttributes( { iconColorValue: colorValue } );
 							},
 							label: __( 'Icon color' ),
@@ -189,7 +182,6 @@ export function SocialLinksEdit( props ) {
 								iconBackgroundColorValue,
 							onChange: ( colorValue ) => {
 								setIconBackgroundColor( colorValue );
-								// Set explicit color value used to add CSS variable in save.js
 								setAttributes( {
 									iconBackgroundColorValue: colorValue,
 								} );

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -7,6 +7,7 @@ import { share as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
@@ -54,4 +55,5 @@ export const settings = {
 	icon,
 	edit,
 	save,
+	deprecated,
 };

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -18,13 +18,8 @@ export default function save( props ) {
 		'has-icon-background-color': iconBackgroundColorValue,
 	} );
 
-	const style = {
-		'--wp--social-links--icon-color': iconColorValue,
-		'--wp--social-links--icon-background-color': iconBackgroundColorValue,
-	};
-
 	return (
-		<ul { ...useBlockProps.save( { className, style } ) }>
+		<ul { ...useBlockProps.save( { className } ) }>
 			<InnerBlocks.Content />
 		</ul>
 	);

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -68,19 +68,6 @@
 	&.alignright {
 		justify-content: flex-end;
 	}
-
-	// Ensure user color selections are applied to inner Social Link blocks.
-	// Double selectors to increase specificity to avoid themes overwriting user selection.
-	&.has-icon-color.has-icon-color {
-		> .wp-social-link {
-			color: var(--wp--social-links--icon-color);
-		}
-	}
-	&.has-icon-background-color.has-icon-background-color {
-		> .wp-social-link {
-			background-color: var(--wp--social-links--icon-background-color);
-		}
-	}
 }
 
 .wp-social-link {

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -4,10 +4,11 @@
  * External dependencies
  */
 import {
-	get,
+	camelCase,
 	isFunction,
 	isNil,
 	isPlainObject,
+	mapKeys,
 	omit,
 	pick,
 	pickBy,
@@ -149,7 +150,7 @@ const LEGACY_CATEGORY_MAPPING = {
 	layout: 'design',
 };
 
-export let serverSideBlockDefinitions = {};
+export const serverSideBlockDefinitions = {};
 
 /**
  * Sets the server side block definition of blocks.
@@ -158,10 +159,12 @@ export let serverSideBlockDefinitions = {};
  */
 // eslint-disable-next-line camelcase
 export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
-	serverSideBlockDefinitions = {
-		...serverSideBlockDefinitions,
-		...definitions,
-	};
+	for ( const blockName of Object.keys( definitions ) ) {
+		serverSideBlockDefinitions[ blockName ] = mapKeys(
+			pickBy( definitions[ blockName ], ( value ) => ! isNil( value ) ),
+			( value, key ) => camelCase( key )
+		);
+	}
 }
 
 /**
@@ -186,10 +189,7 @@ export function registerBlockType( name, settings ) {
 		supports: {},
 		styles: [],
 		save: () => null,
-		...pickBy(
-			get( serverSideBlockDefinitions, name, {} ),
-			( value ) => ! isNil( value )
-		),
+		...serverSideBlockDefinitions?.[ name ],
 		...settings,
 	};
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -160,6 +160,11 @@ export const serverSideBlockDefinitions = {};
 // eslint-disable-next-line camelcase
 export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 	for ( const blockName of Object.keys( definitions ) ) {
+		// Don't overwrite if already set. It covers the case when metadata
+		// was initialized from the server.
+		if ( serverSideBlockDefinitions[ blockName ] ) {
+			continue;
+		}
 		serverSideBlockDefinitions[ blockName ] = mapKeys(
 			pickBy( definitions[ blockName ], ( value ) => ! isNil( value ) ),
 			( value, key ) => camelCase( key )

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -350,6 +350,41 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		it( 'should map incompatible keys returned from the server', () => {
+			const blockName = 'core/test-block-with-incompatible-keys';
+			unstable__bootstrapServerSideBlockDefinitions( {
+				[ blockName ]: {
+					api_version: 2,
+					provides_context: {
+						fontSize: 'fontSize',
+					},
+					uses_context: [ 'textColor' ],
+				},
+			} );
+
+			const blockType = {
+				title: 'block title',
+			};
+			registerBlockType( blockName, blockType );
+			expect( getBlockType( blockName ) ).toEqual( {
+				apiVersion: 2,
+				name: blockName,
+				save: expect.any( Function ),
+				title: 'block title',
+				icon: {
+					src: blockIcon,
+				},
+				attributes: {},
+				providesContext: {
+					fontSize: 'fontSize',
+				},
+				usesContext: [ 'textColor' ],
+				keywords: [],
+				supports: {},
+				styles: [],
+			} );
+		} );
+
 		it( 'should validate the icon', () => {
 			const blockType = {
 				save: noop,

--- a/packages/e2e-tests/plugins/register-block-type-hooks.php
+++ b/packages/e2e-tests/plugins/register-block-type-hooks.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Register Block Type Hooks
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-register-block-type-hooks
+ */
+
+/**
+ * Changes the category for the paragraph block.
+ *
+ * @param array $metadata Array of metadata for registering a block type.
+ *
+ * @return array Filtered metadata for registering a block type.
+ */
+function gutenberg_test_block_type_metadata( $metadata ) {
+	if ( 'core/paragraph' !== $metadata['name'] ) {
+		return $metadata;
+	}
+
+	return array_merge(
+		$metadata,
+		array( 'category' => 'widgets' )
+	);
+}
+
+add_filter( 'block_type_metadata', 'gutenberg_test_block_type_metadata' );

--- a/packages/e2e-tests/specs/editor/plugins/register-block-type-hooks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/register-block-type-hooks.test.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	openGlobalBlockInserter,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Register block type hooks', () => {
+	beforeEach( async () => {
+		await activatePlugin( 'gutenberg-test-register-block-type-hooks' );
+		await createNewPost();
+	} );
+
+	afterEach( async () => {
+		await deactivatePlugin( 'gutenberg-test-register-block-type-hooks' );
+	} );
+
+	it( 'has a custom category for Paragraph block', async () => {
+		await openGlobalBlockInserter();
+
+		const widgetsCategory = await page.$(
+			'.block-editor-block-types-list[aria-label="Widgets"]'
+		);
+
+		expect(
+			await widgetsCategory.$( '.editor-block-list-item-paragraph' )
+		).toBeDefined();
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/reusable-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/reusable-blocks.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Reusable blocks allows conversion back to blocks when the reusable block has unsaved edits 1`] = `
+"<!-- wp:paragraph -->
+<p>12</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Reusable blocks can be created from multiselection and converted back to regular blocks 1`] = `
 "<!-- wp:paragraph -->
 <p>Hello there!</p>

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -339,7 +339,11 @@ describe( 'Reusable blocks', () => {
 		expect( reusableBlockWithParagraph ).toBeTruthy();
 
 		// Convert back to regular blocks.
-		await clickBlockToolbarButton( 'Select Reusable block' );
+		await page.click( '[aria-label="Outline"]' );
+		const [ parentBlockButton ] = await page.$x(
+			'//*[@aria-label="Block navigation structure"]//button[text()="Untitled Reusable Block"]'
+		);
+		await parentBlockButton.click();
 		await clickBlockToolbarButton( 'Convert to regular blocks' );
 		await page.waitForXPath( selector, {
 			hidden: true,

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -323,4 +323,29 @@ describe( 'Reusable blocks', () => {
 			expect( content ).toEqual( 'Awesome Paragraph modified' );
 		} );
 	} );
+
+	// Check for regressions of https://github.com/WordPress/gutenberg/issues/26421.
+	it( 'allows conversion back to blocks when the reusable block has unsaved edits', async () => {
+		await createReusableBlock( '1', 'Edited block' );
+
+		// Make an edit to the reusable block and assert that there's only a
+		// paragraph in a reusable block.
+		await page.waitForSelector( 'p[aria-label="Paragraph block"]' );
+		await page.click( 'p[aria-label="Paragraph block"]' );
+		await page.keyboard.type( '2' );
+		const selector =
+			'//div[@aria-label="Block: Reusable block"]//p[@aria-label="Paragraph block"][.="12"]';
+		const reusableBlockWithParagraph = await page.$x( selector );
+		expect( reusableBlockWithParagraph ).toBeTruthy();
+
+		// Convert back to regular blocks.
+		await clickBlockToolbarButton( 'Select Reusable block' );
+		await clickBlockToolbarButton( 'Convert to regular blocks' );
+		await page.waitForXPath( selector, {
+			hidden: true,
+		} );
+
+		// Check that there's only a paragraph.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -163,7 +163,9 @@ describe( 'Navigation editor', () => {
 		await visitNavigationEditor();
 
 		// Wait for the header to show that no menus are available.
-		await page.waitForXPath( '//h2[contains(., "No menus available")]' );
+		await page.waitForXPath( '//h2[contains(., "No menus available")]', {
+			visible: true,
+		} );
 
 		// Prepare the menu endpoint for creating a menu.
 		await setUpResponseMocking( [
@@ -204,6 +206,10 @@ describe( 'Navigation editor', () => {
 		);
 		await addAllPagesButton.click();
 
+		// When the block is created the root element changes from a div (for the placeholder)
+		// to a nav (for the navigation itself). Wait for this to happen.
+		await page.waitForSelector( 'nav[aria-label="Block: Navigation"]' );
+
 		expect( await getSerializedBlocks() ).toMatchSnapshot();
 	} );
 
@@ -215,7 +221,12 @@ describe( 'Navigation editor', () => {
 		await visitNavigationEditor();
 
 		// Wait for the header to show the menu name.
-		await page.waitForXPath( '//h2[contains(., "Editing: Test Menu 1")]' );
+		await page.waitForXPath( '//h2[contains(., "Editing: Test Menu 1")]', {
+			visible: true,
+		} );
+
+		// Wait for the block to be present.
+		await page.waitForSelector( 'nav[aria-label="Block: Navigation"]' );
 
 		expect( await getSerializedBlocks() ).toMatchSnapshot();
 	} );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -127,7 +127,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 
 		return {
 			canUseUnfilteredHTML: canUserUseUnfilteredHTML(),
-			reusableBlocks: select( 'core' ).getEntityRecords(
+			reusableBlocks: select( coreStore ).getEntityRecords(
 				'postType',
 				'wp_block',
 				/**
@@ -151,11 +151,11 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		() => ( {
 			...pick( settings, [
 				'__experimentalBlockDirectory',
-				'__experimentalBlockPatterns',
 				'__experimentalBlockPatternCategories',
+				'__experimentalBlockPatterns',
 				'__experimentalFeatures',
-				'__experimentalGlobalStylesUserEntityId',
 				'__experimentalGlobalStylesBaseStyles',
+				'__experimentalGlobalStylesUserEntityId',
 				'__experimentalPreferredStyleVariations',
 				'__experimentalSetIsInserterOpened',
 				'alignWide',
@@ -167,16 +167,17 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'disableCustomColors',
 				'disableCustomFontSizes',
 				'disableCustomGradients',
-				'enableCustomUnits',
 				'enableCustomLineHeight',
+				'enableCustomSpacing',
+				'enableCustomUnits',
 				'focusMode',
 				'fontSizes',
 				'gradients',
 				'hasFixedToolbar',
 				'hasReducedUI',
+				'imageDimensions',
 				'imageEditing',
 				'imageSizes',
-				'imageDimensions',
 				'isRTL',
 				'keepCaretInsideBlock',
 				'maxWidth',

--- a/packages/reusable-blocks/src/store/controls.js
+++ b/packages/reusable-blocks/src/store/controls.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isFunction } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -68,7 +73,11 @@ const controls = {
 					oldBlock.attributes.ref
 				);
 
-			const newBlocks = parse( reusableBlock.content );
+			const newBlocks = parse(
+				isFunction( reusableBlock.content )
+					? reusableBlock.content( reusableBlock )
+					: reusableBlock.content
+			);
 			registry
 				.dispatch( 'core/block-editor' )
 				.replaceBlocks( oldBlock.clientId, newBlocks );


### PR DESCRIPTION
Cherry-picks these PRs into `wp/5.7` for WordPress 5.7 RC 2:

- Blocks: Map block type definitions that use PHP naming convention for keys #28953
- Blocks: Ensure that metadata registered on the server for core block is preserved on the client #29213
- Social Links: Replace CSS variables with block context approach #29330
- Fix reusable block crash when converting a just created reusable block to blocks. #29292
- Add enableCustomSpacing to block editor settings #29277
- Fix legacy button center alignments inside the buttons block #29281