### PR TITLE
Allow enqueing a webfont if used

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1249,7 +1249,7 @@ class WP_Theme_JSON {
 		return $this->theme_json;
 	}
 
-		/**
+	/**
 	 * Enqueues a webfont if it used.
 	 *
 	 * @param string $value The font-family.


### PR DESCRIPTION
## Description
Right now themes define the available font-families in the theme.json file like this:
```json
"fontFamilies": [
  {
    "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
    "slug": "system",
    "name": "System"
  },
  {
    "fontFamily": "Constantia, \"Lucida Bright\", Lucidabright, \"Lucida Serif\", Lucida, \"DejaVu Serif\", \"Bitstream Vera Serif\", \"Liberation Serif\", Georgia, serif",
    "name": "Serif",
    "slug": "serif"
  },
  {
    "fontFamily": "Consolas, \"Andale Mono WT\", \"Andale Mono\", \"Lucida Console\", \"Lucida Sans Typewriter\", \"DejaVu Sans Mono\", \"Bitstream Vera Sans Mono\", \"Liberation Mono\", \"Nimbus Mono L\", Monaco, \"Courier New\", Courier, monospace",
    "name": "Monospace",
    "slug": "monospace"
  }
],
```
If a theme wants to add webfonts from a 3rd-party service, they need to manually detect if the font-family is used, and then manually enqueue it. At this time it is impossible for a theme to determine if a font-family is actually used in global-styles (there are no hooks available) so themes are forced to simply load all webfonts they want to make available, regardless of whether they are actually used or not.

In this PR I'm attempting to explore the logic a bit and see how we can detect the use of webfonts and automatically enqueue one if needed.

To test, you can add this webfont to the JSON:
```json
  {
    "fontFamily": "Literata, Constantia, \"Lucida Bright\", Lucidabright, \"Lucida Serif\", Lucida, \"DejaVu Serif\", \"Bitstream Vera Serif\", \"Liberation Serif\", Georgia, serif",
    "name": "Literata",
    "slug": "literata",
    "webfontStylesUri": "https://fonts.googleapis.com/css2?family=Literata:wght@200..900&display=optional"
  }
```

The `webfontStylesUri` is a link to the google-API containing the styles for this webfont (can be any API, google-fonts was just used for convenience here).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
