### PR TITLE
Expose a higher API to interact with Global Styles

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -393,6 +393,15 @@ class WP_Theme_JSON_Resolver {
 	}
 
 	/**
+	 * Returns the template part data of current theme.
+	 *
+	 * @return array
+	 */
+	public static function get_template_parts() {
+		return WP_Theme_JSON_Resolver::get_theme_data()->get( array( 'templateParts' ) );
+	}
+
+	/**
 	 * Returns the settings & styles from the theme.
 	 *
 	 * @param array $theme_support_data Existing block editor settings.

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -419,7 +419,7 @@ class WP_Theme_JSON_Resolver {
 	 * @return array
 	 */
 	public static function get_theme_styles_and_settings( $theme_support_data = array() ) {
-		$raw_data = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get_raw_data();
+		$raw_data = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get();
 		return array(
 			'settings' => $raw_data['settings'],
 			'styles'   => $raw_data['styles'],

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -402,6 +402,15 @@ class WP_Theme_JSON_Resolver {
 	}
 
 	/**
+	 * Returns the page templates of the current theme.
+	 *
+	 * @return array
+	 */
+	public static function get_custom_templates() {
+		return WP_Theme_JSON_Resolver::get_theme_data()->get( array( 'customTemplates' ) );
+	}
+
+	/**
 	 * Returns the settings & styles from the theme.
 	 *
 	 * @param array $theme_support_data Existing block editor settings.

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -320,7 +320,7 @@ class WP_Theme_JSON_Resolver {
 	 */
 	public static function get_settings( $theme_support_data = array() ) {
 		$tree = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' );
-		return $tree->get_settings();
+		return $tree->get( array( 'settings' ) );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -393,6 +393,22 @@ class WP_Theme_JSON_Resolver {
 	}
 
 	/**
+	 * Returns the settings & styles from the theme.
+	 *
+	 * @param array $theme_support_data Existing block editor settings.
+	 *                                  Empty array by default.
+	 *
+	 * @return array
+	 */
+	public static function get_theme_styles_and_settings( $theme_support_data = array() ) {
+		$raw_data = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get_raw_data();
+		return array(
+			'settings' => $raw_data['settings'],
+			'styles'   => $raw_data['styles'],
+		);
+	}
+
+	/**
 	 * Returns the CPT that contains the user's origin config
 	 * for the current theme or a void array if none found.
 	 *
@@ -499,7 +515,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @return WP_Theme_JSON
 	 */
-	public static function get_merged_data( $theme_support_data = array(), $origin = 'user' ) {
+	private static function get_merged_data( $theme_support_data = array(), $origin = 'user' ) {
 		if ( 'theme' === $origin ) {
 			$result = new WP_Theme_JSON();
 			$result->merge( self::get_core_data() );

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1048,12 +1048,16 @@ class WP_Theme_JSON {
 	/**
 	 * Helper to get the tree or any of its subtrees.
 	 *
-	 * @param array $path Array of keys to get.
+	 * @param array $path Array of keys to get. If it's null, it'll return the whole theme.json.
 	 * @param any   $default The return value if the path does not exist within the array or if $path is not array. Default: empty array.
 	 *
 	 * @return array
 	 */
-	public function get( $path, $default = array() ) {
+	public function get( $path = null, $default = array() ) {
+		if ( null === $path ) {
+			return $this->theme_json;
+		}
+
 		return _wp_array_get( $this->theme_json, $path, $default );
 	}
 
@@ -1081,7 +1085,7 @@ class WP_Theme_JSON {
 	 * @param WP_Theme_JSON $incoming Data to merge.
 	 */
 	public function merge( $incoming ) {
-		$incoming_data    = $incoming->get_raw_data();
+		$incoming_data    = $incoming->get();
 		$this->theme_json = array_replace_recursive( $this->theme_json, $incoming_data );
 
 		// The array_replace_recursive algorithm merges at the leaf level.
@@ -1204,15 +1208,6 @@ class WP_Theme_JSON {
 				$this->theme_json['styles'][ $block_selector ] = $escaped_styles;
 			}
 		}
-	}
-
-	/**
-	 * Returns the raw data.
-	 *
-	 * @return array Raw data.
-	 */
-	public function get_raw_data() {
-		return $this->theme_json;
 	}
 
 }

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1059,15 +1059,15 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Returns the template part data of current theme.
+	 * Helper to get the tree or any of its subtrees.
+	 *
+	 * @param array $path Array of keys to get.
+	 * @param any   $default The return value if the path does not exist within the array or if $path is not array. Default: empty array.
 	 *
 	 * @return array
 	 */
-	public function get_template_parts() {
-		if ( ! isset( $this->theme_json['templateParts'] ) ) {
-			return array();
-		}
-		return $this->theme_json['templateParts'];
+	public function get( $path, $default = array() ) {
+		return _wp_array_get( $this->theme_json, $path, $default );
 	}
 
 	/**

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1018,34 +1018,6 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Returns the existing settings for each block.
-	 *
-	 * Example:
-	 *
-	 * {
-	 *   'root': {
-	 *     'color': {
-	 *       'custom': true
-	 *     }
-	 *   },
-	 *   'core/paragraph': {
-	 *     'spacing': {
-	 *       'customPadding': true
-	 *     }
-	 *   }
-	 * }
-	 *
-	 * @return array Settings per block.
-	 */
-	public function get_settings() {
-		if ( ! isset( $this->theme_json['settings'] ) ) {
-			return array();
-		} else {
-			return $this->theme_json['settings'];
-		}
-	}
-
-	/**
 	 * Helper to get the tree or any of its subtrees.
 	 *
 	 * @param array $path Array of keys to get. If it's null, it'll return the whole theme.json.

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1046,19 +1046,6 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Returns the page templates of the current theme.
-	 *
-	 * @return array
-	 */
-	public function get_custom_templates() {
-		if ( ! isset( $this->theme_json['customTemplates'] ) ) {
-			return array();
-		} else {
-			return $this->theme_json['customTemplates'];
-		}
-	}
-
-	/**
 	 * Helper to get the tree or any of its subtrees.
 	 *
 	 * @param array $path Array of keys to get.

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -125,7 +125,7 @@ function _gutenberg_get_template_files( $template_type ) {
  */
 function _gutenberg_add_template_part_area_info( $template_info ) {
 	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
-		$theme_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_parts();
+		$theme_data = WP_Theme_JSON_Resolver::get_template_parts();
 	}
 
 	if ( isset( $theme_data[ $template_info['slug'] ]['area'] ) ) {

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -19,7 +19,7 @@ function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_t
 		return $templates;
 	}
 
-	$data             = WP_Theme_JSON_Resolver::get_theme_data()->get_custom_templates();
+	$data             = WP_Theme_JSON_Resolver::get_custom_templates();
 	$custom_templates = array();
 	if ( isset( $data ) ) {
 		foreach ( $data  as $key => $template ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -167,7 +167,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		gutenberg_is_fse_theme()
 	) {
 		$user_cpt_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
-		$base_styles = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get_raw_data();
+		$base_styles = WP_Theme_JSON_Resolver::get_theme_styles_and_settings( $theme_support_data );
 
 		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $base_styles;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -226,7 +226,7 @@ function gutenberg_global_styles_filter_post( $content ) {
 		unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
 		$theme_json = new WP_Theme_JSON( $decoded_data );
 		$theme_json->remove_insecure_properties();
-		$data_to_encode                                = $theme_json->get_raw_data();
+		$data_to_encode                                = $theme_json->get();
 		$data_to_encode['isGlobalStylesUserThemeJSON'] = true;
 		return wp_json_encode( $data_to_encode );
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -820,7 +820,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$page_templates = $theme_json->get_custom_templates();
+		$page_templates = $theme_json->get( array( 'customTemplates' ) );
 
 		$this->assertEqualSetsWithIndex(
 			$page_templates,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -37,7 +37,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			)
 		);
-		$result     = $theme_json->get_raw_data();
+		$result     = $theme_json->get();
 
 		$expected = array(
 			'styles' => array(
@@ -85,7 +85,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$actual   = $theme_json->get_raw_data();
+		$actual   = $theme_json->get();
 		$expected = array(
 			'styles' => array(
 				'core/group' => array(
@@ -130,7 +130,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			)
 		);
-		$result     = $theme_json->get_raw_data();
+		$result     = $theme_json->get();
 
 		$expected = array(
 			'styles' => array(
@@ -167,7 +167,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$actual   = $theme_json->get_raw_data();
+		$actual   = $theme_json->get();
 		$expected = array(
 			'styles' => array(
 				$root_name => array(
@@ -585,7 +585,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json->merge( new WP_Theme_JSON( $add_key_in_styles ) );
 		$theme_json->merge( new WP_Theme_JSON( $add_invalid_context ) );
 		$theme_json->merge( new WP_Theme_JSON( $update_presets ) );
-		$result = $theme_json->get_raw_data();
+		$result = $theme_json->get();
 
 		$this->assertEqualSetsWithIndex( $expected, $result );
 	}
@@ -608,7 +608,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			true
 		);
 		$theme_json->remove_insecure_properties();
-		$result   = $theme_json->get_raw_data();
+		$result   = $theme_json->get();
 		$expected = array(
 			'styles' => array(
 				'core/group' => array(
@@ -640,7 +640,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			true
 		);
 		$theme_json->remove_insecure_properties();
-		$result   = $theme_json->get_raw_data();
+		$result   = $theme_json->get();
 		$expected = array(
 			'styles' => array(
 				'core/group' => array(
@@ -692,7 +692,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			true
 		);
 		$theme_json->remove_insecure_properties();
-		$result   = $theme_json->get_raw_data();
+		$result   = $theme_json->get();
 		$expected = array(
 			'settings' => array(
 				$root_name => array(
@@ -781,7 +781,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			true
 		);
 		$theme_json->remove_insecure_properties();
-		$result   = $theme_json->get_raw_data();
+		$result   = $theme_json->get();
 		$expected = array(
 			'settings' => array(
 				$root_name => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -203,7 +203,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$result = $theme_json->get_settings();
+		$result = $theme_json->get( array( 'settings' ) );
 
 		$expected = array(
 			$root_name => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -843,7 +843,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$template_parts = $theme_json->get_template_parts();
+		$template_parts = $theme_json->get( array( 'templateParts' ) );
 
 		$this->assertEqualSetsWithIndex(
 			$template_parts,


### PR DESCRIPTION
Inspired by and alternative to https://github.com/WordPress/gutenberg/pull/29667

This PR creates a higher API for the existing `WP_Theme_JSON_Resolver`. Previously it exposed lower-level primitives to interact with the different origins of data (core, theme, user). By exposing a higher-level API the data input and the code paths supported by this API are clearer.

1. The API changes slightly for the functions in use by non-global styles code:

| Use case                   | Before                                                       | After                                            |
| -------------------------- | ------------------------------------------------------------ | ------------------------------------------------ |
| Check theme has theme.json | `WP_Theme_JSON_Resolver::theme_has_support()`                | `WP_Theme_JSON_Resolver::theme_has_support()`    |
| Get template parts         | `WP_Theme_JSON_Resolver::get_theme_data()->get_template_parts()` | `WP_Theme_JSON_Resolver::get_template_parts()`   |
| Get custom templates       | `WP_Theme_JSON_Resolver::get_theme_data()->get_custom_templates()` | `WP_Theme_JSON_Resolver::get_custom_templates()` |

2. The API is vastly simplified for global styles internals:

|                                                              | Before                                                       | After                                                        |
| ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
| Register user CPT on `init`                                  | `WP_Theme_JSON_Resolver::register_user_custom_post_type()`   | `WP_Theme_JSON_Resolver::register_user_custom_post_type();`  |
| Get user CPT id on `block_editor_settings`                   | `WP_Theme_JSON_Resolver::get_user_custom_post_type_id();`    | `WP_Theme_JSON_Resolver::get_user_custom_post_type_id();`    |
| Get settings for editor on `block_editor_settings`       | `$origin = some_code_for_origin_calculation();`<br />`$tree = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, $origin );`<br />`$tree->get_settings();` | `WP_Theme_JSON_Resolver::get_settings( $theme_support_data );` |
| Get stylesheet for front-end on `wp_enqueue_scripts`         | `$all = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data );`<br />`$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );` | `WP_Theme_JSON_Resolver::get_stylesheet( $theme_support_data );` |
| Get stylesheet for editors other than edit-site on `block_editor_settings` | `$origin = some_code_for_origin_calculation();`<br />`$tree = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, $origin );`<br />`$css_vars = gutenberg_experimental_global_styles_get_stylesheet( $tree, 'css_variables' );`<br />`$block_styles = gutenberg_experimental_global_styles_get_stylesheet( $tree, 'block_styles' );` | `$css_vars = WP_Theme_Config_Resolver::get_stylesheet( $theme_support_data, 'css_variables' );`<br />`$block_styles = WP_Theme_Config_Resolver::get_stylesheet( $theme_support_data, 'block_styles' );` |
| Get base styles (json) for edit-site on `block_editor_settings` | `WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get_raw_data();` | `WP_Theme_Config_Resolver::get_theme_styles_and_settings( $theme_support_data );` |

## How to test

- Verify that all the tests pass (`npm run test-unit-php`).
- Go to the site editor (TT1 theme) and verify it works as expected (theme presets are there, etc).
- In the style editor, change something via the global styles sidebar (the color of the global text) and publish. Verify the front-end works as expected.

