### PR TITLE
Update WP compatibility check in `gutenberg_pre_init()`

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -209,6 +209,7 @@ function gutenberg_pre_init() {
 	// X.Y for its major releases.
 	if ( version_compare( $version, '5.6', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
+		return;
 	}
 
 	require_once __DIR__ . '/lib/load.php';

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -169,7 +169,7 @@ add_action( 'welcome_panel', 'modify_welcome_panel', 40 );
 function gutenberg_wordpress_version_notice() {
 	echo '<div class="error"><p>';
 	/* translators: %s: Minimum required version */
-	printf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), '5.3.0' );
+	printf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), '5.6' );
 	echo '</p></div>';
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -204,7 +204,10 @@ function gutenberg_pre_init() {
 	// Strip '-src' from the version string. Messes up version_compare().
 	$version = str_replace( '-src', '', $wp_version );
 
-	if ( version_compare( $version, '5.3.0', '<' ) ) {
+	// Compare against major release versions (X.Y) rather than minor (X.Y.Z)
+	// unless a minor release is the actual minimum requirement. WordPress reports
+	// X.Y for its major releases.
+	if ( version_compare( $version, '5.6', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
 		return;
 	}

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -209,7 +209,6 @@ function gutenberg_pre_init() {
 	// X.Y for its major releases.
 	if ( version_compare( $version, '5.6', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
-		return;
 	}
 
 	require_once __DIR__ . '/lib/load.php';


### PR DESCRIPTION
## Description

This updates the `version_compare()` check in `gutenberg_pre_init()` in a few ways:

1. Move from requiring 5.3 to 5.6. The plugin relies on `WP_Block_Supports`, which was added in WP 5.6, and `register_block_format()`, which was added in WP 5.5.
2. Fix the version comparison. WordPress reports its version as `5.7` rather than `5.7.0`. `version_compare( '5.7', '5.7.0', '<' )` evaluates as `true`, which puts 5.7.1 as the actual minimum version. When compatibility is checked against a major WP release, the X.Y version number should be used. See previously, #15565.
3. After adding an admin notice, the plugin bails with `return;` and Gutenberg libraries are not loaded. Other hooks are added by the plugin that require those libraries, and a fatal error occurs rather than a compatibility notice. This removes the `return`, which helps to eliminate immediate fatal errors and allows the notice to be shown.

A (likely preferable) alternative to item 3 would be to remove all other functionality from the main plugin file so that it too is only loaded when `gutenberg_pre_init()` fires successfully.

Current culprits appear to be:
* `modify_welcome_panel()`
* `modify_admin_bar()`
* `gutenberg_site_editor_menu()`
* `gutenberg_menu()`

## How has this been tested?

I've tested by updating core back and forth between WP 5.3, 5.5, 5.6, and 5.7 while the plugin is in an active an inactive state.

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [NA] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [NA] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [NA] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
