### PR TITLE
Disable tab  focus on nav panel when it is hidden

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -49,7 +49,7 @@ const NavigationPanel = ( { isOpen } ) => {
 			ref={ panelRef }
 			tabIndex="-1"
 		>
-			<div className="edit-site-navigation-panel__inner">
+			<div className={isOpen?"edit-site-navigation-panel__inner" :  "d-none" }>
 				<div className="edit-site-navigation-panel__site-title-container">
 					<div className="edit-site-navigation-panel__site-title">
 						{ siteTitle }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -45,11 +45,12 @@ const NavigationPanel = ( { isOpen } ) => {
 		<div
 			className={ classnames( `edit-site-navigation-panel`, {
 				'is-open': isOpen,
+				'display-none': !isOpen,
 			} ) }
 			ref={ panelRef }
 			tabIndex="-1"
 		>
-			<div className={isOpen?"edit-site-navigation-panel__inner" :  "d-none" }>
+			<div className="edit-site-navigation-panel__inner">
 				<div className="edit-site-navigation-panel__site-title-container">
 					<div className="edit-site-navigation-panel__site-title">
 						{ siteTitle }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -124,3 +124,6 @@
 		min-width: 300px;
 	}
 }
+.d-none{
+	display: none;
+}

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -124,6 +124,6 @@
 		min-width: 300px;
 	}
 }
-.d-none{
+.display-none{
 	display: none;
 }


### PR DESCRIPTION
Disable tab  focus on nav panel when it is hidden according to issue - https://github.com/WordPress/gutenberg/issues/29536
Just dynamical classes for add display none style  to hidden nav panel