### PR TITLE
Polish nav screen slightly.

### DIFF
--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -1,18 +1,19 @@
 .edit-navigation-header {
 	display: flex;
 	align-items: center;
-	padding: $grid-unit-15;
+	padding: $grid-unit-15 $grid-unit-30 $grid-unit-15 20px;
 }
 
 .edit-navigation-header__title-subtitle {
 	flex-grow: 1;
-	padding-left: $grid-unit-10;
 }
 
 .edit-navigation-header__title {
-	font-size: $default-font-size;
-	line-height: $default-line-height;
+	font-size: 23px;
+	font-weight: 400;
 	margin: 0;
+	padding: 7px 0 4px 0;
+	line-height: 1.3;
 }
 
 .edit-navigation-header__subtitle {
@@ -23,9 +24,21 @@
 
 .edit-navigation-header__actions {
 	display: flex;
+
+	> .components-dropdown {
+		margin-right: $grid-unit-15;
+	}
 }
 
 .edit-navigation-header__menu-switcher-dropdown {
 	// Appear below the modal overlay.
 	z-index: z-index(".components-popover.edit-navigation-header__menu-switcher-dropdown");
+}
+
+// Hide notices.
+.gutenberg_page_gutenberg-navigation {
+	.notice,
+	#wpfooter {
+		display: none;
+	}
 }


### PR DESCRIPTION
## Description

Slight polish to the navigation screen:

- Hide notices
- Tweak padding/margin of header
- Make primary heading match other sections

## Screenshots <!-- if applicable -->

Before:

<img width="1270" alt="Screenshot 2021-03-17 at 10 05 56" src="https://user-images.githubusercontent.com/1204802/111442188-5fb33400-8708-11eb-8b51-e9186471d410.png">

After:

<img width="1270" alt="Screenshot 2021-03-17 at 10 04 20" src="https://user-images.githubusercontent.com/1204802/111442198-617cf780-8708-11eb-9a3a-9b8f0529e4e3.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
