### PR TITLE
Custom Link Color: Do not apply to buttons

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -12,7 +12,7 @@
 	// Gradients
 	@include gradient-colors();
 
-	.has-link-color a {
+	.has-link-color a:not(.wp-block-button__link) {
 		color: var(--wp--style--color--link, #00e);
 	}
 }


### PR DESCRIPTION
## Description
When a custom link color is set it will apply to buttons:

<img width="674" alt="Screenshot 2021-03-04 at 10 46 56" src="https://user-images.githubusercontent.com/275961/109952652-fb8b7b80-7cd6-11eb-97cf-57617039d365.png">

With this change it will look like this:
<img width="648" alt="Screenshot 2021-03-04 at 10 50 04" src="https://user-images.githubusercontent.com/275961/109952986-62a93000-7cd7-11eb-85b4-be1eadf8d98d.png">


## How has this been tested?
- Switch to the Seedlet theme
- Apply this patch: https://github.com/Automattic/themes/pull/3325
- Apply a background color and link color to a group block.
- Notice that your buttons are impacted by the link color

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
