### PR TITLE
Restore the margins of blocks relying on the figure element

### DIFF
--- a/packages/block-library/src/audio/style.scss
+++ b/packages/block-library/src/audio/style.scss
@@ -1,4 +1,6 @@
 .wp-block-audio {
+	margin: 0;
+
 	// Supply caption styles to audio blocks, even if the theme hasn't opted in.
 	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
 	// so we supply the styles so as to not appear broken or unstyled in those themes.

--- a/packages/block-library/src/audio/style.scss
+++ b/packages/block-library/src/audio/style.scss
@@ -1,5 +1,5 @@
 .wp-block-audio {
-	margin: 0;
+	margin: 0 0 1em 0;
 
 	// Supply caption styles to audio blocks, even if the theme hasn't opted in.
 	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -20,6 +20,8 @@
 }
 
 .wp-block-embed {
+	margin: 0;
+
 	// Supply caption styles to embeds, even if the theme hasn't opted in.
 	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,
 	// so we supply the styles so as to not appear broken or unstyled in those.

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -20,7 +20,7 @@
 }
 
 .wp-block-embed {
-	margin: 0;
+	margin: 0 0 1em 0;
 
 	// Supply caption styles to embeds, even if the theme hasn't opted in.
 	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -28,9 +28,6 @@
 	figcaption {
 		@include caption-style();
 	}
-	// The embed block is in a `figure` element, and many themes zero this out.
-	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
-	margin-bottom: 1em;
 
 	// Don't allow iframe to overflow it's container.
 	iframe {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -1,5 +1,5 @@
 .wp-block-image {
-	margin: 0;
+	margin: 0 0 1em 0;
 
 	img {
 		max-width: 100%;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -1,7 +1,5 @@
 .wp-block-image {
-	// The image block is in a `figure` element, and many themes zero this out.
-	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
-	margin-bottom: 1em;
+	margin: 0;
 
 	img {
 		max-width: 100%;

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -1,5 +1,5 @@
 .wp-block-pullquote {
-	margin: 0;
+	margin: 0 0 1em 0;
 	padding: 3em 0;
 	text-align: center;
 

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -1,7 +1,6 @@
 .wp-block-pullquote {
+	margin: 0;
 	padding: 3em 0;
-	margin-left: 0;
-	margin-right: 0;
 	text-align: center;
 
 	&.alignleft,

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -1,4 +1,5 @@
 .wp-block-table {
+	margin: 0;
 	$subtle-light-gray: #f3f4f5;
 	$subtle-pale-green: #e9fbe5;
 	$subtle-pale-blue: #e7f5fe;

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -1,5 +1,5 @@
 .wp-block-table {
-	margin: 0;
+	margin: 0 0 1em 0;
 	$subtle-light-gray: #f3f4f5;
 	$subtle-pale-green: #e9fbe5;
 	$subtle-pale-blue: #e7f5fe;

--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -1,7 +1,5 @@
 .wp-block-video {
-	// Remove the left and right margin the figure is born with.
-	margin-left: 0;
-	margin-right: 0;
+	margin: 0;
 
 	video {
 		width: 100%;

--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -1,5 +1,5 @@
 .wp-block-video {
-	margin: 0;
+	margin: 0 0 1em 0;
 
 	video {
 		width: 100%;


### PR DESCRIPTION
Our goal for the block editor should be that the frontend matches the backend by default. Meaning that if a theme has no stylesheet, all blocks should look similar in the frontend and the backend. We tend to break this rule in some small details here and there. 

I noticed that the blocks  in the editor assume that the "figure" doesn't have margins but by default in the DOM, all figure elements have margins, this PR restores the margins for the blocks relying on that element so that themes don't have to make these adjustments themselves.

**Testing instructions**

Check the image, embed, video, audio, pullquote and table block margins in several themes and ensure there's no visual regression.