### PR TITLE
Global Styles: do not add padding sub-properties if there's no values in theme.json

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -114,6 +114,11 @@ function getBlockStylesDeclarations( blockSupports, blockStyles = {} ) {
 
 			if ( !! properties ) {
 				properties.forEach( ( prop ) => {
+					if ( ! get( blockStyles, [ ...value, prop ], false ) ) {
+						// Do not create a declaration
+						// for sub-properties that don't have any value.
+						return;
+					}
 					const cssProperty = key.startsWith( '--' )
 						? key
 						: kebabCase( `${ key }${ capitalize( prop ) }` );


### PR DESCRIPTION
This fixes a bug by which, in the site editor, there will be additional style rules for blocks that support padding but don't have any value declare via theme.json.

## How to test

- Install and activate this theme: https://github.com/WordPress/gutenberg/files/6041956/emptytheme.zip
- Go to the site editor.
- Search for the style rule that contains `.editor-styles-wrapper a {color: var(--wp--style--color--link, #00e);}` and verify that it doesn't have anything else.

In `trunk`, it contains two additional rules:

```css
.editor-styles-wrapper .wp-block-group { padding-top: undefined, padding-left: undefined, padding-bottom: undefined; padding-right: undefined }
.editor-styles-wrapper .wp-block-cover { padding-top: undefined, padding-left: undefined, padding-bottom: undefined; padding-right: undefined }
```
