### PR TITLE
dom: Add types to focusable

### DIFF
--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -35,7 +35,7 @@ const SELECTOR = [
  * Returns true if the specified element is visible (i.e. neither display: none
  * nor visibility: hidden).
  *
- * @param {Element} element DOM element to test.
+ * @param {HTMLElement} element DOM element to test.
  *
  * @return {boolean} Whether element is visible.
  */
@@ -67,16 +67,18 @@ function skipFocus( element ) {
  * false otherwise. Area is only focusable if within a map where a named map
  * referenced by an image somewhere in the document.
  *
- * @param {Element} element DOM area element to test.
+ * @param {HTMLAreaElement} element DOM area element to test.
  *
  * @return {boolean} Whether area element is valid for focus.
  */
 function isValidFocusableArea( element ) {
+	/** @type {HTMLMapElement | null} */
 	const map = element.closest( 'map[name]' );
 	if ( ! map ) {
 		return false;
 	}
 
+	/** @type {HTMLImageElement | null} */
 	const img = element.ownerDocument.querySelector(
 		'img[usemap="#' + map.name + '"]'
 	);
@@ -91,6 +93,9 @@ function isValidFocusableArea( element ) {
  * @return {Element[]} Focusable elements.
  */
 export function find( context ) {
+	/* eslint-disable jsdoc/no-undefined-types */
+	/** @type {NodeListOf<HTMLElement>} */
+	/* eslint-enable jsdoc/no-undefined-types */
 	const elements = context.querySelectorAll( SELECTOR );
 
 	return Array.from( elements ).filter( ( element ) => {
@@ -100,7 +105,9 @@ export function find( context ) {
 
 		const { nodeName } = element;
 		if ( 'AREA' === nodeName ) {
-			return isValidFocusableArea( element );
+			return isValidFocusableArea(
+				/** @type {HTMLAreaElement} */ ( element )
+			);
 		}
 
 		return true;

--- a/packages/dom/tsconfig.json
+++ b/packages/dom/tsconfig.json
@@ -4,5 +4,8 @@
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},
-	"include": [ "src/data-transfer.js" ]
+	"include": [
+		"src/data-transfer.js",
+		"src/focusable.js",
+	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds types to the `focusable.js` module of the `dom` package.

There are no runtime changes necessary for this.

Part of #18838 

## How has this been tested?
Typecheck passes (static analysis CI passes).

## Types of changes
Non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
