### PR TITLE
Fix block selection issues when the block's wrapper is replaced in the DOM

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -121,9 +121,12 @@ export function useEventHandlers( clientId ) {
 			}
 
 			node.addEventListener( 'focusin', onFocus );
-			node.addEventListener( 'keydown', onKeyDown );
-			node.addEventListener( 'mouseleave', onMouseLeave );
-			node.addEventListener( 'dragstart', onDragStart );
+
+			if ( isSelected( clientId ) ) {
+				node.addEventListener( 'keydown', onKeyDown );
+				node.addEventListener( 'mouseleave', onMouseLeave );
+				node.addEventListener( 'dragstart', onDragStart );
+			}
 
 			return () => {
 				node.removeEventListener( 'focusin', onFocus );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -59,7 +59,7 @@ export function useEventHandlers( clientId ) {
 			function onFocus( event ) {
 				// If an inner block is focused, that block is responsible for
 				// setting the selected block.
-				if ( isSelected && ! isInsideRootBlock( node, event.target ) ) {
+				if ( isSelected || ! isInsideRootBlock( node, event.target ) ) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -48,30 +48,22 @@ export function useEventHandlers( clientId ) {
 
 	return useRefEffect(
 		( node ) => {
-			if ( ! isSelected ) {
-				/**
-				 * Marks the block as selected when focused and not already
-				 * selected. This specifically handles the case where block does not
-				 * set focus on its own (via `setFocus`), typically if there is no
-				 * focusable input in the block.
-				 *
-				 * @param {FocusEvent} event Focus event.
-				 */
-				function onFocus( event ) {
-					// If an inner block is focussed, that block is resposible for
-					// setting the selected block.
-					if ( ! isInsideRootBlock( node, event.target ) ) {
-						return;
-					}
-
-					selectBlock( clientId );
+			/**
+			 * Marks the block as selected when focused and not already
+			 * selected. This specifically handles the case where block does not
+			 * set focus on its own (via `setFocus`), typically if there is no
+			 * focusable input in the block.
+			 *
+			 * @param {FocusEvent} event Focus event.
+			 */
+			function onFocus( event ) {
+				// If an inner block is focused, that block is responsible for
+				// setting the selected block.
+				if ( isSelected && ! isInsideRootBlock( node, event.target ) ) {
+					return;
 				}
 
-				node.addEventListener( 'focusin', onFocus );
-
-				return () => {
-					node.removeEventListener( 'focusin', onFocus );
-				};
+				selectBlock( clientId );
 			}
 
 			/**
@@ -125,11 +117,13 @@ export function useEventHandlers( clientId ) {
 				event.preventDefault();
 			}
 
+			node.addEventListener( 'focusin', onFocus );
 			node.addEventListener( 'keydown', onKeyDown );
 			node.addEventListener( 'mouseleave', onMouseLeave );
 			node.addEventListener( 'dragstart', onDragStart );
 
 			return () => {
+				node.removeEventListener( 'focusin', onFocus );
 				node.removeEventListener( 'mouseleave', onMouseLeave );
 				node.removeEventListener( 'keydown', onKeyDown );
 				node.removeEventListener( 'dragstart', onDragStart );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -35,7 +35,7 @@ export function useEventHandlers( clientId ) {
 			} = select( blockEditorStore );
 
 			return {
-				isSelected: isBlockSelected( clientId ),
+				isSelected: isBlockSelected,
 				rootClientId: getBlockRootClientId( clientId ),
 				index: getBlockIndex( clientId ),
 			};
@@ -59,7 +59,10 @@ export function useEventHandlers( clientId ) {
 			function onFocus( event ) {
 				// If an inner block is focused, that block is responsible for
 				// setting the selected block.
-				if ( isSelected || ! isInsideRootBlock( node, event.target ) ) {
+				if (
+					isSelected( clientId ) ||
+					! isInsideRootBlock( node, event.target )
+				) {
 					return;
 				}
 
@@ -130,6 +133,7 @@ export function useEventHandlers( clientId ) {
 			};
 		},
 		[
+			clientId,
 			isSelected,
 			rootClientId,
 			index,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28166
Possibly #29678 (cc @kjellr)

This change specifically seems to happen when a block's wrapping DOM element is replaced. This happens in the Navigation block when the block transitions from its placeholder state—the element is changed from a `div` to a `nav`, so React must replace it in the DOM (edit: having said that, it seems to happen anyway, regardless of the element type, the only way I could stop it was to use a `key`).

The problem was the following code only binds event handlers if the block is unselected:
https://github.com/WordPress/gutenberg/blob/b8e4d7bfc8a2cdb7df6843c954b941acf5fb0a47/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js#L51-L75

In the navigation block's case the block remains selected, so even though the hook is triggered, `addEventListener` is never called.

There's a separate issue though. When the block's wrapper is replaced in the DOM, a loss of focus also occurs, a problem for anyone who relies on keyboard navigation.

## How has this been tested?
1. Add a navigation block
2. Click Start empty
3. Deselect the block
4. Try to select it again
5. It should become selected (the block toolbar should be visible.)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
