### PR TITLE
docgen: Find parameters by index rather than name and handle array destructuring

### DIFF
--- a/packages/docgen/lib/get-jsdoc-from-token.js
+++ b/packages/docgen/lib/get-jsdoc-from-token.js
@@ -27,7 +27,10 @@ module.exports = ( token ) => {
 		if ( jsdoc ) {
 			let paramCount = 0;
 			jsdoc.tags = jsdoc.tags.map( ( tag ) => {
-				const index = tag.tag === 'param' ? paramCount++ : null;
+				const isUnqualifiedParam =
+					tag.tag === 'param' && ! tag.name.includes( '.' );
+				const index = isUnqualifiedParam ? paramCount++ : paramCount;
+
 				return {
 					...tag,
 					type: getTypeAnnotation( tag, token, index ),

--- a/packages/docgen/lib/get-jsdoc-from-token.js
+++ b/packages/docgen/lib/get-jsdoc-from-token.js
@@ -25,10 +25,12 @@ module.exports = ( token ) => {
 			spacing: 'preserve',
 		} )[ 0 ];
 		if ( jsdoc ) {
+			let paramCount = 0;
 			jsdoc.tags = jsdoc.tags.map( ( tag ) => {
+				const index = tag.tag === 'param' ? paramCount++ : null;
 				return {
 					...tag,
-					type: getTypeAnnotation( tag, token ),
+					type: getTypeAnnotation( tag, token, index ),
 					description:
 						tag.description === '\n'
 							? tag.description.trim()

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -425,16 +425,14 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 
 	try {
 		const paramType = paramToken.typeAnnotation.typeAnnotation;
-		if ( babelTypes.isIdentifier( paramToken ) ) {
-			return getTypeAnnotation( paramType );
-		} else if ( babelTypes.isRestElement( paramToken ) ) {
+		if (
+			babelTypes.isIdentifier( paramToken ) ||
+			babelTypes.isRestElement( paramToken ) ||
+			( babelTypes.isArrayPattern( paramToken ) &&
+				! tag.name.includes( '.' ) )
+		) {
 			return getTypeAnnotation( paramType );
 		} else if ( babelTypes.isArrayPattern( paramToken ) ) {
-			if ( ! tag.name.includes( '.' ) ) {
-				// unqualified name
-				return getTypeAnnotation( paramType );
-			}
-
 			// qualified name i.e., an element of the array being destructured
 			const position = parseInt(
 				tag.name.split( '.' ).slice( -1 )[ 0 ],

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -391,7 +391,7 @@ function getFunctionToken( token ) {
 function getFunctionNameForError( declarationToken ) {
 	let namedFunctionToken = declarationToken;
 	if ( babelTypes.isExportNamedDeclaration( declarationToken ) ) {
-		namedFunctionToken = declarationToken;
+		namedFunctionToken = declarationToken.declaration;
 	}
 
 	if ( babelTypes.isVariableDeclaration( namedFunctionToken ) ) {

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -404,14 +404,10 @@ function getFunctionNameForError( declarationToken ) {
 /**
  * @param {CommentTag} tag The documented parameter.
  * @param {ASTNode} declarationToken The function the parameter is documented on.
- * @param {number | null} paramIndex The parameter index.
+ * @param {number} paramIndex The parameter index.
  * @return {null | string} The parameter's type annotation.
  */
 function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
-	if ( paramIndex === null ) {
-		throw new Error( '`paramIndex` must not be null' );
-	}
-
 	const functionToken = getFunctionToken( declarationToken );
 
 	// otherwise find the corresponding parameter token for the documented parameter

--- a/packages/docgen/test/fixtures/type-annotations/array-destructuring-any-other-type/example.ts
+++ b/packages/docgen/test/fixtures/type-annotations/array-destructuring-any-other-type/example.ts
@@ -1,0 +1,3 @@
+function fn( [ first, second ]: ( T & S ) | V ): S {
+	return second;
+}

--- a/packages/docgen/test/fixtures/type-annotations/array-destructuring-any-other-type/get-node.js
+++ b/packages/docgen/test/fixtures/type-annotations/array-destructuring-any-other-type/get-node.js
@@ -1,0 +1,363 @@
+module.exports = () => ( {
+	type: 'FunctionDeclaration',
+	start: 74,
+	end: 144,
+	loc: {
+		start: {
+			line: 7,
+			column: 0,
+		},
+		end: {
+			line: 9,
+			column: 1,
+		},
+	},
+	leadingComments: [
+		{
+			type: 'CommentBlock',
+			value:
+				'*\n * @param param0\n * @param param0.0\n * @param param0.1\n * @return\n ',
+			start: 0,
+			end: 73,
+			loc: {
+				start: {
+					line: 1,
+					column: 0,
+				},
+				end: {
+					line: 6,
+					column: 3,
+				},
+			},
+		},
+	],
+	id: {
+		type: 'Identifier',
+		start: 83,
+		end: 85,
+		loc: {
+			start: {
+				line: 7,
+				column: 9,
+			},
+			end: {
+				line: 7,
+				column: 11,
+			},
+			identifierName: 'fn',
+		},
+		name: 'fn',
+	},
+	generator: false,
+	async: false,
+	params: [
+		{
+			type: 'ArrayPattern',
+			start: 87,
+			end: 119,
+			loc: {
+				start: {
+					line: 7,
+					column: 13,
+				},
+				end: {
+					line: 7,
+					column: 45,
+				},
+			},
+			elements: [
+				{
+					type: 'Identifier',
+					start: 89,
+					end: 94,
+					loc: {
+						start: {
+							line: 7,
+							column: 15,
+						},
+						end: {
+							line: 7,
+							column: 20,
+						},
+						identifierName: 'first',
+					},
+					name: 'first',
+				},
+				{
+					type: 'Identifier',
+					start: 96,
+					end: 102,
+					loc: {
+						start: {
+							line: 7,
+							column: 22,
+						},
+						end: {
+							line: 7,
+							column: 28,
+						},
+						identifierName: 'second',
+					},
+					name: 'second',
+				},
+			],
+			typeAnnotation: {
+				type: 'TSTypeAnnotation',
+				start: 104,
+				end: 119,
+				loc: {
+					start: {
+						line: 7,
+						column: 30,
+					},
+					end: {
+						line: 7,
+						column: 45,
+					},
+				},
+				typeAnnotation: {
+					type: 'TSUnionType',
+					start: 106,
+					end: 119,
+					loc: {
+						start: {
+							line: 7,
+							column: 32,
+						},
+						end: {
+							line: 7,
+							column: 45,
+						},
+					},
+					types: [
+						{
+							type: 'TSParenthesizedType',
+							start: 106,
+							end: 115,
+							loc: {
+								start: {
+									line: 7,
+									column: 32,
+								},
+								end: {
+									line: 7,
+									column: 41,
+								},
+							},
+							typeAnnotation: {
+								type: 'TSIntersectionType',
+								start: 108,
+								end: 113,
+								loc: {
+									start: {
+										line: 7,
+										column: 34,
+									},
+									end: {
+										line: 7,
+										column: 39,
+									},
+								},
+								types: [
+									{
+										type: 'TSTypeReference',
+										start: 108,
+										end: 109,
+										loc: {
+											start: {
+												line: 7,
+												column: 34,
+											},
+											end: {
+												line: 7,
+												column: 35,
+											},
+										},
+										typeName: {
+											type: 'Identifier',
+											start: 108,
+											end: 109,
+											loc: {
+												start: {
+													line: 7,
+													column: 34,
+												},
+												end: {
+													line: 7,
+													column: 35,
+												},
+												identifierName: 'T',
+											},
+											name: 'T',
+										},
+									},
+									{
+										type: 'TSTypeReference',
+										start: 112,
+										end: 113,
+										loc: {
+											start: {
+												line: 7,
+												column: 38,
+											},
+											end: {
+												line: 7,
+												column: 39,
+											},
+										},
+										typeName: {
+											type: 'Identifier',
+											start: 112,
+											end: 113,
+											loc: {
+												start: {
+													line: 7,
+													column: 38,
+												},
+												end: {
+													line: 7,
+													column: 39,
+												},
+												identifierName: 'S',
+											},
+											name: 'S',
+										},
+									},
+								],
+							},
+						},
+						{
+							type: 'TSTypeReference',
+							start: 118,
+							end: 119,
+							loc: {
+								start: {
+									line: 7,
+									column: 44,
+								},
+								end: {
+									line: 7,
+									column: 45,
+								},
+							},
+							typeName: {
+								type: 'Identifier',
+								start: 118,
+								end: 119,
+								loc: {
+									start: {
+										line: 7,
+										column: 44,
+									},
+									end: {
+										line: 7,
+										column: 45,
+									},
+									identifierName: 'V',
+								},
+								name: 'V',
+							},
+						},
+					],
+				},
+			},
+		},
+	],
+	returnType: {
+		type: 'TSTypeAnnotation',
+		start: 121,
+		end: 124,
+		loc: {
+			start: {
+				line: 7,
+				column: 47,
+			},
+			end: {
+				line: 7,
+				column: 50,
+			},
+		},
+		typeAnnotation: {
+			type: 'TSTypeReference',
+			start: 123,
+			end: 124,
+			loc: {
+				start: {
+					line: 7,
+					column: 49,
+				},
+				end: {
+					line: 7,
+					column: 50,
+				},
+			},
+			typeName: {
+				type: 'Identifier',
+				start: 123,
+				end: 124,
+				loc: {
+					start: {
+						line: 7,
+						column: 49,
+					},
+					end: {
+						line: 7,
+						column: 50,
+					},
+					identifierName: 'S',
+				},
+				name: 'S',
+			},
+		},
+	},
+	body: {
+		type: 'BlockStatement',
+		start: 125,
+		end: 144,
+		loc: {
+			start: {
+				line: 7,
+				column: 51,
+			},
+			end: {
+				line: 9,
+				column: 1,
+			},
+		},
+		body: [
+			{
+				type: 'ReturnStatement',
+				start: 128,
+				end: 142,
+				loc: {
+					start: {
+						line: 8,
+						column: 1,
+					},
+					end: {
+						line: 8,
+						column: 15,
+					},
+				},
+				argument: {
+					type: 'Identifier',
+					start: 135,
+					end: 141,
+					loc: {
+						start: {
+							line: 8,
+							column: 8,
+						},
+						end: {
+							line: 8,
+							column: 14,
+						},
+						identifierName: 'second',
+					},
+					name: 'second',
+				},
+			},
+		],
+		directives: [],
+	},
+} );

--- a/packages/docgen/test/fixtures/type-annotations/array-destructuring-array-type/example.ts
+++ b/packages/docgen/test/fixtures/type-annotations/array-destructuring-array-type/example.ts
@@ -1,0 +1,3 @@
+function fn< T >( [ head ]: T[] ): T {
+	return head;
+}

--- a/packages/docgen/test/fixtures/type-annotations/array-destructuring-array-type/get-node.js
+++ b/packages/docgen/test/fixtures/type-annotations/array-destructuring-array-type/get-node.js
@@ -1,0 +1,281 @@
+module.exports = () => ( {
+	type: 'FunctionDeclaration',
+	start: 88,
+	end: 142,
+	loc: {
+		start: {
+			line: 6,
+			column: 0,
+		},
+		end: {
+			line: 8,
+			column: 1,
+		},
+	},
+	leadingComments: [
+		{
+			type: 'CommentBlock',
+			value:
+				'*\n * @param foo Array.\n * @param foo.0 The first foo.\n * @return The head of foo.\n ',
+			start: 0,
+			end: 87,
+			loc: {
+				start: {
+					line: 1,
+					column: 0,
+				},
+				end: {
+					line: 5,
+					column: 3,
+				},
+			},
+		},
+	],
+	id: {
+		type: 'Identifier',
+		start: 97,
+		end: 99,
+		loc: {
+			start: {
+				line: 6,
+				column: 9,
+			},
+			end: {
+				line: 6,
+				column: 11,
+			},
+			identifierName: 'fn',
+		},
+		name: 'fn',
+	},
+	generator: false,
+	async: false,
+	typeParameters: {
+		type: 'TSTypeParameterDeclaration',
+		start: 99,
+		end: 104,
+		loc: {
+			start: {
+				line: 6,
+				column: 11,
+			},
+			end: {
+				line: 6,
+				column: 16,
+			},
+		},
+		params: [
+			{
+				type: 'TSTypeParameter',
+				start: 101,
+				end: 102,
+				loc: {
+					start: {
+						line: 6,
+						column: 13,
+					},
+					end: {
+						line: 6,
+						column: 14,
+					},
+				},
+				name: 'T',
+			},
+		],
+	},
+	params: [
+		{
+			type: 'ArrayPattern',
+			start: 106,
+			end: 119,
+			loc: {
+				start: {
+					line: 6,
+					column: 18,
+				},
+				end: {
+					line: 6,
+					column: 31,
+				},
+			},
+			elements: [
+				{
+					type: 'Identifier',
+					start: 108,
+					end: 112,
+					loc: {
+						start: {
+							line: 6,
+							column: 20,
+						},
+						end: {
+							line: 6,
+							column: 24,
+						},
+						identifierName: 'head',
+					},
+					name: 'head',
+				},
+			],
+			typeAnnotation: {
+				type: 'TSTypeAnnotation',
+				start: 114,
+				end: 119,
+				loc: {
+					start: {
+						line: 6,
+						column: 26,
+					},
+					end: {
+						line: 6,
+						column: 31,
+					},
+				},
+				typeAnnotation: {
+					type: 'TSArrayType',
+					start: 116,
+					end: 119,
+					loc: {
+						start: {
+							line: 6,
+							column: 28,
+						},
+						end: {
+							line: 6,
+							column: 31,
+						},
+					},
+					elementType: {
+						type: 'TSTypeReference',
+						start: 116,
+						end: 117,
+						loc: {
+							start: {
+								line: 6,
+								column: 28,
+							},
+							end: {
+								line: 6,
+								column: 29,
+							},
+						},
+						typeName: {
+							type: 'Identifier',
+							start: 116,
+							end: 117,
+							loc: {
+								start: {
+									line: 6,
+									column: 28,
+								},
+								end: {
+									line: 6,
+									column: 29,
+								},
+								identifierName: 'T',
+							},
+							name: 'T',
+						},
+					},
+				},
+			},
+		},
+	],
+	returnType: {
+		type: 'TSTypeAnnotation',
+		start: 121,
+		end: 124,
+		loc: {
+			start: {
+				line: 6,
+				column: 33,
+			},
+			end: {
+				line: 6,
+				column: 36,
+			},
+		},
+		typeAnnotation: {
+			type: 'TSTypeReference',
+			start: 123,
+			end: 124,
+			loc: {
+				start: {
+					line: 6,
+					column: 35,
+				},
+				end: {
+					line: 6,
+					column: 36,
+				},
+			},
+			typeName: {
+				type: 'Identifier',
+				start: 123,
+				end: 124,
+				loc: {
+					start: {
+						line: 6,
+						column: 35,
+					},
+					end: {
+						line: 6,
+						column: 36,
+					},
+					identifierName: 'T',
+				},
+				name: 'T',
+			},
+		},
+	},
+	body: {
+		type: 'BlockStatement',
+		start: 125,
+		end: 142,
+		loc: {
+			start: {
+				line: 6,
+				column: 37,
+			},
+			end: {
+				line: 8,
+				column: 1,
+			},
+		},
+		body: [
+			{
+				type: 'ReturnStatement',
+				start: 128,
+				end: 140,
+				loc: {
+					start: {
+						line: 7,
+						column: 1,
+					},
+					end: {
+						line: 7,
+						column: 13,
+					},
+				},
+				argument: {
+					type: 'Identifier',
+					start: 135,
+					end: 139,
+					loc: {
+						start: {
+							line: 7,
+							column: 8,
+						},
+						end: {
+							line: 7,
+							column: 12,
+						},
+						identifierName: 'head',
+					},
+					name: 'head',
+				},
+			},
+		],
+		directives: [],
+	},
+} );

--- a/packages/docgen/test/fixtures/type-annotations/array-destructuring-tuple-type/example.ts
+++ b/packages/docgen/test/fixtures/type-annotations/array-destructuring-tuple-type/example.ts
@@ -1,0 +1,3 @@
+function second< T, S = T >( [ head, sec ]: [ T, S ] ): S {
+	return sec;
+}

--- a/packages/docgen/test/fixtures/type-annotations/array-destructuring-tuple-type/get-node.js
+++ b/packages/docgen/test/fixtures/type-annotations/array-destructuring-tuple-type/get-node.js
@@ -1,0 +1,380 @@
+module.exports = () => ( {
+	type: 'FunctionDeclaration',
+	start: 120,
+	end: 194,
+	loc: {
+		start: {
+			line: 7,
+			column: 0,
+		},
+		end: {
+			line: 9,
+			column: 1,
+		},
+	},
+	leadingComments: [
+		{
+			type: 'CommentBlock',
+			value:
+				'*\n * @param foo Array.\n * @param foo.0 The first foo.\n * @param foo.1 The second foo.\n * @return The head of foo.\n ',
+			start: 0,
+			end: 119,
+			loc: {
+				start: {
+					line: 1,
+					column: 0,
+				},
+				end: {
+					line: 6,
+					column: 3,
+				},
+			},
+		},
+	],
+	id: {
+		type: 'Identifier',
+		start: 129,
+		end: 135,
+		loc: {
+			start: {
+				line: 7,
+				column: 9,
+			},
+			end: {
+				line: 7,
+				column: 15,
+			},
+			identifierName: 'second',
+		},
+		name: 'second',
+	},
+	generator: false,
+	async: false,
+	typeParameters: {
+		type: 'TSTypeParameterDeclaration',
+		start: 135,
+		end: 147,
+		loc: {
+			start: {
+				line: 7,
+				column: 15,
+			},
+			end: {
+				line: 7,
+				column: 27,
+			},
+		},
+		params: [
+			{
+				type: 'TSTypeParameter',
+				start: 137,
+				end: 138,
+				loc: {
+					start: {
+						line: 7,
+						column: 17,
+					},
+					end: {
+						line: 7,
+						column: 18,
+					},
+				},
+				name: 'T',
+			},
+			{
+				type: 'TSTypeParameter',
+				start: 140,
+				end: 145,
+				loc: {
+					start: {
+						line: 7,
+						column: 20,
+					},
+					end: {
+						line: 7,
+						column: 25,
+					},
+				},
+				name: 'S',
+				default: {
+					type: 'TSTypeReference',
+					start: 144,
+					end: 145,
+					loc: {
+						start: {
+							line: 7,
+							column: 24,
+						},
+						end: {
+							line: 7,
+							column: 25,
+						},
+					},
+					typeName: {
+						type: 'Identifier',
+						start: 144,
+						end: 145,
+						loc: {
+							start: {
+								line: 7,
+								column: 24,
+							},
+							end: {
+								line: 7,
+								column: 25,
+							},
+							identifierName: 'T',
+						},
+						name: 'T',
+					},
+				},
+			},
+		],
+	},
+	params: [
+		{
+			type: 'ArrayPattern',
+			start: 149,
+			end: 172,
+			loc: {
+				start: {
+					line: 7,
+					column: 29,
+				},
+				end: {
+					line: 7,
+					column: 52,
+				},
+			},
+			elements: [
+				{
+					type: 'Identifier',
+					start: 151,
+					end: 155,
+					loc: {
+						start: {
+							line: 7,
+							column: 31,
+						},
+						end: {
+							line: 7,
+							column: 35,
+						},
+						identifierName: 'head',
+					},
+					name: 'head',
+				},
+				{
+					type: 'Identifier',
+					start: 157,
+					end: 160,
+					loc: {
+						start: {
+							line: 7,
+							column: 37,
+						},
+						end: {
+							line: 7,
+							column: 40,
+						},
+						identifierName: 'sec',
+					},
+					name: 'sec',
+				},
+			],
+			typeAnnotation: {
+				type: 'TSTypeAnnotation',
+				start: 162,
+				end: 172,
+				loc: {
+					start: {
+						line: 7,
+						column: 42,
+					},
+					end: {
+						line: 7,
+						column: 52,
+					},
+				},
+				typeAnnotation: {
+					type: 'TSTupleType',
+					start: 164,
+					end: 172,
+					loc: {
+						start: {
+							line: 7,
+							column: 44,
+						},
+						end: {
+							line: 7,
+							column: 52,
+						},
+					},
+					elementTypes: [
+						{
+							type: 'TSTypeReference',
+							start: 166,
+							end: 167,
+							loc: {
+								start: {
+									line: 7,
+									column: 46,
+								},
+								end: {
+									line: 7,
+									column: 47,
+								},
+							},
+							typeName: {
+								type: 'Identifier',
+								start: 166,
+								end: 167,
+								loc: {
+									start: {
+										line: 7,
+										column: 46,
+									},
+									end: {
+										line: 7,
+										column: 47,
+									},
+									identifierName: 'T',
+								},
+								name: 'T',
+							},
+						},
+						{
+							type: 'TSTypeReference',
+							start: 169,
+							end: 170,
+							loc: {
+								start: {
+									line: 7,
+									column: 49,
+								},
+								end: {
+									line: 7,
+									column: 50,
+								},
+							},
+							typeName: {
+								type: 'Identifier',
+								start: 169,
+								end: 170,
+								loc: {
+									start: {
+										line: 7,
+										column: 49,
+									},
+									end: {
+										line: 7,
+										column: 50,
+									},
+									identifierName: 'S',
+								},
+								name: 'S',
+							},
+						},
+					],
+				},
+			},
+		},
+	],
+	returnType: {
+		type: 'TSTypeAnnotation',
+		start: 174,
+		end: 177,
+		loc: {
+			start: {
+				line: 7,
+				column: 54,
+			},
+			end: {
+				line: 7,
+				column: 57,
+			},
+		},
+		typeAnnotation: {
+			type: 'TSTypeReference',
+			start: 176,
+			end: 177,
+			loc: {
+				start: {
+					line: 7,
+					column: 56,
+				},
+				end: {
+					line: 7,
+					column: 57,
+				},
+			},
+			typeName: {
+				type: 'Identifier',
+				start: 176,
+				end: 177,
+				loc: {
+					start: {
+						line: 7,
+						column: 56,
+					},
+					end: {
+						line: 7,
+						column: 57,
+					},
+					identifierName: 'S',
+				},
+				name: 'S',
+			},
+		},
+	},
+	body: {
+		type: 'BlockStatement',
+		start: 178,
+		end: 194,
+		loc: {
+			start: {
+				line: 7,
+				column: 58,
+			},
+			end: {
+				line: 9,
+				column: 1,
+			},
+		},
+		body: [
+			{
+				type: 'ReturnStatement',
+				start: 181,
+				end: 192,
+				loc: {
+					start: {
+						line: 8,
+						column: 1,
+					},
+					end: {
+						line: 8,
+						column: 12,
+					},
+				},
+				argument: {
+					type: 'Identifier',
+					start: 188,
+					end: 191,
+					loc: {
+						start: {
+							line: 8,
+							column: 8,
+						},
+						end: {
+							line: 8,
+							column: 11,
+						},
+						identifierName: 'sec',
+					},
+					name: 'sec',
+				},
+			},
+		],
+		directives: [],
+	},
+} );

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -12,6 +12,9 @@ const getExportedVariableDeclarationNode = require( './fixtures/type-annotations
 const getImportsParameterizedRestOperatorPredicateIndexerTypeNode = require( './fixtures/type-annotations/imports-parameterized-rest-operator-predicate-indexers/get-node' );
 const getMissingTypesNode = require( './fixtures/type-annotations/missing-types/get-node' );
 const getArrowFunctionNode = require( './fixtures/type-annotations/arrow-function/get-node' );
+const getArrayDestructuringArrayTypeNode = require( './fixtures/type-annotations/array-destructuring-array-type/get-node' );
+const getArrayDestructuringTupleTypeNode = require( './fixtures/type-annotations/array-destructuring-tuple-type/get-node' );
+const getArrayDestructuringAnyOtherTypeNode = require( './fixtures/type-annotations/array-destructuring-any-other-type/get-node' );
 
 describe( 'Type annotations', () => {
 	it( 'are taken from JSDoc if any', () => {
@@ -20,7 +23,7 @@ describe( 'Type annotations', () => {
 			type: 'number',
 		};
 		const node = {};
-		const result = getTypeAnnotation( tag, node );
+		const result = getTypeAnnotation( tag, node, 0 );
 		expect( result ).toBe( 'number' );
 	} );
 
@@ -29,7 +32,7 @@ describe( 'Type annotations', () => {
 			tag: 'unknown',
 		};
 		const node = {};
-		const result = getTypeAnnotation( tag, node );
+		const result = getTypeAnnotation( tag, node, 0 );
 		expect( result ).toBe( '' );
 	} );
 
@@ -67,7 +70,9 @@ describe( 'Type annotations', () => {
 			`should get the parameter type for an %s`,
 			( paramType, expected ) => {
 				const node = getSimpleTypeNode( { paramType } );
-				expect( getTypeAnnotation( paramTag, node ) ).toBe( expected );
+				expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe(
+					expected
+				);
 			}
 		);
 
@@ -75,7 +80,9 @@ describe( 'Type annotations', () => {
 			`should get the return type for an %s`,
 			( returnType, expected ) => {
 				const node = getSimpleTypeNode( { returnType } );
-				expect( getTypeAnnotation( returnTag, node ) ).toBe( expected );
+				expect( getTypeAnnotation( returnTag, node, 0 ) ).toBe(
+					expected
+				);
 			}
 		);
 	} );
@@ -84,13 +91,13 @@ describe( 'Type annotations', () => {
 		const node = getArraysGenericTypesUnionsAndIntersctionsNode();
 
 		it( 'should get the param type', () => {
-			expect( getTypeAnnotation( paramTag, node ) ).toBe(
+			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe(
 				'MyType< string | number >[]'
 			);
 		} );
 
 		it( 'should get the return type', () => {
-			expect( getTypeAnnotation( returnTag, node ) ).toBe(
+			expect( getTypeAnnotation( returnTag, node, 0 ) ).toBe(
 				'MyType< string & number >[]'
 			);
 		} );
@@ -113,7 +120,7 @@ describe( 'Type annotations', () => {
 						literalType,
 						literalValue,
 					} );
-					expect( getTypeAnnotation( tag, node ) ).toBe(
+					expect( getTypeAnnotation( tag, node, 0 ) ).toBe(
 						literalResult
 					);
 				}
@@ -125,13 +132,13 @@ describe( 'Type annotations', () => {
 		const node = getTypeLiteralNode();
 
 		it( 'should get the param type literal annotation', () => {
-			expect( getTypeAnnotation( paramTag, node ) ).toBe(
+			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe(
 				"{ ( bar: string ): void; bar: string; optionalBar?: 'left' | 'right'; [ key: number ]: string; }"
 			);
 		} );
 
 		it( 'should get the return type literal annotation', () => {
-			expect( getTypeAnnotation( returnTag, node ) ).toBe(
+			expect( getTypeAnnotation( returnTag, node, 0 ) ).toBe(
 				"{ ( bar: string ): void; bar: string; optionalBar?: 'left' | 'right'; [ key: number ]: string; }"
 			);
 		} );
@@ -141,11 +148,11 @@ describe( 'Type annotations', () => {
 		const node = getNamedExportNode();
 
 		it( 'should get the param type', () => {
-			expect( getTypeAnnotation( paramTag, node ) ).toBe( 'string' );
+			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe( 'string' );
 		} );
 
 		it( 'should get the return type', () => {
-			expect( getTypeAnnotation( returnTag, node ) ).toBe( 'string' );
+			expect( getTypeAnnotation( returnTag, node, 0 ) ).toBe( 'string' );
 		} );
 	} );
 
@@ -153,11 +160,11 @@ describe( 'Type annotations', () => {
 		const node = getExportedVariableDeclarationNode();
 
 		it( 'should get the param type', () => {
-			expect( getTypeAnnotation( paramTag, node ) ).toBe( 'string' );
+			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe( 'string' );
 		} );
 
 		it( 'should get the return type', () => {
-			expect( getTypeAnnotation( returnTag, node ) ).toBe( 'void' );
+			expect( getTypeAnnotation( returnTag, node, 0 ) ).toBe( 'void' );
 		} );
 	} );
 
@@ -165,45 +172,85 @@ describe( 'Type annotations', () => {
 		const node = getImportsParameterizedRestOperatorPredicateIndexerTypeNode();
 
 		it( 'should get the index accessed import type', () => {
-			expect( getTypeAnnotation( paramTag, node ) ).toBe(
+			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe(
 				"import( 'react' ).bar.baz.types.ComponentType[ 'displayName' ]"
 			);
 		} );
 
 		it( 'should get the parameterized tuple rest type', () => {
 			expect(
-				getTypeAnnotation( { ...paramTag, name: 'rest' }, node )
+				getTypeAnnotation( { ...paramTag, name: 'rest' }, node, 1 )
 			).toBe( '[ string | number, ...( keyof constant ) ]' );
 		} );
 
 		it( 'should get the type predicate return type', () => {
-			expect( getTypeAnnotation( returnTag, node ) ).toBe(
+			expect( getTypeAnnotation( returnTag, node, 1 ) ).toBe(
 				'foo is string'
 			);
 		} );
 	} );
 
-	describe( 'missing types', () => {
+	describe.skip( 'missing types', () => {
 		const node = getMissingTypesNode();
 
 		it( 'should throw an error if there is no return type', () => {
-			expect( () => getTypeAnnotation( returnTag, node ) ).toThrow(
+			expect( () => getTypeAnnotation( returnTag, node, 0 ) ).toThrow(
 				"Could not find return type for function 'fn'."
 			);
 		} );
 
 		it( 'should throw an error if there is no param type', () => {
-			expect( () => getTypeAnnotation( paramTag, node ) ).toThrow(
+			expect( () => getTypeAnnotation( paramTag, node, 0 ) ).toThrow(
 				"Could not find type for parameter 'foo' in function 'fn'."
 			);
 		} );
+	} );
 
-		it( 'should throw an error if it cannot find the param by name', () => {
-			expect( () =>
-				getTypeAnnotation( { ...paramTag, name: 'notFoo' }, node )
-			).toThrow(
-				"Could not find corresponding parameter token for documented parameter 'notFoo' in function 'fn'."
-			);
+	describe( 'function argument array-destructuring', () => {
+		describe( 'array-type', () => {
+			const node = getArrayDestructuringArrayTypeNode();
+
+			it( 'should grab the whole type for the unqualified name', () => {
+				expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe( 'T[]' );
+			} );
+
+			it( 'should get the individual type for the qualified name', () => {
+				expect(
+					getTypeAnnotation( { ...paramTag, name: 'foo.0' }, node, 0 )
+				).toBe( 'T' );
+			} );
+		} );
+
+		describe( 'tuple-type', () => {
+			const node = getArrayDestructuringTupleTypeNode();
+
+			it( 'should grab the whole type for the unqualified name', () => {
+				expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe(
+					'[ T, S ]'
+				);
+			} );
+
+			it( 'should get the individual type for the qualified name', () => {
+				expect(
+					getTypeAnnotation( { ...paramTag, name: 'foo.1' }, node, 0 )
+				).toBe( 'S' );
+			} );
+		} );
+
+		describe( 'any-other-type', () => {
+			const node = getArrayDestructuringAnyOtherTypeNode();
+
+			it( 'should get the full type name for the unqualified name', () => {
+				expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe(
+					'( T & S ) | V'
+				);
+			} );
+
+			it( 'should get the full type name for the qualified name', () => {
+				expect(
+					getTypeAnnotation( { ...paramTag, name: 'foo.1' }, node, 0 )
+				).toBe( '( T & S ) | V' );
+			} );
 		} );
 	} );
 

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -190,7 +190,7 @@ describe( 'Type annotations', () => {
 		} );
 	} );
 
-	describe.skip( 'missing types', () => {
+	describe( 'missing types', () => {
 		const node = getMissingTypesNode();
 
 		it( 'should throw an error if there is no return type', () => {
@@ -246,10 +246,10 @@ describe( 'Type annotations', () => {
 				);
 			} );
 
-			it( 'should get the full type name for the qualified name', () => {
+			it( 'should get the full type with a qualification for the qualified name', () => {
 				expect(
 					getTypeAnnotation( { ...paramTag, name: 'foo.1' }, node, 0 )
-				).toBe( '( T & S ) | V' );
+				).toBe( '( ( T & S ) | V )[ 1 ]' );
 			} );
 		} );
 	} );

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -259,7 +259,7 @@ describe( 'Type annotations', () => {
 
 		it( 'should correctly format the arrow function', () => {
 			expect(
-				getTypeAnnotation( { ...paramTag, name: 'callback' }, node )
+				getTypeAnnotation( { ...paramTag, name: 'callback' }, node, 0 )
 			).toBe( '( foo: string, ...rest: any[] ) => GenericType< T >' );
 		} );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
See the solution proposed in #29944. This PR implements that solution.

Partially fixes #29944 for array destructuring but not for object destructuring. Object destructuring will happen in a separate PR to reduce the size of the PRs.

## How has this been tested?
`npm run docs:build` should have no changes (docs continue to build successfully as they were before).

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
