### PR TITLE
Fix edge case where the default layout could be undefined

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -194,7 +194,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 		const { name, attributes } = props;
 		const supportLayout = hasBlockSupport( name, '__experimentalLayout' );
 		const id = useInstanceId( BlockListBlock );
-		const defaultLayout = useEditorFeature( 'layout' );
+		const defaultLayout = useEditorFeature( 'layout' ) || {};
 		if ( ! supportLayout ) {
 			return <BlockListBlock { ...props } />;
 		}

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -25,7 +25,7 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 		},
 		[ clientId ]
 	);
-	const defaultLayout = useEditorFeature( 'layout' );
+	const defaultLayout = useEditorFeature( 'layout' ) || {};
 	const { tagName: TagName = 'div', templateLock, layout = {} } = attributes;
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { contentSize, wideSize } = usedLayout;

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -16,7 +16,7 @@ function Content( { layout, postType, postId } ) {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings()?.supportsLayout;
 	}, [] );
-	const defaultLayout = useEditorFeature( 'layout' );
+	const defaultLayout = useEditorFeature( 'layout' ) || {};
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { contentSize, wideSize } = usedLayout;
 	const alignments =


### PR DESCRIPTION
In theory this should never happen: having a block somewhere with "layout inherit true" and the default layout not defined because the option to inherit is only visible if the default layout is defined, that said, it doesn't hurt to add a fallback. 