### PR TITLE
Allow for group and columns blocks to specify an unlocked template.

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -13,7 +13,7 @@
 			"type": "string"
 		},
 		"templateLock": {
-			"type": "string"
+			"enum": [ "all", "insert", false ]
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -8,7 +8,7 @@
 			"default": "div"
 		},
 		"templateLock": {
-			"type": "string"
+			"enum": [ "all", "insert", false ]
 		}
 	},
 	"supports": {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #29799
A valid use case for templates is to have a locked outer template, with an inner unlocked area.

This allows users to create templates that have both editable and non-editable parts (in terms of adding blocks).

There are two blocks that support a `templateLock` attribute, columns and group. Both of those don't support `templateLock` being set to `false`, because their attribute type is `string`. `A string of 'false'` is interpreted as truthy.

In this PR I've switched those blocks to use an enum instead (`[ 'all', 'insert', false ]` ).

## How has this been tested?
1. Use the following code snippet to create a custom Books post type with an `all` locked template, but an unlocked inner group block.
```

function myplugin_register_book_post_type() {
	$args = array(
		'public'        => true,
		'label'         => 'Books',
		'show_in_rest'  => true,
		'template_lock' => true,
		'template'      => array(
			array( 'core/video' ),
			array(
				'core/group',
				array(
					'templateLock' => false,
				),
				array(
					array( 'core/image' ),
				),
			),
			array( 'core/video' ),
		),
	);
	register_post_type( 'book', $args );
}
add_action( 'init', 'myplugin_register_book_post_type' );
```
2. Click the image block and insert blocks before/after it.
3. Click one of the video blocks and notice that blocks cannot be inserted before/after
4. Save and reload
5. The content should remain the same.


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix - this is mostly non-breaking, unless the user specified a template lock of something other than 'all', 'insert', which wouldn't work as expected anyway.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
