### PR TITLE
Add i18n support for template part variations' descriptions

### DIFF
--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -24,8 +24,9 @@ const variations = [
 	{
 		name: 'header',
 		title: __( 'Header' ),
-		description:
-			"The header template defines a page area that typically contains a title, logo, and main navigation. Since it's a global element it can be present across all pages and posts.",
+		description: __(
+			"The header template defines a page area that typically contains a title, logo, and main navigation. Since it's a global element it can be present across all pages and posts."
+		),
 		icon: header,
 		isActive: createIsActiveBasedOnArea( 'header' ),
 		scope: [],
@@ -33,8 +34,9 @@ const variations = [
 	{
 		name: 'footer',
 		title: __( 'Footer' ),
-		description:
-			"The footer template defines a page area that typically contains site credits, social links, or any other combination of blocks. Since it's a global element it can be present across all pages and posts.",
+		description: __(
+			"The footer template defines a page area that typically contains site credits, social links, or any other combination of blocks. Since it's a global element it can be present across all pages and posts."
+		),
 		icon: footer,
 		isActive: createIsActiveBasedOnArea( 'footer' ),
 		scope: [],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
By reviewing [another PR](https://github.com/WordPress/gutenberg/pull/28456#discussion_r587408464) I saw that i18n support for template part variations' descriptions was missing. This PR just adds that.
<!-- Please describe what you have changed or added -->
