### PR TITLE
Fix sibling block inserter displaying at end of block list.

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -200,9 +200,9 @@ function InsertionPointPopover( {
 		}
 	}
 
-	// Only show the inserter when there's a `nextElement`. At the end of the
-	// block list the trailing appender should serve the purpose of inserting
-	// blocks.
+	// Only show the inserter when there's a `nextElement` (a block after the
+	// insertion point). At the end of the block list the trailing appender
+	// should serve the purpose of inserting blocks.
 	const showInsertionPointInserter =
 		! isHidden && nextElement && ( isInserterShown || isInserterForced );
 

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -200,6 +200,18 @@ function InsertionPointPopover( {
 		}
 	}
 
+	// Only show the inserter when there's a `nextElement`. At the end of the
+	// block list the trailing appender should serve the purpose of inserting
+	// blocks.
+	const showInsertionPointInserter =
+		! isHidden && nextElement && ( isInserterShown || isInserterForced );
+
+	// Show the indicator if the insertion point inserter is visible, or if
+	// the `showInsertionPoint` state is `true`. The latter is generally true
+	// when hovering blocks for insertion in the block library.
+	const showInsertionPointIndicator =
+		! isHidden && ( showInsertionPointInserter || showInsertionPoint );
+
 	/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	// While ideally it would be enough to capture the
 	// bubbling focus event from the Inserter, due to the
@@ -224,13 +236,10 @@ function InsertionPointPopover( {
 				className={ className }
 				style={ style }
 			>
-				{ ! isHidden &&
-					( showInsertionPoint ||
-						isInserterShown ||
-						isInserterForced ) && (
-						<div className="block-editor-block-list__insertion-point-indicator" />
-					) }
-				{ ! isHidden && ( isInserterShown || isInserterForced ) && (
+				{ showInsertionPointIndicator && (
+					<div className="block-editor-block-list__insertion-point-indicator" />
+				) }
+				{ showInsertionPointInserter && (
 					<InsertionPointInserter
 						rootClientId={ rootClientId }
 						clientId={ nextClientId }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -210,7 +210,7 @@ function InsertionPointPopover( {
 	// the `showInsertionPoint` state is `true`. The latter is generally true
 	// when hovering blocks for insertion in the block library.
 	const showInsertionPointIndicator =
-		! isHidden && ( showInsertionPointInserter || showInsertionPoint );
+		showInsertionPointInserter || ( ! isHidden && showInsertionPoint );
 
 	/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	// While ideally it would be enough to capture the

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	canvas,
-	trashAllPosts,
-	activateTheme,
-} from '@wordpress/e2e-test-utils';
+import { trashAllPosts, activateTheme } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -58,9 +54,15 @@ describe( 'Document Settings', () => {
 
 		describe( 'and a template part is clicked in the template', () => {
 			it( "should display the selected template part's name in the document header", async () => {
-				// Click on a template part in the template
-				const header = await canvas().$( '.site-header' );
-				await header.click();
+				// Select the header template part via list view.
+				await page.click( 'button[aria-label="List View"]' );
+				const headerTemplatePartListViewButton = await page.waitForXPath(
+					'//button[contains(@class, "block-editor-block-navigation-block-select-button")][contains(., "Header")]'
+				);
+				headerTemplatePartListViewButton.click();
+				await page.click(
+					'button[aria-label="Close list view sidebar"]'
+				);
 
 				// Evaluate the document settings secondary title
 				const actual = await getDocumentSettingsSecondaryTitle();

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -7,7 +7,6 @@ import {
 	publishPost,
 	trashAllPosts,
 	activateTheme,
-	canvas,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -189,9 +188,13 @@ describe( 'Multi-entity save flow', () => {
 			await navigationPanel.clickItemByText( 'Index' );
 			await navigationPanel.close();
 
-			// Click the first block so that the template part inserts in the right place.
-			const firstBlock = await canvas().$( '.wp-block' );
-			await firstBlock.click();
+			// Select the first template part via list view.
+			await page.click( 'button[aria-label="List View"]' );
+			const headerTemplatePartListViewButton = await page.waitForXPath(
+				'//button[contains(@class, "block-editor-block-navigation-block-select-button")][contains(., "Header")]'
+			);
+			headerTemplatePartListViewButton.click();
+			await page.click( 'button[aria-label="Close list view sidebar"]' );
 
 			// Insert something to dirty the editor.
 			await insertBlock( 'Paragraph' );

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -188,7 +188,7 @@ describe( 'Multi-entity save flow', () => {
 			await navigationPanel.clickItemByText( 'Index' );
 			await navigationPanel.close();
 
-			// Select the first template part via list view.
+			// Select the header template part via list view.
 			await page.click( 'button[aria-label="List View"]' );
 			const headerTemplatePartListViewButton = await page.waitForXPath(
 				'//button[contains(@class, "block-editor-block-navigation-block-select-button")][contains(., "Header")]'


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28907



## How has this been tested?
1. Add a Navigation Block
2. Start empty and add a couple of links
3. Hover in the area after the last link
4. The inserter should not be displayed
5. Hover between the links
6. The inserter should be displayed
7. Select the last link
8. Click the 'Add block' button from the editor's top toolbar
9. Hover over a block in the block library
10. The insertion point (blue line) should be displayed at the end of the navigation block.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
