### PR TITLE
Latest Posts: Add support for typography properties

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -453,6 +453,7 @@ These are the current typography properties supported by blocks:
 | Global | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | Code | - | Yes | - | - | - | - | - |
 | Heading [1] | - | Yes | - | - | Yes | - | - |
+| Latest Posts | Yes | Yes | Yes | Yes | Yes | - | Yes |
 | List | - | Yes | - | - | - | - | - |
 | Navigation | Yes | Yes | Yes | Yes | - | Yes | Yes |
 | Paragraph | - | Yes | - | - | Yes | - | - |

--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -83,7 +83,13 @@
 	},
 	"supports": {
 		"align": true,
-		"html": false
+		"html": false,
+		"fontSize": true,
+		"lineHeight": true,
+		"__experimentalFontFamily": true,
+		"__experimentalFontWeight": true,
+		"__experimentalTextTransform": true
+
 	},
 	"editorStyle": "wp-block-latest-posts-editor",
 	"style": "wp-block-latest-posts"

--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -88,8 +88,8 @@
 		"lineHeight": true,
 		"__experimentalFontFamily": true,
 		"__experimentalFontWeight": true,
-		"__experimentalTextTransform": true
-
+		"__experimentalTextTransform": true,
+		"__experimentalSelector": "wp-block-latest-posts__post-title"
 	},
 	"editorStyle": "wp-block-latest-posts-editor",
 	"style": "wp-block-latest-posts"

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -536,7 +536,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 									) }
 								</div>
 							) }
-							<a href={ post.link } rel="noreferrer noopener">
+							<a href={ post.link } rel="noreferrer noopener" className="wp-block-latest-posts__post-title">
 								{ titleTrimmed ? (
 									<RawHTML>{ titleTrimmed }</RawHTML>
 								) : (


### PR DESCRIPTION
## Description
Adds support for typography properties in the Latest Posts block.

## How has this been tested?
- Switch to TT1 Blocks
- Add a Latest Posts block
- Use the typography settings in the sidebar

## Screenshots <!-- if applicable -->
<img width="1440" alt="Screenshot 2021-03-08 at 12 52 16" src="https://user-images.githubusercontent.com/275961/110323872-1fb7c700-800d-11eb-9fd5-3c0baa17e039.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
