### PR TITLE
Fix persistence of Preferences in site editor

### DIFF
--- a/packages/edit-site/src/store/index.js
+++ b/packages/edit-site/src/store/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 
 /**
@@ -22,4 +22,6 @@ export const storeConfig = {
 
 export const store = createReduxStore( STORE_NAME, storeConfig );
 
-register( store );
+// Once we build a more generic persistence plugin that works across types of stores
+// we'd be able to replace this with a register call.
+registerStore( STORE_NAME, storeConfig );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/29386

The preferences `Top toolbar` and `Spotlight mode` were not persisted as the `edit-site` store was not using the Persistence plugin.

## Testing instructions
1. Go to the site editor
2. From Preferences select `Top toolbar` and then refresh.
3. In trunk it's not persisted and in this branch is.
