### PR TITLE
Unset font weight and text decoration inheritance in nav block

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -237,6 +237,12 @@ $color-control-label-height: 20px;
 	position: relative;
 	z-index: 1;
 
+	// If an ancestor has a text-decoration property applied, it is inherited regardless of
+	// the specificity of a child element. Only pulling the child out of the flow fixes it.
+	// See also https://www.w3.org/TR/CSS21/text.html#propdef-text-decoration.
+	float: left;
+	width: 100%;
+
 	// Show when selected.
 	.is-selected & {
 		display: flex;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,6 +1,7 @@
 .components-button {
 	display: inline-flex;
 	text-decoration: none;
+	font-weight: normal;
 	font-size: $default-font-size;
 	margin: 0;
 	border: 0;


### PR DESCRIPTION
## Description

If you insert an empty navigation block and set the font weight and text decoration, those bleed into the setup state:

<img width="785" alt="Screenshot 2021-03-19 at 09 03 09" src="https://user-images.githubusercontent.com/1204802/111751372-b64d7900-8894-11eb-80f1-6c867b7de4c0.png">

This PR fixes that by unsetting the font weight on the button component, and writing some special CSS for the text decoration:

![after](https://user-images.githubusercontent.com/1204802/111751412-c1a0a480-8894-11eb-875a-abd644b0f816.gif)

The thing about text decoration is that apparently text-decoration rules are inherited by all children, and cannot be overridden, even by a `text-decoration: none !important`— see https://stackoverflow.com/questions/1823341/how-do-i-get-this-css-text-decoration-override-to-work

The solution was to pull that container out of the flow using a float. Sigh.

## How has this been tested?

Please test that the empty navigation block does not inherit text decoration or font weight, and that the special rule we had to add for the placeholde state, the float, doesn't have any adverse effects on adjacent blocks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
