### PR TITLE
Add regression test for editor JS crash caused by rtlcss parsing exception, take 2

### DIFF
--- a/packages/e2e-tests/plugins/rtl.php
+++ b/packages/e2e-tests/plugins/rtl.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Activate RTL
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team / Yoav Farhi
+ *
+ * Based on the code from http://wordpress.org/extend/plugins/rtl-tester/.
+ *
+ * @package gutenberg-test-plugin-activate-rtl
+ */
+
+function gutenberg_test_plugin_activate_rtl_set_direction() {
+	global $wp_locale, $wp_styles;
+
+	$wp_locale->text_direction = 'rtl';
+	if ( ! is_a( $wp_styles, 'WP_Styles' ) ) {
+		$wp_styles = new WP_Styles();
+	}
+	$wp_styles->text_direction = 'rtl';
+}
+
+add_action( 'init', 'gutenberg_test_plugin_activate_rtl_set_direction' );

--- a/packages/e2e-tests/plugins/rtl.php
+++ b/packages/e2e-tests/plugins/rtl.php
@@ -9,6 +9,9 @@
  * @package gutenberg-test-plugin-activate-rtl
  */
 
+/**
+ * Set the locale's and styles' text direction to RTL.
+ */
 function gutenberg_test_plugin_activate_rtl_set_direction() {
 	global $wp_locale, $wp_styles;
 

--- a/packages/e2e-tests/specs/editor/various/rtl.test.js
+++ b/packages/e2e-tests/specs/editor/various/rtl.test.js
@@ -5,6 +5,8 @@ import {
 	createNewPost,
 	getEditedPostContent,
 	pressKeyWithModifier,
+	activatePlugin,
+	deactivatePlugin,
 } from '@wordpress/e2e-test-utils';
 
 // Avoid using three, as it looks too much like two with some fonts.
@@ -13,12 +15,16 @@ const ARABIC_ONE = '١';
 const ARABIC_TWO = '٢';
 
 describe( 'RTL', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-plugin-activate-rtl' );
+	} );
+
 	beforeEach( async () => {
 		await createNewPost();
-		await page.evaluate( () => {
-			document.querySelector( '.is-root-container' ).dir = 'rtl';
-			wp.i18n.isRTL = () => true;
-		} );
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-plugin-activate-rtl' );
 	} );
 
 	it( 'should arrow navigate', async () => {


### PR DESCRIPTION
## Description

Issue: https://github.com/WordPress/gutenberg/issues/29250.
Follow up to https://github.com/WordPress/gutenberg/pull/29326. 

The previous approach in #29326 worked but was too hacky. @ockham kindly pointed out that the WP instance used by the GB E2E tests can include plugins to help with testing, and that there are already two helper functions: `activatePlugin` and `deactivatePlugin` that automate the whole process of activate/deactivating a given plugin in the UI. Neat! 

This approach based on the suggestion by @ockham uses some modified code from https://github.com/yoavf/RTL-Tester (with due credit) to properly set the direction to RTL upon activation. It sets the RTL before all tests which acts as a regression test for the CSS parsing issue we experienced (and any similar issues that might happen at this level).

This also simplifies the given test by not requiring the RTL to be changed in the frontend using JS.

## How to test

1. Easiest way is to checkout `v10.0.0` (or revert commit `2f93c432a3`), then `npm ci && npm run build` and start a wp-env instance from there. Finally, in another Gutenberg copy, check out this branch (`add/regression-test-rtlcss-parser-comment-crash`) and run this test _(you might also call `only` in the `it` to restrict the run to the single test added in this PR, if you'd like)_. All tests from the `rtl.test.js` should fail 🔴.


2. Now, where you had `v10.0.0` checkout, checkout `v10.0.2` (or `master`) instead, run `npm ci && npm run build` and go back to the other Gutenberg instance, and run the test again. All tests should pass 🟢.

## Types of changes

Change in E2E test (JS) + addition of a new test plugin (PHP).

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

