### PR TITLE
Site Editor: close navigation panel after template selection

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -187,7 +187,6 @@ describe( 'Multi-entity save flow', () => {
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
 			await navigationPanel.clickItemByText( 'Index' );
-			await navigationPanel.close();
 
 			// Click the first block so that the template part inserts in the right place.
 			const firstBlock = await canvas().$( '.wp-block' );

--- a/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
@@ -71,7 +71,6 @@ describe( 'Settings sidebar', () => {
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
 			await navigationPanel.clickItemByText( '404' );
-			await navigationPanel.close();
 			const templateCardAfterNavigation = await getTemplateCard();
 
 			expect( templateCardBeforeNavigation ).toMatchObject( {

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -66,7 +66,6 @@ describe( 'Template Part', () => {
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
 			await navigationPanel.clickItemByText( 'Index' );
-			await navigationPanel.close();
 		}
 
 		async function triggerEllipsisMenuItem( textPrompt ) {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
@@ -33,7 +33,9 @@ export default function ContentNavigationItem( { item } ) {
 		},
 		[ isPreviewVisible ]
 	);
-	const { setPage } = useDispatch( editSiteStore );
+	const { setPage, setIsNavigationPanelOpened } = useDispatch(
+		editSiteStore
+	);
 
 	const onActivateItem = useCallback( () => {
 		const { type, slug, link, id } = item;
@@ -46,6 +48,7 @@ export default function ContentNavigationItem( { item } ) {
 				postId: id,
 			},
 		} );
+		setIsNavigationPanelOpened( false );
 	}, [ setPage, item ] );
 
 	if ( ! item ) {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -27,17 +27,25 @@ export default function TemplateNavigationItem( { item } ) {
 				  },
 		[]
 	);
-	const { setTemplate, setTemplatePart } = useDispatch( editSiteStore );
+	const {
+		setTemplate,
+		setTemplatePart,
+		setIsNavigationPanelOpened,
+	} = useDispatch( editSiteStore );
 	const [ isPreviewVisible, setIsPreviewVisible ] = useState( false );
 
 	if ( ! item ) {
 		return null;
 	}
 
-	const onActivateItem = () =>
-		'wp_template' === item.type
-			? setTemplate( item.id, item.slug )
-			: setTemplatePart( item.id );
+	const onActivateItem = () => {
+		if ( 'wp_template' === item.type ) {
+			setTemplate( item.id, item.slug );
+		} else {
+			setTemplatePart( item.id );
+		}
+		setIsNavigationPanelOpened( false );
+	};
 
 	return (
 		<NavigationItem


### PR DESCRIPTION
## Description

Automatically closes the navigation panel within the site editor after selecting a template or content item.

Follow-up to https://github.com/WordPress/gutenberg/pull/29489: it's particularly helpful on smaller screens, where you would otherwise be left with the navigation panel taking up most of the screen after making a selection.

## How has this been tested?

- Click on a template or content item in the site editor navigation panel
- The panel will close and the template will be loaded

## Screenshots <!-- if applicable -->

![site-editor-navigation-panel-close-on-select](https://user-images.githubusercontent.com/1699996/110892068-f28f4100-82b8-11eb-91af-ea03ca133ec4.gif)

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
