### PR TITLE
Expose Template part block variations to the Inserter

### DIFF
--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -11,6 +11,9 @@
 		},
 		"tagName": {
 			"type": "string"
+		},
+		"area": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -28,10 +28,11 @@ import { TemplatePartAdvancedControls } from './advanced-controls';
 import { getTagBasedOnArea } from './get-tag-based-on-area';
 
 export default function TemplatePartEdit( {
-	attributes: { slug, theme, tagName, layout = {} },
+	attributes,
 	setAttributes,
 	clientId,
 } ) {
+	const { slug, theme, tagName, layout = {} } = attributes;
 	const templatePartId = theme && slug ? theme + '//' + slug : null;
 
 	const [ hasAlreadyRendered, RecursionProvider ] = useNoRecursiveRenders(
@@ -116,6 +117,7 @@ export default function TemplatePartEdit( {
 			<TagName { ...blockProps }>
 				{ isPlaceholder && (
 					<TemplatePartPlaceholder
+						area={ attributes.area }
 						setAttributes={ setAttributes }
 						innerBlocks={ innerBlocks }
 					/>

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -15,26 +15,34 @@ import { store as coreStore } from '@wordpress/core-data';
 import TemplatePartSelection from '../selection';
 
 export default function TemplatePartPlaceholder( {
+	area,
 	setAttributes,
 	innerBlocks,
 } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const onCreate = useCallback( async () => {
 		const title = __( 'Untitled Template Part' );
+		const record = {
+			title,
+			slug: 'template-part',
+			content: serialize( innerBlocks ),
+		};
+		// If we have `area` set from block attributes, means an exposed
+		// block variation was inserted. So add this prop to the template
+		// part entity on creation. Afterwards remove `area` value from
+		// block attributes.
+		if ( [ 'header', 'footer' ].includes( area ) ) record.area = area;
 		const templatePart = await saveEntityRecord(
 			'postType',
 			'wp_template_part',
-			{
-				title,
-				slug: 'template-part',
-				content: serialize( innerBlocks ),
-			}
+			record
 		);
 		setAttributes( {
 			slug: templatePart.slug,
 			theme: templatePart.theme,
+			area: undefined,
 		} );
-	}, [ setAttributes ] );
+	}, [ setAttributes, area ] );
 
 	return (
 		<Placeholder

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -22,16 +22,18 @@ export default function TemplatePartPlaceholder( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const onCreate = useCallback( async () => {
 		const title = __( 'Untitled Template Part' );
-		const record = {
-			title,
-			slug: 'template-part',
-			content: serialize( innerBlocks ),
-		};
 		// If we have `area` set from block attributes, means an exposed
 		// block variation was inserted. So add this prop to the template
 		// part entity on creation. Afterwards remove `area` value from
 		// block attributes.
-		if ( [ 'header', 'footer' ].includes( area ) ) record.area = area;
+		const record = {
+			title,
+			slug: 'template-part',
+			content: serialize( innerBlocks ),
+			// `area` is filterable on the server and defaults to `UNCATEGORIZED`
+			// if provided value is not allowed.
+			area,
+		};
 		const templatePart = await saveEntityRecord(
 			'postType',
 			'wp_template_part',

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -49,7 +49,7 @@ function TemplatePartItem( {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const onClick = useCallback( () => {
-		setAttributes( { slug, theme } );
+		setAttributes( { slug, theme, area: undefined } );
 		createSuccessNotice(
 			sprintf(
 				/* translators: %s: template part title. */

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -6,20 +6,6 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
-const createIsActiveBasedOnArea = ( area ) => ( { theme, slug } ) => {
-	if ( ! slug ) {
-		return false;
-	}
-
-	const entity = select( coreDataStore ).getEntityRecord(
-		'postType',
-		'wp_template_part',
-		`${ theme }//${ slug }`
-	);
-
-	return entity?.area === area;
-};
-
 const variations = [
 	{
 		name: 'header',
@@ -28,7 +14,7 @@ const variations = [
 			"The header template defines a page area that typically contains a title, logo, and main navigation. Since it's a global element it can be present across all pages and posts."
 		),
 		icon: header,
-		isActive: createIsActiveBasedOnArea( 'header' ),
+		attributes: { area: 'header' },
 		scope: [ 'inserter' ],
 	},
 	{
@@ -38,9 +24,33 @@ const variations = [
 			"The footer template defines a page area that typically contains site credits, social links, or any other combination of blocks. Since it's a global element it can be present across all pages and posts."
 		),
 		icon: footer,
-		isActive: createIsActiveBasedOnArea( 'footer' ),
+		attributes: { area: 'footer' },
 		scope: [ 'inserter' ],
 	},
 ];
+
+/**
+ * Add `isActive` function to all `Template Part` variations, if not defined.
+ * `isActive` function is used to find a variation match from a created
+ *  Block by providing its attributes.
+ */
+variations.forEach( ( variation ) => {
+	if ( variation.isActive ) return;
+	variation.isActive = ( blockAttributes, variationAttributes ) => {
+		const { area, theme, slug } = blockAttributes;
+		// We first check the `area` block attribute which is set during insertion.
+		// This property is removed on the creation of a template part.
+		if ( area ) return area === variationAttributes.area;
+		// Find a matching variation from the created template part
+		// by checking the entity's `area` property.
+		if ( ! slug ) return false;
+		const entity = select( coreDataStore ).getEntityRecord(
+			'postType',
+			'wp_template_part',
+			`${ theme }//${ slug }`
+		);
+		return entity?.area === variationAttributes.area;
+	};
+} );
 
 export default variations;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related: https://github.com/WordPress/gutenberg/pull/30020

This PR exposes the `Template part` block variation to the Inserter. In order to do that I have created an `area` block attribute in Template Part which is taken into account in `isActive` function to find a matching block variation.

This new attribute is removed after the actual `save` of the Template part and is only used for the Placeholder/insertion part for various reasons like passing this value to the Template part entity, proper display information in BlockCard etc...

It is removed because the Template part block renders its own entity internally.  Any attributes on the outer block itself are just block attributes, and thus saved as part of the post it is a child of (template, page, etc).  The `area` term allows us to save that value with the template part post type.

In block variations `isActive` function first we check for `area` block attribute and if is not there it means that either we have selected the base `Template part` block or that it has been created so we try to find a matching block variation from the entity (post type).


## Testing instructions
1. You have to enable a block-based theme
2. Go to a page/post etc
3. Add a `Header` or `Footer` block from any Inserter (main, slash, etc..)
4. Observe that the proper information are show in all places (BlockCard, icons..)
5. Two scenarios here:
   1. Click `New template part` and observe in `Advanced settings` the `area`. Also that the proper information are shown.
   2. Click `Choose existing` and see that the `area` in `Advanced settings` comes from the existing template part.

In both cases before you click anything, you can see in the `code editor` that the `area` block attribute is set and after either action from the above, the `area` block attribute has been removed.

## Screenshots <!-- if applicable -->
![tplpvariations](https://user-images.githubusercontent.com/16275880/111807136-51694180-88db-11eb-9c85-0f2cb061d953.gif)

### Removal of the attribute
![removedAttribute](https://user-images.githubusercontent.com/16275880/111808042-482ca480-88dc-11eb-8a44-a585fcd9a5f0.gif)


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
