### PR TITLE
Add possibility to position help text below the label of CheckboxControl component

### DIFF
--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -8,6 +8,7 @@ import { Icon, check } from '@wordpress/icons';
  * Internal dependencies
  */
 import BaseControl from '../base-control';
+import { StyledHelp } from '../base-control/styles/base-control-styles';
 
 export default function CheckboxControl( {
 	label,
@@ -15,6 +16,7 @@ export default function CheckboxControl( {
 	heading,
 	checked,
 	help,
+	helpPosition = 'left',
 	onChange,
 	...props
 } ) {
@@ -26,7 +28,7 @@ export default function CheckboxControl( {
 		<BaseControl
 			label={ heading }
 			id={ id }
-			help={ help }
+			help={ helpPosition === 'left' ? help : '' }
 			className={ className }
 		>
 			<span className="components-checkbox-control__input-container">
@@ -48,12 +50,22 @@ export default function CheckboxControl( {
 					/>
 				) : null }
 			</span>
-			<label
-				className="components-checkbox-control__label"
-				htmlFor={ id }
-			>
-				{ label }
-			</label>
+			<span className="components-checkbox-control__label-container">
+				<label
+					className="components-checkbox-control__label"
+					htmlFor={ id }
+				>
+					{ label }
+				</label>
+				{ helpPosition === 'center' && (
+					<StyledHelp
+						id={ id + '__help' }
+						className="components-base-control__help"
+					>
+						{ help }
+					</StyledHelp>
+				) }
+			</span>
 		</BaseControl>
 	);
 }

--- a/packages/components/src/checkbox-control/stories/index.js
+++ b/packages/components/src/checkbox-control/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { text } from '@storybook/addon-knobs';
+import { select, text } from '@storybook/addon-knobs';
 
 /**
  * WordPress dependencies
@@ -40,12 +40,21 @@ export const all = () => {
 	const heading = text( 'Heading', 'User' );
 	const label = text( 'Label', 'Is author' );
 	const help = text( 'Help', 'Is the user an author or not?' );
+	const helpPosition = select(
+		'align',
+		{
+			left: 'left',
+			center: 'center',
+		},
+		'center'
+	);
 
 	return (
 		<CheckboxControlWithState
 			heading={ heading }
 			label={ label }
 			help={ help }
+			helpPosition={ helpPosition }
 			checked
 		/>
 	);

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -78,3 +78,16 @@ svg.components-checkbox-control__checked {
 	user-select: none;
 	pointer-events: none;
 }
+
+.components-checkbox-control__label-container {
+	display: inline-block;
+}
+
+.components-checkbox-control__centered-help-text {
+	position: fixed;
+}
+
+.components-checkbox-control__label-container .components-base-control__help {
+	margin: 0;
+	position: fixed;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closes https://github.com/WordPress/gutenberg/issues/30023

Adds a property `helpPosition` to `CheckboxControl` allowing to change the place where `help` is rendered, allowing to display the text under the label (as it is proposed in a design for https://github.com/WordPress/gutenberg/pull/29458).

The property is set to `left` by default which means to render help text the same as it used to be.

Broken CheckboxControl header addressed in a separate PR https://github.com/WordPress/gutenberg/pull/30037

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

In order to test a component, please see `/story/components-checkboxcontrol--all` in the storybook

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/8398557/111794246-5243a880-88c6-11eb-9ff8-ed2396761140.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature added to the `CheckboxControl` component

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
