### PR TITLE
Limit number of items to 1 if selecting the option to use query from query string

### DIFF
--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, usePrevious } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
 import {
 	BlockControls,
@@ -33,18 +33,26 @@ export function QueryContent( { attributes, setAttributes } ) {
 				+getSettings().postsPerPage || DEFAULTS_POSTS_PER_PAGE,
 		};
 	}, [] );
+
+	const previousQuery = usePrevious( query );
 	// Changes in query property (which is an object) need to be in the same callback,
 	// because updates are batched after the render and changes in different query properties
 	// would cause to overide previous wanted changes.
 	useEffect( () => {
 		const newQuery = {};
-		if ( ! query.perPage && postsPerPage ) {
+		if (
+			( ! query.perPage && postsPerPage ) ||
+			( ! query.inherit && previousQuery?.inherit )
+		) {
 			newQuery.perPage = postsPerPage;
+		}
+		if ( query.inherit ) {
+			newQuery.perPage = 1;
 		}
 		if ( !! Object.keys( newQuery ).length ) {
 			updateQuery( newQuery );
 		}
-	}, [ query.perPage, query.inherit ] );
+	}, [ query.perPage, query.inherit, previousQuery ] );
 	// We need this for multi-query block pagination.
 	// Query parameters for each block are scoped to their ID.
 	useEffect( () => {

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -42,7 +42,7 @@ export function QueryContent( { attributes, setAttributes } ) {
 		const newQuery = {};
 		if (
 			( ! query.perPage && postsPerPage ) ||
-			( ! query.inherit && previousQuery?.inherit )
+			( ! query.inherit && previousQuery?.inherit && postsPerPage )
 		) {
 			newQuery.perPage = postsPerPage;
 		}

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -52,7 +52,7 @@ export function QueryContent( { attributes, setAttributes } ) {
 		if ( !! Object.keys( newQuery ).length ) {
 			updateQuery( newQuery );
 		}
-	}, [ query.perPage, query.inherit, previousQuery ] );
+	}, [ query.perPage, query.inherit ] );
 	// We need this for multi-query block pagination.
 	// Query parameters for each block are scoped to their ID.
 	useEffect( () => {

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -46,7 +46,7 @@ export function QueryContent( { attributes, setAttributes } ) {
 		) {
 			newQuery.perPage = postsPerPage;
 		}
-		if ( query.inherit ) {
+		if ( query.inherit && query.perPage !== 1 ) {
 			newQuery.perPage = 1;
 		}
 		if ( !! Object.keys( newQuery ).length ) {


### PR DESCRIPTION
Potential fix for #29438

## Description
Currently when selecting `Inherit query from url` the query loop block still shows the default number of posts from `getSettings().postsPerPage` or `DEFAULTS_POSTS_PER_PAGE` which means the editor doesn't match the frontend where a single post/page is likely to display.

## How has this been tested?
Just manually currently

## Types of changes
If `Inherit query from url` is toggled on sets the posts per page to 1 in order to better match what is shown in the editor to what you see in from end.

## Testing

Checkout PR to local dev env
Enable FSE theme
In FSE editor edit page template and add a Query block
Toggle `Inherit query from url`  on and make sure only one page/posts displays in front end and editor
Toggle `Inherit query from url` off and make sure the default number of posts per page displays in editor and frontend

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
