### PR TITLE
Components: Add types to Shortcut

### DIFF
--- a/packages/components/src/shortcut/index.js
+++ b/packages/components/src/shortcut/index.js
@@ -3,6 +3,17 @@
  */
 import { isString, isObject } from 'lodash';
 
+/** @typedef {string | { display: string, ariaLabel: string }} Shortcut */
+/**
+ * @typedef Props
+ * @property {Shortcut} shortcut Shortcut configuration
+ * @property {string} [className] Classname
+ */
+
+/**
+ * @param {Props} props Props
+ * @return {JSX.Element | null} Element
+ */
 function Shortcut( { shortcut, className } ) {
 	if ( ! shortcut ) {
 		return null;

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -19,6 +19,7 @@
 		"src/dashicon/**/*",
 		"src/flex/**/*",
 		"src/form-group/**/*",
+		"src/shortcut/**/*",
 		"src/spinner/**/*",
 		"src/tip/**/*",
 		"src/ui/**/*",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds types to the Shortcut component

## How has this been tested?
Type check passes

## Types of changes
Type additions, no code changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
