### PR TITLE
Packages: Enforce version bump for production packages after WP major

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -121,6 +121,10 @@ async function updatePackages(
 		}
 	);
 
+	const productionPackageNames = Object.keys(
+		require( '../../../package.json' ).dependencies
+	);
+
 	const processedPackages = await Promise.all(
 		changelogFilesPublicPackages.map( async ( changelogPath ) => {
 			const fileStream = fs.createReadStream( changelogPath );
@@ -133,13 +137,23 @@ async function updatePackages(
 				lines.push( line );
 			}
 
-			const versionBump = calculateVersionBumpFromChangelog(
+			let versionBump = calculateVersionBumpFromChangelog(
 				lines,
 				minimumVersionBump
 			);
 			const packageName = `@wordpress/${
 				changelogPath.split( '/' ).reverse()[ 1 ]
 			}`;
+			// Enforce version bump for production packages when
+			// the stable minor or major version bump requested.
+			if (
+				! versionBump &&
+				! isPrerelease &&
+				minimumVersionBump !== 'patch' &&
+				productionPackageNames.includes( packageName )
+			) {
+				versionBump = minimumVersionBump;
+			}
 			const packageJSONPath = changelogPath.replace(
 				'CHANGELOG.md',
 				'package.json'


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

See https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/release.md#synchronizing-wordpress-trunk and the following part:

> Assuming the package versions are written using this format `major.minor.patch`, **make sure to bump at least the minor version number after every major WordPress release**. For example, if the CHANGELOG of the package to be released indicates that the next unreleased version is` 5.6.1`, choose `5.7.0` as a version in case of minor version. This is important as the patch version numbers should be reserved in case bug fixes are needed for a minor WordPress release (see below).

This PR enforces version bump for the production packages whenever `minor` or `major` version bump is selected. By default `patch` version bump is applied that should get applied only to packages that had changes detected by Lerna.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I will test with when publishing with:

`./bin/commander npm-latest` 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
