### PR TITLE
Revert "Block edit: avoid memoized block context in favour of useSelect"

### DIFF
--- a/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
@@ -1,7 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BlockControls should render a dynamic toolbar of controls 1`] = `
-<ContextProvider>
+<ContextProvider
+  value={
+    Object {
+      "clientId": undefined,
+      "isSelected": true,
+      "name": undefined,
+    }
+  }
+>
   <WithFilters(Edit)
     isSelected={true}
   >

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -2,41 +2,21 @@
  * WordPress dependencies
  */
 import { createContext, useContext } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { store as blockEditorStore } from '../../store';
-
-const Context = createContext();
+const Context = createContext( {
+	name: '',
+	isSelected: false,
+	clientId: null,
+} );
 const { Provider } = Context;
 
 export { Provider as BlockEditContextProvider };
 
 /**
- * A hook that returns the block client ID, name and selected status.
+ * A hook that returns the block edit context.
  *
- * @return {Object} Block client ID, name and selected status.
+ * @return {Object} Block edit context
  */
 export function useBlockEditContext() {
-	const clientId = useContext( Context );
-	return useSelect(
-		( select ) => {
-			if ( ! clientId ) {
-				return {};
-			}
-
-			const { getBlockName, isBlockSelected } = select(
-				blockEditorStore
-			);
-
-			return {
-				clientId,
-				name: getBlockName( clientId ),
-				isSelected: isBlockSelected( clientId ),
-			};
-		},
-		[ clientId ]
-	);
+	return useContext( Context );
 }

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Edit from './edit';
@@ -7,8 +12,19 @@ import { BlockEditContextProvider, useBlockEditContext } from './context';
 export { useBlockEditContext };
 
 export default function BlockEdit( props ) {
+	const { name, isSelected, clientId } = props;
+	const context = {
+		name,
+		isSelected,
+		clientId,
+	};
 	return (
-		<BlockEditContextProvider value={ props.clientId }>
+		<BlockEditContextProvider
+			// It is important to return the same object if props haven't
+			// changed to avoid  unnecessary rerenders.
+			// See https://reactjs.org/docs/context.html#caveats.
+			value={ useMemo( () => context, Object.values( context ) ) }
+		>
 			<Edit { ...props } />
 		</BlockEditContextProvider>
 	);


### PR DESCRIPTION
Reverts WordPress/gutenberg#29333

* There's a negative performance impact. While it seems to be undone by #29309, it's probably better to merged these together.
* There's an issue with the navigation block.