### PR TITLE
Prevent clicking on tag and category links in the site editor

### DIFF
--- a/packages/block-library/src/post-hierarchical-terms/use-hierarchical-term-links.js
+++ b/packages/block-library/src/post-hierarchical-terms/use-hierarchical-term-links.js
@@ -33,7 +33,11 @@ export default function useHierarchicalTermLinks( { postId, postType, term } ) {
 				}
 
 				return (
-					<a key={ itemId } href={ item.link }>
+					<a
+					key={ itemId }
+					href={ item.link }
+					onClick={ ( event ) => event.preventDefault() }
+					>
 						{ item.name }
 					</a>
 				);

--- a/packages/block-library/src/post-hierarchical-terms/use-hierarchical-term-links.js
+++ b/packages/block-library/src/post-hierarchical-terms/use-hierarchical-term-links.js
@@ -34,9 +34,9 @@ export default function useHierarchicalTermLinks( { postId, postType, term } ) {
 
 				return (
 					<a
-					key={ itemId }
-					href={ item.link }
-					onClick={ ( event ) => event.preventDefault() }
+						key={ itemId }
+						href={ item.link }
+						onClick={ ( event ) => event.preventDefault() }
 					>
 						{ item.name }
 					</a>

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -36,7 +36,11 @@ export default function PostTagsEdit( { context, attributes, setAttributes } ) {
 					return ( loaded = false );
 				}
 				return (
-					<a key={ tagId } href={ tag.link }>
+					<a
+					key={ tagId }
+					href={ tag.link }
+					onClick={ ( event ) => event.preventDefault() }
+					>
 						{ tag.name }
 					</a>
 				);

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -37,9 +37,9 @@ export default function PostTagsEdit( { context, attributes, setAttributes } ) {
 				}
 				return (
 					<a
-					key={ tagId }
-					href={ tag.link }
-					onClick={ ( event ) => event.preventDefault() }
+						key={ tagId }
+						href={ tag.link }
+						onClick={ ( event ) => event.preventDefault() }
 					>
 						{ tag.name }
 					</a>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes https://github.com/WordPress/gutenberg/issues/29539

When you clicked on a link inside a tag or hierarchical terms block, the archive page for that tag or category was opened within the site editor iframe.

This PR prevents the default behavior of the click, without disabling the link.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Activated TT1 Blocks and loaded the site editor.
2. Clicked on links inside Post Tags and Categories block(s),
3. Confirmed that the targeted archive page is not opened in the site editor.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
