### PR TITLE
Make colors for calendar optional

### DIFF
--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -4,7 +4,7 @@
 	th,
 	tbody td {
 		padding: 0.25em;
-		border: 1px solid $gray-300;
+		border: 1px solid;
 	}
 
 	tfoot td {
@@ -18,15 +18,10 @@
 
 	table th {
 		font-weight: 400;
-		background: $gray-300;
 	}
 
 	a {
 		text-decoration: underline;
 	}
 
-	table tbody,
-	table caption {
-		color: #40464d;
-	}
 }

--- a/packages/block-library/src/calendar/theme.scss
+++ b/packages/block-library/src/calendar/theme.scss
@@ -1,0 +1,15 @@
+.wp-block-calendar {
+	th,
+	tbody td {
+		border-color: $gray-300;
+	}
+
+	table th {
+		background: $gray-300;
+	}
+
+	table tbody,
+	table caption {
+		color: #40464d;
+	}
+}

--- a/packages/block-library/src/theme.scss
+++ b/packages/block-library/src/theme.scss
@@ -4,6 +4,7 @@
 }
 
 @import "./audio/theme.scss";
+@import "./calendar/theme.scss";
 @import "./code/theme.scss";
 @import "./embed/theme.scss";
 @import "./gallery/theme.scss";


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/29714

The calendar block has more design surface than most blocks: header, contents with the table, borders, etc. All of those parts can be styled quite differently depending on theme choices. The current block CSS is of the opinion that the header should use a color along the lines of the border and content. This makes it slightly more difficult for themes to style (specificity) and when users set the text and background color globally, there're some weird results.

This PR does the following:

- reduces the number of colors used by the block
- lets the browser make the color choices for this block unless the theme opts-in into `wp-block-styles`.

Alternatively, we could remove the colors entirely. I think the issue https://github.com/WordPress/gutenberg/pull/29714 highlights is bigger, though. I'll comment there. I'm not sure this PR is a good idea or not, but thought I'd share to gather feedback anyway.

In `trunk`:

![210310-182111-calendar-trunk](https://user-images.githubusercontent.com/583546/110671656-14ac9480-81cf-11eb-9765-b8520a47fb63.png)

With this PR:

![210310-181753-table-colors-opt-in](https://user-images.githubusercontent.com/583546/110671676-1a09df00-81cf-11eb-9894-ab57e07fc954.png)

## How to test

- Install and activate the empty theme.
- Comment `add_theme_support( 'wp-block-styles' );` in functions.php, so the theme doesn't opt-in into theme.scss styles.
- Load the site editor.
- Set text and background color in the global sidebar.
