### PR TITLE
List View and Block List: Update hover, focus, highlight, select borders

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -61,7 +61,6 @@
 			right: $border-width;
 
 			// Everything else.
-			// 2px outside.
 			box-shadow: 0 0 0 $border-width $gray-900;
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -778,6 +778,9 @@ div.block-editor-block-list__layout .block-editor-block-list__block.is-outline-m
 
 	&.is-selected:focus::after,
 	&.is-selected.is-editing::after {
-		box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		box-shadow:
+			inset 0 0 0 $border-width $white,
+			inset 0 0 0 ($border-width * 2) $gray-900,
+			0 0 0 calc(var(--wp-admin-border-width-focus) + #{$border-width}) var(--wp-admin-theme-color);
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -763,3 +763,21 @@
 .is-dragging-components-draggable .components-tooltip {
 	display: none;
 }
+
+// EXPERIMENTAL
+div.block-editor-block-list__layout .block-editor-block-list__block.is-outline-mode:not(.is-typing) {
+	&.is-hovered::after,
+	&.is-highlighted::after,
+	&.is-selected::after {
+		box-shadow: inset 0 0 0 $border-width $gray-900;
+	}
+
+	&:focus::after {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	}
+
+	&.is-selected:focus::after,
+	&.is-selected.is-editing::after {
+		box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	}
+}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -781,6 +781,6 @@ div.block-editor-block-list__layout .block-editor-block-list__block.is-outline-m
 		box-shadow:
 			inset 0 0 0 $border-width $white,
 			inset 0 0 0 ($border-width * 2) $gray-900,
-			0 0 0 calc(var(--wp-admin-border-width-focus) + #{$border-width}) var(--wp-admin-theme-color);
+			0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -62,7 +62,7 @@
 
 			// Everything else.
 			// 2px outside.
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 $border-width $gray-900;
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 
 			// Windows High Contrast mode will show this outline.
@@ -70,7 +70,7 @@
 
 			// Show a lighter color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+				box-shadow: 0 0 0 $border-width $dark-theme-focus;
 			}
 		}
 
@@ -219,7 +219,7 @@
 			left: $border-width;
 			right: $border-width;
 			bottom: $border-width;
-			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 $border-width $gray-900;
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 		}
 	}
@@ -762,25 +762,4 @@
 
 .is-dragging-components-draggable .components-tooltip {
 	display: none;
-}
-
-// EXPERIMENTAL
-div.block-editor-block-list__layout .block-editor-block-list__block.is-outline-mode:not(.is-typing) {
-	&.is-hovered::after,
-	&.is-highlighted::after,
-	&.is-selected::after {
-		box-shadow: inset 0 0 0 $border-width $gray-900;
-	}
-
-	&:focus::after {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-	}
-
-	&.is-selected:focus::after,
-	&.is-selected.is-editing::after {
-		box-shadow:
-			inset 0 0 0 $border-width $white,
-			inset 0 0 0 ($border-width * 2) $gray-900,
-			0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-	}
 }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -34,6 +34,7 @@ export default function BlockNavigationBlock( {
 	block,
 	isSelected,
 	isBranchSelected,
+	isLastOfSelectedBranch,
 	onClick,
 	position,
 	level,
@@ -41,7 +42,6 @@ export default function BlockNavigationBlock( {
 	siblingBlockCount,
 	showBlockMovers,
 	path,
-	isLast,
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -121,9 +121,10 @@ export default function BlockNavigationBlock( {
 				'is-branch-selected':
 					withExperimentalPersistentListViewFeatures &&
 					isBranchSelected,
+				'is-last-of-selected-branch':
+					withExperimentalPersistentListViewFeatures &&
+					isLastOfSelectedBranch,
 				'is-dragging': isDragging,
-				'is-last-of-branch':
-					withExperimentalPersistentListViewFeatures && isLast,
 			} ) }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -41,6 +41,7 @@ export default function BlockNavigationBlock( {
 	siblingBlockCount,
 	showBlockMovers,
 	path,
+	isLast,
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -121,6 +122,8 @@ export default function BlockNavigationBlock( {
 					withExperimentalPersistentListViewFeatures &&
 					isBranchSelected,
 				'is-dragging': isDragging,
+				'is-last-of-branch':
+					withExperimentalPersistentListViewFeatures && isLast,
 			} ) }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -33,6 +33,7 @@ import { store as blockEditorStore } from '../../store';
 export default function BlockNavigationBlock( {
 	block,
 	isSelected,
+	isBranchSelected,
 	onClick,
 	position,
 	level,
@@ -116,6 +117,9 @@ export default function BlockNavigationBlock( {
 		<BlockNavigationLeaf
 			className={ classnames( {
 				'is-selected': isSelected,
+				'is-branch-selected':
+					withExperimentalPersistentListViewFeatures &&
+					isBranchSelected,
 				'is-dragging': isDragging,
 			} ) }
 			onMouseEnter={ onMouseEnter }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -27,7 +27,7 @@ export default function BlockNavigationBranch( props ) {
 		terminatedLevels = [],
 		path = [],
 		isBranchSelected = false,
-		lastOfMap = false,
+		isLastOfBranch = false,
 	} = props;
 
 	const isTreeRoot = ! parentBlockClientId;
@@ -61,7 +61,11 @@ export default function BlockNavigationBranch( props ) {
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBranch );
 
-				const shouldDoStuff = isSelected || lastOfMap;
+				// Logic needed to target the last item of a selected branch which might be deeply nested.
+				const isLastBlock = index === blockCount - 1;
+				const isLast = isSelected || ( isLastOfBranch && isLastBlock );
+				const isLastOfSelectedBranch =
+					isLastOfBranch && ! hasNestedBranch && isLastBlock;
 
 				return (
 					<Fragment key={ clientId }>
@@ -70,6 +74,7 @@ export default function BlockNavigationBranch( props ) {
 							onClick={ selectBlock }
 							isSelected={ isSelected }
 							isBranchSelected={ isSelectedBranch }
+							isLastOfSelectedBranch={ isLastOfSelectedBranch }
 							level={ level }
 							position={ position }
 							rowCount={ rowCount }
@@ -77,7 +82,6 @@ export default function BlockNavigationBranch( props ) {
 							showBlockMovers={ showBlockMovers }
 							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }
-							isLast={ lastOfMap && ! hasNestedBranch }
 						/>
 						{ hasNestedBranch && (
 							<BlockNavigationBranch
@@ -85,6 +89,7 @@ export default function BlockNavigationBranch( props ) {
 								selectedBlockClientId={ selectedBlockClientId }
 								selectBlock={ selectBlock }
 								isBranchSelected={ isSelectedBranch }
+								isLastOfBranch={ isLast }
 								showAppender={ showAppender }
 								showBlockMovers={ showBlockMovers }
 								showNestedBlocks={ showNestedBlocks }
@@ -92,11 +97,6 @@ export default function BlockNavigationBranch( props ) {
 								level={ level + 1 }
 								terminatedLevels={ updatedTerminatedLevels }
 								path={ updatedPath }
-								lastOfMap={
-									shouldDoStuff &&
-									( index === filteredBlocks.length - 1 ||
-										isSelected )
-								}
 							/>
 						) }
 					</Fragment>

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -62,6 +62,7 @@ export default function BlockNavigationBranch( props ) {
 					isBranchSelected || ( isSelected && hasNestedBranch );
 
 				// Logic needed to target the last item of a selected branch which might be deeply nested.
+				// This is currently only needed for styling purposes. See: `.is-last-of-selected-branch`.
 				const isLastBlock = index === blockCount - 1;
 				const isLast = isSelected || ( isLastOfBranch && isLastBlock );
 				const isLastOfSelectedBranch =

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -54,7 +54,11 @@ export default function BlockNavigationBranch( props ) {
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 				const hasNestedAppender = itemHasAppender( clientId );
+				const hasNestedBranch = hasNestedBlocks || hasNestedAppender;
+
 				const isSelected = selectedBlockClientId === clientId;
+				const isSelectedBranch =
+					isBranchSelected || ( isSelected && hasNestedBranch );
 
 				return (
 					<Fragment key={ clientId }>
@@ -62,7 +66,7 @@ export default function BlockNavigationBranch( props ) {
 							block={ block }
 							onClick={ selectBlock }
 							isSelected={ isSelected }
-							isBranchSelected={ isBranchSelected || isSelected }
+							isBranchSelected={ isSelectedBranch }
 							level={ level }
 							position={ position }
 							rowCount={ rowCount }
@@ -71,14 +75,12 @@ export default function BlockNavigationBranch( props ) {
 							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }
 						/>
-						{ ( hasNestedBlocks || hasNestedAppender ) && (
+						{ hasNestedBranch && (
 							<BlockNavigationBranch
 								blocks={ innerBlocks }
 								selectedBlockClientId={ selectedBlockClientId }
 								selectBlock={ selectBlock }
-								isBranchSelected={
-									isBranchSelected || isSelected
-								}
+								isBranchSelected={ isSelectedBranch }
 								showAppender={ showAppender }
 								showBlockMovers={ showBlockMovers }
 								showNestedBlocks={ showNestedBlocks }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -27,6 +27,7 @@ export default function BlockNavigationBranch( props ) {
 		terminatedLevels = [],
 		path = [],
 		isBranchSelected = false,
+		lastOfMap = false,
 	} = props;
 
 	const isTreeRoot = ! parentBlockClientId;
@@ -60,6 +61,8 @@ export default function BlockNavigationBranch( props ) {
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBranch );
 
+				const shouldDoStuff = isSelected || lastOfMap;
+
 				return (
 					<Fragment key={ clientId }>
 						<BlockNavigationBlock
@@ -74,6 +77,7 @@ export default function BlockNavigationBranch( props ) {
 							showBlockMovers={ showBlockMovers }
 							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }
+							isLast={ lastOfMap && ! hasNestedBranch }
 						/>
 						{ hasNestedBranch && (
 							<BlockNavigationBranch
@@ -88,6 +92,11 @@ export default function BlockNavigationBranch( props ) {
 								level={ level + 1 }
 								terminatedLevels={ updatedTerminatedLevels }
 								path={ updatedPath }
+								lastOfMap={
+									shouldDoStuff &&
+									( index === filteredBlocks.length - 1 ||
+										isSelected )
+								}
 							/>
 						) }
 					</Fragment>

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -26,6 +26,7 @@ export default function BlockNavigationBranch( props ) {
 		level = 1,
 		terminatedLevels = [],
 		path = [],
+		isBranchSelected = false,
 	} = props;
 
 	const isTreeRoot = ! parentBlockClientId;
@@ -53,13 +54,15 @@ export default function BlockNavigationBranch( props ) {
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 				const hasNestedAppender = itemHasAppender( clientId );
+				const isSelected = selectedBlockClientId === clientId;
 
 				return (
 					<Fragment key={ clientId }>
 						<BlockNavigationBlock
 							block={ block }
 							onClick={ selectBlock }
-							isSelected={ selectedBlockClientId === clientId }
+							isSelected={ isSelected }
+							isBranchSelected={ isBranchSelected || isSelected }
 							level={ level }
 							position={ position }
 							rowCount={ rowCount }
@@ -73,6 +76,9 @@ export default function BlockNavigationBranch( props ) {
 								blocks={ innerBlocks }
 								selectedBlockClientId={ selectedBlockClientId }
 								selectBlock={ selectBlock }
+								isBranchSelected={
+									isBranchSelected || isSelected
+								}
 								showAppender={ showAppender }
 								showBlockMovers={ showBlockMovers }
 								showNestedBlocks={ showNestedBlocks }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -34,6 +34,14 @@
 		color: $white;
 	}
 
+	&.is-branch-selected.is-selected .block-editor-block-navigation-block-contents {
+		border-radius: 2px 2px 0 0;
+	}
+	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
+		background: $gray-100;
+		border-radius: 0;
+	}
+
 	&.is-dragging {
 		display: none;
 	}
@@ -51,10 +59,13 @@
 		white-space: nowrap;
 
 		&:hover {
-			background: $gray-100;
+			box-shadow: inset 0 0 0 $border-width $gray-900;
 		}
 
 		&:focus {
+			box-shadow:
+				inset 0 0 0 1px $white,
+				0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			z-index: 1;
 		}
 
@@ -244,13 +255,4 @@
 .block-editor-block-navigator-indentation {
 	flex-shrink: 0;
 	width: $grid-unit-30 + $grid-unit-05; // Indent a full icon size, plus 4px which optically aligns child icons to the text label above.
-}
-
-// EXPERIMENTAL
-tr.block-editor-block-navigation-leaf {
-	&.is-selected .block-editor-block-navigation-block-contents {
-		&:focus {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		}
-	}
 }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -248,22 +248,7 @@
 
 // EXPERIMENTAL
 tr.block-editor-block-navigation-leaf {
-	.block-editor-block-navigation-block-contents {
-		&:hover {
-			background-color: transparent;
-			box-shadow: inset 0 0 0 $border-width $gray-900;
-		}
-		&:focus {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		}
-	}
-	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
-		background: $gray-100;
-	}
 	&.is-selected .block-editor-block-navigation-block-contents {
-		background: $gray-900;
-		color: $white;
-
 		&:focus {
 			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -245,3 +245,27 @@
 	flex-shrink: 0;
 	width: $grid-unit-30 + $grid-unit-05; // Indent a full icon size, plus 4px which optically aligns child icons to the text label above.
 }
+
+// EXPERIMENTAL
+tr.block-editor-block-navigation-leaf {
+	.block-editor-block-navigation-block-contents {
+		&:hover {
+			background-color: transparent;
+			box-shadow: inset 0 0 0 $border-width $gray-900;
+		}
+		&:focus {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
+	}
+	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
+		background: $gray-100;
+	}
+	&.is-selected .block-editor-block-navigation-block-contents {
+		background: $gray-900;
+		color: $white;
+
+		&:focus {
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
+	}
+}

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -37,6 +37,7 @@
 	&.is-branch-selected.is-selected .block-editor-block-navigation-block-contents {
 		border-radius: 2px 2px 0 0;
 	}
+
 	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
 		background: $gray-100;
 		border-radius: 0;
@@ -44,6 +45,10 @@
 		&:hover {
 			background: $gray-300;
 		}
+	}
+
+	&.is-branch-selected.is-last-of-branch .block-editor-block-navigation-block-contents {
+		border-radius: 0 0 2px 2px;
 	}
 
 	&.is-dragging {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -37,7 +37,6 @@
 	&.is-branch-selected.is-selected .block-editor-block-navigation-block-contents {
 		border-radius: 2px 2px 0 0;
 	}
-
 	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
 		background: $gray-100;
 		border-radius: 0;
@@ -46,8 +45,7 @@
 			background: $gray-300;
 		}
 	}
-
-	&.is-branch-selected.is-last-of-branch .block-editor-block-navigation-block-contents {
+	&.is-branch-selected.is-last-of-selected-branch .block-editor-block-navigation-block-contents {
 		border-radius: 0 0 2px 2px;
 	}
 

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -40,6 +40,10 @@
 	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
 		background: $gray-100;
 		border-radius: 0;
+
+		&:hover {
+			background: $gray-300;
+		}
 	}
 
 	&.is-dragging {
@@ -59,7 +63,7 @@
 		white-space: nowrap;
 
 		&:hover {
-			box-shadow: inset 0 0 0 $border-width $gray-900;
+			background: $gray-100;
 		}
 
 		&:focus {

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -64,15 +64,15 @@
 
 // Ensures a border is present when a child block is selected.
 .block-editor-block-list__block[data-type="core/template-part"] {
-	&.is-selected,
 	&.has-child-selected {
 		&::after {
-			top: $border-width;
-			bottom: $border-width;
-			left: $border-width;
-			right: $border-width;
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
-			box-shadow: 0 0 0 $border-width $gray-900;
+			border: $border-width dotted $gray-900;
+		}
+
+		&.is-hovered {
+			&::after {
+				border: none;
+			}
 		}
 	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -69,7 +69,8 @@
 			border: $border-width dotted $gray-900;
 		}
 
-		&.is-hovered {
+		&.is-hovered,
+		&.is-highlighted {
 			&::after {
 				border: none;
 			}


### PR DESCRIPTION
## Description

Fixes #29467

The initial implementation of the Persistent List View had a pretty big usability issue caused by the fact that the component wasn't designed to stick around after an item was selected.
The persistence required a visual clue to indicate that, on item selection, the focus shifted from the list to the block.

This PR subtly updates the outlines of both the List View items, and the blocks in the canvas, to make their relationship clearer.

- In canvas, the primary selection (selected, hovered, highlighted) outline changed from `2px --wp-admin-theme-color` (typically blue) to `1px $gray-900`.
- In canvas, the Template Part block's outline becomes `dotted` when one of its children is selected.
- In the List View, focused items gain a white halo inside their blue outline.

This PR also highlight the entire children branch of a selected item.
This required the introduction of some additional logic in the `BlockNavigation` component.
To avoid regressions and incompatibilities, like the other Persistent List View-only features, this too is gated behind the `__experimentalPersistentListViewFeatures` flag.

## How has this been tested?

- Activate an FSE theme such as TT1 Blocks.
- Enter the Site Editor, and open the List View.
- Play around with it, making sure the focus position is clear enough at all times.

## Screenshots <!-- if applicable -->

Grey outline of a hovered block:

<img width="897" alt="Screenshot 2021-03-15 at 16 58 39" src="https://user-images.githubusercontent.com/2070010/111191308-d7218000-85af-11eb-997a-681a81b4d6ca.png">

Dotted outline of a template part with a child selected:
<img width="899" alt="Screenshot 2021-03-15 at 16 58 19" src="https://user-images.githubusercontent.com/2070010/111191341-df79bb00-85af-11eb-9d27-f40173fb512d.png">

List View item's focus halo:

<img width="332" alt="Screenshot 2021-03-15 at 16 59 13" src="https://user-images.githubusercontent.com/2070010/111191501-0a640f00-85b0-11eb-8477-f83e42e39714.png">

List View's selected branch:

<img width="329" alt="Screenshot 2021-03-15 at 16 57 51" src="https://user-images.githubusercontent.com/2070010/111191546-16e86780-85b0-11eb-88c8-39ca2b969a4f.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
