### PR TITLE
Site Editor: Fix block toolbar from overlapping navigation panel

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -105,8 +105,8 @@ $z-layers: (
 	// Show the navigation toggle above the skeleton header
 	".edit-site-navigation-toggle": 31,
 
-	// Show the FSE template previews above the editor (same z-index as the skeleton header)
-	".edit-site-navigation-panel__preview": 30,
+	// Show the FSE template previews above the editor and any open block toolbars
+	".edit-site-navigation-panel__preview": 32,
 
 	// Show notices below expanded editor bar
 	// .edit-post-header { z-index: 30 }

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -128,16 +128,6 @@ html.interface-interface-skeleton__html-container {
 	border-bottom: $border-width solid $gray-200;
 	z-index: z-index(".interface-interface-skeleton__header");
 	color: $gray-900;
-
-	// On Mobile the header is sticky.
-	position: sticky;
-	top: 0;
-
-	// Cancel the fixed positioning used on Mobile.
-	@include break-small() {
-		position: initial;
-		top: 0;
-	}
 }
 
 .interface-interface-skeleton__footer {


### PR DESCRIPTION
## Description

Prevent the block toolbar from overlapping the navigation panel and related template/content previews.

| **Before** | **After** |
| - | - |
| <img width="864" alt="Screen Shot 2021-03-16 at 21 54 51" src="https://user-images.githubusercontent.com/1699996/111408259-049b2600-86a3-11eb-93cf-4ec21aa5d1cb.png"> | <img width="878" alt="Screen Shot 2021-03-16 at 21 59 15" src="https://user-images.githubusercontent.com/1699996/111408279-0c5aca80-86a3-11eb-8caa-fbb9d1cf6bb3.png"> |
| <img width="662" alt="Screen Shot 2021-03-16 at 21 55 37" src="https://user-images.githubusercontent.com/1699996/111408291-12e94200-86a3-11eb-80c8-f41d4400c829.png"> | <img width="661" alt="Screen Shot 2021-03-16 at 21 58 35" src="https://user-images.githubusercontent.com/1699996/111408305-18df2300-86a3-11eb-89de-9c423d789f3c.png"> |

Fixes #29615 and #29392.

## How has this been tested?

1. With a block toolbar visible in the site editor, open the navigation panel and hover over a template to show its preview.
2. The preview should display on top of the toolbar.
3. For medium screen sizes, open the navigation panel with a block toolbar open at the top, under the header.
4. The toolbar should display to the right of the navigation panel, not on top of it.
5. Try the same with top toolbar setting toggled. Also check the page/post editor for regressions.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
