### PR TITLE
Update post content icon, unuse justify.

### DIFF
--- a/packages/block-library/src/post-comment-content/index.js
+++ b/packages/block-library/src/post-comment-content/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { alignJustify as icon } from '@wordpress/icons';
+import { postContent as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { _x } from '@wordpress/i18n';
-import { alignJustify as icon } from '@wordpress/icons';
+import { postContent as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -140,6 +140,7 @@ export { default as plusCircleFilled } from './library/plus-circle-filled';
 export { default as plusCircle } from './library/plus-circle';
 export { default as plus } from './library/plus';
 export { default as postCategories } from './library/post-categories';
+export { default as postContent } from './library/post-content';
 export { default as postComments } from './library/post-comments';
 export { default as postCommentsCount } from './library/post-comments-count';
 export { default as postCommentsForm } from './library/post-comments-form';

--- a/packages/icons/src/library/post-content.js
+++ b/packages/icons/src/library/post-content.js
@@ -3,10 +3,10 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const alignJustify = (
+const postContent = (
 	<SVG xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M4 12.8h16v-1.5H4v1.5zm0 7h12.4v-1.5H4v1.5zM4 4.3v1.5h16V4.3H4z" />
+		<Path d="M4 20h16v-1.5H4V20zm0-4.8h16v-1.5H4v1.5zm0-6.4v1.5h16V8.8H4zM16 4H4v1.5h12V4z" />
 	</SVG>
 );
 
-export default alignJustify;
+export default postContent;


### PR DESCRIPTION
## Description

The Post Content block used an incorrect icon, "alignjustify", and the justify icon was not in the new style. 

This PR fixes both. It creates a new post content icon, and it updates the align justify icon, and it points the two blocks that used the post content icon to use the new icon.

Post content before:

<img width="322" alt="Screenshot 2021-03-15 at 11 30 25" src="https://user-images.githubusercontent.com/1204802/111143647-57cb8680-8586-11eb-8f27-3580b5307113.png">

After:

<img width="356" alt="Screenshot 2021-03-15 at 11 57 19" src="https://user-images.githubusercontent.com/1204802/111143655-5a2de080-8586-11eb-8e7d-b937537e312a.png">

Here it is on the grid:

<img width="408" alt="Screenshot 2021-03-15 at 11 35 29" src="https://user-images.githubusercontent.com/1204802/111143927-b09b1f00-8586-11eb-8a16-6a0a69911a0c.png">

Technically the new justify icon isn't used at all now, because there aren't any visible tools to justify text for paragraphs. However as part of global styles, it might become an option, so I kept it in:

<img width="822" alt="Screenshot 2021-03-15 at 11 35 19" src="https://user-images.githubusercontent.com/1204802/111144064-d9bbaf80-8586-11eb-9817-ce4031559fa7.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
