### PR TITLE
 Fix to  text color picker

### DIFF
--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -397,6 +397,9 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
+		// Dismiss color picker popover
+		await page.keyboard.press( 'Escape' );
+
 		// Navigate to the block.
 		await page.keyboard.press( 'Tab' );
 		await pressKeyWithModifier( 'primary', 'a' );

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -87,9 +87,7 @@ function TextColorEdit( {
 					onClose={ disableIsAddingColor }
 					activeAttributes={ activeAttributes }
 					value={ value }
-					onChange={ ( ...args ) => {
-						onChange( ...args );
-					} }
+					onChange={ onChange }
 					contentRef={ contentRef }
 				/>
 			) }

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -89,7 +89,6 @@ function TextColorEdit( {
 					value={ value }
 					onChange={ ( ...args ) => {
 						onChange( ...args );
-						disableIsAddingColor();
 					} }
 					contentRef={ contentRef }
 				/>


### PR DESCRIPTION
Hello ) this is a fix to "From WordPress 5.7, the cursor of the custom color picker cannot be moved" #29848 issue