### PR TITLE
Use the interface package for the navigation screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12666,6 +12666,7 @@
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
+				"@wordpress/interface": "file:packages/interface",
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
@@ -13232,8 +13233,7 @@
 					"integrity": "sha512-AH8NYyMNLNhcUEF97QbMxPNLNW+oiSBlvm1rsMNzgJ1d5TQzdh/AOJGsxeeESp3m9YIWGLCgUvGTVoVLs0p68A=="
 				},
 				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+					"version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
 					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 				}
 			}

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -318,7 +318,7 @@ describe( 'Navigation editor', () => {
 		expect( submenuLinkVisible ).toBeDefined();
 
 		// click in the top left corner of the canvas.
-		const canvas = await page.$( '.edit-navigation-layout__canvas' );
+		const canvas = await page.$( '.edit-navigation-layout__content-area' );
 		const boundingBox = await canvas.boundingBox();
 		await page.mouse.click( boundingBox.x + 5, boundingBox.y + 5 );
 

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -40,6 +40,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/interface": "file:../interface",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -8,6 +8,7 @@ import { find } from 'lodash';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dropdown, DropdownMenu, Popover } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { PinnedItems } from '@wordpress/interface';
 
 /**
@@ -26,6 +27,7 @@ export default function Header( {
 } ) {
 	const selectedMenu = find( menus, { id: selectedMenuId } );
 	const menuName = selectedMenu ? selectedMenu.name : undefined;
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	let actionHeaderText;
 
 	if ( menuName ) {
@@ -103,8 +105,9 @@ export default function Header( {
 					/>
 
 					<SaveButton navigationPost={ navigationPost } />
-
-					<PinnedItems.Slot scope="core/edit-navigation" />
+					{ isMobileViewport && (
+						<PinnedItems.Slot scope="core/edit-navigation" />
+					) }
 					<Popover.Slot name="block-toolbar" />
 				</div>
 			) }

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -8,6 +8,7 @@ import { find } from 'lodash';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dropdown, DropdownMenu, Popover } from '@wordpress/components';
+import { PinnedItems } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -103,6 +104,7 @@ export default function Header( {
 
 					<SaveButton navigationPost={ navigationPost } />
 
+					<PinnedItems.Slot scope="core/edit-navigation" />
 					<Popover.Slot name="block-toolbar" />
 				</div>
 			) }

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -8,7 +8,6 @@ import { find } from 'lodash';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dropdown, DropdownMenu, Popover } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { PinnedItems } from '@wordpress/interface';
 
 /**
@@ -27,7 +26,6 @@ export default function Header( {
 } ) {
 	const selectedMenu = find( menus, { id: selectedMenuId } );
 	const menuName = selectedMenu ? selectedMenu.name : undefined;
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	let actionHeaderText;
 
 	if ( menuName ) {
@@ -105,9 +103,7 @@ export default function Header( {
 					/>
 
 					<SaveButton navigationPost={ navigationPost } />
-					{ isMobileViewport && (
-						<PinnedItems.Slot scope="core/edit-navigation" />
-					) }
+					<PinnedItems.Slot scope="core/edit-navigation" />
 					<Popover.Slot name="block-toolbar" />
 				</div>
 			) }

--- a/packages/edit-navigation/src/components/inspector-additions/style.scss
+++ b/packages/edit-navigation/src/components/inspector-additions/style.scss
@@ -1,16 +1,3 @@
-.block-editor-block-inspector__no-blocks,
-.block-editor-block-inspector {
-	width: $sidebar-width;
-	background: $white;
-	border-left: 1px solid $gray-300;
-	position: fixed;
-	top: $grid-unit-40;
-	right: 0;
-	bottom: 0;
-	z-index: 1;
-	overflow: auto;
-}
-
 .edit-navigation-inspector-additions__delete-menu-panel {
 	text-align: center;
 }

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -45,7 +45,7 @@ const interfaceLabels = {
 	/* translators: accessibility text for the navigation screen top bar landmark region. */
 	header: __( 'Navigation top bar' ),
 	/* translators: accessibility text for the navigation screen content landmark region. */
-	body: __( 'Menu blocks' ),
+	body: __( 'Navigation menu blocks' ),
 	/* translators: accessibility text for the widgets screen settings landmark region. */
 	sidebar: __( 'Navigation settings' ),
 };

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -51,7 +51,7 @@ const interfaceLabels = {
 };
 
 export default function Layout( { blockEditorSettings } ) {
-	const canvasRef = useBlockSelectionClearer();
+	const contentAreaRef = useBlockSelectionClearer();
 	const [ isMenuNameControlFocused, setIsMenuNameControlFocused ] = useState(
 		false
 	);
@@ -112,6 +112,7 @@ export default function Layout( { blockEditorSettings } ) {
 								) }
 							>
 								<InterfaceSkeleton
+									className="edit-navigation-layout"
 									labels={ interfaceLabels }
 									header={
 										<Header
@@ -138,8 +139,8 @@ export default function Layout( { blockEditorSettings } ) {
 														saveBlocks={ savePost }
 													/>
 													<div
-														className="edit-navigation-layout__canvas"
-														ref={ canvasRef }
+														className="edit-navigation-layout__content-area"
+														ref={ contentAreaRef }
 													>
 														<Editor
 															isPending={

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -98,7 +98,6 @@ export default function Layout( { blockEditorSettings } ) {
 						settings={ {
 							...blockEditorSettings,
 							templateLock: 'all',
-							hasFixedToolbar: true,
 						} }
 						useSubRegistry={ false }
 					>
@@ -133,16 +132,7 @@ export default function Layout( { blockEditorSettings } ) {
 												! hasMenus && <EmptyState /> }
 
 											{ isBlockEditorReady && (
-												<BlockEditorProvider
-													value={ blocks }
-													onInput={ onInput }
-													onChange={ onChange }
-													settings={ {
-														...blockEditorSettings,
-														templateLock: 'all',
-													} }
-													useSubRegistry={ false }
-												>
+												<>
 													<BlockEditorKeyboardShortcuts />
 													<NavigationEditorShortcuts
 														saveBlocks={ savePost }
@@ -166,7 +156,7 @@ export default function Layout( { blockEditorSettings } ) {
 															deleteMenu
 														}
 													/>
-												</BlockEditorProvider>
+												</>
 											) }
 										</>
 									}

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -133,22 +133,16 @@ export default function Layout( { blockEditorSettings } ) {
 												! hasMenus && <EmptyState /> }
 
 											{ isBlockEditorReady && (
-												<>
-													<BlockEditorKeyboardShortcuts />
-													<NavigationEditorShortcuts
-														saveBlocks={ savePost }
+												<div
+													className="edit-navigation-layout__content-area"
+													ref={ contentAreaRef }
+												>
+													<Editor
+														isPending={
+															! hasLoadedMenus
+														}
+														blocks={ blocks }
 													/>
-													<div
-														className="edit-navigation-layout__content-area"
-														ref={ contentAreaRef }
-													>
-														<Editor
-															isPending={
-																! hasLoadedMenus
-															}
-															blocks={ blocks }
-														/>
-													</div>
 													<InspectorAdditions
 														menuId={
 															selectedMenuId
@@ -157,7 +151,7 @@ export default function Layout( { blockEditorSettings } ) {
 															deleteMenu
 														}
 													/>
-												</>
+												</div>
 											) }
 										</>
 									}

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -1,25 +1,25 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
+import {
+	BlockEditorKeyboardShortcuts,
+	BlockEditorProvider,
+	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
+} from '@wordpress/block-editor';
 import {
 	DropZoneProvider,
 	Popover,
 	SlotFillProvider,
 	Spinner,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import {
-	BlockEditorKeyboardShortcuts,
-	BlockEditorProvider,
-	BlockInspector,
-	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
-} from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useState } from '@wordpress/element';
+import {
+	InterfaceSkeleton,
+	ComplementaryArea,
+	store as interfaceStore,
+} from '@wordpress/interface';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -34,11 +34,21 @@ import {
 } from '../../hooks';
 import ErrorBoundary from '../error-boundary';
 import NavigationEditorShortcuts from './shortcuts';
+import Sidebar from './sidebar';
 import Header from '../header';
 import Notices from '../notices';
 import Editor from '../editor';
 import InspectorAdditions from '../inspector-additions';
 import { store as editNavigationStore } from '../../store';
+
+const interfaceLabels = {
+	/* translators: accessibility text for the navigation screen top bar landmark region. */
+	header: __( 'Navigation top bar' ),
+	/* translators: accessibility text for the navigation screen content landmark region. */
+	body: __( 'Menu blocks' ),
+	/* translators: accessibility text for the widgets screen settings landmark region. */
+	sidebar: __( 'Navigation settings' ),
+};
 
 export default function Layout( { blockEditorSettings } ) {
 	const canvasRef = useBlockSelectionClearer();
@@ -62,6 +72,12 @@ export default function Layout( { blockEditorSettings } ) {
 		navigationPost
 	);
 
+	const { hasSidebarEnabled } = useSelect( ( select ) => ( {
+		hasSidebarEnabled: !! select(
+			interfaceStore
+		).getActiveComplementaryArea( 'core/edit-navigation' ),
+	} ) );
+
 	useMenuNotifications( selectedMenuId );
 
 	const hasMenus = !! menus?.length;
@@ -73,13 +89,18 @@ export default function Layout( { blockEditorSettings } ) {
 				<DropZoneProvider>
 					<BlockEditorKeyboardShortcuts.Register />
 					<NavigationEditorShortcuts.Register />
-
+					<NavigationEditorShortcuts saveBlocks={ savePost } />
 					<Notices />
-
-					<div
-						className={ classnames( 'edit-navigation-layout', {
-							'has-block-inspector': isBlockEditorReady,
-						} ) }
+					<BlockEditorProvider
+						value={ blocks }
+						onInput={ onInput }
+						onChange={ onChange }
+						settings={ {
+							...blockEditorSettings,
+							templateLock: 'all',
+							hasFixedToolbar: true,
+						} }
+						useSubRegistry={ false }
 					>
 						<MenuIdContext.Provider value={ selectedMenuId }>
 							<IsMenuNameControlFocusedContext.Provider
@@ -91,57 +112,74 @@ export default function Layout( { blockEditorSettings } ) {
 									[ isMenuNameControlFocused ]
 								) }
 							>
-								<Header
-									isPending={ ! hasLoadedMenus }
-									menus={ menus }
-									selectedMenuId={ selectedMenuId }
-									onSelectMenu={ selectMenu }
-									navigationPost={ navigationPost }
+								<InterfaceSkeleton
+									labels={ interfaceLabels }
+									header={
+										<Header
+											isPending={ ! hasLoadedMenus }
+											menus={ menus }
+											selectedMenuId={ selectedMenuId }
+											onSelectMenu={ selectMenu }
+											navigationPost={ navigationPost }
+										/>
+									}
+									content={
+										<>
+											{ ! hasFinishedInitialLoad && (
+												<Spinner />
+											) }
+
+											{ hasFinishedInitialLoad &&
+												! hasMenus && <EmptyState /> }
+
+											{ isBlockEditorReady && (
+												<BlockEditorProvider
+													value={ blocks }
+													onInput={ onInput }
+													onChange={ onChange }
+													settings={ {
+														...blockEditorSettings,
+														templateLock: 'all',
+													} }
+													useSubRegistry={ false }
+												>
+													<BlockEditorKeyboardShortcuts />
+													<NavigationEditorShortcuts
+														saveBlocks={ savePost }
+													/>
+													<div
+														className="edit-navigation-layout__canvas"
+														ref={ canvasRef }
+													>
+														<Editor
+															isPending={
+																! hasLoadedMenus
+															}
+															blocks={ blocks }
+														/>
+													</div>
+													<InspectorAdditions
+														menuId={
+															selectedMenuId
+														}
+														onDeleteMenu={
+															deleteMenu
+														}
+													/>
+												</BlockEditorProvider>
+											) }
+										</>
+									}
+									sidebar={
+										hasSidebarEnabled && (
+											<ComplementaryArea.Slot scope="core/edit-navigation" />
+										)
+									}
 								/>
-
-								{ ! hasFinishedInitialLoad && <Spinner /> }
-
-								{ hasFinishedInitialLoad && ! hasMenus && (
-									<EmptyState />
-								) }
-
-								{ isBlockEditorReady && (
-									<BlockEditorProvider
-										value={ blocks }
-										onInput={ onInput }
-										onChange={ onChange }
-										settings={ {
-											...blockEditorSettings,
-											templateLock: 'all',
-										} }
-										useSubRegistry={ false }
-									>
-										<BlockEditorKeyboardShortcuts />
-										<NavigationEditorShortcuts
-											saveBlocks={ savePost }
-										/>
-										<div
-											className="edit-navigation-layout__canvas"
-											ref={ canvasRef }
-										>
-											<Editor
-												isPending={ ! hasLoadedMenus }
-												blocks={ blocks }
-											/>
-										</div>
-										<InspectorAdditions
-											menuId={ selectedMenuId }
-											onDeleteMenu={ deleteMenu }
-										/>
-										<BlockInspector
-											bubblesVirtually={ false }
-										/>
-									</BlockEditorProvider>
-								) }
+								<Sidebar />
 							</IsMenuNameControlFocusedContext.Provider>
 						</MenuIdContext.Provider>
-					</div>
-
+					</BlockEditorProvider>
 					<Popover.Slot />
 				</DropZoneProvider>
 			</SlotFillProvider>

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -57,7 +57,6 @@ const interfaceLabels = {
 };
 
 export default function Layout( { blockEditorSettings } ) {
-	const hasPermanentSidebar = useViewportMatch( 'medium' );
 	const contentAreaRef = useBlockSelectionClearer();
 	const [ isMenuNameControlFocused, setIsMenuNameControlFocused ] = useState(
 		false
@@ -92,6 +91,7 @@ export default function Layout( { blockEditorSettings } ) {
 
 	const hasMenus = !! menus?.length;
 	const isBlockEditorReady = !! ( hasMenus && navigationPost );
+	const hasPermanentSidebar = useViewportMatch( 'medium' ) && hasMenus;
 
 	return (
 		<ErrorBoundary>

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -12,6 +17,7 @@ import {
 	SlotFillProvider,
 	Spinner,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useState } from '@wordpress/element';
 import {
@@ -51,6 +57,7 @@ const interfaceLabels = {
 };
 
 export default function Layout( { blockEditorSettings } ) {
+	const hasPermanentSidebar = useViewportMatch( 'medium' );
 	const contentAreaRef = useBlockSelectionClearer();
 	const [ isMenuNameControlFocused, setIsMenuNameControlFocused ] = useState(
 		false
@@ -72,11 +79,14 @@ export default function Layout( { blockEditorSettings } ) {
 		navigationPost
 	);
 
-	const { hasSidebarEnabled } = useSelect( ( select ) => ( {
-		hasSidebarEnabled: !! select(
-			interfaceStore
-		).getActiveComplementaryArea( 'core/edit-navigation' ),
-	} ) );
+	const { hasSidebarEnabled } = useSelect(
+		( select ) => ( {
+			hasSidebarEnabled: !! select(
+				interfaceStore
+			).getActiveComplementaryArea( 'core/edit-navigation' ),
+		} ),
+		[]
+	);
 
 	useMenuNotifications( selectedMenuId );
 
@@ -112,7 +122,12 @@ export default function Layout( { blockEditorSettings } ) {
 								) }
 							>
 								<InterfaceSkeleton
-									className="edit-navigation-layout"
+									className={ classnames(
+										'edit-navigation-layout',
+										{
+											'has-permanent-sidebar': hasPermanentSidebar,
+										}
+									) }
 									labels={ interfaceLabels }
 									header={
 										<Header
@@ -156,12 +171,15 @@ export default function Layout( { blockEditorSettings } ) {
 										</>
 									}
 									sidebar={
-										hasSidebarEnabled && (
+										( hasPermanentSidebar ||
+											hasSidebarEnabled ) && (
 											<ComplementaryArea.Slot scope="core/edit-navigation" />
 										)
 									}
 								/>
-								<Sidebar />
+								<Sidebar
+									hasPermanentSidebar={ hasPermanentSidebar }
+								/>
 							</IsMenuNameControlFocusedContext.Provider>
 						</MenuIdContext.Provider>
 					</BlockEditorProvider>

--- a/packages/edit-navigation/src/components/layout/sidebar.js
+++ b/packages/edit-navigation/src/components/layout/sidebar.js
@@ -2,30 +2,57 @@
  * WordPress dependencies
  */
 import { BlockInspector } from '@wordpress/block-editor';
-import { Platform } from '@wordpress/element';
-import { ComplementaryArea } from '@wordpress/interface';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import {
+	ComplementaryArea,
+	store as interfaceStore,
+} from '@wordpress/interface';
 import { __ } from '@wordpress/i18n';
 import { cog } from '@wordpress/icons';
 
-const BLOCK_INSPECTOR_IDENTIFIER = 'edit-widgets/block-inspector';
+const BLOCK_INSPECTOR_SCOPE = 'core/edit-navigation';
+const BLOCK_INSPECTOR_IDENTIFIER = 'edit-navigation/block-inspector';
 
-const SIDEBAR_ACTIVE_BY_DEFAULT = Platform.select( {
-	web: true,
-	native: false,
-} );
+function useTogglePermanentSidebar( hasPermanentSidebar ) {
+	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
+		interfaceStore
+	);
 
-export default function Sidebar() {
+	useEffect( () => {
+		if ( hasPermanentSidebar ) {
+			enableComplementaryArea(
+				BLOCK_INSPECTOR_SCOPE,
+				BLOCK_INSPECTOR_IDENTIFIER
+			);
+		} else {
+			disableComplementaryArea(
+				BLOCK_INSPECTOR_SCOPE,
+				BLOCK_INSPECTOR_IDENTIFIER
+			);
+		}
+	}, [
+		hasPermanentSidebar,
+		enableComplementaryArea,
+		disableComplementaryArea,
+	] );
+}
+
+export default function Sidebar( { hasPermanentSidebar } ) {
+	useTogglePermanentSidebar( hasPermanentSidebar );
+
 	return (
 		<ComplementaryArea
 			className="edit-navigation-sidebar"
 			/* translators: button label text should, if possible, be under 16 characters. */
 			title={ __( 'Settings' ) }
 			closeLabel={ __( 'Close settings' ) }
-			scope="core/edit-navigation"
+			scope={ BLOCK_INSPECTOR_SCOPE }
 			identifier={ BLOCK_INSPECTOR_IDENTIFIER }
 			icon={ cog }
-			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
+			isActiveByDefault={ hasPermanentSidebar }
 			header={ <></> }
+			isPinnable={ ! hasPermanentSidebar }
 		>
 			<BlockInspector />
 		</ComplementaryArea>

--- a/packages/edit-navigation/src/components/layout/sidebar.js
+++ b/packages/edit-navigation/src/components/layout/sidebar.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockInspector } from '@wordpress/block-editor';
+import { Platform } from '@wordpress/element';
+import { ComplementaryArea } from '@wordpress/interface';
+import { __ } from '@wordpress/i18n';
+import { cog } from '@wordpress/icons';
+
+const BLOCK_INSPECTOR_IDENTIFIER = 'edit-widgets/block-inspector';
+
+const SIDEBAR_ACTIVE_BY_DEFAULT = Platform.select( {
+	web: true,
+	native: false,
+} );
+
+export default function Sidebar() {
+	return (
+		<ComplementaryArea
+			className="edit-navigation-sidebar"
+			/* translators: button label text should, if possible, be under 16 characters. */
+			title={ __( 'Settings' ) }
+			closeLabel={ __( 'Close settings' ) }
+			scope="core/edit-navigation"
+			identifier={ BLOCK_INSPECTOR_IDENTIFIER }
+			icon={ cog }
+			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
+			header={ <></> }
+		>
+			<BlockInspector />
+		</ComplementaryArea>
+	);
+}

--- a/packages/edit-navigation/src/components/layout/sidebar.js
+++ b/packages/edit-navigation/src/components/layout/sidebar.js
@@ -11,8 +11,13 @@ import {
 import { __ } from '@wordpress/i18n';
 import { cog } from '@wordpress/icons';
 
-const BLOCK_INSPECTOR_SCOPE = 'core/edit-navigation';
-const BLOCK_INSPECTOR_IDENTIFIER = 'edit-navigation/block-inspector';
+/**
+ * Internal dependencies
+ */
+import {
+	COMPLEMENTARY_AREA_SCOPE,
+	COMPLEMENTARY_AREA_ID,
+} from '../../constants';
 
 function useTogglePermanentSidebar( hasPermanentSidebar ) {
 	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
@@ -22,13 +27,13 @@ function useTogglePermanentSidebar( hasPermanentSidebar ) {
 	useEffect( () => {
 		if ( hasPermanentSidebar ) {
 			enableComplementaryArea(
-				BLOCK_INSPECTOR_SCOPE,
-				BLOCK_INSPECTOR_IDENTIFIER
+				COMPLEMENTARY_AREA_SCOPE,
+				COMPLEMENTARY_AREA_ID
 			);
 		} else {
 			disableComplementaryArea(
-				BLOCK_INSPECTOR_SCOPE,
-				BLOCK_INSPECTOR_IDENTIFIER
+				COMPLEMENTARY_AREA_SCOPE,
+				COMPLEMENTARY_AREA_ID
 			);
 		}
 	}, [
@@ -47,8 +52,8 @@ export default function Sidebar( { hasPermanentSidebar } ) {
 			/* translators: button label text should, if possible, be under 16 characters. */
 			title={ __( 'Settings' ) }
 			closeLabel={ __( 'Close settings' ) }
-			scope={ BLOCK_INSPECTOR_SCOPE }
-			identifier={ BLOCK_INSPECTOR_IDENTIFIER }
+			scope={ COMPLEMENTARY_AREA_SCOPE }
+			identifier={ COMPLEMENTARY_AREA_ID }
 			icon={ cog }
 			isActiveByDefault={ hasPermanentSidebar }
 			header={ <></> }

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -22,7 +22,7 @@
 }
 
 .edit-navigation-layout {
-	&.has-block-inspector {
+	&.has-permanent-sidebar {
 		margin-right: $sidebar-width;
 	}
 
@@ -38,6 +38,24 @@
 		// of the editing canvas needs to be full-height for block
 		// deselection to work.
 		flex-grow: 1;
+	}
+
+	// Force the sidebar to the right side of the screen on larger
+	// breakpoints.
+	&.has-permanent-sidebar .interface-interface-skeleton__sidebar {
+		width: $sidebar-width;
+		position: fixed !important;
+		top: $grid-unit-40;
+		right: 0;
+		bottom: 0;
+		left: auto;
+		z-index: 1;
+		overflow: auto;
+
+		// Hide the toggle as the sidebar should be permanently open.
+		.interface-complementary-area-header {
+			display: none;
+		}
 	}
 }
 

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -40,6 +40,10 @@
 		flex-grow: 1;
 	}
 
+	.interface-interface-skeleton__header {
+		border-bottom-color: transparent;
+	}
+
 	// Force the sidebar to the right side of the screen on larger
 	// breakpoints.
 	&.has-permanent-sidebar .interface-interface-skeleton__sidebar {

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -47,14 +47,11 @@
 	// Force the sidebar to the right side of the screen on larger
 	// breakpoints.
 	&.has-permanent-sidebar .interface-interface-skeleton__sidebar {
-		width: $sidebar-width;
 		position: fixed !important;
 		top: $grid-unit-40;
 		right: 0;
 		bottom: 0;
 		left: auto;
-		z-index: 1;
-		overflow: auto;
 
 		// Hide the toggle as the sidebar should be permanently open.
 		.interface-complementary-area-header {

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -30,7 +30,7 @@
 		margin: $navigation-editor-spacing-top auto 0;
 	}
 
-	.edit-navigation-layout__canvas {
+	.edit-navigation-layout__content-area {
 		// Provide space for the floating block toolbar.
 		padding-top: $navigation-editor-spacing-top;
 

--- a/packages/edit-navigation/src/constants/index.js
+++ b/packages/edit-navigation/src/constants/index.js
@@ -25,3 +25,17 @@ export const NAVIGATION_POST_KIND = 'root';
  * @type {string}
  */
 export const NAVIGATION_POST_POST_TYPE = 'postType';
+
+/**
+ * The scope name of the editor's complementary area.
+ *
+ * @type {string}
+ */
+export const COMPLEMENTARY_AREA_SCOPE = 'core/edit-navigation';
+
+/**
+ * The identifier of the editor's complementary area.
+ *
+ * @type {string}
+ */
+export const COMPLEMENTARY_AREA_ID = 'edit-navigation/block-inspector';

--- a/packages/edit-navigation/src/hooks/use-menu-entity.js
+++ b/packages/edit-navigation/src/hooks/use-menu-entity.js
@@ -5,7 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { MENU_KIND, MENU_POST_TYPE } from '../utils/constants';
+import { MENU_KIND, MENU_POST_TYPE } from '../constants';
 
 import { untitledMenu } from './index';
 

--- a/packages/edit-navigation/src/hooks/use-menu-notifications.js
+++ b/packages/edit-navigation/src/hooks/use-menu-notifications.js
@@ -7,7 +7,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import { MENU_POST_TYPE, MENU_KIND } from '../utils/constants';
+import { MENU_POST_TYPE, MENU_KIND } from '../constants';
 
 export default function useMenuNotifications( menuId ) {
 	const { lastSaveError, lastDeleteError } = useSelect(

--- a/packages/edit-navigation/src/hooks/use-navigation-block-editor.js
+++ b/packages/edit-navigation/src/hooks/use-navigation-block-editor.js
@@ -8,10 +8,7 @@ import { useEntityBlockEditor } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import {
-	NAVIGATION_POST_KIND,
-	NAVIGATION_POST_POST_TYPE,
-} from '../utils/constants';
+import { NAVIGATION_POST_KIND, NAVIGATION_POST_POST_TYPE } from '../constants';
 import { store as editNavigationStore } from '../store';
 
 export default function useNavigationBlockEditor( post ) {

--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -11,10 +11,7 @@ import { parse, createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import {
-	NAVIGATION_POST_KIND,
-	NAVIGATION_POST_POST_TYPE,
-} from '../utils/constants';
+import { NAVIGATION_POST_KIND, NAVIGATION_POST_POST_TYPE } from '../constants';
 import { resolveMenuItems, dispatch } from './controls';
 import { buildNavigationPostId } from './utils';
 

--- a/packages/edit-navigation/src/store/selectors.js
+++ b/packages/edit-navigation/src/store/selectors.js
@@ -11,10 +11,7 @@ import { createRegistrySelector } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import {
-	NAVIGATION_POST_KIND,
-	NAVIGATION_POST_POST_TYPE,
-} from '../utils/constants';
+import { NAVIGATION_POST_KIND, NAVIGATION_POST_POST_TYPE } from '../constants';
 
 import { buildNavigationPostId } from './utils';
 

--- a/packages/edit-navigation/src/store/test/resolvers.js
+++ b/packages/edit-navigation/src/store/test/resolvers.js
@@ -6,7 +6,7 @@ import { resolveMenuItems, dispatch } from '../controls';
 import {
 	NAVIGATION_POST_KIND,
 	NAVIGATION_POST_POST_TYPE,
-} from '../../utils/constants';
+} from '../../constants';
 
 import { buildNavigationPostId } from '../utils';
 

--- a/packages/edit-navigation/src/store/test/selectors.js
+++ b/packages/edit-navigation/src/store/test/selectors.js
@@ -9,7 +9,7 @@ import {
 import {
 	NAVIGATION_POST_KIND,
 	NAVIGATION_POST_POST_TYPE,
-} from '../../utils/constants';
+} from '../../constants';
 
 import { buildNavigationPostId } from '../utils';
 

--- a/packages/edit-navigation/src/style.scss
+++ b/packages/edit-navigation/src/style.scss
@@ -1,5 +1,5 @@
 $navigation-editor-width: 420px;
-$navigation-editor-spacing-top: $grid-unit-40 * 2;
+$navigation-editor-spacing-top: $grid-unit-50 * 2;
 
 *,
 *::before,

--- a/packages/edit-navigation/src/style.scss
+++ b/packages/edit-navigation/src/style.scss
@@ -8,6 +8,7 @@ $navigation-editor-spacing-top: $grid-unit-40 * 2;
 }
 
 @import "./components/add-menu/style.scss";
+@import "../../interface/src/style.scss";
 @import "./components/editor/style.scss";
 @import "./components/error-boundary/style.scss";
 @import "./components/header/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Progresses #29100

Implements the interface package in the navigation screen again. Most of this is lifted from the previous attempt at #28686.

I've gone a bit further this time though. For larger viewports there should be very little difference to `trunk`. A react effect and some styling fixes the sidebar to the side and makes it permanently open. Another styling tweak removes the header border that interface adds.

On mobile the experience is much improved, the editor area spans the full width and the sidebar is now toggleable:

https://user-images.githubusercontent.com/677833/111760742-0995ea80-88da-11eb-9fee-d0a03ba46e9f.mp4

There are still a few things to fix on mobile, but I'll push those to a later PR that enventually solves #29100.

## How has this been tested?
1. Test various aspects of the nav screen on mobile and desktop.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
