### PR TITLE
Multi entity save panel - remove dynamic copy.

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -7,7 +7,7 @@ import { some, groupBy } from 'lodash';
  * WordPress dependencies
  */
 import { Button, withFocusReturn } from '@wordpress/components';
-import { __, sprintf, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { close as closeIcon } from '@wordpress/icons';
@@ -16,36 +16,6 @@ import { close as closeIcon } from '@wordpress/icons';
  * Internal dependencies
  */
 import EntityTypeList from './entity-type-list';
-
-const ENTITY_NAMES = {
-	wp_template_part: ( number ) =>
-		_n( 'template part', 'template parts', number ),
-	wp_template: ( number ) => _n( 'template', 'templates', number ),
-	post: ( number ) => _n( 'post', 'posts', number ),
-	page: ( number ) => _n( 'page', 'pages', number ),
-	site: ( number ) => _n( 'site', 'sites', number ),
-};
-
-const PLACEHOLDER_PHRASES = {
-	// 0 is a back up, but should never be observed.
-	0: __( 'There are no changes.' ),
-	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	1: __( 'The following changes have been made to your %s.' ),
-	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	2: __( 'The following changes have been made to your %1$s and %2$s.' ),
-	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	3: __(
-		'The following changes have been made to your %1$s, %2$s, and %3$s.'
-	),
-	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	4: __(
-		'The following changes have been made to your %1$s, %2$s, %3$s, and %4$s.'
-	),
-	/* translators: placeholders represent pre-translated singular/plural entity names (page, post, template, site, etc.) */
-	5: __(
-		'The following changes have been made to your %1$s, %2$s, %3$s, %4$s, and %5$s.'
-	),
-};
 
 function EntitiesSavedStates( { isOpen, close } ) {
 	const { dirtyEntityRecords } = useSelect( ( select ) => {
@@ -61,23 +31,6 @@ function EntitiesSavedStates( { isOpen, close } ) {
 	const partitionedSavables = Object.values(
 		groupBy( dirtyEntityRecords, 'name' )
 	);
-
-	// Get labels for text-prompt phrase.
-	const entityNamesForPrompt = [];
-	partitionedSavables.forEach( ( list ) => {
-		if ( ENTITY_NAMES[ list[ 0 ].name ] ) {
-			entityNamesForPrompt.push(
-				ENTITY_NAMES[ list[ 0 ].name ]( list.length )
-			);
-		}
-	} );
-	// Get text-prompt phrase based on number of entity types changed.
-	const placeholderPhrase =
-		PLACEHOLDER_PHRASES[ entityNamesForPrompt.length ] ||
-		// Fallback for edge case that should not be observed (more than 5 entity types edited).
-		__( 'The following changes have been made to multiple entities.' );
-	// eslint-disable-next-line @wordpress/valid-sprintf
-	const promptPhrase = sprintf( placeholderPhrase, ...entityNamesForPrompt );
 
 	// Unchecked entities to be ignored by save function.
 	const [ unselectedEntities, _setUnselectedEntities ] = useState( [] );
@@ -148,7 +101,7 @@ function EntitiesSavedStates( { isOpen, close } ) {
 
 			<div className="entities-saved-states__text-prompt">
 				<strong>{ __( 'Are you ready to save?' ) }</strong>
-				<p>{ promptPhrase }</p>
+				<p>{ __( 'The following changes have been made:' ) }</p>
 			</div>
 
 			{ partitionedSavables.map( ( list ) => {

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -100,10 +100,10 @@ function EntitiesSavedStates( { isOpen, close } ) {
 			</div>
 
 			<div className="entities-saved-states__text-prompt">
-				<strong>{ __( 'Are you ready to save?' ) }</strong>
+				<strong>{ __( 'Select the changes you want to save' ) }</strong>
 				<p>
 					{ __(
-						'Select the following changes you want to save. Some changes may affect other areas of your site.'
+						'Some changes may affect other areas of your site.'
 					) }
 				</p>
 			</div>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -101,7 +101,9 @@ function EntitiesSavedStates( { isOpen, close } ) {
 
 			<div className="entities-saved-states__text-prompt">
 				<strong>{ __( 'Are you ready to save?' ) }</strong>
-				<p>{ __( 'The following changes have been made:' ) }</p>
+				<p>
+					{ __( 'Review and select the following changes to save:' ) }
+				</p>
 			</div>
 
 			{ partitionedSavables.map( ( list ) => {

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -102,7 +102,9 @@ function EntitiesSavedStates( { isOpen, close } ) {
 			<div className="entities-saved-states__text-prompt">
 				<strong>{ __( 'Are you ready to save?' ) }</strong>
 				<p>
-					{ __( 'Review and select the following changes to save:' ) }
+					{ __(
+						'Select the following changes you want to save. Some changes may affect other areas of your site.'
+					) }
 				</p>
 			</div>
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
For reasons listed in https://github.com/WordPress/gutenberg/issues/29635 - this dynamic copy is problematic for i18n and no longer necessary given the new state of the save panel.  Therefore, here we are moving the dynamic copy:

![Screen Shot 2021-03-08 at 10 38 42 AM](https://user-images.githubusercontent.com/28742426/110360240-78d32b00-800c-11eb-812e-3610bcf9ca16.png)

and replacing it with

![Screen Shot 2021-03-09 at 2 23 29 PM](https://user-images.githubusercontent.com/28742426/110525865-1dc03780-80e3-11eb-84c7-fe6460184bd2.png)

Discussion on the copy to use is happening in the issue noted above.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Test the multi entity save panel in the site editor by making changes to one and/or various entities.
verify the new copy shows up and save flow works as expected.

Test this in the post editor as well by adding another entity to the post such as a template part.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
