### PR TITLE
Fix renderAppender docs

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -128,32 +128,33 @@ If locking is not set in an `InnerBlocks` area: the locking of the parent `Inner
 If the block is a top level block: the locking of the Custom Post Type is used.
 
 ### `renderAppender`
-* **Type:** `Function|false`
-* **Default:** - `undefined`. When `renderAppender` is not specific the `<DefaultBlockAppender>` component is as a default. It automatically inserts whichever block is configured as the default block via `wp.blocks.setDefaultBlockName` (typically `paragraph`). If a `false` value is provider, no appender is rendered.
+* **Type:** `Component|false`
+* **Default:** - `undefined`. When `renderAppender` is not specified, the default appender is shown. If a `false` value is provided, no appender is rendered.
 
-A 'render prop' function that can be used to customize the block's appender.
+A component to show as the trailing appender for the inner blocks list.
 
 #### Notes
-* For convenience two predefined appender components are exposed on `InnerBlocks` which can be consumed within the render function:
-	- `<InnerBlocks.ButtonBlockAppender />` -  display a `+` (plus) icon button that, when clicked, displays the block picker menu. No default Block is inserted.
-	- `<InnerBlocks.DefaultBlockAppender />` - display the default block appender as set by `wp.blocks.setDefaultBlockName`. Typically this is the `paragraph` block.
-* Consumers are also free to pass any valid render function. This provides the full flexibility to define a bespoke block appender.
+* For convenience two predefined appender components are exposed on `InnerBlocks` which can be used for the prop:
+	- `InnerBlocks.ButtonBlockAppender` -  display a `+` (plus) icon button that, when clicked, displays the block picker menu. No default Block is inserted.
+	- `InnerBlocks.DefaultBlockAppender` - display the default block appender.
+* Consumers are also free to pass any valid render component. This provides the full flexibility to define a bespoke block appender.
 
 #### Example usage
 
 ```jsx
 // Utilise a predefined component
 <InnerBlocks
-	renderAppender={ () => (
-		<InnerBlocks.ButtonBlockAppender />
-	) }
+	renderAppender={ InnerBlocks.ButtonBlockAppender }
+/>
+
+// Utilise a predefined component
+<InnerBlocks
+	renderAppender={ false }
 />
 
 // Fully custom
 <InnerBlocks
-	renderAppender={ () => (
-		<button className="bespoke-appender" type="button">Some Special Appender</button>
-	) }
+	renderAppender={ MyAmazingAppender }
 />
 ```
 

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -135,9 +135,9 @@ A component to show as the trailing appender for the inner blocks list.
 
 #### Notes
 * For convenience two predefined appender components are exposed on `InnerBlocks` which can be used for the prop:
-	- `InnerBlocks.ButtonBlockAppender` -  display a `+` (plus) icon button that, when clicked, displays the block picker menu. No default Block is inserted.
-	- `InnerBlocks.DefaultBlockAppender` - display the default block appender.
-* Consumers are also free to pass any valid render component. This provides the full flexibility to define a bespoke block appender.
+	- `InnerBlocks.ButtonBlockAppender` -  display a `+` (plus) icon button as the appender.
+	- `InnerBlocks.DefaultBlockAppender` - display the default block appender, typically the paragraph style appender when the paragraph block is allowed.
+* Consumers are also free to pass any valid component. This provides the full flexibility to define a bespoke block appender.
 
 #### Example usage
 
@@ -147,7 +147,7 @@ A component to show as the trailing appender for the inner blocks list.
 	renderAppender={ InnerBlocks.ButtonBlockAppender }
 />
 
-// Utilise a predefined component
+// Don't display an appender
 <InnerBlocks
 	renderAppender={ false }
 />
@@ -165,7 +165,7 @@ A component to show as the trailing appender for the inner blocks list.
 
 Determines whether the toolbars of _all_ child Blocks (applied deeply, recursive) should have their toolbars "captured" and shown on the Block which is consuming `InnerBlocks`.
 
-For example, a button block, deeply nested in several levels of block `X` that utilises this property will see the button block's toolbar displayed on block `X`'s toolbar area.
+For example, a button block, deeply nested in several levels of block `X` that utilizes this property will see the button block's toolbar displayed on block `X`'s toolbar area.
 
 ### `placeholder`
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
The `renderAppender` docs are mostly wrong, seems they've been that way for a while.

It's best to pass a component to `renderAppender`, as is done in most core blocks. Passing a callback function will cause React to treat this as a new function component on every render causing reconciliation issues.

Also fixed some of the info that was outdated since the introduction of the quick inserter, and had a few typos.

## Types of changes
Documentation
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
