### PR TITLE
Verse block: Add support for the padding to the verse block

### DIFF
--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -17,7 +17,10 @@
 	"supports": {
 		"anchor": true,
 		"__experimentalFontFamily": true,
-		"fontSize": true
+		"fontSize": true,
+		"spacing": {
+			"padding": true
+		}
 	},
 	"style": "wp-block-verse",
 	"editorStyle": "wp-block-verse-editor"

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -29,7 +29,7 @@ export default function VerseEdit( {
 	} );
 
 	return (
-		<>
+		<div className="wp-block-verse-padding-controls-wrapper">
 			<BlockControls>
 				<AlignmentToolbar
 					value={ textAlign }
@@ -59,6 +59,6 @@ export default function VerseEdit( {
 				{ ...blockProps }
 				__unstablePastePlainText
 			/>
-		</>
+		</div>
 	);
 }

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -13,13 +13,17 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import {
+	__experimentalBoxControl as BoxControl,
+} from '@wordpress/components';
+const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
 export default function VerseEdit( {
 	attributes,
 	setAttributes,
 	mergeBlocks,
 } ) {
-	const { textAlign, content } = attributes;
+	const { textAlign, content, style } = attributes;
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -36,6 +40,10 @@ export default function VerseEdit( {
 					} }
 				/>
 			</BlockControls>
+			<BoxControlVisualizer
+				values={ style?.spacing?.padding }
+				showValues={ style?.visualizers?.padding }
+			/>
 			<RichText
 				tagName="pre"
 				identifier="content"

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -13,15 +13,13 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
-const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
 export default function VerseEdit( {
 	attributes,
 	setAttributes,
 	mergeBlocks,
 } ) {
-	const { textAlign, content, style } = attributes;
+	const { textAlign, content } = attributes;
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -29,7 +27,7 @@ export default function VerseEdit( {
 	} );
 
 	return (
-		<div className="wp-block-verse-padding-controls-wrapper">
+		<>
 			<BlockControls>
 				<AlignmentToolbar
 					value={ textAlign }
@@ -38,10 +36,6 @@ export default function VerseEdit( {
 					} }
 				/>
 			</BlockControls>
-			<BoxControlVisualizer
-				values={ style?.spacing?.padding }
-				showValues={ style?.visualizers?.padding }
-			/>
 			<RichText
 				tagName="pre"
 				identifier="content"
@@ -59,6 +53,6 @@ export default function VerseEdit( {
 				{ ...blockProps }
 				__unstablePastePlainText
 			/>
-		</div>
+		</>
 	);
 }

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -13,9 +13,7 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import {
-	__experimentalBoxControl as BoxControl,
-} from '@wordpress/components';
+import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
 export default function VerseEdit( {

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,4 +1,3 @@
 pre.wp-block-verse {
 	color: $gray-900;
-	padding: 1em;
 }

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,3 +1,7 @@
 pre.wp-block-verse {
 	color: $gray-900;
 }
+
+.wp-block-verse-padding-controls-wrapper {
+	position: relative;
+}

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,7 +1,3 @@
 pre.wp-block-verse {
 	color: $gray-900;
 }
-
-.wp-block-verse-padding-controls-wrapper {
-	position: relative;
-}


### PR DESCRIPTION
## Description
This adds support for custom padding to the Verse block. This also removed padding from the block in the editor, so that the editor and the frontend match.

## How has this been tested?
- Add a verse block to a post
- Adjust the padding in the editor
- Check that the padding is updated in the frontend

## Screenshots <!-- if applicable -->
Editor:
<img width="1138" alt="Screenshot 2021-03-12 at 13 02 45" src="https://user-images.githubusercontent.com/275961/110943594-4d657e80-8333-11eb-9df6-1f5b06af446b.png">

Frontend:
<img width="797" alt="Screenshot 2021-03-12 at 13 02 51" src="https://user-images.githubusercontent.com/275961/110943612-53f3f600-8333-11eb-9fc3-e3808741ae76.png">

## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
