### PR TITLE
Try: Add post content description.

### DIFF
--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -5,12 +5,15 @@
 
 .block-editor-block-card__content {
 	flex-grow: 1;
+	margin-bottom: $grid-unit-05;
 }
 
 .block-editor-block-card__title {
 	font-weight: 500;
+
 	&.block-editor-block-card__title {
-		margin: 0 0 5px;
+		line-height: $button-size-small;
+		margin: 0 0 $grid-unit-05;
 	}
 }
 
@@ -19,10 +22,9 @@
 }
 
 .block-editor-block-card .block-editor-block-icon {
-	flex: 0 0 $button-size;
-	margin-left: -2px;
-	margin-right: 10px;
-	padding: 0 3px;
-	width: $button-size;
+	flex: 0 0 $button-size-small;
+	margin-left: 0;
+	margin-right: $grid-unit-15;
+	width: $button-size-small;
 	height: $button-size-small;
 }

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postContent as icon } from '@wordpress/icons';
 
 /**
@@ -15,6 +15,9 @@ export { metadata, name };
 
 export const settings = {
 	title: _x( 'Post Content', 'block title' ),
+	description: __(
+		'Displays the contents of a post, without title or metadata like tags or categories.'
+	),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -15,9 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: _x( 'Post Content', 'block title' ),
-	description: __(
-		'Displays the contents of a post, without title or metadata like tags or categories.'
-	),
+	description: __( 'Displays the contents of a post or page.' ),
 	icon,
 	edit,
 };


### PR DESCRIPTION
## Description

Fixes #29943.

This PR does two things: 

- It adds a description to the post content block.
- It polishes that whole description area, the metrics were off.

Before:

<img width="362" alt="Screenshot 2021-03-18 at 11 32 00" src="https://user-images.githubusercontent.com/1204802/111612235-9149ff00-87dd-11eb-9d69-7cec9518005a.png">


After:

<img width="323" alt="Screenshot 2021-03-18 at 11 28 48" src="https://user-images.githubusercontent.com/1204802/111612036-619af700-87dd-11eb-9ce8-002fdcc4362f.png">

The metrics of other descriptions also looks better now:

<img width="339" alt="Screenshot 2021-03-18 at 11 28 31" src="https://user-images.githubusercontent.com/1204802/111612058-6790d800-87dd-11eb-8fa5-a8a7a6e66998.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
