### PR TITLE
Fix navigation screen inserter horizontal scrollbar.

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -325,10 +325,6 @@ $block-inserter-tabs-height: 44px;
 	float: left;
 }
 
-.block-editor-inserter__quick-inserter .block-editor-inserter__panel-content {
-	padding: $grid-unit-10;
-}
-
 .block-editor-inserter__quick-inserter.has-search .block-editor-inserter__panel-content,
 .block-editor-inserter__quick-inserter.has-expand .block-editor-inserter__panel-content {
 	padding: $grid-unit-20;


### PR DESCRIPTION
## Description

On the navigation screen, and in any block context that limits the quick inserter to not showing search, the quick inserter had a horizontal scrollbar:

<img width="509" alt="Screenshot 2021-03-17 at 13 01 03" src="https://user-images.githubusercontent.com/1204802/111464280-d8be8580-8720-11eb-8ea1-be11afd53f35.png">

This fixes that:

<img width="468" alt="Screenshot 2021-03-17 at 12 58 43" src="https://user-images.githubusercontent.com/1204802/111464198-bfb5d480-8720-11eb-8746-be8e8d469210.png">

Please test that no quick inserters regress:

<img width="550" alt="Screenshot 2021-03-17 at 12 58 18" src="https://user-images.githubusercontent.com/1204802/111464218-c5abb580-8720-11eb-84e3-853b0d9cd1b8.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
