### PR TITLE
Fix link items in navigation screen.

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -126,6 +126,7 @@
 
 // All links.
 .wp-block-navigation-link__content {
+	display: block;
 	color: inherit;
 	padding: 0.5em 1em;
 


### PR DESCRIPTION
## Description
The recent markup change to navigation items caused a small issue with the navigation screen:

![before](https://user-images.githubusercontent.com/1204802/111745714-4ab3dd80-888d-11eb-8204-ddb000fb6ea2.gif)

This PR fixes that:

![after](https://user-images.githubusercontent.com/1204802/111745726-4e476480-888d-11eb-87d3-0a21dd3e1d72.gif)

Note that #29975 was created to fix the same issue, and does, but that's a bigger PR. If that needs more time for testing, this separate PR is small and digestible and can land in the mean time.


## How has this been tested?

Please use a not-block-based theme, and test the new navigation editor menu.

Test and verify the hover and select styles look good.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
