### PR TITLE
List View: Visual and design improvements

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -63,7 +63,7 @@ $spinner-size: 18px;
  */
 
 $shadow-popover: 0 2px 6px rgba($black, 0.05);
-$shadow-modal: 0 3px 30px rgba($black, 0.2);
+$shadow-modal: 0 10px 10px rgba($black, 0.25);
 
 
 /**

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -15,6 +15,12 @@
 	border-collapse: collapse;
 	padding: 0;
 	margin: 0;
+
+	// Move upwards when in modal.
+	.components-modal__content & {
+		margin: (-$grid-unit-15) (-$grid-unit-15 / 2) 0;
+		width: calc(100% + #{ $grid-unit-15 });
+	}
 }
 
 .block-editor-block-navigation-leaf {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -243,5 +243,5 @@
 
 .block-editor-block-navigator-indentation {
 	flex-shrink: 0;
-	width: $grid-unit-30;
+	width: $grid-unit-30 + $grid-unit-05; // Indent a full icon size, plus 4px which optically aligns child icons to the text label above.
 }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -237,5 +237,5 @@
 
 .block-editor-block-navigator-indentation {
 	flex-shrink: 0;
-	width: 18px;
+	width: $grid-unit-30;
 }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -122,7 +122,11 @@
 		vertical-align: top;
 		@include reduce-motion("transition");
 
+		// Show on hover, visible, and show above to keep the hit area size.
+		&:hover,
 		&.is-visible {
+			position: relative;
+			z-index: 1;
 			opacity: 1;
 			@include edit-post__fade-in-animation;
 		}
@@ -146,29 +150,31 @@
 		align-items: center;
 	}
 
-	// Keep the tap target large but the focus target small
+	// Keep the tap target large but the focus target small.
 	.block-editor-block-mover-button {
 		position: relative;
 		width: $button-size;
 		height: $button-size-small;
 
-		// Position the icon
+		// Position the icon.
 		svg {
 			position: relative;
 			height: $button-size-small;
 		}
 
 		&.is-up-button {
+			margin-top: -$grid-unit-15 / 2;
 			align-items: flex-end;
 			svg {
-				bottom: -4px;
+				bottom: -$grid-unit-05;
 			}
 		}
 
 		&.is-down-button {
+			margin-bottom: -$grid-unit-15 / 2;
 			align-items: flex-start;
 			svg {
-				top: -4px;
+				top: -$grid-unit-05;
 			}
 		}
 

--- a/packages/block-library/src/navigation/use-block-navigator.js
+++ b/packages/block-library/src/navigation/use-block-navigator.js
@@ -17,7 +17,7 @@ export default function useBlockNavigator( clientId, __experimentalFeatures ) {
 	const navigatorToolbarButton = (
 		<ToolbarButton
 			className="components-toolbar__control"
-			label={ __( 'Open block navigator' ) }
+			label={ __( 'Open block navigation' ) }
 			onClick={ () => setIsNavigationListOpen( true ) }
 			icon={ listView }
 		/>
@@ -25,7 +25,7 @@ export default function useBlockNavigator( clientId, __experimentalFeatures ) {
 
 	const navigatorModal = isNavigationListOpen && (
 		<Modal
-			title={ __( 'Block Navigator' ) }
+			title={ __( 'Navigation' ) }
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ () => {
 				setIsNavigationListOpen( false );

--- a/packages/components/src/modal/header.js
+++ b/packages/components/src/modal/header.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { close } from '@wordpress/icons';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -40,7 +40,11 @@ const ModalHeader = ( {
 				) }
 			</div>
 			{ isDismissible && (
-				<Button onClick={ onClose } icon={ close } label={ label } />
+				<Button
+					onClick={ onClose }
+					icon={ closeSmall }
+					label={ label }
+				/>
 			) }
 		</div>
 	);

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -61,7 +61,7 @@
 .components-modal__header {
 	box-sizing: border-box;
 	border-bottom: $border-width solid $gray-300;
-	padding: 0 $grid-unit-30;
+	padding: 0 $grid-unit-40;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -75,7 +75,7 @@
 	position: relative;
 	position: sticky;
 	top: 0;
-	margin: 0 -#{$grid-unit-30} $grid-unit-30;
+	margin: 0 -#{$grid-unit-40} $grid-unit-30;
 
 	// Rules inside this query are only run by Microsoft Edge.
 	// Edge has bugs around position: sticky;, so it needs a separate top rule.
@@ -123,7 +123,7 @@
 .components-modal__content {
 	box-sizing: border-box;
 	height: 100%;
-	padding: 0 $grid-unit-30 $grid-unit-30;
+	padding: 0 $grid-unit-40 $grid-unit-30;
 
 	// Rules inside this query are only run by Microsoft Edge.
 	// This is a companion top padding to the fixed rule in line 77.

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -23,9 +23,9 @@
 	left: 0;
 	box-sizing: border-box;
 	margin: 0;
-	border: $border-width solid $gray-300;
 	background: $white;
 	box-shadow: $shadow-modal;
+	border-radius: $radius-block-ui;
 	overflow: auto;
 
 	// Show a centered modal on bigger screens.

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -121,9 +121,9 @@
 .edit-post-manage-blocks-modal__results {
 	height: 100%;
 	overflow: auto;
-	margin-left: -$grid-unit-30;
-	margin-right: -$grid-unit-30;
-	padding-left: $grid-unit-30;
-	padding-right: $grid-unit-30;
+	margin-left: -$grid-unit-40;
+	margin-right: -$grid-unit-40;
+	padding-left: $grid-unit-40;
+	padding-right: $grid-unit-40;
 	border-top: $border-width solid $gray-300;
 }


### PR DESCRIPTION
## Description

In #26141 and #29727, a few tiny design refinements are shown that affect the modal dialog, and items in the list view. Specifically:

- A modal padding that affords a folding chevron on the left.
- A rounded modal and more visible drop shadow. 
- A 36px list view item height, without reducing the hit area size of mover controls.
- A full 24px indentation for nested items.

This PR addresses all of those, so that #26141 can be about adding the folding chevrons alone, and #29727 can be about adding the drag handle and graduating the drag and drop behavior.

## How has this been tested?

Please test every screen that leverages the list view, including the Site editor with the persistent list view, the post editor block navigation, and the modal list view from the Navigation block:

![nav](https://user-images.githubusercontent.com/1204802/110782154-14f86e80-8267-11eb-994e-1d82dfb81be6.gif)

Observe the new design is applied across, but with no regressions. 

Specifically please test also modal dialogs such as keyboard shortcuts or block manager, to see that the tweaked margin works well.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
