### PR TITLE
E2E: stabilize failing tests in trunk

### DIFF
--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -290,14 +290,14 @@ describe( 'adding blocks', () => {
 			inserterMenuInputSelector
 		);
 		inserterMenuSearchInput.type( 'cover' );
-		// We need to wait a bit after typing otherwise we might an "early" result
-		// that is going to be "detached" when trying to click on it
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitForTimeout( 200 );
-		const coverBlock = await page.waitForSelector(
+		await page.waitForSelector(
 			'.block-editor-block-types-list .editor-block-list-item-cover'
 		);
-		await coverBlock.click();
+		// clicking may be too quick and may select a detached node.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -347,26 +347,17 @@ describe( 'Navigation editor', () => {
 		);
 		await startEmptyButton.click();
 
-		// NOTE - the following code is commented out.
-		// In CI the editor doesn't seem to support variations.
-		// The following code can be re-introduced once that's resolved.
-		// Add an inner link block.
-		// const appender = await page.waitForSelector(
-		// 	'button[aria-label="Add block"]'
-		// );
-		// await appender.click();
+		const appender = await page.waitForSelector(
+			'button[aria-label="Add block"]'
+		);
+		await appender.click();
 
 		// Must be an exact match to the word 'Link' as other
 		// variations also contain the word 'Link'.
-		// const linkInserterItem = await page.waitForXPath(
-		// 	'//button[@role="option"]//span[.="Link"]'
-		// );
-		// await linkInserterItem.click();
-
-		const appender = await page.waitForSelector(
-			'button[aria-label="Add Link"]'
+		const linkInserterItem = await page.waitForXPath(
+			'//button[@role="option"]//span[.="Link"]'
 		);
-		await appender.click();
+		await linkInserterItem.click();
 
 		await page.waitForSelector( 'input[aria-label="URL"]' );
 


### PR DESCRIPTION
This PR fixes breaking E2E tests that are present in trunk. See [example run](https://github.com/WordPress/gutenberg/runs/2097255869)
<img width="1326" alt="Screen Shot 2021-03-12 at 10 45 11 AM" src="https://user-images.githubusercontent.com/1270189/110984912-9bbd5200-8320-11eb-93fd-c1df847ab6ca.png">

Having flakey/broken tests in trunk reduces confidence in tests. After verifying if it's a real breakage let's fix or disable them. If it's a tricky one to test, it's okay to skip, but then follow up with a more stable test.

### Testing Instructions

Local and CI runs for this branch should be green:
```
npm run test-e2e -- --puppeteer-interactive specs/experiments/navigation-editor.test.js
npm run test-e2e -- --puppeteer-interactive specs/editor/various/adding-blocks.test.js
```