### PR TITLE
Try: Fix overzealous aspect ratio scaling for embeds

### DIFF
--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -83,7 +83,9 @@ describe( 'utils', () => {
 		it( 'should return the same falsy value as passed for existing classes when no new classes are added', () => {
 			const html = '<iframe></iframe>';
 			const expected = undefined;
-			expect( getClassNames( html, undefined, false ) ).toEqual( expected );
+			expect( getClassNames( html, undefined, false ) ).toEqual(
+				expected
+			);
 		} );
 
 		it( 'should preserve existing classes and replace aspect ratio related classes with the current embed preview', () => {

--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -56,19 +56,19 @@ describe( 'utils', () => {
 		} );
 	} );
 	describe( 'getClassNames', () => {
-		test( 'getClassNames returns aspect ratio class names for iframes with width and height', () => {
+		it( 'should return aspect ratio class names for iframes with width and height', () => {
 			const html = '<iframe height="9" width="16"></iframe>';
 			const expected = 'wp-embed-aspect-16-9 wp-has-aspect-ratio';
 			expect( getClassNames( html ) ).toEqual( expected );
 		} );
 
-		test( 'getClassNames does not return aspect ratio class names if we do not allow responsive', () => {
+		it( 'should not return aspect ratio class names if we do not allow responsive', () => {
 			const html = '<iframe height="9" width="16"></iframe>';
 			const expected = '';
 			expect( getClassNames( html, '', false ) ).toEqual( expected );
 		} );
 
-		test( 'getClassNames preserves exsiting class names when removing responsive classes', () => {
+		it( 'should preserve exsiting class names when removing responsive classes', () => {
 			const html = '<iframe height="9" width="16"></iframe>';
 			const expected = 'lovely';
 			expect(
@@ -79,6 +79,13 @@ describe( 'utils', () => {
 				)
 			).toEqual( expected );
 		} );
+
+		it( 'should return the same falsy value as passed for existing classes when no new classes are added', () => {
+			const html = '<iframe></iframe>';
+			const expected = undefined;
+			expect( getClassNames( html, undefined, false ) ).toEqual( expected );
+		} );
+
 		it( 'should preserve existing classes and replace aspect ratio related classes with the current embed preview', () => {
 			const html = '<iframe height="3" width="4"></iframe>';
 			const expected =
@@ -93,6 +100,12 @@ describe( 'utils', () => {
 		} );
 	} );
 	describe( 'removeAspectRatioClasses', () => {
+		it( 'should return the same falsy value as received', () => {
+			const existingClassNames = undefined;
+			expect( removeAspectRatioClasses( existingClassNames ) ).toEqual(
+				existingClassNames
+			);
+		} );
 		it( 'should preserve existing classes, if no aspect ratio classes exist', () => {
 			const existingClassNames = 'wp-block-embed is-type-video';
 			expect( removeAspectRatioClasses( existingClassNames ) ).toEqual(

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -198,6 +198,14 @@ export function getClassNames(
 		) {
 			const potentialRatio = ASPECT_RATIOS[ ratioIndex ];
 			if ( aspectRatio >= potentialRatio.ratio ) {
+				// Evaluate the difference between actual aspect ratio and closest match.
+				// If the difference is too big, do not scale the embed according to aspect ratio.
+				const ratioDiff = aspectRatio - potentialRatio.ratio;
+				if ( ratioDiff > 0.1 ) {
+					// No close aspect ratio match found.
+					return removeAspectRatioClasses( existingClassNames );
+				}
+				// Close aspect ratio match found.
 				return classnames(
 					removeAspectRatioClasses( existingClassNames ),
 					potentialRatio.className,

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -156,6 +156,12 @@ export const createUpgradedEmbedBlock = (
  * @return {string} The class names without any aspect ratio related class.
  */
 export const removeAspectRatioClasses = ( existingClassNames ) => {
+	if ( ! existingClassNames ) {
+		// Avoids extraneous work and also, by returning the same value as
+		// received, ensures the post is not dirtied by a change of the block
+		// attribute from `undefined` to an emtpy string.
+		return existingClassNames;
+	}
 	const aspectRatioClassNames = ASPECT_RATIOS.reduce(
 		( accumulator, { className } ) => {
 			accumulator[ className ] = false;
@@ -176,7 +182,7 @@ export const removeAspectRatioClasses = ( existingClassNames ) => {
  */
 export function getClassNames(
 	html,
-	existingClassNames = '',
+	existingClassNames,
 	allowResponsive = true
 ) {
 	if ( ! allowResponsive ) {

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/embedding.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/embedding.test.js.snap
@@ -7,7 +7,7 @@ exports[`Embedding content should allow the user to convert unembeddable URLs to
 `;
 
 exports[`Embedding content should allow the user to try embedding a failed URL again 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/wooyaygutenberg123454312\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"className\\":\\"\\"} -->
+"<!-- wp:embed {\\"url\\":\\"https://twitter.com/wooyaygutenberg123454312\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
 <figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
 https://twitter.com/wooyaygutenberg123454312
 </div></figure>
@@ -15,13 +15,13 @@ https://twitter.com/wooyaygutenberg123454312
 `;
 
 exports[`Embedding content should render embeds in the correct state 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"className\\":\\"\\"} -->
+"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
 <figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->
 
-<!-- wp:embed {\\"url\\":\\"https://twitter.com/wooyaygutenberg123454312\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"embed-handler\\",\\"responsive\\":true,\\"className\\":\\"\\"} -->
+<!-- wp:embed {\\"url\\":\\"https://twitter.com/wooyaygutenberg123454312\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"embed-handler\\",\\"responsive\\":true} -->
 <figure class=\\"wp-block-embed is-type-rich is-provider-embed-handler wp-block-embed-embed-handler\\"><div class=\\"wp-block-embed__wrapper\\">
 https://twitter.com/wooyaygutenberg123454312
 </div></figure>
@@ -39,7 +39,7 @@ https://twitter.com/thatbunty
 </div></figure>
 <!-- /wp:embed -->
 
-<!-- wp:embed {\\"url\\":\\"https://wordpress.org/gutenberg/handbook/block-api/attributes/\\",\\"type\\":\\"wp-embed\\",\\"providerNameSlug\\":\\"wordpress\\",\\"className\\":\\"\\"} -->
+<!-- wp:embed {\\"url\\":\\"https://wordpress.org/gutenberg/handbook/block-api/attributes/\\",\\"type\\":\\"wp-embed\\",\\"providerNameSlug\\":\\"wordpress\\"} -->
 <figure class=\\"wp-block-embed is-type-wp-embed is-provider-wordpress wp-block-embed-wordpress\\"><div class=\\"wp-block-embed__wrapper\\">
 https://wordpress.org/gutenberg/handbook/block-api/attributes/
 </div></figure>
@@ -59,7 +59,7 @@ https://cloudup.com/cQFlxqtY4ob
 `;
 
 exports[`Embedding content should retry embeds that could not be embedded with trailing slashes, without the trailing slashes 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki/\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"embed-handler\\",\\"responsive\\":true,\\"className\\":\\"\\"} -->
+"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki/\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"embed-handler\\",\\"responsive\\":true} -->
 <figure class=\\"wp-block-embed is-type-rich is-provider-embed-handler wp-block-embed-embed-handler\\"><div class=\\"wp-block-embed__wrapper\\">
 https://twitter.com/notnownikki/
 </div></figure>


### PR DESCRIPTION
## Description

Fixes #27720.
Fixes #28347.

Spotify embeds default to 300x380, but the embed is smart enough to resize itself to the context it ends up in.

In the block editor, the aspect ratio of an embed is detected, so that 4:3 or 16:9 videos can be smartly scaled up or down, responsively, according to their intrinsic dimensions:

<img width="278" alt="Screenshot 2021-03-03 at 12 31 33" src="https://user-images.githubusercontent.com/1204802/109799605-8196bc00-7c1c-11eb-8848-8f3d8401a2ba.png">

However this scaling behavior applies even to embeds that aren't really meant to scale according to an aspect ratio, such as Spotify playlists:

<img width="745" alt="Screenshot 2021-03-03 at 12 24 34" src="https://user-images.githubusercontent.com/1204802/109799688-9a9f6d00-7c1c-11eb-9c18-0a7f8e01fcab.png">

What happens currently is this:

- The width/height reported from the embed is calculated to an aspect ratio. 
- This aspect ratio is looped through and assigned a [predefined aspect ratio](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/embed/constants.js) according to its closest match.

This PR changes that, so unless a _very_ close match is found, the embed is not scaled according to any aspect ratio at all:

<img width="774" alt="Screenshot 2021-03-03 at 12 24 09" src="https://user-images.githubusercontent.com/1204802/109799975-efdb7e80-7c1c-11eb-99c8-7afc160bdc58.png">

In the case of the Spotify embed used in this example, its calculated aspect ratio is 0.78, and its closest match is 0.56 which is 9:16 (meant for portrait mode video).

However the feature should still work for actually close matches. Here's a 4:3 video, for example, it should still be detected as 4:3:

<img width="738" alt="Screenshot 2021-03-03 at 12 26 46" src="https://user-images.githubusercontent.com/1204802/109800148-21544a00-7c1d-11eb-8010-c2488ed97a7e.png">

## How has this been tested?

This needs to be tested with a wide range of supported embeds, ideally all of them. Right now I've set the threshold for "close match" to `0.1` (for the spotify example, the actual aspect ratio was 0.78, the closest match was 0.56, and the diff between the two comes to 0.22, i.e. above the threshold). But we need to have a sense of how many embed blocks might be affected by this, because this PR touches not just the Spotify embed, but all embeds.

You can test with this Spotify playlist: `https://open.spotify.com/artist/7BJ4OeS4NgyI4M87ZijwBI`, or this 4.3 aspect ratio YouTube video: `https://www.youtube.com/watch?v=ftxP_KDqvnc`.

Please verify that embeds look correct — i.e. videos have correct aspect ratios, and things like Spotify embeds don't look super tall.

Please test editor and frontend.

## Types of changes

This PR is in a draft mode, and I will need code help landing it:

- Is the threshold good? Is the method for comparing them sound?
- I believe the way this PR handles bad matches (i.e. Spotify) is broken, because the post is marked "dirty" as soon as the embed loads, even if saved and reloaded.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
