### PR TITLE
Decouple block.json and theme.json config.

### DIFF
--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -104,11 +104,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'settings' => array(
-					'invalid/key' => array(
-						'color' => array(
-							'custom' => false,
-						),
-					),
 					$root_name    => array(
 						'invalid/key' => false,
 					),
@@ -143,41 +138,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEqualSetsWithIndex( $expected, $result );
-	}
-
-	function test_schema_validation_subtree_is_removed_if_style_not_supported_by_block() {
-		$root_name  = WP_Theme_JSON::ROOT_BLOCK_NAME;
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'styles' => array(
-					$root_name => array(
-						'color'   => array(
-							'text' => 'var:preset|color|dark-gray',
-						),
-						'spacing' => array(
-							'padding' => array(
-								'top'    => '1px',
-								'right'  => '1px',
-								'bottom' => '1px',
-								'left'   => '1px',
-							),
-						),
-					),
-				),
-			)
-		);
-
-		$actual   = $theme_json->get_raw_data();
-		$expected = array(
-			'styles' => array(
-				$root_name => array(
-					'color' => array(
-						'text' => 'var:preset|color|dark-gray',
-					),
-				),
-			),
-		);
-		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
 	function test_get_settings() {
@@ -462,16 +422,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$add_invalid_context = array(
-			'styles' => array(
-				'core/para' => array(
-					'typography' => array(
-						'lineHeight' => '12',
-					),
-				),
-			),
-		);
-
 		$update_presets = array(
 			'settings' => array(
 				$root_name => array(
@@ -583,7 +533,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json->merge( new WP_Theme_JSON( $update_key_in_settings ) );
 		$theme_json->merge( new WP_Theme_JSON( $add_styles ) );
 		$theme_json->merge( new WP_Theme_JSON( $add_key_in_styles ) );
-		$theme_json->merge( new WP_Theme_JSON( $add_invalid_context ) );
 		$theme_json->merge( new WP_Theme_JSON( $update_presets ) );
 		$result = $theme_json->get_raw_data();
 


### PR DESCRIPTION
Extracted from #29667

In other words Adding a style to a "block" context of theme.json always results in a style regardless of "support" flags.
This PR also makes the theme.json class less dependent on the registration of the blocks. Only the `get_stylesheet` function is.
