### PR TITLE
Site icon: Simplify focus style.

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -13,21 +13,33 @@
 		border-radius: 0;
 		height: $header-height;
 		width: $header-height;
-
-		&:hover {
-			background: #32373d; // WP-admin light-gray.
-		}
+		position: relative;
 
 		&:active {
 			color: $white;
 		}
 
 		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 ($border-width-focus + 1px) $white;
+			box-shadow: none;
+		}
+
+		&:focus::before {
+			content: "";
+			display: block;
+			position: absolute;
+			top: 9px;
+			right: 9px;
+			bottom: 9px;
+			left: 9px;
+			border-radius: $radius-block-ui + $border-width + $border-width;
+
+			// Lightened spot color focus.
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
 }
 
 .edit-post-fullscreen-mode-close_site-icon {
-	width: 36px;
+	width: $button-size;
+	border-radius: $radius-block-ui;
 }


### PR DESCRIPTION
## Description

This PR changes the focus style of the wp-admin button to add a small radius to share DNA with buttons, to work better when site icons are defined, and to be inset.

GIFs:

![lightened blue](https://user-images.githubusercontent.com/1204802/111168957-d7ffe500-85a2-11eb-9189-49104de42f17.gif)

![lightened blue site icon](https://user-images.githubusercontent.com/1204802/111168963-d9311200-85a2-11eb-8444-d99acf761397.gif)

![default color scheme](https://user-images.githubusercontent.com/1204802/111168968-d9c9a880-85a2-11eb-9a9f-92935da1c3e4.gif)

## How has this been tested?

Please test the button focus style with and without a site icon defined. These are defined in the site editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
