### PR TITLE
Added a "plain" style for quote blocks

### DIFF
--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -36,6 +36,7 @@
 			"label": "Default",
 			"isDefault": true
 		},
+		{ "name": "plain", "label": "Plain" },
 		{ "name": "large", "label": "Large" }
 	],
 	"editorStyle": "wp-block-quote-editor",

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -23,6 +23,7 @@
 		padding-left: 0;
 	}
 
+	&.is-style-plain,
 	&.is-style-large,
 	&.is-large {
 		border: none;

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/style-variation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/style-variation.test.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`adding blocks Should switch the style of the quote block 1`] = `
-"<!-- wp:quote {\\"className\\":\\"is-style-large\\"} -->
-<blockquote class=\\"wp-block-quote is-style-large\\"><p>Quote content</p></blockquote>
-<!-- /wp:quote -->"
-`;
-
 exports[`adding blocks Should switch to the large style of the quote block 1`] = `
 "<!-- wp:quote {\\"className\\":\\"is-style-large\\"} -->
 <blockquote class=\\"wp-block-quote is-style-large\\"><p>Quote content</p></blockquote>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/style-variation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/style-variation.test.js.snap
@@ -5,3 +5,9 @@ exports[`adding blocks Should switch the style of the quote block 1`] = `
 <blockquote class=\\"wp-block-quote is-style-large\\"><p>Quote content</p></blockquote>
 <!-- /wp:quote -->"
 `;
+
+exports[`adding blocks Should switch to the large style of the quote block 1`] = `
+"<!-- wp:quote {\\"className\\":\\"is-style-large\\"} -->
+<blockquote class=\\"wp-block-quote is-style-large\\"><p>Quote content</p></blockquote>
+<!-- /wp:quote -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/style-variation.test.js
+++ b/packages/e2e-tests/specs/editor/various/style-variation.test.js
@@ -13,17 +13,17 @@ describe( 'adding blocks', () => {
 		await createNewPost();
 	} );
 
-	it( 'Should switch the style of the quote block', async () => {
+	it( 'Should switch to the large style of the quote block', async () => {
 		// Inserting a quote block
 		await insertBlock( 'Quote' );
 		await page.keyboard.type( 'Quote content' );
 
 		await clickBlockToolbarButton( 'Quote' );
 
-		const styleVariations = await page.$$(
-			'.block-editor-block-styles__item'
+		const largeStyleButton = await page.waitForXPath(
+			'//*[@role="menuitem"][contains(., "Large")]'
 		);
-		await styleVariations[ 1 ].click();
+		await largeStyleButton.click();
 
 		// Check the content
 		const content = await getEditedPostContent();


### PR DESCRIPTION
## Description
- Implements #28524

## How has this been tested?
Ran `npm run test`. All tests passing.

## Screenshots
![image](https://user-images.githubusercontent.com/16845197/111082334-f2639100-84c4-11eb-853d-5ce07251eff5.png)
![image](https://user-images.githubusercontent.com/16845197/111082347-fee7e980-84c4-11eb-9f0f-47c5091bee80.png)
![image](https://user-images.githubusercontent.com/16845197/111082355-0d360580-84c5-11eb-864f-0fa98f710f76.png)

## Types of changes
Simply adds a "Plain" style to quotes to allow them(in part) to function as text indentation. Selecting "Plain" will set border-left: none in the code.

## Checklist:
- [ X ] My code is tested.
- [ X ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ X ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ X ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ N/A ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ N/A ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ N/A ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
