### PR TITLE
Components: Allow multiple words in the autocomplete phrase matcher

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -451,9 +451,18 @@ function Autocomplete( {
 					return false;
 				}
 
-				return /^\S*$/.test(
-					text.slice( index + triggerPrefix.length )
+				const textWithoutTrigger = text.slice(
+					index + triggerPrefix.length
 				);
+
+				if (
+					/^\s/.test( textWithoutTrigger ) ||
+					/\s\s+$/.test( textWithoutTrigger )
+				) {
+					return false;
+				}
+
+				return /[\u0000-\uFFFF]*$/.test( textWithoutTrigger );
 			}
 		);
 
@@ -463,7 +472,9 @@ function Autocomplete( {
 		}
 
 		const safeTrigger = escapeRegExp( completer.triggerPrefix );
-		const match = text.match( new RegExp( `${ safeTrigger }(\\S*)$` ) );
+		const match = text.match(
+			new RegExp( `${ safeTrigger }([\u0000-\uFFFF]*)$` )
+		);
 		const query = match && match[ 1 ];
 
 		setAutocompleter( completer );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

A try to fix #29495.

> Currently, if you are trying to search for a block that has more than 1 word with the `/` command, you're unable to complete the search. For example, you can't type `/site logo` as the second you add a space the `/` command goes away. This came up in the latest [FSE Outreach Program's call for testing](https://make.wordpress.org/test/2021/02/18/fse-program-testing-call-2-build-a-homepage-with-site-editing-blocks/) particularly as many of the Site Editor blocks have two words in their name. 
> 
> https://user-images.githubusercontent.com/26996883/109734878-0206df80-7b7f-11eb-8bbf-b1ca9e0d6e07.mov

The approach I explore works as follows:
- we ignore phrases that start with whitespace after the trigger
- we ignore phrases that contain multiple whitespaces at the end
- we allow all Unicode characters to match translated fields in the block definition

My hope is that the review process and test coverage will confirm that this proposal is reasonable.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Add a Paragraph block and type `/social icons` and make sure it is able to select a block.

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/699132/111509848-7039cd80-874d-11eb-89c9-13d8ec1950c9.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
