### PR TITLE
Eslint Plugin: Add TypeScript as peer dependency and make it optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12899,7 +12899,8 @@
 				"eslint-plugin-react-hooks": "^4.2.0",
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
-				"requireindex": "^1.2.0"
+				"requireindex": "^1.2.0",
+				"typescript": "^4.1.3"
 			}
 		},
 		"@wordpress/format-library": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12899,8 +12899,7 @@
 				"eslint-plugin-react-hooks": "^4.2.0",
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
-				"requireindex": "^1.2.0",
-				"typescript": "^4.1.3"
+				"requireindex": "^1.2.0"
 			}
 		},
 		"@wordpress/format-library": {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- Adds TypeScript as a peer dependency and makes it optional when not installed ([#29942](https://github.com/WordPress/gutenberg/pull/29942)).
+
 ## 9.0.0 (2021-03-17)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -24,7 +24,7 @@ To opt-in to the default configuration, extend your own project's `.eslintrc` fi
 
 Refer to the [ESLint documentation on Shareable Configs](http://eslint.org/docs/developer-guide/shareable-configs) for more information.
 
-The `recommended` preset will include rules governing an ES2015+ environment, and includes rules from the [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y), [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react), and [`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) projects.
+The `recommended` preset will include rules governing an ES2015+ environment, and includes rules from the [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y), [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react), and [`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) projects. It also includes an optional integration with [`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint) that gets activated when the [`typescript`](https://www.npmjs.com/package/typescript) package is installed in the project.
 
 There is also `recommended-with-formatting` ruleset for projects that want to opt out from [Prettier](https://prettier.io). It has the native ESLint code formatting rules enabled instead.
 

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -8,30 +8,38 @@ const { cosmiconfigSync } = require( 'cosmiconfig' );
  */
 const defaultPrettierConfig = require( '@wordpress/prettier-config' );
 
+/**
+ * Internal dependencies
+ */
+const { isPackageInstalled } = require( '../utils' );
+
 const { config: localPrettierConfig } =
 	cosmiconfigSync( 'prettier' ).search() || {};
 const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
 
-module.exports = {
-	settings: {
+const config = {
+	extends: [
+		require.resolve( './recommended-with-formatting.js' ),
+		'plugin:prettier/recommended',
+		'prettier/react',
+	],
+	rules: {
+		'prettier/prettier': [ 'error', prettierConfig ],
+	},
+};
+
+if ( isPackageInstalled( 'typescript' ) ) {
+	config.settings = {
 		'import/resolver': {
 			node: {
 				extensions: [ '.js', '.jsx', '.ts', '.tsx' ],
 			},
 		},
 		'import/core-modules': [ 'react' ],
-	},
-	extends: [
-		require.resolve( './recommended-with-formatting.js' ),
-		'plugin:prettier/recommended',
-		'prettier/react',
-		'plugin:@typescript-eslint/eslint-recommended',
-	],
-	ignorePatterns: [ '**/*.d.ts' ],
-	rules: {
-		'prettier/prettier': [ 'error', prettierConfig ],
-	},
-	overrides: [
+	};
+	config.extends.push( 'plugin:@typescript-eslint/eslint-recommended' );
+	config.ignorePatterns = [ '**/*.d.ts' ];
+	config.overrides = [
 		{
 			files: [ '**/*.ts', '**/*.tsx' ],
 			parser: '@typescript-eslint/parser',
@@ -43,5 +51,7 @@ module.exports = {
 				'no-unused-vars': 'off',
 			},
 		},
-	],
-};
+	];
+}
+
+module.exports = config;

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -50,7 +50,7 @@
 	},
 	"peerDependencies": {
 		"eslint": "^6 || ^7",
-		"typescript": "^4.1.3"
+		"typescript": "^4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -46,7 +46,8 @@
 		"eslint-plugin-react-hooks": "^4.2.0",
 		"globals": "^12.0.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
-		"requireindex": "^1.2.0"
+		"requireindex": "^1.2.0",
+		"typescript": "^4.1.3"
 	},
 	"peerDependencies": {
 		"eslint": "^6 || ^7"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -52,6 +52,11 @@
 		"eslint": "^6 || ^7",
 		"typescript": "^4"
 	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -46,11 +46,11 @@
 		"eslint-plugin-react-hooks": "^4.2.0",
 		"globals": "^12.0.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
-		"requireindex": "^1.2.0",
-		"typescript": "^4.1.3"
+		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {
-		"eslint": "^6 || ^7"
+		"eslint": "^6 || ^7",
+		"typescript": "^4.1.3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/eslint-plugin/utils/index.js
+++ b/packages/eslint-plugin/utils/index.js
@@ -9,6 +9,7 @@ const {
 const { getTranslateFunctionArgs } = require( './get-translate-function-args' );
 const { getTextContentFromNode } = require( './get-text-content-from-node' );
 const { getTranslateFunctionName } = require( './get-translate-function-name' );
+const isPackageInstalled = require( './is-package-installed' );
 
 module.exports = {
 	TRANSLATION_FUNCTIONS,
@@ -17,4 +18,5 @@ module.exports = {
 	getTranslateFunctionArgs,
 	getTextContentFromNode,
 	getTranslateFunctionName,
+	isPackageInstalled,
 };

--- a/packages/eslint-plugin/utils/is-package-installed.js
+++ b/packages/eslint-plugin/utils/is-package-installed.js
@@ -1,0 +1,16 @@
+/**
+ * Checks whether the passed package name is installed in the project.
+ *
+ * @param {string} packageName The name of npm package.
+ * @return {boolean} Returns true when the package is installed or false otherwise.
+ */
+const isPackageInstalled = ( packageName ) => {
+	try {
+		if ( require.resolve( packageName ) ) {
+			return true;
+		}
+	} catch ( error ) {}
+	return false;
+};
+
+module.exports = isPackageInstalled;

--- a/packages/eslint-plugin/utils/test/is-package-installed.js
+++ b/packages/eslint-plugin/utils/test/is-package-installed.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import isPackageInstalled from '../is-package-installed';
+
+describe( 'isPackageInstalled', () => {
+	test( 'returns false when package not installed', () => {
+		const result = isPackageInstalled( 'nonexistent-package-name' );
+
+		expect( result ).toBe( false );
+	} );
+
+	test( 'returns true when package installed', () => {
+		const result = isPackageInstalled( 'eslint' );
+
+		expect( result ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds an explicit dependency on TypeScript to `eslint-plugin`.

See https://github.com/WordPress/gutenberg/issues/29940 for details.

Fixes #29940

## How has this been tested?
1. Checkout this branch
2. Run `npm run build`
3. Follow the reproduction steps in #29940 but point `scripts` to `file:../gutenberg/packages/scripts` (assuming `gutenberg` lives in the same repository as the test folder for the test `package.json`)
For example:

```json
{
  "name": "ts",
  "version": "0.0.0",
  "description": "",
  "main": "index.js",
  "author": "",
  "license": "private",
  "devDependencies": {
    "@wordpress/scripts": "file:../gutenberg/packages/scripts"
  }
}
```

There should be no errors when running `npx wp-scripts lint-js index.js`

You must `npm install` in your test directory before running `npx ...`

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
