### PR TITLE
wp-env: Fix chown cannot access 'wp-config.php'

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -257,8 +257,8 @@ module.exports = function buildDockerComposeConfig( config ) {
 			},
 		},
 		volumes: {
-			...( ! config.coreSource && { wordpress: {} } ),
-			...( ! config.coreSource && { 'tests-wordpress': {} } ),
+			...( ! config.env.development.coreSource && { wordpress: {} } ),
+			...( ! config.env.tests.coreSource && { 'tests-wordpress': {} } ),
 			mysql: {},
 			'mysql-test': {},
 			'phpunit-uploads': {},

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -23,8 +23,6 @@ const initConfig = require( '../init-config' );
 const downloadSources = require( '../download-sources' );
 const {
 	checkDatabaseConnection,
-	makeContentDirectoriesWritable,
-	makeConfigWritable,
 	configureWordPress,
 	setupWordPressDirectories,
 } = require( '../wordpress' );
@@ -141,22 +139,9 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 			: [],
 	} );
 
-	await Promise.all( [
-		makeConfigWritable( 'development', config ),
-		makeConfigWritable( 'tests', config ),
-	] );
-
 	// Only run WordPress install/configuration when config has changed.
 	if ( shouldConfigureWp ) {
 		spinner.text = 'Configuring WordPress.';
-
-		if ( config.coreSource === null ) {
-			// Don't chown wp-content when it exists on the user's local filesystem.
-			await Promise.all( [
-				makeContentDirectoriesWritable( 'development', config ),
-				makeContentDirectoriesWritable( 'tests', config ),
-			] );
-		}
 
 		try {
 			await checkDatabaseConnection( config );

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -19,7 +19,8 @@ const buildDockerComposeConfig = require( './build-docker-compose-config' );
 
 /**
  * Initializes the local environment so that Docker commands can be run. Reads
- * ./.wp-env.json, creates ~/.wp-env, and creates ~/.wp-env/docker-compose.yml.
+ * ./.wp-env.json, creates ~/.wp-env, ~/.wp-env/docker-compose.yml, and
+ * ~/.wp-env/Dockerfile.
  *
  * @param {Object}  options
  * @param {Object}  options.spinner      A CLI spinner which indicates progress.

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -19,56 +19,6 @@ const copyDir = util.promisify( require( 'copy-dir' ) );
  */
 
 /**
- * Makes the WordPress content directories (wp-content, wp-content/plugins,
- * wp-content/themes) owned by the www-data user. This ensures that WordPress
- * can write to these directories.
- *
- * This is necessary when running wp-env with `"core": null` because Docker
- * will automatically create these directories as the root user when binding
- * volumes during `docker-compose up`, and `docker-compose up` doesn't support
- * the `-u` option.
- *
- * See https://github.com/docker-library/wordpress/issues/436.
- *
- * @param {WPEnvironment} environment The environment to check. Either 'development' or 'tests'.
- * @param {WPConfig}      config      The wp-env config object.
- */
-async function makeContentDirectoriesWritable(
-	environment,
-	{ dockerComposeConfigPath, debug }
-) {
-	await dockerCompose.exec(
-		environment === 'development' ? 'wordpress' : 'tests-wordpress',
-		'chown www-data:www-data wp-content wp-content/plugins wp-content/themes',
-		{
-			config: dockerComposeConfigPath,
-			log: debug,
-		}
-	);
-}
-
-/**
- * Makes wp-config.php owned by www-data so that WordPress can work with the
- * file.
- *
- * @param {WPEnvironment} environment The environment to check. Either 'development' or 'tests'.
- * @param {WPConfig}      config      The wp-env config object.
- */
-async function makeConfigWritable(
-	environment,
-	{ dockerComposeConfigPath, debug }
-) {
-	await dockerCompose.exec(
-		environment === 'development' ? 'wordpress' : 'tests-wordpress',
-		'chown www-data:www-data wp-config.php',
-		{
-			config: dockerComposeConfigPath,
-			log: debug,
-		}
-	);
-}
-
-/**
  * Checks a WordPress database connection. An error is thrown if the test is
  * unsuccessful.
  *
@@ -280,8 +230,6 @@ async function copyCoreFiles( fromPath, toPath ) {
 
 module.exports = {
 	hasSameCoreSource,
-	makeContentDirectoriesWritable,
-	makeConfigWritable,
 	checkDatabaseConnection,
 	configureWordPress,
 	resetDatabase,

--- a/packages/env/test/build-docker-compose-config.js
+++ b/packages/env/test/build-docker-compose-config.js
@@ -115,4 +115,35 @@ describe( 'buildDockerComposeConfig', () => {
 			expectedVolumes
 		);
 	} );
+
+	it( 'should create "wordpress" and "tests-wordpress" volumes if they are needed by containers', () => {
+		// CONFIG has no coreSource entry, so there are no core sources on the
+		// local filesystem, so a volume should be created to contain core
+		// sources.
+		const dockerConfig = buildDockerComposeConfig( {
+			env: { development: CONFIG, tests: CONFIG },
+		} );
+
+		expect( dockerConfig.volumes.wordpress ).not.toBe( undefined );
+		expect( dockerConfig.volumes[ 'tests-wordpress' ] ).not.toBe(
+			undefined
+		);
+	} );
+
+	it( 'should NOT create "wordpress" and "tests-wordpress" volumes if they are not needed by containers', () => {
+		const envConfig = {
+			...CONFIG,
+			coreSource: {
+				path: '/some/random/path',
+				local: true,
+			},
+		};
+
+		const dockerConfig = buildDockerComposeConfig( {
+			env: { development: envConfig, tests: envConfig },
+		} );
+
+		expect( dockerConfig.volumes.wordpress ).toBe( undefined );
+		expect( dockerConfig.volumes[ 'tests-wordpress' ] ).toBe( undefined );
+	} );
 } );


### PR DESCRIPTION
## Description

**IMPORTANT**: Do not merge this until https://github.com/docker-library/wordpress/pull/587 gets pushed to Docker Hub. **Update**: The change has been pushed to Docker Hub and this PR is safe to merge. 

This PR fixes #29814. We used to manually run `chown` on `wp-config.php` because Docker Hub Wordpress image would create it with root being the owner, which means we can't access `wp-config.php` with wp cli and that caused problems. The problem with this manual solution was that there was a race condition: After containers start, the files are not actually ready, and if we run `chown` before files are copied, the issue #29814 happens.

Since the permission problem is now solved at the root, in the Docker Hub image in the aforementioned PR, there's no longer any need for manually doing `chown`, so this PR removes that.

## How is this tested

EDIT: Now that the Docker Hub image has been updated, this PR can be tested by simply getting it locally and trying `wp-env start`

I manually built the WordPress image from the aforementioned PR https://github.com/docker-library/wordpress/pull/587 and used this PR for `wp-env`. If you want to test the same way, it will be necessary to change `FROM` in the Dockerfile to the image that you manually build, that is here:

https://github.com/WordPress/gutenberg/blob/8a43a9091911ea2ea78a156a5c486108364f3bed/packages/env/lib/init-config.js#L106-L108
