### PR TITLE
Editor: Avoid focus attempt on a non-existent post title in code editor

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -64,6 +64,10 @@ export default function PostTitle() {
 	} );
 
 	useEffect( () => {
+		if ( ! ref.current ) {
+			return;
+		}
+
 		const { ownerDocument } = ref.current;
 		const { activeElement, body } = ownerDocument;
 


### PR DESCRIPTION
## Description

If a post type has no title support, then `ref.current` is `undefined` and there is no `ownerDocument` to read nor title to focus. See #29921

## How has this been tested?

1. Register a post type with no title support
2. Add a new post of that post type
3. Attempt to switch to code editor view

<br>

1. Register a post type with title support
2. Add a new post of that post type
3. Attempt to switch to code editor view

## Types of changes

Bug fix, see #29921.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR.

