### PR TITLE
Fix 100% width buttons alignment with other buttons

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -62,8 +62,12 @@ $blocks-block__margin: 0.5em;
 	}
 
 	&.wp-block-button__width-100 {
-		margin-right: 0;
-		width: 100%;
+		width: calc(100% - #{ $blocks-block__margin });
+
+		&:only-child {
+			margin-right: 0;
+			width: 100%;
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Button margins are included in the % width calculations for all options except 100% width buttons, so only 100% buttons actually take up their full 100%. The result is that if a 100% button appears slightly longer than, say, two 50% buttons (see screenshots below).

This PR includes the regular button margin for 100% width buttons, so that they will sit flush with other buttons when in a grid. The margin is _not_ included if it is a single button.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested manually in the editor and on the frontend with:
* A single button set to 100% width takes up the full width of the container with no margin
* In a grid of buttons (see screenshots), a 100% button is aligned flush with two 50% buttons when:
    * The 100% button is the first button in the list
    * The 100% button is in the middle of the list
    * The 100% button is the last button in the list
    * The buttons are left-aligned
    * The buttons are center-aligned
    * The buttons are right-aligned


## Screenshots <!-- if applicable -->


<img width="647" alt="Screen Shot 2021-03-11 at 9 38 51 AM" src="https://user-images.githubusercontent.com/63313398/110831058-ba531880-824e-11eb-8d27-e20d77fb5c87.png">

_What the buttons look like before the changes; the 100% button is not flush with two 50% buttons._

<img width="648" alt="Screen Shot 2021-03-11 at 9 38 03 AM" src="https://user-images.githubusercontent.com/63313398/110831155-d1920600-824e-11eb-9697-2fc168ca0f13.png">

_With the changes applied, the buttons align correctly._

<img width="637" alt="Screen Shot 2021-03-11 at 9 41 12 AM" src="https://user-images.githubusercontent.com/63313398/110831231-deaef500-824e-11eb-8f18-c1af9bad02d4.png">

_When a 100% width button has no siblings, it takes up the full container with no margin._

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
