### PR TITLE
Components: Fix snapshots for interpolated components classname

### DIFF
--- a/packages/components/src/ui/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/card/test/__snapshots__/index.js.snap
@@ -11,8 +11,8 @@ Snapshot Diff:
         title="WordPress.org"
       />
       <div
--       class="components-card-inner-body wp-components-card-inner-body css-1n7epz"
-+       class="components-scrollable wp-components-scrollable components-card-body wp-components-card-body css-1hp1ar"
+-       class="components-card-inner-body wp-components-card-inner-body ic-b8zmsr ic-192yz5d css-1n7epz"
++       class="components-scrollable wp-components-scrollable components-card-body wp-components-card-body ic-1reds0m ic-y3p1xi ic-192yz5d css-1hp1ar"
         data-g2-c16t="true"
 -       data-g2-component="CardInnerBody"
 +       data-g2-component="CardBody"
@@ -20,7 +20,7 @@ Snapshot Diff:
         Code is Poetry.
       </div>
       <div
-        class="components-flex wp-components-flex components-card-footer wp-components-card-footer css-1qwgs3h"
+        class="components-flex wp-components-flex components-card-footer wp-components-card-footer ic-i2oc6g ic-17cs4ki ic-192yz5d css-1qwgs3h"
 `;
 
 exports[`props should render correctly 1`] = `
@@ -411,29 +411,29 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-surface wp-components-surface components-card wp-components-card emotion-6"
+  class="components-surface wp-components-surface components-card wp-components-card ic-1vr61kr ic-15506ld ic-192yz5d emotion-6"
   data-g2-c16t="true"
   data-g2-component="Card"
 >
   <div
-    class="emotion-3"
+    class="ic-192yz5d emotion-3"
     data-g2-component="CardContent"
   >
     <div
-      class="components-flex wp-components-flex components-card-header wp-components-card-header emotion-0"
+      class="components-flex wp-components-flex components-card-header wp-components-card-header ic-1jf72r7 ic-17cs4ki ic-192yz5d emotion-0"
       data-g2-c16t="true"
       data-g2-component="CardHeader"
       title="WordPress.org"
     />
     <div
-      class="components-scrollable wp-components-scrollable components-card-body wp-components-card-body emotion-1"
+      class="components-scrollable wp-components-scrollable components-card-body wp-components-card-body ic-1reds0m ic-y3p1xi ic-192yz5d emotion-1"
       data-g2-c16t="true"
       data-g2-component="CardBody"
     >
       Code is Poetry.
     </div>
     <div
-      class="components-flex wp-components-flex components-card-footer wp-components-card-footer emotion-2"
+      class="components-flex wp-components-flex components-card-footer wp-components-card-footer ic-i2oc6g ic-17cs4ki ic-192yz5d emotion-2"
       data-g2-c16t="true"
       data-g2-component="CardFooter"
     >
@@ -444,13 +444,13 @@ exports[`props should render correctly 1`] = `
   </div>
   <div
     aria-hidden="true"
-    class="components-elevation wp-components-elevation emotion-4"
+    class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-4"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
   <div
     aria-hidden="true"
-    class="components-elevation wp-components-elevation emotion-5"
+    class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-5"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
@@ -463,20 +463,20 @@ Snapshot Diff:
 + Second value
 
 @@ -7,16 +7,16 @@
-      class="css-1kk7lqu"
+      class="ic-192yz5d css-1kk7lqu"
       data-g2-component="CardContent"
     />
     <div
       aria-hidden="true"
--     class="components-elevation wp-components-elevation css-1vg495v"
-+     class="components-elevation wp-components-elevation css-1wkolpp"
+-     class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d css-1vg495v"
++     class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d css-1wkolpp"
       data-g2-c16t="true"
       data-g2-component="CardElevation"
     />
     <div
       aria-hidden="true"
--     class="components-elevation wp-components-elevation css-dgxm8l"
-+     class="components-elevation wp-components-elevation css-1zwi7l"
+-     class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d css-dgxm8l"
++     class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d css-1zwi7l"
       data-g2-c16t="true"
       data-g2-component="CardElevation"
     />

--- a/packages/components/src/ui/control-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/control-group/test/__snapshots__/index.js.snap
@@ -341,13 +341,13 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex components-control-group wp-components-control-group emotion-6"
+  class="components-flex wp-components-flex components-control-group wp-components-control-group ic-s9h86e ic-17cs4ki ic-192yz5d emotion-6"
   data-g2-c16t="true"
   data-g2-component="ControlGroup"
 >
   <button
     aria-busy="false"
-    class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-2"
+    class="components-flex wp-components-flex ic-17cs4ki components-base-button wp-components-base-button components-button wp-components-button ic-i0z4gr ic-1d6ec17 ic-192yz5d emotion-2"
     data-active="false"
     data-destructive="false"
     data-focused="false"
@@ -356,21 +356,21 @@ exports[`props should render correctly 1`] = `
     data-icon="false"
   >
     <span
-      class="components-flex-item wp-components-flex-item emotion-0"
+      class="components-flex-item wp-components-flex-item ic-1p3tlc8 ic-192yz5d emotion-0"
       data-g2-c16t="true"
       data-g2-component="ButtonContent"
     >
       Code is Poetry
     </span>
     <span
-      class="components-elevation wp-components-elevation emotion-1"
+      class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-1"
       data-g2-c16t="true"
       data-g2-component="ButtonElevation"
     />
   </button>
   <button
     aria-busy="false"
-    class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-2"
+    class="components-flex wp-components-flex ic-17cs4ki components-base-button wp-components-base-button components-button wp-components-button ic-i0z4gr ic-1d6ec17 ic-192yz5d emotion-2"
     data-active="false"
     data-destructive="false"
     data-focused="false"
@@ -379,14 +379,14 @@ exports[`props should render correctly 1`] = `
     data-icon="false"
   >
     <span
-      class="components-flex-item wp-components-flex-item emotion-0"
+      class="components-flex-item wp-components-flex-item ic-1p3tlc8 ic-192yz5d emotion-0"
       data-g2-c16t="true"
       data-g2-component="ButtonContent"
     >
       WordPress.org
     </span>
     <span
-      class="components-elevation wp-components-elevation emotion-1"
+      class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-1"
       data-g2-c16t="true"
       data-g2-component="ButtonElevation"
     />
@@ -1229,33 +1229,33 @@ exports[`props should render mixed control types 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex components-control-group wp-components-control-group emotion-10"
+  class="components-flex wp-components-flex components-control-group wp-components-control-group ic-s9h86e ic-17cs4ki ic-192yz5d emotion-10"
   data-g2-c16t="true"
   data-g2-component="ControlGroup"
 >
   <div
-    class="components-flex wp-components-flex components-base-field wp-components-base-field components-select wp-components-select emotion-4"
+    class="components-flex wp-components-flex components-base-field wp-components-base-field ic-172ogxm ic-17cs4ki components-select wp-components-select ic-gutgg1 ic-192yz5d emotion-4"
     data-g2-c16t="true"
     data-g2-component="SelectWrapper"
   >
     <select
-      class="emotion-0"
+      class="ic-192yz5d emotion-0"
       data-g2-c16t="true"
       data-g2-component="Select"
       id="salutations"
     />
     <div
-      class="components-flex-item wp-components-flex-item emotion-3"
+      class="components-flex-item wp-components-flex-item ic-knvlgp ic-192yz5d ic-1p3tlc8 ic-192yz5d emotion-3"
       data-g2-c16t="true"
       data-g2-component="FlexItem"
     >
       <span
-        class="components-truncate wp-components-truncate components-text wp-components-text emotion-2"
+        class="components-truncate wp-components-truncate components-text wp-components-text ic-7u3orf ic-1m45iq3 ic-192yz5d emotion-2"
         data-g2-c16t="true"
         data-g2-component="Text"
       >
         <div
-          class="components-icon wp-components-icon emotion-1"
+          class="components-icon wp-components-icon ic-2q44rw ic-192yz5d emotion-1"
           data-g2-c16t="true"
           data-g2-component="Icon"
         >
@@ -1278,13 +1278,13 @@ exports[`props should render mixed control types 1`] = `
     </div>
   </div>
   <div
-    class="components-flex wp-components-flex components-base-field wp-components-base-field components-text-input wp-components-text-input emotion-6"
+    class="components-flex wp-components-flex components-base-field wp-components-base-field ic-172ogxm ic-17cs4ki components-text-input wp-components-text-input ic-19funlj ic-192yz5d emotion-6"
     data-g2-c16t="true"
     data-g2-component="TextInputWrapper"
   >
     <input
       autocomplete="off"
-      class="emotion-5"
+      class="ic-192yz5d emotion-5"
       data-g2-c16t="true"
       data-g2-component="TextInput"
       id="fname"
@@ -1295,7 +1295,7 @@ exports[`props should render mixed control types 1`] = `
   </div>
   <button
     aria-busy="false"
-    class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-9"
+    class="components-flex wp-components-flex ic-17cs4ki components-base-button wp-components-base-button components-button wp-components-button ic-i0z4gr ic-1d6ec17 ic-192yz5d emotion-9"
     data-active="false"
     data-destructive="false"
     data-focused="false"
@@ -1304,14 +1304,14 @@ exports[`props should render mixed control types 1`] = `
     data-icon="false"
   >
     <span
-      class="components-flex-item wp-components-flex-item emotion-7"
+      class="components-flex-item wp-components-flex-item ic-1p3tlc8 ic-192yz5d emotion-7"
       data-g2-c16t="true"
       data-g2-component="ButtonContent"
     >
       Code is Poetry
     </span>
     <span
-      class="components-elevation wp-components-elevation emotion-8"
+      class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-8"
       data-g2-c16t="true"
       data-g2-component="ButtonElevation"
     />

--- a/packages/components/src/ui/control-label/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/control-label/test/__snapshots__/index.js.snap
@@ -68,7 +68,7 @@ exports[`props should render correctly 1`] = `
 }
 
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label emotion-0"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label ic-k1x6d ic-7u3orf ic-1m45iq3 ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
 >
@@ -140,7 +140,7 @@ exports[`props should render no truncate 1`] = `
 }
 
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label emotion-0"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label ic-k1x6d ic-7u3orf ic-1m45iq3 ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
 >
@@ -216,7 +216,7 @@ exports[`props should render size 1`] = `
 }
 
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label emotion-0"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label ic-k1x6d ic-7u3orf ic-1m45iq3 ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
 >

--- a/packages/components/src/ui/elevation/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/elevation/test/__snapshots__/index.js.snap
@@ -54,7 +54,7 @@ exports[`props should render active 1`] = `
 
 <div
   aria-hidden="true"
-  class="components-elevation wp-components-elevation emotion-0"
+  class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Elevation"
 />
@@ -106,7 +106,7 @@ exports[`props should render correctly 1`] = `
 
 <div
   aria-hidden="true"
-  class="components-elevation wp-components-elevation emotion-0"
+  class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Elevation"
 />
@@ -162,7 +162,7 @@ exports[`props should render hover 1`] = `
 
 <div
   aria-hidden="true"
-  class="components-elevation wp-components-elevation emotion-0"
+  class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Elevation"
 />
@@ -222,7 +222,7 @@ exports[`props should render isInteractive 1`] = `
 
 <div
   aria-hidden="true"
-  class="components-elevation wp-components-elevation emotion-0"
+  class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Elevation"
 />
@@ -282,7 +282,7 @@ exports[`props should render offset 1`] = `
 
 <div
   aria-hidden="true"
-  class="components-elevation wp-components-elevation emotion-0"
+  class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Elevation"
 />
@@ -334,7 +334,7 @@ exports[`props should render value 1`] = `
 
 <div
   aria-hidden="true"
-  class="components-elevation wp-components-elevation emotion-0"
+  class="components-elevation wp-components-elevation ic-i1zzlu ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Elevation"
 />

--- a/packages/components/src/ui/flex/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/flex/test/__snapshots__/index.js.snap
@@ -6,16 +6,16 @@ Snapshot Diff:
 + Second value
 
 @@ -7,14 +7,10 @@
-      class="components-flex-item wp-components-flex-item css-uyw6h0"
+      class="components-flex-item wp-components-flex-item ic-1p3tlc8 ic-192yz5d css-uyw6h0"
       data-g2-c16t="true"
       data-g2-component="FlexItem"
     />
     <div
--     class="css-1nqjm19"
+-     class="ic-192yz5d css-1nqjm19"
 -   />
 -   <div />
 -   <div
-      class="components-flex-item wp-components-flex-item components-flex-block wp-components-flex-block css-2e3tg1"
+      class="components-flex-item wp-components-flex-item components-flex-block wp-components-flex-block ic-1e1meti ic-1p3tlc8 ic-192yz5d css-2e3tg1"
       data-g2-c16t="true"
       data-g2-component="FlexBlock"
     />
@@ -161,17 +161,17 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex emotion-2"
+  class="components-flex wp-components-flex ic-17cs4ki ic-192yz5d emotion-2"
   data-g2-c16t="true"
   data-g2-component="Flex"
 >
   <div
-    class="components-flex-item wp-components-flex-item emotion-0"
+    class="components-flex-item wp-components-flex-item ic-1p3tlc8 ic-192yz5d emotion-0"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   />
   <div
-    class="components-flex-item wp-components-flex-item components-flex-block wp-components-flex-block emotion-1"
+    class="components-flex-item wp-components-flex-item components-flex-block wp-components-flex-block ic-1e1meti ic-1p3tlc8 ic-192yz5d emotion-1"
     data-g2-c16t="true"
     data-g2-component="FlexBlock"
   />

--- a/packages/components/src/ui/form-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/form-group/test/__snapshots__/index.js.snap
@@ -91,12 +91,12 @@ exports[`props should render alignLabel 1`] = `
 }
 
 <div
-  class="components-form-group wp-components-form-group emotion-1"
+  class="components-form-group wp-components-form-group ic-1tpea9i ic-192yz5d emotion-1"
   data-g2-c16t="true"
   data-g2-component="FormGroup"
 >
   <label
-    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label emotion-0"
+    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label ic-k1x6d ic-7u3orf ic-1m45iq3 ic-192yz5d emotion-0"
     data-g2-c16t="true"
     data-g2-component="ControlLabel"
     for="fname"
@@ -201,12 +201,12 @@ exports[`props should render vertically 1`] = `
 }
 
 <div
-  class="components-form-group wp-components-form-group emotion-1"
+  class="components-form-group wp-components-form-group ic-1tpea9i ic-192yz5d emotion-1"
   data-g2-c16t="true"
   data-g2-component="FormGroup"
 >
   <label
-    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label emotion-0"
+    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label ic-k1x6d ic-7u3orf ic-1m45iq3 ic-192yz5d emotion-0"
     data-g2-c16t="true"
     data-g2-component="ControlLabel"
     for="fname"

--- a/packages/components/src/ui/h-stack/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/h-stack/test/__snapshots__/index.js.snap
@@ -79,15 +79,15 @@ exports[`props should render alignment 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex components-h-stack wp-components-h-stack emotion-2"
+  class="components-flex wp-components-flex components-h-stack wp-components-h-stack ic-15rn87 ic-17cs4ki ic-192yz5d emotion-2"
   data-g2-c16t="true"
   data-g2-component="HStack"
 >
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
 </div>
 `;
@@ -171,15 +171,15 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex components-h-stack wp-components-h-stack emotion-2"
+  class="components-flex wp-components-flex components-h-stack wp-components-h-stack ic-15rn87 ic-17cs4ki ic-192yz5d emotion-2"
   data-g2-c16t="true"
   data-g2-component="HStack"
 >
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
 </div>
 `;
@@ -263,15 +263,15 @@ exports[`props should render spacing 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex components-h-stack wp-components-h-stack emotion-2"
+  class="components-flex wp-components-flex components-h-stack wp-components-h-stack ic-15rn87 ic-17cs4ki ic-192yz5d emotion-2"
   data-g2-c16t="true"
   data-g2-component="HStack"
 >
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
 </div>
 `;

--- a/packages/components/src/ui/scrollable/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/scrollable/test/__snapshots__/index.js.snap
@@ -60,7 +60,7 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-scrollable wp-components-scrollable emotion-0"
+  class="components-scrollable wp-components-scrollable ic-y3p1xi ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Scrollable"
 >

--- a/packages/components/src/ui/spinner/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/spinner/test/__snapshots__/index.js.snap
@@ -6,11 +6,11 @@ Snapshot Diff:
 + Second value
 
 @@ -10,11 +10,10 @@
-      class="css-16xh7r5"
+      class="ic-1blhbvo ic-192yz5d css-16xh7r5"
       style="transform: scale(0.4444444444444444);"
     >
       <div
-        class="css-1frx7qu"
+        class="ic-1c3kh7b ic-192yz5d css-1frx7qu"
 -       style="color: blue;"
       >
         <div
@@ -235,18 +235,18 @@ exports[`props should render correctly 1`] = `
 
 <div
   aria-busy="true"
-  class="components-spinner wp-components-spinner emotion-2"
+  class="components-spinner wp-components-spinner ic-134ljdn ic-otytyz ic-192yz5d emotion-2"
   data-g2-c16t="true"
   data-g2-component="Spinner"
   style="height: 16px; width: 16px;"
 >
   <div
     aria-hidden="true"
-    class="emotion-1"
+    class="ic-1blhbvo ic-192yz5d emotion-1"
     style="transform: scale(0.4444444444444444);"
   >
     <div
-      class="emotion-0"
+      class="ic-1c3kh7b ic-192yz5d emotion-0"
     >
       <div
         class="InnerBar1"
@@ -297,7 +297,7 @@ Snapshot Diff:
 @@ -1,16 +1,16 @@
   <div
     aria-busy="true"
-    class="components-spinner wp-components-spinner css-10r9amq"
+    class="components-spinner wp-components-spinner ic-134ljdn ic-otytyz ic-192yz5d css-10r9amq"
     data-g2-c16t="true"
     data-g2-component="Spinner"
 -   style="height: 31px; width: 31px;"
@@ -305,12 +305,12 @@ Snapshot Diff:
   >
     <div
       aria-hidden="true"
-      class="css-16xh7r5"
+      class="ic-1blhbvo ic-192yz5d css-16xh7r5"
 -     style="transform: scale(0.8611111111111112);"
 +     style="transform: scale(0.4444444444444444);"
     >
       <div
-        class="css-1frx7qu"
+        class="ic-1c3kh7b ic-192yz5d css-1frx7qu"
       >
         <div
 `;

--- a/packages/components/src/ui/surface/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/surface/test/__snapshots__/index.js.snap
@@ -6,8 +6,8 @@ Snapshot Diff:
 + Second value
 
   <div
--   class="components-surface wp-components-surface css-2anhki"
-+   class="components-surface wp-components-surface css-9yhif5"
+-   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-2anhki"
++   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-9yhif5"
     data-g2-c16t="true"
     data-g2-component="Surface"
   >
@@ -21,8 +21,8 @@ Snapshot Diff:
 + Second value
 
   <div
--   class="components-surface wp-components-surface css-17q8f3e"
-+   class="components-surface wp-components-surface css-9yhif5"
+-   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-17q8f3e"
++   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-9yhif5"
     data-g2-c16t="true"
     data-g2-component="Surface"
   >
@@ -36,8 +36,8 @@ Snapshot Diff:
 + Second value
 
   <div
--   class="components-surface wp-components-surface css-187zti8"
-+   class="components-surface wp-components-surface css-9yhif5"
+-   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-187zti8"
++   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-9yhif5"
     data-g2-c16t="true"
     data-g2-component="Surface"
   >
@@ -51,8 +51,8 @@ Snapshot Diff:
 + Second value
 
   <div
--   class="components-surface wp-components-surface css-evf9lw"
-+   class="components-surface wp-components-surface css-9yhif5"
+-   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-evf9lw"
++   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-9yhif5"
     data-g2-c16t="true"
     data-g2-component="Surface"
   >
@@ -66,8 +66,8 @@ Snapshot Diff:
 + Second value
 
   <div
--   class="components-surface wp-components-surface css-19tpeum"
-+   class="components-surface wp-components-surface css-9yhif5"
+-   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-19tpeum"
++   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-9yhif5"
     data-g2-c16t="true"
     data-g2-component="Surface"
   >
@@ -109,7 +109,7 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-surface wp-components-surface emotion-0"
+  class="components-surface wp-components-surface ic-15506ld ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Surface"
 >
@@ -123,8 +123,8 @@ Snapshot Diff:
 + Second value
 
   <div
--   class="components-surface wp-components-surface css-icckk4"
-+   class="components-surface wp-components-surface css-9yhif5"
+-   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-icckk4"
++   class="components-surface wp-components-surface ic-15506ld ic-192yz5d css-9yhif5"
     data-g2-c16t="true"
     data-g2-component="Surface"
   >

--- a/packages/components/src/ui/text/test/__snapshots__/text.js.snap
+++ b/packages/components/src/ui/text/test/__snapshots__/text.js.snap
@@ -42,7 +42,7 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
 }
 
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text emotion-0"
+  class="components-truncate wp-components-truncate components-text wp-components-text ic-7u3orf ic-1m45iq3 ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -90,7 +90,7 @@ exports[`Text snapshot tests should render correctly 1`] = `
 }
 
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text emotion-0"
+  class="components-truncate wp-components-truncate components-text wp-components-text ic-7u3orf ic-1m45iq3 ic-192yz5d emotion-0"
   data-g2-c16t="true"
   data-g2-component="Text"
 >

--- a/packages/components/src/ui/v-stack/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/v-stack/test/__snapshots__/index.js.snap
@@ -79,15 +79,15 @@ exports[`props should render alignment 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex components-h-stack wp-components-h-stack components-v-stack wp-components-v-stack emotion-2"
+  class="components-flex wp-components-flex components-h-stack wp-components-h-stack components-v-stack wp-components-v-stack ic-osizff ic-15rn87 ic-17cs4ki ic-192yz5d emotion-2"
   data-g2-c16t="true"
   data-g2-component="VStack"
 >
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
 </div>
 `;
@@ -171,15 +171,15 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex components-h-stack wp-components-h-stack components-v-stack wp-components-v-stack emotion-2"
+  class="components-flex wp-components-flex components-h-stack wp-components-h-stack components-v-stack wp-components-v-stack ic-osizff ic-15rn87 ic-17cs4ki ic-192yz5d emotion-2"
   data-g2-c16t="true"
   data-g2-component="VStack"
 >
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
 </div>
 `;
@@ -263,15 +263,15 @@ exports[`props should render spacing 1`] = `
 }
 
 <div
-  class="components-flex wp-components-flex components-h-stack wp-components-h-stack components-v-stack wp-components-v-stack emotion-2"
+  class="components-flex wp-components-flex components-h-stack wp-components-h-stack components-v-stack wp-components-v-stack ic-osizff ic-15rn87 ic-17cs4ki ic-192yz5d emotion-2"
   data-g2-c16t="true"
   data-g2-component="VStack"
 >
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
   <div
-    class="emotion-0"
+    class="ic-192yz5d emotion-0"
   />
 </div>
 `;

--- a/packages/components/src/ui/view/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/view/test/__snapshots__/index.js.snap
@@ -27,7 +27,7 @@ exports[`props should render as another element 1`] = `
 }
 
 <p
-  class="emotion-0"
+  class="ic-192yz5d emotion-0"
 >
   <span />
 </p>
@@ -60,7 +60,7 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="emotion-0"
+  class="ic-192yz5d emotion-0"
 >
   <span />
 </div>
@@ -95,7 +95,7 @@ exports[`props should render with custom styles (Array) 1`] = `
 }
 
 <p
-  class="emotion-0"
+  class="ic-192yz5d emotion-0"
 >
   <span />
 </p>
@@ -129,7 +129,7 @@ exports[`props should render with custom styles (object) 1`] = `
 }
 
 <p
-  class="emotion-0"
+  class="ic-192yz5d emotion-0"
 >
   <span />
 </p>
@@ -163,7 +163,7 @@ exports[`props should render with custom styles (string) 1`] = `
 }
 
 <p
-  class="emotion-0"
+  class="ic-192yz5d emotion-0"
 >
   <span />
 </p>

--- a/packages/components/src/ui/visually-hidden/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/visually-hidden/test/__snapshots__/index.js.snap
@@ -61,7 +61,7 @@ exports[`VisuallyHidden should render correctly 1`] = `
 }
 
 <div
-  class="components-visually-hidden wp-components-visually-hidden emotion-0"
+  class="components-visually-hidden wp-components-visually-hidden ic-192yz5d emotion-0"
 >
   This is hidden
 </div>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes snapshot tests for to add the interpolated component classname.

## How has this been tested?
Unit tests pass

## Types of changes
Test fix

## Checklist:
- [x] My code is tested.
- [N/A] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
