### PR TITLE
Mobile Release v1.47.2

### DIFF
--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -133,6 +133,10 @@ public class Gutenberg: NSObject {
         sendEvent(.replaceBlock, body: ["html": block.content, "clientId": block.id])
     }
 
+    public func replace(blockID: String, content: String) {
+        sendEvent(.replaceBlock, body: ["html": content, "clientId": blockID])
+    }
+
     public func updateCapabilities() {
         let capabilites = dataSource.gutenbergCapabilities()
         sendEvent(.updateCapabilities, body: capabilites.toJSPayload())

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,9 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+## 1.47.2
+* [**] Adds a `replaceBlock` method to iOS bridge delegate with a string to match the clientID and the contents to replace with. [#29734]
+
 ## 1.47.0
 * [**] Add support for setting Cover block focal point. [#25810]
 


### PR DESCRIPTION
## Description

Release 1.47.2 of the react-native-editor and Gutenberg-Mobile.

**This version is going to be released only on WPiOS.** 

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3246

## How has this been tested?

Test in the associated WordPress-iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16059

## Types of changes

* This a non-breaking bug fix for the Stories block on iOS.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
