### PR TITLE
Fix navigation block styles in the navigation editor

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -21,6 +21,10 @@
 	.wp-block-navigation-link {
 		display: block;
 
+		&.has-child:hover > .wp-block-navigation-link__container {
+			display: none;
+		}
+
 		// Fix focus outlines
 		&.is-selected > .wp-block-navigation-link__content,
 		&.is-selected:hover > .wp-block-navigation-link__content {
@@ -75,14 +79,16 @@
 	}
 
 	// Override Nav block styling for deeply nested submenus.
-	.has-child .wp-block-navigation__container .wp-block-navigation__container {
+	.has-child .wp-block-navigation__container .wp-block-navigation__container,
+	.has-child .wp-block-navigation__container .wp-block-navigation-link__container {
 		left: auto;
 	}
 
 	// When editing a link with children, highlight the parent
 	// and adjust the spacing and submenu icon.
 	.wp-block-navigation-link.has-child.is-editing {
-		> .wp-block-navigation__container {
+		> .wp-block-navigation__container,
+		> .wp-block-navigation-link__container {
 			opacity: 1;
 			visibility: visible;
 			position: relative;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Recently, some of the block styles in the navigation editor were broken, this PR fixes.

Brings back accordion style menus. Ideally this code would be part of the block itself, see https://github.com/WordPress/gutenberg/issues/29747.

## How has this been tested?
1. Build a nested menu in the navigation editor

## Screenshots <!-- if applicable -->
### Before
<img width="450" alt="Screenshot 2021-03-11 at 9 30 20 am" src="https://user-images.githubusercontent.com/677833/110721983-78c16e00-824c-11eb-8a2c-70f510462e3e.png">

### After
<img width="451" alt="Screenshot 2021-03-11 at 9 30 40 am" src="https://user-images.githubusercontent.com/677833/110722001-7fe87c00-824c-11eb-9b79-e4ca79cec6bb.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
