### PR TITLE
Keep post publishing popover open when a date is clicked

### DIFF
--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -84,3 +84,10 @@ This function will be called on each day, every time user browses into a differe
 
 - Type: `Function`
 - Required: No
+
+### keepOpen
+
+Whether focus should stay on the `DateTimePicker` after clicking on a date in the calendar.
+
+- Type: `bool`
+- Required: No

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -59,7 +59,7 @@ class DatePicker extends Component {
 	}
 
 	onChangeMoment( newDate ) {
-		const { currentDate, onChange } = this.props;
+		const { currentDate, onChange, keepOpen } = this.props;
 
 		// If currentDate is null, use now as momentTime to designate hours, minutes, seconds.
 		const momentDate = currentDate ? moment( currentDate ) : moment();
@@ -70,6 +70,11 @@ class DatePicker extends Component {
 		};
 
 		onChange( newDate.set( momentTime ).format( TIMEZONELESS_FORMAT ) );
+
+		// Keep focus on the date picker popover.
+		if ( keepOpen ) {
+			this.keepFocusInside();
+		}
 	}
 
 	/**

--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -28,6 +28,7 @@ function DateTimePicker(
 		onMonthPreviewed,
 		onChange,
 		events,
+		keepOpen,
 	},
 	ref
 ) {
@@ -54,6 +55,7 @@ function DateTimePicker(
 						isInvalidDate={ isInvalidDate }
 						onMonthPreviewed={ onMonthPreviewed }
 						events={ events }
+						keepOpen={ keepOpen }
 					/>
 				</>
 			) }

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -33,6 +33,7 @@ export function PostSchedule( { date, onUpdateDate } ) {
 			currentDate={ date }
 			onChange={ onChange }
 			is12Hour={ is12HourTime }
+			keepOpen={ true }
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Add a keepOpen prop to the DateTimePicker and keep focus on the date picker popover when true.

This isn't an ideal solution, given [the note to remove](https://github.com/WordPress/gutenberg/blob/86a9dc74cce28da4b5f43123e4d57a2982d203fb/packages/components/src/date-time/date.js#L31) `keepFocusInside()`, but removing it would require either changes to [react-dates](https://github.com/airbnb/react-dates) or [replacing react-dates](https://github.com/WordPress/gutenberg/issues/21820). 
- Open `react-dates` issue to keep focus after user changes month: https://github.com/airbnb/react-dates/issues/1065
- There's a prop [`isFocused`](https://github.com/airbnb/react-dates/blob/6c2cb61c5e876fbdac72e6efed49c0bd64f06d6b/src/components/DayPickerSingleDateController.jsx#L96) we can pass to `<DayPickerSingleDateController>`, but the focus doesn't persist after transitioning to a different month. 

To do: Open a follow-up issue to fix the popover changing position as the date changes (the popover position is relative to the publish date width).

Fixes #24206 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
    1. Create a new post
    2. Open the schedule popover by clicking on the publish date
    3. Click on a date in the picker and confirm that the popover does not close.
    4. Navigate to the next month
    5. Click on a date and confirm that the popover does not close.
    6. Navigate to a date via the keyboard and select it. Confirm that the popover does not close.

## Screenshots <!-- if applicable -->
Gif of the popover staying open after clicking on a date:
![datetimepickerstaysopen](https://user-images.githubusercontent.com/1689238/110687153-36495400-81ae-11eb-9f55-3526da99f1d1.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix: adds a `keepOpen` prop to `DateTimePicker` and uses `keepFocusInside()` to keep the popover open when true.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
