### PR TITLE
Social Links: Improve selected state of empty block

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -23,12 +23,8 @@
 	@include reduce-motion("transition");
 
 	.is-selected > & {
-		opacity: 0.1;
-	}
-
-	// Show more opaque in dark themes.
-	.is-dark-theme .is-selected & {
-		opacity: 0.4;
+		opacity: 0;
+		width: 0; // This allows the appender to sit on the left as it should.
 	}
 
 	// Use the first link to set the height.
@@ -57,6 +53,10 @@
 		}
 	}
 
+	& + .block-list-appender {
+		box-shadow: inset 0 0 0 $border-width $gray-700;
+	}
+
 	.wp-social-link::before {
 		content: "";
 		display: block;
@@ -71,30 +71,45 @@
 }
 
 // Polish the Appender.
-.wp-block-social-links .wp-block-social-links__social-placeholder + .block-list-appender {
-	position: absolute;
-}
-
 .wp-block-social-links .block-list-appender {
-	padding: 0;
+	// Match the overall silhouette of social links.
+	margin: 4px auto 4px 0;
+	border-radius: 9999px; // This works as both circular and pill shapes.
 
-	&::before {
-		content: "";
-		display: block;
+	// Treat just like a social icon.
+	.block-editor-inserter {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: inherit;
 		width: 1em;
 		height: 1em;
 	}
 
-	.block-editor-inserter {
-		position: absolute;
-		top: 0;
+	// Duplicate the font sizes from style.scss to size the appender.
+	.has-small-icon-size & {
+		font-size: 16px; // 16 makes for a quarter-padding that keeps the icon centered.
+	}
+
+	// Normal/default.
+	.has-normal-icon-size & {
+		font-size: 24px;
+	}
+
+	// Large.
+	.has-large-icon-size & {
+		font-size: 36px;
+	}
+
+	// Huge.
+	.has-huge-icon-size & {
+		font-size: 48px;
+	}
+
+	&::before {
+		content: none;
 	}
 }
-
-.wp-block-social-links.is-style-logos-only .block-list-appender {
-	padding: 4px;
-}
-
 
 // Center flex items. This has an equivalent in style.scss.
 .wp-block[data-align="center"] > .wp-block-social-links {


### PR DESCRIPTION
## Description

Recent conversations and testing of the social links setup state makes it clear that it's not obvious that you need to add the blocks and configure them yourself. 

The block features a placeholder skeleton showing blobs that emulate the appearance of 3 social links. This skeleton serves to indicate that a social links block has been inserted. 

But it is not yet configured, you have to click it and add blocks yourself, as we have no way to know what social profiles to link to.

This PR changes the behavior so instead of fading out the skeleton indicator partially onselect, it disappears completely, and the appender button instead becomes shaped like the social link, to help indicate the next step.

Before:

![before](https://user-images.githubusercontent.com/1204802/110765683-b924ea00-8254-11eb-8fcf-869ca41e71e0.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/110765701-bde99e00-8254-11eb-9857-999c3299bab8.gif)

The PR here is inspired by designs in https://github.com/WordPress/gutenberg/issues/29505, and by conversation in https://github.com/WordPress/gutenberg/pull/29366.

A further enhancement would be to show a text-label, "Click the plus to add your first link", in the body of the empty block. But I'll need a little help to make that happen, if we feel it necessary, and I think it might be good to start with this first.


## How has this been tested?

You can test with this demo content:

```
<!-- wp:social-links {"size":"has-huge-icon-size","className":"is-style-pill-shape"} -->
<ul class="wp-block-social-links has-huge-icon-size is-style-pill-shape"><!-- wp:social-link {"url":"hjklhklh","service":"wordpress"} /-->

<!-- wp:social-link {"url":"hklj","service":"amazon"} /--></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-huge-icon-size","className":"is-style-pill-shape"} -->
<ul class="wp-block-social-links has-huge-icon-size is-style-pill-shape"><!-- wp:social-link {"url":"ghjk","service":"fivehundredpx"} /-->

<!-- wp:social-link {"url":"hjklhklj","service":"bandcamp"} /--></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-large-icon-size","className":"is-style-pill-shape"} -->
<ul class="wp-block-social-links has-large-icon-size is-style-pill-shape"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-normal-icon-size","className":"is-style-pill-shape"} -->
<ul class="wp-block-social-links has-normal-icon-size is-style-pill-shape"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-small-icon-size","className":"is-style-pill-shape"} -->
<ul class="wp-block-social-links has-small-icon-size is-style-pill-shape"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-huge-icon-size","className":"is-style-default"} -->
<ul class="wp-block-social-links has-huge-icon-size is-style-default"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-large-icon-size","className":"is-style-default"} -->
<ul class="wp-block-social-links has-large-icon-size is-style-default"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-normal-icon-size","className":"is-style-default"} -->
<ul class="wp-block-social-links has-normal-icon-size is-style-default"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-small-icon-size","className":"is-style-default"} -->
<ul class="wp-block-social-links has-small-icon-size is-style-default"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-huge-icon-size","className":"is-style-logos-only"} -->
<ul class="wp-block-social-links has-huge-icon-size is-style-logos-only"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-large-icon-size","className":"is-style-logos-only"} -->
<ul class="wp-block-social-links has-large-icon-size is-style-logos-only"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-normal-icon-size","className":"is-style-logos-only"} -->
<ul class="wp-block-social-links has-normal-icon-size is-style-logos-only"></ul>
<!-- /wp:social-links -->

<!-- wp:social-links {"size":"has-small-icon-size","className":"is-style-logos-only"} -->
<ul class="wp-block-social-links has-small-icon-size is-style-logos-only"></ul>
<!-- /wp:social-links -->

<!-- wp:navigation {"orientation":"horizontal"} /-->

<!-- wp:navigation {"orientation":"horizontal"} -->
<!-- wp:navigation-link {"type":"page"} /-->
<!-- /wp:navigation -->
```

Please test all variations of social links blocks, and all size combinations. Please test with and without blocks inside.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
