### PR TITLE
Add manage with live preview link

### DIFF
--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -5,7 +5,9 @@ import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { blockDefault } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -53,6 +55,15 @@ export default function WidgetAreas( { selectedWidgetAreaId } ) {
 							) }
 						</p>
 					) }
+					<Button
+						href={ addQueryArgs( 'customize.php', {
+							'autofocus[panel]': 'widgets',
+							return: 'themes.php?page=gutenberg-widgets',
+						} ) }
+						isSecondary
+					>
+						{ __( 'Manage with live preview' ) }
+					</Button>
 				</div>
 			</div>
 		</div>

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -61,7 +61,7 @@ export default function WidgetAreas( { selectedWidgetAreaId } ) {
 								'autofocus[panel]': 'widgets',
 								return: 'themes.php?page=gutenberg-widgets',
 							} ) }
-							isSecondary
+							isTertiary
 						>
 							{ __( 'Manage with live preview' ) }
 						</Button>

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -55,15 +55,17 @@ export default function WidgetAreas( { selectedWidgetAreaId } ) {
 							) }
 						</p>
 					) }
-					<Button
-						href={ addQueryArgs( 'customize.php', {
-							'autofocus[panel]': 'widgets',
-							return: 'themes.php?page=gutenberg-widgets',
-						} ) }
-						isSecondary
-					>
-						{ __( 'Manage with live preview' ) }
-					</Button>
+					{ ! selectedWidgetArea && (
+						<Button
+							href={ addQueryArgs( 'customize.php', {
+								'autofocus[panel]': 'widgets',
+								return: 'themes.php?page=gutenberg-widgets',
+							} ) }
+							isSecondary
+						>
+							{ __( 'Manage with live preview' ) }
+						</Button>
+					) }
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #26244

This small PR proposes a place for the manage with live preview button, which allows users to switch between the customizer and the stand along widgets editor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Go to Appearance > Widgets
2. Without anything selected, in the sidebar (inspector) notice the Manage with live preview button

## Screenshots <!-- if applicable -->

### The old button

<img width="294" alt="Screen Shot 2020-10-16 at 5 26 15 PM" src="https://user-images.githubusercontent.com/8726005/96331288-0340d100-1011-11eb-9b38-56f784035d04.png">

### The new button

<img width="1055" alt="Screen Shot 2021-03-12 at 22 02 49" src="https://user-images.githubusercontent.com/107534/110992577-c1794400-837e-11eb-9fce-01f6a493cafe.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Adds one button to the widgets complimentary area. Non breaking change.

