### PR TITLE
Cover/Columns/Media & Text/Group: Remove margins on inner blocks

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -712,3 +712,22 @@
 		}
 	}
 }
+
+@mixin innerblock-margin-clear($container) {
+
+	// Clear the top margin for the first-child.
+	> #{$container} > *:first-child {
+		margin-top: 0;
+	}
+
+	// Last child that is not the appender.
+	> #{$container} > *:last-child:not(.block-list-appender) {
+		margin-bottom: 0;
+	}
+
+	// When selected, the last item becomes the second last because of the appender.
+	&.has-child-selected > #{$container} > *:nth-last-child(2),
+	&.is-selected > #{$container} > *:nth-last-child(2) {
+		margin-bottom: 0;
+	}
+}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -27,6 +27,8 @@
 	&.are-vertically-aligned-bottom {
 		align-items: flex-end;
 	}
+
+	@include innerblock-margin-clear(".wp-block-column");
 }
 
 .wp-block-column {

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -186,6 +186,8 @@
 		border: none;
 		box-shadow: none;
 	}
+
+	@include innerblock-margin-clear(".wp-block-cover__inner-container");
 }
 
 .wp-block-cover__video-background {

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,4 +1,6 @@
 .wp-block-group {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+
+	@include innerblock-margin-clear(".wp-block-group__inner-container");
 }

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -10,6 +10,8 @@
 	&.has-media-on-the-right {
 		grid-template-columns: 1fr 50%;
 	}
+
+	@include innerblock-margin-clear(".wp-block-media-text__content");
 }
 
 .wp-block-media-text.is-vertically-aligned-top {


### PR DESCRIPTION
## Description
Inner blocks inside Cover, Columns, Group and Media & Text blocks should be collapsed on the first and last child in the inner blocks wrapper.

We have this code in Twenty Twenty-One blocks, and many other themes. Without it there are a lot of extra margins inside these blocks.

## How has this been tested?
- In TT1 Blocks

## Screenshots <!-- if applicable -->
<img width="1155" alt="Screenshot 2021-03-03 at 17 17 30" src="https://user-images.githubusercontent.com/275961/109846044-ae12fe00-7c45-11eb-9f38-0760f28a1e80.png">
<img width="643" alt="Screenshot 2021-03-03 at 17 13 57" src="https://user-images.githubusercontent.com/275961/109846053-b0755800-7c45-11eb-8b82-894f6aae0a79.png">
<img width="673" alt="Screenshot 2021-03-03 at 17 05 18" src="https://user-images.githubusercontent.com/275961/109846055-b10dee80-7c45-11eb-8ad6-1cf6c34c3f78.png">
<img width="673" alt="Screenshot 2021-03-03 at 16 56 40" src="https://user-images.githubusercontent.com/275961/109846057-b10dee80-7c45-11eb-9868-cafdf656468f.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
