### PR TITLE
Try: Add line-height to Navigation block

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -52,6 +52,7 @@
 		"html": false,
 		"inserter": true,
 		"fontSize": true,
+		"lineHeight": true,
 		"__experimentalFontStyle": true,
 		"__experimentalFontWeight": true,
 		"__experimentalTextTransform": true,


### PR DESCRIPTION
## Description

This PR enables the line-height control in the navigation block. Before:

<img width="411" alt="Screenshot 2021-03-19 at 08 34 03" src="https://user-images.githubusercontent.com/1204802/111747319-7afc7b80-888f-11eb-8e19-484903dddb75.png">

After:

![after](https://user-images.githubusercontent.com/1204802/111747324-7c2da880-888f-11eb-8fd0-9de9feebcd14.gif)

Fixes #29959
Note that the sidebar design is sub-par here, and makes it all the more urgent to have a system like #27331 in place. But in the mean time, this seems worth shipping as it fixes a need.

## How has this been tested?

Please try the navigation block and verify the navigation block has a line height option. 

Please verify the line-height property does work, and works for both menu items and the Page List block, including on the frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
