### PR TITLE
Polish site button focus/hover styles in post and site editor

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -1,3 +1,6 @@
+// Developer notes: these rules are duplicated for the site editor.
+// They need to be updated in both places.
+
 .edit-post-fullscreen-mode-close.has-icon {
 	// Do not show the toolbar icon on small screens,
 	// when Fullscreen Mode is not an option in the "More" menu.

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -26,7 +26,9 @@
 			box-shadow: none;
 		}
 
-		&:focus::before {
+		&::before {
+			transition: box-shadow 0.1s ease;
+			@include reduce-motion("transition");
 			content: "";
 			display: block;
 			position: absolute;
@@ -35,8 +37,16 @@
 			bottom: 9px;
 			left: 9px;
 			border-radius: $radius-block-ui + $border-width + $border-width;
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) #23282e;
+		}
 
-			// Lightened spot color focus.
+		// Hover color.
+		&:hover::before {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
+		}
+
+		// Lightened spot color focus.
+		&:focus::before {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -62,7 +62,6 @@
 }
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {
-	border-radius: 0;
 	height: $button-size;
 	margin-top: $grid-unit-30;
 	padding: $grid-unit $grid-unit-20 $grid-unit $grid-unit;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -33,7 +33,9 @@
 			box-shadow: none;
 		}
 
-		&:focus::before {
+		&::before {
+			transition: box-shadow 0.1s ease;
+			@include reduce-motion("transition");
 			content: "";
 			display: block;
 			position: absolute;
@@ -42,8 +44,16 @@
 			bottom: 9px;
 			left: 9px;
 			border-radius: $radius-block-ui + $border-width + $border-width;
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) #23282e;
+		}
 
-			// Lightened spot color focus.
+		// Hover color.
+		&:hover::before {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
+		}
+
+		// Lightened spot color focus.
+		&:focus::before {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -1,3 +1,6 @@
+// Developer notes: these rules are duplicated for the post editor.
+// They need to be updated in both places.
+
 .edit-site-navigation-toggle {
 	align-items: center;
 	background: $gray-900;
@@ -21,19 +24,32 @@
 	&.has-icon {
 		min-width: $header-height;
 
-		&:hover {
-			background: #32373d; // WP-admin light-gray.
-			color: $white;
-		}
+		&:hover,
 		&:active {
 			color: $white;
 		}
+
 		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 3px $white;
+			box-shadow: none;
+		}
+
+		&:focus::before {
+			content: "";
+			display: block;
+			position: absolute;
+			top: 9px;
+			right: 9px;
+			bottom: 9px;
+			left: 9px;
+			border-radius: $radius-block-ui + $border-width + $border-width;
+
+			// Lightened spot color focus.
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
 }
 
 .edit-site-navigation-toggle__site-icon {
-	width: 36px;
+	width: $button-size;
+	border-radius: $radius-block-ui;
 }


### PR DESCRIPTION
## Description

This is a followup to #29872. I had forgotten that a lot of the structural CSS is duplicated between post and site editors, as opposed to being reused.

This PR brings the new focus styles to the site editor as well.

It also polished a small border radius, and adds a hover state:

![menu](https://user-images.githubusercontent.com/1204802/111290604-9aed2e80-8646-11eb-8515-7b49aa3a244a.gif)

![site icon](https://user-images.githubusercontent.com/1204802/111290608-9b85c500-8646-11eb-8e2a-80515c095d5b.gif)

## How has this been tested?

Hover and focus the site button in the post editor. Do the same in the site editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
