### PR TITLE
[RNMobile] Partial fix splitting & merging Paragraph/Heading issue in ReactAztec Android

### DIFF
--- a/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -76,6 +76,7 @@ public class ReactAztecText extends AztecText {
     boolean shouldHandleActiveFormatsChange = false;
 
     boolean shouldDeleteEnter = false;
+    boolean ignoreSelectionChangesAfterEnter = false;
 
     // This optional variable holds the outer HTML tag that will be added to the text when the user start typing in it
     // This is required to keep placeholder text working, and start typing with styled text.
@@ -355,6 +356,12 @@ public class ReactAztecText extends AztecText {
         if (!shouldHandleOnSelectionChange) {
             return;
         }
+
+        if (ignoreSelectionChangesAfterEnter) {
+            ignoreSelectionChangesAfterEnter = false;
+            return;
+        }
+
         String content = toHtml(getText(), false);
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
@@ -426,6 +433,7 @@ public class ReactAztecText extends AztecText {
 
     private boolean onEnter(Spannable text, boolean firedAfterTextChanged, int selStart, int selEnd) {
         disableTextChangedListener();
+        ignoreSelectionChangesAfterEnter = true;
         String content = toHtml(text, false);
         int cursorPositionStart = firedAfterTextChanged ? selStart : getSelectionStart();
         int cursorPositionEnd = firedAfterTextChanged ? selEnd : getSelectionEnd();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

Fixes https://github.com/WordPress/gutenberg/issues/29478
Gutenberg Mobile https://github.com/wordpress-mobile/gutenberg-mobile/pull/3233
## Description
<!-- Please describe what you have changed or added -->
This solution resolves a bug with the splitting/merging behavior of the Paragraph/Heading block. 

There are currently two mechanisms for processing enter events within the `ReactAztecText` component. 

1. The `KeyListener` is utilized to listen to key presses that are triggered from a physical keyboard.  - The editor behaves as expected.
2. The `EnterPressedWatcher` that observes text changes that occur as a result of the soft keyboard. - The editor does not behave as expected.

Currently, within the editor, once the user moves the cursor within the content a selection change event is triggered as the `selectionStart` and `selectionEnd` properties are modified and the content changes are processed as a result. 

### The Problem 
There are several events are created when the editor notifies listeners of`onEnter`, `onBackspace`, `onPaste` etc. actions.  
In the case of this bug, the editor has created two events instead of one. First the `onEnter` event is triggered and then the `propagateSelectionChanges`. I think then when the `propagateSelectionChanges` event is triggered, it is overwriting the content that was appropriately processed by the `onEnter` event, thus putting the `RichText` component in an inconsistent state. 

### The Partial Solution
The solution I came up with, was to dedicate a flag specifically to toggling the `propagateSelectionChanges` during the execution of the `onEnter` function. I could have utilized the `shouldHandleOnSelectionChange` but I decided not to as I wanted to use a flag that would be specific to the issue in case it can be refactored later.

During testing, I sometimes end up with the bug. I think it's as a result of a selection change bypassing the flag. This will require more investigation. I might try disabling the listener depending on if text watchers are processed before selection change events.

## How has this been tested?

1. Open the mobile editor
2. Write (or paste) a paragraph with a few lines
3. Set the caret by the half of the paragraph
4. Press Enter to split the block into two. (if using the emulator, use the device keyboard)
5. Move the caret to the front of the words in the second block.
6. Press the backspace until the blocks merge.
7. Notice that the merger took place without content duplication.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/1509205/110433684-c8523f00-807e-11eb-9457-f1f66128dfbc.mp4



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
