### PR TITLE
Create block: Require WordPress 5.7 by default and source it from the main plugin file

### DIFF
--- a/packages/create-block-tutorial-template/CHANGELOG.md
+++ b/packages/create-block-tutorial-template/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancement
 
 -   Scaffolded block is now registered from `block.json` with the `register_block_type_from_metadata` helper ([#28883](https://github.com/WordPress/gutenberg/pull/28883)).
+-   Scaffolded plugin requires WordPress 5.7 now ([#29757](https://github.com/WordPress/gutenberg/pull/29757).
 
 ## 1.0.0 (2021-01-21)
 

--- a/packages/create-block-tutorial-template/templates/$slug.php.mustache
+++ b/packages/create-block-tutorial-template/templates/$slug.php.mustache
@@ -1,22 +1,24 @@
 <?php
 /**
- * Plugin Name:     {{title}}
+ * Plugin Name:       {{title}}
 {{#description}}
- * Description:     {{description}}
+ * Description:       {{description}}
 {{/description}}
- * Version:         {{version}}
+ * Requires at least: 5.7
+ * Requires PHP:      7.0
+ * Version:           {{version}}
 {{#author}}
- * Author:          {{author}}
+ * Author:            {{author}}
 {{/author}}
 {{#license}}
- * License:         {{license}}
+ * License:           {{license}}
 {{/license}}
 {{#licenseURI}}
- * License URI:     {{{licenseURI}}}
+ * License URI:       {{{licenseURI}}}
 {{/licenseURI}}
- * Text Domain:     {{textdomain}}
+ * Text Domain:       {{textdomain}}
  *
- * @package         {{namespace}}
+ * @package           {{namespace}}
  */
 
 /**

--- a/packages/create-block-tutorial-template/templates/readme.txt.mustache
+++ b/packages/create-block-tutorial-template/templates/readme.txt.mustache
@@ -3,10 +3,8 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Requires at least: 5.5.3
 Tested up to:      5.7.0
 Stable tag:        {{version}}
-Requires PHP:      7.0.0
 {{#license}}
 License:           {{license}}
 {{/license}}

--- a/packages/create-block-tutorial-template/templates/src/index.js.mustache
+++ b/packages/create-block-tutorial-template/templates/src/index.js.mustache
@@ -29,11 +29,6 @@ import save from './save';
  */
 registerBlockType( '{{namespace}}/{{slug}}', {
 	/**
-	 * @see https://make.wordpress.org/core/2020/11/18/block-api-version-2/
-	 */
-	apiVersion: {{apiVersion}},
-
-	/**
 	 * Used to construct a preview for the block to be shown in the block inserter.
 	 */
 	example: {

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancement
 
 -   Block scaffolded with `esnext` template is now registered from `block.json` with the `register_block_type_from_metadata` helper ([#28883](https://github.com/WordPress/gutenberg/pull/28883)).
+-   Scaffolded plugin requires WordPress 5.7 now ([#29757](https://github.com/WordPress/gutenberg/pull/29757)).
 
 ### Bug Fixes
 

--- a/packages/create-block/lib/templates/es5/$slug.php.mustache
+++ b/packages/create-block/lib/templates/es5/$slug.php.mustache
@@ -1,22 +1,24 @@
 <?php
 /**
- * Plugin Name:     {{title}}
+ * Plugin Name:       {{title}}
 {{#description}}
- * Description:     {{description}}
+ * Description:       {{description}}
 {{/description}}
- * Version:         {{version}}
+ * Requires at least: 5.7
+ * Requires PHP:      7.0
+ * Version:           {{version}}
 {{#author}}
- * Author:          {{author}}
+ * Author:            {{author}}
 {{/author}}
 {{#license}}
- * License:         {{license}}
+ * License:           {{license}}
 {{/license}}
 {{#licenseURI}}
- * License URI:     {{{licenseURI}}}
+ * License URI:       {{{licenseURI}}}
 {{/licenseURI}}
- * Text Domain:     {{textdomain}}
+ * Text Domain:       {{textdomain}}
  *
- * @package         {{namespace}}
+ * @package           {{namespace}}
  */
 
 /**
@@ -33,6 +35,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		'{{namespace}}-{{slug}}-block-editor',
 		plugins_url( $index_js, __FILE__ ),
 		array(
+			'wp-block-editor',
 			'wp-blocks',
 			'wp-i18n',
 			'wp-element',

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -3,10 +3,8 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Requires at least: 5.6.0
 Tested up to:      5.7.0
 Stable tag:        {{version}}
-Requires PHP:      7.0.0
 {{#license}}
 License:           {{license}}
 {{/license}}

--- a/packages/create-block/lib/templates/esnext/$slug.php.mustache
+++ b/packages/create-block/lib/templates/esnext/$slug.php.mustache
@@ -1,22 +1,24 @@
 <?php
 /**
- * Plugin Name:     {{title}}
+ * Plugin Name:       {{title}}
 {{#description}}
- * Description:     {{description}}
+ * Description:       {{description}}
 {{/description}}
- * Version:         {{version}}
+ * Requires at least: 5.7
+ * Requires PHP:      7.0
+ * Version:           {{version}}
 {{#author}}
- * Author:          {{author}}
+ * Author:            {{author}}
 {{/author}}
 {{#license}}
- * License:         {{license}}
+ * License:           {{license}}
 {{/license}}
 {{#licenseURI}}
- * License URI:     {{{licenseURI}}}
+ * License URI:       {{{licenseURI}}}
 {{/licenseURI}}
- * Text Domain:     {{textdomain}}
+ * Text Domain:       {{textdomain}}
  *
- * @package         {{namespace}}
+ * @package           {{namespace}}
  */
 
 /**

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -3,10 +3,8 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Requires at least: 5.6.0
 Tested up to:      5.7.0
 Stable tag:        {{version}}
-Requires PHP:      7.0.0
 {{#license}}
 License:           {{license}}
 {{/license}}

--- a/packages/create-block/lib/templates/esnext/src/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/index.js.mustache
@@ -27,11 +27,6 @@ import save from './save';
  */
 registerBlockType( '{{namespace}}/{{slug}}', {
 	/**
-	 * @see https://make.wordpress.org/core/2020/11/18/block-api-version-2/
-	 */
-	apiVersion: {{apiVersion}},
-
-	/**
 	 * @see ./edit.js
 	 */
 	edit: Edit,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Related to #29646.

Now that the new major version of WordPress (5.7) is out, we can set it as the default required version of the plugin to use the latest Block API. It means we no longer need to set `apiVersion` in JavaScript when using `block.json` for block registraton on the server.

This PR also moves the setting for minimum WP and PHP version to the main plugin file as explained in https://github.com/WordPress/gutenberg/pull/29646#discussion_r591912716:

> > Do you think we can remove this entirely from here? I mean we already have this value defined in readme.txt isn't that enough?
> 
> Just noting that WordPress 5.8 aims to remove parsing `readme.txt` files from `validate_plugin_requirements()`, see https://core.trac.wordpress.org/ticket/48520. Per discussion with Otto, apparently that file should only have been used for the Plugin Directory and not for core, which should retrieve the data it needs from the main plugin file instead.
> 
> So I would suggest removing the `Requires at least` and `Requires PHP` headers from the `readme.txt` file, and keeping them only in the main plugin file. The Plugin Directory supports that too, see https://meta.trac.wordpress.org/ticket/4514.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npx wp-create-block -t es5` should work as before.

## Screenshots

You should see such message when you use older version of WordPress than required.

<img width="797" alt="Screen Shot 2021-03-11 at 11 00 12" src="https://user-images.githubusercontent.com/699132/110769955-0acf7380-8259-11eb-804c-77d48cfb07be.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Enhancement related to the WordPress major version release.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
