### PR TITLE
Block editor: fix misplaced rich text inline toolbar

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -19,7 +19,7 @@ const FormatToolbarContainer = ( { inline, anchorRef } ) => {
 				focusOnMount={ false }
 				anchorRef={ anchorRef }
 				className="block-editor-rich-text__inline-format-toolbar"
-				__unstableSlotName="block-toolbar"
+				__unstableSlotName="__unstable-block-inline-toolbar"
 			>
 				<FormatToolbar />
 			</Popover>

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -102,6 +102,7 @@ export default function Header( {
 					<SaveButton navigationPost={ navigationPost } />
 
 					<Popover.Slot name="block-toolbar" />
+					<Popover.Slot name="__unstable-block-inline-toolbar" />
 				</div>
 			) }
 		</div>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -66,6 +66,7 @@ export default function VisualEditor( { styles } ) {
 			<EditorStyles styles={ styles } />
 			<VisualEditorGlobalKeyboardShortcuts />
 			<Popover.Slot name="block-toolbar" />
+			<Popover.Slot name="__unstable-block-inline-toolbar" />
 			<div
 				ref={ mergedRefs }
 				className="editor-styles-wrapper"

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -94,6 +94,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			</SidebarInspectorFill>
 			<div className="edit-site-visual-editor" onWheel={ onWheel }>
 				<Popover.Slot name="block-toolbar" />
+				<Popover.Slot name="__unstable-block-inline-toolbar" />
 				<Iframe
 					style={ resizedCanvasStyles }
 					headHTML={ window.__editorStyles.html }

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -27,6 +27,7 @@ export default function WidgetAreasBlockEditorContent( {
 			<BlockEditorKeyboardShortcuts />
 			<Notices />
 			<Popover.Slot name="block-toolbar" />
+			<Popover.Slot name="__unstable-block-inline-toolbar" />
 			<BlockSelectionClearer>
 				<WritingFlow>
 					<ObserveTyping>

--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -44,6 +44,7 @@ function App() {
 						</div>
 						<div className="editor-styles-wrapper">
 							<Popover.Slot name="block-toolbar" />
+							<Popover.Slot name="__unstable-block-inline-toolbar" />
 							<BlockEditorKeyboardShortcuts />
 							<WritingFlow>
 								<ObserveTyping>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #26114.
Alternative to #28420.

Currently the inline toolbar popover is misplaced and positioned _before_ the block toolbar, which means that you have to tab through the block toolbar to access it. The inline toolbar popover should be positioned after the block toolbar popover so it receives focus before the block toolbar when reverse tabbing from the block.

Both popovers are filled into the same slot and unfortunately it's not possible to set the order from a fill. I added another slot to enforce the order. Ideally, we should have a better API to define the toolbar area for a block editor.

In the GIF below I use Shift+Tab to navigate to the block toolbar and through the buttons to "Bold".

![inline-toolbar](https://user-images.githubusercontent.com/4710635/111170187-5745e680-85ac-11eb-8aa1-7cc2ec7bc7d2.gif)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
