### PR TITLE
[RNMobile]: Remove the cancel button from settings options

### DIFF
--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -198,6 +198,7 @@ function AudioEdit( {
 								{ value: 'metadata', label: __( 'Metadata' ) },
 								{ value: 'none', label: __( 'None' ) },
 							] }
+							hideCancelButton={ true }
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -286,6 +286,7 @@ export class FileEdit extends Component {
 						value={ textLinkHref }
 						onChange={ this.onChangeLinkDestinationOption }
 						options={ linkDestinationOptions }
+						hideCancelButton={ true }
 					/>
 					<ToggleControl
 						icon={ external }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -381,6 +381,7 @@ function GalleryEdit( props ) {
 						value={ linkTo }
 						onChange={ setLinkTo }
 						options={ linkOptions }
+						hideCancelButton={ true }
 					/>
 					{ shouldShowSizeOptions && (
 						<SelectControl
@@ -388,6 +389,7 @@ function GalleryEdit( props ) {
 							value={ sizeSlug }
 							options={ imageSizeOptions }
 							onChange={ updateImagesSize }
+							hideCancelButton={ true }
 						/>
 					) }
 				</PanelBody>

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -82,6 +82,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 				value={ preload }
 				onChange={ onChangePreload }
 				options={ options }
+				hideCancelButton={ true }
 			/>
 		</>
 	);

--- a/packages/components/src/query-controls/index.native.js
+++ b/packages/components/src/query-controls/index.native.js
@@ -68,6 +68,7 @@ const QueryControls = memo(
 					value={ `${ orderBy }/${ order }` }
 					options={ options }
 					onChange={ onChange }
+					hideCancelButton={ true }
 				/>
 			),
 			onCategoryChange && (
@@ -77,6 +78,7 @@ const QueryControls = memo(
 					noOptionLabel={ __( 'All' ) }
 					selectedCategoryId={ selectedCategoryId }
 					onChange={ onCategoryChange }
+					hideCancelButton={ true }
 				/>
 			),
 			onNumberOfItemsChange && (


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3222. This effects Android only. Removes the cancel button from the settings options (SelectControl). This PR affects the following blocks:
- Audio
- File
- Latest Posts
- Video
- Gallery

## Gutenberg Mobile PR
https://github.com/wordpress-mobile/gutenberg-mobile/pull/3229

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Change only effects Android:
1. Open **Audio Block** settings. Tap **Preload**. Verify no cancel button in options sheet.
2. Open **File Block** settings. Tap **Link To**. Verify no cancel button in options sheet.
3. Open **Latest Posts Block** settings. Tap **Order by**. Verify no cancel button in options sheet. Tap **Category**, Verify no cancel button in options sheet.
4. Open **Video Block** settings. Tap **Preload**. Verify no cancel button in options sheet.
5. Open **Gallery block** settings. Tap **Link to**. Verify no cancel button in options sheet.

## Screenshots <!-- if applicable -->

### Audio Block

Before | After
-- | --
![audio-before](https://user-images.githubusercontent.com/5810477/110192252-dd1ea080-7dfa-11eb-9c8d-1a32683b12fd.png)|![audio-after](https://user-images.githubusercontent.com/5810477/110192254-de4fcd80-7dfa-11eb-8c55-11f43ac3a88a.png)


### File Block

Before | After
-- | --
![file-before](https://user-images.githubusercontent.com/5810477/110192263-e445ae80-7dfa-11eb-8f4f-33cedeb263b8.png)|![file-after](https://user-images.githubusercontent.com/5810477/110192264-e576db80-7dfa-11eb-8d5f-d5291f73a1ba.png)


### Latest Posts Block

Before | After
-- | --
![latest-posts-before](https://user-images.githubusercontent.com/5810477/110192272-ec055300-7dfa-11eb-9f96-cc1d1946bddf.png)|![latest-posts-after](https://user-images.githubusercontent.com/5810477/110192276-edcf1680-7dfa-11eb-891e-bbca6c074913.png)
![latest-posts-2-before](https://user-images.githubusercontent.com/5810477/110192279-f3c4f780-7dfa-11eb-90f3-b0316c1cb0c2.png)|![latest-posts-2-after](https://user-images.githubusercontent.com/5810477/110192280-f58ebb00-7dfa-11eb-9cee-7a5060752f0d.png)



### Video Block

Before | After
-- | --
![video-before](https://user-images.githubusercontent.com/5810477/110192283-fc1d3280-7dfa-11eb-9126-07234f695f1c.png)|![video-after](https://user-images.githubusercontent.com/5810477/110192285-fd4e5f80-7dfa-11eb-95a2-434b7a8e2966.png)


### Gallery Block

Before | After
-- | --
![gallery-before](https://user-images.githubusercontent.com/5810477/110192286-050e0400-7dfb-11eb-9644-c66d0b40ef2d.png)|![gallery-after](https://user-images.githubusercontent.com/5810477/110192288-063f3100-7dfb-11eb-941c-0b38a4eebe25.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
