### PR TITLE
Revert moving is-typing class

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -15,7 +15,12 @@ import {
 	hasBlockSupport,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import { withDispatch, withSelect, useDispatch } from '@wordpress/data';
+import {
+	withDispatch,
+	withSelect,
+	useDispatch,
+	useSelect,
+} from '@wordpress/data';
 import { compose, pure, ifCondition } from '@wordpress/compose';
 
 /**
@@ -83,6 +88,21 @@ function BlockListBlock( {
 } ) {
 	const { removeBlock } = useDispatch( blockEditorStore );
 	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
+	const isTypingWithinBlock = useSelect(
+		( select ) => {
+			const { isTyping, hasSelectedInnerBlock } = select(
+				blockEditorStore
+			);
+			return (
+				// We only care about this prop when the block is selected
+				// Thus to avoid unnecessary rerenders we avoid updating the
+				// prop if the block is not selected.
+				( isSelected || hasSelectedInnerBlock( clientId, true ) ) &&
+				isTyping()
+			);
+		},
+		[ clientId, isSelected ]
+	);
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces
@@ -163,7 +183,10 @@ function BlockListBlock( {
 		isSelected,
 		index,
 		// The wp-block className is important for editor styles.
-		className: classnames( className, { 'wp-block': ! isAligned } ),
+		className: classnames( className, {
+			'wp-block': ! isAligned,
+			'is-typing': isTypingWithinBlock,
+		} ),
 		wrapperProps: omit( wrapperProps, [ 'data-align' ] ),
 	};
 	const memoizedValue = useMemo( () => value, Object.values( value ) );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -27,7 +27,6 @@ export function useBlockClassNames( clientId ) {
 	return useSelect(
 		( select ) => {
 			const {
-				isTyping,
 				isBlockBeingDragged,
 				isBlockHighlighted,
 				isBlockSelected,
@@ -60,11 +59,6 @@ export function useBlockClassNames( clientId ) {
 				'is-multi-selected': isBlockMultiSelected( clientId ),
 				'is-reusable': isReusableBlock( getBlockType( name ) ),
 				'is-dragging': isDragging,
-				// We only care about this prop when the block is selected
-				// Thus to avoid unnecessary rerenders we avoid updating the prop if
-				// the block is not selected.
-				'is-typing':
-					( isSelected || isAncestorOfSelectedBlock ) && isTyping(),
 				'is-focused':
 					focusMode &&
 					isLargeViewport &&


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #29391.
Introduced by #29186.
Alternative to #29596: there's no need to revert the whole commit.

Fixes an error in the navigation block if you type in a child block. Partly reverts #29186. Somehow moving the `is-typing` class causes the problem, but I haven't tracked down why it causes an infinite loop.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
