### PR TITLE
Drop zone: fix media lib duplicate issue

### DIFF
--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -6,14 +6,10 @@ import { find, some, filter, includes, throttle } from 'lodash';
 /**
  * WordPress dependencies
  */
-import {
-	createContext,
-	useEffect,
-	useRef,
-	useContext,
-} from '@wordpress/element';
+import { createContext, useRef, useContext } from '@wordpress/element';
 import { getFilesFromDataTransfer } from '@wordpress/dom';
 import isShallowEqual from '@wordpress/is-shallow-equal';
+import { useRefEffect } from '@wordpress/compose';
 
 export const Context = createContext();
 
@@ -109,135 +105,138 @@ export const INITIAL_DROP_ZONE_STATE = {
 	type: null,
 };
 
-export function useDrop( ref ) {
+export function useDrop() {
 	const dropZones = useContext( Context );
 
-	useEffect( () => {
-		const { ownerDocument } = ref.current;
-		const { defaultView } = ownerDocument;
+	return useRefEffect(
+		( node ) => {
+			const { ownerDocument } = node;
+			const { defaultView } = ownerDocument;
 
-		let lastRelative;
+			let lastRelative;
 
-		function updateDragZones( event ) {
-			if ( lastRelative && lastRelative.contains( event.target ) ) {
-				return;
-			}
-
-			const dragEventType = getDragEventType( event );
-			const position = getPosition( event );
-			const hoveredDropZone = getHoveredDropZone(
-				dropZones,
-				position,
-				dragEventType
-			);
-
-			if ( hoveredDropZone && hoveredDropZone.isRelative ) {
-				lastRelative = hoveredDropZone.element.current.offsetParent;
-			} else {
-				lastRelative = null;
-			}
-
-			// Notifying the dropzones
-			dropZones.forEach( ( dropZone ) => {
-				const isDraggingOverDropZone = dropZone === hoveredDropZone;
-				const newState = {
-					isDraggingOverDocument: isTypeSupportedByDropZone(
-						dragEventType,
-						dropZone
-					),
-					isDraggingOverElement: isDraggingOverDropZone,
-					x:
-						isDraggingOverDropZone && dropZone.withPosition
-							? position.x
-							: null,
-					y:
-						isDraggingOverDropZone && dropZone.withPosition
-							? position.y
-							: null,
-					type: isDraggingOverDropZone ? dragEventType : null,
-				};
-
-				dropZone.setState( ( state ) => {
-					if ( isShallowEqual( state, newState ) ) {
-						return state;
-					}
-
-					return newState;
-				} );
-			} );
-
-			event.preventDefault();
-		}
-
-		const throttledUpdateDragZones = throttle( updateDragZones, 200 );
-
-		function onDragOver( event ) {
-			throttledUpdateDragZones( event );
-			event.preventDefault();
-		}
-
-		function resetDragState() {
-			// Avoid throttled drag over handler calls
-			throttledUpdateDragZones.cancel();
-
-			dropZones.forEach( ( dropZone ) =>
-				dropZone.setState( INITIAL_DROP_ZONE_STATE )
-			);
-		}
-
-		function onDrop( event ) {
-			// This seemingly useless line has been shown to resolve a Safari issue
-			// where files dragged directly from the dock are not recognized
-			event.dataTransfer && event.dataTransfer.files.length; // eslint-disable-line no-unused-expressions
-
-			const dragEventType = getDragEventType( event );
-			const position = getPosition( event );
-			const hoveredDropZone = getHoveredDropZone(
-				dropZones,
-				position,
-				dragEventType
-			);
-
-			resetDragState();
-
-			if ( hoveredDropZone ) {
-				switch ( dragEventType ) {
-					case 'file':
-						hoveredDropZone.onFilesDrop(
-							getFilesFromDataTransfer( event.dataTransfer ),
-							position
-						);
-						break;
-					case 'html':
-						hoveredDropZone.onHTMLDrop(
-							event.dataTransfer.getData( 'text/html' ),
-							position
-						);
-						break;
-					case 'default':
-						hoveredDropZone.onDrop( event, position );
+			function updateDragZones( event ) {
+				if ( lastRelative && lastRelative.contains( event.target ) ) {
+					return;
 				}
+
+				const dragEventType = getDragEventType( event );
+				const position = getPosition( event );
+				const hoveredDropZone = getHoveredDropZone(
+					dropZones,
+					position,
+					dragEventType
+				);
+
+				if ( hoveredDropZone && hoveredDropZone.isRelative ) {
+					lastRelative = hoveredDropZone.element.current.offsetParent;
+				} else {
+					lastRelative = null;
+				}
+
+				// Notifying the dropzones
+				dropZones.forEach( ( dropZone ) => {
+					const isDraggingOverDropZone = dropZone === hoveredDropZone;
+					const newState = {
+						isDraggingOverDocument: isTypeSupportedByDropZone(
+							dragEventType,
+							dropZone
+						),
+						isDraggingOverElement: isDraggingOverDropZone,
+						x:
+							isDraggingOverDropZone && dropZone.withPosition
+								? position.x
+								: null,
+						y:
+							isDraggingOverDropZone && dropZone.withPosition
+								? position.y
+								: null,
+						type: isDraggingOverDropZone ? dragEventType : null,
+					};
+
+					dropZone.setState( ( state ) => {
+						if ( isShallowEqual( state, newState ) ) {
+							return state;
+						}
+
+						return newState;
+					} );
+				} );
+
+				event.preventDefault();
 			}
 
-			event.stopPropagation();
-			event.preventDefault();
-		}
+			const throttledUpdateDragZones = throttle( updateDragZones, 200 );
 
-		ref.current.addEventListener( 'drop', onDrop );
-		defaultView.addEventListener( 'dragover', onDragOver );
-		defaultView.addEventListener( 'mouseup', resetDragState );
-		// Note that `dragend` doesn't fire consistently for file and HTML drag
-		// events where the drag origin is outside the browser window.
-		// In Firefox it may also not fire if the originating node is removed.
-		defaultView.addEventListener( 'dragend', resetDragState );
+			function onDragOver( event ) {
+				throttledUpdateDragZones( event );
+				event.preventDefault();
+			}
 
-		return () => {
-			ref.current.removeEventListener( 'drop', onDrop );
-			defaultView.removeEventListener( 'dragover', onDragOver );
-			defaultView.removeEventListener( 'mouseup', resetDragState );
-			defaultView.removeEventListener( 'dragend', resetDragState );
-		};
-	}, [ ref, dropZones ] );
+			function resetDragState() {
+				// Avoid throttled drag over handler calls
+				throttledUpdateDragZones.cancel();
+
+				dropZones.forEach( ( dropZone ) =>
+					dropZone.setState( INITIAL_DROP_ZONE_STATE )
+				);
+			}
+
+			function onDrop( event ) {
+				// This seemingly useless line has been shown to resolve a Safari issue
+				// where files dragged directly from the dock are not recognized
+				event.dataTransfer && event.dataTransfer.files.length; // eslint-disable-line no-unused-expressions
+
+				const dragEventType = getDragEventType( event );
+				const position = getPosition( event );
+				const hoveredDropZone = getHoveredDropZone(
+					dropZones,
+					position,
+					dragEventType
+				);
+
+				resetDragState();
+
+				if ( hoveredDropZone ) {
+					switch ( dragEventType ) {
+						case 'file':
+							hoveredDropZone.onFilesDrop(
+								getFilesFromDataTransfer( event.dataTransfer ),
+								position
+							);
+							break;
+						case 'html':
+							hoveredDropZone.onHTMLDrop(
+								event.dataTransfer.getData( 'text/html' ),
+								position
+							);
+							break;
+						case 'default':
+							hoveredDropZone.onDrop( event, position );
+					}
+				}
+
+				event.stopPropagation();
+				event.preventDefault();
+			}
+
+			node.addEventListener( 'drop', onDrop );
+			defaultView.addEventListener( 'dragover', onDragOver );
+			defaultView.addEventListener( 'mouseup', resetDragState );
+			// Note that `dragend` doesn't fire consistently for file and HTML drag
+			// events where the drag origin is outside the browser window.
+			// In Firefox it may also not fire if the originating node is removed.
+			defaultView.addEventListener( 'dragend', resetDragState );
+
+			return () => {
+				node.removeEventListener( 'drop', onDrop );
+				defaultView.removeEventListener( 'dragover', onDragOver );
+				defaultView.removeEventListener( 'mouseup', resetDragState );
+				defaultView.removeEventListener( 'dragend', resetDragState );
+			};
+		},
+		[ dropZones ]
+	);
 }
 
 export function DropZoneContextProvider( props ) {
@@ -246,8 +245,7 @@ export function DropZoneContextProvider( props ) {
 }
 
 function DropContainer( { children } ) {
-	const ref = useRef();
-	useDrop( ref );
+	const ref = useDrop();
 	return (
 		<div ref={ ref } className="components-drop-zone__provider">
 			{ children }

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -223,7 +223,7 @@ export function useDrop( ref ) {
 			event.preventDefault();
 		}
 
-		defaultView.addEventListener( 'drop', onDrop );
+		ref.current.addEventListener( 'drop', onDrop );
 		defaultView.addEventListener( 'dragover', onDragOver );
 		defaultView.addEventListener( 'mouseup', resetDragState );
 		// Note that `dragend` doesn't fire consistently for file and HTML drag
@@ -232,7 +232,7 @@ export function useDrop( ref ) {
 		defaultView.addEventListener( 'dragend', resetDragState );
 
 		return () => {
-			defaultView.removeEventListener( 'drop', onDrop );
+			ref.current.removeEventListener( 'drop', onDrop );
 			defaultView.removeEventListener( 'dragover', onDragOver );
 			defaultView.removeEventListener( 'mouseup', resetDragState );
 			defaultView.removeEventListener( 'dragend', resetDragState );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -36,7 +36,7 @@ import {
 	InterfaceSkeleton,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { close } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
@@ -172,9 +172,7 @@ function Layout( { styles } ) {
 		},
 		[ entitiesSavedStatesCallback ]
 	);
-	const ref = useRef();
-
-	useDrop( ref );
+	const ref = useDrop( ref );
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

[Diff without whitespace.](https://github.com/WordPress/gutenberg/pull/29567/files?diff=split&w=1)

Regression caused by #27079.
Fixes #28512.

The drop handler should be attached to the drop zone element, not the window. Since we're now using the element, we need to use a ref callback.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
