### PR TITLE
Image: Manually update resizable box state when we don't have dimenssions

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -89,6 +89,7 @@ export default function Image( {
 	containerRef,
 } ) {
 	const captionRef = useRef();
+	const resizableBoxRef = useRef();
 	const prevUrl = usePrevious( url );
 	const { block, currentId, image, multiImageSelection } = useSelect(
 		( select ) => {
@@ -176,6 +177,17 @@ export default function Image( {
 			captionRef.current.focus();
 		}
 	}, [ url, prevUrl ] );
+
+	// Set resizable box dimensions to "auto" when we don't have width/height.
+	// This is done to reset inline styles after changing to a different image.
+	useEffect( () => {
+		if ( url && resizableBoxRef.current && ! width && ! height ) {
+			resizableBoxRef.current.updateSize( {
+				width: 'auto',
+				height: 'auto',
+			} );
+		}
+	}, [ url, width, height ] );
 
 	function onResizeStart() {
 		toggleSelection( false );
@@ -510,6 +522,7 @@ export default function Image( {
 
 		img = (
 			<ResizableBox
+				ref={ resizableBoxRef }
 				size={ { width, height } }
 				showHandle={ isSelected }
 				minWidth={ minWidth }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -89,7 +89,6 @@ export default function Image( {
 	containerRef,
 } ) {
 	const captionRef = useRef();
-	const resizableBoxRef = useRef();
 	const prevUrl = usePrevious( url );
 	const { block, currentId, image, multiImageSelection } = useSelect(
 		( select ) => {
@@ -177,17 +176,6 @@ export default function Image( {
 			captionRef.current.focus();
 		}
 	}, [ url, prevUrl ] );
-
-	// Set resizable box dimensions to "auto" when we don't have width/height.
-	// This is done to reset inline styles after changing to a different image.
-	useEffect( () => {
-		if ( url && resizableBoxRef.current && ! width && ! height ) {
-			resizableBoxRef.current.updateSize( {
-				width: 'auto',
-				height: 'auto',
-			} );
-		}
-	}, [ url, width, height ] );
 
 	function onResizeStart() {
 		toggleSelection( false );
@@ -522,8 +510,10 @@ export default function Image( {
 
 		img = (
 			<ResizableBox
-				ref={ resizableBoxRef }
-				size={ { width, height } }
+				size={ {
+					width: width ?? 'auto',
+					height: height ?? 'auto',
+				} }
 				showHandle={ isSelected }
 				minWidth={ minWidth }
 				maxWidth={ maxWidthBuffer }


### PR DESCRIPTION
## Description
When changing to a different image, we reset dimension attributes, including size props for the resizable box. But this doesn't automatically reset dimensions in the resizable box state, which is used for inline styles. So we have to do it manually.

Fixes #23985.

P.S. This might be an issue with the upstream package - `re-resizable`.

## How has this been tested?
1. Add image block and set image
2. Resize the image.
3. Replace it with a different image.
4. See if a resizable box is reset.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
