### PR TITLE
Fix the button component styles when used with a dashicon

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -299,7 +299,7 @@
 			display: inline-block;
 			flex: 0 0 auto;
 			margin-left: 2px;
-			margin-right: 10px;
+			margin-right: 2px;
 		}
 
 		&.has-text {
@@ -308,6 +308,10 @@
 
 		&.has-text svg {
 			margin-right: 8px;
+		}
+
+		&.has-text .dashicon {
+			margin-right: 10px;
 		}
 	}
 


### PR DESCRIPTION
closes #29603

This PR adds the correct styles to the button component when a dashicon is provided (and no text), the previous styles were only meant to address the "dashicon + text" case