### PR TITLE
Add block variations page to Block API summary

### DIFF
--- a/docs/reference-guides/README.md
+++ b/docs/reference-guides/README.md
@@ -11,7 +11,7 @@
 -   [Transformations](/docs/reference-guides/block-api/block-transforms.md)
 -   [Templates](/docs/reference-guides/block-api/block-templates.md)
 -   [Metadata](/docs/reference-guides/block-api/block-metadata.md)
--   [Block Patterns](/docs/reference-guides/block-api/block-variations.md)
+-   [Block Variations](/docs/reference-guides/block-api/block-variations.md)
 -   [Block Patterns](/docs/reference-guides/block-api/block-patterns.md)
 -   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
 -   [Versions](/docs/reference-guides/block-api/versions.md)

--- a/docs/reference-guides/README.md
+++ b/docs/reference-guides/README.md
@@ -11,6 +11,7 @@
 -   [Transformations](/docs/reference-guides/block-api/block-transforms.md)
 -   [Templates](/docs/reference-guides/block-api/block-templates.md)
 -   [Metadata](/docs/reference-guides/block-api/block-metadata.md)
+-   [Block Patterns](/docs/reference-guides/block-api/block-variations.md)
 -   [Block Patterns](/docs/reference-guides/block-api/block-patterns.md)
 -   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
 -   [Versions](/docs/reference-guides/block-api/versions.md)

--- a/docs/reference-guides/block-api/README.md
+++ b/docs/reference-guides/block-api/README.md
@@ -13,6 +13,7 @@ The following sections will walk you through the existing block APIs:
 -   [Transformations](/docs/reference-guides/block-api/block-transforms.md)
 -   [Templates](/docs/reference-guides/block-api/block-templates.md)
 -   [Metadata](/docs/reference-guides/block-api/block-metadata.md)
+-   [Block Variations](/docs/reference-guides/block-api/block-variations.md)
 -   [Block Patterns](/docs/reference-guides/block-api/block-patterns.md)
 -   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
 -   [Versions](/docs/reference-guides/block-api/versions.md)


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/29663#issuecomment-795204088