### PR TITLE
Group Block: Add support for custom border settings

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -41,7 +41,7 @@ By using the `experimental-theme.json` file to set style properties in a structu
 
 Some of the advantages are:
 
-- Reduce the amount of CSS enqueued. 
+- Reduce the amount of CSS enqueued.
 - Prevent specificity wars.
 
 ### CSS Custom Properties
@@ -403,10 +403,10 @@ The `defaults` block selector can't be part of the `styles` section and will be 
 
 #### Border Properties
 
-| Block | Radius |
-| --- | --- |
-| Group | Yes |
-| Image | Yes |
+| Block | Color | Radius | Style | Width |
+| --- | --- | --- | --- | --- |
+| Group | Yes | Yes | Yes | Yes |
+| Image | Yes | - | - | - |
 
 #### Color Properties
 

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -26,7 +26,10 @@
 			"padding": true
 		},
 		"__experimentalBorder": {
-			"radius": true
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
 		}
 	},
 	"editorStyle": "wp-block-group-editor",


### PR DESCRIPTION
## Description
This makes it possible to customize the border settings of the group block. This is necessary for TT1-Blocks, which has a border-style for the group block

## How has this been tested?
- Switch to TT1 Blocks
- Add a group block and give it a background
- Add these lines to the `styles` section of theme.json:
```
		"core/group": {
			"border": {
				"color": "var(--wp--preset--color--gray)",
				"radius": "20px",
				"style": "solid",
				"width": "3px"
			}
		}
```

## Screenshots
Now TT1 Blocks ground blocks look like this:
<img width="642" alt="Screenshot 2021-03-05 at 16 48 31" src="https://user-images.githubusercontent.com/275961/110146568-a2087700-7dd2-11eb-888e-94a45a4fcd3d.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
