### PR TITLE
Navigation Block: Fix Anchor Support

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -30,6 +30,9 @@
 		"showSubmenuIcon": {
 			"type": "boolean",
 			"default": true
+		},
+		"anchor": {
+			"type": "string"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -141,16 +141,20 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';
 
-	$wrapper_attributes = get_block_wrapper_attributes(
-		array(
-			'class' => implode( ' ', $classes ),
-			'style' => $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'],
-		)
+	$wrapper_attributes = array(
+		'class' => implode( ' ', $classes ),
+		'style' => $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'],
 	);
+
+	if ( ! empty( $attributes['anchor'] ) ) {
+		$wrapper_attributes['id'] = $attributes['anchor'];
+	}
+
+	$rendered_wrapper_attributes = get_block_wrapper_attributes( $wrapper_attributes );
 
 	return sprintf(
 		'<nav %1$s><ul class="wp-block-navigation__container">%2$s</ul></nav>',
-		$wrapper_attributes,
+		$rendered_wrapper_attributes,
 		$inner_blocks_html
 	);
 }


### PR DESCRIPTION
Closes #29401

Adds support for the anchor element in the Navigation block. It was not rendering and was being lost on save due to it being a dynamic block. Adding the `anchor` attribute explicitly fixed the saving issue, and adding it to the render callback fixed the markup.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested with and without an anchor element to ensure that the `id` attribute is only set if there is one.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
