### PR TITLE
Navigation Menu: Show submenus only on select in the editor.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -48,7 +48,7 @@
 	// Do not show it on hover.
 	&,
 	&:hover {
-		> .wp-block-navigation__container {
+		> .wp-block-navigation-link__container {
 			opacity: 0;
 			visibility: hidden;
 		}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -42,18 +42,16 @@
 	background-color: inherit;
 }
 
+// Only show the flyout on hover if the parent menu item is selected.
+.wp-block-navigation:not(.is-selected):not(.has-child-selected) .has-child:hover {
+	> .wp-block-navigation-link__container {
+		opacity: 0;
+		visibility: hidden;
+	}
+}
+
 // Styles for submenu flyout
 .has-child {
-	// Only show the flyout when the parent menu item is selected.
-	// Do not show it on hover.
-	&,
-	&:hover {
-		> .wp-block-navigation-link__container {
-			opacity: 0;
-			visibility: hidden;
-		}
-	}
-
 	&.is-selected,
 	&.has-child-selected,
 	// Show the submenu list when is dragging and drag enter the list item.
@@ -65,7 +63,7 @@
 	}
 }
 
-// IE fix for submenu visibility on parent focus
+// IE fix for submenu visibility on parent focus.
 .is-editing > .wp-block-navigation__container {
 	visibility: visible;
 	opacity: 1;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -10,7 +10,7 @@
 		margin: $grid-unit-15 auto;
 	}
 
-	// Adapt the layout of the Navigation and Link blocks
+	// Adapt the layout of the Navigation and Link blocks.
 	// to work better in the context of the Navigation Screen.
 	.wp-block-navigation {
 		margin: 0;
@@ -21,11 +21,15 @@
 	.wp-block-navigation-link {
 		display: block;
 
-		&.has-child:hover > .wp-block-navigation-link__container {
+		// Show submenus on click.
+		> .wp-block-navigation-link__container {
+			// This unsets some styles inherited from the block, meant to only show submenus on click, not hover, when inside the editor.
+			opacity: 1;
+			visibility: visible;
 			display: none;
 		}
 
-		// Fix focus outlines
+		// Fix focus outlines.
 		&.is-selected > .wp-block-navigation-link__content,
 		&.is-selected:hover > .wp-block-navigation-link__content {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);


### PR DESCRIPTION
## Description

This PR does two things.

1. It addresses feedback from https://github.com/WordPress/gutenberg/issues/25012#issuecomment-799353377, and shows navigation block submenus only on click, never on hover, when inside the editor. This appears to have been dead CSS that this PR simply resurrects. Fixes #25012.
2. It tweaks some CSS inside the navigation screen so that submenus are expanded on click.

For the 2nd item, I'm not entirely sure I understood correctly the intended behavior here, so I have marked this PR as draft until I can get a sanity check that I didn't misunderstand something.

GIFs:

![only on select](https://user-images.githubusercontent.com/1204802/111151317-944fb000-858f-11eb-9260-d9303e8caec2.gif)

![on click](https://user-images.githubusercontent.com/1204802/111151322-96197380-858f-11eb-8d4b-8cd481c0db64.gif)

Please, notably on the 2nd gif showing expanding of submenu items on the navigation screen, let me know whether this is the correct behavior, as it seems right to me.

## How has this been tested?

Please test a navigation block with submenus. Submenus should only show up when you click the parent item first. Frontend should be the same, and show them on hover or focus.

Please test the navigation screen and verify that submenus behave as they should.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
