### PR TITLE
Page List & Navigation Screen: Fix flyout bg color in page list.

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -84,9 +84,10 @@
 	}
 }
 
-// Default background and font color
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container {
-	.wp-block-navigation-link__container {
+// Default background and font color.
+.wp-block-navigation:not(.has-background) {
+	.submenu-container, // This target items created by the Page List block.
+	.wp-block-navigation__container .wp-block-navigation-link__container {
 		// Set a background color for submenus so that they're not transparent.
 		// NOTE TO DEVS - if refactoring this code, please double-check that
 		// submenus have a default background color, this feature has regressed

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -4,13 +4,6 @@
 	.wp-block-page-list {
 		background-color: inherit;
 	}
-	// Make the dropdown background white if there's no background color set.
-	&:not(.has-background) {
-		.submenu-container {
-			color: $gray-900;
-			background-color: $white;
-		}
-	}
 }
 
 // Make links unclickable in the editor

--- a/packages/block-library/src/page-list/style.scss
+++ b/packages/block-library/src/page-list/style.scss
@@ -13,12 +13,14 @@
 	}
 }
 
-// The Pages block should inherit navigation styles when nested within it
+// The Page List block should inherit navigation styles when nested within it
 .wp-block-navigation {
 	.wp-block-page-list {
 		display: flex;
 		flex-wrap: wrap;
+		background-color: inherit;
 	}
+
 	.wp-block-pages-list__item__link {
 		display: block;
 		color: inherit;
@@ -33,10 +35,9 @@
 		> a {
 			padding-right: 0.5em;
 		}
+
 		> .submenu-container {
 			border: $border-width solid rgba(0, 0, 0, 0.15);
-			background-color: inherit;
-			color: inherit;
 			position: absolute;
 			left: 0;
 			top: 100%;
@@ -89,6 +90,11 @@
 				opacity: 1;
 			}
 		}
+	}
+
+	&.has-background .wp-block-pages-list__item.has-child > .submenu-container {
+		background-color: inherit;
+		color: inherit;
 	}
 
 	.submenu-container {


### PR DESCRIPTION
## Description

Background color inheritance wasn't fully working in the Page List block. This PR fixes that.

Specifically, if a navigation block has a background color defined, that background color should also be used to colorize flyout submenus.

But if it doesn't, then we have to define both a background color, and a text color, in order to be sure flyout menus are legible. 

Before:

<img width="541" alt="published post before" src="https://user-images.githubusercontent.com/1204802/111468967-723c6600-8726-11eb-8666-68c041b5f239.png">

<img width="600" alt="before nav" src="https://user-images.githubusercontent.com/1204802/111468972-749ec000-8726-11eb-95b4-52e1276ba0fa.png">

After:

<img width="772" alt="Screenshot 2021-03-17 at 13 38 57" src="https://user-images.githubusercontent.com/1204802/111468986-78324700-8726-11eb-9ade-cf00158faa0d.png">

<img width="737" alt="Screenshot 2021-03-17 at 13 36 58" src="https://user-images.githubusercontent.com/1204802/111468991-79637400-8726-11eb-96d3-23262a7449e0.png">

<img width="750" alt="Screenshot 2021-03-17 at 13 37 52" src="https://user-images.githubusercontent.com/1204802/111468994-7a94a100-8726-11eb-886d-aff15e4f7652.png">


## How has this been tested?

Please use a non-FSE theme, because there's an issue with the navigation screen where style files aren't applied in that context.

Please test the navigation screen, and the navigation block. You need to have both a number of pages and subpages published. The in the navigation block, please use both the Page List block, and a custom menu item with a number of submenus defined.

Try with and without a background color for the navigation block. Please verify submenu item colors are correctly applied.

Fixes #29101.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
