### PR TITLE
BlockList: use InnerBlocks internally

### DIFF
--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -6,7 +6,6 @@ import { createContext, useContext } from '@wordpress/element';
 export const DEFAULT_BLOCK_EDIT_CONTEXT = {
 	name: '',
 	isSelected: false,
-	clientId: null,
 };
 
 const Context = createContext( DEFAULT_BLOCK_EDIT_CONTEXT );

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -3,11 +3,13 @@
  */
 import { createContext, useContext } from '@wordpress/element';
 
-const Context = createContext( {
+export const DEFAULT_BLOCK_EDIT_CONTEXT = {
 	name: '',
 	isSelected: false,
 	clientId: null,
-} );
+};
+
+const Context = createContext( DEFAULT_BLOCK_EDIT_CONTEXT );
 const { Provider } = Context;
 
 export { Provider as BlockEditContextProvider };

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -15,7 +15,6 @@ import { createContext, useState, useMemo } from '@wordpress/element';
  */
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
-import useBlockDropZone from '../use-block-drop-zone';
 import { useInBetweenInserter } from './use-in-between-inserter';
 import { store as blockEditorStore } from '../../store';
 import { usePreParsePatterns } from '../../utils/pre-parse-patterns';

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -22,12 +22,17 @@ import { usePreParsePatterns } from '../../utils/pre-parse-patterns';
 import { LayoutProvider, defaultLayout } from './layout';
 import BlockToolsBackCompat from '../block-tools/back-compat';
 import { useBlockSelectionClearer } from '../block-selection-clearer';
+import { useInnerBlocksProps } from '../inner-blocks';
+import {
+	BlockEditContextProvider,
+	DEFAULT_BLOCK_EDIT_CONTEXT,
+} from '../block-edit/context';
 
 const elementContext = createContext();
 
 export const IntersectionObserver = createContext();
 
-function Root( { className, children } ) {
+function Root( { className, ...settings } ) {
 	const [ element, setElement ] = useState();
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const { isOutlineMode, isFocusMode, isNavigationMode } = useSelect(
@@ -44,38 +49,35 @@ function Root( { className, children } ) {
 		},
 		[]
 	);
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			ref: useMergeRefs( [
+				useBlockSelectionClearer(),
+				useInBetweenInserter(),
+				setElement,
+			] ),
+			className: classnames( 'is-root-container', className, {
+				'is-outline-mode': isOutlineMode,
+				'is-focus-mode': isFocusMode && isLargeViewport,
+				'is-navigate-mode': isNavigationMode,
+			} ),
+		},
+		settings
+	);
 	return (
 		<elementContext.Provider value={ element }>
-			<div
-				ref={ useMergeRefs( [
-					useBlockSelectionClearer(),
-					useBlockDropZone(),
-					useInBetweenInserter(),
-					setElement,
-				] ) }
-				className={ classnames(
-					'block-editor-block-list__layout is-root-container',
-					className,
-					{
-						'is-outline-mode': isOutlineMode,
-						'is-focus-mode': isFocusMode && isLargeViewport,
-						'is-navigate-mode': isNavigationMode,
-					}
-				) }
-			>
-				{ children }
-			</div>
+			<div { ...innerBlocksProps } />
 		</elementContext.Provider>
 	);
 }
 
-export default function BlockList( { className, ...props } ) {
+export default function BlockList( settings ) {
 	usePreParsePatterns();
 	return (
 		<BlockToolsBackCompat>
-			<Root className={ className }>
-				<BlockListItems { ...props } />
-			</Root>
+			<BlockEditContextProvider value={ DEFAULT_BLOCK_EDIT_CONTEXT }>
+				<Root { ...settings } />
+			</BlockEditContextProvider>
 		</BlockToolsBackCompat>
 	);
 }

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -139,6 +139,10 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
 	const hasOverlay = useSelect(
 		( select ) => {
+			if ( ! clientId ) {
+				return;
+			}
+
 			const {
 				getBlockName,
 				isBlockSelected,
@@ -162,6 +166,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			rootClientId: clientId,
 		} ),
 	] );
+
 	const InnerBlocks =
 		options.value && options.onChange
 			? ControlledInnerBlocks
@@ -177,7 +182,11 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				'has-overlay': hasOverlay,
 			}
 		),
-		children: <InnerBlocks { ...options } clientId={ clientId } />,
+		children: clientId ? (
+			<InnerBlocks { ...options } clientId={ clientId } />
+		) : (
+			<BlockListItems { ...options } />
+		),
 	};
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Pretty straightforward. The intention is to avoid (also future) duplication such as `useBlockDropZone`. The root block list is no different from any blocks with inner blocks. The only difference is that the block list is not in a block, it is at the root (`clientID === ''`).

While I think it's generally good to reuse `useInnerBlocksProps` internally, it will also be beneficial in the future if we want to allow all the same options of `InnerBlocks` for the root of the block editor such as template, allowed blocks, orientation...

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
