### PR TITLE
Try: Remove important on disabled switcher state.

### DIFF
--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -54,7 +54,7 @@
 	// Since it's not clickable, though, don't show a hover state.
 	&,
 	.block-editor-block-icon.has-colors {
-		color: $gray-900 !important;
+		color: $gray-900;
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #29130 by removing an !important selector.

## How has this been tested?

Paste this in your functions.php

```
/**
 * Custom post type and template
 */

// Create a custom post type.
function myplugin_custom_post_type() {
	register_post_type( 'podcast',
		array(
			'labels' => array(
				'name' => __( 'Podcasts' ),
				'singular_name' => __( 'Podcast' )
			),
			'public' => true,
			'has_archive' => true,
			'rewrite' => array('slug' => 'podcast'),
			'show_in_rest' => true,
			'supports' => [
				'title', 'editor', 'custom-fields', // Custom fields must be supported for meta handling to function.
			],
		)
	);
}
add_action( 'init', 'myplugin_custom_post_type' );

// Assign a post template to our custom post type
function myplugin_register_template() {
	$post_type_object = get_post_type_object( 'podcast' );
	$post_type_object->template = array(
		array( 'core/heading', array( 'level' => 3, 'content' => 'Description', ) ),
		array( 'core/paragraph', array( 'placeholder' => 'Add description', ) ),
		array( 'core/heading', array( 'level' => 3, 'content' => 'Heading', ) ),
		array( 'core/paragraph', array( 'placeholder' => 'Add show notes', ) ),
	);

	// Lock the template from being rearranged or items deleted.
	$post_type_object->template_lock = 'all'; // Can be "all" or "insert", the latter allows moving blocks around.
}
add_action( 'init', 'myplugin_register_template' );
```

Now you have a new CPT, "Podcasts", create a new such and note how the blocks are locked. By being locked, they can't be transformed, meaning the rule to ensure no hover style on the block switcher icon takes effect:

<img width="509" alt="Screenshot 2021-03-04 at 09 26 43" src="https://user-images.githubusercontent.com/1204802/109933486-c0d01600-7ccb-11eb-9dbb-70cccd9c18b1.png">

This icon should stay black even when hovering.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
