### PR TITLE
[RNMobile] Fix missing context prop in BlockEdit component

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.native.js
+++ b/packages/block-editor/src/components/block-edit/edit.native.js
@@ -1,12 +1,42 @@
 /**
+ * External dependencies
+ */
+import { pick } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { withFilters } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
+import { useContext, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BlockContext from '../block-context';
+
+/**
+ * Default value used for blocks which do not define their own context needs,
+ * used to guarantee that a block's `context` prop will always be an object. It
+ * is assigned as a constant since it is always expected to be an empty object,
+ * and in order to avoid unnecessary React reconciliations of a changing object.
+ *
+ * @type {{}}
+ */
+const DEFAULT_BLOCK_CONTEXT = {};
 
 export const Edit = ( props ) => {
 	const { name } = props;
 	const blockType = getBlockType( name );
+
+	const blockContext = useContext( BlockContext );
+
+	// Assign context values using the block type's declared context needs.
+	const context = useMemo( () => {
+		return blockType && blockType.usesContext
+			? pick( blockContext, blockType.usesContext )
+			: DEFAULT_BLOCK_CONTEXT;
+	}, [ blockType, blockContext ] );
 
 	if ( ! blockType ) {
 		return null;
@@ -14,7 +44,7 @@ export const Edit = ( props ) => {
 
 	const Component = blockType.edit;
 
-	return <Component { ...props } />;
+	return <Component { ...props } context={ context } />;
 };
 
 export default withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/block-editor/src/components/block-edit/test/edit.native.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.native.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { shallow, mount } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	registerBlockType,
+	unregisterBlockType,
+	getBlockTypes,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { Edit } from '../edit';
+import { BlockContextProvider } from '../../block-context';
+
+describe( 'Edit', () => {
+	afterEach( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'should return null if block type not defined', () => {
+		const wrapper = shallow( <Edit name="core/test-block" /> );
+
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should use edit implementation of block', () => {
+		const edit = () => <div />;
+		registerBlockType( 'core/test-block', {
+			category: 'text',
+			title: 'block title',
+			edit,
+		} );
+
+		const wrapper = shallow( <Edit name="core/test-block" /> );
+
+		expect( wrapper.exists( edit ) ).toBe( true );
+	} );
+
+	it( 'should assign context', () => {
+		const edit = ( { context } ) => context.value;
+		registerBlockType( 'core/test-block', {
+			category: 'text',
+			title: 'block title',
+			usesContext: [ 'value' ],
+			edit,
+		} );
+
+		const wrapper = mount(
+			<BlockContextProvider value={ { value: 'Ok' } }>
+				<Edit name="core/test-block" />
+			</BlockContextProvider>
+		);
+
+		expect( wrapper.html() ).toBe( 'Ok' );
+	} );
+} );


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3208

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
In the native version of the `BlockEdit` component the `context` prop is not being passed to the edit component of the block so the context is not available if the `usesContext` property was set in the block's metadata.

Based on the web version implementation, I added the logic related to fetching and passing the block context to the edit component of a block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
We don't have any block that has the `usesContext` property in the metadata except the `core/social-link` block. However although this block is registered, [it's marked as a hidden block](https://github.com/WordPress/gutenberg/blob/256acf763753668c439128d6dfc0987954b93444/packages/block-library/src/index.native.js#L170:L170) and it's only used as an inner block of `core/social-links` which [already passes its own block context](https://github.com/WordPress/gutenberg/blob/256acf763753668c439128d6dfc0987954b93444/packages/block-editor/src/components/inner-blocks/index.native.js#L93-L108).

Being that said, testing this PR requires to introduce some code changes:
1. Add the following code to a block's metadata (in this example we're going to use the [paragraph block](https://github.com/wordpress/gutenberg/blob/trunk/packages/block-library/src/paragraph/block.json)):
```
"usesContext": [ "postId", "postType" ],
```
2. Add `context` to the props list in the [edit component](https://github.com/WordPress/gutenberg/blob/dff5d769b068b895619f74d2b6463e3f94f348d8/packages/block-library/src/paragraph/edit.native.js#L24) of the paragraph block.
3. Print the context content by adding `console.log( context );` in the component function.
4. Open or create a post and add a paragraph block.
5. Check the app's log and verify that it's printing an object with `postId` and `postType`, for regular post it should print `{postId: 1, postType: "post"}`.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
