### PR TITLE
Navigation Link: Match Editor Markup to Rendered

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -428,7 +428,9 @@ export default function NavigationLinkEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<li { ...blockProps }>
-				<div className={ classes }>
+				{/* eslint-disable jsx-a11y/anchor-is-valid */}
+				<a className={ classes }>
+				{/* eslint-enable */}
 					{ ! url ? (
 						<div className="wp-block-navigation-link__placeholder-text">
 							<KeyboardShortcuts
@@ -550,7 +552,7 @@ export default function NavigationLinkEdit( {
 							/>
 						</Popover>
 					) }
-				</div>
+				</a>
 				{ hasDescendants && showSubmenuIcon && (
 					<span className="wp-block-navigation-link__submenu-icon">
 						<ItemSubmenuIcon />

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -428,9 +428,9 @@ export default function NavigationLinkEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<li { ...blockProps }>
-				{/* eslint-disable jsx-a11y/anchor-is-valid */}
+				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>
-				{/* eslint-enable */}
+					{ /* eslint-enable */ }
 					{ ! url ? (
 						<div className="wp-block-navigation-link__placeholder-text">
 							<KeyboardShortcuts

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -39,6 +39,10 @@
 		display: block;
 	}
 
+	.wp-block-navigation-link__content {
+		cursor: text;
+	}
+
 	&.is-editing,
 	&.is-selected {
 		min-width: 20px;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closes #28575

Changes the element structure of the navigation link block in the editor to match the rendered output.

### Editor markup:
```html
<nav class="… wp-block-navigation" …>
	<ul class="wp-block-navigation__container …">
		<li class="… wp-block-navigation-link" …>
			<a class="wp-block-navigation-link__content">
				<div … class="block-editor-rich-text__editable …" contenteditable="true">example.com</div>
			</a>
			…
		</li>
		…
	</ul>
</nav>
```
### Rendered markup:
```html
<nav class="wp-block-navigation">
	<ul class="wp-block-navigation__container">
		<li class="wp-block-navigation-link">
			<a class="wp-block-navigation-link__content" href="http://example.com">
				<span class="wp-block-navigation-link__label">example.com</span>
			</a>
		</li>
	</ul>
</nav>
```


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually tested on desktop Firefox

## Screenshots <!-- if applicable -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
