### PR TITLE
Writing Flow: Shorter writing prompt

### DIFF
--- a/docs/how-to-guides/designers/block-design.md
+++ b/docs/how-to-guides/designers/block-design.md
@@ -158,7 +158,7 @@ The most basic unit of the editor. The Paragraph block is a simple input field.
 
 ### Placeholder:
 
-- Simple placeholder text that reads “Start writing or type / to choose a block”. The placeholder disappears when the block is selected.
+- Simple placeholder text that reads “Type / to choose a block”. The placeholder disappears when the block is selected.
 
 ### Selected state:
 

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -31,8 +31,7 @@ export function DefaultBlockAppender( {
 	}
 
 	const value =
-		decodeEntities( placeholder ) ||
-		__( 'Start writing or type / to choose a block' );
+		decodeEntities( placeholder ) || __( 'Type / to choose a block' );
 
 	// The appender "button" is in-fact a text field so as to support
 	// transitions by WritingFlow occurring by arrow key press. WritingFlow

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -23,7 +23,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     }
     readOnly={true}
     role="button"
-    value="Start writing or type / to choose a block"
+    value="Type / to choose a block"
   />
   <WithSelect(WithDispatch(IfCondition(Inserter)))
     __experimentalIsQuick={true}
@@ -44,7 +44,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     onFocus={[MockFunction]}
     readOnly={true}
     role="button"
-    value="Start writing or type / to choose a block"
+    value="Type / to choose a block"
   />
   <WithSelect(WithDispatch(IfCondition(Inserter)))
     __experimentalIsQuick={true}

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -134,10 +134,7 @@ function ParagraphBlock( {
 						  )
 				}
 				data-empty={ content ? false : true }
-				placeholder={
-					placeholder ||
-					__( 'Start writing or type / to choose a block' )
-				}
+				placeholder={ placeholder || __( 'Type / to choose a block' ) }
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations
 			/>


### PR DESCRIPTION
## Description

The current writing prompt is rather verbose when duplicated (#13599), and even when there's only one:

<img width="448" alt="before" src="https://user-images.githubusercontent.com/1204802/110295335-4962f500-7ff1-11eb-8205-3abbb814eb1b.png">

This reduces it:

<img width="449" alt="after" src="https://user-images.githubusercontent.com/1204802/110295350-4d8f1280-7ff1-11eb-9305-3e08355b799b.png">

I like the shorter prompt as it indicates that there's an empty block. The writing feels implied with the reduced block borders.

If we are fans, this needs a core patch (see also #5549).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
