### PR TITLE
RangeControl: Fix RTL rendering based on document.dir

### DIFF
--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -7,7 +7,7 @@ import { clamp, isFinite, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useRef, useState, forwardRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 
@@ -18,6 +18,7 @@ import BaseControl from '../base-control';
 import Button from '../button';
 import Icon from '../icon';
 import { color } from '../utils/colors';
+import { isDocumentRTL as isRTL } from '../utils/rtl';
 import { floatClamp, useControlledRangeValue } from './utils';
 import InputRange from './input-range';
 import RangeRail from './rail';

--- a/packages/components/src/range-control/rail.js
+++ b/packages/components/src/range-control/rail.js
@@ -1,13 +1,9 @@
 /**
- * WordPress dependencies
- */
-import { isRTL } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import RangeMark from './mark';
 import { MarksWrapper, Rail } from './styles/range-control-styles';
+import { isDocumentRTL as isRTL } from '../utils/rtl';
 
 export default function RangeRail( {
 	disabled = false,

--- a/packages/components/src/utils/rtl.js
+++ b/packages/components/src/utils/rtl.js
@@ -4,15 +4,22 @@
 import { css } from '@emotion/core';
 import { mapKeys } from 'lodash';
 
-/**
- * WordPress dependencies
- */
-import { isRTL } from '@wordpress/i18n';
-
 const LOWER_LEFT_REGEXP = new RegExp( /-left/g );
 const LOWER_RIGHT_REGEXP = new RegExp( /-right/g );
 const UPPER_LEFT_REGEXP = new RegExp( /Left/g );
 const UPPER_RIGHT_REGEXP = new RegExp( /Right/g );
+
+/**
+ * Checks the LTR/RTL direction for the window.document.
+ *
+ * @return {boolean} Whether the document is RTL.
+ */
+export function isDocumentRTL() {
+	if ( typeof window !== 'undefined' ) {
+		return !! ( window?.document?.dir === 'rtl' );
+	}
+	return false;
+}
 
 /**
  * Flips a CSS property from left <-> right.
@@ -70,12 +77,14 @@ export const convertLTRToRTL = ( ltrStyles = {} ) => {
  */
 export function rtl( ltrStyles = {}, rtlStyles ) {
 	return () => {
+		const isRTL = isDocumentRTL();
+
 		if ( rtlStyles ) {
 			// @ts-ignore: `css` types are wrong, it can accept an object: https://emotion.sh/docs/object-styles#with-css
-			return isRTL() ? css( rtlStyles ) : css( ltrStyles );
+			return isRTL ? css( rtlStyles ) : css( ltrStyles );
 		}
 
 		// @ts-ignore: `css` types are wrong, it can accept an object: https://emotion.sh/docs/object-styles#with-css
-		return isRTL() ? css( convertLTRToRTL( ltrStyles ) ) : css( ltrStyles );
+		return isRTL ? css( convertLTRToRTL( ltrStyles ) ) : css( ltrStyles );
 	};
 }

--- a/packages/components/src/utils/test/rtl.js
+++ b/packages/components/src/utils/test/rtl.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { convertLTRToRTL } from '../rtl';
+import { isDocumentRTL, convertLTRToRTL } from '../rtl';
 
 describe( 'convertLTRToRTL', () => {
 	it( 'converts (*)Left <-> (*)Right', () => {
@@ -120,5 +120,31 @@ describe( 'convertLTRToRTL', () => {
 
 		// Edge cases
 		expect( nextStyle[ 'text-combine-upright' ] ).toBe( 'none' );
+	} );
+} );
+
+describe( 'isDocumentRTL', () => {
+	afterEach( () => {
+		document.dir = '';
+	} );
+
+	test( 'should return false when document has no dir setting', () => {
+		expect( isDocumentRTL() ).toBe( false );
+	} );
+
+	test( 'should return false when document is ltr', () => {
+		document.dir = 'ltr';
+		expect( isDocumentRTL() ).toBe( false );
+
+		document.documentElement.setAttribute( 'dir', 'ltr' );
+		expect( isDocumentRTL() ).toBe( false );
+	} );
+
+	test( 'should return true when document is rtl', () => {
+		document.dir = 'rtl';
+		expect( isDocumentRTL() ).toBe( true );
+
+		document.documentElement.setAttribute( 'dir', 'rtl' );
+		expect( isDocumentRTL() ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
This update fixes RTL rendering for the `RangeControl` component.

Previously, `RangeControl` and the CSS-in-JS RTL rendering util was relying on the RTL function from [`@wordpress/i18n`](https://github.com/WordPress/gutenberg/blob/trunk/packages/i18n/src/create-i18n.js#L89). This function checks for language settings only, rather than the `direction` attribute set on the `document`.

This caused some issues when testing with [RTL Tester](https://github.com/WordPress/gutenberg/issues/29519#issuecomment-789791271).

The solution was to create an alternative `document.dir` based RTL detector, and to use that for `RangeControl` (for now).

Resolves https://github.com/WordPress/gutenberg/issues/29519#issuecomment-789791271

---

## RTL Detection Strategy?

I'm uncertain how we want to approach RTL detection in the JS-based code moving forward.
We're still using `isRTL` from `@wordpress/i18n` in several places, so this would still be a problem. However, it may not be as noticeable.

I think using `isRTL` from `@wordpress/i18n` makes sense as it's a more realistic way to determine RTL based on language setting. However, detecting the setting from the `document.dir` directly may be more full proof.

## How has this been tested?

Tested locally in Gutenberg

Test conditions:
1. Change language to Arabic for language based RTL rendering
2. Set language to English. Install the [RTL Tester plugin](https://en-ca.wordpress.org/plugins/rtl-tester/) and activate it.

Add a Columns block into Gutenberg.
Ensure the slider direction works correctly.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
