### PR TITLE
Fix wp-env docker-compose config with explicit users and passwords

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -179,6 +179,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 					MYSQL_ROOT_PASSWORD: 'password',
 					MYSQL_DATABASE: 'wordpress',
 				},
+				volumes: [ 'mysql:/var/lib/mysql' ],
 			},
 			'tests-mysql': {
 				image: 'mariadb',
@@ -187,6 +188,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 					MYSQL_ROOT_PASSWORD: 'password',
 					MYSQL_DATABASE: 'tests-wordpress',
 				},
+				volumes: [ 'mysql-test:/var/lib/mysql' ],
 			},
 			wordpress: {
 				build: '.',
@@ -259,6 +261,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 			...( ! config.coreSource && { wordpress: {} } ),
 			...( ! config.coreSource && { 'tests-wordpress': {} } ),
 			mysql: {},
+			'mysql-test': {},
 			'phpunit-uploads': {},
 		},
 	};

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -176,9 +176,17 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: 'mariadb',
 				ports: [ '3306' ],
 				environment: {
-					MYSQL_ALLOW_EMPTY_PASSWORD: 'yes',
+					MYSQL_ROOT_PASSWORD: 'password',
+					MYSQL_DATABASE: 'wordpress',
 				},
-				volumes: [ 'mysql:/var/lib/mysql' ],
+			},
+			'tests-mysql': {
+				image: 'mariadb',
+				ports: [ '3306' ],
+				environment: {
+					MYSQL_ROOT_PASSWORD: 'password',
+					MYSQL_DATABASE: 'tests-wordpress',
+				},
 			},
 			wordpress: {
 				build: '.',
@@ -187,15 +195,20 @@ module.exports = function buildDockerComposeConfig( config ) {
 				ports: [ developmentPorts ],
 				environment: {
 					WORDPRESS_DB_NAME: 'wordpress',
+					WORDPRESS_DB_USER: 'root',
+					WORDPRESS_DB_PASSWORD: 'password',
 				},
 				volumes: developmentMounts,
 			},
 			'tests-wordpress': {
-				depends_on: [ 'mysql' ],
+				depends_on: [ 'tests-mysql' ],
 				image: testsWpImage,
 				ports: [ testsPorts ],
 				environment: {
 					WORDPRESS_DB_NAME: 'tests-wordpress',
+					WORDPRESS_DB_USER: 'root',
+					WORDPRESS_DB_PASSWORD: 'password',
+					WORDPRESS_DB_HOST: 'tests-mysql',
 				},
 				volumes: testsMounts,
 			},
@@ -204,12 +217,23 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: developmentWpCliImage,
 				volumes: developmentMounts,
 				user: cliUser,
+				environment: {
+					WORDPRESS_DB_NAME: 'wordpress',
+					WORDPRESS_DB_USER: 'root',
+					WORDPRESS_DB_PASSWORD: 'password',
+				},
 			},
 			'tests-cli': {
 				depends_on: [ 'tests-wordpress' ],
 				image: testsWpCliImage,
 				volumes: testsMounts,
 				user: cliUser,
+				environment: {
+					WORDPRESS_DB_NAME: 'tests-wordpress',
+					WORDPRESS_DB_USER: 'root',
+					WORDPRESS_DB_PASSWORD: 'password',
+					WORDPRESS_DB_HOST: 'tests-mysql',
+				},
 			},
 			composer: {
 				image: 'composer',


### PR DESCRIPTION
closes https://github.com/WordPress/gutenberg/issues/29752

There has been some update  to the WordPress default docker image with these two updates:

 - It doesn't create a database by default now.
 - It  doesn't use the default username/password for the database.

This PR fixes that  by assigning explicit values for these, the issue though is that all pre-existing wp-env usage is broken including third-party and old branches.