### PR TITLE
Try updating the minimum required WordPress version for the plugin

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Gutenberg ===
 Contributors: matveb, joen, karmatosed
-Requires at least: 5.5.0
+Requires at least: 5.5
 Tested up to: 5.6
 Requires PHP: 5.6
 Stable tag: V.V.V


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #29551 (or at least should hopefully help prevent it)

On the Gutenberg plugin screen, WordPress '5.3 or higher' is incorrectly shown as the supported WordPress versions - https://wordpress.org/plugins/gutenberg/.

Gutenberg supports two versions back, so this should be 5.5. The readme.txt shows `5.5.0`. It was suggested on slack to try `5.5` to match the other version formats in that file (https://wordpress.slack.com/archives/C02QB2JS7/p1614856437066300).

So I'm doing that here. Hopefully the next time the plugin is published it'll show 5.5.