### PR TITLE
Allow insertion of elements before and after a block, when the default block is not supported in the parent container

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -188,7 +188,8 @@ _Returns_
 
 ### getBlockHierarchyRootClientId
 
-Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.
+Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself
+for root level blocks.
 
 _Parameters_
 

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -30,8 +30,9 @@ export default function BlockActions( {
 		getBlocksByClientId,
 		canRemoveBlocks,
 		getTemplateLock,
+		__experimentalGetDefaultBlockForAllowedBlocks,
 	} = useSelect( ( select ) => select( blockEditorStore ), [] );
-	const { getDefaultBlockName, getGroupingBlockName } = useSelect(
+	const { getGroupingBlockName } = useSelect(
 		( select ) => select( blocksStore ),
 		[]
 	);
@@ -46,11 +47,11 @@ export default function BlockActions( {
 		);
 	} );
 
-	const canInsertDefaultBlock = canInsertBlockType(
-		getDefaultBlockName(),
+	const defaultBlock = __experimentalGetDefaultBlockForAllowedBlocks(
 		rootClientId
 	);
 
+	const canInsertDefaultBlock = !! defaultBlock;
 	const canRemove = canRemoveBlocks( clientIds, rootClientId );
 
 	const {

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -52,6 +52,7 @@ function UncontrolledInnerBlocks( props ) {
 		orientation,
 		placeholder,
 		__experimentalLayout,
+		__experimentalDefaultBlock,
 	} = props;
 
 	useNestedSettingsUpdate(
@@ -60,7 +61,8 @@ function UncontrolledInnerBlocks( props ) {
 		templateLock,
 		captureToolbars,
 		orientation,
-		__experimentalLayout
+		__experimentalLayout,
+		__experimentalDefaultBlock
 	);
 
 	useInnerBlockTemplateSync(

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -29,6 +29,10 @@ import { getLayoutType } from '../../layouts';
  * @param {string}   orientation     The direction in which the block
  *                                   should face.
  * @param {Object}   layout          The layout object for the block container.
+ *
+ * @param {[]}   __experimentalDefaultBlock     The default block: [ blockName, { blockAttributes } ].
+ *                                              Used to insert blocks of this type, before/after blocks
+ *                                              in inner blocks.
  */
 export default function useNestedSettingsUpdate(
 	clientId,
@@ -36,7 +40,8 @@ export default function useNestedSettingsUpdate(
 	templateLock,
 	captureToolbars,
 	orientation,
-	layout
+	layout,
+	__experimentalDefaultBlock
 ) {
 	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 
@@ -64,6 +69,7 @@ export default function useNestedSettingsUpdate(
 	useLayoutEffect( () => {
 		const newSettings = {
 			allowedBlocks: _allowedBlocks,
+			__experimentalDefaultBlock,
 			templateLock:
 				templateLock === undefined ? parentLock : templateLock,
 		};

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -24,6 +24,7 @@ import createSelector from 'rememo';
 import {
 	getBlockType,
 	getBlockTypes,
+	getDefaultBlockName,
 	hasBlockSupport,
 	getPossibleBlockTransformations,
 	parse,
@@ -499,7 +500,8 @@ export const getBlockParentsByBlockName = createSelector(
 );
 
 /**
- * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.
+ * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself
+ * for root level blocks.
  *
  * @param {Object} state    Editor state.
  * @param {string} clientId Block from which to find root client ID.
@@ -1989,6 +1991,32 @@ export const __experimentalGetPatternTransformItems = createSelector(
  */
 export function getBlockListSettings( state, clientId ) {
 	return state.blockListSettings[ clientId ];
+}
+
+/**
+ * Returns the default block name for a list of allowed blocks, if any exist.
+ *
+ * @param {Object}  state    Editor state.
+ * @param {?string} clientId Block client ID.
+ *
+ * @return {?[]}    default block, [ blockName, { blockAttributes } ].
+ */
+export function __experimentalGetDefaultBlockForAllowedBlocks(
+	state,
+	clientId
+) {
+	const settings = getBlockListSettings( state, clientId );
+
+	const [
+		blockName,
+		blockAttributes = {},
+	] = settings?.__experimentalDefaultBlock ?? [ getDefaultBlockName() ];
+
+	if ( ! canInsertBlockType( state, blockName, clientId ) ) {
+		return;
+	}
+
+	return [ blockName, blockAttributes ];
 }
 
 /**

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -31,6 +31,7 @@ const {
 	hideInsertionPoint,
 	insertBlock,
 	insertBlocks,
+	insertDefaultBlock,
 	mergeBlocks,
 	moveBlocksToPosition,
 	multiSelect,
@@ -456,6 +457,23 @@ describe( 'actions', () => {
 					initialPosition: 0,
 				},
 			} );
+		} );
+	} );
+
+	describe( 'insertDefaultBlock', () => {
+		it( 'should check for allowed default block', () => {
+			const insertDefaultBlockGenerator = insertDefaultBlock(
+				{},
+				'testclientid',
+				0
+			);
+			expect( insertDefaultBlockGenerator.next().value ).toEqual(
+				controls.select(
+					blockEditorStoreName,
+					'__experimentalGetDefaultBlockForAllowedBlocks',
+					'testclientid'
+				)
+			);
 		} );
 	} );
 

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -21,6 +21,7 @@ import { useSelect } from '@wordpress/data';
 import { name as buttonBlockName } from '../button';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
+const DEFAULT_BLOCK = [ buttonBlockName ];
 const LAYOUT = {
 	type: 'default',
 	alignments: [],
@@ -52,6 +53,7 @@ function ButtonsEdit( {
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
+		__experimentalDefaultBlock: DEFAULT_BLOCK,
 		template: [
 			[
 				buttonBlockName,

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -50,6 +50,11 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 ];
 
+const DEFAULT_BLOCK = [
+	'core/navigation-link',
+	{ type: 'page', kind: 'post-type' },
+];
+
 const LAYOUT = {
 	type: 'default',
 	alignments: [],
@@ -166,6 +171,7 @@ function Navigation( {
 			allowedBlocks: ALLOWED_BLOCKS,
 			orientation: attributes.orientation,
 			renderAppender: CustomAppender || appender,
+			__experimentalDefaultBlock: DEFAULT_BLOCK,
 
 			// Ensure block toolbar is not too far removed from item
 			// being edited when in vertical mode.


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/23603 where we'd like to insert additional links in navigation links before and after items.

In trunk, "insert before"/"insert after" is only allowed when a parent block supports insertion of the default block (typically this is a paragraph block).

Proposed changes here add a `__experimentalDefaultBlock` option to block list settings. If this is set, we can choose a different default block in allowedBlocks for that parent container. 

Changes also includes adding defaults for:
* Buttons
* Social Links
* Navigation

If folks like this approach, I can add an e2e test in a follow up. See https://github.com/WordPress/gutenberg/pull/29543

| Before | After |
|------|------|
| <img width="640" alt="Screen Shot 2021-03-03 at 6 35 48 PM" src="https://user-images.githubusercontent.com/1270189/109902718-af492880-7c4f-11eb-9fcf-8f9fd1180fe9.png"> | <img width="749" alt="Screen Shot 2021-03-03 at 6 36 43 PM" src="https://user-images.githubusercontent.com/1270189/109902703-ab1d0b00-7c4f-11eb-9f7c-9fd5e9b13d2f.png"> |


https://user-images.githubusercontent.com/1270189/110156058-58506a00-7d9b-11eb-9e02-070df9d5c7f4.mp4


### Testing Instructions
- Checkout this branch on a local instance of your choice. Leave a comment if folks need more detailed instructions
- Add a navigation block
- Add a navigation item
- Click on the three dots
- Click on insert before
- A new link should be inserted before the selected block
- Click on insert after
- A new link should be inserted after the selected block
- No regressions when using "insert before" or "insert after" in other containers.