### PR TITLE
RichText: remove dead and deprecated setFocusedElement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,7 +13396,6 @@
 				"@babel/runtime": "^7.12.5",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
-				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/escape-html": "file:packages/escape-html",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -29,7 +29,6 @@
 		"@babel/runtime": "^7.12.5",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
-		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -18,7 +18,6 @@ import {
 	SPACE,
 	ESCAPE,
 } from '@wordpress/keycodes';
-import deprecated from '@wordpress/deprecated';
 import { getFilesFromDataTransfer } from '@wordpress/dom';
 import { useMergeRefs } from '@wordpress/compose';
 
@@ -147,8 +146,6 @@ function RichText(
 		onSelectionChange,
 		onChange,
 		unstableOnFocus: onFocus,
-		setFocusedElement,
-		instanceId,
 		clientId,
 		identifier,
 		__unstableMultilineTag: multilineTag,
@@ -963,12 +960,6 @@ function RichText(
 	 * documented, as the current requirements where it is used are subject to
 	 * future refactoring following `isSelected` handling.
 	 *
-	 * In contrast with `setFocusedElement`, this is only triggered in response
-	 * to focus within the contenteditable field, whereas `setFocusedElement`
-	 * is triggered on focus within any `RichText` descendent element.
-	 *
-	 * @see setFocusedElement
-	 *
 	 * @private
 	 */
 	function handleFocus() {
@@ -1010,13 +1001,6 @@ function RichText(
 		rafId.current = getWin().requestAnimationFrame( handleSelectionChange );
 
 		getDoc().addEventListener( 'selectionchange', handleSelectionChange );
-
-		if ( setFocusedElement ) {
-			deprecated( 'wp.blockEditor.RichText setFocusedElement prop', {
-				alternative: 'selection state from the block editor store.',
-			} );
-			setFocusedElement( instanceId );
-		}
 	}
 
 	function handleBlur() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Was deprecated in #17421.
This code no longer runs since the props is no longer passed down to the internal RichText component since [#23034](https://github.com/WordPress/gutenberg/commit/aa0abb915e843e2d636d4242aa249e504284abbc#diff-bec072c72a2f961596701aef67f67575b0a3b918135a6587229a0cd79bb3db44L531).

No one has complained so far it seems, and if a plugin still needs it even though it's not been working for a while, they should probably use `unstableOnFocus` or check the block editor store for selection information.

Reduces some maintenance headaches.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
