### PR TITLE
Add backports for 5.7 RC 3

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fix a regression where the Cover block migration would not work with a non-default contentPosition ([#29542](https://github.com/WordPress/gutenberg/pull/29542))
+
 ## 2.28.0 (2021-02-01)
 
 ### New Features

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -88,6 +88,9 @@ const deprecated = [
 			customGradient: {
 				type: 'string',
 			},
+			contentPosition: {
+				type: 'string',
+			},
 		},
 		supports: {
 			align: true,

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -89,6 +89,9 @@ const deprecated = [
 				type: 'string',
 			},
 		},
+		supports: {
+			align: true,
+		},
 		save( { attributes } ) {
 			const {
 				backgroundType,
@@ -219,6 +222,9 @@ const deprecated = [
 				type: 'string',
 			},
 		},
+		supports: {
+			align: true,
+		},
 		save( { attributes } ) {
 			const {
 				backgroundType,
@@ -321,6 +327,9 @@ const deprecated = [
 			customGradient: {
 				type: 'string',
 			},
+		},
+		supports: {
+			align: true,
 		},
 		save( { attributes } ) {
 			const {

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -592,7 +592,7 @@ function CoverEdit( {
 						style={ { backgroundImage: gradientValue } }
 					/>
 				) }
-				{ isImageBackground && isImgElement && (
+				{ url && isImageBackground && isImgElement && (
 					<img
 						ref={ isDarkElement }
 						className="wp-block-cover__image-background"
@@ -601,7 +601,7 @@ function CoverEdit( {
 						style={ mediaStyle }
 					/>
 				) }
-				{ isVideoBackground && (
+				{ url && isVideoBackground && (
 					<video
 						ref={ isDarkElement }
 						className="wp-block-cover__video-background"

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -51,6 +51,9 @@ figure.wp-block-gallery {
 			left: 0;
 			z-index: 1;
 		}
+		figcaption {
+			z-index: 2;
+		}
 	}
 
 	figure.is-transient img {

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -303,6 +303,30 @@ _Returns_
 
 -   `boolean`: Reduced motion preference value.
 
+<a name="useRefEffect" href="#useRefEffect">#</a> **useRefEffect**
+
+Effect-like ref callback. Just like with `useEffect`, this allows you to
+return a cleanup function to be run if the ref changes or one of the
+dependencies changes. The ref is provided as an argument to the callback
+functions. The main difference between this and `useEffect` is that
+the `useEffect` callback is not called when the ref changes, but this is.
+Pass the returned ref callback as the component's ref and merge multiple refs
+with `useMergeRefs`.
+
+It's worth noting that if the dependencies array is empty, there's not
+strictly a need to clean up event handlers for example, because the node is
+to be removed. It _is_ necessary if you add dependencies because the ref
+callback will be called multiple times for the same node.
+
+_Parameters_
+
+-   _calllback_ `Function`: Callback with ref as argument.
+-   _dependencies_ `Array`: Dependencies of the callback.
+
+_Returns_
+
+-   `Function`: Ref callback.
+
 <a name="useResizeObserver" href="#useResizeObserver">#</a> **useResizeObserver**
 
 Hook which allows to listen the resize event of any target element when it changes sizes.

--- a/packages/compose/src/hooks/use-ref-effect/index.js
+++ b/packages/compose/src/hooks/use-ref-effect/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useRef } from '@wordpress/element';
+
+/**
+ * Effect-like ref callback. Just like with `useEffect`, this allows you to
+ * return a cleanup function to be run if the ref changes or one of the
+ * dependencies changes. The ref is provided as an argument to the callback
+ * functions. The main difference between this and `useEffect` is that
+ * the `useEffect` callback is not called when the ref changes, but this is.
+ * Pass the returned ref callback as the component's ref and merge multiple refs
+ * with `useMergeRefs`.
+ *
+ * It's worth noting that if the dependencies array is empty, there's not
+ * strictly a need to clean up event handlers for example, because the node is
+ * to be removed. It *is* necessary if you add dependencies because the ref
+ * callback will be called multiple times for the same node.
+ *
+ * @param {Function} calllback    Callback with ref as argument.
+ * @param {Array}    dependencies Dependencies of the callback.
+ *
+ * @return {Function} Ref callback.
+ */
+export default function useRefEffect( calllback, dependencies ) {
+	const cleanup = useRef();
+	return useCallback( ( node ) => {
+		if ( node ) {
+			cleanup.current = calllback( node );
+		} else if ( cleanup.current ) {
+			cleanup.current();
+		}
+	}, dependencies );
+}

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -32,3 +32,4 @@ export { default as useAsyncList } from './hooks/use-async-list';
 export { default as useWarnOnChange } from './hooks/use-warn-on-change';
 export { default as useDebounce } from './hooks/use-debounce';
 export { default as useThrottle } from './hooks/use-throttle';
+export { default as useRefEffect } from './hooks/use-ref-effect';

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.html
@@ -24,3 +24,12 @@
 	</div>
 </div>
 <!-- /wp:cover -->
+<!-- wp:cover {"url":"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg","id":134,"contentPosition":"bottom right"} -->
+<div class="wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right"><img class="wp-block-cover__image-background wp-image-134" alt="" src="http://localhost:8888/wp-content/uploads/2021/02/percy.jpg" data-object-fit="cover"/>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p class="has-text-align-center has-large-font-size">test</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
@@ -65,5 +65,36 @@
             }
         ],
         "originalContent": "<div\n\tclass=\"wp-block-cover alignfull\"\n\tstyle=\"background-image: url( https://example.com/some-background-image.png ); min-height: 48vw; background-position: 50% 40%;\"\n>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
+    },
+    {
+        "clientId": "_clientId_2",
+        "name": "core/cover",
+        "isValid": true,
+        "attributes": {
+            "url": "http://localhost:8888/wp-content/uploads/2021/02/percy.jpg",
+            "id": 134,
+            "hasParallax": false,
+            "isRepeated": false,
+            "dimRatio": 50,
+            "backgroundType": "image",
+            "contentPosition": "bottom right"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "align": "center",
+                    "content": "test",
+                    "dropCap": false,
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p class=\"has-text-align-center has-large-font-size\">test</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right\"><img class=\"wp-block-cover__image-background wp-image-134\" alt=\"\" src=\"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg\" data-object-fit=\"cover\"/>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.json
@@ -49,7 +49,7 @@
             "isRepeated": false,
             "minHeight": 48,
             "minHeightUnit": "vw",
-            "className": "alignfull"
+            "align": "full"
         },
         "innerBlocks": [
             {

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.parsed.json
@@ -76,5 +76,43 @@
         "innerContent": [
             "\n"
         ]
+    },
+    {
+        "blockName": "core/cover",
+        "attrs": {
+            "url": "http://localhost:8888/wp-content/uploads/2021/02/percy.jpg",
+            "id": 134,
+            "contentPosition": "bottom right"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "center",
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-text-align-center has-large-font-size\">test</p>\n\t\t",
+                "innerContent": [
+                    "\n\t\t<p class=\"has-text-align-center has-large-font-size\">test</p>\n\t\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right\"><img class=\"wp-block-cover__image-background wp-image-134\" alt=\"\" src=\"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg\" data-object-fit=\"cover\"/>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right\"><img class=\"wp-block-cover__image-background wp-image-134\" alt=\"\" src=\"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg\" data-object-fit=\"cover\"/>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
+            null,
+            "\n\t</div>\n</div>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
@@ -11,3 +11,9 @@
 <p></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->
+
+<!-- wp:cover {"url":"http://localhost:8888/wp-content/uploads/2021/02/percy.jpg","id":134,"contentPosition":"bottom right"} -->
+<div class="wp-block-cover has-background-dim has-custom-content-position is-position-bottom-right"><img class="wp-block-cover__image-background wp-image-134" alt="" src="http://localhost:8888/wp-content/uploads/2021/02/percy.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size">test</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-6.serialized.html
@@ -6,7 +6,7 @@
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->
 
-<!-- wp:cover {"url":"https://example.com/some-background-image.png","id":1933,"dimRatio":0,"focalPoint":{"x":"0.50","y":"0.40"},"minHeight":48,"minHeightUnit":"vw","className":"alignfull"} -->
+<!-- wp:cover {"url":"https://example.com/some-background-image.png","id":1933,"dimRatio":0,"focalPoint":{"x":"0.50","y":"0.40"},"minHeight":48,"minHeightUnit":"vw","align":"full"} -->
 <div class="wp-block-cover alignfull" style="min-height:48vw"><img class="wp-block-cover__image-background wp-image-1933" alt="" src="https://example.com/some-background-image.png" style="object-position:50% 40%" data-object-fit="cover" data-object-position="50% 40%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div></div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -36,7 +36,7 @@ import {
 	InterfaceSkeleton,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { close } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
@@ -172,9 +172,7 @@ function Layout( { styles } ) {
 		},
 		[ entitiesSavedStatesCallback ]
 	);
-	const ref = useRef();
-
-	useDrop( ref );
+	const ref = useDrop( ref );
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 	} );


### PR DESCRIPTION
Cherry-picks these PRs into `wp/5.7` for WordPress 5.7 RC 2:

- Drop zone: fix media lib duplicate issue #29567
- Fix cover block content position not migrating correctly from deprecated version #29542
- Fix solid-color only cover has small gray border in the editor only #29499
- Add z-index to gallery fig caption to make sure it is still selectable over absolute positioned border #28992
- Cover: Add missing align attr to deprecation #28796