### PR TITLE
Revert "[Mobile] - Fix splitting/merging of Paragraph and Heading"

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -7,7 +7,7 @@
  * WordPress dependencies
  */
 import RCTAztecView from '@wordpress/react-native-aztec';
-import { View, Platform, InteractionManager } from 'react-native';
+import { View, Platform } from 'react-native';
 import {
 	showUserSuggestions,
 	showXpostSuggestions,
@@ -18,10 +18,7 @@ import memize from 'memize';
 /**
  * WordPress dependencies
  */
-import {
-	BlockFormatControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { BlockFormatControls } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -559,7 +556,6 @@ export class RichText extends Component {
 
 		// Check if value is up to date with latest state of native AztecView
 		if (
-			this.isIOS &&
 			event.nativeEvent.text &&
 			event.nativeEvent.text !== this.props.value
 		) {
@@ -619,9 +615,7 @@ export class RichText extends Component {
 
 		// update text before updating selection
 		// Make sure there are changes made to the content before upgrading it upward
-		if ( this.isIOS ) {
-			this.onTextUpdate( event );
-		}
+		this.onTextUpdate( event );
 
 		// Aztec can send us selection change events after it has lost focus.
 		// For instance the autocorrect feature will complete a partially written
@@ -769,9 +763,7 @@ export class RichText extends Component {
 				this.props.selectionEnd || 0
 			);
 		} else if ( ! isSelected && prevIsSelected ) {
-			InteractionManager.runAfterInteractions( () => {
-				this._editor?.blur();
-			} );
+			this._editor.blur();
 		}
 	}
 
@@ -1006,7 +998,7 @@ const withFormatTypes = ( WrappedComponent ) => ( props ) => {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockParents, getBlock, getSettings } = select(
-			blockEditorStore
+			'core/block-editor'
 		);
 		const parents = getBlockParents( clientId, true );
 		const parentBlock = parents ? getBlock( parents[ 0 ] ) : undefined;


### PR DESCRIPTION
Reverts WordPress/gutenberg#29502

Since these changes didn't fix the regression I'm reverting until we have a solution for this.