### PR TITLE
Navigation Editor: Show all menus in manage locations

### DIFF
--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -96,7 +96,9 @@ export default function Header( {
 								{ __( 'Manage locations' ) }
 							</Button>
 						) }
-						renderContent={ () => <ManageLocations /> }
+						renderContent={ () => (
+							<ManageLocations menus={ menus } />
+						) }
 					/>
 
 					<SaveButton navigationPost={ navigationPost } />

--- a/packages/edit-navigation/src/components/header/manage-locations.js
+++ b/packages/edit-navigation/src/components/header/manage-locations.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { Spinner, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -10,9 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import useMenuLocations from '../../hooks/use-menu-locations';
 
-export default function ManageLocations() {
-	const menus = useSelect( ( select ) => select( 'core' ).getMenus(), [] );
-
+export default function ManageLocations( { menus } ) {
 	const [ menuLocations, assignMenuToLocation ] = useMenuLocations();
 
 	if ( ! menus || ! menuLocations ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #28933.
The Menu Locations dropdown in the Navigation editor was showing only 10 items because it was doing it's own API call to get the list of menus.
This PR fixes this and reuses the menus got by the navigation editor itself.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested locally.

To test:

1. Add more 12 menus
2. Go to Gutenberg > Navigation (beta)
3. See that in the manage locations select(s) you see all 12 menus

## Screenshots <!-- if applicable -->

<img width="852" alt="Screen Shot 2021-03-16 at 19 51 59" src="https://user-images.githubusercontent.com/107534/111356517-1ecc0880-8691-11eb-9d02-e7636b99198c.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Non breaking bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
