### PR TITLE
Block Editor: Fix the issue with block style preview when example missing

### DIFF
--- a/packages/block-editor/src/components/block-switcher/block-styles-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-styles-menu.js
@@ -17,10 +17,8 @@ import {
 import BlockStyles from '../block-styles';
 import PreviewBlockPopover from './preview-block-popover';
 
-export default function BlockStylesMenu( {
-	hoveredBlock: { name, clientId },
-	onSwitch,
-} ) {
+export default function BlockStylesMenu( { hoveredBlock, onSwitch } ) {
+	const { name, clientId } = hoveredBlock;
 	const [ hoveredClassName, setHoveredClassName ] = useState();
 	const blockType = useSelect(
 		( select ) => select( blocksStore ).getBlockType( name ),
@@ -43,7 +41,7 @@ export default function BlockStylesMenu( {
 									},
 									innerBlocks: blockType.example.innerBlocks,
 							  } )
-							: cloneBlock( blockType, {
+							: cloneBlock( hoveredBlock, {
 									className: hoveredClassName,
 							  } )
 					}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #29876.

The issue was described as follows:

> Step-by-step reproduction instructions
> 1. Create a simple block, eg by using [create-guten-block](https://github.com/ahmadawais/create-guten-block)
> 2. Modify the block to add block styles/variations with the [registerBlockStyle](https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/) filter (code snippet example given below)
> 3. The style switcher in the block inspector works fine (green arrow in screenshot below), but the inline style switcher (red arrow in screenshot below) will not load a preview, instead it crash the editor with an error when the desired style is hovered over.
> 4. The way to stop the issue is to pass an empty (supposedly optional) _example_ object in the [block registration object](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/) (code snippet workaround is given below)
>
> Editor crashes with error
> ![gutenberg-styles-issue-eg](https://user-images.githubusercontent.com/1689871/111176962-b4886a80-85a1-11eb-9b6b-540931c8ec81.png)
> ![gutenberg-editor-crash](https://user-images.githubusercontent.com/1689871/111176989-b9e5b500-85a1-11eb-8160-593a987d31fc.png)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I applied the following diff in the Gutenberg repository to reproduce the issue for the Query block:

```diff
diff --git a/packages/block-library/src/quote/index.js b/packages/block-library/src/quote/index.js
index 95aba9a267..dc30ca4473 100644
--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -24,14 +24,14 @@ export const settings = {
 	),
 	icon,
 	keywords: [ __( 'blockquote' ), __( 'cite' ) ],
-	example: {
+	/*example: {
 		attributes: {
 			value:
 				'<p>' + __( 'In quoting others, we cite ourselves.' ) + '</p>',
 			citation: 'Julio Cortázar',
 			className: 'is-style-large',
 		},
-	},
+	},*/
 	styles: [
 		{
 			name: 'default',
```

Then I tested with this branch:
1. Insert the Query block
2. Click the block icon in the toolbar.
3. Hover over the block style variations for the block.
4. You should see the preview without the error.

## Screenshots <!-- if applicable -->

<img width="709" alt="Screen Shot 2021-03-16 at 15 15 29" src="https://user-images.githubusercontent.com/699132/111323797-7c009380-866a-11eb-8b9f-22084a10d6ff.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
