### PR TITLE
Site Editor: prevent navigation panel focus when hidden 

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -13,15 +13,25 @@
 	}
 }
 
-.edit-site-navigation-panel.is-open {
-	width: $nav-sidebar-width;
-}
-
 .edit-site-navigation-panel__inner {
 	position: relative;
 	width: $nav-sidebar-width;
 	height: 100%;
 	overflow: hidden;
+	// Inner container is hidden to remove menu from the accessibility tree when not visible.
+	// Setting visibility here (rather than on the parent container) preserves the slide transition.
+	visibility: hidden;
+	// Transition settings should match parent container.
+	transition: visibility 100ms linear;
+	@include reduce-motion("transition");
+}
+
+.edit-site-navigation-panel.is-open {
+	width: $nav-sidebar-width;
+
+	.edit-site-navigation-panel__inner {
+		visibility: visible;
+	}
 }
 
 .edit-site-navigation-panel__site-title-container {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -5,7 +5,7 @@
 	display: none;
 	position: absolute;
 	z-index: z-index(".edit-site-navigation-toggle");
-	height: $header-height + $border-width; // Cover header border
+	height: $header-height;
 	width: $header-height;
 
 	@include break-medium() {
@@ -14,26 +14,17 @@
 
 	body.is-navigation-sidebar-open & {
 		display: flex;
-
-		.edit-site-navigation-toggle__button {
-			border-bottom: 1px solid transparent;
-			border-radius: 0;
-		}
 	}
 }
 
 .edit-site-navigation-toggle__button {
 	align-items: center;
 	background: $gray-900;
+	border-radius: 0;
 	color: $white;
-	height: $header-height + $border-width; // Cover header border
+	height: $header-height;
 	width: $header-height;
 	z-index: 1;
-
-	// Adds a bottom border to match the header toolbar
-	border-bottom: 1px solid $gray-200;
-	// Prevents the bottom border from being clipped by border-bottom radius
-	border-radius: 2px 2px 0 0;
 
 	&.has-icon {
 		min-width: $header-height;


### PR DESCRIPTION
## Description

Removes the site editor navigation panel from the accessibility tree when hidden, so it can't receive keyboard focus.

Also removes an unneeded border from the toggle button to improve the slide animation.

Fixes https://github.com/WordPress/gutenberg/issues/29536

## How has this been tested?

Using the keyboard to navigate through the site editor header.

## Screenshots <!-- if applicable -->

**Keyboard navigation in header menu**

![Screen Recording 2021-03-05 at 22 06 16](https://user-images.githubusercontent.com/1699996/110194775-f5dd8500-7dff-11eb-87cc-de8706d82f17.gif)

**Remove bottom border from navigation toggle when closing panel**

| Before | After |
| - | - |
| ![Screen Shot 2021-03-05 at 22 11 50](https://user-images.githubusercontent.com/1699996/110194801-3d641100-7e00-11eb-97a6-21341b4db6c6.png) | ![Screen Shot 2021-03-05 at 22 11 39](https://user-images.githubusercontent.com/1699996/110194795-32a97c00-7e00-11eb-9b81-c000854cdd64.png) |

## Types of changes

Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] ~~I've included developer documentation if appropriate.~~ (n/a) <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ (n/a) <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
