### PR TITLE
dom: Add types to `focusable`

### DIFF
--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -102,7 +102,7 @@ function mapElementToObjectTabbable( element, index ) {
  * An array map callback, returning an element of the given mapped object's
  * element value.
  *
- * @param {{ element: Element }} object Mapped object with index.
+ * @param {{ element: Element }} object Mapped object with element.
  *
  * @return {Element} Mapped object element.
  */

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -18,7 +18,7 @@ import { find as findFocusable } from './focusable';
  *
  * @param {Element} element Element from which to retrieve.
  *
- * @return {?number} Tab index of element (default 0).
+ * @return {number} Tab index of element (default 0).
  */
 function getTabIndex( element ) {
 	const tabIndex = element.getAttribute( 'tabindex' );
@@ -36,18 +36,24 @@ export function isTabbableIndex( element ) {
 	return getTabIndex( element ) !== -1;
 }
 
+/** @typedef {Element & { type?: string, checked?: boolean, name?: string }} MaybeHTMLInputElement */
+
 /**
  * Returns a stateful reducer function which constructs a filtered array of
  * tabbable elements, where at most one radio input is selected for a given
  * name, giving priority to checked input, falling back to the first
  * encountered.
  *
- * @return {Function} Radio group collapse reducer.
+ * @return {(acc: MaybeHTMLInputElement[], el: MaybeHTMLInputElement) => MaybeHTMLInputElement[]} Radio group collapse reducer.
  */
 function createStatefulCollapseRadioGroup() {
+	/** @type {Record<string, MaybeHTMLInputElement>} */
 	const CHOSEN_RADIO_BY_NAME = {};
 
-	return function collapseRadioGroup( result, element ) {
+	return function collapseRadioGroup(
+		/** @type {MaybeHTMLInputElement[]} */ result,
+		/** @type {MaybeHTMLInputElement} */ element
+	) {
 		const { nodeName, type, checked, name } = element;
 
 		// For all non-radio tabbables, construct to array by concatenating.
@@ -86,7 +92,7 @@ function createStatefulCollapseRadioGroup() {
  * @param {Element} element Element.
  * @param {number}  index   Array index of element.
  *
- * @return {Object} Mapped object with element, index.
+ * @return {{ element: Element, index: number }} Mapped object with element, index.
  */
 function mapElementToObjectTabbable( element, index ) {
 	return { element, index };
@@ -96,7 +102,7 @@ function mapElementToObjectTabbable( element, index ) {
  * An array map callback, returning an element of the given mapped object's
  * element value.
  *
- * @param {Object} object Mapped object with index.
+ * @param {{ element: Element }} object Mapped object with index.
  *
  * @return {Element} Mapped object element.
  */
@@ -109,8 +115,8 @@ function mapObjectTabbableToElement( object ) {
  *
  * @see mapElementToObjectTabbable
  *
- * @param {Object} a First object to compare.
- * @param {Object} b Second object to compare.
+ * @param {{ element: Element, index: number }} a First object to compare.
+ * @param {{ element: Element, index: number }} b Second object to compare.
  *
  * @return {number} Comparator result.
  */
@@ -128,9 +134,9 @@ function compareObjectTabbables( a, b ) {
 /**
  * Givin focusable elements, filters out tabbable element.
  *
- * @param {Array} focusables Focusable elements to filter.
+ * @param {Element[]} focusables Focusable elements to filter.
  *
- * @return {Array} Tabbable elements.
+ * @return {Element[]} Tabbable elements.
  */
 function filterTabbable( focusables ) {
 	return focusables
@@ -141,6 +147,10 @@ function filterTabbable( focusables ) {
 		.reduce( createStatefulCollapseRadioGroup(), [] );
 }
 
+/**
+ * @param {Element} context
+ * @return {Element[]} Tabbable elements within the context.
+ */
 export function find( context ) {
 	return filterTabbable( findFocusable( context ) );
 }

--- a/packages/dom/tsconfig.json
+++ b/packages/dom/tsconfig.json
@@ -7,5 +7,6 @@
 	"include": [
 		"src/data-transfer.js",
 		"src/focusable.js",
+		"src/tabbable.js",
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds types to `dom`'s `focusable` module. There are no runtime changes necessary.

## How has this been tested?
Type check passes

## Types of changes
New feature: types for focusable.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
