### PR TITLE
Cover: Allow drag n drop media replacement

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -240,6 +240,38 @@ function mediaPosition( { x, y } ) {
 	return `${ Math.round( x * 100 ) }% ${ Math.round( y * 100 ) }%`;
 }
 
+function CoverPlaceholder( {
+	coverUrl,
+	children,
+	noticeUI,
+	noticeOperations,
+	onSelectMedia,
+} ) {
+	const { removeAllNotices, createErrorNotice } = noticeOperations;
+	return (
+		<MediaPlaceholder
+			icon={ <BlockIcon icon={ icon } /> }
+			labels={ {
+				title: __( 'Cover' ),
+				instructions: __(
+					'Upload an image or video file, or pick one from your media library.'
+				),
+			} }
+			onSelect={ onSelectMedia }
+			accept="image/*,video/*"
+			allowedTypes={ ALLOWED_MEDIA_TYPES }
+			notices={ noticeUI }
+			disableMediaButtons={ !! coverUrl }
+			onError={ ( message ) => {
+				removeAllNotices();
+				createErrorNotice( message );
+			} }
+		>
+			{ children }
+		</MediaPlaceholder>
+	);
+}
+
 function CoverEdit( {
 	attributes,
 	isSelected,
@@ -329,7 +361,6 @@ function CoverEdit( {
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
 
 	const [ temporaryMinHeight, setTemporaryMinHeight ] = useState( null );
-	const { removeAllNotices, createErrorNotice } = noticeOperations;
 
 	const minHeightWithUnit = minHeightUnit
 		? `${ minHeight }${ minHeightUnit }`
@@ -507,9 +538,6 @@ function CoverEdit( {
 	);
 
 	if ( ! hasBackground ) {
-		const placeholderIcon = <BlockIcon icon={ icon } />;
-		const label = __( 'Cover' );
-
 		return (
 			<>
 				{ controls }
@@ -520,22 +548,10 @@ function CoverEdit( {
 						blockProps.className
 					) }
 				>
-					<MediaPlaceholder
-						icon={ placeholderIcon }
-						labels={ {
-							title: label,
-							instructions: __(
-								'Upload an image or video file, or pick one from your media library.'
-							),
-						} }
-						onSelect={ onSelectMedia }
-						accept="image/*,video/*"
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						notices={ noticeUI }
-						onError={ ( message ) => {
-							removeAllNotices();
-							createErrorNotice( message );
-						} }
+					<CoverPlaceholder
+						noticeUI={ noticeUI }
+						onSelectMedia={ onSelectMedia }
+						noticeOperations={ noticeOperations }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette
@@ -545,7 +561,7 @@ function CoverEdit( {
 								clearable={ false }
 							/>
 						</div>
-					</MediaPlaceholder>
+					</CoverPlaceholder>
 				</div>
 			</>
 		);
@@ -627,6 +643,12 @@ function CoverEdit( {
 					/>
 				) }
 				{ isBlogUrl && <Spinner /> }
+				<CoverPlaceholder
+					coverUrl={ url }
+					noticeUI={ noticeUI }
+					onSelectMedia={ onSelectMedia }
+					noticeOperations={ noticeOperations }
+				/>
 				<div { ...innerBlocksProps } />
 			</div>
 		</>

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -69,7 +69,8 @@
 // Only target direct dropzone.
 .wp-block-cover > .components-drop-zone {
 	&.is-active {
-		transition: 0.3s opacity, 0.3s border;
+		transition: 0.2s opacity, 0.2s border;
+		@include reduce-motion("transition");
 	}
 
 	&.is-dragging-over-element {
@@ -84,8 +85,8 @@
 	.components-drop-zone__content {
 		display: flex;
 		align-items: center;
-		top: -36px;
-		left: -36px;
+		top: -($grid-unit-15 * 3);
+		left: -($grid-unit-15 * 3);
 		transform: none;
 	}
 

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -65,3 +65,42 @@
 	// Important is used to have higher specificity than the inline style set by re-resizable library.
 	height: auto !important;
 }
+
+// Only target direct dropzone.
+.wp-block-cover > .components-drop-zone {
+	&.is-active {
+		transition: 0.3s opacity, 0.3s border;
+	}
+
+	&.is-dragging-over-element {
+		background-color: transparent;
+		border: $grid-unit-60 solid var(--wp-admin-theme-color);
+
+		.components-drop-zone__content {
+			transform: none;
+		}
+	}
+
+	.components-drop-zone__content {
+		display: flex;
+		align-items: center;
+		top: -36px;
+		left: -36px;
+		transform: none;
+	}
+
+	.components-drop-zone__content-icon,
+	.components-drop-zone__content-text {
+		display: inline;
+	}
+
+	.components-drop-zone__content-icon {
+		// Reset margin.
+		margin: 0;
+		margin-right: $grid-unit;
+	}
+
+	.components-drop-zone__content-text {
+		font-size: $default-font-size;
+	}
+}


### PR DESCRIPTION
## Description
Adds dropzone for the cover block background image.

Thanks, @jasmussen, @paaljoachim for the initial mockups. Sorry if any metrics are off compared to mockups.

Fixes #26388.

## How has this been tested?
Manually on local dev environment.

Steps:
1. Add cover block.
2. Upload a background image.
3. Drag and drop replacement image.
4. Dropzone indicator element should appear.
5. See if the background image is replaced.

## Screenshots
<img width="1280" alt="cover-image-dropzone" src="https://user-images.githubusercontent.com/240569/110924585-a76a4200-833b-11eb-8202-284158b3d4ac.png">

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
