### PR TITLE
add left margin to checkbox so the header is no longer overlapping it

### DIFF
--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -8,6 +8,10 @@ import { Icon, check } from '@wordpress/icons';
  * Internal dependencies
  */
 import BaseControl from '../base-control';
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
 
 export default function CheckboxControl( {
 	label,
@@ -27,7 +31,10 @@ export default function CheckboxControl( {
 			label={ heading }
 			id={ id }
 			help={ help }
-			className={ className }
+			className={ classnames(
+				'components-checkbox-control__header',
+				className
+			) }
 		>
 			<span className="components-checkbox-control__input-container">
 				<input

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -51,7 +51,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 .components-checkbox-control__input-container {
 	position: relative;
 	display: inline-block;
-	margin-right: 12px;
+	margin: 0 12px;
 	vertical-align: middle;
 	width: $checkbox-input-size-sm;
 	height: $checkbox-input-size-sm;

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -1,6 +1,11 @@
 $checkbox-input-size: 20px;
 $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 
+
+.components-checkbox-control__header .components-base-control__label {
+	margin-right: 12px;
+}
+
 .components-checkbox-control__input[type="checkbox"] {
 	@include checkbox-control;
 	background: $white;
@@ -51,7 +56,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 .components-checkbox-control__input-container {
 	position: relative;
 	display: inline-block;
-	margin: 0 12px;
+	margin-right: 12px;
 	vertical-align: middle;
 	width: $checkbox-input-size-sm;
 	height: $checkbox-input-size-sm;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closes https://github.com/WordPress/gutenberg/issues/30036

Fixes the behavior of CheckboxControl header which was too close to the checkbox
![image](https://user-images.githubusercontent.com/8398557/111813947-2b8f6d00-88da-11eb-8830-bcdf9dc0d223.png)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to storybook
2. Select checkbox control component `/story/components-checkboxcontrol--all`
3. Select `All` to display the heading
![image](https://user-images.githubusercontent.com/8398557/111813183-28e04800-88d9-11eb-94ea-bc9304c83f02.png)
4. see the heading is not overlapping the label
## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/8398557/111813859-0c90db00-88da-11eb-9521-dfe57126926f.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
