### PR TITLE
Add padding on text control input type color

### DIFF
--- a/packages/components/src/text-control/stories/index.js
+++ b/packages/components/src/text-control/stories/index.js
@@ -32,12 +32,21 @@ export const _default = () => {
 	const className = text( 'Class Name', '' );
 
 	return (
-		<TextControlWithState
-			label={ label }
-			hideLabelFromVision={ hideLabelFromVision }
-			help={ help }
-			type={ type }
-			className={ className }
-		/>
+		<>
+			<TextControlWithState
+				label={ label }
+				hideLabelFromVision={ hideLabelFromVision }
+				help={ help }
+				type={ type }
+				className={ className }
+			/>
+			<TextControlWithState
+				label={ label }
+				hideLabelFromVision={ hideLabelFromVision }
+				help={ help }
+				type="color"
+				className={ className }
+			/>
+		</>
 	);
 };

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -15,3 +15,7 @@
 	width: 100%;
 	@include input-control;
 }
+
+.components-text-control__input[type="color"] {
+	padding: 0 3px;
+}


### PR DESCRIPTION
## Description
Fix #14377 
Add padding on text control input type color; also added on the storybook, please let me know if need to remove it.

## How has this been tested?
Run storybook and test text control.

## Screenshots <!-- if applicable -->
Before
<img width="660" alt="螢幕快照 2021-03-17 下午10 35 17" src="https://user-images.githubusercontent.com/56378160/111565068-295dcf00-8771-11eb-92dc-855be6005c65.png">

After
<img width="658" alt="螢幕快照 2021-03-17 下午10 35 42" src="https://user-images.githubusercontent.com/56378160/111565076-2c58bf80-8771-11eb-978f-0232db82d188.png">

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
