### PR TITLE
Fix broken image link in the docs main README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 **Gutenberg** is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. The project is right now in the second phase of a four-phase process that will touch every piece of WordPress -- Editing, **Customization** (which includes Full Site Editing, Block Patterns, Block Directory and Block based themes), Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor (which is the topic of the current documentation).
 
-![Quick view of the block editor](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/assets/quick-view-of-the-block-editor.png)
+![Quick view of the block editor](https://raw.githubusercontent.com/WordPress/gutenberg/trunk/docs/assets/quick-view-of-the-block-editor.png)
 
 **Legend :**
 


### PR DESCRIPTION
This fixes the broken link on the image in the docs main README file.

The broken link was introduced in https://github.com/WordPress/gutenberg/pull/29808.