### PR TITLE
Make the lists more wysiwyg

### DIFF
--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -5,3 +5,11 @@ ol.has-background.has-background,
 ul.has-background.has-background {
 	padding: $block-bg-padding--v $block-bg-padding--h;
 }
+
+ul,
+ol {
+	li {
+		// This overrides a bottom margin globally applied to list items in wp-admin.
+		margin-bottom: initial;
+	}
+}

--- a/packages/block-library/src/list/style.scss
+++ b/packages/block-library/src/list/style.scss
@@ -2,3 +2,22 @@ ol.has-background,
 ul.has-background {
 	padding: $block-bg-padding--v $block-bg-padding--h;
 }
+
+ul,
+ol {
+	margin: 0;
+	padding-left: 1.3em;
+}
+
+ul {
+	list-style-type: disc;
+}
+
+ol {
+	list-style-type: decimal;
+}
+
+ul ul,
+ol ul {
+	list-style-type: circle;
+}

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -7,7 +7,9 @@
 
 	ul {
 		display: flex;
+		list-style: none;
 	}
+
 	li {
 		margin: 0;
 	}

--- a/packages/edit-site/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-site/src/components/sidebar/settings-header/style.scss
@@ -7,6 +7,7 @@
 
 	ul {
 		display: flex;
+		list-style: none;
 	}
 	li {
 		margin: 0;

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -22,7 +22,6 @@ body {
 	margin-right: -10px;
 }
 
-
 /* Headings */
 // Adjust line spacing for larger headings.
 h1,
@@ -84,37 +83,6 @@ p {
 	line-height: inherit;
 	margin-top: $default-block-margin;
 	margin-bottom: $default-block-margin;
-}
-
-ul,
-ol {
-	margin-bottom: $default-block-margin;
-	padding-left: 1.3em;
-	margin-left: 1.3em;
-
-	// Remove bottom margin from nested lists.
-	ul,
-	ol {
-		margin-bottom: 0;
-	}
-
-	li {
-		// This overrides a bottom margin globally applied to list items in wp-admin.
-		margin-bottom: initial;
-	}
-}
-
-ul {
-	list-style-type: disc;
-}
-
-ol {
-	list-style-type: decimal;
-}
-
-ul ul,
-ol ul {
-	list-style-type: circle;
 }
 
 .wp-align-wrapper {

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -112,3 +112,9 @@ kbd {
 	font-size: inherit;
 	font-family: monospace;
 }
+
+// This is just here to override a wp-admin default style
+// it shouldn't be necessary after iframing the editor.
+ul {
+	list-style-type: disc;
+}


### PR DESCRIPTION
Similar to #29517 

When using lists in a theme without any stylesheet, the result in the frontend is different than the result in the backend, the problem is that in the backend there are default styles for lists. In order to solve this, we have two options:

 - Remove the lists editor styles (make the editor map the frontend)
 - Normalize the lists (make the frontend look like the editor)

I thought that the editor styles applied were better defaults for lists than what comes with the browser so I went with the second option. That said, it's the most impactful option, but I think most themes already override these styles in their stylesheets so it might not be that impactful.

What do you think?

**Testing instructions**

 - Test lists, nested and numbered lists in various themes, both frontend and backend.