### PR TITLE
Fix template saving issue after switching themes.

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -399,9 +399,14 @@ function gutenberg_filter_wp_template_unique_post_slug( $_slug, $slug, $post_ID,
 	// Template slugs must be unique within the same theme.
 	// TODO - Figure out how to update this to work for a multi-theme
 	// environment.  Unfortunately using `get_the_terms` for the 'wp-theme'
-	// term does not work since it is too early in the process to have been
-	// saved to the entity.  So for now we use the currently activated theme.
+	// term does not work in the case of new entities since is too early in
+	// the process to have been saved to the entity.  So for now we use the
+	// currently activated theme for creation.
 	$theme = wp_get_theme()->get_stylesheet();
+	$terms = get_the_terms( $post_ID, 'wp_theme' );
+	if ( $terms && ! is_wp_error( $terms ) ) {
+		$theme = $terms[0]->name;
+	}
 
 	$check_query_args = array(
 		'post_name__in'  => array( $_slug ),

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -408,7 +408,7 @@ function gutenberg_filter_wp_template_unique_post_slug( $_slug, $slug, $post_ID,
 		'post_type'      => $post_type,
 		'posts_per_page' => 1,
 		'no_found_rows'  => true,
-		'post__not_in'   => $post_ID,
+		'post__not_in'   => array( $post_ID ),
 		'tax_query'      => array(
 			array(
 				'taxonomy' => 'wp_theme',

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -380,20 +380,20 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 /**
  * Generates a unique slug for templates or template parts.
  *
- * @param string $_slug         The filtered value of the slug (starts as `null` from apply_filter).
+ * @param string $override_slug The filtered value of the slug (starts as `null` from apply_filter).
  * @param string $slug          The original/un-filtered slug (post_name).
  * @param int    $post_ID       Post ID.
  * @param string $post_status   No uniqueness checks are made if the post is still draft or pending.
  * @param string $post_type     Post type.
  * @return string The original, desired slug.
  */
-function gutenberg_filter_wp_template_unique_post_slug( $_slug, $slug, $post_ID, $post_status, $post_type ) {
+function gutenberg_filter_wp_template_unique_post_slug( $override_slug, $slug, $post_ID, $post_status, $post_type ) {
 	if ( 'wp_template' !== $post_type && 'wp_template_part' !== $post_type ) {
-		return $_slug;
+		return $override_slug;
 	}
 
-	if ( ! $_slug ) {
-		$_slug = $slug;
+	if ( ! $override_slug ) {
+		$override_slug = $slug;
 	}
 
 	// Template slugs must be unique within the same theme.
@@ -409,7 +409,7 @@ function gutenberg_filter_wp_template_unique_post_slug( $_slug, $slug, $post_ID,
 	}
 
 	$check_query_args = array(
-		'post_name__in'  => array( $_slug ),
+		'post_name__in'  => array( $override_slug ),
 		'post_type'      => $post_type,
 		'posts_per_page' => 1,
 		'no_found_rows'  => true,
@@ -429,14 +429,14 @@ function gutenberg_filter_wp_template_unique_post_slug( $_slug, $slug, $post_ID,
 		$suffix = 2;
 		do {
 			$query_args                  = $check_query_args;
-			$alt_post_name               = _truncate_post_slug( $_slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
+			$alt_post_name               = _truncate_post_slug( $override_slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
 			$query_args['post_name__in'] = array( $alt_post_name );
 			$query                       = new WP_Query( $query_args );
 			$suffix++;
 		} while ( count( $query->get_posts() ) > 0 );
-		$_slug = $alt_post_name;
+		$override_slug = $alt_post_name;
 	}
 
-	return $_slug;
+	return $override_slug;
 }
 add_filter( 'pre_wp_unique_post_slug', 'gutenberg_filter_wp_template_unique_post_slug', 10, 5 );

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -395,7 +395,12 @@ function gutenberg_filter_wp_template_unique_post_slug( $_slug, $slug, $post_ID,
 	if ( ! $_slug ) {
 		$_slug = $slug;
 	}
+
 	// Template slugs must be unique within the same theme.
+	// TODO - Figure out how to update this to work for a multi-theme
+	// environment.  Unfortunately using `get_the_terms` for the 'wp-theme'
+	// term does not work since it is too early in the process to have been
+	// saved to the entity.  So for now we use the currently activated theme.
 	$theme = wp_get_theme()->get_stylesheet();
 
 	$check_query_args = array(

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -359,7 +359,26 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	$template_query       = new WP_Query( $wp_query_args );
 	$posts                = $template_query->get_posts();
 
+	// Check we actually retrieved the correct item (???)
+	// It seems if a post doesnt exist for the given $theme in the above 'tax_query',
+	// that it will fall back to retreiving another post with the 'wp_theme` taxomonomy
+	// even if it has a different $theme value than we queried for.
+	// This means that if we saved an item for "Theme A", if we switch to "Theme B" and
+	// try to save this query will return the item from "Theme A" unexpectedly.
+	$foundCorrectPost = false;
 	if ( count( $posts ) > 0 ) {
+		$terms = get_the_terms( $posts[0], 'wp_theme' );
+
+		if ( is_wp_error( $terms ) || ! $terms ) {
+			$foundCorrectPost = false;
+		}
+
+		if ( count( $terms ) > 0 && $terms[0] === $theme ) {
+			$foundCorrectPost = true;
+		}
+	}
+
+	if ( $foundCorrectPost ) {
 		$template = _gutenberg_build_template_result_from_post( $posts[0] );
 
 		if ( ! is_wp_error( $template ) ) {

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -360,15 +360,18 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	$posts                = $template_query->get_posts();
 
 	/**
-	 * Check that we have retrieved the correct post.
-	 * When a post doesn't exist that matches the above tax_query, the WP_Query can
-	 * return a post matching the other above parameters (slug, post_type, etc.).
-	 * This means if we have a template saved for "Theme-A", if we switch to "Theme-B"
-	 * the query will return "Theme-A"s template.  As noted in
-	 * https://github.com/WordPress/gutenberg/issues/28951, retrieving this incorrect
-	 * post can cause bugs with saving resulting in overwriting "Theme-A"s template
-	 * when actually trying to save the one for "Theme-B", while "Theme-B"s template
-	 * will remain dirty in the editor and make it appear as if save is unresponsive.
+	 * Ignore this change for now, its not a fully working solution and will be
+	 * adapted when we figure out the best way to move forward.
+	 *
+	 * Problem:  When we provide a 'name' field to the query, it gets marked as a
+	 * singular query and the taxonomy part of the query does not run.  Thus the
+	 * post with the corresponding name and post type is retrieved regardless of our
+	 * tax restriction.
+	 * As noted in https://github.com/WordPress/gutenberg/issues/28951, retrieving
+	 * this incorrect post can cause bugs with saving resulting in overwriting
+	 * "Theme-A"s template when actually trying to save the one for "Theme-B", while
+	 * "Theme-B"s template will remain dirty in the editor and make it appear as if
+	 * save is unresponsive.
 	 */
 	$foundCorrectPost = false;
 	if ( count( $posts ) > 0 ) {

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -380,22 +380,26 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 /**
  * Generates a unique slug for templates or template parts.
  *
- * @param string $slug          The resolved slug (post_name).
+ * @param string $_slug         The filtered value of the slug (starts as `null` from apply_filter).
+ * @param string $slug          The original/un-filtered slug (post_name).
  * @param int    $post_ID       Post ID.
  * @param string $post_status   No uniqueness checks are made if the post is still draft or pending.
  * @param string $post_type     Post type.
  * @return string The original, desired slug.
  */
-function gutenberg_filter_wp_template_unique_post_slug( $placeholder, $slug, $post_ID, $post_status, $post_type ) {
+function gutenberg_filter_wp_template_unique_post_slug( $_slug, $slug, $post_ID, $post_status, $post_type ) {
 	if ( 'wp_template' !== $post_type && 'wp_template_part' !== $post_type ) {
-		return $slug;
+		return $_slug;
 	}
 
+	if ( ! $_slug ) {
+		$_slug = $slug;
+	}
 	// Template slugs must be unique within the same theme.
 	$theme = wp_get_theme()->get_stylesheet();
 
 	$check_query_args = array(
-		'post_name__in'  => array( $slug ),
+		'post_name__in'  => array( $_slug ),
 		'post_type'      => $post_type,
 		'posts_per_page' => 1,
 		'no_found_rows'  => true,
@@ -415,14 +419,14 @@ function gutenberg_filter_wp_template_unique_post_slug( $placeholder, $slug, $po
 		$suffix = 2;
 		do {
 			$query_args                  = $check_query_args;
-			$alt_post_name               = _truncate_post_slug( $slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
+			$alt_post_name               = _truncate_post_slug( $_slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
 			$query_args['post_name__in'] = array( $alt_post_name );
 			$query                       = new WP_Query( $query_args );
 			$suffix++;
 		} while ( count( $query->get_posts() ) > 0 );
-		$slug = $alt_post_name;
+		$_slug = $alt_post_name;
 	}
 
-	return $slug;
+	return $_slug;
 }
 add_filter( 'pre_wp_unique_post_slug', 'gutenberg_filter_wp_template_unique_post_slug', 10, 5 );

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -368,12 +368,9 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	$foundCorrectPost = false;
 	if ( count( $posts ) > 0 ) {
 		$terms = get_the_terms( $posts[0], 'wp_theme' );
+		$isFound = $terms && ! is_wp_error( $terms ) && count( $terms ) > 0;
 
-		if ( is_wp_error( $terms ) || ! $terms ) {
-			$foundCorrectPost = false;
-		}
-
-		if ( count( $terms ) > 0 && $terms[0] === $theme ) {
+		if ( $isFound && $terms[0] === $theme ) {
 			$foundCorrectPost = true;
 		}
 	}

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -20,6 +20,24 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		gutenberg_register_wp_theme_taxonomy();
 		gutenberg_register_wp_template_part_area_taxonomy();
 
+		// Set up a template post corresponding to a different theme.
+		// We do this to ensure resolution and slug creation works as expected,
+		// even with another post of that same name present for another theme.
+		$args       = array(
+			'post_type'    => 'wp_template',
+			'post_name'    => 'my_template',
+			'post_title'   => 'My Template',
+			'post_content' => 'Content',
+			'post_excerpt' => 'Description of my template',
+			'tax_input'    => array(
+				'wp_theme' => array(
+					'this-theme-should-not-resolve',
+				),
+			),
+		);
+		self::$post = self::factory()->post->create_and_get( $args );
+		wp_set_post_terms( self::$post->ID, 'this-theme-should-not-resolve', 'wp_theme' );
+
 		// Set up template post.
 		$args       = array(
 			'post_type'    => 'wp_template',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Potential solution for https://github.com/WordPress/gutenberg/issues/28951 - This seems to solve the problem.

There were 2 main issues I found:
* Using `name` and `tax_query` in a WP_Query do not play nice together (the tax_query gets bypassed).  However, it seems we can easily fix this by using `post_name__in`.
* The function for handling the unique post slug had a handful of issues.  First, it was set on a hook that runs after a suffix had already been added automatically (thus, `header` would become `header-1` before even getting to this function if there was already a `header` saved for ANY theme).  Second, the early return was always being triggered due to a logic error.  There we also some issues with the way the query was written.  (more in code review comments below).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Follow repro steps outlined in https://github.com/WordPress/gutenberg/issues/28951 and verify this issue no longer exists when running this PR.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
