### PR TITLE
Cover: Improve disabled media buttons check for placeholder

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -241,7 +241,7 @@ function mediaPosition( { x, y } ) {
 }
 
 function CoverPlaceholder( {
-	coverUrl,
+	hasBackground = false,
 	children,
 	noticeUI,
 	noticeOperations,
@@ -261,7 +261,7 @@ function CoverPlaceholder( {
 			accept="image/*,video/*"
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			notices={ noticeUI }
-			disableMediaButtons={ !! coverUrl }
+			disableMediaButtons={ hasBackground }
 			onError={ ( message ) => {
 				removeAllNotices();
 				createErrorNotice( message );
@@ -644,7 +644,7 @@ function CoverEdit( {
 				) }
 				{ isBlogUrl && <Spinner /> }
 				<CoverPlaceholder
-					coverUrl={ url }
+					hasBackground={ hasBackground }
 					noticeUI={ noticeUI }
 					onSelectMedia={ onSelectMedia }
 					noticeOperations={ noticeOperations }


### PR DESCRIPTION
## Description
Prevents placeholder from being rendered, when using cover block without media. See #29813.

Thanks, @jasmussen for catching this issue.

## How has this been tested?
1. Add cover block.
2. Select color.
3. See if the placeholder is rendered.

## Types of changes
Bugfix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
