### PR TITLE
Navigation: nav created drafts should not render on frontend

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -289,9 +289,10 @@ export default function NavigationLinkEdit( {
 
 		return {
 			id: page.id,
-			postType,
+			type: postType,
 			title: page.title.rendered,
 			url: page.link,
+			kind: 'post-type',
 		};
 	}
 
@@ -513,6 +514,8 @@ export default function NavigationLinkEdit( {
 									url: newURL = '',
 									opensInNewTab: newOpensInNewTab,
 									id,
+									kind: newKind = '',
+									type: newType = '',
 								} = {} ) =>
 									setAttributes( {
 										url: encodeURI( newURL ),
@@ -540,6 +543,14 @@ export default function NavigationLinkEdit( {
 										} )(),
 										opensInNewTab: newOpensInNewTab,
 										id,
+										...( newKind && {
+											kind: newKind,
+										} ),
+										...( newType &&
+											newType !== 'URL' &&
+											newType !== 'post-format' && {
+												type: newType,
+											} ),
 									} )
 								}
 							/>

--- a/packages/block-library/src/navigation-link/fallback-variations.js
+++ b/packages/block-library/src/navigation-link/fallback-variations.js
@@ -26,28 +26,28 @@ const fallbackVariations = [
 		icon: postIcon,
 		title: __( 'Post Link' ),
 		description: __( 'A link to a post.' ),
-		attributes: { type: 'post' },
+		attributes: { type: 'post', kind: 'post-type' },
 	},
 	{
 		name: 'page',
 		icon: pageIcon,
 		title: __( 'Page Link' ),
 		description: __( 'A link to a page.' ),
-		attributes: { type: 'page' },
+		attributes: { type: 'page', kind: 'post-type' },
 	},
 	{
 		name: 'category',
 		icon: categoryIcon,
 		title: __( 'Category Link' ),
 		description: __( 'A link to a category.' ),
-		attributes: { type: 'category' },
+		attributes: { type: 'category', kind: 'taxonomy' },
 	},
 	{
 		name: 'tag',
 		icon: tagIcon,
 		title: __( 'Tag Link' ),
 		description: __( 'A link to a tag.' ),
-		attributes: { type: 'tag' },
+		attributes: { type: 'tag', kind: 'taxonomy' },
 	},
 ];
 

--- a/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
+++ b/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
@@ -17,6 +17,7 @@ Object {
     },
     Object {
       "attributes": Object {
+        "kind": "post-type",
         "type": "post",
       },
       "description": "A link to a post.",
@@ -34,6 +35,7 @@ Object {
     },
     Object {
       "attributes": Object {
+        "kind": "post-type",
         "type": "page",
       },
       "description": "A link to a page.",
@@ -51,6 +53,7 @@ Object {
     },
     Object {
       "attributes": Object {
+        "kind": "taxonomy",
         "type": "category",
       },
       "description": "A link to a category.",
@@ -70,6 +73,7 @@ Object {
     },
     Object {
       "attributes": Object {
+        "kind": "taxonomy",
         "type": "tag",
       },
       "description": "A link to a tag.",

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -13,6 +13,12 @@ import { __ } from '@wordpress/i18n';
  */
 
 /**
+ * A link with an id may be of kind post-type or taxonomy
+ *
+ * @typedef { 'post-type' | 'taxonomy' } WPKind
+ */
+
+/**
  * @typedef WPLinkSearchOptions
  *
  * @property {boolean}             [isInitialSuggestions] Displays initial search suggestions, when true.
@@ -29,6 +35,7 @@ import { __ } from '@wordpress/i18n';
  * @property {string} url    Link url.
  * @property {string} title  Title of the link.
  * @property {string} type   The taxonomy or post type slug or type URL.
+ * @property {WPKind} [kind] Link kind of post-type or taxonomy
  */
 
 /**
@@ -87,7 +94,16 @@ const fetchLinkSuggestions = async (
 					type: 'post',
 					subtype,
 				} ),
-			} ).catch( () => [] ) // fail by returning no results
+			} )
+				.then( ( results ) => {
+					return results.map( ( result ) => {
+						return {
+							...result,
+							meta: { kind: 'post-type', subtype },
+						};
+					} );
+				} )
+				.catch( () => [] ) // fail by returning no results
 		);
 	}
 
@@ -101,7 +117,16 @@ const fetchLinkSuggestions = async (
 					type: 'term',
 					subtype,
 				} ),
-			} ).catch( () => [] )
+			} )
+				.then( ( results ) => {
+					return results.map( ( result ) => {
+						return {
+							...result,
+							meta: { kind: 'taxonomy', subtype },
+						};
+					} );
+				} )
+				.catch( () => [] )
 		);
 	}
 
@@ -146,6 +171,7 @@ const fetchLinkSuggestions = async (
 							decodeEntities( result.title || '' ) ||
 							__( '(no title)' ),
 						type: result.subtype || result.type,
+						kind: result?.meta?.kind,
 					};
 				}
 			);

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -93,6 +93,7 @@ describe( 'fetchLinkSuggestions', () => {
 					title: 'Contact Page',
 					type: 'page',
 					url: 'http://wordpress.local/contact-page/',
+					kind: 'post-type',
 				},
 			] )
 		);
@@ -108,12 +109,14 @@ describe( 'fetchLinkSuggestions', () => {
 					title: 'Cats',
 					url: 'http://wordpress.local/category/cats/',
 					type: 'category',
+					kind: 'taxonomy',
 				},
 				{
 					id: 1,
 					title: 'Uncategorized',
 					url: 'http://wordpress.local/category/uncategorized/',
 					type: 'category',
+					kind: 'taxonomy',
 				},
 			] )
 		);
@@ -155,18 +158,21 @@ describe( 'fetchLinkSuggestions', () => {
 					title: 'Contact Page',
 					url: 'http://wordpress.local/contact-page/',
 					type: 'page',
+					kind: 'post-type',
 				},
 				{
 					id: 9,
 					title: 'Cats',
 					url: 'http://wordpress.local/category/cats/',
 					type: 'category',
+					kind: 'taxonomy',
 				},
 				{
 					id: 1,
 					title: 'Uncategorized',
 					url: 'http://wordpress.local/category/uncategorized/',
 					type: 'category',
+					kind: 'taxonomy',
 				},
 				{
 					id: 'gallery',
@@ -195,6 +201,7 @@ describe( 'fetchLinkSuggestions', () => {
 					title: 'Limit Case',
 					url: 'http://wordpress.local/limit-case/',
 					type: 'page',
+					kind: 'post-type',
 				},
 			] )
 		);
@@ -211,6 +218,7 @@ describe( 'fetchLinkSuggestions', () => {
 					title: 'Page Case',
 					url: 'http://wordpress.local/page-case/',
 					type: 'page',
+					kind: 'post-type',
 				},
 			] )
 		);

--- a/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
@@ -48,12 +48,12 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"id\\":\\"https://wordpress.org\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\",\\"kind\\":\\"post-type\\"} /-->
 <!-- /wp:navigation -->"
 `;
 
 exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\",\\"kind\\":\\"post-type\\"} /-->
 <!-- /wp:navigation -->"
 `;


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/29691

### Problem

Some drafts will render on the published page/post frontend. This happens in two ways:

1. Creating draft pages when searching for things to link to. Like so:

https://user-images.githubusercontent.com/1270189/110677113-a1346400-8189-11eb-8bb9-619d65afddc6.mp4

2. Adding a link using the general "link" variation

https://user-images.githubusercontent.com/1270189/110677384-f83a3900-8189-11eb-8821-e7fad5d19478.mp4

#### Why Does This Happen?

In trunk when we link from the general "link" variation this is missing the "type" attribute. Without this information, we can't blindly check to see if an id is a draft. It might actually be a term-id, leading to a bug like: https://github.com/WordPress/gutenberg/issues/28712

### Proposed changes:

Changes in this PR add the `type` block attributes to the link consistently regardless of what link variation we use to create the link. This will **fix newly added links but not existing links**. (The worst case is that we have an old link to a draft that still renders on the front end).

In order to support future custom post types and taxonomies, we should also return the `kind` (taxonomy|post-type) to make this more clear. Type is not enough information to differentiate if we can check for draft status besides our built-in types (post,page,post_tag,category).

Example custom PortfolioTag Search Result:
<img width="502" alt="Screen Shot 2021-03-10 at 10 28 38 AM" src="https://user-images.githubusercontent.com/1270189/110678840-97136500-818b-11eb-8533-82f2613cf888.png">


Before:
```
<!-- wp:navigation-link {"label":"PortfolioTag2","id":5,"url":"http://wordpress.local/portfolio_tag/portfoliotag2/"} /-->
```

After:
```
<!-- wp:navigation-link {"label":"PortfolioTag2","type":"portfolio_tag","id":5,"url":"http://wordpress.local/portfolio_tag/portfoliotag2/","kind":"taxonomy"} /-->
```

### Testing Instructions w/ WP 5.7
- Install a plugin with custom taxonomies and post types. Create new CPTs and terms.
- Navigate to the post editor
- Add a navigation block
- Add an element using the general link variation
- Search for a (post|page|category|tag)
- Look at code editor

<img width="339" alt="Screen Shot 2021-03-10 at 10 34 26 AM" src="https://user-images.githubusercontent.com/1270189/110679361-3f292e00-818c-11eb-97b7-585f2505a7ca.png">

- Verify that in the block editor that the `kind` and `type` attributes are present and make sense.

<img width="842" alt="Screen Shot 2021-03-10 at 10 36 55 AM" src="https://user-images.githubusercontent.com/1270189/110679687-9a5b2080-818c-11eb-80cf-24890c839fdc.png">

- If it's a draft, verify that the link is visible only in the editor, but not on the published page of the navigation links.

- Verify that links like `www.wordpress.org` do not contain the `id` `type` or `kind` block attributes.

### Testing Instructions w/ WP latest (Custom Link Variations)
- Install a plugin with custom taxonomies and post types. Create new CPTs and terms.
- (Optional) You may also want to edit the plugin to add the new post-labels `item_link` and `item_link_description`

<img width="915" alt="Screen Shot 2021-03-10 at 10 45 46 AM" src="https://user-images.githubusercontent.com/1270189/110680723-d5aa1f00-818d-11eb-9741-fbca5b6f3081.png">

- Spin up wordpress-desktop and checkout trunk
- Verify that new link variations appear in inserter:

<img width="1012" alt="Screen Shot 2021-03-10 at 10 46 47 AM" src="https://user-images.githubusercontent.com/1270189/110680823-f3778400-818d-11eb-93c9-f3c13cf10c86.png">

- Add an element using the general link variation
- Search for a (post|page|category|tag)
- Look at code editor
- Verify that in the block editor that the `kind` and `type` attributes are present and make sense.
- Add an element using the custom link variations (post, page, category, your new post type/taxonomy)
- Look at code editor
- Verify that in the block editor that the `kind` and `type` attributes are present and make sense.
- Verify that links like `www.wordpress.org` do not contain the `id`, `type` or `kind` block attributes.

### Test Post-Format Links

A post format link looks like `http://wordpress.local/type/quote/`. This points at the archive of a post type format like quote or image.

<img width="539" alt="Screen Shot 2021-03-10 at 1 30 41 PM" src="https://user-images.githubusercontent.com/1270189/110701417-fe3e1300-81a5-11eb-9ef4-6cff35dd28ab.png">

To test:
- Install a theme that supports post-formats like Twenty Thirteen
- Create a post using one of the post-format types like "Quote"
- Add a navigation block
- Add a navigation link using the general link variation
- Search for the post-format and individual quote

- Verify that the individual link to a quote has type 'post' and kind 'post-type'.
- Verify that the link to the post-format only has `url` and `label`

<img width="1150" alt="Screen Shot 2021-03-10 at 1 35 28 PM" src="https://user-images.githubusercontent.com/1270189/110701717-60971380-81a6-11eb-8b5b-53f9257d513e.png">

### Behavior when loading links from a menu

- Drafts will render on frontend due to https://github.com/WordPress/gutenberg/issues/29793
- Let's fix this in a follow up

### TODO:
- [x] Copy any changes from `packages/editor/src/components/provider/use-block-editor-settings.js` to `packages/edit-navigation/src/index.js`. 
- [x] How to test post-formats?
- [x] Update tests/add new ones
- [x] Test links created in Navigation editor
- [x] Test loading menus