### PR TITLE
Revert: Show empty paragraphs on fronted.

### DIFF
--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -40,8 +40,3 @@ p.has-background {
 p.has-text-color a {
 	color: inherit;
 }
-
-// Prevent an empty P tag from collapsing, so it matches the backend.
-p:empty::before {
-	content: "\200B";
-}


### PR DESCRIPTION
## Description

This PR is a followup to feedback in https://github.com/WordPress/gutenberg/pull/27995#issuecomment-797029996 and https://core.trac.wordpress.org/ticket/52764.

In 27995 we merged a change where an empty paragraph written in the editor, would correspond to en empty paragraph on the frontend. This fixed #10051.

However shortcodes when they get parsed commonly generate lots of empty paragraphs (`<p></p>`), which causes layout issues when those get inflated.

This PR reverts the change.

Editor/frontend before:

| <img width="833" alt="before-editor" src="https://user-images.githubusercontent.com/1204802/110908338-f51c8580-830e-11eb-9380-7f940098ccba.png">  | <img width="732" alt="before-frontend" src="https://user-images.githubusercontent.com/1204802/110908360-fbaafd00-830e-11eb-97e3-11f749900e3e.png">  |
|---|---|

Editor/frontend after:

| <img width="882" alt="Screenshot 2021-03-12 at 08 41 17" src="https://user-images.githubusercontent.com/1204802/110908396-09608280-830f-11eb-9e81-59fa9b2e94c5.png"> | <img width="850" alt="Screenshot 2021-03-12 at 08 41 21" src="https://user-images.githubusercontent.com/1204802/110908409-0ebdcd00-830f-11eb-91f3-28f552ec4491.png"> |
|---|---|

## How has this been tested?

Insert text, then a slew of linebreaks, then text again, and compare editor with frontend. 

Observe that before, editor and frontend would match perfectly. Observe that after this PR, the paragraphs on the frontend collapse to zero height.

## Types of changes

It's unfortunate that we might not be able to get accurate behavior here. But it is potentially something that could be revisited in the future.

Let me know your thoughts!

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
