### PR TITLE
[RNMobile] Fixes for e2e tests (Gutenberg demo build cache + error logging in setup)

### DIFF
--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -59,7 +59,7 @@ jobs:
       run: npm run native test:e2e:bundle:ios
 
     - name: Switch Xcode Version
-      run: sudo xcode-select --switch /Applications/Xcode_12.app
+      run: sudo xcode-select --switch /Applications/Xcode_12.2.app
 
     - name: Build (if needed)
       run: test -e packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/GutenbergDemo || npm run native test:e2e:build-app:ios

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -62,7 +62,7 @@ jobs:
       run: sudo xcode-select --switch /Applications/Xcode_12.app
 
     - name: Build (if needed)
-      run: test -e packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/gutenberg || npm run native test:e2e:build-app:ios
+      run: test -e packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/GutenbergDemo || npm run native test:e2e:build-app:ios
 
     - name: Run iOS Device Tests
       run: TEST_RN_PLATFORM=ios npm run native device-tests:local  ${{ matrix.native-test-name }}

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
+        xcode: [12.2]
         native-test-name: [
           gutenberg-editor-gallery
         ]
@@ -38,7 +39,7 @@ jobs:
       uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
       with:
         path: packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app
-        key: ${{ runner.os }}-ios-build-${{ hashFiles('ios-checksums.txt') }}
+        key: ${{ runner.os }}-ios-build-${{ matrix.xcode }}-${{ hashFiles('ios-checksums.txt') }}
 
     - name: Restore pods cache
       uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
@@ -58,8 +59,8 @@ jobs:
     - name: Bundle iOS
       run: npm run native test:e2e:bundle:ios
 
-    - name: Switch Xcode Version
-      run: sudo xcode-select --switch /Applications/Xcode_12.2.app
+    - name: Switch Xcode version to ${{ matrix.xcode }}
+      run: sudo xcode-select --switch /Applications/Xcode_${{ matrix.xcode }}.app
 
     - name: Build (if needed)
       run: test -e packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/GutenbergDemo || npm run native test:e2e:build-app:ios

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -13,6 +13,7 @@ const ios = {
 
 exports.iosLocal = {
 	...ios,
+	waitForQuiescence: true,
 	deviceName: 'iPhone 11',
 };
 

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -13,7 +13,6 @@ const ios = {
 
 exports.iosLocal = {
 	...ios,
-	waitForQuiescence: true,
 	deviceName: 'iPhone 11',
 };
 

--- a/packages/react-native-editor/jest_ui_test_environment.js
+++ b/packages/react-native-editor/jest_ui_test_environment.js
@@ -13,8 +13,13 @@ const JSDOMEnvironment = require( 'jest-environment-jsdom' );
 
 class CustomEnvironment extends JSDOMEnvironment {
 	async setup() {
-		await super.setup();
-		this.global.editorPage = await initializeEditorPage();
+		try {
+			await super.setup();
+			this.global.editorPage = await initializeEditorPage();
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'E2E setup exception:', error );
+		}
 	}
 
 	async teardown() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

I added a couple of fixes for the native e2e tests:
1. Fix the app's path that is used to check if the Gutenberg demo app has been cached to prevent running the build step.
2. Add an error handler in the e2e setup function that logs the error in case there's any issue when setting up Appium.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
### Gutenberg demo app's path
1. Remove the app if it was already built with the command: `rm -rf packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app`.
1. Run `test -e packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/GutenbergDemo || echo "Trigger build"`.
1. Observe that the previous command logs `Trigger build` because the app is not present.
1. Run `npm run native test:e2e:bundle:ios && npm run native test:e2e:build-app:ios` to build the app.
1. Run `test -e packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/GutenbergDemo || echo "Trigger build"`.
1. Observe that no log is displayed because the app is present.

### Error handler
1. Add a wrong platform version value in the [Appium's `caps` file](https://github.com/WordPress/gutenberg/blob/cf420c2896b484f793b039a48c7d307a3d441a73/packages/react-native-editor/__device-tests__/helpers/caps.js#L16), something like:
```
exports.iosLocal = {
	...ios,
	platformVersion: '1.0',
	deviceName: 'iPhone 11',
};
```
2. Run the e2e tests with the command: `TEST_RN_PLATFORM=ios npm run native device-tests:local  gutenberg-editor-gallery`.
3. Observe that the command fails and shows an error related to the platform version.
4. Revert the changes applied to [Appium's `caps` file](https://github.com/WordPress/gutenberg/blob/cf420c2896b484f793b039a48c7d307a3d441a73/packages/react-native-editor/__device-tests__/helpers/caps.js#L16).
5. Run the e2e tests with the command: `TEST_RN_PLATFORM=ios npm run native device-tests:local  gutenberg-editor-gallery`.
6. Observe that they pass.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
