### PR TITLE
Storybook playground - Fix block editor shortcuts

### DIFF
--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -44,6 +44,7 @@ function App() {
 						</div>
 						<div className="editor-styles-wrapper">
 							<Popover.Slot name="block-toolbar" />
+							<BlockEditorKeyboardShortcuts.Register />
 							<BlockEditorKeyboardShortcuts />
 							<WritingFlow>
 								<ObserveTyping>


### PR DESCRIPTION
## Description
Small change that fixes block editor keyboard shortcuts within the storybook playground, came across the solution when reading a PR to fix shortcuts for the navigation widget - WordPress/gutenberg#28257

Originally this work was to fix an issue in the standalone editor https://github.com/getdave/standalone-block-editor/issues/18 but then while working on that I realized that the storybook also had this issue.

## How has this been tested?

- Tested the live storybook and found that keyboard shortcuts were not working
- Tested the development version of storybook and found that keyboard shortcut were not working
- Made changes then retested development version of storybook and found that keyboard shortcuts were now working

Keyboard shortcuts tested;
* backspace - when multiple blocks are selected - removes selected blocks
* shift command D - when multiple blocks are selected - duplicates selected blocks 


## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
