### PR TITLE
Fix navigation editor block toolbar not visible on small screens

### DIFF
--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -6,9 +6,11 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { BlockToolbar } from '@wordpress/block-editor';
 import { Button, Dropdown, DropdownMenu, Popover } from '@wordpress/components';
 import { PinnedItems } from '@wordpress/interface';
+import { useViewportMatch } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,6 +26,7 @@ export default function Header( {
 	isPending,
 	navigationPost,
 } ) {
+	const isLargeViewport = useViewportMatch( 'medium' );
 	const selectedMenu = find( menus, { id: selectedMenuId } );
 	const menuName = selectedMenu ? selectedMenu.name : undefined;
 	let actionHeaderText;
@@ -105,6 +108,12 @@ export default function Header( {
 					<SaveButton navigationPost={ navigationPost } />
 					<PinnedItems.Slot scope="core/edit-navigation" />
 					<Popover.Slot name="block-toolbar" />
+
+					{ ! isLargeViewport && (
+						<div className="edit-widgets-header__block-toolbar">
+							<BlockToolbar hideDragHandle />
+						</div>
+					) }
 				</div>
 			) }
 		</div>

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -6,10 +6,8 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { BlockToolbar } from '@wordpress/block-editor';
-import { Button, Dropdown, DropdownMenu, Popover } from '@wordpress/components';
+import { Button, Dropdown, DropdownMenu } from '@wordpress/components';
 import { PinnedItems } from '@wordpress/interface';
-import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -26,7 +24,6 @@ export default function Header( {
 	isPending,
 	navigationPost,
 } ) {
-	const isLargeViewport = useViewportMatch( 'medium' );
 	const selectedMenu = find( menus, { id: selectedMenuId } );
 	const menuName = selectedMenu ? selectedMenu.name : undefined;
 	let actionHeaderText;
@@ -107,13 +104,6 @@ export default function Header( {
 
 					<SaveButton navigationPost={ navigationPost } />
 					<PinnedItems.Slot scope="core/edit-navigation" />
-					<Popover.Slot name="block-toolbar" />
-
-					{ ! isLargeViewport && (
-						<div className="edit-widgets-header__block-toolbar">
-							<BlockToolbar hideDragHandle />
-						</div>
-					) }
 				</div>
 			) }
 		</div>

--- a/packages/edit-navigation/src/components/layout/block-toolbar.js
+++ b/packages/edit-navigation/src/components/layout/block-toolbar.js
@@ -1,16 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { BlockToolbar } from '@wordpress/block-editor';
+import {
+	BlockToolbar,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { Popover } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 
 export default function NavigationEditorBlockToolbar( { isFixed } ) {
+	const isNavigationMode = useSelect(
+		( select ) => select( blockEditorStore ).isNavigationMode(),
+		[]
+	);
 	return (
 		<>
 			<Popover.Slot name="block-toolbar" />
 			{ isFixed && (
 				<div className="edit-navigation-layout__block-toolbar">
-					<BlockToolbar hideDragHandle />
+					{ ! isNavigationMode && <BlockToolbar hideDragHandle /> }
 				</div>
 			) }
 		</>

--- a/packages/edit-navigation/src/components/layout/block-toolbar.js
+++ b/packages/edit-navigation/src/components/layout/block-toolbar.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockToolbar } from '@wordpress/block-editor';
+import { Popover } from '@wordpress/components';
+
+export default function NavigationEditorBlockToolbar( { isFixed } ) {
+	return (
+		<>
+			<Popover.Slot name="block-toolbar" />
+			{ isFixed && (
+				<div className="edit-navigation-layout__block-toolbar">
+					<BlockToolbar hideDragHandle />
+				</div>
+			) }
+		</>
+	);
+}

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -153,7 +153,7 @@ export default function Layout( { blockEditorSettings } ) {
 												<>
 													<Popover.Slot name="block-toolbar" />
 													{ ! isLargeViewport && (
-														<div className="edit-widgets-header__block-toolbar">
+														<div className="edit-navigation-layout__block-toolbar">
 															<BlockToolbar
 																hideDragHandle
 															/>

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
+	BlockToolbar,
 	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 } from '@wordpress/block-editor';
 import {
@@ -58,6 +59,7 @@ const interfaceLabels = {
 
 export default function Layout( { blockEditorSettings } ) {
 	const contentAreaRef = useBlockSelectionClearer();
+	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isMenuNameControlFocused, setIsMenuNameControlFocused ] = useState(
 		false
 	);
@@ -91,7 +93,7 @@ export default function Layout( { blockEditorSettings } ) {
 
 	const hasMenus = !! menus?.length;
 	const isBlockEditorReady = !! ( hasMenus && navigationPost );
-	const hasPermanentSidebar = useViewportMatch( 'medium' ) && hasMenus;
+	const hasPermanentSidebar = isLargeViewport && hasMenus;
 
 	return (
 		<ErrorBoundary>
@@ -148,25 +150,35 @@ export default function Layout( { blockEditorSettings } ) {
 												! hasMenus && <EmptyState /> }
 
 											{ isBlockEditorReady && (
-												<div
-													className="edit-navigation-layout__content-area"
-													ref={ contentAreaRef }
-												>
-													<Editor
-														isPending={
-															! hasLoadedMenus
-														}
-														blocks={ blocks }
-													/>
-													<InspectorAdditions
-														menuId={
-															selectedMenuId
-														}
-														onDeleteMenu={
-															deleteMenu
-														}
-													/>
-												</div>
+												<>
+													<Popover.Slot name="block-toolbar" />
+													{ ! isLargeViewport && (
+														<div className="edit-widgets-header__block-toolbar">
+															<BlockToolbar
+																hideDragHandle
+															/>
+														</div>
+													) }
+													<div
+														className="edit-navigation-layout__content-area"
+														ref={ contentAreaRef }
+													>
+														<Editor
+															isPending={
+																! hasLoadedMenus
+															}
+															blocks={ blocks }
+														/>
+														<InspectorAdditions
+															menuId={
+																selectedMenuId
+															}
+															onDeleteMenu={
+																deleteMenu
+															}
+														/>
+													</div>
+												</>
 											) }
 										</>
 									}

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
-	BlockToolbar,
 	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 } from '@wordpress/block-editor';
 import {
@@ -44,6 +43,7 @@ import NavigationEditorShortcuts from './shortcuts';
 import Sidebar from './sidebar';
 import Header from '../header';
 import Notices from '../notices';
+import BlockToolbar from './block-toolbar';
 import Editor from '../editor';
 import InspectorAdditions from '../inspector-additions';
 import { store as editNavigationStore } from '../../store';
@@ -151,14 +151,11 @@ export default function Layout( { blockEditorSettings } ) {
 
 											{ isBlockEditorReady && (
 												<>
-													<Popover.Slot name="block-toolbar" />
-													{ ! isLargeViewport && (
-														<div className="edit-navigation-layout__block-toolbar">
-															<BlockToolbar
-																hideDragHandle
-															/>
-														</div>
-													) }
+													<BlockToolbar
+														isFixed={
+															! isLargeViewport
+														}
+													/>
 													<div
 														className="edit-navigation-layout__content-area"
 														ref={ contentAreaRef }

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -31,8 +31,12 @@
 	}
 
 	.edit-navigation-layout__content-area {
-		// Provide space for the floating block toolbar.
-		padding-top: $navigation-editor-spacing-top;
+		// Add some margin above the fixed mobile toolbar.
+		padding-top: $grid-unit-15;
+		@include break-medium() {
+			// Provide space for the floating block toolbar.
+			padding-top: $navigation-editor-spacing-top;
+		}
 
 		// Ensure the entire layout is full-height, the background
 		// of the editing canvas needs to be full-height for block
@@ -60,9 +64,21 @@
 	}
 }
 
-.edit-navigation-empty-state {
+.edit-navigation-layout__block-toolbar {
+	background: $white;
+	border: $border-width solid $gray-900;
+	border-radius: $radius-block-ui;
+	height: 47px;
 	width: $navigation-editor-width;
-	margin-top: $navigation-editor-spacing-top;
+	margin: auto;
+}
+
+.edit-navigation-empty-state {
+	max-width: $navigation-editor-width;
 	margin-left: auto;
 	margin-right: auto;
+	@include break-medium() {
+		// Match the padding top of the editor canvas.
+		margin-top: $navigation-editor-spacing-top;
+	}
 }

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -65,12 +65,25 @@
 }
 
 .edit-navigation-layout__block-toolbar {
-	background: $white;
-	border: $border-width solid $gray-900;
-	border-radius: $radius-block-ui;
-	height: 47px;
-	width: $navigation-editor-width;
-	margin: auto;
+	.block-editor-block-toolbar {
+		background: $white;
+		border: $border-width solid $gray-900;
+		border-radius: $radius-block-ui;
+		max-width: $navigation-editor-width;
+		margin: auto;
+	}
+
+	.components-toolbar,
+	.components-toolbar-group {
+		border-right-color: $gray-900;
+
+		.components-toolbar,
+		.components-toolbar-group {
+			border-width: 0;
+		}
+	}
+
+	height: $block-toolbar-height;
 }
 
 .edit-navigation-empty-state {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28875

Implements the 'fixed' version of the block toolbar that's available on smaller screen sizes.

The styling for this isn't perfect, but I'd expect it to improve as part of #29100, when the screen has proper responsive styles.

Working on this was far more complicated than it should really have to be, so I've made a separate issue with some thoughts about block toolbars - https://github.com/WordPress/gutenberg/issues/29965

## How has this been tested?
1. Open the nav editor
2. Create a menu if you don't have one already
3. Make your browser viewport smaller
4. Select a block
5. The toolbar should be present and usable

## Screenshots <!-- if applicable -->
<img width="446" alt="Screenshot 2021-03-18 at 4 54 43 pm" src="https://user-images.githubusercontent.com/677833/111603907-c40ceb00-880f-11eb-9710-bc03035ee2b5.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
