### PR TITLE
Fix paragraph margin specificity inside layout containers

### DIFF
--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -18,7 +18,7 @@ function appendSelectors( selectors, append ) {
 		.split( ',' )
 		.map(
 			( subselector ) =>
-				'.editor-styles-wrapper ' + subselector + ' ' + append
+				`.editor-styles-wrapper ${ subselector } ${ append }`
 		)
 		.join( ',' );
 }

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -8,9 +8,18 @@ export const defaultLayout = { type: 'default' };
 const Layout = createContext( defaultLayout );
 
 function appendSelectors( selectors, append ) {
+	// Ideally we shouldn't need the `.editor-styles-wrapper` increased specificity here
+	// The problem though is that we have a `.editor-styles-wrapper p { margin: reset; }` style
+	// it's used to reset the default margin added by wp-admin to paragraphs
+	// so we need this to be higher speficity otherwise, it won't be applied to paragraphs inside containers
+	// When the post editor is fully iframed, this extra classname could be removed.
+
 	return selectors
 		.split( ',' )
-		.map( ( subselector ) => subselector + ' ' + append )
+		.map(
+			( subselector ) =>
+				'.editor-styles-wrapper ' + subselector + ' ' + append
+		)
 		.join( ',' );
 }
 


### PR DESCRIPTION
Fix a small bug with paragraphs inside container blocks with layouts. (See the comment in the code for more details)