### PR TITLE
Keep post publishing popover open when a date is clicked, by default

### DIFF
--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -85,9 +85,3 @@ This function will be called on each day, every time user browses into a differe
 - Type: `Function`
 - Required: No
 
-### keepOpen
-
-Whether focus should stay on the `DateTimePicker` after clicking on a date in the calendar.
-
-- Type: `bool`
-- Required: No

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -59,7 +59,7 @@ class DatePicker extends Component {
 	}
 
 	onChangeMoment( newDate ) {
-		const { currentDate, onChange, keepOpen } = this.props;
+		const { currentDate, onChange } = this.props;
 
 		// If currentDate is null, use now as momentTime to designate hours, minutes, seconds.
 		const momentDate = currentDate ? moment( currentDate ) : moment();
@@ -72,9 +72,7 @@ class DatePicker extends Component {
 		onChange( newDate.set( momentTime ).format( TIMEZONELESS_FORMAT ) );
 
 		// Keep focus on the date picker popover.
-		if ( keepOpen ) {
-			this.keepFocusInside();
-		}
+		this.keepFocusInside();
 	}
 
 	/**

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -71,7 +71,7 @@ class DatePicker extends Component {
 
 		onChange( newDate.set( momentTime ).format( TIMEZONELESS_FORMAT ) );
 
-		// Keep focus on the date picker popover.
+		// Keep focus on the date picker.
 		this.keepFocusInside();
 	}
 

--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -28,7 +28,6 @@ function DateTimePicker(
 		onMonthPreviewed,
 		onChange,
 		events,
-		keepOpen,
 	},
 	ref
 ) {
@@ -55,7 +54,6 @@ function DateTimePicker(
 						isInvalidDate={ isInvalidDate }
 						onMonthPreviewed={ onMonthPreviewed }
 						events={ events }
-						keepOpen={ keepOpen }
 					/>
 				</>
 			) }

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -33,7 +33,6 @@ export function PostSchedule( { date, onUpdateDate } ) {
 			currentDate={ date }
 			onChange={ onChange }
 			is12Hour={ is12HourTime }
-			keepOpen={ true }
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Follow-up to https://github.com/WordPress/gutenberg/pull/29738 to remove the `keepOpen` prop and keep focus on the date picker by default.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Create a new post
2. Open the schedule popover by clicking on the publish date
3. Click on a date in the picker and confirm that the popover does not close.
4. Navigate to the next month
5. Click on a date and confirm that the popover does not close.
6. Navigate to a date via the keyboard and select it. Confirm that the popover does not close.

## Screenshots <!-- if applicable -->
Gif of the popover staying open after clicking on a date:
![datetimepickerstaysopen](https://user-images.githubusercontent.com/1689238/110687153-36495400-81ae-11eb-9f55-3526da99f1d1.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix: Uses `keepFocusInside()` to keep the date picker open on date change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
