### PR TITLE
docgen: Fix arrow functions and TS index module support

### DIFF
--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -26,26 +26,24 @@ function getFunctionTypeAnnotation( typeAnnotation, returnIndicator ) {
 		)
 		.join( ', ' );
 
-	const {
-		argument: restParamArgument,
-		typeAnnotation: restParamTypeAnnotation,
-		// There's only every one rest param
-	} = typeAnnotation.parameters.find( babelTypes.isRestElement ) || {};
-	const restParam =
-		restParamArgument && restParamTypeAnnotation
-			? `, ...${ restParamArgument.name }: ${ getTypeAnnotation(
-					restParamTypeAnnotation.typeAnnotation
-			  ) }`
-			: '';
-
-	const params = `( ${ nonRestParams }${ restParam } )`;
+	let params = nonRestParams;
+	const restParam = typeAnnotation.parameters.find(
+		babelTypes.isRestElement
+	);
+	if ( restParam ) {
+		const paramName = restParam.argument.name;
+		const paramType = getTypeAnnotation(
+			restParam.typeAnnotation.typeAnnotation
+		);
+		params += `, ...${ paramName }: ${ paramType }`;
+	}
 
 	const returnType = getTypeAnnotation(
 		typeAnnotation.returnType ||
 			typeAnnotation.typeAnnotation.typeAnnotation
 	);
 
-	return `${ params }${ returnIndicator }${ returnType }`;
+	return `( ${ params } )${ returnIndicator }${ returnType }`;
 }
 
 /**

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -12,8 +12,8 @@ const { types: babelTypes } = require( '@babel/core' );
 /* eslint-enable jsdoc/valid-types */
 
 /**
- * @param {babelTypes.TSCallSignatureDeclaration | babelTypes.TSFunctionType} typeAnnotation
- * @param {' => ' | ': ' | null} returnIndicator The return indicator to use. Allows using the same function for function annotations and object call properties.
+ * @param {babelTypes.TSCallSignatureDeclaration | babelTypes.TSFunctionType | babelTypes.TSConstructSignatureDeclaration} typeAnnotation
+ * @param {' => ' | ': '} returnIndicator The return indicator to use. Allows using the same function for function annotations and object call properties.
  */
 function getFunctionTypeAnnotation( typeAnnotation, returnIndicator ) {
 	const nonRestParams = typeAnnotation.parameters
@@ -39,10 +39,6 @@ function getFunctionTypeAnnotation( typeAnnotation, returnIndicator ) {
 			: '';
 
 	const params = `( ${ nonRestParams }${ restParam } )`;
-
-	if ( returnIndicator === null ) {
-		return params;
-	}
 
 	const returnType = getTypeAnnotation(
 		typeAnnotation.returnType ||
@@ -277,7 +273,7 @@ function getTypeAnnotation( typeAnnotation ) {
 			return '';
 		}
 		case 'TSConstructorType': {
-			return `new ${ getFunctionTypeAnnotation( typeAnnotation, null ) }`;
+			return `new ${ getFunctionTypeAnnotation( typeAnnotation, ': ' ) }`;
 		}
 		case 'TSExpressionWithTypeArguments': {
 			// Unsure with this is

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -25,23 +25,20 @@ function getFunctionTypeAnnotation( typeAnnotation, returnIndicator ) {
 				) }`
 		)
 		.join( ', ' );
-	const restParam = typeAnnotation.parameters
-		.filter( ( p ) => babelTypes.isRestElement( p ) )
-		.map( ( p ) => {
-			if ( babelTypes.isIdentifier( p.argument ) ) {
-				return `...${ p.argument.name }: ${ getTypeAnnotation(
-					p.typeAnnotation.typeAnnotation
-				) }`;
-			}
 
-			// if it's not an identifier I'm not sure what we should do
-			return '';
-			// there's only ever one rest param
-		} )[ 0 ];
+	const {
+		argument: restParamArgument,
+		typeAnnotation: restParamTypeAnnotation,
+		// There's only every one rest param
+	} = typeAnnotation.parameters.find( babelTypes.isRestElement ) || {};
+	const restParam =
+		restParamArgument && restParamTypeAnnotation
+			? `, ...${ restParamArgument.name }: ${ getTypeAnnotation(
+					restParamTypeAnnotation.typeAnnotation
+			  ) }`
+			: '';
 
-	const params = `( ${ nonRestParams }${
-		restParam ? `, ${ restParam }` : ''
-	} )`;
+	const params = `( ${ nonRestParams }${ restParam } )`;
 
 	if ( returnIndicator === null ) {
 		return params;

--- a/packages/docgen/lib/index.js
+++ b/packages/docgen/lib/index.js
@@ -15,20 +15,25 @@ const isSymbolPrivate = require( './is-symbol-private' );
 /**
  * Helpers functions.
  */
-
+const extensions = [ '.js', '.ts', '.tsx' ];
 const relativeToAbsolute = ( basePath, relativePath ) => {
 	const target = path.join( path.dirname( basePath ), relativePath );
-	if ( path.extname( target ) === '.js' ) {
+	const extension = path.extname( target );
+	if ( extensions.includes( extension ) ) {
 		return target;
 	}
-	let targetFile = target + '.js';
-	if ( fs.existsSync( targetFile ) ) {
-		return targetFile;
+
+	for ( const ext of extensions ) {
+		let targetFile = target + ext;
+		if ( fs.existsSync( targetFile ) ) {
+			return targetFile;
+		}
+		targetFile = path.join( target, 'index' + ext );
+		if ( fs.existsSync( targetFile ) ) {
+			return targetFile;
+		}
 	}
-	targetFile = path.join( target, 'index.js' );
-	if ( fs.existsSync( targetFile ) ) {
-		return targetFile;
-	}
+
 	process.stderr.write( '\nRelative path does not exists.' );
 	process.stderr.write( '\n' );
 	process.stderr.write( `\nBase: ${ basePath }` );

--- a/packages/docgen/lib/index.js
+++ b/packages/docgen/lib/index.js
@@ -24,13 +24,13 @@ const relativeToAbsolute = ( basePath, relativePath ) => {
 	}
 
 	for ( const ext of extensions ) {
-		let targetFile = target + ext;
-		if ( fs.existsSync( targetFile ) ) {
-			return targetFile;
+		const targetFileWithExtension = target + ext;
+		if ( fs.existsSync( targetFileWithExtension ) ) {
+			return targetFileWithExtension;
 		}
-		targetFile = path.join( target, 'index' + ext );
-		if ( fs.existsSync( targetFile ) ) {
-			return targetFile;
+		const targetFileAsIndexModule = path.join( target, 'index' + ext );
+		if ( fs.existsSync( targetFileAsIndexModule ) ) {
+			return targetFileAsIndexModule;
 		}
 	}
 

--- a/packages/docgen/test/fixtures/type-annotations/arrow-function/example.ts
+++ b/packages/docgen/test/fixtures/type-annotations/arrow-function/example.ts
@@ -1,0 +1,3 @@
+export const fn = (
+	callback: ( foo: string, ...rest: any[] ) => GenericType< T >
+): void => {};

--- a/packages/docgen/test/fixtures/type-annotations/arrow-function/get-node.js
+++ b/packages/docgen/test/fixtures/type-annotations/arrow-function/get-node.js
@@ -1,0 +1,407 @@
+module.exports = () => ( {
+	type: 'ExportNamedDeclaration',
+	start: 0,
+	end: 97,
+	loc: {
+		start: {
+			line: 1,
+			column: 0,
+		},
+		end: {
+			line: 3,
+			column: 14,
+		},
+	},
+	exportKind: 'value',
+	specifiers: [],
+	source: null,
+	declaration: {
+		type: 'VariableDeclaration',
+		start: 7,
+		end: 97,
+		loc: {
+			start: {
+				line: 1,
+				column: 7,
+			},
+			end: {
+				line: 3,
+				column: 14,
+			},
+		},
+		declarations: [
+			{
+				type: 'VariableDeclarator',
+				start: 13,
+				end: 96,
+				loc: {
+					start: {
+						line: 1,
+						column: 13,
+					},
+					end: {
+						line: 3,
+						column: 13,
+					},
+				},
+				id: {
+					type: 'Identifier',
+					start: 13,
+					end: 15,
+					loc: {
+						start: {
+							line: 1,
+							column: 13,
+						},
+						end: {
+							line: 1,
+							column: 15,
+						},
+						identifierName: 'fn',
+					},
+					name: 'fn',
+				},
+				init: {
+					type: 'ArrowFunctionExpression',
+					start: 18,
+					end: 96,
+					loc: {
+						start: {
+							line: 1,
+							column: 18,
+						},
+						end: {
+							line: 3,
+							column: 13,
+						},
+					},
+					returnType: {
+						type: 'TSTypeAnnotation',
+						start: 84,
+						end: 90,
+						loc: {
+							start: {
+								line: 3,
+								column: 1,
+							},
+							end: {
+								line: 3,
+								column: 7,
+							},
+						},
+						typeAnnotation: {
+							type: 'TSVoidKeyword',
+							start: 86,
+							end: 90,
+							loc: {
+								start: {
+									line: 3,
+									column: 3,
+								},
+								end: {
+									line: 3,
+									column: 7,
+								},
+							},
+						},
+					},
+					id: null,
+					generator: false,
+					async: false,
+					params: [
+						{
+							type: 'Identifier',
+							start: 21,
+							end: 82,
+							loc: {
+								start: {
+									line: 2,
+									column: 1,
+								},
+								end: {
+									line: 2,
+									column: 62,
+								},
+								identifierName: 'callback',
+							},
+							name: 'callback',
+							typeAnnotation: {
+								type: 'TSTypeAnnotation',
+								start: 29,
+								end: 82,
+								loc: {
+									start: {
+										line: 2,
+										column: 9,
+									},
+									end: {
+										line: 2,
+										column: 62,
+									},
+								},
+								typeAnnotation: {
+									type: 'TSFunctionType',
+									start: 31,
+									end: 82,
+									loc: {
+										start: {
+											line: 2,
+											column: 11,
+										},
+										end: {
+											line: 2,
+											column: 62,
+										},
+									},
+									parameters: [
+										{
+											type: 'Identifier',
+											start: 33,
+											end: 44,
+											loc: {
+												start: {
+													line: 2,
+													column: 13,
+												},
+												end: {
+													line: 2,
+													column: 24,
+												},
+												identifierName: 'foo',
+											},
+											name: 'foo',
+											typeAnnotation: {
+												type: 'TSTypeAnnotation',
+												start: 36,
+												end: 44,
+												loc: {
+													start: {
+														line: 2,
+														column: 16,
+													},
+													end: {
+														line: 2,
+														column: 24,
+													},
+												},
+												typeAnnotation: {
+													type: 'TSStringKeyword',
+													start: 38,
+													end: 44,
+													loc: {
+														start: {
+															line: 2,
+															column: 18,
+														},
+														end: {
+															line: 2,
+															column: 24,
+														},
+													},
+												},
+											},
+										},
+										{
+											type: 'RestElement',
+											start: 46,
+											end: 60,
+											loc: {
+												start: {
+													line: 2,
+													column: 26,
+												},
+												end: {
+													line: 2,
+													column: 40,
+												},
+											},
+											argument: {
+												type: 'Identifier',
+												start: 49,
+												end: 53,
+												loc: {
+													start: {
+														line: 2,
+														column: 29,
+													},
+													end: {
+														line: 2,
+														column: 33,
+													},
+													identifierName: 'rest',
+												},
+												name: 'rest',
+											},
+											typeAnnotation: {
+												type: 'TSTypeAnnotation',
+												start: 53,
+												end: 60,
+												loc: {
+													start: {
+														line: 2,
+														column: 33,
+													},
+													end: {
+														line: 2,
+														column: 40,
+													},
+												},
+												typeAnnotation: {
+													type: 'TSArrayType',
+													start: 55,
+													end: 60,
+													loc: {
+														start: {
+															line: 2,
+															column: 35,
+														},
+														end: {
+															line: 2,
+															column: 40,
+														},
+													},
+													elementType: {
+														type: 'TSAnyKeyword',
+														start: 55,
+														end: 58,
+														loc: {
+															start: {
+																line: 2,
+																column: 35,
+															},
+															end: {
+																line: 2,
+																column: 38,
+															},
+														},
+													},
+												},
+											},
+										},
+									],
+									typeAnnotation: {
+										type: 'TSTypeAnnotation',
+										start: 63,
+										end: 82,
+										loc: {
+											start: {
+												line: 2,
+												column: 43,
+											},
+											end: {
+												line: 2,
+												column: 62,
+											},
+										},
+										typeAnnotation: {
+											type: 'TSTypeReference',
+											start: 66,
+											end: 82,
+											loc: {
+												start: {
+													line: 2,
+													column: 46,
+												},
+												end: {
+													line: 2,
+													column: 62,
+												},
+											},
+											typeName: {
+												type: 'Identifier',
+												start: 66,
+												end: 77,
+												loc: {
+													start: {
+														line: 2,
+														column: 46,
+													},
+													end: {
+														line: 2,
+														column: 57,
+													},
+													identifierName:
+														'GenericType',
+												},
+												name: 'GenericType',
+											},
+											typeParameters: {
+												type:
+													'TSTypeParameterInstantiation',
+												start: 77,
+												end: 82,
+												loc: {
+													start: {
+														line: 2,
+														column: 57,
+													},
+													end: {
+														line: 2,
+														column: 62,
+													},
+												},
+												params: [
+													{
+														type: 'TSTypeReference',
+														start: 79,
+														end: 80,
+														loc: {
+															start: {
+																line: 2,
+																column: 59,
+															},
+															end: {
+																line: 2,
+																column: 60,
+															},
+														},
+														typeName: {
+															type: 'Identifier',
+															start: 79,
+															end: 80,
+															loc: {
+																start: {
+																	line: 2,
+																	column: 59,
+																},
+																end: {
+																	line: 2,
+																	column: 60,
+																},
+																identifierName:
+																	'T',
+															},
+															name: 'T',
+														},
+													},
+												],
+											},
+										},
+									},
+								},
+							},
+						},
+					],
+					body: {
+						type: 'BlockStatement',
+						start: 94,
+						end: 96,
+						loc: {
+							start: {
+								line: 3,
+								column: 11,
+							},
+							end: {
+								line: 3,
+								column: 13,
+							},
+						},
+						body: [],
+						directives: [],
+					},
+				},
+			},
+		],
+		kind: 'const',
+	},
+} );

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -11,6 +11,7 @@ const getNamedExportNode = require( './fixtures/type-annotations/named-export/ge
 const getExportedVariableDeclarationNode = require( './fixtures/type-annotations/exported-variable-declaration/get-node' );
 const getImportsParameterizedRestOperatorPredicateIndexerTypeNode = require( './fixtures/type-annotations/imports-parameterized-rest-operator-predicate-indexers/get-node' );
 const getMissingTypesNode = require( './fixtures/type-annotations/missing-types/get-node' );
+const getArrowFunctionNode = require( './fixtures/type-annotations/arrow-function/get-node' );
 
 describe( 'Type annotations', () => {
 	it( 'are taken from JSDoc if any', () => {
@@ -203,6 +204,16 @@ describe( 'Type annotations', () => {
 			).toThrow(
 				"Could not find corresponding parameter token for documented parameter 'notFoo' in function 'fn'."
 			);
+		} );
+	} );
+
+	describe( 'arrow function parameters', () => {
+		const node = getArrowFunctionNode();
+
+		it( 'should correctly format the arrow function', () => {
+			expect(
+				getTypeAnnotation( { ...paramTag, name: 'callback' }, node )
+			).toBe( '( foo: string, ...rest: any[] ) => GenericType< T >' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes four bugs in docgen:
1. `docgen` was not able to detect `ts` or `tsx` files that were `index` modules in a folder. That is fixed in `index.js` by checking all three relevant extensions (tested in #30027)
2. `docgen` was unable to generate the correct types for `rest` params in functions
3. `getFunctionTypeAnnotation` was not being passed a return indicator for arrow functions and therefore rendering `undefined` for the return indicator. This is fixed by always passing the return indicator
4. `getFunctionTypeAnnotation` was being used to get the param list for a constructor type, it's now able to actually do this by passing `null` as the return indicator. This will cause the function to only return the param list.

## How has this been tested?
unit tests and the module detection was tested in #30027.

## Types of changes
Bug fixes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
