### PR TITLE
Color-palette: Match color value and color variable from palette

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -22,7 +22,10 @@ import { sprintf, __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getColorObjectByAttributeValues, getColorObjectByColorValue } from '../colors';
+import {
+	getColorObjectByAttributeValues,
+	getColorObjectByColorValue,
+} from '../colors';
 import { __experimentalGetGradientObjectByGradientValue } from '../gradients';
 import useEditorFeature from '../use-editor-feature';
 
@@ -51,17 +54,21 @@ function VisualLabel( {
 	if ( currentTab === 'color' ) {
 		if ( colorValue ) {
 			value = colorValue;
-			if (colorValue?.includes('var(')) {
+			if ( colorValue?.includes( 'var(' ) ) {
 				const regexSlug = /--(?!.*--)(.*)\)/;
-				const match = colorValue.match(regexSlug);
-				slug = match[1];
-				colorObject = getColorObjectByAttributeValues( colors, slug, value);
+				const match = colorValue.match( regexSlug );
+				slug = match[ 1 ];
+				colorObject = getColorObjectByAttributeValues(
+					colors,
+					slug,
+					value
+				);
 			} else {
 				colorObject = getColorObjectByColorValue( colors, value );
 			}
 			const colorName = colorObject && colorObject.name;
 			tooltip = colorObject?.color || value;
-			ariaLabel = sprintf( colorIndicatorAriaLabel, tooltip );
+			ariaLabel = sprintf( colorIndicatorAriaLabel, colorName );
 		}
 	} else if ( currentTab === 'gradient' && gradientValue ) {
 		value = gradientValue;
@@ -81,7 +88,10 @@ function VisualLabel( {
 			{ label }
 			{ !! value && (
 				<Tooltip text={ tooltip }>
-					<ColorIndicator colorValue={ value } aria-label={ ariaLabel } />
+					<ColorIndicator
+						colorValue={ value }
+						aria-label={ ariaLabel }
+					/>
 				</Tooltip>
 			) }
 		</>

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -25,13 +25,27 @@ export default function ColorPalette( {
 	value,
 } ) {
 	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
+	function get(slug) {
+		return 'var(--wp--preset--color--' + slug + ')';
+	}
+	function match(value, color, slug) {
+		if (value?.includes('var(')) {
+			const regexSlug = /--(?!.*--)(.*)\)/;
+			const match = value.match(regexSlug);
+			value = match[1] || value;
+		}
+		if (value === color || value === slug) {
+			return true;
+		}
+		return false;
+	}
 	const colorOptions = useMemo( () => {
-		return map( colors, ( { color, name } ) => (
+		return map( colors, ( { color, name, slug } ) => (
 			<CircularOptionPicker.Option
 				key={ color }
-				isSelected={ value === color }
+				isSelected={ match(value, color, slug) }
 				selectedIconProps={
-					value === color
+					match(value, color, slug)
 						? {
 								fill: tinycolor
 									.mostReadable( color, [ '#000', '#fff' ] )
@@ -46,7 +60,7 @@ export default function ColorPalette( {
 				}
 				style={ { backgroundColor: color, color } }
 				onClick={
-					value === color ? clearColor : () => onChange( color )
+					match(value, color, slug) ? clearColor : () => onChange( get(slug) )
 				}
 				aria-label={
 					name

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -25,16 +25,16 @@ export default function ColorPalette( {
 	value,
 } ) {
 	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
-	function get(slug) {
+	function get( slug ) {
 		return 'var(--wp--preset--color--' + slug + ')';
 	}
-	function match(value, color, slug) {
-		if (value?.includes('var(')) {
+	function match( val, color, slug ) {
+		if ( val?.includes( 'var(' ) ) {
 			const regexSlug = /--(?!.*--)(.*)\)/;
-			const match = value.match(regexSlug);
-			value = match[1] || value;
+			const matches = val.match( regexSlug );
+			val = matches[ 1 ] || val;
 		}
-		if (value === color || value === slug) {
+		if ( val === color || val === slug ) {
 			return true;
 		}
 		return false;
@@ -43,9 +43,9 @@ export default function ColorPalette( {
 		return map( colors, ( { color, name, slug } ) => (
 			<CircularOptionPicker.Option
 				key={ color }
-				isSelected={ match(value, color, slug) }
+				isSelected={ match( value, color, slug ) }
 				selectedIconProps={
-					match(value, color, slug)
+					match( value, color, slug )
 						? {
 								fill: tinycolor
 									.mostReadable( color, [ '#000', '#fff' ] )
@@ -60,7 +60,9 @@ export default function ColorPalette( {
 				}
 				style={ { backgroundColor: color, color } }
 				onClick={
-					match(value, color, slug) ? clearColor : () => onChange( get(slug) )
+					match( value, color, slug )
+						? clearColor
+						: () => onChange( get( slug ) )
 				}
 				aria-label={
 					name

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -16,7 +16,12 @@ import ColorPalette from '../';
 export default { title: 'Components/ColorPalette', component: ColorPalette };
 
 const ColorPaletteWithState = ( props ) => {
-	const [ color, setColor ] = useState( '#F00' );
+	const [ color, setColor ] = useState( '#f00' );
+	return <ColorPalette { ...props } value={ color } onChange={ setColor } />;
+};
+
+const ColorPaletteWithVariableState = ( props ) => {
+	const [ color, setColor ] = useState( 'white' );
 	return <ColorPalette { ...props } value={ color } onChange={ setColor } />;
 };
 
@@ -28,6 +33,16 @@ export const _default = () => {
 	];
 
 	return <ColorPaletteWithState colors={ colors } />;
+};
+
+export const withVariable = () => {
+	const colors = [
+		{ name: 'red', slug: 'red', color: '#f00' },
+		{ name: 'white', slug: 'white', color: '#fff' },
+		{ name: 'blue', slug: 'blue', color: '#00f' },
+	];
+
+	return <ColorPaletteWithVariableState colors={ colors } />;
 };
 
 export const withKnobs = () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
The color-palette component could only handle real color values like hex, rgba and hsla. I enhanced the component by handling also color variable definitions like `background-color : var(--wp--preset--color--{slug})`.
Now you can define the color value where the component is used as an variable reference and the palette matches it from the given colors inside. I added also an story for this to test it with an given color slug.

## How has this been tested?
I tested it with the storybook. I am going to test it with an fse-theme, but there is no difference from the given values.

## Screenshots
Not available

## Types of changes
New feature: hex, rgba and hsla values are still functional, additionally you can type the color variable into the value.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [ ] I've tested my changes with keyboard and screen readers.
- [ ] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR.
