### PR TITLE
wp-env.json: Bump tt1-blocks dependency to v0.4.5

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,7 +3,7 @@
 	"plugins": [
 		"."
 	],
-	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.3" ],
+	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.4" ],
 	"env": {
 		"tests": {
 			"mappings": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,7 +3,7 @@
 	"plugins": [
 		"."
 	],
-	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.4" ],
+	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.5" ],
 	"env": {
 		"tests": {
 			"mappings": {

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -77,8 +77,7 @@ describe( 'Document Settings', () => {
 			// Navigate to a template part
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
-			// TODO: Change General to Headers once TT1 blocks categorise the template parts
-			await navigationPanel.navigate( [ 'Template Parts', 'General' ] );
+			await navigationPanel.navigate( [ 'Template Parts', 'Headers' ] );
 			await navigationPanel.clickItemByText( 'header' );
 
 			// Evaluate the document settings title

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -149,8 +149,7 @@ describe( 'Multi-entity editor states', () => {
 
 	it( 'should not dirty an entity by switching to it in the template dropdown', async () => {
 		await siteEditor.visit();
-		// TODO: Change General to Headers once TT1 blocks categorise the template parts
-		await clickTemplateItem( [ 'Template Parts', 'General' ], 'header' );
+		await clickTemplateItem( [ 'Template Parts', 'Headers' ], 'header' );
 		await page.waitForFunction( () =>
 			Array.from( window.frames ).find(
 				( { name } ) => name === 'editor-canvas'

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -42,8 +42,7 @@ describe( 'Template Part', () => {
 			// Switch to editing the header template part.
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
-			// TODO: Change General to Headers once TT1 blocks categorise the template parts
-			await navigationPanel.navigate( [ 'Template Parts', 'General' ] );
+			await navigationPanel.navigate( [ 'Template Parts', 'Headers' ] );
 			await navigationPanel.clickItemByText( 'header' );
 		}
 

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -213,8 +213,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $template->status );
 		$this->assertEquals( 'theme', $template->source );
 		$this->assertEquals( 'wp_template_part', $template->type );
-		// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part area info.
-		$this->assertEquals( WP_TEMPLATE_PART_AREA_UNCATEGORIZED, $template->area );
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_HEADER, $template->area );
 	}
 
 	/**

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -275,8 +275,13 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		// Filter template part by area.
 		$templates    = gutenberg_get_block_templates( array( 'area' => WP_TEMPLATE_PART_AREA_HEADER ), 'wp_template_part' );
 		$template_ids = get_template_ids( $templates );
-		// TODO - update following array result once tt1-blocks theme.json is updated for area info.
-		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template_part' ), $template_ids );
+		$this->assertEquals(
+			array(
+				get_stylesheet() . '//' . 'my_template_part',
+				get_stylesheet() . '//' . 'header',
+			),
+			$template_ids
+		);
 	}
 
 	/**

--- a/phpunit/class-wp-rest-template-controller-test.php
+++ b/phpunit/class-wp-rest-template-controller-test.php
@@ -98,8 +98,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'source'         => 'theme',
 				'type'           => 'wp_template_part',
 				'wp_id'          => null,
-				// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part area info.
-				'area'           => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
+				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
@@ -153,8 +152,7 @@ class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase 
 				'source'         => 'theme',
 				'type'           => 'wp_template_part',
 				'wp_id'          => null,
-				// TODO - update 'UNCATEGORIZED' to 'HEADER' once tt1-blocks theme.json updated for template part area info.
-				'area'           => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
+				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
 			),
 			$data


### PR DESCRIPTION
## Description
As of #28741, we've been pinning the version of the Twenty Twenty One Blocks theme (`tt1-blocks`) used by Gutenberg to a fixed version, in order to prevent breakage of e2e tests by changes to that theme, as previously seen with https://github.com/WordPress/gutenberg/pull/28638.

The version we pinned `tt1-blocks` to was `0.4.3`. A new version -- ~`0.4.4`~ `0.4.5` -- has now been tagged, so let's try to update Gutenberg to use that.

## How has this been tested?
Verify that tests (unit and e2e) are passing (see cI). Some additional smoke testing (especially of the Site Editor) is also recommended.