### PR TITLE
api-fetch: Type several of the middlewares

### DIFF
--- a/packages/api-fetch/src/middlewares/namespace-endpoint.js
+++ b/packages/api-fetch/src/middlewares/namespace-endpoint.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('../types').ApiFetchMiddleware}
+ */
 const namespaceAndEndpointMiddleware = ( options, next ) => {
 	let path = options.path;
 	let namespaceTrimmed, endpointTrimmed;

--- a/packages/api-fetch/src/middlewares/nonce.js
+++ b/packages/api-fetch/src/middlewares/nonce.js
@@ -4,11 +4,9 @@
  */
 function createNonceMiddleware( nonce ) {
 	/**
-	 * @param {import('../types').ApiFetchRequestProps} options
-	 * @param {(options: import('../types').ApiFetchRequestProps) => import('../types').ApiFetchRequestProps} next
-	 * @return {import('../types').ApiFetchRequestProps} The enhanced request.
+	 * @type {import('../types').ApiFetchMiddleware & { nonce: string }}
 	 */
-	function middleware( options, next ) {
+	const middleware = ( options, next ) => {
 		const { headers = {} } = options;
 
 		// If an 'X-WP-Nonce' header (or any case-insensitive variation
@@ -29,7 +27,7 @@ function createNonceMiddleware( nonce ) {
 				'X-WP-Nonce': middleware.nonce,
 			},
 		} );
-	}
+	};
 
 	middleware.nonce = nonce;
 

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -33,11 +33,15 @@ export function getStablePath( path ) {
 	);
 }
 
+/**
+ * @param {Record<string, any>} preloadedData
+ * @return {import('../types').ApiFetchMiddleware} Preloading middleware.
+ */
 function createPreloadingMiddleware( preloadedData ) {
 	const cache = Object.keys( preloadedData ).reduce( ( result, path ) => {
 		result[ getStablePath( path ) ] = preloadedData[ path ];
 		return result;
-	}, {} );
+	}, /** @type {Record<string, any>} */ ( {} ) );
 
 	return ( options, next ) => {
 		const { parse = true } = options;

--- a/packages/api-fetch/src/middlewares/root-url.js
+++ b/packages/api-fetch/src/middlewares/root-url.js
@@ -3,6 +3,10 @@
  */
 import namespaceAndEndpointMiddleware from './namespace-endpoint';
 
+/**
+ * @param {string} rootURL
+ * @return {import('../types').ApiFetchMiddleware} Root URL middleware.
+ */
 const createRootURLMiddleware = ( rootURL ) => ( options, next ) => {
 	return namespaceAndEndpointMiddleware( options, ( optionsWithPath ) => {
 		let url = optionsWithPath.url;

--- a/packages/api-fetch/src/middlewares/user-locale.js
+++ b/packages/api-fetch/src/middlewares/user-locale.js
@@ -3,7 +3,10 @@
  */
 import { addQueryArgs, hasQueryArg } from '@wordpress/url';
 
-function userLocaleMiddleware( options, next ) {
+/**
+ * @type {import('../types').ApiFetchMiddleware}
+ */
+const userLocaleMiddleware = ( options, next ) => {
 	if (
 		typeof options.url === 'string' &&
 		! hasQueryArg( options.url, '_locale' )
@@ -19,6 +22,6 @@ function userLocaleMiddleware( options, next ) {
 	}
 
 	return next( options );
-}
+};
 
 export default userLocaleMiddleware;

--- a/packages/api-fetch/src/types.ts
+++ b/packages/api-fetch/src/types.ts
@@ -12,7 +12,7 @@ export interface ApiFetchRequestProps {
 	method?: string;
 }
 
-export type ApiFetchMiddleware< T = any > = (
+export type ApiFetchMiddleware = (
 	options: ApiFetchRequestProps,
-	next: ( nextOptions: ApiFetchRequestProps ) => ApiFetchRequestProps
-) => ApiFetchRequestProps | Promise< T >;
+	next: ( nextOptions: ApiFetchRequestProps ) => Promise< any >
+) => Promise< any >;

--- a/packages/api-fetch/src/types.ts
+++ b/packages/api-fetch/src/types.ts
@@ -9,9 +9,10 @@ export interface ApiFetchRequestProps {
 	data?: any;
 	namespace?: string;
 	endpoint?: string;
+	method?: string;
 }
 
-export type ApiFetchMiddleware = (
+export type ApiFetchMiddleware< T = any > = (
 	options: ApiFetchRequestProps,
 	next: ( nextOptions: ApiFetchRequestProps ) => ApiFetchRequestProps
-) => ApiFetchRequestProps;
+) => ApiFetchRequestProps | Promise< T >;

--- a/packages/api-fetch/src/types.ts
+++ b/packages/api-fetch/src/types.ts
@@ -7,6 +7,8 @@ export interface ApiFetchRequestProps {
 	 */
 	parse?: boolean;
 	data?: any;
+	namespace?: string;
+	endpoint?: string;
 }
 
 export type ApiFetchMiddleware = (

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -8,6 +8,7 @@
 		"src/middlewares/namespace-endpoint.js",
 		"src/middlewares/nonce.js",
 		"src/middlewares/preloading.js",
+		"src/middlewares/root-url.js",
 		"src/types.ts"
 	]
 }

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -7,6 +7,7 @@
 	"include": [
 		"src/middlewares/namespace-endpoint.js",
 		"src/middlewares/nonce.js",
+		"src/middlewares/preloading.js",
 		"src/types.ts"
 	]
 }

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -4,5 +4,9 @@
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},
-	"include": [ "src/types.ts", "src/middlewares/nonce.js" ]
+	"include": [
+		"src/middlewares/namespace-endpoint.js",
+		"src/middlewares/nonce.js",
+		"src/types.ts"
+	]
 }

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -9,6 +9,7 @@
 		"src/middlewares/nonce.js",
 		"src/middlewares/preloading.js",
 		"src/middlewares/root-url.js",
+		"src/middlewares/user-locale.js",
 		"src/types.ts"
 	]
 }

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -4,6 +4,9 @@
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},
+	"references": [
+		{ "path": "../url" }
+	],
 	"include": [
 		"src/middlewares/namespace-endpoint.js",
 		"src/middlewares/nonce.js",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds type checking to the following middleware:
* namespace-endpoint
* preloading
* root-url
* user-locale

It also simplifies the types used in the `nonce` middleware.

It also corrects the return types for the `ApiFetchMiddleware` and its `next` function. These eventually always return a `Promise` as the final middleware eventually calls to the default handler. Each middleware itself can also return a Promise instead of calling `next` (see `preloading` and `media-upload`).

Part of #18838 

## How has this been tested?
Type check passes. No runtime changes except converting some `function`s to arrow functions so that we can type them as `ApiFetchMiddleware` instead of having to annotate the parameter types manually (see the changes to the `nonce` middleware for an example of this).

## Types of changes
Non-breaking changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
