### PR TITLE
Update template details popover

### DIFF
--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Button, __experimentalText as Text } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -31,27 +31,14 @@ export default function TemplateDetails( { template, onClose } ) {
 	return (
 		<>
 			<div className="edit-site-template-details">
-				<Text variant="sectionheading">
-					{ __( 'Template details' ) }
-				</Text>
-
-				{ title && (
-					<Text variant="body">
-						{ sprintf(
-							/* translators: %s: Name of the template. */
-							__( 'Name: %s' ),
-							title
-						) }
-					</Text>
-				) }
+				<Text variant="subtitle">{ title }</Text>
 
 				{ description && (
-					<Text variant="body">
-						{ sprintf(
-							/* translators: %s: Description of the template. */
-							__( 'Description: %s' ),
-							description
-						) }
+					<Text
+						variant="body"
+						className="edit-site-template-details__description"
+					>
+						{ description }
 					</Text>
 				) }
 			</div>

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -6,6 +6,10 @@
 	}
 }
 
+.edit-site-template-details__description {
+	color: $gray-700;
+}
+
 .edit-site-template-details__show-all-button.components-button {
 	display: block;
 	background: $gray-900;


### PR DESCRIPTION
This PR simplifies the template details popover by removing the "Template details" heading and the "Name" and "Description" labels:

| Before | After |
| --- | --- |
| <img width="332" alt="Screenshot 2021-03-01 at 14 39 31" src="https://user-images.githubusercontent.com/846565/109512387-f68eb800-7a9b-11eb-8818-0611a60d24be.png"> | <img width="398" alt="Screenshot 2021-03-01 at 14 31 20" src="https://user-images.githubusercontent.com/846565/109512217-c5ae8300-7a9b-11eb-8d91-6a3c7ae4ce43.png"> | 