### PR TITLE
Update Readme of Animate Component to remove todo comment

### DIFF
--- a/packages/components/src/animate/README.md
+++ b/packages/components/src/animate/README.md
@@ -8,7 +8,7 @@ Simple interface to introduce animations to components.
 import { Animate } from '@wordpress/components';
 
 const MyAnimatedNotice = () => (
-	<Animate todo="Add missing props">
+	<Animate type="slide-in" options={{ origin: 'top' }}>
 		{ ( { className } ) => (
 			<Notice className={ className } status="success">
 				<p>Animation finished.</p>


### PR DESCRIPTION
The Documentation previously had `todo="Add missing props"` in the code example. I have updated the example to reflect the actually usage of the component. 

## Types of changes
Documentation
