### PR TITLE
Persistent List View: Add visual support for multiple selected blocks

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -46,12 +46,13 @@ export default function BlockNavigationBlock( {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const { clientId } = block;
-	const { isDragging, blockParents } = useSelect(
+	const { isDragging, blockParents, isMultiSelected } = useSelect(
 		( select ) => {
 			const {
 				isBlockBeingDragged,
 				isAncestorBeingDragged,
 				getBlockParents,
+				isBlockMultiSelected,
 			} = select( blockEditorStore );
 
 			return {
@@ -59,6 +60,7 @@ export default function BlockNavigationBlock( {
 					isBlockBeingDragged( clientId ) ||
 					isAncestorBeingDragged( clientId ),
 				blockParents: getBlockParents( clientId ),
+				isMultiSelected: isBlockMultiSelected( clientId ),
 			};
 		},
 		[ clientId ]
@@ -114,18 +116,21 @@ export default function BlockNavigationBlock( {
 		highlightBlock( clientId, false );
 	};
 
+	const classes = classnames( {
+		'is-selected':
+			isSelected ||
+			( withExperimentalPersistentListViewFeatures && isMultiSelected ),
+		'is-branch-selected':
+			withExperimentalPersistentListViewFeatures && isBranchSelected,
+		'is-last-of-selected-branch':
+			withExperimentalPersistentListViewFeatures &&
+			isLastOfSelectedBranch,
+		'is-dragging': isDragging,
+	} );
+
 	return (
 		<BlockNavigationLeaf
-			className={ classnames( {
-				'is-selected': isSelected,
-				'is-branch-selected':
-					withExperimentalPersistentListViewFeatures &&
-					isBranchSelected,
-				'is-last-of-selected-branch':
-					withExperimentalPersistentListViewFeatures &&
-					isLastOfSelectedBranch,
-				'is-dragging': isDragging,
-			} ) }
+			className={ classes }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
 			onFocus={ onMouseEnter }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -46,13 +46,12 @@ export default function BlockNavigationBlock( {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const { clientId } = block;
-	const { isDragging, blockParents, isMultiSelected } = useSelect(
+	const { isDragging, blockParents } = useSelect(
 		( select ) => {
 			const {
 				isBlockBeingDragged,
 				isAncestorBeingDragged,
 				getBlockParents,
-				isBlockMultiSelected,
 			} = select( blockEditorStore );
 
 			return {
@@ -60,7 +59,6 @@ export default function BlockNavigationBlock( {
 					isBlockBeingDragged( clientId ) ||
 					isAncestorBeingDragged( clientId ),
 				blockParents: getBlockParents( clientId ),
-				isMultiSelected: isBlockMultiSelected( clientId ),
 			};
 		},
 		[ clientId ]
@@ -117,9 +115,7 @@ export default function BlockNavigationBlock( {
 	};
 
 	const classes = classnames( {
-		'is-selected':
-			isSelected ||
-			( withExperimentalPersistentListViewFeatures && isMultiSelected ),
+		'is-selected': isSelected,
 		'is-branch-selected':
 			withExperimentalPersistentListViewFeatures && isBranchSelected,
 		'is-last-of-selected-branch':

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -18,7 +18,7 @@ export default function BlockNavigationBranch( props ) {
 	const {
 		blocks,
 		selectBlock,
-		selectedBlockClientId,
+		selectedBlockClientIds,
 		showAppender,
 		showBlockMovers,
 		showNestedBlocks,
@@ -35,7 +35,7 @@ export default function BlockNavigationBranch( props ) {
 	const itemHasAppender = ( parentClientId ) =>
 		showAppender &&
 		! isTreeRoot &&
-		isClientIdSelected( parentClientId, selectedBlockClientId );
+		isClientIdSelected( parentClientId, selectedBlockClientIds );
 	const hasAppender = itemHasAppender( parentBlockClientId );
 	// Add +1 to the rowCount to take the block appender into account.
 	const blockCount = filteredBlocks.length;
@@ -59,7 +59,7 @@ export default function BlockNavigationBranch( props ) {
 
 				const isSelected = isClientIdSelected(
 					clientId,
-					selectedBlockClientId
+					selectedBlockClientIds
 				);
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBranch );
@@ -90,7 +90,9 @@ export default function BlockNavigationBranch( props ) {
 						{ hasNestedBranch && (
 							<BlockNavigationBranch
 								blocks={ innerBlocks }
-								selectedBlockClientId={ selectedBlockClientId }
+								selectedBlockClientIds={
+									selectedBlockClientIds
+								}
 								selectBlock={ selectBlock }
 								isBranchSelected={ isSelectedBranch }
 								isLastOfBranch={ isLast }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -13,7 +13,7 @@ import { Fragment } from '@wordpress/element';
  */
 import BlockNavigationBlock from './block';
 import BlockNavigationAppender from './appender';
-
+import { isClientIdSelected } from './utils';
 export default function BlockNavigationBranch( props ) {
 	const {
 		blocks,
@@ -35,7 +35,7 @@ export default function BlockNavigationBranch( props ) {
 	const itemHasAppender = ( parentClientId ) =>
 		showAppender &&
 		! isTreeRoot &&
-		selectedBlockClientId === parentClientId;
+		isClientIdSelected( parentClientId, selectedBlockClientId );
 	const hasAppender = itemHasAppender( parentBlockClientId );
 	// Add +1 to the rowCount to take the block appender into account.
 	const blockCount = filteredBlocks.length;
@@ -57,7 +57,10 @@ export default function BlockNavigationBranch( props ) {
 				const hasNestedAppender = itemHasAppender( clientId );
 				const hasNestedBranch = hasNestedBlocks || hasNestedAppender;
 
-				const isSelected = selectedBlockClientId === clientId;
+				const isSelected = isClientIdSelected(
+					clientId,
+					selectedBlockClientId
+				);
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBranch );
 

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { isArray, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockNavigationTree from './tree';
+import { isClientIdSelected } from './utils';
 import { store as blockEditorStore } from '../../store';
 
 export default function BlockNavigation( {
@@ -30,11 +31,14 @@ export default function BlockNavigation( {
 
 			const _selectedBlockClientId = getSelectedBlockClientId();
 			const _rootBlocks = __unstableGetClientIdsTree();
-			const _rootBlock = _selectedBlockClientId
-				? __unstableGetClientIdWithClientIdsTree(
-						getBlockHierarchyRootClientId( _selectedBlockClientId )
-				  )
-				: null;
+			const _rootBlock =
+				selectedBlockClientId && ! isArray( selectedBlockClientId )
+					? __unstableGetClientIdWithClientIdsTree(
+							getBlockHierarchyRootClientId(
+								_selectedBlockClientId
+							)
+					  )
+					: null;
 
 			return {
 				rootBlock: _rootBlock,
@@ -56,7 +60,7 @@ export default function BlockNavigation( {
 
 	const hasHierarchy =
 		rootBlock &&
-		( rootBlock.clientId !== selectedBlockClientId ||
+		( isClientIdSelected( rootBlock.clientId, selectedBlockClientId ) ||
 			( rootBlock.innerBlocks && rootBlock.innerBlocks.length !== 0 ) );
 
 	return (

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -71,7 +71,7 @@ export default function BlockNavigation( {
 
 			<BlockNavigationTree
 				blocks={ hasHierarchy ? [ rootBlock ] : rootBlocks }
-				selectedBlockClientId={ selectedBlockClientId }
+				selectedBlockClientIds={ [ selectedBlockClientId ] }
 				selectBlock={ selectEditorBlock }
 				__experimentalFeatures={ __experimentalFeatures }
 				showNestedBlocks

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -60,7 +60,7 @@ export default function BlockNavigation( {
 
 	const hasHierarchy =
 		rootBlock &&
-		( isClientIdSelected( rootBlock.clientId, selectedBlockClientId ) ||
+		( ! isClientIdSelected( rootBlock.clientId, selectedBlockClientId ) ||
 			( rootBlock.innerBlocks && rootBlock.innerBlocks.length !== 0 ) );
 
 	return (

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -3,9 +3,9 @@
  */
 
 import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
 /**
  * Internal dependencies
  */
@@ -21,10 +21,14 @@ import useBlockNavigationDropZone from './use-block-navigation-drop-zone';
  * @param {Object}  props                                          Components props.
  * @param {boolean} props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean} props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
+ * @param {string}  props.selectedBlockClientId                    Deprecated. See props.selectedBlockClientIds.
+ * @param {Array}   props.selectedBlockClientIds                   List of selected block client IDs.
  */
 export default function BlockNavigationTree( {
 	__experimentalFeatures,
 	__experimentalPersistentListViewFeatures,
+	selectedBlockClientId,
+	selectedBlockClientIds,
 	...props
 } ) {
 	const treeGridRef = useRef();
@@ -47,6 +51,26 @@ export default function BlockNavigationTree( {
 		]
 	);
 
+	// Deprecate selectedBlockClientId
+	if ( selectedBlockClientId ) {
+		deprecated(
+			'selectedBlockClientId (singular) prop of the BlockNavigationTree component',
+			{
+				alternative:
+					'selectedBlockClientIds (renamed to plural) of the BlockNavigationTree component',
+				hint: 'The renamed prop is an array',
+			}
+		);
+	}
+	// Convert selectedBlockClientId to selectedBlockClientIds for backward compatibility.
+	const updatedProps = {
+		...props,
+		selectedBlockClientIds:
+			selectedBlockClientId && ! selectedBlockClientIds
+				? [ selectedBlockClientId ]
+				: selectedBlockClientIds,
+	};
+
 	return (
 		<TreeGrid
 			className="block-editor-block-navigation-tree"
@@ -54,7 +78,7 @@ export default function BlockNavigationTree( {
 			ref={ treeGridRef }
 		>
 			<BlockNavigationContext.Provider value={ contextValue }>
-				<BlockNavigationBranch { ...props } />
+				<BlockNavigationBranch { ...updatedProps } />
 			</BlockNavigationContext.Provider>
 		</TreeGrid>
 	);

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -3,7 +3,6 @@
  */
 
 import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
@@ -21,14 +20,10 @@ import useBlockNavigationDropZone from './use-block-navigation-drop-zone';
  * @param {Object}  props                                          Components props.
  * @param {boolean} props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean} props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
- * @param {string}  props.selectedBlockClientId                    Deprecated. See props.selectedBlockClientIds.
- * @param {Array}   props.selectedBlockClientIds                   List of selected block client IDs.
  */
 export default function BlockNavigationTree( {
 	__experimentalFeatures,
 	__experimentalPersistentListViewFeatures,
-	selectedBlockClientId,
-	selectedBlockClientIds,
 	...props
 } ) {
 	const treeGridRef = useRef();
@@ -51,26 +46,6 @@ export default function BlockNavigationTree( {
 		]
 	);
 
-	// Deprecate selectedBlockClientId
-	if ( selectedBlockClientId ) {
-		deprecated(
-			'selectedBlockClientId (singular) prop of the BlockNavigationTree component',
-			{
-				alternative:
-					'selectedBlockClientIds (renamed to plural) of the BlockNavigationTree component',
-				hint: 'The renamed prop is an array',
-			}
-		);
-	}
-	// Convert selectedBlockClientId to selectedBlockClientIds for backward compatibility.
-	const updatedProps = {
-		...props,
-		selectedBlockClientIds:
-			selectedBlockClientId && ! selectedBlockClientIds
-				? [ selectedBlockClientId ]
-				: selectedBlockClientIds,
-	};
-
 	return (
 		<TreeGrid
 			className="block-editor-block-navigation-tree"
@@ -78,7 +53,7 @@ export default function BlockNavigationTree( {
 			ref={ treeGridRef }
 		>
 			<BlockNavigationContext.Provider value={ contextValue }>
-				<BlockNavigationBranch { ...updatedProps } />
+				<BlockNavigationBranch { ...props } />
 			</BlockNavigationContext.Provider>
 		</TreeGrid>
 	);

--- a/packages/block-editor/src/components/block-navigation/utils.js
+++ b/packages/block-editor/src/components/block-navigation/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isArray } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -11,3 +16,17 @@ export const getBlockPositionDescription = ( position, siblingCount, level ) =>
 		siblingCount,
 		level
 	);
+
+/**
+ * Returns true if the client ID occurs within the block selection or multi-selection,
+ * or false otherwise.
+ *
+ * @param {string}          clientId              Block client ID.
+ * @param {string|string[]} selectedBlockClientId Selected block client ID, or an array of multi-selected blocks client IDs.
+ *
+ * @return {boolean} Whether the block is in multi-selection set.
+ */
+export const isClientIdSelected = ( clientId, selectedBlockClientId ) =>
+	isArray( selectedBlockClientId ) && selectedBlockClientId.length
+		? selectedBlockClientId.indexOf( clientId ) !== -1
+		: selectedBlockClientId === clientId;

--- a/packages/block-editor/src/components/block-navigation/utils.js
+++ b/packages/block-editor/src/components/block-navigation/utils.js
@@ -21,12 +21,12 @@ export const getBlockPositionDescription = ( position, siblingCount, level ) =>
  * Returns true if the client ID occurs within the block selection or multi-selection,
  * or false otherwise.
  *
- * @param {string}          clientId              Block client ID.
- * @param {string|string[]} selectedBlockClientId Selected block client ID, or an array of multi-selected blocks client IDs.
+ * @param {string}          clientId               Block client ID.
+ * @param {string|string[]} selectedBlockClientIds Selected block client ID, or an array of multi-selected blocks client IDs.
  *
  * @return {boolean} Whether the block is in multi-selection set.
  */
-export const isClientIdSelected = ( clientId, selectedBlockClientId ) =>
-	isArray( selectedBlockClientId ) && selectedBlockClientId.length
-		? selectedBlockClientId.indexOf( clientId ) !== -1
-		: selectedBlockClientId === clientId;
+export const isClientIdSelected = ( clientId, selectedBlockClientIds ) =>
+	isArray( selectedBlockClientIds ) && selectedBlockClientIds.length
+		? selectedBlockClientIds.indexOf( clientId ) !== -1
+		: selectedBlockClientIds === clientId;

--- a/packages/block-library/src/navigation/block-navigation-list.js
+++ b/packages/block-library/src/navigation/block-navigation-list.js
@@ -31,7 +31,7 @@ export default function BlockNavigationList( {
 	return (
 		<__experimentalBlockNavigationTree
 			blocks={ blocks }
-			selectedBlockClientId={ selectedBlockClientId }
+			selectedBlockClientIds={ [ selectedBlockClientId ] }
 			selectBlock={ selectBlock }
 			__experimentalFeatures={ __experimentalFeatures }
 			showNestedBlocks

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -23,13 +23,13 @@ import { ESCAPE } from '@wordpress/keycodes';
 import { store as editSiteStore } from '../../store';
 
 export default function ListViewSidebar() {
-	const { clientIdsTree, selectedBlockClientId } = useSelect( ( select ) => {
+	const { clientIdsTree, selectedBlockClientIds } = useSelect( ( select ) => {
 		const { __unstableGetClientIdsTree, getSelectedBlockClientId } = select(
 			blockEditorStore
 		);
 		return {
 			clientIdsTree: __unstableGetClientIdsTree(),
-			selectedBlockClientId: getSelectedBlockClientId(),
+			selectedBlockClientIds: getSelectedBlockClientId(),
 		};
 	} );
 	const { setIsListViewOpened } = useDispatch( editSiteStore );
@@ -74,7 +74,7 @@ export default function ListViewSidebar() {
 				<BlockNavigationTree
 					blocks={ clientIdsTree }
 					selectBlock={ selectEditorBlock }
-					selectedBlockClientId={ selectedBlockClientId }
+					selectedBlockClientId={ selectedBlockClientIds }
 					showNestedBlocks
 					__experimentalPersistentListViewFeatures
 				/>

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -74,7 +74,7 @@ export default function ListViewSidebar() {
 				<BlockNavigationTree
 					blocks={ clientIdsTree }
 					selectBlock={ selectEditorBlock }
-					selectedBlockClientId={ selectedBlockClientIds }
+					selectedBlockClientIds={ selectedBlockClientIds }
 					showNestedBlocks
 					__experimentalPersistentListViewFeatures
 				/>

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -24,12 +24,13 @@ import { store as editSiteStore } from '../../store';
 
 export default function ListViewSidebar() {
 	const { clientIdsTree, selectedBlockClientIds } = useSelect( ( select ) => {
-		const { __unstableGetClientIdsTree, getSelectedBlockClientId } = select(
-			blockEditorStore
-		);
+		const {
+			__unstableGetClientIdsTree,
+			getSelectedBlockClientIds,
+		} = select( blockEditorStore );
 		return {
 			clientIdsTree: __unstableGetClientIdsTree(),
-			selectedBlockClientIds: getSelectedBlockClientId(),
+			selectedBlockClientIds: getSelectedBlockClientIds(),
 		};
 	} );
 	const { setIsListViewOpened } = useDispatch( editSiteStore );


### PR DESCRIPTION
## Description

Fix #29469

When selecting multiple blocks, the selected client IDs are stored in a separate state property than single selected blocks.
The non-persistent List View has no real reason to support multi-selected blocks, so it's ok for it to not displaying anything as selected when multiple blocks are selected.
On the other hand, the Persistent List View would look odd.

This PR adds visual support to the Persistent List View for multiple selected blocks.
This new feature is gated behind the `__experimentalPersistentListViewFeatures` flag to avoid conflicts with non-persistent uses of the List View.

When multiple blocks are selected, opening the List View won't focus on the selected item anymore.
I'm not sure if focusing the first selected item would make more sense, though. 🤔 

_Note: this PR does **not** add support for selecting multiple block in the List View.
I'm not sure if it's possible, but I'd rather keep it simple for now._

## How has this been tested?

- Activate an FSE theme such as TT1 Blocks.
- Enter the Site Editor, and open the List View.
- Select multiple blocks in the canvas, and make sure they all appear selected (black background) in the List View.

Also check for regressions of the List View dropdown in the Post Editor.

## Screenshots <!-- if applicable -->

<img width="1438" alt="Screenshot 2021-03-17 at 11 40 11" src="https://user-images.githubusercontent.com/846565/111461826-9b082f80-8715-11eb-9f69-35bdf85cebf9.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
