### PR TITLE
useMergeRefs: call when dependency changes after ref change

### DIFF
--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -47,8 +47,13 @@ export default function useMergeRefs( refs ) {
 		} );
 
 		previousRefs.current = refs;
-		didElementChange.current = false;
 	}, refs );
+
+	// No dependencies, must be reset after every render so ref callbacks are
+	// correctly called after a ref change.
+	useLayoutEffect( () => {
+		didElementChange.current = false;
+	} );
 
 	// There should be no dependencies so that `callback` is only called when
 	// the node changes.

--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -218,4 +218,59 @@ describe( 'useMergeRefs', () => {
 			[ [], [ newElement, null ] ],
 		] );
 	} );
+
+	it( 'should work for dependency change after node change', () => {
+		const rootElement = document.getElementById( 'root' );
+
+		ReactDOM.render( <MergedRefs />, rootElement );
+
+		const originalElement = rootElement.firstElementChild;
+
+		ReactDOM.render( <MergedRefs tagName="button" />, rootElement );
+
+		const newElement = rootElement.firstElementChild;
+
+		// After a render with the original element and a second render with the
+		// new element, expect the initial callback functions to be called with
+		// the original element, then null, then the new element.
+		// Again, the new callback functions should not be called! There has
+		// been no dependency change.
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, null, newElement ],
+				[ originalElement, null, newElement ],
+			],
+			[ [], [] ],
+		] );
+
+		ReactDOM.render(
+			<MergedRefs tagName="button" count={ 1 } />,
+			rootElement
+		);
+
+		// After a third render with a dependency change, expect the inital
+		// callback function to be called with null and the new callback
+		// function to be called with the new element. Note that for callback
+		// one no dependencies have changed.
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, null, newElement ],
+				[ originalElement, null, newElement, null ],
+			],
+			[ [], [] ],
+			[ [], [ newElement ] ],
+		] );
+
+		ReactDOM.render( null, rootElement );
+
+		// Unmount: current callback functions should be called with null.
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, null, newElement, null ],
+				[ originalElement, null, newElement, null ],
+			],
+			[ [], [] ],
+			[ [], [ newElement, null ] ],
+		] );
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #28166.

Fixes a bug in `useMergeRefs`. If a ref changes, `didElementChange` is set to `true` to prevent  refs to be called twice (once on the ref change and once on the dependency change that is triggering the ref change). This flag should be reset on every render, so when dependencies change the next time, the ref calling is not skipped.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
