### PR TITLE
Extract block variations API into its own handbook page

### DIFF
--- a/docs/architecture/key-concepts.md
+++ b/docs/architecture/key-concepts.md
@@ -32,7 +32,7 @@ Blocks have the ability to be transformed into other block types. This allows ba
 
 ### Variations
 
-Given a block type, a block variation is a predefined set of its initial attributes. This API allows creating a single block from which multiple configurations are possible. Variations provide different possible interfaces, including showing up as entirely new blocks in the library, or as presets when inserting a new block. Read [the API documentation](/docs/designers-developers/developers/block-api/block-registration.md#variations-optional) for more details.
+Given a block type, a block variation is a predefined set of its initial attributes. This API allows creating a single block from which multiple configurations are possible. Variations provide different possible interfaces, including showing up as entirely new blocks in the library, or as presets when inserting a new block. Read [the API documentation](/docs/designers-developers/developers/block-api/block-variations.md) for more details.
 
 **More on Blocks**
 

--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -13,6 +13,7 @@ The following sections will walk you through the existing block APIs:
 -   [Transformations](/docs/designers-developers/developers/block-api/block-transforms.md)
 -   [Templates](/docs/designers-developers/developers/block-api/block-templates.md)
 -   [Metadata](/docs/designers-developers/developers/block-api/block-metadata.md)
+-   [Block Variations](/docs/designers-developers/developers/block-api/block-variations.md)
 -   [Block Patterns](/docs/designers-developers/developers/block-api/block-patterns.md)
 -   [Annotations](/docs/designers-developers/developers/block-api/block-annotations.md)
 -   [Versions](/docs/designers-developers/developers/block-api/versions.md)

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -224,69 +224,9 @@ example: {
 
 -   **Type:** `Object[]`
 
-Similarly to how the block's style variations can be declared, a block type can define block variations that the user can pick from. The difference is that, rather than changing only the visual appearance, this field provides a way to apply initial custom attributes and inner blocks at the time when a block is inserted.
+Similarly to how the block's style variations can be declared, a block type can define block variations that the user can pick from. The difference is that, rather than changing only the visual appearance, this field provides a way to apply initial custom attributes and inner blocks at the time when a block is inserted. See the [Block Variations API](/docs/designers-developers/developers/block-api/block-variations.md) for more details.
 
-By default, all variations will show up in the Inserter in addition to the regular block type item. However, setting the `isDefault` flag for any of the variations listed will override the regular block type in the Inserter.
 
-```js
-variations: [
-    {
-		name: 'wordpress',
-		isDefault: true,
-		title: __( 'WordPress' ),
-		description: __( 'Code is poetry!' ),
-		icon: WordPressIcon,
-		attributes: { service: 'wordpress' },
-	},
-	{
-		name: 'google',
-		title: __( 'Google' ),
-		icon: GoogleIcon,
-		attributes: { service: 'google' },
-	},
-	{
-		name: 'twitter',
-		title: __( 'Twitter' ),
-		icon: TwitterIcon,
-		attributes: { service: 'twitter' },
-		keywords: [ __('tweet') ],
-	},
-],
-```
-
-An object describing a variation defined for the block type can contain the following fields:
-
--   `name` (type `string`) – The unique and machine-readable name.
--   `title` (type `string`) – A human-readable variation title.
--   `description` (optional, type `string`) – A detailed variation description.
--   `category` (optional, type `string`) - A category classification, used in search interfaces to arrange block types by category.
--   `icon` (optional, type `string` | `Object`) – An icon helping to visualize the variation. It can have the same shape as the block type.
--   `isDefault` (optional, type `boolean`) – Indicates whether the current variation is the default one. Defaults to `false`.
--   `attributes` (optional, type `Object`) – Values that override block attributes.
--   `innerBlocks` (optional, type `Array[]`) – Initial configuration of nested blocks.
--   `example` (optional, type `Object`) – Example provides structured data for the block preview. You can set to `undefined` to disable the preview shown for the block type.
--   `scope` (optional, type `WPBlockVariationScope[]`) - the list of scopes where the variation is applicable. When not provided, it defaults to `block` and `inserter`. Available options:
-    -   `inserter` - Block Variation is shown on the inserter.
-    -   `block` - Used by blocks to filter specific block variations. Mostly used in Placeholder patterns like `Columns` block.
-    -   `transform` - Block Variation will be shown in the component for Block Variations transformations.
--   `keywords` (optional, type `string[]`) - An array of terms (which can be translated) that help users discover the variation while searching.
--   `isActive` (optional, type `Function`) - A function that accepts a block's attributes and the variation's attributes and determines if a variation is active. This function doesn't try to find a match dynamically based on all block's attributes, as in many cases some attributes are irrelevant. An example would be for `embed` block where we only care about `providerNameSlug` attribute's value.
-
-It's also possible to override the default block style variation using the `className` attribute when defining block variations.
-
-```js
-variations: [
-	{
-		name: 'blue',
-		title: __( 'Blue Quote' ),
-		isDefault: true,
-		attributes: { color: 'blue', className: 'is-style-blue-quote' },
-		icon: 'format-quote',
-		isActive: ( blockAttributes, variationAttributes ) =>
-			blockAttributes.color === variationAttributes.color
-	},
-],
-```
 
 #### supports (optional)
 

--- a/docs/designers-developers/developers/block-api/block-variations.md
+++ b/docs/designers-developers/developers/block-api/block-variations.md
@@ -2,9 +2,9 @@
 
 Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality. Each block variation is differentiated from the others by setting some initial attributes or inner blocks. Then at the time when a block is inserted these attributes and/or inner blocks are applied.
 
-A great way to understand this API better is by using the `embed` block as an example. The numerous existing variations for embed (WordPress, Youtube etc..) share the same functionality for editing, saving and so on, but their basic difference is the `providerNameSlug` attribute's value, that defines which provider needs to be used.
+A great way to understand this API better is by using the `embed` block as an example. The numerous existing variations for embed (WordPress, Youtube, etc..) share the same functionality for editing, saving, and so on, but their basic difference is the `providerNameSlug` attribute's value, which defines the provider that needs to be used.
 
-By default, all variations will show up in the Inserter in addition to the regular block type item. However, setting the `isDefault` flag for any of the variations listed, will override the regular block type in the Inserter.
+By default, all variations will show up in the Inserter in addition to the regular block type item. However, setting the `isDefault` flag for any of the variations listed will override the regular block type in the Inserter.
 
 ```js
 variations: [
@@ -68,10 +68,10 @@ variations: [
 ],
 ```
 
-It's worth mentioning that setting the `isActive` property can be useful for cases you want to use information from the block variation, after a block's creation. For example this API is used in `useBlockDisplayInformation` hook to fetch and display proper information on places like the BlockCard or Breadcrumbs.
+It's worth mentioning that setting the `isActive` property can be useful for cases you want to use information from the block variation, after a block's creation. For example, this API is used in `useBlockDisplayInformation` hook to fetch and display proper information on places like the BlockCard or Breadcrumbs.
 
 
-Block variations can be declared during a block's registration by providing the `variations` key with a proper array of variations, as defined above. In addition there are ways to register and unregister a `block variation` for a block, after its registration.
+Block variations can be declared during a block's registration by providing the `variations` key with a proper array of variations, as defined above. In addition, there are ways to register and unregister a `block variation` for a block, after its registration.
 
 To add a block variation use `wp.blocks.registerBlockVariation()`.
 

--- a/docs/designers-developers/developers/block-api/block-variations.md
+++ b/docs/designers-developers/developers/block-api/block-variations.md
@@ -1,0 +1,94 @@
+# Block Variations
+
+Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality. Each block variation is differentiated from the others by setting some initial attributes or inner blocks. Then at the time when a block is inserted these attributes and/or inner blocks are applied.
+
+A great way to understand this API better is by using the `embed` block as an example. The numerous existing variations for embed (WordPress, Youtube etc..) share the same functionality for editing, saving and so on, but their basic difference is the `providerNameSlug` attribute's value, that defines which provider needs to be used.
+
+By default, all variations will show up in the Inserter in addition to the regular block type item. However, setting the `isDefault` flag for any of the variations listed, will override the regular block type in the Inserter.
+
+```js
+variations: [
+    {
+		name: 'wordpress',
+		isDefault: true,
+		title: __( 'WordPress' ),
+		description: __( 'Code is poetry!' ),
+		icon: WordPressIcon,
+		attributes: { providerNameSlug: 'wordpress' },
+	},
+	{
+		name: 'google',
+		title: __( 'Google' ),
+		icon: GoogleIcon,
+		attributes: { providerNameSlug: 'google' },
+	},
+	{
+		name: 'twitter',
+		title: __( 'Twitter' ),
+		icon: TwitterIcon,
+		attributes: { providerNameSlug: 'twitter' },
+		keywords: [ __('tweet') ],
+	},
+],
+```
+
+An object describing a variation defined for the block type can contain the following fields:
+
+-   `name` (type `string`) – The unique and machine-readable name.
+-   `title` (type `string`) – A human-readable variation title.
+-   `description` (optional, type `string`) – A detailed variation description.
+-   `category` (optional, type `string`) - A category classification, used in search interfaces to arrange block types by category.
+-   `icon` (optional, type `string` | `Object`) – An icon helping to visualize the variation. It can have the same shape as the block type.
+-   `isDefault` (optional, type `boolean`) – Indicates whether the current variation is the default one. Defaults to `false`.
+-   `attributes` (optional, type `Object`) – Values that override block attributes.
+-   `innerBlocks` (optional, type `Array[]`) – Initial configuration of nested blocks.
+-   `example` (optional, type `Object`) – Example provides structured data for the block preview. You can set to `undefined` to disable the preview shown for the block type.
+-   `scope` (optional, type `WPBlockVariationScope[]`) - the list of scopes where the variation is applicable. When not provided, it defaults to `block` and `inserter`. Available options:
+    -   `inserter` - Block Variation is shown on the inserter.
+    -   `block` - Used by blocks to filter specific block variations. Mostly used in Placeholder patterns like `Columns` block.
+    -   `transform` - Block Variation will be shown in the component for Block Variations transformations.
+-   `keywords` (optional, type `string[]`) - An array of terms (which can be translated) that help users discover the variation while searching.
+-   `isActive` (optional, type `Function`) - A function that accepts a block's attributes and the variation's attributes and determines if a variation is active. This function doesn't try to find a match dynamically based on all block's attributes, as in many cases some attributes are irrelevant. An example would be for `embed` block where we only care about `providerNameSlug` attribute's value.
+
+The main difference between style variations and block variations is that a style variation just applies a `css class` to the block, so it can be styled in an alternative way. If we want to apply initial attributes or inner blocks, we fall in block variation territory. 
+
+It's also possible to override the default block style variation using the `className` attribute when defining block variations.
+
+```js
+variations: [
+	{
+		name: 'blue',
+		title: __( 'Blue Quote' ),
+		isDefault: true,
+		attributes: { color: 'blue', className: 'is-style-blue-quote' },
+		icon: 'format-quote',
+		isActive: ( blockAttributes, variationAttributes ) =>
+			blockAttributes.color === variationAttributes.color
+	},
+],
+```
+
+It's worth mentioning that setting the `isActive` property can be useful for cases you want to use information from the block variation, after a block's creation. For example this API is used in `useBlockDisplayInformation` hook to fetch and display proper information on places like the BlockCard or Breadcrumbs.
+
+
+Block variations can be declared during a block's registration by providing the `variations` key with a proper array of variations, as defined above. In addition there are ways to register and unregister a `block variation` for a block, after its registration.
+
+To add a block variation use `wp.blocks.registerBlockVariation()`.
+
+_Example:_
+
+```js
+wp.blocks.registerBlockVariation( 'core/embed', {
+	name: 'custom',
+	attributes: { providerNameSlug: 'custom' }
+} );
+```
+
+
+To remove a block variation use `wp.blocks.unregisterBlockVariation()`.
+
+_Example:_
+
+```js
+wp.blocks.unregisterBlockVariation( 'core/embed', 'youtube' );
+```

--- a/docs/designers-developers/developers/block-api/block-variations.md
+++ b/docs/designers-developers/developers/block-api/block-variations.md
@@ -68,7 +68,7 @@ variations: [
 ],
 ```
 
-It's worth mentioning that setting the `isActive` property can be useful for cases you want to use information from the block variation, after a block's creation. For example, this API is used in `useBlockDisplayInformation` hook to fetch and display proper information on places like the BlockCard or Breadcrumbs.
+It's worth mentioning that setting the `isActive` property can be useful for cases you want to use information from the block variation, after a block's creation. For example, this API is used in `useBlockDisplayInformation` hook to fetch and display proper information on places like the `BlockCard` or `Breadcrumbs` components.
 
 
 Block variations can be declared during a block's registration by providing the `variations` key with a proper array of variations, as defined above. In addition, there are ways to register and unregister a `block variation` for a block, after its registration.

--- a/docs/designers-developers/faq.md
+++ b/docs/designers-developers/faq.md
@@ -324,7 +324,7 @@ This is currently a work in progress and we recommend reviewing the [block based
 
 ## What are block variations? Are they the same as block styles?
 
-No, block variations are different versions of a single base block, sharing a similar functionality, but with slight differences in their implementation, or settings (attributes, InnerBlocks,etc). Block variations are transparent for users, and once there is a registered block variation, it will appear as a new block. For example, the `embed` block registers different block variations to embed content from specific providers.
+No, [block variations](/docs/designers-developers/developers/block-api/block-variations.md) are different versions of a single base block, sharing a similar functionality, but with slight differences in their implementation, or settings (attributes, InnerBlocks,etc). Block variations are transparent for users, and once there is a registered block variation, it will appear as a new block. For example, the `embed` block registers different block variations to embed content from specific providers.
 
 Meanwhile, [block styles](/docs/designers-developers/developers/filters/block-filters.md#block-style-variations) allow you to provide alternative styles to existing blocks, and they work by adding a className to the block’s wrapper. Once a block has registered block styles, a block style selector will appear in its sidebar so that users can choose among the different registered styles.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -150,6 +150,12 @@
 		"parent": "block-api"
 	},
 	{
+		"title": "Block Variations",
+		"slug": "block-variations",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-variations.md",
+		"parent": "block-api"
+	},
+	{
 		"title": "Block Patterns",
 		"slug": "block-patterns",
 		"markdown_source": "../docs/designers-developers/developers/block-api/block-patterns.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -26,6 +26,7 @@
 			{ "docs/designers-developers/developers/block-api/block-transforms.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-templates.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-metadata.md": [] },
+			{ "docs/designers-developers/developers/block-api/block-variations.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-patterns.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-annotations.md": [] },
 			{ "docs/designers-developers/developers/block-api/versions.md": [] }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/25451

This PR extracts and extends the existing Block Variation API docs into a sub-section of "Block API Reference".

You can see the new page [here](https://github.com/WordPress/gutenberg/blob/docs/extract-block-variations-api/docs/designers-developers/developers/block-api/block-variations.md).
<!-- Please describe what you have changed or added -->

