### PR TITLE
Media & Text: Allow drag n drop media replacement

### DIFF
--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -1,3 +1,20 @@
+.wp-block-media-text__media {
+	position: relative;
+
+	&.is-transient img {
+		opacity: 0.3;
+	}
+
+	// Shown while image is being uploaded
+	.components-spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
+	}
+}
+
 .wp-block-media-text .__resizable_base__ {
 	grid-column: 1 / span 2;
 	grid-row: 2;

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -118,6 +118,8 @@ function MediaContainer( props, ref ) {
 		onWidthChange,
 	} = props;
 
+	const isTemporaryMedia = ! mediaId && isBlobURL( mediaUrl );
+
 	const { toggleSelection } = useDispatch( blockEditorStore );
 
 	if ( mediaUrl ) {
@@ -152,7 +154,7 @@ function MediaContainer( props, ref ) {
 				className={ classnames(
 					className,
 					'editor-media-container__resizer',
-					{ 'is-transient': isBlobURL( mediaUrl ) }
+					{ 'is-transient': isTemporaryMedia }
 				) }
 				style={ backgroundStyles }
 				size={ { width: mediaWidth + '%' } }
@@ -173,7 +175,7 @@ function MediaContainer( props, ref ) {
 					mediaId={ mediaId }
 				/>
 				{ ( mediaTypeRenderers[ mediaType ] || noop )() }
-				{ isBlobURL( mediaUrl ) && <Spinner /> }
+				{ isTemporaryMedia && <Spinner /> }
 				<PlaceholderContainer { ...props } />
 			</ResizableBoxContainer>
 		);

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -74,6 +74,7 @@ function PlaceholderContainer( {
 	className,
 	noticeOperations,
 	noticeUI,
+	mediaUrl,
 	onSelectMedia,
 } ) {
 	const onUploadError = ( message ) => {
@@ -93,6 +94,7 @@ function PlaceholderContainer( {
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			notices={ noticeUI }
 			onError={ onUploadError }
+			disableMediaButtons={ mediaUrl }
 		/>
 	);
 }
@@ -169,6 +171,7 @@ function MediaContainer( props, ref ) {
 					mediaId={ mediaId }
 				/>
 				{ ( mediaTypeRenderers[ mediaType ] || noop )() }
+				<PlaceholderContainer { ...props } />
 			</ResizableBoxContainer>
 		);
 	}

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { ResizableBox, withNotices } from '@wordpress/components';
+import { ResizableBox, Spinner, withNotices } from '@wordpress/components';
 import {
 	BlockControls,
 	BlockIcon,
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
+import { isBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -119,7 +120,7 @@ function MediaContainer( props, ref ) {
 
 	const { toggleSelection } = useDispatch( blockEditorStore );
 
-	if ( mediaType && mediaUrl ) {
+	if ( mediaUrl ) {
 		const onResizeStart = () => {
 			toggleSelection( false );
 		};
@@ -150,7 +151,8 @@ function MediaContainer( props, ref ) {
 				as="figure"
 				className={ classnames(
 					className,
-					'editor-media-container__resizer'
+					'editor-media-container__resizer',
+					{ 'is-transient': isBlobURL( mediaUrl ) }
 				) }
 				style={ backgroundStyles }
 				size={ { width: mediaWidth + '%' } }
@@ -171,6 +173,7 @@ function MediaContainer( props, ref ) {
 					mediaId={ mediaId }
 				/>
 				{ ( mediaTypeRenderers[ mediaType ] || noop )() }
+				{ isBlobURL( mediaUrl ) && <Spinner /> }
 				<PlaceholderContainer { ...props } />
 			</ResizableBoxContainer>
 		);


### PR DESCRIPTION
## Description
Adds dropzone to the media part of the block when an image/video is already set. Fixes #26320.

## How has this been tested?
Manually on local dev environment.

Steps:
1. Add the "Media & Text" block to the post.
2. Add media.
3. Drag and drop media replacement.
4. See if the dropzone indicator appears.
5. See if media is replaced.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
