### PR TITLE
Don't display Guide's page control if there is only one page

### DIFF
--- a/packages/components/src/guide/index.js
+++ b/packages/components/src/guide/index.js
@@ -78,11 +78,13 @@ export default function Guide( {
 				<div className="components-guide__page">
 					{ pages[ currentPage ].image }
 
-					<PageControl
-						currentPage={ currentPage }
-						numberOfPages={ pages.length }
-						setCurrentPage={ setCurrentPage }
-					/>
+					{ pages.length > 1 && (
+						<PageControl
+							currentPage={ currentPage }
+							numberOfPages={ pages.length }
+							setCurrentPage={ setCurrentPage }
+						/>
+					) }
 
 					{ pages[ currentPage ].content }
 

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -62,16 +62,18 @@
 	}
 
 	&__page-control {
-		margin: $grid-unit-10 0 $grid-unit-10 0;
+		margin: 0;
 		text-align: center;
 
 		li {
 			display: inline-block;
+			margin: 0;
 		}
 
 		.components-button {
 			height: 30px;
 			min-width: 20px;
+			margin: -6px 0;
 		}
 	}
 

--- a/packages/components/src/guide/test/index.js
+++ b/packages/components/src/guide/test/index.js
@@ -71,6 +71,13 @@ describe( 'Guide', () => {
 		).toHaveLength( 1 );
 	} );
 
+	it( "doesn't display the page control if there is only one page", () => {
+		const wrapper = shallow(
+			<Guide pages={ [ { content: <p>Page 1</p> } ] } />
+		);
+		expect( wrapper.find( PageControl ).exists() ).toBeFalsy();
+	} );
+
 	it( 'calls onFinish when the finish button is clicked', () => {
 		const onFinish = jest.fn();
 		const wrapper = shallow(

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -6,6 +6,7 @@
 	&__image {
 		background: #00a0d2;
 		height: 240px;
+		margin: 0 0 $grid-unit-20;
 
 		&__prm-r {
 			display: none;
@@ -26,7 +27,7 @@
 		font-family: $default-font;
 		font-size: 24px;
 		line-height: 1.4;
-		margin: 0 0 $grid-unit-20 0;
+		margin: $grid-unit-20 0 $grid-unit-20 0;
 		padding: 0 $grid-unit-40;
 	}
 


### PR DESCRIPTION
Fixes #29628.

## Description
Until now, `Guide` assumed there will always be more than one page, so the `PageControl` was always displayed under the image. However, when there is only one page, that control is useless and can be distracting. This PR hides the `PageControl` when only one page is available.

This PR also refactors the styles a bit. Currently, `Guide` was relying on the margin added by the page control to separate the image and the text below. Given that this is no longer always present, I moved some of the styles to the Welcome guide CSS (see screenshots below for the end result).

## How has this been tested?
Testing steps:

1. In the Storybook page for the `Guide` component, set the `numberOfPages` to 1.
2. Notice the blue dot of the `PageControl` is not visible.

Test no regressions in the Welcome guide:
1. In your browser local storage modify the `WP_DATA_USER_1` value so `welcomeGuide` in `core/edit-post` is false. This will force the Welcome guide to appear next time you visit the editor.
2. Create a page or post and verify the Welcome guide looks fine.

## Screenshots

Guide with only one page:

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/3616980/110338226-0face100-8027-11eb-90d2-fa5c3a08039a.png" alt="Screenshot showing the Guide with only one page before the changes" width="634" /> | <img src="https://user-images.githubusercontent.com/3616980/110340256-5996c680-8029-11eb-999d-3c1c8f36c936.png" alt="Screenshot showing the Guide with only one page after the changes" width="634" /> |

I used the welcome guide to simulate more combinations and also to test the style changes included in this PR:

1. Before.
2. After.
3. After with no pagination.
4. After with no image.

| 1 | 2 | 3 | 4 |
| --- | --- | --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/110346063-7930ed80-802f-11eb-9ae5-c3eea66a6389.png) | ![imatge](https://user-images.githubusercontent.com/3616980/110346108-84841900-802f-11eb-8fec-13a9e0aa683f.png) | ![imatge](https://user-images.githubusercontent.com/3616980/110346203-9a91d980-802f-11eb-85e1-8f2c592f7dcc.png) | ![imatge](https://user-images.githubusercontent.com/3616980/110346280-ae3d4000-802f-11eb-8af8-e3ae3eda25ed.png) |

## Types of changes
Behavior change in the `Guide` component from `@wordpress/components`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->