### PR TITLE
i18n: Replace dead link in README.md.

### DIFF
--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -109,7 +109,7 @@ original format string is returned.
 
 _Related_
 
--   <http://www.diveintojavascript.com/projects/javascript-sprintf>
+-   <https://www.npmjs.com/package/sprintf-js>
 
 _Parameters_
 

--- a/packages/i18n/src/sprintf.js
+++ b/packages/i18n/src/sprintf.js
@@ -20,7 +20,7 @@ const logErrorOnce = memoize( console.error ); // eslint-disable-line no-console
  * @param {string}    format The format of the string to generate.
  * @param {...*} args Arguments to apply to the format.
  *
- * @see http://www.diveintojavascript.com/projects/javascript-sprintf
+ * @see https://www.npmjs.com/package/sprintf-js
  *
  * @return {string} The formatted string.
  */


### PR DESCRIPTION
Fixes #29696.

Alters an irrelevant link in the i18n README.md file to a more proper entry.
