### PR TITLE
Navigation block: Allow very thin menus.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -14,11 +14,6 @@
 	padding: $grid-unit-20;
 }
 
-// Ensure that an empty block has space around the appender.
-.wp-block-navigation__container {
-	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
-}
-
 // Ensure sub-menus stay open and visible when a nested block is selected.
 .wp-block-navigation__container.is-parent-of-selected-block {
 	visibility: visible;
@@ -153,15 +148,6 @@ $color-control-label-height: 20px;
 }
 
 .wp-block-navigation-placeholder {
-	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
-
-	.components-spinner {
-		margin-top: -4px;
-		margin-left: 4px;
-		vertical-align: middle;
-		margin-right: 7px;
-	}
-
 	.components-custom-select-control__button {
 		height: auto;
 		padding: 0.375rem 0.75rem 0.375rem 1.5rem;
@@ -211,6 +197,20 @@ $color-control-label-height: 20px;
 /**
  * Setup state
  */
+
+// Ensure that an empty block has space around the appender.
+.wp-block-navigation-placeholder,
+.is-selected .wp-block-navigation__container {
+	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
+}
+
+// Spinner.
+.wp-block-navigation-placeholder .components-spinner {
+	margin-top: -4px;
+	margin-left: 4px;
+	vertical-align: middle;
+	margin-right: 7px;
+}
 
 // Unselected state.
 .wp-block-navigation-placeholder__preview {

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -24,6 +24,6 @@
 	background-color: inherit;
 
 	.components-spinner {
-		margin-top: 0;
+		margin: 0.5em;
 	}
 }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -51,6 +51,11 @@
 		fill: currentColor;
 		margin-right: 1ch;
 	}
+
+	// Don't take up space if the label is empty.
+	&:empty {
+		display: none;
+	}
 }
 
 .components-placeholder__fieldset,


### PR DESCRIPTION
## Description

There exists a `min-height: 44px;` rule for the navigation block. This is meant for the placeholder, but also applies for the menu itself.

This PR moves it to only apply to the placeholder, or when selected (so there's space for the appender), and it aligns a spinner icon better.

## How has this been tested?

Insert a navigation menu, observe the spinner looks good when you press "Add all pages". Here's before:

<img width="246" alt="Screenshot 2021-03-04 at 11 21 50" src="https://user-images.githubusercontent.com/1204802/109950835-4ad4aa80-7cdd-11eb-9118-bc47b57e91eb.png">

If you can find a theme with a very thin menu, it will be allowed to be less than 44px tall. Otherwise just inspect the navigation block and note there isn't a min-height.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
