### PR TITLE
Fix cover block content position not migrating correctly from deprecated version

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fix a regression where the Cover block migration would not work with a non-default contentPosition ([#29542](https://github.com/WordPress/gutenberg/pull/29542))
+
 ## 2.28.0 (2021-02-01)
 
 ### New Features

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -88,6 +88,9 @@ const deprecated = [
 			customGradient: {
 				type: 'string',
 			},
+			contentPosition: {
+				type: 'string',
+			},
 		},
 		supports: {
 			align: true,

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.html
@@ -24,3 +24,12 @@
 	</div>
 </div>
 <!-- /wp:cover -->
+<!-- wp:cover {"url":"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg","id":134,"contentPosition":"bottom right"} -->
+<div class="wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right"><img class="wp-block-cover__image-background wp-image-134" alt="" src="http://localhost:8888/wp-content/uploads/2021/02/percy.jpg" data-object-fit="cover"/>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p class="has-text-align-center has-large-font-size">test</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
@@ -65,5 +65,36 @@
             }
         ],
         "originalContent": "<div\n\tclass=\"wp-block-cover alignfull\"\n\tstyle=\"background-image: url( https://example.com/some-background-image.png ); min-height: 48vw; background-position: 50% 40%;\"\n>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
+    },
+    {
+        "clientId": "_clientId_2",
+        "name": "core/cover",
+        "isValid": true,
+        "attributes": {
+            "url": "http://localhost:8888/wp-content/uploads/2021/02/percy.jpg",
+            "id": 134,
+            "hasParallax": false,
+            "isRepeated": false,
+            "dimRatio": 50,
+            "backgroundType": "image",
+            "contentPosition": "bottom right"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "align": "center",
+                    "content": "test",
+                    "dropCap": false,
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p class=\"has-text-align-center has-large-font-size\">test</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right\"><img class=\"wp-block-cover__image-background wp-image-134\" alt=\"\" src=\"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg\" data-object-fit=\"cover\"/>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.parsed.json
@@ -76,5 +76,43 @@
         "innerContent": [
             "\n"
         ]
+    },
+    {
+        "blockName": "core/cover",
+        "attrs": {
+            "url": "http://localhost:8888/wp-content/uploads/2021/02/percy.jpg",
+            "id": 134,
+            "contentPosition": "bottom right"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "center",
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-text-align-center has-large-font-size\">test</p>\n\t\t",
+                "innerContent": [
+                    "\n\t\t<p class=\"has-text-align-center has-large-font-size\">test</p>\n\t\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right\"><img class=\"wp-block-cover__image-background wp-image-134\" alt=\"\" src=\"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg\" data-object-fit=\"cover\"/>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right\"><img class=\"wp-block-cover__image-background wp-image-134\" alt=\"\" src=\"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg\" data-object-fit=\"cover\"/>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
+            null,
+            "\n\t</div>\n</div>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
@@ -11,3 +11,9 @@
 <p></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->
+
+<!-- wp:cover {"url":"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg","id":134,"contentPosition":"bottom right"} -->
+<div class="wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right"><img class="wp-block-cover__image-background wp-image-134" alt="" src="http://localhost:8888/wp-content/uploads/2021/02/percy.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size">test</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28656

This turned out to be the same issue as #28796, that the `contentPosition` attribute was missing from the deprecation.

This is one of the reasons I don't like the approach used in this codebase where a list of attributes is spread across multiple deprecations—it really easily leads to this sort of problem. Developers seem to start adding a new deprecation by copying the previous one, which is the wrong thing to do.

Instead I think it'd be better to encourage devs to copy the block settings directly from the block.json to make sure nothing is missed. Another idea could be to version the block.json and import that into a deprecation.

## How has this been tested?
Added a new fixture to test for this.

Manual testing:
1. Copy the following markup generated by the old version of the block:
```html
<!-- wp:cover {"url":"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg","id":134,"contentPosition":"bottom right"} -->
<div class="wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right" style="background-image:url(http://localhost:8888/wp-content/uploads/2021/02/percy.jpg)"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">test</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
```
2. Switch back to visual editing
3. Check the toolbar for the cover block, the content position should be set to bottom right:
<img width="166" alt="Screenshot 2021-03-04 at 10 24 20 am" src="https://user-images.githubusercontent.com/677833/109901323-d2b5b700-7cd3-11eb-93b4-a1ec58f2cf83.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
