### PR TITLE
Site Editor: close navigation panel after template selection

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -224,19 +224,23 @@
 	@if $property == "transition" {
 		@media (prefers-reduced-motion: reduce) {
 			transition-duration: 0s;
+			transition-delay: 0s;
 		}
 	}
 
 	@else if $property == "animation" {
 		@media (prefers-reduced-motion: reduce) {
 			animation-duration: 1ms;
+			animation-delay: 0s;
 		}
 	}
 
 	@else {
 		@media (prefers-reduced-motion: reduce) {
 			transition-duration: 0s;
+			transition-delay: 0s;
 			animation-duration: 1ms;
+			animation-delay: 0s;
 		}
 	}
 

--- a/packages/e2e-tests/plugins/disable-animations.php
+++ b/packages/e2e-tests/plugins/disable-animations.php
@@ -11,7 +11,7 @@
  * Enqueue CSS stylesheet disabling animations.
  */
 function enqueue_disable_animations_stylesheet() {
-	$custom_css = '* { animation-duration: 0ms !important; transition-duration: 0s !important; }';
+	$custom_css = '* { animation-duration: 0ms !important; animation-delay: 0s !important; transition-duration: 0s !important; transition-delay: 0s !important; }';
 	wp_add_inline_style( 'wp-components', $custom_css );
 }
 

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -187,7 +187,6 @@ describe( 'Multi-entity save flow', () => {
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
 			await navigationPanel.clickItemByText( 'Index' );
-			await navigationPanel.close();
 
 			// Click the first block so that the template part inserts in the right place.
 			const firstBlock = await canvas().$( '.wp-block' );

--- a/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
@@ -71,7 +71,6 @@ describe( 'Settings sidebar', () => {
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
 			await navigationPanel.clickItemByText( '404' );
-			await navigationPanel.close();
 			const templateCardAfterNavigation = await getTemplateCard();
 
 			expect( templateCardBeforeNavigation ).toMatchObject( {

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -66,7 +66,6 @@ describe( 'Template Part', () => {
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
 			await navigationPanel.clickItemByText( 'Index' );
-			await navigationPanel.close();
 		}
 
 		async function triggerEllipsisMenuItem( textPrompt ) {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
@@ -33,7 +33,9 @@ export default function ContentNavigationItem( { item } ) {
 		},
 		[ isPreviewVisible ]
 	);
-	const { setPage } = useDispatch( editSiteStore );
+	const { setPage, setIsNavigationPanelOpened } = useDispatch(
+		editSiteStore
+	);
 
 	const onActivateItem = useCallback( () => {
 		const { type, slug, link, id } = item;
@@ -46,6 +48,7 @@ export default function ContentNavigationItem( { item } ) {
 				postId: id,
 			},
 		} );
+		setIsNavigationPanelOpened( false );
 	}, [ setPage, item ] );
 
 	if ( ! item ) {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -27,17 +27,25 @@ export default function TemplateNavigationItem( { item } ) {
 				  },
 		[]
 	);
-	const { setTemplate, setTemplatePart } = useDispatch( editSiteStore );
+	const {
+		setTemplate,
+		setTemplatePart,
+		setIsNavigationPanelOpened,
+	} = useDispatch( editSiteStore );
 	const [ isPreviewVisible, setIsPreviewVisible ] = useState( false );
 
 	if ( ! item ) {
 		return null;
 	}
 
-	const onActivateItem = () =>
-		'wp_template' === item.type
-			? setTemplate( item.id, item.slug )
-			: setTemplatePart( item.id );
+	const onActivateItem = () => {
+		if ( 'wp_template' === item.type ) {
+			setTemplate( item.id, item.slug );
+		} else {
+			setTemplatePart( item.id );
+		}
+		setIsNavigationPanelOpened( false );
+	};
 
 	return (
 		<NavigationItem

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -9,6 +9,7 @@ const path = require( 'path' );
  * Internal dependencies
  */
 const { hasSameCoreSource } = require( './wordpress' );
+const { dbEnv } = require( './config' );
 
 /**
  * @typedef {import('./config').WPConfig} WPConfig
@@ -176,9 +177,21 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: 'mariadb',
 				ports: [ '3306' ],
 				environment: {
-					MYSQL_ALLOW_EMPTY_PASSWORD: 'yes',
+					MYSQL_ROOT_PASSWORD:
+						dbEnv.credentials.WORDPRESS_DB_PASSWORD,
+					MYSQL_DATABASE: dbEnv.development.WORDPRESS_DB_NAME,
 				},
 				volumes: [ 'mysql:/var/lib/mysql' ],
+			},
+			'tests-mysql': {
+				image: 'mariadb',
+				ports: [ '3306' ],
+				environment: {
+					MYSQL_ROOT_PASSWORD:
+						dbEnv.credentials.WORDPRESS_DB_PASSWORD,
+					MYSQL_DATABASE: dbEnv.tests.WORDPRESS_DB_NAME,
+				},
+				volumes: [ 'mysql-test:/var/lib/mysql' ],
 			},
 			wordpress: {
 				build: '.',
@@ -186,16 +199,18 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: developmentWpImage,
 				ports: [ developmentPorts ],
 				environment: {
-					WORDPRESS_DB_NAME: 'wordpress',
+					...dbEnv.credentials,
+					...dbEnv.development,
 				},
 				volumes: developmentMounts,
 			},
 			'tests-wordpress': {
-				depends_on: [ 'mysql' ],
+				depends_on: [ 'tests-mysql' ],
 				image: testsWpImage,
 				ports: [ testsPorts ],
 				environment: {
-					WORDPRESS_DB_NAME: 'tests-wordpress',
+					...dbEnv.credentials,
+					...dbEnv.tests,
 				},
 				volumes: testsMounts,
 			},
@@ -204,12 +219,20 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: developmentWpCliImage,
 				volumes: developmentMounts,
 				user: cliUser,
+				environment: {
+					...dbEnv.credentials,
+					...dbEnv.development,
+				},
 			},
 			'tests-cli': {
 				depends_on: [ 'tests-wordpress' ],
 				image: testsWpCliImage,
 				volumes: testsMounts,
 				user: cliUser,
+				environment: {
+					...dbEnv.credentials,
+					...dbEnv.tests,
+				},
 			},
 			composer: {
 				image: 'composer',
@@ -228,6 +251,8 @@ module.exports = function buildDockerComposeConfig( config ) {
 					LOCAL_DIR: 'html',
 					WP_PHPUNIT__TESTS_CONFIG:
 						'/var/www/html/phpunit-wp-config.php',
+					...dbEnv.credentials,
+					...dbEnv.tests,
 				},
 			},
 		},
@@ -235,6 +260,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 			...( ! config.coreSource && { wordpress: {} } ),
 			...( ! config.coreSource && { 'tests-wordpress': {} } ),
 			mysql: {},
+			'mysql-test': {},
 			'phpunit-uploads': {},
 		},
 	};

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -24,6 +24,7 @@ const downloadSources = require( '../download-sources' );
 const {
 	checkDatabaseConnection,
 	makeContentDirectoriesWritable,
+	makeConfigWritable,
 	configureWordPress,
 	setupWordPressDirectories,
 } = require( '../wordpress' );
@@ -139,6 +140,11 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 			? [ '--build', '--force-recreate' ]
 			: [],
 	} );
+
+	await Promise.all( [
+		makeConfigWritable( 'development', config ),
+		makeConfigWritable( 'tests', config ),
+	] );
 
 	// Only run WordPress install/configuration when config has changed.
 	if ( shouldConfigureWp ) {

--- a/packages/env/lib/config/db-env.js
+++ b/packages/env/lib/config/db-env.js
@@ -1,0 +1,23 @@
+// Username and password used in all databases
+const credentials = {
+	WORDPRESS_DB_USER: 'root',
+	WORDPRESS_DB_PASSWORD: 'password',
+};
+
+// Environment for test database
+const tests = {
+	WORDPRESS_DB_NAME: 'tests-wordpress',
+	WORDPRESS_DB_HOST: 'tests-mysql',
+};
+
+// Environment for development database. DB host gets default value which is set
+// elsewhere
+const development = {
+	WORDPRESS_DB_NAME: 'wordpress',
+};
+
+module.exports = {
+	credentials,
+	tests,
+	development,
+};

--- a/packages/env/lib/config/index.js
+++ b/packages/env/lib/config/index.js
@@ -3,6 +3,7 @@
  */
 const readConfig = require( './config' );
 const { ValidationError } = require( './validate-config' );
+const dbEnv = require( './db-env' );
 
 /**
  * @typedef {import('./config').WPConfig} WPConfig
@@ -13,4 +14,5 @@ const { ValidationError } = require( './validate-config' );
 module.exports = {
 	ValidationError,
 	readConfig,
+	dbEnv,
 };

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -48,6 +48,27 @@ async function makeContentDirectoriesWritable(
 }
 
 /**
+ * Makes wp-config.php owned by www-data so that WordPress can work with the
+ * file.
+ *
+ * @param {WPEnvironment} environment The environment to check. Either 'development' or 'tests'.
+ * @param {WPConfig}      config      The wp-env config object.
+ */
+async function makeConfigWritable(
+	environment,
+	{ dockerComposeConfigPath, debug }
+) {
+	await dockerCompose.exec(
+		environment === 'development' ? 'wordpress' : 'tests-wordpress',
+		'chown www-data:www-data wp-config.php',
+		{
+			config: dockerComposeConfigPath,
+			log: debug,
+		}
+	);
+}
+
+/**
  * Checks a WordPress database connection. An error is thrown if the test is
  * unsuccessful.
  *
@@ -260,6 +281,7 @@ async function copyCoreFiles( fromPath, toPath ) {
 module.exports = {
 	hasSameCoreSource,
 	makeContentDirectoriesWritable,
+	makeConfigWritable,
 	checkDatabaseConnection,
 	configureWordPress,
 	resetDatabase,


### PR DESCRIPTION
## Description

Automatically closes the navigation panel within the site editor after selecting a template or content item.

Follow-up to https://github.com/WordPress/gutenberg/pull/29489: it's particularly helpful on smaller screens, where you would otherwise be left with the navigation panel taking up most of the screen after making a selection.

Based off of https://github.com/WordPress/gutenberg/pull/29762, which is required for e2e tests to pass.

## How has this been tested?

- Click on a template or content item in the site editor navigation panel
- The panel will close and the template will be loaded

## Screenshots <!-- if applicable -->

![site-editor-navigation-panel-close-on-select](https://user-images.githubusercontent.com/1699996/110892068-f28f4100-82b8-11eb-91af-ea03ca133ec4.gif)

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
