### PR TITLE
Add padding to link placeholder

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -57,6 +57,10 @@
 		}
 	}
 
+	.wp-block-navigation-link__placeholder {
+		padding: $grid-unit-15;
+	}
+
 	.wp-block-navigation-link__label {
 		padding: $grid-unit-15;
 		padding-left: $grid-unit-30;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -57,14 +57,13 @@
 		}
 	}
 
-	.wp-block-navigation-link__placeholder {
+	.wp-block-navigation-link__label,
+	.wp-block-navigation-link__placeholder-text {
 		padding: $grid-unit-15;
+		padding-left: $grid-unit-30;
 	}
 
 	.wp-block-navigation-link__label {
-		padding: $grid-unit-15;
-		padding-left: $grid-unit-30;
-
 		// Without this Links with submenus display a pointer.
 		cursor: text;
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This adds a small visual tweak to the link placeholder in the navigation block, when it is used in the navigation editor.

To test:

1. Go to Gutenberg -> Navigation
2. Add a menu item but do not select a link, by clicking on the canvas
3. Notice the placeholder
4. It should have padding

## How has this been tested?
Tested locally

## Screenshots

### Before

<img width="760" alt="Screen Shot 2021-03-12 at 18 56 23" src="https://user-images.githubusercontent.com/107534/110976822-11014500-836a-11eb-9f41-1b600433beb9.png">


### After

<img width="768" alt="Screen Shot 2021-03-12 at 19 09 13" src="https://user-images.githubusercontent.com/107534/110976797-0b0b6400-836a-11eb-92d8-61a3ffd97628.png">


## Types of changes
Minimal CSS change
