### PR TITLE
Writing flow: fix tab behaviour

### DIFF
--- a/packages/block-editor/src/components/writing-flow/focus-capture.js
+++ b/packages/block-editor/src/components/writing-flow/focus-capture.js
@@ -13,7 +13,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getBlockDOMNode } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
 
 /**
@@ -38,6 +37,7 @@ const FocusCapture = forwardRef(
 			isReverse,
 			containerRef,
 			noCapture,
+			lastFocus,
 			hasMultiSelection,
 			multiSelectionContainer,
 		},
@@ -79,20 +79,7 @@ const FocusCapture = forwardRef(
 				return;
 			}
 
-			// If there is a selected block, move focus to the first or last
-			// tabbable element depending on the direction.
-			const wrapper = getBlockDOMNode(
-				selectedClientId,
-				ref.current.ownerDocument
-			);
-
-			if ( isReverse ) {
-				const tabbables = focus.tabbable.find( wrapper );
-				const lastTabbable = last( tabbables ) || wrapper;
-				lastTabbable.focus();
-			} else {
-				wrapper.focus();
-			}
+			lastFocus.current.focus();
 		}
 
 		return (

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -368,7 +368,6 @@ export default function WritingFlow( { children } ) {
 				// doesn't refocus this block and so it allows default behaviour
 				// (moving focus to the next tabbable element).
 				noCapture.current = true;
-				lastFocus.current = target;
 				next.current.focus();
 				return;
 			} else if ( isEscape ) {
@@ -520,6 +519,18 @@ export default function WritingFlow( { children } ) {
 			multiSelectionContainer.current.focus();
 		}
 	}, [ hasMultiSelection, isMultiSelecting ] );
+
+	useEffect( () => {
+		function onFocusOut( event ) {
+			lastFocus.current = event.target;
+		}
+
+		container.current.addEventListener( 'focusout', onFocusOut );
+
+		return () => {
+			container.current.removeEventListener( 'focusout', onFocusOut );
+		};
+	}, [] );
 
 	const className = classnames( 'block-editor-writing-flow', {
 		'is-navigate-mode': isNavigationMode,

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -48,6 +48,16 @@ function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
 }
 
+function isFormElement( element ) {
+	const { tagName } = element;
+	return (
+		tagName === 'INPUT' ||
+		tagName === 'BUTTON' ||
+		tagName === 'SELECT' ||
+		tagName === 'TEXTAREA'
+	);
+}
+
 /**
  * Returns true if the element should consider edge navigation upon a keyboard
  * event of the given directional key code, or false otherwise.
@@ -358,6 +368,19 @@ export default function WritingFlow( { children } ) {
 		// Navigation mode (press Esc), to navigate through blocks.
 		if ( selectedBlockClientId ) {
 			if ( isTab ) {
+				const direction = isShift ? 'findPrevious' : 'findNext';
+				// Allow tabbing between form elements rendered in a block,
+				// such as inside a placeholder. Form elements are generally
+				// meant to be UI rather than part of the content. Ideally
+				// these are not rendered in the content and perhaps in the
+				// future they can be rendered in an iframe or shadow DOM.
+				if (
+					isFormElement( target ) &&
+					isFormElement( focus.tabbable[ direction ]( target ) )
+				) {
+					return;
+				}
+
 				const next = isShift
 					? focusCaptureBeforeRef
 					: focusCaptureAfterRef;

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -209,8 +209,6 @@ export default function WritingFlow( { children } ) {
 	// browser behaviour across blocks.
 	const verticalRect = useRef();
 
-	const lastFocus = useRef();
-
 	const onSelectionStart = useMultiSelection( container );
 
 	const {
@@ -520,13 +518,14 @@ export default function WritingFlow( { children } ) {
 		}
 	}, [ hasMultiSelection, isMultiSelecting ] );
 
+	const lastFocus = useRef();
+
 	useEffect( () => {
 		function onFocusOut( event ) {
 			lastFocus.current = event.target;
 		}
 
 		container.current.addEventListener( 'focusout', onFocusOut );
-
 		return () => {
 			container.current.removeEventListener( 'focusout', onFocusOut );
 		};

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -358,31 +358,16 @@ export default function WritingFlow( { children } ) {
 		// Navigation mode (press Esc), to navigate through blocks.
 		if ( selectedBlockClientId ) {
 			if ( isTab ) {
-				const wrapper = getBlockDOMNode(
-					selectedBlockClientId,
-					ownerDocument
-				);
+				const next = isShift
+					? focusCaptureBeforeRef
+					: focusCaptureAfterRef;
 
-				if ( isShift ) {
-					if ( target === wrapper ) {
-						// Disable focus capturing on the focus capture element, so
-						// it doesn't refocus this block and so it allows default
-						// behaviour (moving focus to the next tabbable element).
-						noCapture.current = true;
-						focusCaptureBeforeRef.current.focus();
-						return;
-					}
-				} else {
-					const tabbables = focus.tabbable.find( wrapper );
-					const lastTabbable = last( tabbables ) || wrapper;
-
-					if ( target === lastTabbable ) {
-						// See comment above.
-						noCapture.current = true;
-						focusCaptureAfterRef.current.focus();
-						return;
-					}
-				}
+				// Disable focus capturing on the focus capture element, so
+				// it doesn't refocus this block and so it allows default
+				// behaviour (moving focus to the next tabbable element).
+				noCapture.current = true;
+				next.current.focus();
+				return;
 			} else if ( isEscape ) {
 				setNavigationMode( true );
 			}

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -209,6 +209,8 @@ export default function WritingFlow( { children } ) {
 	// browser behaviour across blocks.
 	const verticalRect = useRef();
 
+	const lastFocus = useRef();
+
 	const onSelectionStart = useMultiSelection( container );
 
 	const {
@@ -366,6 +368,7 @@ export default function WritingFlow( { children } ) {
 				// doesn't refocus this block and so it allows default behaviour
 				// (moving focus to the next tabbable element).
 				noCapture.current = true;
+				lastFocus.current = target;
 				next.current.focus();
 				return;
 			} else if ( isEscape ) {
@@ -532,6 +535,7 @@ export default function WritingFlow( { children } ) {
 				selectedClientId={ selectedBlockClientId }
 				containerRef={ container }
 				noCapture={ noCapture }
+				lastFocus={ lastFocus }
 				hasMultiSelection={ hasMultiSelection }
 				multiSelectionContainer={ multiSelectionContainer }
 			/>
@@ -561,6 +565,7 @@ export default function WritingFlow( { children } ) {
 				selectedClientId={ selectedBlockClientId }
 				containerRef={ container }
 				noCapture={ noCapture }
+				lastFocus={ lastFocus }
 				hasMultiSelection={ hasMultiSelection }
 				multiSelectionContainer={ multiSelectionContainer }
 				isReverse

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -362,9 +362,9 @@ export default function WritingFlow( { children } ) {
 					? focusCaptureBeforeRef
 					: focusCaptureAfterRef;
 
-				// Disable focus capturing on the focus capture element, so
-				// it doesn't refocus this block and so it allows default
-				// behaviour (moving focus to the next tabbable element).
+				// Disable focus capturing on the focus capture element, so it
+				// doesn't refocus this block and so it allows default behaviour
+				// (moving focus to the next tabbable element).
 				noCapture.current = true;
 				next.current.focus();
 				return;

--- a/packages/dom/src/dom/place-caret-at-horizontal-edge.js
+++ b/packages/dom/src/dom/place-caret-at-horizontal-edge.js
@@ -14,8 +14,14 @@ export default function placeCaretAtHorizontalEdge( container, isReverse ) {
 		return;
 	}
 
+	container.focus();
+
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
-		container.focus();
+		// The element may not support selection setting.
+		if ( typeof container.selectionStart !== 'number' ) {
+			return;
+		}
+
 		if ( isReverse ) {
 			container.selectionStart = container.value.length;
 			container.selectionEnd = container.value.length;
@@ -23,10 +29,9 @@ export default function placeCaretAtHorizontalEdge( container, isReverse ) {
 			container.selectionStart = 0;
 			container.selectionEnd = 0;
 		}
+
 		return;
 	}
-
-	container.focus();
 
 	if ( ! container.isContentEditable ) {
 		return;

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -137,6 +137,24 @@ describe( 'Image', () => {
 		).toBe( '1<br data-rich-text-line-break="true">2' );
 	} );
 
+	it( 'should have keyboard navigable toolbar for caption', async () => {
+		await insertBlock( 'Image' );
+		const fileName = await upload( '.wp-block-image input[type="file"]' );
+		await waitForImage( fileName );
+		// Navigate to More, Link, Italic and finally Bold.
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await page.keyboard.press( 'Space' );
+		await page.keyboard.press( 'a' );
+		await page.keyboard.press( 'ArrowRight' );
+
+		expect(
+			await page.evaluate( () => document.activeElement.innerHTML )
+		).toBe( '<strong>a</strong>' );
+	} );
+
 	it( 'should drag and drop files into media placeholder', async () => {
 		await page.keyboard.press( 'Enter' );
 		await insertBlock( 'Image' );

--- a/packages/e2e-tests/specs/editor/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/quote.test.js
@@ -87,7 +87,7 @@ describe( 'Quote', () => {
 			await page.keyboard.type( 'one' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'two' );
-			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'ArrowRight' );
 			await page.keyboard.type( 'cite' );
 			await transformBlockTo( 'Paragraph' );
 
@@ -96,7 +96,7 @@ describe( 'Quote', () => {
 
 		it( 'and renders only one paragraph for the cite, if the quote is void', async () => {
 			await insertBlock( 'Quote' );
-			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'ArrowRight' );
 			await page.keyboard.type( 'cite' );
 			await transformBlockTo( 'Paragraph' );
 
@@ -146,7 +146,7 @@ describe( 'Quote', () => {
 	it( 'is transformed to a heading and a quote if the quote contains a citation', async () => {
 		await insertBlock( 'Quote' );
 		await page.keyboard.type( 'one' );
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'cite' );
 		await transformBlockTo( 'Heading' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -157,7 +157,7 @@ describe( 'Quote', () => {
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'cite' );
 		await transformBlockTo( 'Heading' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -174,7 +174,7 @@ describe( 'Quote', () => {
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'cite' );
 		await transformBlockTo( 'Pullquote' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -214,7 +214,7 @@ describe( 'Quote', () => {
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'c' );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -77,15 +77,15 @@ describe( 'Table', () => {
 		await page.click( 'td' );
 		await page.keyboard.type( 'This' );
 
-		// Tab to the next cell and add some text.
+		// Navigate to the next cell and add some text.
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'is' );
 
-		// Tab to the next cell and add some text.
+		// Navigate to the next cell and add some text.
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'table' );
 
-		// Tab to the next cell and add some text.
+		// Navigate to the next cell and add some text.
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'block' );
 

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -78,15 +78,15 @@ describe( 'Table', () => {
 		await page.keyboard.type( 'This' );
 
 		// Tab to the next cell and add some text.
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'is' );
 
 		// Tab to the next cell and add some text.
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'table' );
 
 		// Tab to the next cell and add some text.
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'block' );
 
 		// Expect the post to have the correct written content inside the table.

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -297,3 +297,9 @@ exports[`Writing Flow should remember initial vertical position 1`] = `
 <p><br>2</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Writing Flow should only consider the content as one tab stop 1`] = `
+"<!-- wp:table -->
+<figure class=\\"wp-block-table\\"><table><tbody><tr><td></td><td>2</td></tr><tr><td></td><td></td></tr></tbody></table></figure>
+<!-- /wp:table -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -42,7 +42,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '[aria-label="Two columns; equal split"]' );
 
 		// Add a paragraph in the first column.
-		await page.keyboard.press( 'Tab' ); // Tab to inserter.
+		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
 		await page.keyboard.press( 'Enter' ); // Activate inserter.
 		await page.keyboard.type( 'Paragraph' );
 		await pressKeyTimes( 'Tab', 2 ); // Tab to paragraph result.
@@ -78,7 +78,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await lastColumnsBlockMenuItem.click();
 
 		// Insert text in the last column block.
-		await page.keyboard.press( 'Tab' ); // Tab to inserter.
+		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
 		await page.keyboard.press( 'Enter' ); // Activate inserter.
 		await page.keyboard.type( 'Paragraph' );
 		await pressKeyTimes( 'Tab', 2 ); // Tab to paragraph result.
@@ -94,7 +94,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '[aria-label="Two columns; equal split"]' );
 
 		// Add a paragraph in the first column.
-		await page.keyboard.press( 'Tab' ); // Tab to inserter.
+		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
 		await page.keyboard.press( 'Enter' ); // Activate inserter.
 		await page.keyboard.type( 'Paragraph' );
 		await pressKeyTimes( 'Tab', 2 ); // Tab to paragraph result.
@@ -121,7 +121,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.waitForSelector( '.is-selected[data-type="core/column"]' );
 
 		// Insert text in the last column block
-		await page.keyboard.press( 'Tab' ); // Tab to inserter.
+		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
 		await page.keyboard.press( 'Enter' ); // Activate inserter.
 		await page.keyboard.type( 'Paragraph' );
 		await pressKeyTimes( 'Tab', 2 ); // Tab to paragraph result.

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -102,17 +102,15 @@ describe( 'Toolbar roving tabindex', () => {
 		await page.keyboard.press( 'Home' );
 		await expectLabelToHaveFocus( 'Table' );
 		await page.click( '.blocks-table__placeholder-button' );
-		await testBlockToolbarKeyboardNavigation( 'Block: Table', 'Table' );
+		await page.keyboard.press( 'Tab' );
+		await testBlockToolbarKeyboardNavigation( 'Body cell text', 'Table' );
 		await wrapCurrentBlockWithGroup( 'Table' );
 		await testGroupKeyboardNavigation( 'Body cell text', 'Table' );
 	} );
 
 	it( 'ensures custom html block toolbar uses roving tabindex', async () => {
 		await insertBlock( 'Custom HTML' );
-		await testBlockToolbarKeyboardNavigation(
-			'Block: Custom HTML',
-			'Custom HTML'
-		);
+		await testBlockToolbarKeyboardNavigation( 'HTML', 'Custom HTML' );
 		await wrapCurrentBlockWithGroup( 'Custom HTML' );
 		await testGroupKeyboardNavigation( 'HTML', 'Custom HTML' );
 	} );

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -105,14 +105,17 @@ describe( 'Toolbar roving tabindex', () => {
 		await page.keyboard.press( 'Tab' );
 		await testBlockToolbarKeyboardNavigation( 'Body cell text', 'Table' );
 		await wrapCurrentBlockWithGroup( 'Table' );
-		await testGroupKeyboardNavigation( 'Body cell text', 'Table' );
+		await testGroupKeyboardNavigation( 'Block: Table', 'Table' );
 	} );
 
 	it( 'ensures custom html block toolbar uses roving tabindex', async () => {
 		await insertBlock( 'Custom HTML' );
 		await testBlockToolbarKeyboardNavigation( 'HTML', 'Custom HTML' );
 		await wrapCurrentBlockWithGroup( 'Custom HTML' );
-		await testGroupKeyboardNavigation( 'HTML', 'Custom HTML' );
+		await testGroupKeyboardNavigation(
+			'Block: Custom HTML',
+			'Custom HTML'
+		);
 	} );
 
 	it( 'ensures block toolbar remembers the last focused item', async () => {

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -104,7 +104,7 @@ describe( 'Toolbar roving tabindex', () => {
 		await page.click( '.blocks-table__placeholder-button' );
 		await testBlockToolbarKeyboardNavigation( 'Block: Table', 'Table' );
 		await wrapCurrentBlockWithGroup( 'Table' );
-		await testGroupKeyboardNavigation( 'Block: Table', 'Table' );
+		await testGroupKeyboardNavigation( 'Body cell text', 'Table' );
 	} );
 
 	it( 'ensures custom html block toolbar uses roving tabindex', async () => {
@@ -114,10 +114,7 @@ describe( 'Toolbar roving tabindex', () => {
 			'Custom HTML'
 		);
 		await wrapCurrentBlockWithGroup( 'Custom HTML' );
-		await testGroupKeyboardNavigation(
-			'Block: Custom HTML',
-			'Custom HTML'
-		);
+		await testGroupKeyboardNavigation( 'HTML', 'Custom HTML' );
 	} );
 
 	it( 'ensures block toolbar remembers the last focused item', async () => {

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -46,7 +46,7 @@ async function testGroupKeyboardNavigation(
 	currentBlockTitle
 ) {
 	await expectLabelToHaveFocus( 'Block: Group' );
-	await page.keyboard.press( 'Tab' );
+	await page.keyboard.press( 'ArrowRight' );
 	await expectLabelToHaveFocus( currentBlockLabel );
 	await pressKeyWithModifier( 'shift', 'Tab' );
 	await expectLabelToHaveFocus( 'Select Group' );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -559,9 +559,6 @@ describe( 'Writing Flow', () => {
 		await clickBlockToolbarButton( 'Align' );
 		await clickButton( 'Wide width' );
 
-		// Focus the block.
-		await page.keyboard.press( 'Tab' );
-
 		// Select the previous block.
 		await page.keyboard.press( 'ArrowUp' );
 

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -591,4 +591,38 @@ describe( 'Writing Flow', () => {
 
 		expect( type ).toBe( 'core/image' );
 	} );
+
+	it( 'should only consider the content as one tab stop', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '/table' );
+		await page.keyboard.press( 'Enter' );
+		// Move into the placeholder UI.
+		await page.keyboard.press( 'ArrowDown' );
+		// Tab to the "Create table" button.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		// Create the table.
+		await page.keyboard.press( 'Space' );
+		// Return focus after focus loss. This should be fixed.
+		await page.keyboard.press( 'Tab' );
+		// Navigate to the second cell.
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.type( '2' );
+		// Confirm correct setup.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+		// The content should only have one tab stop.
+		await page.keyboard.press( 'Tab' );
+		expect(
+			await page.evaluate( () =>
+				document.activeElement.getAttribute( 'aria-label' )
+			)
+		).toBe( 'Post' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		expect(
+			await page.evaluate( () =>
+				document.activeElement.getAttribute( 'aria-label' )
+			)
+		).toBe( 'Table' );
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Discovered in https://github.com/WordPress/gutenberg/pull/29874#issuecomment-800929146.

Currently tab behaviour from a field in a block is unexpectedly moving focus within the block rather than before or after the editor area (toolbar or inspector). This is not consistent with the behaviour that was originally proposed and implemented in #19235. The "specification" we should be following is that of a `textarea`: the editable field containing all blocks is a single tab stop.

See the existing comment at 

https://github.com/WordPress/gutenberg/blob/45715c42415aaeb9bc21deed7e44698a9582feaa/packages/block-editor/src/components/writing-flow/index.js#L393-L398

A nice side effect of making the behaviour more consistent is that it reduces the complexity of writing flow.

One exception that I encountered is when there are form elements within a block, for example as part of a placeholder, in which case the controls can be considered to be editor UI. In that case we should allow navigating by Tab between those controls. Ideally, in the future, these controls should be placed in an iframe so that both the editor UI styling and the Tab behaviour is isolated from the content.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Create an image block and focus the caption. Press Shift+Tab. The toolbar should receive focus, not the block wrapper.
Similarly for a table, Tab from any table cell should focus the toolbar or inspector, not the next/previous table cell. Arrow keys must be used for content navigation like you would in a text area or normal content editable area.

## Screenshots <!-- if applicable -->

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
