### PR TITLE
Site Editor: remove outer content margins to better match front-end

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -1,7 +1,7 @@
 // The button element easily inherits styles that are meant for the editor style.
 // These rules enhance the specificity to reduce that inheritance.
 // This is duplicated in visual-editor.
-.edit-site-block-editor__editor-styles-wrapper  .components-button {
+.edit-site-block-editor__editor-styles-wrapper .components-button {
 	font-family: $default-font;
 	font-size: $default-font-size;
 	padding: 6px 12px;
@@ -9,5 +9,36 @@
 	&.is-tertiary,
 	&.has-icon {
 		padding: 6px;
+	}
+}
+
+/**
+ * Remove the site editor outer margins to better match front-end view
+ */
+
+// Undo the "Editor Normalization Styles" padding
+// !important used to override inline style
+.editor-styles-wrapper {
+	padding-top: 0 !important;
+	padding-bottom: 0 !important;
+}
+
+// Remove the top margin for the header template part
+.edit-site-block-editor__block-list .wp-block-template-part.site-header {
+	margin-top: 0;
+
+	// And the top margin of the first block in the template part
+	.wp-block:first-of-type .block-editor-block-list__block {
+		margin-top: 0;
+	}
+}
+
+// Remove the bottom margin for the fotter
+.edit-site-block-editor__block-list .wp-block-template-part.site-footer {
+	margin-bottom: 0;
+
+	// And the bottom margin of the last block in the template part
+	.wp-block:last-of-type .block-editor-block-list__block {
+		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
## Description

This change demonstrate removing the outer content margins from the site editor, to better match how the content looks on the front-end of the site (addresses #29357)

## How has this been tested?

- Using TT1 Blocks theme and editing a template
- Manually checking the margins in the site editor are removed
- Manually checking that changes do not bleed into the post/page editor

## Screenshots

| **Header** | **Footer** |
| - | - |
| <img width="1287" alt="Screen Shot 2021-03-01 at 15 51 17" src="https://user-images.githubusercontent.com/1699996/109565033-825a1180-7aa7-11eb-9a97-bc72e0da236d.png"> | <img width="1286" alt="Screen Shot 2021-03-01 at 15 50 49" src="https://user-images.githubusercontent.com/1699996/109565431-11672980-7aa8-11eb-9ff8-8ff4337c624c.png"> |

## Types of changes


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
