### PR TITLE
Template Part Block: Use buttons for area selection

### DIFF
--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -3,10 +3,11 @@
  */
 import { useEntityProp } from '@wordpress/core-data';
 import {
+	BaseControl,
 	Button,
 	SelectControl,
 	TextControl,
-	BaseControl,
+	Tooltip,
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
@@ -90,18 +91,24 @@ export function TemplatePartAdvancedControls( {
 
 						<div>
 							{ AREA_OPTIONS.map(
-								( { description, icon, value } ) => (
-									<Button
-										className="template-part-area-control__option"
-										icon={ icon }
-										isSecondary
-										isPressed={ value === area }
+								( { description, icon, label, value } ) => (
+									<Tooltip
+										id={ `template-part-area-option-${ value }` }
+										className="template-part-area-control__option-description"
 										key={ value }
-										label={ description }
-										onClick={ () => setArea( value ) }
-										showTooltip={ true }
-										tooltipPosition="top right"
-									/>
+										position="top right"
+										text={ description }
+									>
+										<Button
+											aria-describedby={ `template-part-area-option-${ value }` }
+											className="template-part-area-control__option"
+											icon={ icon }
+											isSecondary
+											isPressed={ value === area }
+											label={ label }
+											onClick={ () => setArea( value ) }
+										/>
+									</Tooltip>
 								)
 							) }
 						</div>

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -35,8 +35,8 @@ const AREA_OPTIONS = [
 		value: 'footer',
 	},
 	{
-		description: __( 
-			'General templates often perform a specific role like displaying post content, and are not tied to any particular area.' 
+		description: __(
+			'General templates often perform a specific role like displaying post content, and are not tied to any particular area.'
 		),
 		icon: layout,
 		label: __( 'General' ),

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -2,9 +2,15 @@
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { SelectControl, TextControl } from '@wordpress/components';
+import {
+	Button,
+	SelectControl,
+	TextControl,
+	BaseControl,
+} from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
+import { footer, header } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -12,9 +18,25 @@ import { InspectorAdvancedControls } from '@wordpress/block-editor';
 import { getTagBasedOnArea } from './get-tag-based-on-area';
 
 const AREA_OPTIONS = [
-	{ label: __( 'Header' ), value: 'header' },
-	{ label: __( 'Footer' ), value: 'footer' },
 	{
+		description: __(
+			'The Header template defines a page area that typically contains a title, logo, and main navigation.'
+		),
+		icon: header,
+		label: __( 'Header' ),
+		value: 'header',
+	},
+	{
+		description: __(
+			'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.'
+		),
+		icon: footer,
+		label: __( 'Footer' ),
+		value: 'footer',
+	},
+	{
+		description: __( 'The General template.' ),
+		icon: null,
 		label: __( 'General' ),
 		value: 'uncategorized',
 	},
@@ -53,13 +75,35 @@ export function TemplatePartAdvancedControls( {
 						onFocus={ ( event ) => event.target.select() }
 					/>
 
-					<SelectControl
-						label={ __( 'Area' ) }
-						labelPosition="top"
-						options={ AREA_OPTIONS }
-						value={ area }
-						onChange={ setArea }
-					/>
+					<BaseControl
+						id={ `template-part-area-control-${ templatePartId }` }
+						className="template-part-area-control"
+						help={ __(
+							'The area of the page that this block should occupy.'
+						) }
+					>
+						<BaseControl.VisualLabel className="template-part-area-control__label">
+							{ __( 'Area' ) }
+						</BaseControl.VisualLabel>
+
+						<div>
+							{ AREA_OPTIONS.map(
+								( { description, icon, value } ) => (
+									<Button
+										className="template-part-area-control__option"
+										icon={ icon }
+										isSecondary
+										isPressed={ value === area }
+										key={ value }
+										label={ description }
+										onClick={ () => setArea( value ) }
+										showTooltip={ true }
+										tooltipPosition="top right"
+									/>
+								)
+							) }
+						</div>
+					</BaseControl>
 				</>
 			) }
 			<SelectControl

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
-import { footer, header } from '@wordpress/icons';
+import { footer, header, layout } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -35,8 +35,10 @@ const AREA_OPTIONS = [
 		value: 'footer',
 	},
 	{
-		description: __( 'The General template.' ),
-		icon: null,
+		description: __( 
+			'General templates often perform a specific role like displaying post content, and are not tied to any particular area.' 
+		),
+		icon: layout,
 		label: __( 'General' ),
 		value: 'uncategorized',
 	},

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -62,6 +62,22 @@
 	}
 }
 
+.template-part-area-control {
+	.template-part-area-control__label {
+		display: block;
+		margin-bottom: $grid-unit-10;
+	}
+
+	.template-part-area-control__option {
+		box-shadow: none;
+		margin-right: $grid-unit-05;
+
+		&:not(.is-pressed) {
+			color: $gray-900;
+		}
+	}
+}
+
 // Ensures a border is present when a child block is selected.
 .block-editor-block-list__block[data-type="core/template-part"] {
 	&.has-child-selected {

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -72,9 +72,27 @@
 		box-shadow: none;
 		margin-right: $grid-unit-05;
 
+		&.has-icon svg {
+			// Remove icon margin, since inner text content is a tooltip.
+			margin-right: 0;
+		}
+
 		&:not(.is-pressed) {
 			color: $gray-900;
+
+			&:hover:not(:disabled) {
+				color: $gray-900;
+			}
 		}
+	}
+}
+
+// Override the popover styles to wrap the text
+.template-part-area-control__option-description.components-tooltip {
+	.components-popover__content {
+		min-width: calc(#{$sidebar-width} * 0.8);
+		margin-bottom: $grid-unit-15;
+		white-space: normal;
 	}
 }
 

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { includes } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -50,11 +51,13 @@ const getRegularElement = ( { child, eventHandlers, childrenWithPopover } ) =>
 	} );
 
 const addPopoverToGrandchildren = ( {
+	className,
 	grandchildren,
 	isOver,
 	position,
 	text,
 	shortcut,
+	...popoverProps
 } ) =>
 	concatChildren(
 		grandchildren,
@@ -62,10 +65,11 @@ const addPopoverToGrandchildren = ( {
 			<Popover
 				focusOnMount={ false }
 				position={ position }
-				className="components-tooltip"
+				className={ classnames( className, 'components-tooltip' ) }
 				aria-hidden="true"
 				animate={ false }
 				noArrow={ true }
+				{ ...popoverProps }
 			>
 				{ text }
 				<Shortcut
@@ -87,7 +91,14 @@ const emitToChild = ( children, eventName, event ) => {
 	}
 };
 
-function Tooltip( { children, position, text, shortcut } ) {
+function Tooltip( {
+	children,
+	className,
+	position,
+	text,
+	shortcut,
+	...popoverProps
+} ) {
 	/**
 	 * Whether a mouse is currently pressed, used in determining whether
 	 * to handle a focus event as displaying the tooltip immediately.
@@ -201,13 +212,16 @@ function Tooltip( { children, position, text, shortcut } ) {
 
 	const popoverData = {
 		isOver,
+		className,
 		position,
 		text,
 		shortcut,
 	};
 	const childrenWithPopover = addPopoverToGrandchildren( {
 		grandchildren,
+		isOver,
 		...popoverData,
+		...popoverProps,
 	} );
 
 	return getElementWithPopover( {

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -219,7 +219,6 @@ function Tooltip( {
 	};
 	const childrenWithPopover = addPopoverToGrandchildren( {
 		grandchildren,
-		isOver,
 		...popoverData,
 		...popoverProps,
 	} );


### PR DESCRIPTION
## Description

Resolves #29295

## How has this been tested?

1. Open the site editor
2. Select a template part block, such as the header (the list view is an easy way to do this).
3. Open the Advanced section of the sidebar options and choose the area.

## Screenshots <!-- if applicable -->

Template Part Block > Advanced settings in sidebar

<img width="273" alt="image" src="https://user-images.githubusercontent.com/1699996/111818830-a2624100-88ad-11eb-8270-0cfda68c191c.png">

<img width="410" alt="image" src="https://user-images.githubusercontent.com/1699996/111832735-2a047b80-88bf-11eb-8d89-73f61ed66e7a.png">



## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
