### PR TITLE
Components: Use react-i18n in a couple places to prove it works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12431,6 +12431,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/primitives": "file:packages/primitives",
+				"@wordpress/react-i18n": "file:packages/react-i18n",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/warning": "file:packages/warning",
 				"@wp-g2/components": "^0.0.159",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/primitives": "file:../primitives",
+		"@wordpress/react-i18n": "file:../react-i18n",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/warning": "file:../warning",
 		"@wp-g2/components": "^0.0.159",

--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -9,7 +9,6 @@ import 'react-dates/initialize';
  * WordPress dependencies
  */
 import { useState, forwardRef } from '@wordpress/element';
-// import { __, _x } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 
 /**

--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -9,7 +9,8 @@ import 'react-dates/initialize';
  * WordPress dependencies
  */
 import { useState, forwardRef } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+// import { __, _x } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ function DateTimePicker(
 	},
 	ref
 ) {
+	const { __, _x } = useI18n();
 	const [ calendarHelpIsVisible, setCalendarHelpIsVisible ] = useState(
 		false
 	);

--- a/packages/components/src/ui/button-group/component.js
+++ b/packages/components/src/ui/button-group/component.js
@@ -14,7 +14,7 @@ import { RadioGroup, useRadioState } from 'reakit';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -29,6 +29,7 @@ import * as styles from './styles';
  * @param {import('react').Ref<any>} forwardedRef
  */
 function ButtonGroup( props, forwardedRef ) {
+	const { __ } = useI18n();
 	const {
 		baseId,
 		className,

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -4,7 +4,7 @@
 const glob = require( 'glob' ).sync;
 
 // Finds all packages which are transpiled with Babel to force Jest to use their source code.
-const transpiledPackageNames = glob( 'packages/*/src/index.js' ).map(
+const transpiledPackageNames = glob( 'packages/*/src/index.{js,ts,tsx}' ).map(
 	( fileName ) => fileName.split( '/' )[ 1 ]
 );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This just uses `react-i18n` in a couple places in `@wordpress/components` to prove that it works. Because we had a mysterious issue in #29230 with it, I wanted to make sure that the issue was just a fluke and that the package is actually consumable.

As an aside, I think we should just remove the default for `label` in ButtonGroup. It's not a good default, it should just be a required prop.

## How has this been tested?
Storybook. Go to the date-time picker story and click the "Show calendar help" button to see the translated text. Additionally go to the G2 ButtonGroup story and verify that the correct aria-label appears.

## Types of changes
Non-breaking change. `i18n` can be replaced for `react-i18n` in most cases.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
