### PR TITLE
Make border work on the site editor

### DIFF
--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -25,9 +25,21 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		value: [ 'color', 'background' ],
 		support: [ 'color' ],
 	},
+	borderColor: {
+		value: [ 'border', 'color' ],
+		support: [ '__experimentalBorder', 'color' ],
+	},
 	borderRadius: {
 		value: [ 'border', 'radius' ],
 		support: [ '__experimentalBorder', 'radius' ],
+	},
+	borderStyle: {
+		value: [ 'border', 'style' ],
+		support: [ '__experimentalBorder', 'style' ],
+	},
+	borderWidth: {
+		value: [ 'border', 'width' ],
+		support: [ '__experimentalBorder', 'width' ],
 	},
 	color: {
 		value: [ 'color', 'text' ],


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/28049 landed support for border color, width, and style via theme.json, so themes can style those properties. While it works in the front-end and post editor, it doesn't in the site editor. This PR fixes it.

## Test

- Switch to TT1 Blocks.
- Add these lines to the `styles` section of theme.json:
```
		"core/group": {
			"border": {
				"color": "var(--wp--preset--color--gray)",
				"radius": "20px",
				"style": "solid",
				"width": "3px"
			}
		}
```
- Load the post editor and add a group block. Verify that it has those styles applied (also when published).
- Load the site editor and add a group block. Verify that it has those styles applied (also when published).
