### PR TITLE
Set delay to zero in the reduce-motion mixin and tests

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -224,19 +224,23 @@
 	@if $property == "transition" {
 		@media (prefers-reduced-motion: reduce) {
 			transition-duration: 0s;
+			transition-delay: 0s;
 		}
 	}
 
 	@else if $property == "animation" {
 		@media (prefers-reduced-motion: reduce) {
 			animation-duration: 1ms;
+			animation-delay: 0s;
 		}
 	}
 
 	@else {
 		@media (prefers-reduced-motion: reduce) {
 			transition-duration: 0s;
+			transition-delay: 0s;
 			animation-duration: 1ms;
+			animation-delay: 0s;
 		}
 	}
 

--- a/packages/e2e-tests/plugins/disable-animations.php
+++ b/packages/e2e-tests/plugins/disable-animations.php
@@ -11,7 +11,7 @@
  * Enqueue CSS stylesheet disabling animations.
  */
 function enqueue_disable_animations_stylesheet() {
-	$custom_css = '* { animation-duration: 0ms !important; transition-duration: 0s !important; }';
+	$custom_css = '* { animation-duration: 0ms !important; animation-delay: 0s !important; transition-duration: 0s !important; transition-delay: 0s !important; }';
 	wp_add_inline_style( 'wp-components', $custom_css );
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Set `transition-delay` and `animation-delay` to `0s` (basically disabling it) in the `reduce-motion` mixin and E2E tests plugin.

## How has this been tested?
1. See the video below

## Screenshots <!-- if applicable -->

Note, in the video you will see the inserter button to slide to the left in a smooth way. This transition doesn't have `reduce-motion` mixin yet. That's another bug and a separate [PR](https://github.com/WordPress/gutenberg/pull/29764) will fix that.

Inserter button goes behind the W button. And after a few milliseconds, it appears next to the W button. We use `transition-delay` to coordinate the transitions, that's why this is happening. To fix this, we need to set the delay to zero in reduced-motion mode.

### Before
https://user-images.githubusercontent.com/2256104/110773381-fbeac000-825c-11eb-8e95-949fa09f08b0.mov

### After
https://user-images.githubusercontent.com/2256104/110773400-00af7400-825d-11eb-9b80-37f5708f425d.mov

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
