### PR TITLE
Embed: fix select on focus

### DIFF
--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -11,7 +11,6 @@ export default function WpEmbedPreview( { html } ) {
 	useEffect( () => {
 		const { ownerDocument } = ref.current;
 		const { defaultView } = ownerDocument;
-		const { FocusEvent } = defaultView;
 
 		/**
 		 * Checks for WordPress embed events signaling the height change when iframe
@@ -58,8 +57,7 @@ export default function WpEmbedPreview( { html } ) {
 				return;
 			}
 
-			const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
-			activeElement.dispatchEvent( focusEvent );
+			activeElement.focus();
 		}
 
 		defaultView.addEventListener( 'message', resizeWPembeds );

--- a/packages/components/src/focusable-iframe/index.js
+++ b/packages/components/src/focusable-iframe/index.js
@@ -4,7 +4,7 @@
 import { useEffect, useRef } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 
-export default function FocusableIframe( { iframeRef, onFocus, ...props } ) {
+export default function FocusableIframe( { iframeRef, ...props } ) {
 	const fallbackRef = useRef();
 	const ref = useMergeRefs( [ iframeRef, fallbackRef ] );
 
@@ -12,7 +12,6 @@ export default function FocusableIframe( { iframeRef, onFocus, ...props } ) {
 		const iframe = fallbackRef.current;
 		const { ownerDocument } = iframe;
 		const { defaultView } = ownerDocument;
-		const { FocusEvent } = defaultView;
 
 		/**
 		 * Checks whether the iframe is the activeElement, inferring that it has
@@ -23,13 +22,7 @@ export default function FocusableIframe( { iframeRef, onFocus, ...props } ) {
 				return;
 			}
 
-			const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
-
-			iframe.dispatchEvent( focusEvent );
-
-			if ( onFocus ) {
-				onFocus( focusEvent );
-			}
+			iframe.focus();
 		}
 
 		defaultView.addEventListener( 'blur', checkFocus );
@@ -37,7 +30,7 @@ export default function FocusableIframe( { iframeRef, onFocus, ...props } ) {
 		return () => {
 			defaultView.removeEventListener( 'blur', checkFocus );
 		};
-	}, [ onFocus ] );
+	}, [] );
 
 	// Disable reason: The rendered iframe is a pass-through component,
 	// assigning props inherited from the rendering parent. It's the


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #29374. We switched to using the `focusin` event type instead of `focus` for detecting block selection.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
