### PR TITLE
Social Icon: Fix Yelp icon no bg color

### DIFF
--- a/packages/block-library/src/social-link/socials-without-bg.scss
+++ b/packages/block-library/src/social-link/socials-without-bg.scss
@@ -148,8 +148,7 @@
 }
 
 .wp-social-link-yelp {
-	background-color: #d32422;
-	color: #fff;
+	color: #d32422;
 }
 
 .wp-social-link-youtube {


### PR DESCRIPTION
## Description

Fixes #29456.
This PR fixes the background color of the Yelp social icon when the "logos only" is set.

## How has this been tested?

I've manually tested on my local development environment.
Also run unit tests and code linting without issues.

## Screenshots

<img width="1238" alt="Screenshot 2021-03-10 at 4 10 12 AM" src="https://user-images.githubusercontent.com/4146200/110565152-ae842b00-8156-11eb-999e-e19e6ac5a6f6.png">

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
