### PR TITLE
Button: Restore gradients support

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -62,7 +62,8 @@
 		"align": true,
 		"alignWide": false,
 		"color": {
-			"__experimentalSkipSerialization": true
+			"__experimentalSkipSerialization": true,
+			"gradients": true
 		},
 		"reusable": false,
 		"__experimentalSelector": ".wp-block-button__link"


### PR DESCRIPTION
## Description
Restore color gradients support that was missed in https://github.com/WordPress/gutenberg/pull/29382 cc @nosolosw 

## How has this been tested?
- Add button block
- Confirm that the gradient option is available

## Screenshots <!-- if applicable -->

<img width="970" alt="Screenshot 2021-03-18 at 14 32 21" src="https://user-images.githubusercontent.com/1451471/111634428-ca429d80-87f6-11eb-8b7c-944af6641f1d.png">

## Types of changes
Bugfix

@ockham does this one look like a good candidate for a regression test? cc @fullofcaffeine 