### PR TITLE
Post Content: Add support for experimental layout

### DIFF
--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -8,7 +8,8 @@
 	],
 	"supports": {
 		"align": [ "wide", "full" ],
-		"html": false
+		"html": false,
+		"__experimentalLayout": true
 	},
 	"editorStyle": "wp-block-post-content-editor"
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -11,13 +11,12 @@ import {
 } from '@wordpress/block-editor';
 import { useEntityBlockEditor } from '@wordpress/core-data';
 
-function Content( { attributes, postType, postId } ) {
+function Content( { layout, postType, postId } ) {
 	const themeSupportsLayout = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings()?.supportsLayout;
 	}, [] );
 	const defaultLayout = useEditorFeature( 'layout' );
-	const { layout = {} } = attributes;
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { contentSize, wideSize } = usedLayout;
 	const alignments =
@@ -58,9 +57,16 @@ function Placeholder() {
 
 export default function PostContentEdit( {
 	context: { postId: contextPostId, postType: contextPostType },
+	attributes,
 } ) {
+	const { layout = {} } = attributes;
+
 	return contextPostId && contextPostType ? (
-		<Content postType={ contextPostType } postId={ contextPostId } />
+		<Content
+			postType={ contextPostType }
+			postId={ contextPostId }
+			layout={ layout }
+		/>
 	) : (
 		<Placeholder />
 	);

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -15,7 +15,7 @@ function Content( { attributes, postType, postId } ) {
 	const themeSupportsLayout = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings()?.supportsLayout;
-	} );
+	}, [] );
 	const defaultLayout = useEditorFeature( 'layout' );
 	const { layout = {} } = attributes;
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;


### PR DESCRIPTION
## Description
This adds support for experimental layout to the Post Content block.

## How has this been tested?
- Use empty theme
- Add group blocks to the post content
- Check the width of the align "wide" and "full" blocks on the front end

## Screenshots <!-- if applicable -->
|Editor|Frontend|
|---|---|
|<img width="1440" alt="Screenshot 2021-03-18 at 13 59 34" src="https://user-images.githubusercontent.com/275961/111638388-2e169780-87f2-11eb-9154-d616c401d0cf.png">|![localhost_4759__p=443 (2)](https://user-images.githubusercontent.com/275961/111637718-9dd85280-87f1-11eb-8f28-bdc9a163482f.png)|

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
