### PR TITLE
Components: Update CustomSelectControl component README.md

### DIFF
--- a/packages/components/src/custom-select-control/README.md
+++ b/packages/components/src/custom-select-control/README.md
@@ -21,7 +21,7 @@ These are the same as [the ones for `SelectControl`s](/packages/components/src/s
  * WordPress dependencies
  */
 import { CustomSelectControl } from '@wordpress/components';
-import { useState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 const options = [
 	{


### PR DESCRIPTION
I found an error in Usage example, useState is imported from the wrong package; @wordpress/element is the correct package instead of incorrect @wordpress/compose


## Description
Described above

## How has this been tested?
Tested on local development while building custom blocks.

## Screenshots <!-- if applicable -->

## Types of changes
Changes in documentation

