### PR TITLE
Add 'since' versions to the deprecated features

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -11,7 +11,7 @@ import BlockIcon from '../block-icon';
 function BlockCard( { title, icon, description, blockType } ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
-			since: '9.7',
+			since: '5.7',
 			alternative: '`title, icon and description` properties',
 		} );
 		( { title, icon, description } = blockType );

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -11,6 +11,7 @@ import BlockIcon from '../block-icon';
 function BlockCard( { title, icon, description, blockType } ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
+			since: '9.7',
 			alternative: '`title, icon and description` properties',
 		} );
 		( { title, icon, description } = blockType );

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -13,7 +13,7 @@ import { useBlockProps } from './use-block-props';
 const BlockComponent = forwardRef(
 	( { children, tagName: TagName = 'div', ...props }, ref ) => {
 		deprecated( 'wp.blockEditor.__experimentalBlock', {
-			since: '9.1',
+			since: '5.6',
 			alternative: 'wp.blockEditor.useBlockProps',
 		} );
 		const blockProps = useBlockProps( { ...props, ref } );

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -13,6 +13,7 @@ import { useBlockProps } from './use-block-props';
 const BlockComponent = forwardRef(
 	( { children, tagName: TagName = 'div', ...props }, ref ) => {
 		deprecated( 'wp.blockEditor.__experimentalBlock', {
+			since: '9.1',
 			alternative: 'wp.blockEditor.useBlockProps',
 		} );
 		const blockProps = useBlockProps( { ...props, ref } );

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -391,7 +391,7 @@ export function MediaPlaceholder( {
 	if ( dropZoneUIOnly || disableMediaButtons ) {
 		if ( dropZoneUIOnly ) {
 			deprecated( 'wp.blockEditor.MediaPlaceholder dropZoneUIOnly prop', {
-				since: '6.6',
+				since: '5.4',
 				alternative: 'disableMediaButtons',
 			} );
 		}

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -391,6 +391,7 @@ export function MediaPlaceholder( {
 	if ( dropZoneUIOnly || disableMediaButtons ) {
 		if ( dropZoneUIOnly ) {
 			deprecated( 'wp.blockEditor.MediaPlaceholder dropZoneUIOnly prop', {
+				since: '6.6',
 				alternative: 'disableMediaButtons',
 			} );
 		}

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -61,6 +61,7 @@ function useIsAccessibleToolbar( ref ) {
 		const onlyToolbarItem = hasOnlyToolbarItem( tabbables );
 		if ( ! onlyToolbarItem ) {
 			deprecated( 'Using custom components as toolbar controls', {
+				since: '8.8',
 				alternative: 'ToolbarItem or ToolbarButton components',
 				link:
 					'https://developer.wordpress.org/block-editor/components/toolbar-button/#inside-blockcontrols',

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -61,7 +61,7 @@ function useIsAccessibleToolbar( ref ) {
 		const onlyToolbarItem = hasOnlyToolbarItem( tabbables );
 		if ( ! onlyToolbarItem ) {
 			deprecated( 'Using custom components as toolbar controls', {
-				since: '8.8',
+				since: '5.6',
 				alternative: 'ToolbarItem or ToolbarButton components',
 				link:
 					'https://developer.wordpress.org/block-editor/components/toolbar-button/#inside-blockcontrols',

--- a/packages/block-editor/src/components/preserve-scroll-in-reorder/index.js
+++ b/packages/block-editor/src/components/preserve-scroll-in-reorder/index.js
@@ -5,6 +5,7 @@ import deprecated from '@wordpress/deprecated';
 
 export default function PreserveScrollInReorder() {
 	deprecated( 'PreserveScrollInReorder component', {
+		since: '6.6',
 		hint: 'This behavior is now built-in the block list',
 	} );
 	return null;

--- a/packages/block-editor/src/components/preserve-scroll-in-reorder/index.js
+++ b/packages/block-editor/src/components/preserve-scroll-in-reorder/index.js
@@ -5,7 +5,7 @@ import deprecated from '@wordpress/deprecated';
 
 export default function PreserveScrollInReorder() {
 	deprecated( 'PreserveScrollInReorder component', {
-		since: '6.6',
+		since: '5.4',
 		hint: 'This behavior is now built-in the block list',
 	} );
 	return null;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -101,7 +101,7 @@ function getAllowedFormats( {
 	}
 
 	deprecated( 'wp.blockEditor.RichText formattingControls prop', {
-		since: '6.2',
+		since: '5.4',
 		alternative: 'allowedFormats',
 	} );
 
@@ -717,7 +717,7 @@ function RichTextWrapper(
 	}
 
 	deprecated( 'wp.blockEditor.RichText wrapperClassName prop', {
-		since: '6.7',
+		since: '5.4',
 		alternative: 'className prop or create your own wrapper div',
 	} );
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -101,6 +101,7 @@ function getAllowedFormats( {
 	}
 
 	deprecated( 'wp.blockEditor.RichText formattingControls prop', {
+		since: '6.2',
 		alternative: 'allowedFormats',
 	} );
 
@@ -716,6 +717,7 @@ function RichTextWrapper(
 	}
 
 	deprecated( 'wp.blockEditor.RichText wrapperClassName prop', {
+		since: '6.7',
 		alternative: 'className prop or create your own wrapper div',
 	} );
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -575,6 +575,7 @@ export function* insertBlocks(
 		initialPosition = 0;
 		deprecated( "meta argument in wp.data.dispatch('core/block-editor')", {
 			since: '10.1',
+			plugin: 'Gutenberg',
 			hint: 'The meta argument is now the 6th argument of the function',
 		} );
 	}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -574,6 +574,7 @@ export function* insertBlocks(
 		meta = initialPosition;
 		initialPosition = 0;
 		deprecated( "meta argument in wp.data.dispatch('core/block-editor')", {
+			since: '10.1',
 			hint: 'The meta argument is now the 6th argument of the function',
 		} );
 	}

--- a/packages/block-library/src/text-columns/edit.js
+++ b/packages/block-library/src/text-columns/edit.js
@@ -21,8 +21,8 @@ export default function TextColumnsEdit( { attributes, setAttributes } ) {
 	const { width, content, columns } = attributes;
 
 	deprecated( 'The Text Columns block', {
+		since: '5.3',
 		alternative: 'the Columns block',
-		plugin: 'Gutenberg',
 	} );
 
 	return (

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -26,7 +26,7 @@ export { pasteHandler } from './paste-handler';
 
 export function deprecatedGetPhrasingContentSchema( context ) {
 	deprecated( 'wp.blocks.getPhrasingContentSchema', {
-		since: '8.9',
+		since: '5.6',
 		alternative: 'wp.dom.getPhrasingContentSchema',
 	} );
 	return getPhrasingContentSchema( context );

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -26,6 +26,7 @@ export { pasteHandler } from './paste-handler';
 
 export function deprecatedGetPhrasingContentSchema( context ) {
 	deprecated( 'wp.blocks.getPhrasingContentSchema', {
+		since: '8.9',
 		alternative: 'wp.dom.getPhrasingContentSchema',
 	} );
 	return getPhrasingContentSchema( context );

--- a/packages/components/src/button/deprecated.js
+++ b/packages/components/src/button/deprecated.js
@@ -11,6 +11,7 @@ import Button from '../button';
 
 function IconButton( { labelPosition, size, tooltip, label, ...props }, ref ) {
 	deprecated( 'wp.components.IconButton', {
+		since: '7.2',
 		alternative: 'wp.components.Button',
 	} );
 

--- a/packages/components/src/button/deprecated.js
+++ b/packages/components/src/button/deprecated.js
@@ -11,7 +11,7 @@ import Button from '../button';
 
 function IconButton( { labelPosition, size, tooltip, label, ...props }, ref ) {
 	deprecated( 'wp.components.IconButton', {
-		since: '7.2',
+		since: '5.4',
 		alternative: 'wp.components.Button',
 	} );
 

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -51,6 +51,7 @@ export function Button( props, ref ) {
 
 	if ( isDefault ) {
 		deprecated( 'Button isDefault prop', {
+			since: '7.2',
 			alternative: 'isSecondary',
 		} );
 	}

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -51,7 +51,7 @@ export function Button( props, ref ) {
 
 	if ( isDefault ) {
 		deprecated( 'Button isDefault prop', {
-			since: '7.2',
+			since: '5.4',
 			alternative: 'isSecondary',
 		} );
 	}

--- a/packages/components/src/clipboard-button/index.js
+++ b/packages/components/src/clipboard-button/index.js
@@ -27,6 +27,7 @@ export default function ClipboardButton( {
 } ) {
 	deprecated( 'wp.components.ClipboardButton', {
 		since: '10.3',
+		plugin: 'Gutenberg',
 		alternative: 'wp.compose.useCopyToClipboard',
 	} );
 

--- a/packages/components/src/clipboard-button/index.js
+++ b/packages/components/src/clipboard-button/index.js
@@ -26,6 +26,7 @@ export default function ClipboardButton( {
 	...buttonProps
 } ) {
 	deprecated( 'wp.components.ClipboardButton', {
+		since: '10.3',
 		alternative: 'wp.compose.useCopyToClipboard',
 	} );
 

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -54,7 +54,7 @@ function DropdownMenu( {
 } ) {
 	if ( menuLabel ) {
 		deprecated( '`menuLabel` prop in `DropdownComponent`', {
-			since: '6.3',
+			since: '5.3',
 			alternative: '`menuProps` object and its `aria-label` property',
 			plugin: 'Gutenberg',
 		} );
@@ -62,7 +62,7 @@ function DropdownMenu( {
 
 	if ( position ) {
 		deprecated( '`position` prop in `DropdownComponent`', {
-			since: '6.3',
+			since: '5.3',
 			alternative: '`popoverProps` object and its `position` property',
 			plugin: 'Gutenberg',
 		} );

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -54,6 +54,7 @@ function DropdownMenu( {
 } ) {
 	if ( menuLabel ) {
 		deprecated( '`menuLabel` prop in `DropdownComponent`', {
+			since: '6.3',
 			alternative: '`menuProps` object and its `aria-label` property',
 			plugin: 'Gutenberg',
 		} );
@@ -61,6 +62,7 @@ function DropdownMenu( {
 
 	if ( position ) {
 		deprecated( '`position` prop in `DropdownComponent`', {
+			since: '6.3',
 			alternative: '`popoverProps` object and its `position` property',
 			plugin: 'Gutenberg',
 		} );

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -56,7 +56,6 @@ function DropdownMenu( {
 		deprecated( '`menuLabel` prop in `DropdownComponent`', {
 			since: '5.3',
 			alternative: '`menuProps` object and its `aria-label` property',
-			plugin: 'Gutenberg',
 		} );
 	}
 
@@ -64,7 +63,6 @@ function DropdownMenu( {
 		deprecated( '`position` prop in `DropdownComponent`', {
 			since: '5.3',
 			alternative: '`popoverProps` object and its `position` property',
-			plugin: 'Gutenberg',
 		} );
 	}
 

--- a/packages/components/src/guide/index.js
+++ b/packages/components/src/guide/index.js
@@ -32,6 +32,7 @@ export default function Guide( {
 	useEffect( () => {
 		if ( Children.count( children ) ) {
 			deprecated( 'Passing children to <Guide>', {
+				since: '8.2',
 				alternative: 'the `pages` prop',
 			} );
 		}

--- a/packages/components/src/guide/index.js
+++ b/packages/components/src/guide/index.js
@@ -32,7 +32,7 @@ export default function Guide( {
 	useEffect( () => {
 		if ( Children.count( children ) ) {
 			deprecated( 'Passing children to <Guide>', {
-				since: '8.2',
+				since: '5.5',
 				alternative: 'the `pages` prop',
 			} );
 		}

--- a/packages/components/src/guide/page.js
+++ b/packages/components/src/guide/page.js
@@ -7,6 +7,7 @@ import deprecated from '@wordpress/deprecated';
 export default function GuidePage( props ) {
 	useEffect( () => {
 		deprecated( '<GuidePage>', {
+			since: '8.2',
 			alternative: 'the `pages` prop in <Guide>',
 		} );
 	}, [] );

--- a/packages/components/src/guide/page.js
+++ b/packages/components/src/guide/page.js
@@ -7,7 +7,7 @@ import deprecated from '@wordpress/deprecated';
 export default function GuidePage( props ) {
 	useEffect( () => {
 		deprecated( '<GuidePage>', {
-			since: '8.2',
+			since: '5.5',
 			alternative: 'the `pages` prop in <Guide>',
 		} );
 	}, [] );

--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -54,7 +54,7 @@ export default createHigherOrderComponent( ( options ) => {
 
 export const Provider = ( { children } ) => {
 	deprecated( 'wp.components.FocusReturnProvider component', {
-		since: '9.6',
+		since: '5.7',
 		hint:
 			'This provider is not used anymore. You can just remove it from your codebase',
 	} );

--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -54,6 +54,7 @@ export default createHigherOrderComponent( ( options ) => {
 
 export const Provider = ( { children } ) => {
 	deprecated( 'wp.components.FocusReturnProvider component', {
+		since: '9.6',
 		hint:
 			'This provider is not used anymore. You can just remove it from your codebase',
 	} );

--- a/packages/components/src/isolated-event-container/index.js
+++ b/packages/components/src/isolated-event-container/index.js
@@ -9,7 +9,9 @@ function stopPropagation( event ) {
 }
 
 export default forwardRef( ( { children, ...props }, ref ) => {
-	deprecated( 'wp.components.IsolatedEventContainer' );
+	deprecated( 'wp.components.IsolatedEventContainer', {
+		since: '9.6',
+	} );
 
 	// Disable reason: this stops certain events from propagating outside of the component.
 	//   - onMouseDown is disabled as this can cause interactions with other DOM elements

--- a/packages/components/src/isolated-event-container/index.js
+++ b/packages/components/src/isolated-event-container/index.js
@@ -10,7 +10,7 @@ function stopPropagation( event ) {
 
 export default forwardRef( ( { children, ...props }, ref ) => {
 	deprecated( 'wp.components.IsolatedEventContainer', {
-		since: '9.6',
+		since: '5.7',
 	} );
 
 	// Disable reason: this stops certain events from propagating outside of the component.

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -122,7 +122,7 @@ class Modal extends Component {
 
 		if ( isDismissable ) {
 			deprecated( 'isDismissable prop of the Modal component', {
-				since: '6.7',
+				since: '5.4',
 				alternative:
 					'isDismissible prop (renamed) of the Modal component',
 			} );

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -122,6 +122,7 @@ class Modal extends Component {
 
 		if ( isDismissable ) {
 			deprecated( 'isDismissable prop of the Modal component', {
+				since: '6.7',
 				alternative:
 					'isDismissible prop (renamed) of the Modal component',
 			} );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -544,7 +544,7 @@ const Popover = ( {
 		} );
 
 		deprecated( 'Popover onClickOutside prop', {
-			since: '6.3',
+			since: '5.3',
 			alternative: 'onFocusOutside',
 		} );
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -544,6 +544,7 @@ const Popover = ( {
 		} );
 
 		deprecated( 'Popover onClickOutside prop', {
+			since: '6.3',
 			alternative: 'onFocusOutside',
 		} );
 

--- a/packages/components/src/toolbar/index.js
+++ b/packages/components/src/toolbar/index.js
@@ -28,7 +28,7 @@ import ToolbarContainer from './toolbar-container';
 function Toolbar( { className, label, ...props }, ref ) {
 	if ( ! label ) {
 		deprecated( 'Using Toolbar without label prop', {
-			since: '8.8',
+			since: '5.6',
 			alternative: 'ToolbarGroup component',
 			link:
 				'https://developer.wordpress.org/block-editor/components/toolbar/',

--- a/packages/components/src/toolbar/index.js
+++ b/packages/components/src/toolbar/index.js
@@ -28,6 +28,7 @@ import ToolbarContainer from './toolbar-container';
 function Toolbar( { className, label, ...props }, ref ) {
 	if ( ! label ) {
 		deprecated( 'Using Toolbar without label prop', {
+			since: '8.8',
 			alternative: 'ToolbarGroup component',
 			link:
 				'https://developer.wordpress.org/block-editor/components/toolbar/',

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -43,6 +43,7 @@ const listener = new Listener();
  */
 export default function withGlobalEvents( eventTypesToHandlers ) {
 	deprecated( 'wp.compose.withGlobalEvents', {
+		since: '9.5',
 		alternative: 'useEffect',
 	} );
 

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -43,7 +43,7 @@ const listener = new Listener();
  */
 export default function withGlobalEvents( eventTypesToHandlers ) {
 	deprecated( 'wp.compose.withGlobalEvents', {
-		since: '9.5',
+		since: '5.7',
 		alternative: 'useEffect',
 	} );
 

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -25,6 +25,7 @@ import deprecated from '@wordpress/deprecated';
 export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 	deprecated( 'wp.compose.useCopyOnClick', {
 		since: '10.3',
+		plugin: 'Gutenberg',
 		alternative: 'wp.compose.useCopyToClipboard',
 	} );
 

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -24,6 +24,7 @@ import deprecated from '@wordpress/deprecated';
  */
 export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 	deprecated( 'wp.compose.useCopyOnClick', {
+		since: '10.3',
 		alternative: 'wp.compose.useCopyToClipboard',
 	} );
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -294,7 +294,7 @@ export function* getEmbedPreview( url ) {
  */
 export function* hasUploadPermissions() {
 	deprecated( "select( 'core' ).hasUploadPermissions()", {
-		since: '5.0',
+		since: '5.2',
 		alternative: "select( 'core' ).canUser( 'create', 'media' )",
 	} );
 	yield* canUser( 'create', 'media' );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -294,6 +294,7 @@ export function* getEmbedPreview( url ) {
  */
 export function* hasUploadPermissions() {
 	deprecated( "select( 'core' ).hasUploadPermissions()", {
+		since: '5.0',
 		alternative: "select( 'core' ).canUser( 'create', 'media' )",
 	} );
 	yield* canUser( 'create', 'media' );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -634,7 +634,7 @@ export function isPreviewEmbedFallback( state, url ) {
  */
 export function hasUploadPermissions( state ) {
 	deprecated( "select( 'core' ).hasUploadPermissions()", {
-		since: '5.0',
+		since: '5.2',
 		alternative: "select( 'core' ).canUser( 'create', 'media' )",
 	} );
 	return defaultTo( canUser( state, 'create', 'media' ), true );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -634,6 +634,7 @@ export function isPreviewEmbedFallback( state, url ) {
  */
 export function hasUploadPermissions( state ) {
 	deprecated( "select( 'core' ).hasUploadPermissions()", {
+		since: '5.0',
 		alternative: "select( 'core' ).canUser( 'create', 'media' )",
 	} );
 	return defaultTo( canUser( state, 'create', 'media' ), true );

--- a/packages/data-controls/src/index.js
+++ b/packages/data-controls/src/index.js
@@ -39,6 +39,7 @@ export function apiFetch( request ) {
  */
 export function select( ...args ) {
 	deprecated( '`select` control in `@wordpress/data-controls`', {
+		since: '9.3',
 		alternative: 'built-in `resolveSelect` control in `@wordpress/data`',
 	} );
 
@@ -53,6 +54,7 @@ export function select( ...args ) {
  */
 export function syncSelect( ...args ) {
 	deprecated( '`syncSelect` control in `@wordpress/data-controls`', {
+		since: '9.3',
 		alternative: 'built-in `select` control in `@wordpress/data`',
 	} );
 
@@ -67,6 +69,7 @@ export function syncSelect( ...args ) {
  */
 export function dispatch( ...args ) {
 	deprecated( '`dispatch` control in `@wordpress/data-controls`', {
+		since: '9.3',
 		alternative: 'built-in `dispatch` control in `@wordpress/data`',
 	} );
 

--- a/packages/data-controls/src/index.js
+++ b/packages/data-controls/src/index.js
@@ -39,7 +39,7 @@ export function apiFetch( request ) {
  */
 export function select( ...args ) {
 	deprecated( '`select` control in `@wordpress/data-controls`', {
-		since: '9.3',
+		since: '5.7',
 		alternative: 'built-in `resolveSelect` control in `@wordpress/data`',
 	} );
 
@@ -54,7 +54,7 @@ export function select( ...args ) {
  */
 export function syncSelect( ...args ) {
 	deprecated( '`syncSelect` control in `@wordpress/data-controls`', {
-		since: '9.3',
+		since: '5.7',
 		alternative: 'built-in `select` control in `@wordpress/data`',
 	} );
 
@@ -69,7 +69,7 @@ export function syncSelect( ...args ) {
  */
 export function dispatch( ...args ) {
 	deprecated( '`dispatch` control in `@wordpress/data-controls`', {
-		since: '9.3',
+		since: '5.7',
 		alternative: 'built-in `dispatch` control in `@wordpress/data`',
 	} );
 

--- a/packages/data/src/plugins/controls/index.js
+++ b/packages/data/src/plugins/controls/index.js
@@ -5,6 +5,7 @@ import deprecated from '@wordpress/deprecated';
 
 export default ( registry ) => {
 	deprecated( 'wp.data.plugins.controls', {
+		since: '5.4',
 		hint: 'The controls plugins is now baked-in.',
 	} );
 	return registry;

--- a/packages/editor/src/components/deprecated.js
+++ b/packages/editor/src/components/deprecated.js
@@ -65,6 +65,7 @@ export { default as ServerSideRender } from '@wordpress/server-side-render';
 function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
 	const Component = forwardRef( ( props, ref ) => {
 		deprecated( 'wp.editor.' + name, {
+			since: '5.9',
 			alternative: 'wp.blockEditor.' + name,
 		} );
 
@@ -84,6 +85,7 @@ function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
 function deprecateFunction( name, func ) {
 	return ( ...args ) => {
 		deprecated( 'wp.editor.' + name, {
+			since: '5.9',
 			alternative: 'wp.blockEditor.' + name,
 		} );
 

--- a/packages/editor/src/components/deprecated.js
+++ b/packages/editor/src/components/deprecated.js
@@ -65,7 +65,7 @@ export { default as ServerSideRender } from '@wordpress/server-side-render';
 function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
 	const Component = forwardRef( ( props, ref ) => {
 		deprecated( 'wp.editor.' + name, {
-			since: '5.9',
+			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
 		} );
 
@@ -85,7 +85,7 @@ function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
 function deprecateFunction( name, func ) {
 	return ( ...args ) => {
 		deprecated( 'wp.editor.' + name, {
-			since: '5.9',
+			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
 		} );
 

--- a/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
@@ -44,9 +44,8 @@ export default VisualEditorGlobalKeyboardShortcuts;
 
 export function EditorGlobalKeyboardShortcuts() {
 	deprecated( 'EditorGlobalKeyboardShortcuts', {
-		since: '5.0',
+		since: '5.2',
 		alternative: 'VisualEditorGlobalKeyboardShortcuts',
-		plugin: 'Gutenberg',
 	} );
 
 	return <VisualEditorGlobalKeyboardShortcuts />;

--- a/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
@@ -44,6 +44,7 @@ export default VisualEditorGlobalKeyboardShortcuts;
 
 export function EditorGlobalKeyboardShortcuts() {
 	deprecated( 'EditorGlobalKeyboardShortcuts', {
+		since: '5.0',
 		alternative: 'VisualEditorGlobalKeyboardShortcuts',
 		plugin: 'Gutenberg',
 	} );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -116,7 +116,6 @@ export function* resetAutosave( newAutosave ) {
 	deprecated( 'resetAutosave action (`core/editor` store)', {
 		since: '5.3',
 		alternative: 'receiveAutosaves action (`core` store)',
-		plugin: 'Gutenberg',
 	} );
 
 	const postId = yield controls.select( STORE_NAME, 'getCurrentPostId' );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -114,7 +114,7 @@ export function resetPost( post ) {
  */
 export function* resetAutosave( newAutosave ) {
 	deprecated( 'resetAutosave action (`core/editor` store)', {
-		since: '5.6',
+		since: '5.3',
 		alternative: 'receiveAutosaves action (`core` store)',
 		plugin: 'Gutenberg',
 	} );
@@ -162,7 +162,7 @@ export function __experimentalRequestPostUpdateFinish( options = {} ) {
  */
 export function updatePost() {
 	deprecated( "wp.data.dispatch( 'core/editor' ).updatePost", {
-		since: '9.7',
+		since: '5.7',
 		alternative: 'User the core entitires store instead',
 	} );
 	return {
@@ -651,7 +651,7 @@ export function updateEditorSettings( settings ) {
 const getBlockEditorAction = ( name ) =>
 	function* ( ...args ) {
 		deprecated( "`wp.data.dispatch( 'core/editor' )." + name + '`', {
-			since: '5.9',
+			since: '5.3',
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
 		} );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -114,6 +114,7 @@ export function resetPost( post ) {
  */
 export function* resetAutosave( newAutosave ) {
 	deprecated( 'resetAutosave action (`core/editor` store)', {
+		since: '5.6',
 		alternative: 'receiveAutosaves action (`core` store)',
 		plugin: 'Gutenberg',
 	} );
@@ -161,6 +162,7 @@ export function __experimentalRequestPostUpdateFinish( options = {} ) {
  */
 export function updatePost() {
 	deprecated( "wp.data.dispatch( 'core/editor' ).updatePost", {
+		since: '9.7',
 		alternative: 'User the core entitires store instead',
 	} );
 	return {
@@ -649,6 +651,7 @@ export function updateEditorSettings( settings ) {
 const getBlockEditorAction = ( name ) =>
 	function* ( ...args ) {
 		deprecated( "`wp.data.dispatch( 'core/editor' )." + name + '`', {
+			since: '5.9',
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
 		} );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -306,6 +306,7 @@ export const getReferenceByDistinctEdits = createRegistrySelector(
 		deprecated(
 			"`wp.data.select( 'core/editor' ).getReferenceByDistinctEdits`",
 			{
+				since: '6.5',
 				alternative:
 					"`wp.data.select( 'core' ).getReferenceByDistinctEdits`",
 			}
@@ -685,6 +686,7 @@ export const isEditedPostAutosaveable = createRegistrySelector(
  */
 export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
 	deprecated( "`wp.data.select( 'core/editor' ).getAutosave()`", {
+		since: '5.6',
 		alternative:
 			"`wp.data.select( 'core' ).getAutosave( postType, postId, userId )`",
 		plugin: 'Gutenberg',
@@ -713,6 +715,7 @@ export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
  */
 export const hasAutosave = createRegistrySelector( ( select ) => ( state ) => {
 	deprecated( "`wp.data.select( 'core/editor' ).hasAutosave()`", {
+		since: '5.6',
 		alternative:
 			"`!! wp.data.select( 'core' ).getAutosave( postType, postId, userId )`",
 		plugin: 'Gutenberg',
@@ -953,6 +956,7 @@ export function getSuggestedPostFormat( state ) {
  */
 export function getBlocksForSerialization( state ) {
 	deprecated( '`core/editor` getBlocksForSerialization selector', {
+		since: '6.2',
 		plugin: 'Gutenberg',
 		alternative: 'getEditorBlocks',
 		hint: 'Blocks serialization pre-processing occurs at save time',
@@ -1235,6 +1239,7 @@ export function getEditorBlocks( state ) {
  */
 export function getEditorSelectionStart( state ) {
 	deprecated( "select('core/editor').getEditorSelectionStart", {
+		since: '10.0',
 		alternative: "select('core/editor').getEditorSelection",
 	} );
 	return getEditedPostAttribute( state, 'selection' )?.selectionStart;
@@ -1250,6 +1255,7 @@ export function getEditorSelectionStart( state ) {
  */
 export function getEditorSelectionEnd( state ) {
 	deprecated( "select('core/editor').getEditorSelectionStart", {
+		since: '10.0',
 		alternative: "select('core/editor').getEditorSelection",
 	} );
 	return getEditedPostAttribute( state, 'selection' )?.selectionEnd;
@@ -1298,6 +1304,7 @@ export function getEditorSettings( state ) {
  */
 export function getStateBeforeOptimisticTransaction() {
 	deprecated( "select('core/editor').getStateBeforeOptimisticTransaction", {
+		since: '9.7',
 		hint: 'No state history is kept on this store anymore',
 	} );
 
@@ -1311,6 +1318,7 @@ export function getStateBeforeOptimisticTransaction() {
  */
 export function inSomeHistory() {
 	deprecated( "select('core/editor').inSomeHistory", {
+		since: '9.7',
 		hint: 'No state history is kept on this store anymore',
 	} );
 	return false;
@@ -1319,6 +1327,7 @@ export function inSomeHistory() {
 function getBlockEditorSelector( name ) {
 	return createRegistrySelector( ( select ) => ( state, ...args ) => {
 		deprecated( "`wp.data.select( 'core/editor' )." + name + '`', {
+			since: '5.9',
 			alternative: "`wp.data.select( 'core/block-editor' )." + name + '`',
 		} );
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -306,7 +306,7 @@ export const getReferenceByDistinctEdits = createRegistrySelector(
 		deprecated(
 			"`wp.data.select( 'core/editor' ).getReferenceByDistinctEdits`",
 			{
-				since: '6.5',
+				since: '5.4',
 				alternative:
 					"`wp.data.select( 'core' ).getReferenceByDistinctEdits`",
 			}
@@ -686,7 +686,7 @@ export const isEditedPostAutosaveable = createRegistrySelector(
  */
 export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
 	deprecated( "`wp.data.select( 'core/editor' ).getAutosave()`", {
-		since: '5.6',
+		since: '5.3',
 		alternative:
 			"`wp.data.select( 'core' ).getAutosave( postType, postId, userId )`",
 		plugin: 'Gutenberg',
@@ -715,7 +715,7 @@ export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
  */
 export const hasAutosave = createRegistrySelector( ( select ) => ( state ) => {
 	deprecated( "`wp.data.select( 'core/editor' ).hasAutosave()`", {
-		since: '5.6',
+		since: '5.3',
 		alternative:
 			"`!! wp.data.select( 'core' ).getAutosave( postType, postId, userId )`",
 		plugin: 'Gutenberg',
@@ -956,7 +956,7 @@ export function getSuggestedPostFormat( state ) {
  */
 export function getBlocksForSerialization( state ) {
 	deprecated( '`core/editor` getBlocksForSerialization selector', {
-		since: '6.2',
+		since: '5.3',
 		plugin: 'Gutenberg',
 		alternative: 'getEditorBlocks',
 		hint: 'Blocks serialization pre-processing occurs at save time',
@@ -1304,7 +1304,7 @@ export function getEditorSettings( state ) {
  */
 export function getStateBeforeOptimisticTransaction() {
 	deprecated( "select('core/editor').getStateBeforeOptimisticTransaction", {
-		since: '9.7',
+		since: '5.7',
 		hint: 'No state history is kept on this store anymore',
 	} );
 
@@ -1318,7 +1318,7 @@ export function getStateBeforeOptimisticTransaction() {
  */
 export function inSomeHistory() {
 	deprecated( "select('core/editor').inSomeHistory", {
-		since: '9.7',
+		since: '5.7',
 		hint: 'No state history is kept on this store anymore',
 	} );
 	return false;
@@ -1327,7 +1327,7 @@ export function inSomeHistory() {
 function getBlockEditorSelector( name ) {
 	return createRegistrySelector( ( select ) => ( state, ...args ) => {
 		deprecated( "`wp.data.select( 'core/editor' )." + name + '`', {
-			since: '5.9',
+			since: '5.3',
 			alternative: "`wp.data.select( 'core/block-editor' )." + name + '`',
 		} );
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -689,7 +689,6 @@ export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
 		since: '5.3',
 		alternative:
 			"`wp.data.select( 'core' ).getAutosave( postType, postId, userId )`",
-		plugin: 'Gutenberg',
 	} );
 
 	const postType = getCurrentPostType( state );
@@ -718,7 +717,6 @@ export const hasAutosave = createRegistrySelector( ( select ) => ( state ) => {
 		since: '5.3',
 		alternative:
 			"`!! wp.data.select( 'core' ).getAutosave( postType, postId, userId )`",
-		plugin: 'Gutenberg',
 	} );
 
 	const postType = getCurrentPostType( state );
@@ -957,7 +955,6 @@ export function getSuggestedPostFormat( state ) {
 export function getBlocksForSerialization( state ) {
 	deprecated( '`core/editor` getBlocksForSerialization selector', {
 		since: '5.3',
-		plugin: 'Gutenberg',
 		alternative: 'getEditorBlocks',
 		hint: 'Blocks serialization pre-processing occurs at save time',
 	} );
@@ -1240,6 +1237,7 @@ export function getEditorBlocks( state ) {
 export function getEditorSelectionStart( state ) {
 	deprecated( "select('core/editor').getEditorSelectionStart", {
 		since: '10.0',
+		plugin: 'Gutenberg',
 		alternative: "select('core/editor').getEditorSelection",
 	} );
 	return getEditedPostAttribute( state, 'selection' )?.selectionStart;
@@ -1256,6 +1254,7 @@ export function getEditorSelectionStart( state ) {
 export function getEditorSelectionEnd( state ) {
 	deprecated( "select('core/editor').getEditorSelectionStart", {
 		since: '10.0',
+		plugin: 'Gutenberg',
 		alternative: "select('core/editor').getEditorSelection",
 	} );
 	return getEditedPostAttribute( state, 'selection' )?.selectionEnd;

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -21,6 +21,7 @@ function ActionItemSlot( {
 		deprecated(
 			'Passing a tuple of components with `as` prop to `ActionItem.Slot` component',
 			{
+				since: '10.2',
 				alternative: 'a component with `as` prop',
 				version: '10.3',
 			}

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -22,6 +22,7 @@ function ActionItemSlot( {
 			'Passing a tuple of components with `as` prop to `ActionItem.Slot` component',
 			{
 				since: '10.2',
+				plugin: 'Gutenberg',
 				alternative: 'a component with `as` prop',
 				version: '10.3',
 			}

--- a/packages/nux/src/index.js
+++ b/packages/nux/src/index.js
@@ -7,6 +7,6 @@ export { store } from './store';
 export { default as DotTip } from './components/dot-tip';
 
 deprecated( 'wp.nux', {
-	since: '7.2',
+	since: '5.4',
 	hint: 'wp.components.Guide can be used to show a user guide.',
 } );

--- a/packages/nux/src/index.js
+++ b/packages/nux/src/index.js
@@ -7,5 +7,6 @@ export { store } from './store';
 export { default as DotTip } from './components/dot-tip';
 
 deprecated( 'wp.nux', {
+	since: '7.2',
 	hint: 'wp.components.Guide can be used to show a user guide.',
 } );

--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -43,6 +43,7 @@ const ExportedServerSideRender = withSelect( ( select ) => {
 if ( window && window.wp && window.wp.components ) {
 	window.wp.components.ServerSideRender = forwardRef( ( props, ref ) => {
 		deprecated( 'wp.components.ServerSideRender', {
+			since: '6.3',
 			alternative: 'wp.serverSideRender',
 		} );
 		return <ExportedServerSideRender { ...props } ref={ ref } />;

--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -43,7 +43,7 @@ const ExportedServerSideRender = withSelect( ( select ) => {
 if ( window && window.wp && window.wp.components ) {
 	window.wp.components.ServerSideRender = forwardRef( ( props, ref ) => {
 		deprecated( 'wp.components.ServerSideRender', {
-			since: '6.3',
+			since: '5.3',
 			alternative: 'wp.serverSideRender',
 		} );
 		return <ExportedServerSideRender { ...props } ref={ ref } />;


### PR DESCRIPTION
## Description
This is a follow-up of #30017 and adds deprecation versions to the features.

I've used a combination of git history, Github milestones, and inline comments to track down deprecation versions.

## How has this been tested?
Locally by using the deprecated features. Example:
```js
wp.data.select( 'core/editor' ).getSelectedBlock();
```
Calling the following selector in the console should result in a deprecation message with a version it was deprecated.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
