### PR TITLE
Docs: Fix deprecation message to be clear

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md
@@ -2,6 +2,6 @@
 
 ## WARNING
 
-**Deprecated:** It is now no longer recommended to use WP-CLI or create-guten-block to generate block scaffolding.
+**Deprecated:** It is no longer recommended to use WP-CLI or create-guten-block to generate block scaffolding.
 
 The official script to generate a block is the new [@wordpress/create-block](/packages/create-block/README.md) package. This package follows the new block directory guidelines, and creates the proper block, environment, and standards set by the project. See the new [Create a Block tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md) for a complete walk-through.

--- a/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md
@@ -2,6 +2,6 @@
 
 ## WARNING
 
-**Deprecated:** It is not no longer recommended to use WP-CLI or create-guten-block to generate block scaffolding.
+**Deprecated:** It is now no longer recommended to use WP-CLI or create-guten-block to generate block scaffolding.
 
 The official script to generate a block is the new [@wordpress/create-block](/packages/create-block/README.md) package. This package follows the new block directory guidelines, and creates the proper block, environment, and standards set by the project. See the new [Create a Block tutorial](/docs/designers-developers/developers/tutorials/create-block/readme.md) for a complete walk-through.


### PR DESCRIPTION


## Description

A typo that caused minor confusion, the `not` should of been `now` for deprecating using wp-cli to create blocks.


## How has this been tested?

Confirm doc change.
