### PR TITLE
Rename load_separate_block_styles to load_separate_block_assets

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -164,7 +164,7 @@ add_action( 'init', 'gutenberg_reregister_core_block_types' );
  * @return void
  */
 function gutenberg_register_core_block_styles( $block_name ) {
-	if ( ! gutenberg_should_load_separate_block_styles() ) {
+	if ( ! gutenberg_should_load_separate_block_assets() ) {
 		return;
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -348,7 +348,7 @@ function gutenberg_register_packages_styles( $styles ) {
 	);
 	$styles->add_data( 'wp-components', 'rtl', 'replace' );
 
-	$block_library_filename = gutenberg_should_load_separate_block_styles() ? 'common' : 'style';
+	$block_library_filename = gutenberg_should_load_separate_block_assets() ? 'common' : 'style';
 	gutenberg_override_style(
 		$styles,
 		'wp-block-library',

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -84,7 +84,7 @@ add_action( 'wp_default_scripts', 'gutenberg_add_date_settings_timezone', 20 );
  *
  * @return bool
  */
-function gutenberg_should_load_separate_block_styles() {
+function gutenberg_should_load_separate_block_assets() {
 	$load_separate_styles = gutenberg_is_fse_theme();
 	/**
 	 * Determine if separate styles will be loaded for blocks on-render or not.
@@ -93,7 +93,7 @@ function gutenberg_should_load_separate_block_styles() {
 	 *
 	 * @return bool
 	 */
-	return apply_filters( 'load_separate_block_styles', $load_separate_styles );
+	return apply_filters( 'load_separate_block_assets', $load_separate_styles );
 }
 
 /**
@@ -102,7 +102,7 @@ function gutenberg_should_load_separate_block_styles() {
  * @return void
  */
 function gutenberg_remove_hook_wp_enqueue_registered_block_scripts_and_styles() {
-	if ( gutenberg_should_load_separate_block_styles() ) {
+	if ( gutenberg_should_load_separate_block_assets() ) {
 		/**
 		 * Avoid enqueueing block assets of all registered blocks for all posts, instead
 		 * deferring to block render mechanics to enqueue scripts, thereby ensuring only


### PR DESCRIPTION
## Description
This PR renames a filter and a function from *_styles` to `*_assets`. These will be used for scripts as well, so their name needs to be less specific and cover both cases.

* Renames the `load_separate_block_styles` filter to `load_separate_block_assets`
* Renames the `gutenberg_should_load_separate_block_styles` function to `gutenberg_should_load_separate_block_assets`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
