### PR TITLE
Fix: Kind attribute missing subtitle value in video text track

### DIFF
--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -145,9 +145,6 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 					value={ kind }
 					label={ __( 'Kind' ) }
 					onChange={ ( newKind ) => {
-						if ( newKind === DEFAULT_KIND ) {
-							newKind = undefined;
-						}
 						onChange( {
 							...track,
 							kind: newKind,
@@ -166,6 +163,10 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 							}
 							if ( srcLang === '' ) {
 								changes.srcLang = 'en';
+								hasChanges = true;
+							}
+							if ( track.kind === undefined ) {
+								changes.kind = DEFAULT_KIND;
 								hasChanges = true;
 							}
 							if ( hasChanges ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
In video text track, kind attribute takes any value in Gutenberg editor.
When the block is rendered, it shows the selected kind attribute. But in case of `subtitles`, same doesn't happen. It doesn't show the kind attribute.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/41870839/111827376-d66e4e00-890f-11eb-8bd2-6801498e4e58.png)
![image](https://user-images.githubusercontent.com/41870839/111827312-bf2f6080-890f-11eb-9a6a-af36ed2fe971.png)


After:
![image](https://user-images.githubusercontent.com/41870839/111827386-d8d0a800-890f-11eb-8825-dc28d1be2b07.png)
![image](https://user-images.githubusercontent.com/41870839/111827174-9c04b100-890f-11eb-95ed-a21f3cabf62a.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
fixes #26673 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

cc @annezazu @paaljoachim 