### PR TITLE
Gallery Block: Fix the crop images setting

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -78,6 +78,8 @@
 	// Cropped
 	&.is-cropped .blocks-gallery-image,
 	&.is-cropped .blocks-gallery-item {
+		align-self: inherit;
+
 		a,
 		img {
 			// IE11 doesn't support object-fit, so just make sure images aren't skewed.


### PR DESCRIPTION
## Description
https://github.com/WordPress/gutenberg/pull/29367 introduced a bug to the gallery block which meant that the "crop images" option no longer works:
<img width="681" alt="Screenshot 2021-03-12 at 14 12 14" src="https://user-images.githubusercontent.com/275961/110951856-70952b80-833d-11eb-8b18-8bb40c527ac7.png">


## How has this been tested?
- Add a gallery with the "crop images" option checked
- Check that the images stretch to fill the parent

## Screenshots <!-- if applicable -->
<img width="711" alt="Screenshot 2021-03-12 at 14 13 22" src="https://user-images.githubusercontent.com/275961/110951842-6c690e00-833d-11eb-97b6-e78d1b886739.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
