### PR TITLE
Pass block settings to the client for all blocks

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -510,18 +510,6 @@ class WP_Theme_JSON {
 		$blocks   = $registry->get_all_registered();
 		foreach ( $blocks as $block_name => $block_type ) {
 			/*
-			 * Skips blocks that don't declare support,
-			 * they don't generate styles.
-			 */
-			if (
-				! property_exists( $block_type, 'supports' ) ||
-				! is_array( $block_type->supports ) ||
-				empty( $block_type->supports )
-			) {
-				continue;
-			}
-
-			/*
 			 * Extract block support keys that are related to the style properties.
 			 */
 			$block_supports = array();
@@ -529,13 +517,6 @@ class WP_Theme_JSON {
 				if ( gutenberg_experimental_get( $block_type->supports, $metadata['support'] ) ) {
 					$block_supports[] = $key;
 				}
-			}
-
-			/*
-			 * Skip blocks that don't support anything related to styles.
-			 */
-			if ( empty( $block_supports ) ) {
-				continue;
 			}
 
 			/*


### PR DESCRIPTION
The server logic to extract settings from `theme.json` and pass them to the editors has a bug in which it won't pass the settings for blocks that don't have any support for styles. This PR fixes it.

## How to test

- Use a theme with support for `theme.json`. For example, TT1-blocks.
- Add a value for dropCap in the group and post content blocks such as:

```json
"settings": {
  "core/group": {
    "typography": {
      "dropCap": false
      }
    },
  "core/post-content": {
    "typography": {
      "dropCap": false
      }
    }
  }
}
```

- In the editor, verify that the `core/block-editor` store has those values under `settings.__experimentalFeatures`.

Without this PR, the result is that the settings for `core/post-content` are not present in the client (among other blocks as well).