### PR TITLE
Keep submenus open onselect in the editor.

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -6,10 +6,29 @@
 	min-height: $button-size;
 }
 
+
+/**
+ * Submenus.
+ */
+
 // Show submenus above the sibling inserter.
-.has-child .wp-block-navigation-link__container {
-	z-index: z-index(".has-child .wp-block-navigation-link__container");
+.has-child {
+	cursor: pointer;
+
+	.wp-block-navigation-link__container {
+		z-index: z-index(".has-child .wp-block-navigation-link__container");
+	}
+
+	// Show on editor selected, even if on frontend it only stays open on focus-within.
+	&.is-selected,
+	&.has-child-selected {
+		> .wp-block-navigation-link__container {
+			visibility: visible;
+			opacity: 1;
+		}
+	}
 }
+
 
 /**
  * Navigation Items.

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -16,14 +16,19 @@
 	}
 
 	.wp-block-navigation-link__container {
-		border: $border-width solid rgba(0, 0, 0, 0.15);
+		border: 1px solid rgba(0, 0, 0, 0.15);
 		background-color: inherit;
 		color: inherit;
 		position: absolute;
 		left: 0;
 		top: 100%;
-		width: fit-content;
 		z-index: 2;
+		display: flex;
+		flex-direction: column;
+		align-items: normal;
+		min-width: 200px;
+
+		// Hide until hover or focus within.
 		opacity: 0;
 		transition: opacity 0.1s linear;
 		visibility: hidden;
@@ -63,30 +68,19 @@
 		}
 	}
 
-	// Show submenus on hover.
 	// Separating out hover and focus-within so hover works again on IE: https://davidwalsh.name/css-focus-within#comment-513401
 	// We will need to replace focus-within with a JS solution for IE keyboard support.
-	&:hover {
-		cursor: pointer;
 
-		> .wp-block-navigation-link__container {
-			visibility: visible;
-			opacity: 1;
-			display: flex;
-			flex-direction: column;
-		}
+	// Show submenus on hover.
+	&:hover > .wp-block-navigation-link__container {
+		visibility: visible;
+		opacity: 1;
 	}
 
 	// Keep submenus open when focus is within.
-	&:focus-within {
-		cursor: pointer;
-
-		> .wp-block-navigation-link__container {
-			visibility: visible;
-			opacity: 1;
-			display: flex;
-			flex-direction: column;
-		}
+	&:focus-within > .wp-block-navigation-link__container {
+		visibility: visible;
+		opacity: 1;
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -8,14 +8,6 @@
 		margin: 0;
 		padding: 0;
 	}
-
-	// Submenus.
-	.wp-block-navigation__container {
-		.wp-block-navigation__container {
-			align-items: normal;
-			min-width: 200px;
-		}
-	}
 }
 
 .wp-block-navigation__container {


### PR DESCRIPTION
## Description

This PR refactors the navigation block CSS a little bit more, refines a width rule for submenus, and separates style vs. editor CSS slightly better, keeping the focus-within behavior on the frontend, but adding is-selected to the editor view.

The net result is a little less CSS, fewer rules, and easier editing in the editor.

Before, editor:

![editor before](https://user-images.githubusercontent.com/1204802/110622053-4146b900-819b-11eb-831d-b327dfa9f8e7.gif)

Before, frontend:

![front, before](https://user-images.githubusercontent.com/1204802/110622063-4441a980-819b-11eb-8e0c-e5cf03aba957.gif)

After, editor:

![after, editor](https://user-images.githubusercontent.com/1204802/110622076-47d53080-819b-11eb-8893-54ffe04f1b21.gif)

After, frontend:

![after, frontend](https://user-images.githubusercontent.com/1204802/110622088-4ad02100-819b-11eb-99de-9d38d161b2a1.gif)

This PR should not affect the separate editor. Before:

![navigation before](https://user-images.githubusercontent.com/1204802/110622464-c6ca6900-819b-11eb-9971-e754f45a5bca.gif)

After:

![navigation after](https://user-images.githubusercontent.com/1204802/110622470-c92cc300-819b-11eb-8be9-a2e0982f8d81.gif)

## How has this been tested?

Please test a navigation menu, frontend and editor, with menu items and submenu items.

Verify that menu items have an appropriate minimum width, and work well with tabbing and clicking in the editor. Notably you should now be able to click a submenu item, then click elsewhere to set focus there, and the submenu should remain open.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
