### PR TITLE
Mobile Release v1.48.0

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -307,10 +307,6 @@ function RichTextWrapper(
 			const hasPastedBlocks = pastedBlocks.length > 0;
 			let lastPastedBlockIndex = -1;
 
-			// Consider the after value to be the original it is not empty and
-			// the before value *is* empty.
-			const isAfterOriginal = isEmpty( before ) && ! isEmpty( after );
-
 			// Create a block with the content before the caret if there's no pasted
 			// blocks, or if there are pasted blocks and the value is not empty.
 			// We do not want a leading empty block on paste, but we do if split
@@ -321,8 +317,7 @@ function RichTextWrapper(
 						toHTMLString( {
 							value: before,
 							multilineTag,
-						} ),
-						! isAfterOriginal
+						} )
 					)
 				);
 				lastPastedBlockIndex += 1;
@@ -349,8 +344,7 @@ function RichTextWrapper(
 						toHTMLString( {
 							value: after,
 							multilineTag,
-						} ),
-						isAfterOriginal
+						} )
 					)
 				);
 			}

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -27,7 +27,6 @@ function HeadingEdit( {
 	mergeBlocks,
 	onReplace,
 	mergedStyle,
-	clientId,
 } ) {
 	const { textAlign, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
@@ -62,23 +61,15 @@ function HeadingEdit( {
 				value={ content }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				onSplit={ ( value, isOriginal ) => {
-					let block;
-
-					if ( isOriginal || value ) {
-						block = createBlock( 'core/heading', {
-							...attributes,
-							content: value,
-						} );
-					} else {
-						block = createBlock( 'core/paragraph' );
+				onSplit={ ( value ) => {
+					if ( ! value ) {
+						return createBlock( 'core/paragraph' );
 					}
 
-					if ( isOriginal ) {
-						block.clientId = clientId;
-					}
-
-					return block;
+					return createBlock( 'core/heading', {
+						...attributes,
+						content: value,
+					} );
 				} }
 				onReplace={ onReplace }
 				onRemove={ () => onReplace( [] ) }

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -73,7 +73,6 @@ function ParagraphBlock( {
 	onReplace,
 	onRemove,
 	setAttributes,
-	clientId,
 } ) {
 	const {
 		align,
@@ -149,23 +148,15 @@ function ParagraphBlock( {
 				onChange={ ( newContent ) =>
 					setAttributes( { content: newContent } )
 				}
-				onSplit={ ( value, isOriginal ) => {
-					let newAttributes;
-
-					if ( isOriginal || value ) {
-						newAttributes = {
-							...attributes,
-							content: value,
-						};
+				onSplit={ ( value ) => {
+					if ( ! value ) {
+						return createBlock( name );
 					}
 
-					const block = createBlock( name, newAttributes );
-
-					if ( isOriginal ) {
-						block.clientId = clientId;
-					}
-
-					return block;
+					return createBlock( name, {
+						...attributes,
+						content: value,
+					} );
 				} }
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -21,7 +21,6 @@ function ParagraphBlock( {
 	setAttributes,
 	mergedStyle,
 	style,
-	clientId,
 } ) {
 	const isRTL = useSelect( ( select ) => {
 		return !! select( blockEditorStore ).getSettings().isRTL;
@@ -57,23 +56,15 @@ function ParagraphBlock( {
 						content: nextContent,
 					} );
 				} }
-				onSplit={ ( value, isOriginal ) => {
-					let newAttributes;
-
-					if ( isOriginal || value ) {
-						newAttributes = {
-							...attributes,
-							content: value,
-						};
+				onSplit={ ( value ) => {
+					if ( ! value ) {
+						return createBlock( name );
 					}
 
-					const block = createBlock( name, newAttributes );
-
-					if ( isOriginal ) {
-						block.clientId = clientId;
-					}
-
-					return block;
+					return createBlock( name, {
+						...attributes,
+						content: value,
+					} );
 				} }
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.47.0",
+	"version": "1.48.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.47.0",
+	"version": "1.48.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,7 +12,7 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 
 ## 1.48.0
-* [**] Buttons block: added with setting. [#28543]
+* [**] Buttons block: added width setting. [#28543]
 
 ## 1.47.0
 * [**] Add support for setting Cover block focal point. [#25810]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,9 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+## 1.48.0
+* [**] Buttons block: added with setting. [#28543]
+
 ## 1.47.0
 * [**] Add support for setting Cover block focal point. [#25810]
 

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Gutenberg (1.47.0):
+  - Gutenberg (1.48.0):
     - React-Core (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -253,7 +253,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.6-gb):
     - React-Core
-  - RNTAztecView (1.47.0):
+  - RNTAztecView (1.48.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.4)
   - WordPress-Aztec-iOS (1.19.4)
@@ -402,7 +402,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Gutenberg: 103a9ebea785a8e1dd4c8bd4378d4a8a70efa678
+  Gutenberg: 670f7b82bc18bde86a516834b72b7eeded1011e8
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -435,7 +435,7 @@ SPEC CHECKSUMS:
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b
   RNSVG: 46c4b680fe18237fa01eb7d7b311d77618fde31f
-  RNTAztecView: b1dfb9116d5947d9740145d3620cec703b529203
+  RNTAztecView: 985f01fae9ea8ce9cb18a6f7af9b571084d7c9f9
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.47.0",
+	"version": "1.48.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -7,7 +7,7 @@
  * WordPress dependencies
  */
 import RCTAztecView from '@wordpress/react-native-aztec';
-import { View, Platform, InteractionManager } from 'react-native';
+import { View, Platform } from 'react-native';
 import {
 	showUserSuggestions,
 	showXpostSuggestions,
@@ -18,10 +18,7 @@ import memize from 'memize';
 /**
  * WordPress dependencies
  */
-import {
-	BlockFormatControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { BlockFormatControls } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -559,7 +556,6 @@ export class RichText extends Component {
 
 		// Check if value is up to date with latest state of native AztecView
 		if (
-			this.isIOS &&
 			event.nativeEvent.text &&
 			event.nativeEvent.text !== this.props.value
 		) {
@@ -619,9 +615,7 @@ export class RichText extends Component {
 
 		// update text before updating selection
 		// Make sure there are changes made to the content before upgrading it upward
-		if ( this.isIOS ) {
-			this.onTextUpdate( event );
-		}
+		this.onTextUpdate( event );
 
 		// Aztec can send us selection change events after it has lost focus.
 		// For instance the autocorrect feature will complete a partially written
@@ -769,9 +763,7 @@ export class RichText extends Component {
 				this.props.selectionEnd || 0
 			);
 		} else if ( ! isSelected && prevIsSelected ) {
-			InteractionManager.runAfterInteractions( () => {
-				this._editor?.blur();
-			} );
+			this._editor.blur();
 		}
 	}
 
@@ -1006,7 +998,7 @@ const withFormatTypes = ( WrappedComponent ) => ( props ) => {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockParents, getBlock, getSettings } = select(
-			blockEditorStore
+			'core/block-editor'
 		);
 		const parents = getBlockParents( clientId, true );
 		const parentBlock = parents ? getBlock( parents[ 0 ] ) : undefined;


### PR DESCRIPTION
## Description
Release 1.48.0 of the react-native-editor and Gutenberg-Mobile.

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3205

#### Note: When this is ready to merge we shouldn't include this (956cdfc) commit.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->