### PR TITLE
Fix React warning in Text Control

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -89,9 +89,7 @@ export const withInspectorControl = createHigherOrderComponent(
 							</>
 						}
 						value={ props.attributes.anchor || '' }
-						valuePlaceholder={
-							! isWeb ? __( 'Add an anchor' ) : null
-						}
+						placeholder={ ! isWeb ? __( 'Add an anchor' ) : null }
 						onChange={ ( nextValue ) => {
 							nextValue = nextValue.replace( ANCHOR_REGEX, '-' );
 							props.setAttributes( {

--- a/packages/components/src/text-control/index.native.js
+++ b/packages/components/src/text-control/index.native.js
@@ -16,6 +16,7 @@ function TextControl( {
 	instanceId,
 	onChange,
 	type = 'text',
+	placeholder,
 	...props
 } ) {
 	const id = `inspector-text-control-${ instanceId }`;
@@ -31,6 +32,7 @@ function TextControl( {
 			value={ value }
 			onChangeValue={ onChange }
 			aria-describedby={ !! help ? id + '__help' : undefined }
+			valuePlaceholder={ placeholder }
 			{ ...props }
 		/>
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
While reviewing another PR, I noticed this bug that was causing a React warning: `React does not recognize the `valuePlaceholder` prop on a DOM element. `. This was introduced here: https://github.com/WordPress/gutenberg/pull/27935

I would suggest mobile app team to create a follow up with renaming `valuePlaceholder` to `placeholder` for native files, if it makes sense.



## Testing instructions
You have to open the console output in your browser.

1. Add a `Buttons` block and then select a single `Button`.
2. In `Inspector controls` open the `Advanced` panel
3. Observe the error

In this PR repeat the above steps and observe that no error is thrown.



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
