### PR TITLE
Prevent PanelBody title from being overlapped by arrow

### DIFF
--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -77,6 +77,7 @@
 .components-panel__body-toggle.components-button {
 	position: relative;
 	padding: $grid-unit-20;
+	padding-right: 48px;
 	outline: none;
 	width: 100%;
 	font-weight: 500;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -76,8 +76,7 @@
 
 .components-panel__body-toggle.components-button {
 	position: relative;
-	padding: $grid-unit-20;
-	padding-right: 48px;
+	padding: $grid-unit-20 $grid-unit-60 $grid-unit-20 $grid-unit-20;
 	outline: none;
 	width: 100%;
 	font-weight: 500;


### PR DESCRIPTION
## Description
This will fix #29913.

## How has this been tested?
* Checked the updated style in Safari, Chrome and Firefox.

## Types of changes
Non-breaking styling fix for PanelBody title area.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
