### PR TITLE
Fix social icons vertical spacing issue

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -20,7 +20,7 @@
 	.wp-social-link {
 		// This needs specificity to override some themes.
 		&.wp-social-link.wp-social-link {
-			margin: auto 8px auto 0;
+			margin: 4px 8px 4px 0;
 		}
 
 		// By setting the font size, we can scale icons and paddings consistently based on that.


### PR DESCRIPTION
## Description
Fixes #29656.

This PR reverts the change introduced by https://github.com/WordPress/gutenberg/pull/28448.

## How has this been tested?
1. With Twenty Twenty One theme activated, in a post, add the social icons block
2. Add enough social icons so that they wrap on a second line
3. Social icons should have a 4px vertical spacing


## Screenshots

Before:

![social-icons-before](https://user-images.githubusercontent.com/33403964/110440134-9fe73680-80b8-11eb-8222-a65d98fb4002.png)

After:

![social-icons-after](https://user-images.githubusercontent.com/33403964/110440150-a5dd1780-80b8-11eb-8fd5-19ce6f9b9dc8.png)


## Types of changes
CSS change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [NA] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [NA] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [NA] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [NA] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
