### PR TITLE
Global Styles: Add CSS vars for root level settings

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -694,6 +694,26 @@ class WP_Theme_JSON {
 	}
 
 	/**
+	 * Takes the root level settings from theme JSON and creates variables for them.
+	 *
+	 * @param array $declarations Holds the existing declarations.
+	 * @param array $settings Settings to process.
+	 *
+	 * @return array Returns the modified $declarations.
+	 */
+	private static function compute_root_vars( $declarations, $settings ) {
+		$root_values = gutenberg_experimental_get( $settings, array( 'root' ) );
+		$css_vars      = self::flatten_tree( $root_values );
+		foreach ( $css_vars as $key => $value ) {
+			$declarations[] = array(
+				'name'  => '--wp--style--' . $key,
+				'value' => $value,
+			);
+		}
+		return $declarations;
+	}
+
+	/**
 	 * Given an array of settings, it extracts the CSS Custom Properties
 	 * for the custom values and adds them to the $declarations
 	 * array following the format:
@@ -796,6 +816,10 @@ class WP_Theme_JSON {
 
 			$stylesheet .= self::to_ruleset( $selector, $declarations );
 		}
+
+		// Create variables for root level settings
+		$declarations = self::compute_root_vars( array(), $this->theme_json['styles'] );
+		$stylesheet .= self::to_ruleset( ':root', $declarations );
 
 		return $stylesheet;
 	}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -702,6 +702,10 @@ class WP_Theme_JSON {
 	 * @return array Returns the modified $declarations.
 	 */
 	private static function compute_root_vars( $declarations, $settings ) {
+		if ( empty( $settings['styles'] ) ) {
+			return;
+		}
+
 		$root_values = gutenberg_experimental_get( $settings, array( 'root' ) );
 		$css_vars      = self::flatten_tree( $root_values );
 		foreach ( $css_vars as $key => $value ) {
@@ -818,7 +822,7 @@ class WP_Theme_JSON {
 		}
 
 		// Create variables for root level settings
-		$declarations = self::compute_root_vars( array(), $this->theme_json['styles'] );
+		$declarations = self::compute_root_vars( array(), $this->theme_json );
 		$stylesheet .= self::to_ruleset( ':root', $declarations );
 
 		return $stylesheet;

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -4,7 +4,7 @@
 	th,
 	tbody td {
 		padding: 0.25em;
-		border: 1px solid $gray-300;
+		border: 1px solid var(--wp--style--color--text, $gray-300);
 	}
 
 	tfoot td {
@@ -17,8 +17,9 @@
 	}
 
 	table th {
+		color: var(--wp--style--color--background);
 		font-weight: 400;
-		background: $gray-300;
+		background: var(--wp--style--color--text, $gray-300);
 	}
 
 	a {
@@ -27,6 +28,6 @@
 
 	table tbody,
 	table caption {
-		color: #40464d;
+		color: var(--wp--style--color--text, #40464d);
 	}
 }

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -4,7 +4,7 @@
 	th,
 	tbody td {
 		padding: 0.25em;
-		border: 1px solid var(--wp--style--color--text, $gray-300);
+		border: 1px solid $gray-300;
 	}
 
 	tfoot td {
@@ -17,9 +17,8 @@
 	}
 
 	table th {
-		color: var(--wp--style--color--background);
 		font-weight: 400;
-		background: var(--wp--style--color--text, $gray-300);
+		background: $gray-300;
 	}
 
 	a {
@@ -28,6 +27,6 @@
 
 	table tbody,
 	table caption {
-		color: var(--wp--style--color--text, #40464d);
+		color: #40464d;
 	}
 }


### PR DESCRIPTION
## Description
We need a way for blocks to implement the default colors set in root. Often this happens via CSS inheritance but sometimes we want to use the theme colors in a block in a different way, which won't work with inheritance.

This PRs adds CSS variables for root level settings from theme.json:

```
--wp--style--color--background: #0000ff;
 --wp--style--color--text: #ff0000;
 --wp--style--typography--font-size: var(--wp--preset--font-size--normal);
 --wp--style--typography--line-height: var(--wp--custom--line-height--body);
 --wp--style--typography--font-family: var(--wp--preset--font-family--base);
```

This gives blocks a standard way of accessing the default colors for a site which is independent of the theme.

This PR was co-created with @MaggieCabrera 

## How has this been tested?
- Switch to a block theme
- Set colors for the text color and background

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
