### PR TITLE
Editor Layout: open sidebar menu over editor on small screens

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -175,20 +175,6 @@
 		}
 	}
 
-	/* Mobile menu opened. */
-	@media (max-width: #{ ($break-medium + 1) }) {
-		.auto-fold .wp-responsive-open #{$selector} {
-			left: $admin-sidebar-width-big;
-		}
-	}
-
-	/* In small screens with responsive menu expanded there is small white space. */
-	@media (max-width: #{ ($break-small) }) {
-		.auto-fold .wp-responsive-open #{$selector} {
-			margin-left: -18px;
-		}
-	}
-
 	body.is-fullscreen-mode #{$selector} {
 		left: 0 !important;
 	}


### PR DESCRIPTION
## Description

When a sidebar menu is opened on small screens, open the menu on top of the editor content, rather than squishing the content. This mainly applies to the widgets editor.

| **Before** | **After** |
| - | - |
| <img width="395" alt="Screen Shot 2021-03-17 at 11 04 18" src="https://user-images.githubusercontent.com/1699996/111566951-27ddd800-876c-11eb-85f3-31f82e5c60f1.png"> | <img width="396" alt="Screen Shot 2021-03-17 at 11 01 59" src="https://user-images.githubusercontent.com/1699996/111566968-2f04e600-876c-11eb-90b1-40fb73fd053f.png"> |


Additionally, remove the negative margin that causes the content to jump when the menu is opened in the page/post/site editors.

| **Before** | **After** |
| - | - |
| ![open-mobile-menu-before](https://user-images.githubusercontent.com/1699996/111567475-0d582e80-876d-11eb-8c5a-95d62d97b55a.gif) | ![open-mobile-menu-after](https://user-images.githubusercontent.com/1699996/111567514-1a751d80-876d-11eb-9c54-10e0797fc0d6.gif) |

## How has this been tested?

On small screens (that show the mobile version of wpadminbar)

**Widget editor**

1. Activate a non-block theme
2. Navigate to Appearance > Widgets
3. Test opening and closing the wp-admin navigation sidebar menu

**Post/page/site editor**

1. Navigate to the editor
2. Test opening and closing the wp-admin navigation sidebar menu

## Types of changes

Bug fix, more or less

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ (n/a)  <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
