### PR TITLE
[RNMobile] Remove unused bridge delegate methods from demo

### DIFF
--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -237,22 +237,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         print(#function)
     }
 
-    func gutenbergDidRequestMediaFilesEditorLoad(_ mediaFiles: [String], blockId: String) {
-        print(#function)
-    }
-
-    func gutenbergDidRequestMediaFilesFailedRetryDialog(_ mediaFiles: [String]) {
-        print(#function)
-    }
-
-    func gutenbergDidRequestMediaFilesUploadCancelDialog(_ mediaFiles: [String]) {
-        print(#function)
-    }
-
-    func gutenbergDidRequestMediaFilesSaveCancelDialog(_ mediaFiles: [String]) {
-        print(#function)
-	}
-
     func gutenbergDidRequestFocalPointPickerTooltipShown() -> Bool {
         return false;
     }


### PR DESCRIPTION
## Description

This removes a bunch of empty and unused method implementations.

There is already a default protocol extension implementation of these methods here: https://github.com/WordPress/gutenberg/blob/29d60d618db89a86ec06bb4d67f344fff24ba190/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift#L269-L272
Right now, these just generate warnings in Xcode since their signature didn't quite match the protocol anyway (they must not have been updated when the protocol methods were updated), so it makes sense to remove them.

## How has this been tested?
This only changes the `GutenbergViewController`, which is specific to the demo app, so there's no risk of this change affecting the WPiOS client app.

## Types of changes
Remove unused code.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
