### PR TITLE
Fix test plugin clash

### DIFF
--- a/packages/e2e-tests/plugins/inner-blocks-locking-all-embed.php
+++ b/packages/e2e-tests/plugins/inner-blocks-locking-all-embed.php
@@ -10,7 +10,7 @@
 /**
  * Registers a custom script for the plugin.
  */
-function enqueue_container_without_paragraph_plugin_script() {
+function enqueue_inner_blocks_locking_all_embed_plugin_script() {
 	wp_enqueue_script(
 		'gutenberg-test-inner-blocks-locking-all-embed',
 		plugins_url( 'inner-blocks-locking-all-embed/index.js', __FILE__ ),
@@ -25,4 +25,4 @@ function enqueue_container_without_paragraph_plugin_script() {
 	);
 }
 
-add_action( 'init', 'enqueue_container_without_paragraph_plugin_script' );
+add_action( 'init', 'enqueue_inner_blocks_locking_all_embed_plugin_script' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This plugin function name is incorrect, clashes with another, causing problems when activating.