### PR TITLE
[Query block] Remove exclusion of current page id

### DIFF
--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -36,9 +36,6 @@
 		"query": "query",
 		"layout": "layout"
 	},
-	"usesContext": [
-		"postId"
-	],
 	"supports": {
 		"html": false
 	},

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -21,11 +21,7 @@ import QueryBlockSetup from './query-block-setup';
 import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
 
 const TEMPLATE = [ [ 'core/query-loop' ] ];
-export function QueryContent( {
-	attributes,
-	context: { postId },
-	setAttributes,
-} ) {
+export function QueryContent( { attributes, setAttributes } ) {
 	const { queryId, query, layout } = attributes;
 	const instanceId = useInstanceId( QueryContent );
 	const blockProps = useBlockProps();
@@ -42,16 +38,13 @@ export function QueryContent( {
 	// would cause to overide previous wanted changes.
 	useEffect( () => {
 		const newQuery = {};
-		if ( postId && ! query.exclude?.length ) {
-			newQuery.exclude = [ postId ];
-		}
 		if ( ! query.perPage && postsPerPage ) {
 			newQuery.perPage = postsPerPage;
 		}
 		if ( !! Object.keys( newQuery ).length ) {
 			updateQuery( newQuery );
 		}
-	}, [ query.perPage, query.exclude, query.inherit, postId ] );
+	}, [ query.perPage, query.inherit ] );
 	// We need this for multi-query block pagination.
 	// Query parameters for each block are scoped to their ID.
 	useEffect( () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR removes the exclusion of the current `postId` in `Query` block. That was a premature and early addition that is wrong, but aimed to handle some infinite recursion problems if we included `post-content` into itself.

This should be handled with the new hook introduced here: https://github.com/WordPress/gutenberg/pull/28428 probably, and will be in a follow up.

## Testing Instructions

Just insert a Query block and verify it works as before.
The only exception would be the crashing of the editor if you insert a Query in a post/page and include `Post Content` in the loop and include the same page/post you are editing in the results. I wouldn't recommend to try that though :) 
