### PR TITLE
Social Links: Add text placeholder next to appender

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -45,6 +45,7 @@ export function SocialLinksEdit( props ) {
 		attributes,
 		iconBackgroundColor,
 		iconColor,
+		isSelected,
 		setAttributes,
 		setIconBackgroundColor,
 		setIconColor,
@@ -82,6 +83,12 @@ export function SocialLinksEdit( props ) {
 		</div>
 	);
 
+	const SelectedSocialPlaceholder = (
+		<li style={ { fontFamily: 'Comic Sans MS', listStyle: 'none' } }>
+			Add a link
+		</li>
+	);
+
 	// Fallback color values are used maintain selections in case switching
 	// themes and named colors in palette do not match.
 	const className = classNames( size, {
@@ -95,7 +102,7 @@ export function SocialLinksEdit( props ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
-		placeholder: SocialPlaceholder,
+		placeholder: isSelected ? SelectedSocialPlaceholder : SocialPlaceholder,
 		templateLock: false,
 		__experimentalAppenderTagName: 'li',
 	} );

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -73,19 +73,19 @@ export function SocialLinksEdit( props ) {
 	}, [ logosOnly, setAttributes ] );
 
 	const SocialPlaceholder = (
-		<div className="wp-block-social-links__social-placeholder">
+		<li className="wp-block-social-links__social-placeholder">
 			<div className="wp-social-link"></div>
 			<div className="wp-block-social-links__social-placeholder-icons">
 				<div className="wp-social-link wp-social-link-twitter"></div>
 				<div className="wp-social-link wp-social-link-facebook"></div>
 				<div className="wp-social-link wp-social-link-instagram"></div>
 			</div>
-		</div>
+		</li>
 	);
 
 	const SelectedSocialPlaceholder = (
-		<li style={ { fontFamily: 'Comic Sans MS', listStyle: 'none' } }>
-			Add a link
+		<li className="wp-block-social-links__social-prompt">
+			{ __( 'Add link' ) }
 		</li>
 	);
 

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -85,7 +85,7 @@ export function SocialLinksEdit( props ) {
 
 	const SelectedSocialPlaceholder = (
 		<li className="wp-block-social-links__social-prompt">
-			{ __( 'Add link' ) }
+			{ __( 'Click plus to add' ) }
 		</li>
 	);
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -19,13 +19,7 @@
 .wp-block-social-links__social-placeholder {
 	display: flex;
 	opacity: 0.8;
-	transition: all 0.1s ease-in-out;
-	@include reduce-motion("transition");
-
-	.is-selected > & {
-		opacity: 0;
-		width: 0; // This allows the appender to sit on the left as it should.
-	}
+	list-style: none;
 
 	// Use the first link to set the height.
 	> .wp-social-link {
@@ -53,10 +47,6 @@
 		}
 	}
 
-	& + .block-list-appender {
-		box-shadow: inset 0 0 0 $border-width $gray-700;
-	}
-
 	.wp-social-link::before {
 		content: "";
 		display: block;
@@ -67,6 +57,24 @@
 		.is-style-logos-only & {
 			background: currentColor;
 		}
+	}
+}
+
+// Selected placeholder state.
+.wp-block-social-links .wp-block-social-links__social-prompt {
+	list-style: none;
+	order: 2; // Move after the appender button. Because this element is non-interactive, it does not affect tab order.
+
+	// Show as block UI.
+	font-family: $default-font;
+	font-size: $default-font-size;
+	line-height: $button-size-small;
+	margin-top: auto;
+	margin-bottom: auto;
+
+	& + .block-list-appender {
+		margin-right: $grid-unit-15;
+		padding: 0.25em;
 	}
 }
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -71,9 +71,10 @@
 	line-height: $button-size-small;
 	margin-top: auto;
 	margin-bottom: auto;
+	cursor: default;
 
 	& + .block-list-appender {
-		margin-right: $grid-unit-15;
+		margin-right: $grid-unit-10;
 		padding: 0.25em;
 	}
 }


### PR DESCRIPTION

## Description

Create a SelectedPlaceholder to show text next to the appender when selected.

This helps the guide the initial empty state and adding the first links.

Related to #29756 

## How has this been tested?

- Add Social Links block
- Confirm "Add a link" text shows next to appender
- Clicking away shows placeholder icons not text

## Screenshots

![social-links-placeholder](https://user-images.githubusercontent.com/45363/111039031-c2db5880-83e0-11eb-9fdd-e625848f2723.gif)


## Types of changes

Adds new SelectedPlaceholder components and switches what gets passed to InnerBlocks based on selected state

