### PR TITLE
[Mobile] - Fix splitting/merging of Paragraph and Heading

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -746,10 +746,10 @@ export class RichText extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.value !== this.value ) {
-			this.value = this.props.value;
-			this.lastEventCount = undefined;
-		}
+		// if ( this.props.value !== this.value ) {
+		// 	this.value = this.props.value;
+		// 	this.lastEventCount = undefined;
+		// }
 		const { __unstableIsSelected: isSelected } = this.props;
 
 		const { __unstableIsSelected: prevIsSelected } = prevProps;

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -7,7 +7,7 @@
  * WordPress dependencies
  */
 import RCTAztecView from '@wordpress/react-native-aztec';
-import { View, Platform } from 'react-native';
+import { View, Platform, InteractionManager } from 'react-native';
 import {
 	showUserSuggestions,
 	showXpostSuggestions,
@@ -746,10 +746,6 @@ export class RichText extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		// if ( this.props.value !== this.value ) {
-		// 	this.value = this.props.value;
-		// 	this.lastEventCount = undefined;
-		// }
 		const { __unstableIsSelected: isSelected } = this.props;
 
 		const { __unstableIsSelected: prevIsSelected } = prevProps;
@@ -763,7 +759,9 @@ export class RichText extends Component {
 				this.props.selectionEnd || 0
 			);
 		} else if ( ! isSelected && prevIsSelected ) {
-			this._editor.blur();
+			InteractionManager.runAfterInteractions( () => {
+				this._editor?.blur();
+			} );
 		}
 	}
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -18,7 +18,10 @@ import memize from 'memize';
 /**
  * WordPress dependencies
  */
-import { BlockFormatControls } from '@wordpress/block-editor';
+import {
+	BlockFormatControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -746,6 +749,10 @@ export class RichText extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		if ( this.isIOS && this.props.value !== this.value ) {
+			this.value = this.props.value;
+			this.lastEventCount = undefined;
+		}
 		const { __unstableIsSelected: isSelected } = this.props;
 
 		const { __unstableIsSelected: prevIsSelected } = prevProps;
@@ -996,7 +1003,7 @@ const withFormatTypes = ( WrappedComponent ) => ( props ) => {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockParents, getBlock, getSettings } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 		const parents = getBlockParents( clientId, true );
 		const parentBlock = parents ? getBlock( parents[ 0 ] ) : undefined;

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -559,6 +559,7 @@ export class RichText extends Component {
 
 		// Check if value is up to date with latest state of native AztecView
 		if (
+			this.isIOS &&
 			event.nativeEvent.text &&
 			event.nativeEvent.text !== this.props.value
 		) {
@@ -618,7 +619,9 @@ export class RichText extends Component {
 
 		// update text before updating selection
 		// Make sure there are changes made to the content before upgrading it upward
-		this.onTextUpdate( event );
+		if ( this.isIOS ) {
+			this.onTextUpdate( event );
+		}
 
 		// Aztec can send us selection change events after it has lost focus.
 		// For instance the autocorrect feature will complete a partially written
@@ -749,7 +752,7 @@ export class RichText extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.isIOS && this.props.value !== this.value ) {
+		if ( this.props.value !== this.value ) {
 			this.value = this.props.value;
 			this.lastEventCount = undefined;
 		}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/29478

## Description
After adding [some changes](https://github.com/WordPress/gutenberg/pull/28505) to keep the clientId after splitting, it caused a regression on Android generating content duplication.

After some investigation, I saw `onTextUpdate` was replacing the right content with the previous one after the split of the block on **Android**. I added some `isIOS` checks to prevent this from triggering but keeping it for iOS.

I also updated the [block editor store name](https://github.com/WordPress/gutenberg/pull/29502/files#diff-7af18df9c3e07e67518894550a2e1d9d627feb879a2003a2e231ef927d4d06f8R1006) to use the variable instead of a string (it was showing a warning).

Lastly, I brought some pending code from [this PR](https://github.com/WordPress/gutenberg/pull/28101/files#diff-7af18df9c3e07e67518894550a2e1d9d627feb879a2003a2e231ef927d4d06f8R756-R758) that was closed in favor of https://github.com/WordPress/gutenberg/pull/28505. To avoid the keyboard jumping when using the `return` key **on Android**.

## How has this been tested?
I ran E2E tests (including canary) on both platforms.

**Splitting/Merging test on both platforms**:

**Note**: Test this with both Paragraph and Heading block.

1. Open the mobile editor
2. Write (or paste) a paragraph with a few lines
3. Set the caret by the half of the paragraph
4. Press Enter (Intro) to split the block into two. (if using the simulator, use the device keyboard)
5. Move the caret a few words.
6. Delete all those words until the blocks merge.
7. **Expect**: The two blocks should merge without any content duplication.

**Keyboard jumpiness on Android**:

1. Open the mobile editor
2. Create a few Paragraph blocks with some content
3. Tap on one of them
4. Then switch the selection between the Paragraph blocks
5. **Expect** the keyboard to be visible and not jump between selections

## Screenshots <!-- if applicable -->
Splitting Before | Splitting After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/109849506-bd984400-7c51-11eb-9c01-0b7485a5d5a8.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/109849529-c4bf5200-7c51-11eb-9ce3-f2b263dd7e2c.gif" width="250" /></kbd> 

Keyboard jumpiness Before | Keyboard jumpiness After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/109849698-f3d5c380-7c51-11eb-8ca9-39e7575a4d44.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/109849629-e0c2f380-7c51-11eb-93b3-1eecfc862e8b.gif" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
