### PR TITLE
Add theme styles in the site editor

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -170,6 +170,8 @@ function gutenberg_edit_site_init( $hook ) {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-site' );
 	wp_enqueue_style( 'wp-format-library' );
+	wp_enqueue_style( 'wp-block-library-theme' );
+
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
 

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -81,7 +81,7 @@ function gutenberg_get_editor_styles() {
  * @param string $hook Page.
  */
 function gutenberg_edit_site_init( $hook ) {
-	global $current_screen, $post;
+	global $current_screen, $post, $editor_styles;
 
 	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;
@@ -170,7 +170,13 @@ function gutenberg_edit_site_init( $hook ) {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-site' );
 	wp_enqueue_style( 'wp-format-library' );
-	wp_enqueue_style( 'wp-block-library-theme' );
+
+	if (
+		current_theme_supports( 'wp-block-styles' ) ||
+		( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 )
+	) {
+		wp_enqueue_style( 'wp-block-library-theme' );
+	}
 
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );


### PR DESCRIPTION
It looks like we don't enqueue the theme styles in the site editor, but we do in the [widgets](https://github.com/WordPress/gutenberg/blob/e8b901cb7c45fbd23e449b7d0d23da4d7326665c/lib/widgets-page.php#L33-L33) and [post](https://github.com/WordPress/gutenberg/blob/26925dce6c3c5a210dfffe16498a985ed7cbfa3c/lib/client-assets.php#L409-L409) editors. As a result, there're some things that appear broken, such as that a group block with background color doesn't get padding.

This PR enqueues this stylesheet to the site editor as well.

## How to test

- Install and activate this theme: https://github.com/WordPress/gutenberg/files/6041956/emptytheme.zip
- Go to the site editor and add a group block and a paragraph within.
- Set the group's background to some color.

The expected result is that the group block gains some padding.
