### PR TITLE
Fix fatal error in Site Editor if a block defines an array of style/editor_style handles

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -717,11 +717,11 @@ function gutenberg_extend_block_editor_styles_html() {
 
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
 		if ( ! empty( $block_type->style ) ) {
-			$handles[] = $block_type->style;
+			$handles = array_merge( $handles, is_array( $block_type->style ) ? $block_type->style : array( $block_type->style ) );
 		}
 
 		if ( ! empty( $block_type->editor_style ) ) {
-			$handles[] = $block_type->editor_style;
+			$handles = array_merge( $handles, is_array( $block_type->editor_style ) ? $block_type->editor_style : array( $block_type->editor_style ) );
 		}
 	}
 


### PR DESCRIPTION
## Description

[We're currently working on making WooCommerce Blocks compatible with FSE](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3898), and one issue we've come across is the way in which handles are being merged in `gutenberg_extend_block_editor_styles_html` here:

https://github.com/WordPress/gutenberg/blob/da8555d258edbe676fa079fb51252f918ae032e1/lib/client-assets.php#L718-L728

Some of our blocks do not have a single editor_script handle, [for example here we include the block styles, and the vendor styles](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/8ac4e9bfc39b892ed03a729e4a35fa43d0b3ab16/src/BlockTypes/SingleProduct.php#L37), so the handle is an array, not a string.

This results in a white screen/fatal error when loading up the Site Editor (array to string conversion).

To fix this, this PR checks to see if a handle is a string or an array, and merges it appropriately. 

## How has this been tested?
- Ensure Gutenberg, WooCommerce and WooCommerce Blocks are active, as well as a theme supporting FSE
- In admin, go to the site editor. See white screen. Debug log will show an array to string conversion error
- Apply patch. Go to site editor. Page loads successfully.

## Types of changes
This is a Bug fix for the style handle handler.

@nerrad recommended I ping @noisysocks in case this fix needs porting to WP 5.7.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
