### PR TITLE
Restore dot at the end of a sentence

### DIFF
--- a/packages/block-directory/src/plugins/get-install-missing/index.js
+++ b/packages/block-directory/src/plugins/get-install-missing/index.js
@@ -66,7 +66,7 @@ const ModifiedWarning = ( { originalBlock, ...props } ) => {
 	let messageHTML = sprintf(
 		/* translators: %s: block name */
 		__(
-			'Your site doesn’t include support for the %s block. You can try installing the block or remove it entirely!'
+			'Your site doesn’t include support for the %s block. You can try installing the block or remove it entirely.'
 		),
 		originalBlock.title || originalName
 	);


### PR DESCRIPTION
In 61f57f4, dot at the end of one message was replaced with exclamation mark. We don't use exclamation mark that way in WordPress. Plus, it's not inconsistent with [other message](https://github.com/WordPress/gutenberg/blob/6e3bb6c67ee93536a40b54cc6c06641324472622/packages/block-directory/src/plugins/get-install-missing/index.js#L86) that still uses dot at the end.