### PR TITLE
Components: Add types to Draggable

### DIFF
--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -9,6 +9,29 @@ const cloneHeightTransformationBreakpoint = 700;
 const clonePadding = 0;
 const bodyClass = 'is-dragging-components-draggable';
 
+/**
+ * @typedef RenderProp
+ * @property {(event: import('react').DragEvent) => void} onDraggableStart `onDragStart` handler.
+ * @property {(event: import('react').DragEvent) => void} onDraggableEnd `onDragEnd` handler.
+ */
+
+/**
+ * @typedef Props
+ * @property {(props: RenderProp) => JSX.Element | null} children Children.
+ * @property {(event: import('react').DragEvent) => void} [onDragStart] Callback when dragging starts.
+ * @property {(event: import('react').DragEvent) => void} [onDragOver] Callback when dragging happens over ???.
+ * @property {(event: import('react').DragEvent) => void} [onDragEnd] Callback when dragging ends.
+ * @property {string} [cloneClassname] Classname for the cloned element.
+ * @property {string} [elementId] ID for the element.
+ * @property {any} [transferData] Transfer data for the drag event.
+ * @property {import('react').ReactNode} __experimentalDragComponent Component to show when dragging.
+ */
+
+/**
+ *
+ * @param {Props} props
+ * @return {JSX.Element} A draggable component.
+ */
 export default function Draggable( {
 	children,
 	onDragStart,
@@ -19,19 +42,20 @@ export default function Draggable( {
 	transferData,
 	__experimentalDragComponent: dragComponent,
 } ) {
-	const dragComponentRef = useRef();
+	/** @type {import('react').MutableRefObject<HTMLDivElement | null>} */
+	const dragComponentRef = useRef( null );
 	const cleanup = useRef( () => {} );
 
 	/**
 	 * Removes the element clone, resets cursor, and removes drag listener.
 	 *
-	 * @param {Object} event The non-custom DragEvent.
+	 * @param {import('react').DragEvent} event The non-custom DragEvent.
 	 */
 	function end( event ) {
 		event.preventDefault();
 		cleanup.current();
 
-		if ( onDragOver ) {
+		if ( onDragEnd ) {
 			onDragEnd( event );
 		}
 	}
@@ -44,9 +68,10 @@ export default function Draggable( {
 	 * - Sets transfer data.
 	 * - Adds dragover listener.
 	 *
-	 * @param {Object} event The non-custom DragEvent.
+	 * @param {import('react').DragEvent} event The non-custom DragEvent.
 	 */
 	function start( event ) {
+		// @ts-ignore We know that ownerDocument does exist on an Element
 		const { ownerDocument } = event.target;
 
 		event.dataTransfer.setData( 'text', JSON.stringify( transferData ) );
@@ -130,6 +155,9 @@ export default function Draggable( {
 		let cursorLeft = event.clientX;
 		let cursorTop = event.clientY;
 
+		/**
+		 * @param {import('react').DragEvent} e
+		 */
 		function over( e ) {
 			cloneWrapper.style.top = `${
 				parseInt( cloneWrapper.style.top, 10 ) + e.clientY - cursorTop
@@ -156,6 +184,7 @@ export default function Draggable( {
 		// https://reactjs.org/docs/events.html#event-pooling
 		event.persist();
 
+		/** @type {number | undefined} */
 		let timerId;
 
 		if ( onDragStart ) {

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -19,7 +19,7 @@ const bodyClass = 'is-dragging-components-draggable';
  * @typedef Props
  * @property {(props: RenderProp) => JSX.Element | null} children Children.
  * @property {(event: import('react').DragEvent) => void} [onDragStart] Callback when dragging starts.
- * @property {(event: import('react').DragEvent) => void} [onDragOver] Callback when dragging happens over ???.
+ * @property {(event: import('react').DragEvent) => void} [onDragOver] Callback when dragging happens over the document.
  * @property {(event: import('react').DragEvent) => void} [onDragEnd] Callback when dragging ends.
  * @property {string} [cloneClassname] Classname for the cloned element.
  * @property {string} [elementId] ID for the element.
@@ -28,7 +28,6 @@ const bodyClass = 'is-dragging-components-draggable';
  */
 
 /**
- *
  * @param {Props} props
  * @return {JSX.Element} A draggable component.
  */

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -17,6 +17,7 @@
 		"src/animate/**/*",
 		"src/base-control/**/*",
 		"src/dashicon/**/*",
+		"src/draggable/**/*",
 		"src/flex/**/*",
 		"src/form-group/**/*",
 		"src/shortcut/**/*",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds types to the `Draggable` component. No runtime changes except to change the ref from defaulting to `undefined` to default to `null`. This should have no real effect as the null checks were just checking for flasy-ness rather than `undefined` specifically.

Part of #18838 

## How has this been tested?
Storybook (`npm run storybook:dev`) and the Draggable story continues to work as expected. Again, there are no runtime changes except the minor one I mention above so the main thing is that type checks pass 🙂 

## Types of changes
Non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
