### PR TITLE
docgen: Incrementally add types

### DIFF
--- a/packages/docgen/lib/get-leading-comments.js
+++ b/packages/docgen/lib/get-leading-comments.js
@@ -7,14 +7,17 @@ const { last } = require( 'lodash' );
  * Function that returns the leading comment
  * of a Espree node.
  *
- * @param {Object} declaration Espree node to inspect
+ * @param {import('@babel/core').Node} declaration Espree node to inspect
  *
- * @return {?string} Leading comment or undefined if there is none.
+ * @return {string | undefined} Leading comment or undefined if there is none.
  */
 module.exports = ( declaration ) => {
 	let comments;
 	if ( declaration.leadingComments ) {
-		comments = last( declaration.leadingComments ).value;
+		const lastComment = last( declaration.leadingComments );
+		if ( lastComment ) {
+			comments = lastComment.value;
+		}
 	}
 	return comments;
 };

--- a/packages/docgen/tsconfig.json
+++ b/packages/docgen/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "lib",
+		"declarationDir": "build-types"
+	},
+	"include": [ "lib/get-leading-comments.js" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		{ "path": "packages/block-editor" },
 		{ "path": "packages/components" },
 		{ "path": "packages/deprecated" },
+		{ "path": "packages/docgen" },
 		{ "path": "packages/dom" },
 		{ "path": "packages/element" },
 		{ "path": "packages/dom-ready" },


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Begins the process of adding types to the `docgen` package by adding/fixing types for a single module `get-leading-comments.js`. 

Part of #18838 

## How has this been tested?
Type check passes, docgen output has not changed.

## Types of changes
Non-breaking changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
