### PR TITLE
Update the layout alignment description for better clarity

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -131,7 +131,7 @@ function LayoutPanel( { setAttributes, attributes } ) {
 				) }
 				<p className="block-editor-hooks__layout-controls-helptext">
 					{ __(
-						'The content and wide sizes determine the width of centered and wide columns inside.'
+						'Customize the width for all elements that are assigned to the center or wide columns.'
 					) }
 				</p>
 			</PanelBody>


### PR DESCRIPTION
Before:
> The content and wide sizes determine the width of centered and wide columns inside.

After:
![image](https://user-images.githubusercontent.com/548849/111622716-cc522f80-87e9-11eb-92e4-849725d0dffe.png)
