### PR TITLE
[RNMobile] Audio block snapshot  test - fixed the "not wrapped in act(...)" warning

### DIFF
--- a/packages/block-library/src/audio/test/edit.native.js
+++ b/packages/block-library/src/audio/test/edit.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
+import { act, create } from 'react-test-renderer';
 
 /**
  * WordPress dependencies
@@ -14,7 +14,7 @@ import { MediaUploadProgress } from '@wordpress/block-editor';
 import AudioEdit from '../edit.native.js';
 
 const getTestComponentWithContent = ( attributes = {} ) => {
-	return renderer.create(
+	return create(
 		<AudioEdit attributes={ attributes } setAttributes={ jest.fn() } />
 	);
 };
@@ -43,7 +43,12 @@ describe( 'Audio block', () => {
 		} );
 
 		const mediaUpload = component.root.findByType( MediaUploadProgress );
-		mediaUpload.instance.finishMediaUploadWithFailure( { mediaId: -1 } );
+
+		act( () => {
+			mediaUpload.instance.finishMediaUploadWithFailure( {
+				mediaId: -1,
+			} );
+		} );
 
 		const rendered = component.toJSON();
 		expect( rendered ).toMatchSnapshot();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

`gutenberg mobile` PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/3213

## Description

The warning originates in the `NoticeList` [HOC](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/higher-order/with-notices/index.js#L38)
due to the `mediaUpload.instance.finishMediaUploadWithFailure` call within the `renders audio block error state without crashing` test. 

The solution to resolve this as discussed [here](https://github.com/WordPress/gutenberg/pull/29371#pullrequestreview-599649685) is to utilize `act()` to ensure that all the relevant component updates are processed and applied before making subsequent assertions. 

## How has this been tested?

1. Run `npm run native test` and notice that the warning below has disappeared.

<details>
<summary>Audio async test warnings</summary>
<img width="1047" alt="audio-async-test-warnings" src="https://user-images.githubusercontent.com/438664/109315081-c0d59f00-780f-11eb-8390-a3ce60d6dba9.png">
</details>

## Types of changes

1. The `act()` export of the `react-test-renderer` was utilized since the tests are snapshot related. 
2. The `renderer` export was removed and the `create` function was imported directly. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
