### PR TITLE
Media: Use image default size from settings

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -77,7 +77,12 @@ function gutenberg_get_common_block_editor_settings() {
  * @return array Filtered settings.
  */
 function gutenberg_extend_post_editor_settings( $settings ) {
+	$image_default_size = get_option( 'image_default_size', 'large' );
+	$image_sizes        = wp_list_pluck( $settings['imageSizes'], 'slug' );
+
+	$settings['imageDefaultSize'] = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_theme();
+
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -124,6 +124,9 @@ export const SETTINGS_DEFAULTS = {
 		},
 	],
 
+	// Image default size slug.
+	imageDefaultSize: 'large',
+
 	imageSizes: [
 		{ slug: 'thumbnail', name: __( 'Thumbnail' ) },
 		{ slug: 'medium', name: __( 'Medium' ) },

--- a/packages/block-library/src/image/constants.js
+++ b/packages/block-library/src/image/constants.js
@@ -5,4 +5,3 @@ export const LINK_DESTINATION_ATTACHMENT = 'attachment';
 export const LINK_DESTINATION_CUSTOM = 'custom';
 export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
 export const ALLOWED_MEDIA_TYPES = [ 'image' ];
-export const DEFAULT_SIZE_SLUG = 'large';

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -38,14 +38,13 @@ import {
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_NONE,
 	ALLOWED_MEDIA_TYPES,
-	DEFAULT_SIZE_SLUG,
 } from './constants';
 
-export const pickRelevantMediaFiles = ( image ) => {
+export const pickRelevantMediaFiles = ( image, size ) => {
 	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
 	imageProps.url =
-		get( image, [ 'sizes', 'large', 'url' ] ) ||
-		get( image, [ 'media_details', 'sizes', 'large', 'source_url' ] ) ||
+		get( image, [ 'sizes', size, 'url' ] ) ||
+		get( image, [ 'media_details', 'sizes', size, 'source_url' ] ) ||
 		image.url;
 	return imageProps;
 };
@@ -104,9 +103,9 @@ export function ImageEdit( {
 	}, [ caption ] );
 
 	const ref = useRef();
-	const mediaUpload = useSelect( ( select ) => {
+	const { imageDefaultSize, mediaUpload } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		return getSettings().mediaUpload;
+		return pick( getSettings(), [ 'imageDefaultSize', 'mediaUpload' ] );
 	} );
 
 	function onUploadError( message ) {
@@ -126,7 +125,7 @@ export function ImageEdit( {
 			return;
 		}
 
-		let mediaAttributes = pickRelevantMediaFiles( media );
+		let mediaAttributes = pickRelevantMediaFiles( media, imageDefaultSize );
 
 		// If the current image is temporary but an alt text was meanwhile
 		// written by the user, make sure the text is not overwritten.
@@ -148,7 +147,7 @@ export function ImageEdit( {
 			additionalAttributes = {
 				width: undefined,
 				height: undefined,
-				sizeSlug: DEFAULT_SIZE_SLUG,
+				sizeSlug: imageDefaultSize,
 			};
 		} else {
 			// Keep the same url when selecting the same file, so "Image Size"
@@ -209,7 +208,7 @@ export function ImageEdit( {
 				id: undefined,
 				width: undefined,
 				height: undefined,
-				sizeSlug: DEFAULT_SIZE_SLUG,
+				sizeSlug: imageDefaultSize,
 			} );
 		}
 	}

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -106,7 +106,7 @@ export function ImageEdit( {
 	const { imageDefaultSize, mediaUpload } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return pick( getSettings(), [ 'imageDefaultSize', 'mediaUpload' ] );
-	} );
+	}, [] );
 
 	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -175,6 +175,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'gradients',
 				'hasFixedToolbar',
 				'hasReducedUI',
+				'imageDefaultSize',
 				'imageDimensions',
 				'imageEditing',
 				'imageSizes',


### PR DESCRIPTION
## Description
Allows for user-defined image default size setting to be used instead of hardcoded one.

The setting will fallback to the default value, when
* `image_default_size` option isn't defined.
* The option doesn't match any registered image size slug for the block editor.

Fixes #8663, #15091 and #20269.

## How has this been tested?
Manually
1. Set `image_default_size` option to "medium" on `wp-admin/options.php` page.
2. Insert new image block.
3. Media size should be "Medium" by default.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
