### PR TITLE
Button block: use early return to optimize save.js.

### DIFF
--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -23,6 +23,11 @@ export default function save( { attributes, className } ) {
 		url,
 		width,
 	} = attributes;
+
+	if ( ! text ) {
+		return null;
+	}
+
 	const colorProps = getColorAndStyleProps( attributes );
 	const buttonClasses = classnames(
 		'wp-block-button__link',
@@ -45,19 +50,17 @@ export default function save( { attributes, className } ) {
 	} );
 
 	return (
-		text && (
-			<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
-				<RichText.Content
-					tagName="a"
-					className={ buttonClasses }
-					href={ url }
-					title={ title }
-					style={ buttonStyle }
-					value={ text }
-					target={ linkTarget }
-					rel={ rel }
-				/>
-			</div>
-		)
+		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+			<RichText.Content
+				tagName="a"
+				className={ buttonClasses }
+				href={ url }
+				title={ title }
+				style={ buttonStyle }
+				value={ text }
+				target={ linkTarget }
+				rel={ rel }
+			/>
+		</div>
 	);
 }


### PR DESCRIPTION
## Description
Quick and simple optimization. See https://github.com/WordPress/gutenberg/pull/29717#discussion_r592130073.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
