### PR TITLE
Workflows: Add PHP Problem Matchers.

### DIFF
--- a/.github/matchers/phpcs.json
+++ b/.github/matchers/phpcs.json
@@ -1,0 +1,23 @@
+{
+    "problemMatcher": [
+      {
+        "owner": "phpcs",
+        "severity": "error",
+        "pattern": [
+          {
+            "regexp": "^<file name=\"(?:\\/github\\/workspace\\/)?(.*)\">$",
+            "file": 1
+          },
+          {
+            "regexp": "<error line=\"(\\d*)\" column=\"(\\d*)\" severity=\"(error|warning)\" message=\"(.*)\" source=\"(.*)(\"\\/>+)$",
+            "line": 1,
+            "column": 2,
+            "severity": 3,
+            "message": 4,
+            "code": 5,
+            "loop": true
+          }
+        ]
+      }
+    ]
+  }

--- a/.github/matchers/phpunit.json
+++ b/.github/matchers/phpunit.json
@@ -1,0 +1,24 @@
+{
+	"problemMatcher": [
+		{
+			"owner": "phpunit",
+			"pattern": [
+				{
+					"regexp": "^\\d+\\)\\s.*$"
+				},
+				{
+					"regexp": "^(.*Failed\\sasserting\\sthat.*)$",
+					"message": 1
+				},
+				{
+					"regexp": "^\\s*$"
+				},
+				{
+					"regexp": "^(.*):(\\d+)$",
+					"file": 1,
+					"line": 2
+				}
+			]
+		}
+	]
+}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -84,11 +84,11 @@ jobs:
               run: echo "::add-matcher::.github/matchers/phpunit.json"
 
             - name: Running single site unit tests
-              run: npm run test-unit-php
+              run: npm run test-unit-php -- --teamcity
               if: ${{ success() || failure() }}
 
             - name: Running multisite unit tests
-              run: npm run test-unit-php-multisite
+              run: npm run test-unit-php-multisite -- --teamcity
               if: ${{ success() || failure() }}
 
     mobile-unit-js:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -74,8 +74,14 @@ jobs:
               run: |
                   npm run wp-env start
 
+            - name: Set up problem matcher for PHPCS (lint check)
+              run: echo "::add-matcher::.github/matchers/phpcs.json"
+
             - name: Running lint check
               run: npm run lint-php
+
+            - name: Set up problem matcher for phpunit (unit tests)
+              run: echo "::add-matcher::.github/matchers/phpunit.json"
 
             - name: Running single site unit tests
               run: npm run test-unit-php

--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -112,7 +112,7 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals( 'My new global styles title', $data['title']['raw'] );
+		$this->assertEquals( 'blergh', $data['title']['raw'] );
 	}
 
 	public function test_delete_item() {


### PR DESCRIPTION
## Description
Add [problem matchers](https://github.com/actions/toolkit/blob/1cc56db0ff126f4d65aeb83798852e02a2c180c3/docs/problem-matchers.md) for phpunit, and PHPCS.

The phpunit config file is [copied](https://github.com/shivammathur/setup-php/blob/0ce7328fd7ef2e70f616a6367689a818f35dec78/src/configs/phpunit.json) from https://github.com/shivammathur/setup-php, which is MIT licensed.

The PHPCS config file is [copied](https://github.com/chekalsky/phpcs-action/blob/e269c2f264f400adcda7c6b24c8550302350d495/problem-matcher.json) over from https://github.com/chekalsky/phpcs-action, which is MIT licensed.

We'll probably need to add a proper copyright/licences notices.

This will cause GitHub to annotate the lines that cause phpunit and PHPCS lint errors in the diff.

## TODO

- [ ] Fix the the PHPCS problem matcher. It expects Checkstyle report format, whereas we're using "full" report format. See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting.

## How has this been tested?
TBD

## Screenshots <!-- if applicable -->

## Types of changes
Tooling