### PR TITLE
Block Supports: Allow skipping serialization of border

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -38,6 +38,16 @@ function gutenberg_register_border_support( $block_type ) {
  * @return array Border CSS classes and inline styles.
  */
 function gutenberg_apply_border_support( $block_type, $block_attributes ) {
+	$border_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), false );
+
+	if (
+		is_array( $border_support ) &&
+		array_key_exists( '__experimentalSkipSerialization', $border_support ) &&
+		$border_support['__experimentalSkipSerialization']
+	) {
+		return array();
+	}
+
 	// Arrays used to ease addition of further border related features in future.
 	$styles = array();
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -128,6 +128,10 @@ export function addSaveProps( props, blockType, attributes ) {
 
 	const { style } = attributes;
 	const filteredStyle = omitKeysNotToSerialize( style, {
+		[ BORDER_SUPPORT_KEY ]: getBlockSupport(
+			blockType,
+			BORDER_SUPPORT_KEY
+		),
 		[ COLOR_SUPPORT_KEY ]: getBlockSupport( blockType, COLOR_SUPPORT_KEY ),
 	} );
 	props.style = {

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -128,10 +128,7 @@ export function addSaveProps( props, blockType, attributes ) {
 
 	const { style } = attributes;
 	const filteredStyle = omitKeysNotToSerialize( style, {
-		'border': getBlockSupport(
-			blockType,
-			BORDER_SUPPORT_KEY
-		),
+		border: getBlockSupport( blockType, BORDER_SUPPORT_KEY ),
 		[ COLOR_SUPPORT_KEY ]: getBlockSupport( blockType, COLOR_SUPPORT_KEY ),
 	} );
 	props.style = {

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -128,7 +128,7 @@ export function addSaveProps( props, blockType, attributes ) {
 
 	const { style } = attributes;
 	const filteredStyle = omitKeysNotToSerialize( style, {
-		[ BORDER_SUPPORT_KEY ]: getBlockSupport(
+		'border': getBlockSupport(
 			blockType,
 			BORDER_SUPPORT_KEY
 		),


### PR DESCRIPTION
## Description
Part of #28913. Counterpart to #29142 and #29253.

Find affected blocks by grepping `__experimentalBorder` in `block.json` files. This yields the

- Group and
- Image

blocks.

## How has this been tested?

TBD. ~I don't even see the border radius panel for the Group and Image on `trunk`.~ _Edit:_ I just noticed instructions over at https://github.com/WordPress/gutenberg/pull/27667, will try those on Monday.

Anyway, this will need adding `"__experimentalSkipSerialization": true` to the `__experimentalBorder` object in the `block.json` files of the Group and Image blocks:

```diff
diff --git a/packages/block-library/src/group/block.json b/packages/block-library/src/group/block.json
index ad4cc62fc6..e8f3303669 100644
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -26,7 +26,8 @@
                        "color": true,
                        "radius": true,
                        "style": true,
-                       "width": true
+                       "width": true,
+                       "__experimentalSkipSerialization": true
                },
                "__experimentalLayout": true
        },
diff --git a/packages/block-library/src/image/block.json b/packages/block-library/src/image/block.json
index 3952230ded..b664e22593 100644
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -73,7 +73,8 @@
        "supports": {
                "anchor": true,
                "__experimentalBorder": {
-                       "radius": true
+                       "radius": true,
+                       "__experimentalSkipSerialization": true
                }
        },
        "editorStyle": "wp-block-image-editor",

```

## Screenshots

TBD


