### PR TITLE
Block Editor: Add client ID trees selectors

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { getBlockType } from '@wordpress/blocks';
 import { Fill, Slot, VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import {
 	Children,
 	cloneElement,
@@ -24,12 +25,16 @@ import BlockIcon from '../block-icon';
 import { BlockListBlockContext } from '../block-list/block';
 import BlockNavigationBlockSelectButton from './block-select-button';
 import { getBlockPositionDescription } from './utils';
+import { store as blockEditorStore } from '../../store';
 
 const getSlotName = ( clientId ) => `BlockNavigationBlock-${ clientId }`;
 
 function BlockNavigationBlockSlot( props, ref ) {
-	const instanceId = useInstanceId( BlockNavigationBlockSlot );
 	const { clientId } = props.block;
+	const { name } = useSelect( ( select ) =>
+		select( blockEditorStore ).getBlockName( clientId )
+	);
+	const instanceId = useInstanceId( BlockNavigationBlockSlot );
 
 	return (
 		<Slot name={ getSlotName( clientId ) }>
@@ -45,7 +50,6 @@ function BlockNavigationBlockSlot( props, ref ) {
 
 				const {
 					className,
-					block,
 					isSelected,
 					position,
 					siblingBlockCount,
@@ -54,7 +58,6 @@ function BlockNavigationBlockSlot( props, ref ) {
 					onFocus,
 				} = props;
 
-				const { name } = block;
 				const blockType = getBlockType( name );
 				const descriptionId = `block-navigation-block-slot__${ instanceId }`;
 				const blockPositionDescription = getBlockPositionDescription(

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -31,8 +31,9 @@ const getSlotName = ( clientId ) => `BlockNavigationBlock-${ clientId }`;
 
 function BlockNavigationBlockSlot( props, ref ) {
 	const { clientId } = props.block;
-	const { name } = useSelect( ( select ) =>
-		select( blockEditorStore ).getBlockName( clientId )
+	const { name } = useSelect(
+		( select ) => select( blockEditorStore ).getBlockName( clientId ),
+		[ clientId ]
 	);
 	const instanceId = useInstanceId( BlockNavigationBlockSlot );
 

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -6,8 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,13 +15,41 @@ import { __ } from '@wordpress/i18n';
 import BlockNavigationTree from './tree';
 import { store as blockEditorStore } from '../../store';
 
-function BlockNavigation( {
-	rootBlock,
-	rootBlocks,
-	selectedBlockClientId,
-	selectBlock,
+export default function BlockNavigation( {
+	onSelect = noop,
 	__experimentalFeatures,
 } ) {
+	const { rootBlock, rootBlocks, selectedBlockClientId } = useSelect(
+		( select ) => {
+			const {
+				getBlockHierarchyRootClientId,
+				getSelectedBlockClientId,
+				__unstableGetClientIdsTree,
+				__unstableGetClientIdWithClientIdsTree,
+			} = select( blockEditorStore );
+
+			const _selectedBlockClientId = getSelectedBlockClientId();
+			const _rootBlocks = __unstableGetClientIdsTree();
+			const _rootBlock = _selectedBlockClientId
+				? __unstableGetClientIdWithClientIdsTree(
+						getBlockHierarchyRootClientId( _selectedBlockClientId )
+				  )
+				: null;
+
+			return {
+				rootBlock: _rootBlock,
+				rootBlocks: _rootBlocks,
+				selectedBlockClientId: _selectedBlockClientId,
+			};
+		}
+	);
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	function selectEditorBlock( clientId ) {
+		selectBlock( clientId );
+		onSelect( clientId );
+	}
+
 	if ( ! rootBlocks || rootBlocks.length === 0 ) {
 		return null;
 	}
@@ -41,39 +68,10 @@ function BlockNavigation( {
 			<BlockNavigationTree
 				blocks={ hasHierarchy ? [ rootBlock ] : rootBlocks }
 				selectedBlockClientId={ selectedBlockClientId }
-				selectBlock={ selectBlock }
+				selectBlock={ selectEditorBlock }
 				__experimentalFeatures={ __experimentalFeatures }
 				showNestedBlocks
 			/>
 		</div>
 	);
 }
-
-export default compose(
-	withSelect( ( select ) => {
-		const {
-			getSelectedBlockClientId,
-			getBlockHierarchyRootClientId,
-			__unstableGetBlockWithBlockTree,
-			__unstableGetBlockTree,
-		} = select( blockEditorStore );
-		const selectedBlockClientId = getSelectedBlockClientId();
-		return {
-			rootBlocks: __unstableGetBlockTree(),
-			rootBlock: selectedBlockClientId
-				? __unstableGetBlockWithBlockTree(
-						getBlockHierarchyRootClientId( selectedBlockClientId )
-				  )
-				: null,
-			selectedBlockClientId,
-		};
-	} ),
-	withDispatch( ( dispatch, { onSelect = noop } ) => {
-		return {
-			selectBlock( clientId ) {
-				dispatch( blockEditorStore ).selectBlock( clientId );
-				onSelect( clientId );
-			},
-		};
-	} )
-)( BlockNavigation );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -266,8 +266,26 @@ export const __unstableGetBlockTree = createSelector(
 );
 
 /**
- * Returns the client IDs of the post blocks formatted in a nested,
- * tree-like structure.
+ * Returns a stripped down block object containing only its client ID,
+ * and its inner blocks' client IDs.
+ *
+ * @param {Object} state    Editor state.
+ * @param {string} clientId Client ID of the block to get.
+ *
+ * @return {Object} Client IDs of the post blocks.
+ */
+export const __unstableGetClientIdWithClientIdsTree = createSelector(
+	( state, clientId ) => ( {
+		clientId,
+		innerBlocks: __unstableGetClientIdsTree( state, clientId ),
+	} ),
+	( state ) => [ state.blocks.order ]
+);
+
+/**
+ * Returns the block tree represented in the block-editor store from the
+ * given root, consisting of stripped down block objects containing only
+ * their client IDs, and their inner blocks' client IDs.
  *
  * @param {Object}  state        Editor state.
  * @param {?string} rootClientId Optional root client ID of block list.
@@ -276,10 +294,9 @@ export const __unstableGetBlockTree = createSelector(
  */
 export const __unstableGetClientIdsTree = createSelector(
 	( state, rootClientId = '' ) =>
-		map( getBlockOrder( state, rootClientId ), ( clientId ) => ( {
-			clientId,
-			innerBlocks: __unstableGetClientIdsTree( state, clientId ),
-		} ) ),
+		map( getBlockOrder( state, rootClientId ), ( clientId ) =>
+			__unstableGetClientIdWithClientIdsTree( state, clientId )
+		),
 	( state ) => [ state.blocks.order ]
 );
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -266,6 +266,24 @@ export const __unstableGetBlockTree = createSelector(
 );
 
 /**
+ * Returns the client IDs of the post blocks formatted in a nested,
+ * tree-like structure.
+ *
+ * @param {Object}  state        Editor state.
+ * @param {?string} rootClientId Optional root client ID of block list.
+ *
+ * @return {Object[]} Client IDs of the post blocks.
+ */
+export const __unstableGetClientIdsTree = createSelector(
+	( state, rootClientId = '' ) =>
+		map( getBlockOrder( state, rootClientId ), ( clientId ) => ( {
+			clientId,
+			innerBlocks: __unstableGetClientIdsTree( state, clientId ),
+		} ) ),
+	( state ) => [ state.blocks.order ]
+);
+
+/**
  * Returns an array containing the clientIds of all descendants
  * of the blocks given.
  *

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -73,6 +73,8 @@ const {
 	__experimentalGetParsedReusableBlock,
 	__experimentalGetAllowedPatterns,
 	__experimentalGetScopedBlockPatterns,
+	__unstableGetClientIdWithClientIdsTree,
+	__unstableGetClientIdsTree,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -3533,5 +3535,78 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 			'another-plugin/block-b',
 		];
 		expect( items.map( ( { name } ) => name ) ).toEqual( expectedResult );
+	} );
+} );
+
+describe( '__unstableGetClientIdWithClientIdsTree', () => {
+	it( "should return a stripped down block object containing only its client ID and its inner blocks' client IDs", () => {
+		const state = {
+			blocks: {
+				order: {
+					'': [ 'foo' ],
+					foo: [ 'bar', 'baz' ],
+					bar: [ 'qux' ],
+				},
+			},
+		};
+
+		expect(
+			__unstableGetClientIdWithClientIdsTree( state, 'foo' )
+		).toEqual( {
+			clientId: 'foo',
+			innerBlocks: [
+				{
+					clientId: 'bar',
+					innerBlocks: [ { clientId: 'qux', innerBlocks: [] } ],
+				},
+				{ clientId: 'baz', innerBlocks: [] },
+			],
+		} );
+	} );
+} );
+describe( '__unstableGetClientIdsTree', () => {
+	it( "should return the full content tree starting from the given root, consisting of stripped down block object containing only its client ID and its inner blocks' client IDs", () => {
+		const state = {
+			blocks: {
+				order: {
+					'': [ 'foo' ],
+					foo: [ 'bar', 'baz' ],
+					bar: [ 'qux' ],
+				},
+			},
+		};
+
+		expect( __unstableGetClientIdsTree( state, 'foo' ) ).toEqual( [
+			{
+				clientId: 'bar',
+				innerBlocks: [ { clientId: 'qux', innerBlocks: [] } ],
+			},
+			{ clientId: 'baz', innerBlocks: [] },
+		] );
+	} );
+
+	it( "should return the full content tree starting from the root, consisting of stripped down block object containing only its client ID and its inner blocks' client IDs", () => {
+		const state = {
+			blocks: {
+				order: {
+					'': [ 'foo' ],
+					foo: [ 'bar', 'baz' ],
+					bar: [ 'qux' ],
+				},
+			},
+		};
+
+		expect( __unstableGetClientIdsTree( state ) ).toEqual( [
+			{
+				clientId: 'foo',
+				innerBlocks: [
+					{
+						clientId: 'bar',
+						innerBlocks: [ { clientId: 'qux', innerBlocks: [] } ],
+					},
+					{ clientId: 'baz', innerBlocks: [] },
+				],
+			},
+		] );
 	} );
 } );

--- a/packages/block-library/src/navigation/block-navigation-list.js
+++ b/packages/block-library/src/navigation/block-navigation-list.js
@@ -11,14 +11,15 @@ export default function BlockNavigationList( {
 	clientId,
 	__experimentalFeatures,
 } ) {
-	const { block, selectedBlockClientId } = useSelect(
+	const { blocks, selectedBlockClientId } = useSelect(
 		( select ) => {
-			const { getSelectedBlockClientId, getBlock } = select(
-				blockEditorStore
-			);
+			const {
+				getSelectedBlockClientId,
+				__unstableGetClientIdsTree,
+			} = select( blockEditorStore );
 
 			return {
-				block: getBlock( clientId ),
+				blocks: __unstableGetClientIdsTree( clientId ),
 				selectedBlockClientId: getSelectedBlockClientId(),
 			};
 		},
@@ -29,7 +30,7 @@ export default function BlockNavigationList( {
 
 	return (
 		<__experimentalBlockNavigationTree
-			blocks={ block.innerBlocks }
+			blocks={ blocks }
 			selectedBlockClientId={ selectedBlockClientId }
 			selectBlock={ selectBlock }
 			__experimentalFeatures={ __experimentalFeatures }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useState, useMemo, useCallback } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { AsyncModeProvider, useSelect, useDispatch } from '@wordpress/data';
 import {
 	SlotFillProvider,
 	DropZoneProvider,
@@ -158,7 +158,11 @@ function Editor( { initialSettings } ) {
 			return <InserterSidebar />;
 		}
 		if ( isListViewOpen ) {
-			return <ListViewSidebar />;
+			return (
+				<AsyncModeProvider value="true">
+					<ListViewSidebar />
+				</AsyncModeProvider>
+			);
 		}
 		return null;
 	};

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -23,12 +23,12 @@ import { ESCAPE } from '@wordpress/keycodes';
 import { store as editSiteStore } from '../../store';
 
 export default function ListViewSidebar() {
-	const { rootBlocks, selectedBlockClientId } = useSelect( ( select ) => {
-		const { getSelectedBlockClientId, __unstableGetBlockTree } = select(
+	const { clientIdsTree, selectedBlockClientId } = useSelect( ( select ) => {
+		const { __unstableGetClientIdsTree, getSelectedBlockClientId } = select(
 			blockEditorStore
 		);
 		return {
-			rootBlocks: __unstableGetBlockTree(),
+			clientIdsTree: __unstableGetClientIdsTree(),
 			selectedBlockClientId: getSelectedBlockClientId(),
 		};
 	} );
@@ -72,7 +72,7 @@ export default function ListViewSidebar() {
 				ref={ useMergeRefs( [ focusReturnRef, focusOnMountRef ] ) }
 			>
 				<BlockNavigationTree
-					blocks={ rootBlocks }
+					blocks={ clientIdsTree }
 					selectBlock={ selectEditorBlock }
 					selectedBlockClientId={ selectedBlockClientId }
 					showNestedBlocks

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -12,7 +12,7 @@ import {
 	useInstanceId,
 	useMergeRefs,
 } from '@wordpress/compose';
-import { AsyncModeProvider, useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -71,15 +71,13 @@ export default function ListViewSidebar() {
 				className="edit-site-editor__list-view-panel-content"
 				ref={ useMergeRefs( [ focusReturnRef, focusOnMountRef ] ) }
 			>
-				<AsyncModeProvider value="true">
-					<BlockNavigationTree
-						blocks={ clientIdsTree }
-						selectBlock={ selectEditorBlock }
-						selectedBlockClientId={ selectedBlockClientId }
-						showNestedBlocks
-						__experimentalPersistentListViewFeatures
-					/>
-				</AsyncModeProvider>
+				<BlockNavigationTree
+					blocks={ clientIdsTree }
+					selectBlock={ selectEditorBlock }
+					selectedBlockClientId={ selectedBlockClientId }
+					showNestedBlocks
+					__experimentalPersistentListViewFeatures
+				/>
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -12,7 +12,7 @@ import {
 	useInstanceId,
 	useMergeRefs,
 } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { AsyncModeProvider, useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -71,13 +71,15 @@ export default function ListViewSidebar() {
 				className="edit-site-editor__list-view-panel-content"
 				ref={ useMergeRefs( [ focusReturnRef, focusOnMountRef ] ) }
 			>
-				<BlockNavigationTree
-					blocks={ clientIdsTree }
-					selectBlock={ selectEditorBlock }
-					selectedBlockClientId={ selectedBlockClientId }
-					showNestedBlocks
-					__experimentalPersistentListViewFeatures
-				/>
+				<AsyncModeProvider value="true">
+					<BlockNavigationTree
+						blocks={ clientIdsTree }
+						selectBlock={ selectEditorBlock }
+						selectedBlockClientId={ selectedBlockClientId }
+						showNestedBlocks
+						__experimentalPersistentListViewFeatures
+					/>
+				</AsyncModeProvider>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Description

As mentioned in https://github.com/WordPress/gutenberg/pull/29636#pullrequestreview-612936850, keeping the Persistent List View open slows down the editor to a crawl, especially noticeable when typing.

The cause is that the `BlockNavigation` uses the `__unstableGetBlockTree` selector, which depends on `state.blocks.attributes`, which can change quite often, especially while typing, causing a ton of wasted re-renders of the whole list.
This is not noticeable with the non-persistent List View, given that you can't edit your content with the list open.

Turns out that `BlockNavigation` doesn't really need to know all about blocks, but it can easily live with just their `clientId`s, as long as they are nested like the actual block tree.

In this PR I've created a new `__unstableGetClientIdsTree` which is fundamentally similar to the full-fledged `__unstableGetBlockTree`, but only uses `clientId`s.

The list doesn't re-render anymore when a block changes.
Although, the list does re-render when a block is added, removed, or moved around. The result is that there's still a noticeable delay between the click and the action outcome.

### Notes

To avoid having to change the internal logic of `BlockNavigation` (and to keep this PR slim), the tree is pre-formatted with the expected properties:
`[ { clientId, innerBlocks: [ { ... }, ... ] }, { ... }, ... ]`

I'm happy with rewriting all the things, but first I'd like to be sure this is the right way to go.
Same thing about the unit tests: I'll add them if we are cool with this approach.

I've also avoided to delete the `__unstableGetBlockTree` selector, as it's used elsewhere.

## How has this been tested?

- Install a FSE theme such as TT1 Blocks and open the Site Editor.
- Open the List View, and select a Paragraph block.
- Make sure the typing experience doesn't suffer any noticeable delays.

Also double-check all the uses of the List View for regressions:
- Persistent List View in the Site Editor.
- Non-persistent List View in the Post Editor.
- Block Navigation in the Navigation block (almost a palindrome!).

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
