### PR TITLE
Gallery block refactor: Respect sort order from Media Library

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -231,6 +231,16 @@ function GalleryEdit( props ) {
 				return file;
 			} );
 
+		// Because we are reusing existing innerImage blocks any reordering
+		// done in the media libary will be lost so we need to reapply that ordering
+		// once the new image blocks are merged in with existing.
+		const newOrderMap = processedImages.reduce(
+			( result, image, index ) => (
+				( result[ image.id ] = index ), result
+			),
+			{}
+		);
+
 		const existingImageBlocks = ! newFileUploads
 			? innerBlockImages.filter( ( block ) =>
 					processedImages.find(
@@ -255,7 +265,11 @@ function GalleryEdit( props ) {
 
 		replaceInnerBlocks(
 			clientId,
-			concat( existingImageBlocks, newBlocks )
+			concat( existingImageBlocks, newBlocks ).sort(
+				( a, b ) =>
+					newOrderMap[ a.attributes.id ] -
+					newOrderMap[ b.attributes.id ]
+			)
 		);
 	}
 


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/30004

## Test

- Check out this PR and turn on refactored gallery experiment
- Add a new gallery block with images
- Select media library from placeholder and then 'Edit gallery'
- Drag and drop to reorder images and then 'Update gallery'
- Make sure order set in Media library is applied to the block

Note: There seems to be a bug in trunk which means that all the existing images display in 'add to gallery' list even if already in gallery, if you toggle between Edit and Add the Add list then just shows images not already in the gallery - this doesn't seem to be related to either this or the main gallery refactor PR.