### PR TITLE
Enable list view

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -41,7 +41,6 @@ function Navigation( {
 	className,
 	hasSubmenuIndicatorSetting = true,
 	hasItemJustificationControls = attributes.orientation === 'horizontal',
-	hasListViewModal = true,
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -124,11 +123,9 @@ function Navigation( {
 						} }
 					/>
 				) }
-				{ hasListViewModal && (
-					<ToolbarGroup>{ navigatorToolbarButton }</ToolbarGroup>
-				) }
+				<ToolbarGroup>{ navigatorToolbarButton }</ToolbarGroup>
 			</BlockControls>
-			{ hasListViewModal && navigatorModal }
+			{ navigatorModal }
 			<InspectorControls>
 				{ hasSubmenuIndicatorSetting && (
 					<PanelBody title={ __( 'Display settings' ) }>

--- a/packages/edit-navigation/src/filters/add-menu-name-editor.js
+++ b/packages/edit-navigation/src/filters/add-menu-name-editor.js
@@ -15,8 +15,8 @@ const addMenuNameEditor = createHigherOrderComponent(
 		}
 		return (
 			<>
-				<BlockEdit { ...props } />
 				<NameDisplay />
+				<BlockEdit { ...props } />
 			</>
 		);
 	},

--- a/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
+++ b/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
@@ -15,7 +15,7 @@ const removeNavigationBlockEditUnsupportedFeatures = createHigherOrderComponent(
 				{ ...props }
 				hasSubmenuIndicatorSetting={ false }
 				hasItemJustificationControls={ false }
-				hasListViewModal={ false }
+				hasListViewModal={ true }
 			/>
 		);
 	},

--- a/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
+++ b/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
@@ -15,7 +15,6 @@ const removeNavigationBlockEditUnsupportedFeatures = createHigherOrderComponent(
 				{ ...props }
 				hasSubmenuIndicatorSetting={ false }
 				hasItemJustificationControls={ false }
-				hasListViewModal={ true }
 			/>
 		);
 	},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Advances #28856

Adds listview back to the navigation block used in the navigation editor and reorders menu items as the mockup in the link issue shows.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested locally.

1. Go to Gutenberg > Navugation (beta)
2. Add a menu
3. Add a menu link
4. Select the parent via the parent selector
5. Observe the list view toolbar item  


## Screenshots <!-- if applicable -->

<img width="861" alt="Screen Shot 2021-03-17 at 17 04 28" src="https://user-images.githubusercontent.com/107534/111490749-f3562600-8743-11eb-83aa-ec7a47d437a8.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Update block settings and order of block toolbar additions.
I am unsure that the order will be the one in code all the time, but I have not been able to make it break.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
