### PR TITLE
[RNMobile] Reduce the number of items per page when fetching reusable blocks

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -131,10 +131,10 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'postType',
 				'wp_block',
 				/**
-				 * Unbounded queries are not supported on native so as a workaround we set per_page with the maximum value.
+				 * Unbounded queries are not supported on native so as a workaround, we set per_page with the maximum value that native version can handle.
 				 * Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2661
 				 */
-				{ per_page: Platform.select( { web: -1, native: 100 } ) }
+				{ per_page: Platform.select( { web: -1, native: 10 } ) }
 			),
 			hasUploadPermissions: defaultTo(
 				canUser( 'create', 'media' ),


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/WordPress/gutenberg/pull/29626

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Change the `per_page` value of the reusable blocks fetch in the editor provider for native version.

This is required because fetching and processing more than 27 items triggers the `Maximum call stack size exceeded" exception on Android.

### Why is "Maximum call stack size exceeded" exception triggered?

I noticed that [the `useSelect` callback of the `useBlockEditorSettings` hooks](https://github.com/WordPress/gutenberg/blob/4cc22124703b32d48ce26c12cfd44dc3357fc23b/packages/editor/src/components/provider/use-block-editor-settings.js#L116-L146) is called each time [a reusable block is processed](https://github.com/WordPress/gutenberg/blob/a81afe83377ff10ebb33db281ebc9917fede0c27/packages/core-data/src/resolvers.js#L221-L237). Making 28 calls doesn't look like a quantity that should trigger the exception but most likely there are more calls happening underneath that the JS engine detects as an infinite loop.

However this is not happening on the web version, my impression is that the threshold for the exception is higher than on native version. On Android JS code is run in the [Hermes engine](https://github.com/facebook/hermes/blob/b5025285f2c1c851c7b8b995676d6c9674538419/lib/VM/Runtime.cpp#L1279) so most likely it's there where the threshold is defined. Besides when the app is debugged via the Chrome debugger this exception is not triggered because the JS code is executed locally in your machine.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Add more than 27 reusable blocks to a site (28 items should trigger the exception), this has to be done in the web version because creating reusable blocks from the app is not yet available.
2. Open a post from the WPAndroid app.
3. Observe that no crash or exception is produced.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
