### PR TITLE
Components: Fix color source mode not being saved

### DIFF
--- a/packages/block-editor/src/components/color-palette/with-color-context.js
+++ b/packages/block-editor/src/components/color-palette/with-color-context.js
@@ -16,6 +16,7 @@ import useEditorFeature from '../use-editor-feature';
 export default createHigherOrderComponent( ( WrappedComponent ) => {
 	return ( props ) => {
 		const colorsFeature = useEditorFeature( 'color.palette' );
+		const colorPickerMode = useEditorFeature( 'color.pickerMode' );
 		const disableCustomColorsFeature = ! useEditorFeature( 'color.custom' );
 		const colors =
 			props.colors === undefined ? colorsFeature : props.colors;
@@ -29,6 +30,7 @@ export default createHigherOrderComponent( ( WrappedComponent ) => {
 				{ ...{
 					...props,
 					colors,
+					colorPickerMode,
 					disableCustomColors,
 					hasColorsToChoose,
 				} }

--- a/packages/block-editor/src/components/color-palette/with-color-context.js
+++ b/packages/block-editor/src/components/color-palette/with-color-context.js
@@ -7,16 +7,19 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-
+import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
 import useEditorFeature from '../use-editor-feature';
+import { store as blockEditorStore } from '../../store';
 
 export default createHigherOrderComponent( ( WrappedComponent ) => {
 	return ( props ) => {
 		const colorsFeature = useEditorFeature( 'color.palette' );
-		const colorPickerMode = useEditorFeature( 'color.pickerMode' );
+		const { colorPickerMode } = useSelect( ( select ) => {
+			return select( blockEditorStore ).getSettings();
+		} );
 		const disableCustomColorsFeature = ! useEditorFeature( 'color.custom' );
 		const colors =
 			props.colors === undefined ? colorsFeature : props.colors;

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -86,6 +86,8 @@ function ColorGradientControlInner( {
 	label,
 	onColorChange,
 	onGradientChange,
+	colorPickerMode,
+	onSourceChange,
 	colorValue,
 	gradientValue,
 	clearable,
@@ -151,7 +153,12 @@ function ColorGradientControlInner( {
 								  }
 								: onColorChange
 						}
-						{ ...{ colors, disableCustomColors } }
+						{ ...{
+							colors,
+							disableCustomColors,
+							onSourceChange,
+							colorPickerMode,
+						} }
 						clearable={ clearable }
 					/>
 				) }
@@ -166,7 +173,12 @@ function ColorGradientControlInner( {
 								  }
 								: onGradientChange
 						}
-						{ ...{ gradients, disableCustomGradients } }
+						{ ...{
+							gradients,
+							disableCustomGradients,
+							onSourceChange,
+							colorPickerMode,
+						} }
 						clearable={ clearable }
 					/>
 				) }

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -20,6 +20,7 @@ const deprecatedFlags = {
 		settings.colors === undefined ? undefined : settings.colors,
 	'color.gradients': ( settings ) =>
 		settings.gradients === undefined ? undefined : settings.gradients,
+	'color.pickerMode': ( settings ) => settings.colorPickerMode,
 	'color.custom': ( settings ) =>
 		settings.disableCustomColors === undefined
 			? undefined

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -20,7 +20,6 @@ const deprecatedFlags = {
 		settings.colors === undefined ? undefined : settings.colors,
 	'color.gradients': ( settings ) =>
 		settings.gradients === undefined ? undefined : settings.gradients,
-	'color.pickerMode': ( settings ) => settings.colorPickerMode,
 	'color.custom': ( settings ) =>
 		settings.disableCustomColors === undefined
 			? undefined

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -9,6 +9,7 @@ import { isObject } from 'lodash';
  */
 import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useRef, useEffect, Platform } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -26,6 +27,7 @@ import {
 	getGradientValueBySlug,
 	getGradientSlugByValue,
 } from '../components/gradients';
+import { store as blockEditorStore } from '../store';
 import { cleanEmptyObject } from './utils';
 import ColorPanel from './color-panel';
 import useEditorFeature from '../components/use-editor-feature';
@@ -212,12 +214,16 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
  *
  * @return {WPElement} Color edit element.
  */
+// TODO: PR Colorpicker: add onChangeSource
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
 	const isLinkColorEnabled = useEditorFeature( 'color.link' );
 	const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
 	const gradients = useEditorFeature( 'color.gradients' ) || EMPTY_ARRAY;
-
+	const { updateSettings } = useDispatch( blockEditorStore );
+	const { colorPickerMode } = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings();
+	} );
 	// Shouldn't be needed but right now the ColorGradientsPanel
 	// can trigger both onChangeColor and onChangeBackground
 	// synchronously causing our two callbacks to override changes
@@ -316,6 +322,10 @@ export function ColorEdit( props ) {
 		} );
 	};
 
+	const onChangeSource = ( value ) => {
+		updateSettings( { colorPickerMode: value } );
+	};
+
 	return (
 		<ColorPanel
 			enableContrastChecking={
@@ -329,6 +339,8 @@ export function ColorEdit( props ) {
 							{
 								label: __( 'Text Color' ),
 								onColorChange: onChangeColor( 'text' ),
+								onSourceChange: onChangeSource,
+								colorPickerMode,
 								colorValue: getColorObjectByAttributeValues(
 									colors,
 									textColor,
@@ -344,6 +356,8 @@ export function ColorEdit( props ) {
 								onColorChange: hasBackground
 									? onChangeColor( 'background' )
 									: undefined,
+								onSourceChange: onChangeSource,
+								colorPickerMode,
 								colorValue: getColorObjectByAttributeValues(
 									colors,
 									backgroundColor,
@@ -361,6 +375,8 @@ export function ColorEdit( props ) {
 							{
 								label: __( 'Link Color' ),
 								onColorChange: onChangeLinkColor,
+								onSourceChange: onChangeSource,
+								colorPickerMode,
 								colorValue: getLinkColorFromAttributeValue(
 									colors,
 									style?.color?.link

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -94,6 +94,7 @@ export const SETTINGS_DEFAULTS = {
 			color: '#9b51e0',
 		},
 	],
+	colorPickerMode: 'hex',
 	// fontSizes setting is not used anymore now defaults are passed from theme.json on the server and core has its own defaults.
 	// The setting is only kept for backward compatibility purposes.
 	fontSizes: [

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -21,6 +21,7 @@ export default function ColorPalette( {
 	className,
 	colors,
 	disableCustomColors = false,
+	colorPickerMode = 'hex',
 	onChange,
 	value,
 } ) {
@@ -61,7 +62,8 @@ export default function ColorPalette( {
 	const renderCustomColorPicker = () => (
 		<ColorPicker
 			color={ value }
-			onChangeComplete={ ( color ) => onChange( color.hex ) }
+			source={ colorPickerMode }
+			onChangeComplete={ ( { hex, source } ) => onChange( hex, source ) }
 			disableAlpha
 		/>
 	);

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -23,6 +23,7 @@ export default function ColorPalette( {
 	disableCustomColors = false,
 	colorPickerMode = 'hex',
 	onChange,
+	onSourceChange,
 	value,
 } ) {
 	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
@@ -63,7 +64,8 @@ export default function ColorPalette( {
 		<ColorPicker
 			color={ value }
 			source={ colorPickerMode }
-			onChangeComplete={ ( { hex, source } ) => onChange( hex, source ) }
+			onChangeComplete={ ( color ) => onChange( color.hex ) }
+			onSourceChangeComplete={ ( source ) => onSourceChange( source ) }
 			disableAlpha
 		/>
 	);

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -81,6 +81,7 @@ exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`]
           "r": 255,
         }
       }
+      source="hex"
     />
   </div>
 </div>

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -176,7 +176,7 @@ export default class ColorPicker extends Component {
 
 	handleInputChange( data ) {
 		this.setState( { source: data.source } );
-		switch ( data.action ) {
+		switch ( data.state ) {
 			case 'reset':
 				this.resetDraftValues();
 				break;

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -130,7 +130,6 @@ export default class ColorPicker extends Component {
 
 		if ( isValidColor( data ) ) {
 			const colors = colorToState( data, data.h || oldHue );
-			const { source } = this.state;
 			this.setState(
 				{
 					...colors,
@@ -138,18 +137,9 @@ export default class ColorPicker extends Component {
 					draftHsl: colors.hsl,
 					draftRgb: colors.rgb,
 				},
-				debounce(
-					partial( onChangeComplete, { ...colors, source } ),
-					100
-				)
+				debounce( partial( onChangeComplete, colors ), 100 )
 			);
 		}
-	}
-
-	componentWillUnmount() {
-		const { onChangeComplete = noop } = this.props;
-		const { source } = this.state;
-		onChangeComplete( { hex: this.state.hex, source } );
 	}
 
 	resetDraftValues() {
@@ -174,8 +164,14 @@ export default class ColorPicker extends Component {
 		}
 	}
 
+	commitSourceChange() {
+		const { onSourceChangeComplete = noop } = this.props;
+		const { source } = this.state;
+		onSourceChangeComplete( source );
+	}
+
 	handleInputChange( data ) {
-		this.setState( { source: data.source } );
+		this.setState( { source: data.source }, this.commitSourceChange );
 		switch ( data.state ) {
 			case 'reset':
 				this.resetDraftValues();

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -109,11 +109,12 @@ const dataToColors = ( oldColors, { source, valueKey, value } ) => {
 };
 
 export default class ColorPicker extends Component {
-	constructor( { color = '0071a1' } ) {
+	constructor( { color = '0071a1', source = 'hex' } ) {
 		super( ...arguments );
 		const colors = colorToState( color );
 		this.state = {
 			...colors,
+			source,
 			draftHex: toLowerCase( colors.hex ),
 			draftRgb: colors.rgb,
 			draftHsl: colors.hsl,
@@ -129,6 +130,7 @@ export default class ColorPicker extends Component {
 
 		if ( isValidColor( data ) ) {
 			const colors = colorToState( data, data.h || oldHue );
+			const { source } = this.state;
 			this.setState(
 				{
 					...colors,
@@ -136,9 +138,18 @@ export default class ColorPicker extends Component {
 					draftHsl: colors.hsl,
 					draftRgb: colors.rgb,
 				},
-				debounce( partial( onChangeComplete, colors ), 100 )
+				debounce(
+					partial( onChangeComplete, { ...colors, source } ),
+					100
+				)
 			);
 		}
+	}
+
+	componentWillUnmount() {
+		const { onChangeComplete = noop } = this.props;
+		const { source } = this.state;
+		onChangeComplete( { hex: this.state.hex, source } );
 	}
 
 	resetDraftValues() {
@@ -164,7 +175,8 @@ export default class ColorPicker extends Component {
 	}
 
 	handleInputChange( data ) {
-		switch ( data.state ) {
+		this.setState( { source: data.source } );
+		switch ( data.action ) {
 			case 'reset':
 				this.resetDraftValues();
 				break;
@@ -190,6 +202,7 @@ export default class ColorPicker extends Component {
 			draftHex,
 			draftHsl,
 			draftRgb,
+			source,
 		} = this.state;
 		const classes = classnames( className, {
 			'components-color-picker': true,
@@ -232,6 +245,7 @@ export default class ColorPicker extends Component {
 					</div>
 
 					<Inputs
+						source={ source }
 						rgb={ draftRgb }
 						hsl={ draftHsl }
 						hex={ draftHex }

--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -91,10 +91,10 @@ export class Input extends Component {
 const PureButton = pure( Button );
 
 export class Inputs extends Component {
-	constructor( { hsl } ) {
+	constructor( { source: view } ) {
 		super( ...arguments );
 
-		const view = hsl.a === 1 ? 'hex' : 'rgb';
+		//const view = hsl.a === 1 ? 'hex' : 'rgb';
 		this.state = { view };
 
 		this.toggleViews = this.toggleViews.bind( this );
@@ -134,7 +134,8 @@ export class Inputs extends Component {
 
 	resetDraftValues() {
 		return this.props.onChange( {
-			state: 'reset',
+			action: 'reset',
+			source: this.state.view,
 		} );
 	}
 

--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -134,7 +134,7 @@ export class Inputs extends Component {
 
 	resetDraftValues() {
 		return this.props.onChange( {
-			action: 'reset',
+			state: 'reset',
 			source: this.state.view,
 		} );
 	}

--- a/packages/components/src/color-picker/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-picker/test/__snapshots__/index.js.snap
@@ -488,6 +488,167 @@ Snapshot Diff:
         <div
 `;
 
+exports[`ColorPicker should commit color source mode changes when switching between views 1`] = `
+Snapshot Diff:
+- First value
++ Second value
+
+@@ -22,11 +22,11 @@
+          />
+          <div
+            className="components-color-picker__saturation-black"
+          />
+          <button
+-           aria-describedby="color-picker-saturation-12"
++           aria-describedby="color-picker-saturation-11"
+            aria-label="Choose a shade"
+            className="components-button components-color-picker__saturation-pointer"
+            onKeyDown={[Function preventKeyEvents]}
+            style={
+              Object {
+@@ -36,11 +36,11 @@
+            }
+            type="button"
+          />
+          <div
+            className="components-visually-hidden"
+-           id="color-picker-saturation-12"
++           id="color-picker-saturation-11"
+          >
+            Use your arrow keys to change the base color. Move up to lighten the color, down to darken, left to decrease saturation, and right to increase saturation.
+          </div>
+        </div>
+      </div>
+@@ -78,11 +78,11 @@
+                onMouseDown={[Function bound handleMouseDown]}
+                onTouchMove={[Function bound handleChange]}
+                onTouchStart={[Function bound handleChange]}
+              >
+                <div
+-                 aria-describedby="components-color-picker__hue-description-12"
++                 aria-describedby="components-color-picker__hue-description-11"
+                  aria-label="Hue value in degrees, from 0 to 359."
+                  aria-orientation="horizontal"
+                  aria-valuemax="1"
+                  aria-valuemin="359"
+                  aria-valuenow={0}
+@@ -96,11 +96,11 @@
+                  }
+                  tabIndex="0"
+                />
+                <p
+                  className="components-visually-hidden"
+-                 id="components-color-picker__hue-description-12"
++                 id="components-color-picker__hue-description-11"
+                >
+                  Move the arrow left or right to change hue.
+                </p>
+              </div>
+            </div>
+@@ -108,16 +108,10 @@
+        </div>
+      </div>
+      <div
+        className="components-color-picker__inputs-wrapper"
+      >
+-       <fieldset>
+-         <legend
+-           className="components-visually-hidden"
+-         >
+-           Color value in RGB
+-         </legend>
+        <div
+          className="components-color-picker__inputs-fields"
+        >
+          <div
+            className="components-base-control components-color-picker__inputs-field css-wdf2ti-Wrapper e1puf3u0"
+@@ -125,79 +119,26 @@
+            <div
+              className="components-base-control__field css-11vcxb9-StyledField e1puf3u1"
+            >
+              <label
+                className="components-base-control__label css-pezhm9-StyledLabel e1puf3u2"
+-                 htmlFor="inspector-text-control-13"
+-               >
+-                 r
+-               </label>
+-               <input
+-                 className="components-text-control__input"
+-                 id="inspector-text-control-13"
+-                 max="255"
+-                 min="0"
+-                 onBlur={[Function bound handleBlur]}
+-                 onChange={[Function onChangeValue]}
+-                 onKeyDown={[Function bound handleKeyDown]}
+-                 type="number"
+-                 value={255}
+-               />
+-             </div>
+-           </div>
+-           <div
+-             className="components-base-control components-color-picker__inputs-field css-wdf2ti-Wrapper e1puf3u0"
+-           >
+-             <div
+-               className="components-base-control__field css-11vcxb9-StyledField e1puf3u1"
+-             >
+-               <label
+-                 className="components-base-control__label css-pezhm9-StyledLabel e1puf3u2"
+-                 htmlFor="inspector-text-control-14"
++               htmlFor="inspector-text-control-11"
+              >
+-                 g
++               Color value in hexadecimal
+              </label>
+              <input
+                className="components-text-control__input"
+-                 id="inspector-text-control-14"
+-                 max="255"
+-                 min="0"
++               id="inspector-text-control-11"
+                onBlur={[Function bound handleBlur]}
+                onChange={[Function onChangeValue]}
+                onKeyDown={[Function bound handleKeyDown]}
+-                 type="number"
+-                 value={255}
+-               />
+-             </div>
+-           </div>
+-           <div
+-             className="components-base-control components-color-picker__inputs-field css-wdf2ti-Wrapper e1puf3u0"
+-           >
+-             <div
+-               className="components-base-control__field css-11vcxb9-StyledField e1puf3u1"
+-             >
+-               <label
+-                 className="components-base-control__label css-pezhm9-StyledLabel e1puf3u2"
+-                 htmlFor="inspector-text-control-15"
+-               >
+-                 b
+-               </label>
+-               <input
+-                 className="components-text-control__input"
+-                 id="inspector-text-control-15"
+-                 max="255"
+-                 min="0"
+-                 onBlur={[Function bound handleBlur]}
+-                 onChange={[Function onChangeValue]}
+-                 onKeyDown={[Function bound handleKeyDown]}
+-                 type="number"
+-                 value={255}
++               type="text"
++               value="#ffffff"
+              />
+            </div>
+          </div>
+        </div>
+-       </fieldset>
+        <div
+          className="components-color-picker__inputs-toggle-wrapper"
+        >
+          <button
+            aria-describedby={null}
+`;
+
 exports[`ColorPicker should only update input view for draft changes 1`] = `
 Snapshot Diff:
 - First value

--- a/packages/components/src/color-picker/test/index.js
+++ b/packages/components/src/color-picker/test/index.js
@@ -15,13 +15,16 @@ import ColorPicker from '../';
 
 describe( 'ColorPicker', () => {
 	const color = '#FFF';
+	const source = 'hex';
 	let base;
 
 	beforeEach( () => {
 		base = TestRenderer.create(
 			<ColorPicker
 				color={ color }
+				source={ source }
 				onChangeComplete={ () => {} }
+				onSourceChangeComplete={ () => {} }
 				disableAlpha
 			/>
 		);
@@ -35,6 +38,8 @@ describe( 'ColorPicker', () => {
 		const testRenderer = TestRenderer.create(
 			<ColorPicker
 				color={ color }
+				source={ source }
+				onSourceChangeComplete={ () => {} }
 				onChangeComplete={ () => {} }
 				disableAlpha
 			/>
@@ -50,6 +55,8 @@ describe( 'ColorPicker', () => {
 		const testRenderer = TestRenderer.create(
 			<ColorPicker
 				color={ color }
+				source={ source }
+				onSourceChangeComplete={ () => {} }
 				onChangeComplete={ () => {} }
 				disableAlpha
 			/>
@@ -66,6 +73,8 @@ describe( 'ColorPicker', () => {
 		const testRenderer = TestRenderer.create(
 			<ColorPicker
 				color={ color }
+				source={ source }
+				onSourceChangeComplete={ () => {} }
 				onChangeComplete={ () => {} }
 				disableAlpha
 			/>
@@ -84,6 +93,8 @@ describe( 'ColorPicker', () => {
 		const testRenderer = TestRenderer.create(
 			<ColorPicker
 				color={ color }
+				source={ source }
+				onSourceChangeComplete={ () => {} }
 				onChangeComplete={ () => {} }
 				disableAlpha
 			/>
@@ -102,6 +113,8 @@ describe( 'ColorPicker', () => {
 		const testRenderer = TestRenderer.create(
 			<ColorPicker
 				color={ color }
+				source={ source }
+				onSourceChangeComplete={ () => {} }
 				onChangeComplete={ () => {} }
 				disableAlpha
 			/>
@@ -112,6 +125,26 @@ describe( 'ColorPicker', () => {
 		testRenderer.root
 			.findByType( 'input' )
 			.props.onKeyDown( { keyCode: ENTER } );
+
+		expect( testRenderer.toJSON() ).toMatchDiffSnapshot( base.toJSON() );
+	} );
+
+	test( 'should commit color source mode changes when switching between views', () => {
+		const testRenderer = TestRenderer.create(
+			<ColorPicker
+				color={ color }
+				source={ source }
+				onSourceChangeComplete={ () => {} }
+				onChangeComplete={ () => {} }
+				disableAlpha
+			/>
+		);
+
+		testRenderer.root
+			.findByProps( {
+				className: 'components-color-picker__inputs-toggle',
+			} )
+			.props.onClick();
 
 		expect( testRenderer.toJSON() ).toMatchDiffSnapshot( base.toJSON() );
 	} );

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -115,6 +115,8 @@ function ControlPoints( {
 	onChange,
 	onStartControlPointChange,
 	onStopControlPointChange,
+	colorPickerMode: source,
+	onSourceChange,
 } ) {
 	const controlPointMoveState = useRef();
 
@@ -224,6 +226,8 @@ function ControlPoints( {
 						<>
 							<ColorPicker
 								color={ point.color }
+								source={ source }
+								onSourceChangeComplete={ onSourceChange }
 								onChangeComplete={ ( { color } ) => {
 									onChange(
 										updateControlPointColor(
@@ -264,6 +268,8 @@ function InsertPoint( {
 	onOpenInserter,
 	onCloseInserter,
 	insertPosition,
+	colorPickerMode: source,
+	onSourceChange,
 } ) {
 	const [ alreadyInsertedPoint, setAlreadyInsertedPoint ] = useState( false );
 	return (
@@ -317,6 +323,8 @@ function InsertPoint( {
 							);
 						}
 					} }
+					source={ source }
+					onSourceChangeComplete={ onSourceChange }
 				/>
 			) }
 			popoverProps={ COLOR_POPOVER_PROPS }

--- a/packages/components/src/custom-gradient-bar/index.js
+++ b/packages/components/src/custom-gradient-bar/index.js
@@ -76,6 +76,8 @@ export default function CustomGradientBar( {
 	hasGradient,
 	value: controlPoints,
 	onChange,
+	colorPickerMode,
+	onSourceChange,
 } ) {
 	const gradientPickerDomRef = useRef();
 
@@ -134,6 +136,8 @@ export default function CustomGradientBar( {
 						insertPosition={ gradientBarState.insertPosition }
 						value={ controlPoints }
 						onChange={ onChange }
+						colorPickerMode={ colorPickerMode }
+						onSourceChange={ onSourceChange }
 						onOpenInserter={ () => {
 							gradientBarStateDispatch( {
 								type: 'OPEN_INSERTER',
@@ -155,6 +159,8 @@ export default function CustomGradientBar( {
 					}
 					value={ controlPoints }
 					onChange={ onChange }
+					colorPickerMode={ colorPickerMode }
+					onSourceChange={ onSourceChange }
 					onStartControlPointChange={ () => {
 						gradientBarStateDispatch( {
 							type: 'START_CONTROL_CHANGE',

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -103,7 +103,12 @@ const GradientTypePicker = ( { gradientAST, hasGradient, onChange } ) => {
 	);
 };
 
-export default function CustomGradientPicker( { value, onChange } ) {
+export default function CustomGradientPicker( {
+	value,
+	onChange,
+	colorPickerMode,
+	onSourceChange,
+} ) {
 	const gradientAST = getGradientAstWithDefault( value );
 	// On radial gradients the bar should display a linear gradient.
 	// On radial gradients the bar represents a slice of the gradient from the center until the outside.
@@ -124,6 +129,8 @@ export default function CustomGradientPicker( { value, onChange } ) {
 			<CustomGradientBar
 				background={ background }
 				hasGradient={ hasGradient }
+				colorPickerMode={ colorPickerMode }
+				onSourceChange={ onSourceChange }
 				value={ controlPoints }
 				onChange={ ( newControlPoints ) => {
 					onChange(

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -20,6 +20,8 @@ export default function GradientPicker( {
 	gradients,
 	onChange,
 	value,
+	colorPickerMode,
+	onSourceChange,
 	clearable = true,
 	disableCustomGradients = false,
 } ) {
@@ -68,7 +70,12 @@ export default function GradientPicker( {
 			}
 		>
 			{ ! disableCustomGradients && (
-				<CustomGradientPicker value={ value } onChange={ onChange } />
+				<CustomGradientPicker
+					value={ value }
+					colorPickerMode={ colorPickerMode }
+					onChange={ onChange }
+					onSourceChange={ onSourceChange }
+				/>
 			) }
 		</CircularOptionPicker>
 	);

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -53,11 +53,13 @@ const ColorPicker = ( { name, value, onChange } ) => {
 		return get( getSettings(), [ 'colors' ], [] );
 	} );
 	const { updateSettings } = useDispatch( blockEditorStore );
+	const onSourceChange = useCallback( ( source ) => {
+		if ( source ) {
+			updateSettings( { colorPickerMode: source } );
+		}
+	} );
 	const onColorChange = useCallback(
-		( color, source ) => {
-			if ( source ) {
-				updateSettings( { colorPickerMode: source } );
-			}
+		( color ) => {
 			if ( color ) {
 				const colorObject = getColorObjectByColorValue( colors, color );
 				onChange(
@@ -87,7 +89,13 @@ const ColorPicker = ( { name, value, onChange } ) => {
 		colors,
 	] );
 
-	return <ColorPalette value={ activeColor } onChange={ onColorChange } />;
+	return (
+		<ColorPalette
+			value={ activeColor }
+			onChange={ onColorChange }
+			onSourceChange={ onSourceChange }
+		/>
+	);
 };
 
 export default function InlineColorUI( {

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { useCallback, useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	applyFormat,
 	removeFormat,
@@ -15,6 +15,7 @@ import {
 	useAnchorRef,
 } from '@wordpress/rich-text';
 import {
+	store as blockEditorStore,
 	ColorPalette,
 	URLPopover,
 	getColorClassName,
@@ -51,8 +52,12 @@ const ColorPicker = ( { name, value, onChange } ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return get( getSettings(), [ 'colors' ], [] );
 	} );
+	const { updateSettings } = useDispatch( blockEditorStore );
 	const onColorChange = useCallback(
-		( color ) => {
+		( color, source ) => {
+			if ( source ) {
+				updateSettings( { colorPickerMode: source } );
+			}
 			if ( color ) {
 				const colorObject = getColorObjectByColorValue( colors, color );
 				onChange(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This aims to fix #11790. Adds the preferred color picker mode as an editor setting.

## How has this been tested?
Only with manual interactions in the post pages: switch color source mode and reopening color picker; changing color source mode on the sidebar and testing the inline color source mode; etc.

## Types of changes
Bug fix.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
