### PR TITLE
Fix navigation editor link search suggestions

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -349,7 +349,8 @@ describe( 'Navigation editor', () => {
 
 		// Add an inner link block.
 		const appender = await page.waitForSelector(
-			'button[aria-label="Add block"]'
+			'button[aria-label="Add block"]',
+			{ visible: true }
 		);
 		await appender.click();
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -3,6 +3,7 @@
  */
 import {
 	createJSONResponse,
+	pressKeyWithModifier,
 	setUpResponseMocking,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
@@ -13,6 +14,13 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { useExperimentalFeatures } from '../../experimental-features';
 import menuItemsFixture from './fixtures/menu-items-response-fixture.json';
+
+const TYPE_NAMES = {
+	post: 'post',
+	page: 'page',
+	post_tag: 'tag',
+	category: 'category',
+};
 
 const menusFixture = [
 	{
@@ -29,6 +37,35 @@ const menusFixture = [
 	},
 ];
 
+const searchFixture = [
+	{
+		id: 300,
+		title: 'Home',
+		url: 'https://example.com/home',
+		type: 'post',
+		subtype: 'page',
+	},
+	{
+		id: 301,
+		title: 'About',
+		url: 'https://example.com/about',
+		type: 'post',
+		subtype: 'page',
+	},
+	{
+		id: 302,
+		title: 'Boats',
+		url: 'https://example.com/?cat=123',
+		type: 'category',
+	},
+	{
+		id: 303,
+		title: 'Faves',
+		url: 'https://example.com/?tag=456',
+		type: 'post_tag',
+	},
+];
+
 // Matching against variations of the same URL encoded and non-encoded
 // produces the most reliable mocking.
 const REST_MENUS_ROUTES = [
@@ -40,9 +77,14 @@ const REST_MENU_ITEMS_ROUTES = [
 	`rest_route=${ encodeURIComponent( '/__experimental/menu-items' ) }`,
 ];
 
+const REST_SEARCH_ROUTES = [
+	'/wp/v2/search',
+	`rest_route=${ encodeURIComponent( '/wp/v2/search' ) }`,
+];
+
 /**
  * Determines if a given URL matches any of a given collection of
- * routes (extressed as substrings).
+ * routes (expressed as substrings).
  *
  * @param {string} reqUrl the full URL to be tested for matches.
  * @param {Array} routes array of strings to match against the URL.
@@ -86,6 +128,10 @@ function getMenuMocks( responsesByMethod ) {
 
 function getMenuItemMocks( responsesByMethod ) {
 	return getEndpointMocks( REST_MENU_ITEMS_ROUTES, responsesByMethod );
+}
+
+function getSearchMocks( responsesByMethod ) {
+	return getEndpointMocks( REST_SEARCH_ROUTES, responsesByMethod );
 }
 
 async function visitNavigationEditor() {
@@ -281,5 +327,61 @@ describe( 'Navigation editor', () => {
 			hidden: true,
 		} );
 		expect( submenuLinkHidden ).toBeDefined();
+	} );
+
+	it( 'displays suggestions when adding a link', async () => {
+		await setUpResponseMocking( [
+			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),
+			...getSearchMocks( { GET: searchFixture } ),
+		] );
+
+		await visitNavigationEditor();
+
+		// Wait for the block to be present and start an empty block.
+		const navBlock = await page.waitForSelector(
+			'div[aria-label="Block: Navigation"]'
+		);
+		await navBlock.click();
+		const startEmptyButton = await page.waitForXPath(
+			'//button[.="Start empty"]'
+		);
+		await startEmptyButton.click();
+
+		// Add an inner link block.
+		const appender = await page.waitForSelector(
+			'button[aria-label="Add block"]'
+		);
+		await appender.click();
+
+		// Must be an exact match to the word 'Link' as other
+		// variations also contain the word 'Link'.
+		const linkInserterItem = await page.waitForXPath(
+			'//button[@role="option"]//span[.="Link"]'
+		);
+		await linkInserterItem.click();
+
+		await page.waitForSelector( 'input[aria-label="URL"]' );
+
+		// The link suggestions should be searchable.
+		for ( let i = 0; i < searchFixture.length; i++ ) {
+			const { title, type, subtype, url } = searchFixture[ i ];
+			const expectedURL = url.replace( 'https://', '' );
+			const expectedType = TYPE_NAMES[ subtype || type ];
+
+			await page.keyboard.type( title );
+			const suggestionTitle = await page.waitForXPath(
+				`//button[@role="option"]//span[.="${ title }"]`
+			);
+			const suggestionType = await page.waitForXPath(
+				`//button[@role="option"]//span[.="${ expectedType }"]`
+			);
+			const suggestionURL = await page.waitForXPath(
+				`//button[@role="option"]//span[.="${ expectedURL }"]`
+			);
+			expect( suggestionTitle ).toBeTruthy();
+			expect( suggestionType ).toBeTruthy();
+			expect( suggestionURL ).toBeTruthy();
+			await pressKeyWithModifier( 'primary', 'A' );
+		}
 	} );
 } );

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -347,18 +347,26 @@ describe( 'Navigation editor', () => {
 		);
 		await startEmptyButton.click();
 
+		// NOTE - the following code is commented out.
+		// In CI the editor doesn't seem to support variations.
+		// The following code can be re-introduced once that's resolved.
 		// Add an inner link block.
+		// const appender = await page.waitForSelector(
+		// 	'button[aria-label="Add block"]'
+		// );
+		// await appender.click();
+
+		// Must be an exact match to the word 'Link' as other
+		// variations also contain the word 'Link'.
+		// const linkInserterItem = await page.waitForXPath(
+		// 	'//button[@role="option"]//span[.="Link"]'
+		// );
+		// await linkInserterItem.click();
+
 		const appender = await page.waitForSelector(
 			'button[aria-label="Add Link"]'
 		);
 		await appender.click();
-
-		// Must be an exact match to the word 'Link' as other
-		// variations also contain the word 'Link'.
-		const linkInserterItem = await page.waitForXPath(
-			'//button[@role="option"]//span[.="Link"]'
-		);
-		await linkInserterItem.click();
 
 		await page.waitForSelector( 'input[aria-label="URL"]' );
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -349,8 +349,7 @@ describe( 'Navigation editor', () => {
 
 		// Add an inner link block.
 		const appender = await page.waitForSelector(
-			'button[aria-label="Add block"]',
-			{ visible: true }
+			'button[aria-label="Add Link"]'
 		);
 		await appender.click();
 

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -26,8 +26,10 @@ export function initialize( id, settings ) {
 		__experimentalRegisterExperimentalCoreBlocks();
 	}
 
-	settings.__experimentalFetchLinkSuggestions = () =>
-		fetchLinkSuggestions( settings );
+	settings.__experimentalFetchLinkSuggestions = (
+		searchText,
+		searchOptions
+	) => fetchLinkSuggestions( searchText, searchOptions, settings );
 
 	render(
 		<Layout blockEditorSettings={ settings } />,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
#29012 caused a regression in the link suggestions for the navigation editor, resulting in some very long failing HTTP requests:
<img width="776" alt="Screenshot 2021-03-10 at 5 41 13 pm" src="https://user-images.githubusercontent.com/677833/110609101-d790d400-81c7-11eb-92d5-eb90b1e2db11.png">

The line of code that cause the issue is:
https://github.com/WordPress/gutenberg/pull/29012/files#diff-8b871841ffe5cb86e63dd3e6df4e2230028ca02ff8ecebad37fac39cf5aa2b99R29-R30

This provided no way for the search text or search options to be passed into the `fetchLinkSuggestions` function. It's remedied in this PR.

## How has this been tested?
1. Open the navigation editor.
2. Add a link to a menu
3. Search for an existing page/post (this won't work if you have no pages or posts)
4. Search results should display

## Screenshots <!-- if applicable -->
<img width="371" alt="Screenshot 2021-03-10 at 5 39 46 pm" src="https://user-images.githubusercontent.com/677833/110608894-a3b5ae80-81c7-11eb-997f-17ef83483e8d.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
