### PR TITLE
Try: more accessible labels.

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -19,7 +19,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 
 	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label      = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
+	$label      = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service ) . ": " . $url;
 	$class_name = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -19,7 +19,12 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 
 	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label      = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service ) . ": " . $url;
+	$label      = ( isset( $attributes['label'] ) ) ? $attributes['label'] : sprintf(
+		/* translators: %1$s: Social-network name. %2$s: URL. */
+		__( '%1$s: %2$s', 'gutenberg' ),
+		block_core_social_link_get_name( $service ),
+		$url
+	);
 	$class_name = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.


### PR DESCRIPTION
## Description

Fixes #21840.

This PR adds the URL as an additional aria label suffix to social links. 

<img width="1270" alt="Screenshot 2021-03-09 at 10 20 48" src="https://user-images.githubusercontent.com/1204802/110448050-20aa3080-80c1-11eb-8cd3-f8a565bda8d1.png">
<img width="753" alt="Screenshot 2021-03-09 at 10 20 17" src="https://user-images.githubusercontent.com/1204802/110448054-2142c700-80c1-11eb-9619-6feb496ea370.png">

This is a small improvement to the aria label for social links. Users can still add a more verbose label in the interface:

<img width="1270" alt="Screenshot 2021-03-09 at 10 21 24" src="https://user-images.githubusercontent.com/1204802/110448237-4a635780-80c1-11eb-900a-c26d80f0af7d.png">

<img width="753" alt="Screenshot 2021-03-09 at 10 20 17" src="https://user-images.githubusercontent.com/1204802/110448247-4cc5b180-80c1-11eb-8f10-c8c1f45a881d.png">


## How has this been tested?

- Insert social links.
- Add a few links.
- Inspect the rendered markup and observe more legible aria labels, such as "Mail: example@example.com" instead of "Mail", and "WordPress: https://wordpress.org/myprofile" instead of just "WordPress".

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
