### PR TITLE
Fix mover width/size regressions

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -581,6 +581,10 @@
 	.block-editor-block-mover.is-horizontal .block-editor-block-mover-button.block-editor-block-mover-button {
 		min-width: $block-toolbar-height/2;
 		width: $block-toolbar-height/2;
+
+		svg {
+			min-width: $block-toolbar-height/2;
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -36,6 +36,11 @@
 			width: $block-toolbar-height - $grid-unit-15 / 2;
 			padding-right: $grid-unit-15 - $border-width !important;
 			padding-left: $grid-unit-15 / 2 !important;
+
+			// Extra specificity to override standard toolbar button styles.
+			&.block-editor-block-mover-button {
+				min-width: $block-toolbar-height - $grid-unit-15 / 2;
+			}
 		}
 
 		// Focus style.


### PR DESCRIPTION
## Description

This PR fixes two regressions I introduced myself in work committed to https://github.com/WordPress/gutenberg/pull/29247.

Specifically:

- The horizonal mover button was too small.
- The entire mover control was about 8px wider than it should be overal.

Before:

<img width="530" alt="Screenshot 2021-03-16 at 13 19 04" src="https://user-images.githubusercontent.com/1204802/111307785-34720b80-865a-11eb-8e1c-6f2b1b467b3b.png">

<img width="519" alt="Screenshot 2021-03-16 at 13 19 09" src="https://user-images.githubusercontent.com/1204802/111307791-363bcf00-865a-11eb-8584-bc960f127667.png">


After:

<img width="461" alt="after, vertical" src="https://user-images.githubusercontent.com/1204802/111307650-0a204e00-865a-11eb-9a4b-ca2829567b4f.png">

<img width="651" alt="after, horizontal" src="https://user-images.githubusercontent.com/1204802/111307658-0b517b00-865a-11eb-8fc0-aa4b5849ee55.png">


## How has this been tested?

Please test vertical and horizontal mover controls.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
