### PR TITLE
Add check for button text before rendering button block

### DIFF
--- a/packages/block-library/src/button/deprecated.js
+++ b/packages/block-library/src/button/deprecated.js
@@ -10,8 +10,14 @@ import classnames from 'classnames';
 import {
 	RichText,
 	getColorClassName,
+	useBlockProps,
 	__experimentalGetGradientClass,
 } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import getColorAndStyleProps from './color-props';
 
 const migrateCustomColorsAndGradients = ( attributes ) => {
 	if (
@@ -81,6 +87,100 @@ const blockAttributes = {
 };
 
 const deprecated = [
+	{
+		supports: {
+			anchor: true,
+			align: true,
+			alignWide: false,
+			color: {
+				__experimentalSkipSerialization: true,
+			},
+			reusable: false,
+			__experimentalSelector: '.wp-block-button__link',
+		},
+		attributes: {
+			...blockAttributes,
+			linkTarget: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'a',
+				attribute: 'target',
+			},
+			rel: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'a',
+				attribute: 'rel',
+			},
+			placeholder: {
+				type: 'string',
+			},
+			borderRadius: {
+				type: 'number',
+			},
+			backgroundColor: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+			gradient: {
+				type: 'string',
+			},
+			style: {
+				type: 'object',
+			},
+			width: {
+				type: 'number',
+			},
+		},
+		save( { attributes, className } ) {
+			const {
+				borderRadius,
+				linkTarget,
+				rel,
+				text,
+				title,
+				url,
+				width,
+			} = attributes;
+			const colorProps = getColorAndStyleProps( attributes );
+			const buttonClasses = classnames(
+				'wp-block-button__link',
+				colorProps.className,
+				{
+					'no-border-radius': borderRadius === 0,
+				}
+			);
+			const buttonStyle = {
+				borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+				...colorProps.style,
+			};
+
+			// The use of a `title` attribute here is soft-deprecated, but still applied
+			// if it had already been assigned, for the sake of backward-compatibility.
+			// A title will no longer be assigned for new or updated button block links.
+
+			const wrapperClasses = classnames( className, {
+				[ `has-custom-width wp-block-button__width-${ width }` ]: width,
+			} );
+
+			return (
+				<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+					<RichText.Content
+						tagName="a"
+						className={ buttonClasses }
+						href={ url }
+						title={ title }
+						style={ buttonStyle }
+						value={ text }
+						target={ linkTarget }
+						rel={ rel }
+					/>
+				</div>
+			);
+		},
+	},
 	{
 		supports: {
 			align: true,

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -45,17 +45,19 @@ export default function save( { attributes, className } ) {
 	} );
 
 	return (
-		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
-			<RichText.Content
-				tagName="a"
-				className={ buttonClasses }
-				href={ url }
-				title={ title }
-				style={ buttonStyle }
-				value={ text }
-				target={ linkTarget }
-				rel={ rel }
-			/>
-		</div>
+		text && (
+			<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+				<RichText.Content
+					tagName="a"
+					className={ buttonClasses }
+					href={ url }
+					title={ title }
+					style={ buttonStyle }
+					value={ text }
+					target={ linkTarget }
+					rel={ rel }
+				/>
+			</div>
+		)
 	);
 }


### PR DESCRIPTION
## Description
This PR continues the code and conversation from #24064, so props @richtabor, @ZebulanStanphill, and @youknowriad from there.

@mamaduka also helped put this PR together and with testing.

This PR adds a check for button text before rendering the Button block on the front-end. This prevents an empty `<div class="wp-block-button"><a class="wp-block-button__link"></a></div>` from displaying on the front-end.

Closes #17221.

## How has this been tested?
Tested using wp-env and trunk.
Locally, with wp-env, tests pass as well.

## Screenshots <!-- if applicable -->
### Before:
Editor:
<img width="732" alt="Editor - Before" src="https://user-images.githubusercontent.com/1034160/110624987-39f6ce00-81e2-11eb-9260-f254d5007092.png">
Front-end:
<img width="777" alt="Front-end Before" src="https://user-images.githubusercontent.com/1034160/110625015-42e79f80-81e2-11eb-9e5d-7f9d06dc0d83.png">

### After:
Editor:
<img width="711" alt="Editor - After" src="https://user-images.githubusercontent.com/1034160/110625060-4c710780-81e2-11eb-9495-0413f47dcccd.png">

Front-end:
<img width="729" alt="Front-end - After" src="https://user-images.githubusercontent.com/1034160/110625079-53981580-81e2-11eb-8edd-547362fbbc3d.png">

## Types of changes
Bug fix.
It does, however, change how buttons without text are displayed after a post with such buttons is loaded, then saved again.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
