### PR TITLE
Docs: Remove superfluous sentence in create block tutorial

### DIFF
--- a/docs/getting-started/tutorials/create-block/block-anatomy.md
+++ b/docs/getting-started/tutorials/create-block/block-anatomy.md
@@ -41,7 +41,7 @@ The **title** is the title of the block shown in the Inserter.
 
 The **icon** is the icon shown in the Inserter. The icon property expects any Dashicon name as a string, see [list of available icons](https://developer.wordpress.org/resource/dashicons/). You can also provide an SVG object, but for now it's easiest to just pick a Dashicon name.
 
-The **category** specified is a string and must be one of: "common, formatting, layout, widgets, or embed". You can create your own custom category name, [see documentation for details](/docs/reference-guides/filters/block-filters.md#managing-block-categories). For this tutorial, I specified "widgets" as the category.
+The **category** specified is a string and must be one of: "common, formatting, layout, widgets, or embed". You can create your own custom category name, [see documentation for details](/docs/reference-guides/filters/block-filters.md#managing-block-categories).
 
 The last two block object properties are **edit** and **save**, these are the key parts of a block. Both properties should be defined as functions.
 

--- a/docs/getting-started/tutorials/create-block/block-anatomy.md
+++ b/docs/getting-started/tutorials/create-block/block-anatomy.md
@@ -2,7 +2,7 @@
 
 At its simplest, a block in the WordPress block editor is a JavaScript object with a specific set of properties.
 
-**Note:** Block development uses ESNext syntax, this refers to the latest JavaScript standard. If this is unfamiliar, I recommend reviewing the [ESNext syntax documentation](/docs/how-to-guides/javascript/esnext-js.md) to familiarize yourself with the newer syntax used in modern JavaScript development.
+**Note:** Block development uses ESNext syntax, this refers to the latest JavaScript standard. If this is unfamiliar, review the [ESNext syntax documentation](/docs/how-to-guides/javascript/esnext-js.md) to familiarize yourself with the newer syntax used in modern JavaScript development.
 
 Here is the complete code for registering a block:
 


### PR DESCRIPTION
Small docs change, removing an unnecessary sentence. The sentence is superfluous because it's clear that the paragraph is describing the block of code above it, and readers can see for themselves what the value of "category" is. Also the sentence uses "I" which sounds a bit weird given that many people edit these files.