### PR TITLE
Fix in between inserter edge case

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -250,6 +250,7 @@ export default compose( [
 						getBlockIndex,
 						getBlockSelectionEnd,
 						getBlockOrder,
+						getBlockRootClientId,
 					} = select( blockEditorStore );
 
 					// If the clientId is defined, we insert at the position of the block.
@@ -259,7 +260,11 @@ export default compose( [
 
 					// If there a selected block, we insert after the selected block.
 					const end = getBlockSelectionEnd();
-					if ( ! isAppender && end ) {
+					if (
+						! isAppender &&
+						end &&
+						getBlockRootClientId( end ) === rootClientId
+					) {
 						return getBlockIndex( end, rootClientId ) + 1;
 					}
 


### PR DESCRIPTION
In some small edge cases, the in between inserter behaves weirdly.
To reproduce in master, do this:

 - Insert a buttons block
 - type something on the first button
 - select a block outside the buttons block
 - Try adding a button after the first button using the in-between inserter
 - you'll notice that the block gets added before the button and not after it  (which is fixed in this PR).