### PR TITLE
Fix navigation editor saving

### DIFF
--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -7,7 +7,7 @@ import { v4 as uuid } from 'uuid';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -17,6 +17,7 @@ import {
 	getMenuItemToClientIdMapping,
 	resolveMenuItems,
 	dispatch,
+	select,
 	apiFetch,
 } from './controls';
 import {
@@ -89,13 +90,25 @@ export const saveNavigationPost = serializeProcessing( function* ( post ) {
 
 	try {
 		// Save edits to the menu, like the menu name.
-		const menuResponse = yield dispatch(
+		yield dispatch(
 			'core',
 			'saveEditedEntityRecord',
 			'root',
 			'menu',
 			menuId
 		);
+
+		const error = yield select(
+			'core',
+			'getLastEntitySaveError',
+			'root',
+			'menu',
+			menuId
+		);
+
+		if ( error ) {
+			throw new Error( error.message );
+		}
 
 		// Save blocks as menu items.
 		const batchSaveResponse = yield* batchSave(
@@ -104,8 +117,8 @@ export const saveNavigationPost = serializeProcessing( function* ( post ) {
 			post.blocks[ 0 ]
 		);
 
-		if ( ! batchSaveResponse.success || ! menuResponse ) {
-			throw new Error();
+		if ( ! batchSaveResponse.success ) {
+			throw new Error( batchSaveResponse.data.message );
 		}
 
 		yield dispatch(
@@ -116,15 +129,17 @@ export const saveNavigationPost = serializeProcessing( function* ( post ) {
 				type: 'snackbar',
 			}
 		);
-	} catch ( e ) {
-		yield dispatch(
-			noticesStore,
-			'createErrorNotice',
-			__( 'There was an error.' ),
-			{
-				type: 'snackbar',
-			}
-		);
+	} catch ( saveError ) {
+		const errorMessage = saveError
+			? sprintf(
+					/* translators: %s: The text of an error message (potentially untranslated). */
+					__( "Unable to save: '%s'" ),
+					saveError
+			  )
+			: __( 'Unable to save: An error ocurred.' );
+		yield dispatch( noticesStore, 'createErrorNotice', errorMessage, {
+			type: 'snackbar',
+		} );
 	}
 } );
 

--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -134,7 +134,7 @@ export const saveNavigationPost = serializeProcessing( function* ( post ) {
 			? sprintf(
 					/* translators: %s: The text of an error message (potentially untranslated). */
 					__( "Unable to save: '%s'" ),
-					saveError
+					saveError.message
 			  )
 			: __( 'Unable to save: An error ocurred.' );
 		yield dispatch( noticesStore, 'createErrorNotice', errorMessage, {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes a regression from #29012

The saving code introduced in that PR triggered an error message to show, although the menu was saving correctly.

## How has this been tested?
1. Create a navigation menu
2. Add some blocks
3. Save

Expected: the menu saves correctly

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
