### PR TITLE
Fix the alignment of the block format toolbar autocomplete 

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -60,6 +60,9 @@ function BlockPopover( {
 	capturingClientId,
 } ) {
 	const {
+		switchToolBar
+	} = useDispatch( blockEditorStore );
+	const {
 		isNavigationMode,
 		isMultiSelecting,
 		isTyping,
@@ -109,6 +112,7 @@ function BlockPopover( {
 		if ( ! shouldShowContextualToolbar ) {
 			setIsToolbarForced( false );
 		}
+		switchToolBar()
 	}, [ shouldShowContextualToolbar ] );
 
 	// Stores the active toolbar item index so the block toolbar can return focus
@@ -322,7 +326,6 @@ export default function WrappedBlockPopover() {
 	if ( ! name ) {
 		return null;
 	}
-
 	return (
 		<BlockPopover
 			clientId={ clientId }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1058,6 +1058,12 @@ export function selectionChange(
 	};
 }
 
+export function switchToolBar() {
+	return {
+		type: 'TOOL_BAR_SWITCH',
+	};
+}
+
 /**
  * Returns an action object used in signalling that a new block of the default
  * type should be added to the block list.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1706,8 +1706,18 @@ export function automaticChangeStatus( state, action ) {
  *
  * @return {string} Updated state.
  */
-export function highlightedBlock( state, action ) {
+export function highlightedBlock( state={toolBarActive:false}, action ) {
 	switch ( action.type ) {
+		case 'TOOL_BAR_SWITCH':
+			if ('toolBarActive' in state){
+				state.toolBarActive = ! state.toolBarActive;
+			} else {
+				state.toolBarActive = false
+			}
+			
+			return state;
+
+		break;
 		case 'TOGGLE_BLOCK_HIGHLIGHT':
 			const { clientId, isHighlighted } = action;
 
@@ -1722,6 +1732,7 @@ export function highlightedBlock( state, action ) {
 			if ( action.clientId !== state ) {
 				return null;
 			}
+
 	}
 
 	return state;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1993,6 +1993,10 @@ export function isNavigationMode( state ) {
 	return state.isNavigationMode;
 }
 
+export function isToolBarActive( state ) {
+	return state.toolBarActive;
+}
+
 /**
  * Returns whether block moving mode is enabled.
  *

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -20,7 +20,8 @@ import {
 	useMergeRefs,
 } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
-
+import { useSelect } from '@wordpress/data';
+//import store ??
 /**
  * Internal dependencies
  */
@@ -261,6 +262,21 @@ const Popover = ( {
 	const isExpanded = expandOnMobile && isMobileViewport;
 	const [ containerResizeListener, contentSize ] = useResizeObserver();
 	noArrow = isExpanded || noArrow;
+
+/* 	function selector( select ) {
+		const {
+			x,
+		} = select( store );
+		return {
+			x: isToolBarActive(),
+		};
+	}
+
+	let {
+		x,
+	} = useSelect( selector, [] );
+	x = x || 12
+	console.log(x); */
 
 	useLayoutEffect( () => {
 		if ( isExpanded ) {
@@ -594,7 +610,9 @@ const Popover = ( {
 					/>
 				</div>
 			) }
-			<div ref={ contentRef } className="components-popover__content">
+			<div ref={ contentRef } className="components-popover__content"
+			// margin-left : 300px on tool bar showed
+			>
 				<div style={ { position: 'relative' } }>
 					{ containerResizeListener }
 					{ children }

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -263,21 +263,6 @@ const Popover = ( {
 	const [ containerResizeListener, contentSize ] = useResizeObserver();
 	noArrow = isExpanded || noArrow;
 
-/* 	function selector( select ) {
-		const {
-			x,
-		} = select( store );
-		return {
-			x: isToolBarActive(),
-		};
-	}
-
-	let {
-		x,
-	} = useSelect( selector, [] );
-	x = x || 12
-	console.log(x); */
-
 	useLayoutEffect( () => {
 		if ( isExpanded ) {
 			setClass( containerRef.current, 'is-without-arrow', noArrow );


### PR DESCRIPTION
Hello ) when tool bar is active or closed I change the state of the reducer  , but how I can get state from store in gutenberg/packages/components/src/popover/index.js file , in which I can dynamical set the margin-left to 300px , that fixes the  #23715 issue ?