### PR TITLE
Inspector Controls: Rephrase, polish, and make consistent color labels.

### DIFF
--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -81,7 +81,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$classes                       = array();
 	$styles                        = array();
 
-	// Text Colors.
+	// Text colors.
 	// Check support for text colors.
 	if ( $has_text_colors_support ) {
 		$has_named_text_color  = array_key_exists( 'textColor', $block_attributes );
@@ -117,7 +117,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	// Background Colors.
+	// Background colors.
 	if ( $has_background_colors_support ) {
 		$has_named_background_color  = array_key_exists( 'backgroundColor', $block_attributes );
 		$has_custom_background_color = isset( $block_attributes['style']['color']['background'] );

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -35,8 +35,8 @@ function getComputedStyle( node ) {
 const DEFAULT_COLORS = [];
 
 const COMMON_COLOR_LABELS = {
-	textColor: __( 'Text Color' ),
-	backgroundColor: __( 'Background Color' ),
+	textColor: __( 'Text color' ),
+	backgroundColor: __( 'Background color' ),
 };
 
 const InspectorControlsColorPanel = ( props ) => (
@@ -48,7 +48,7 @@ const InspectorControlsColorPanel = ( props ) => (
 export default function __experimentalUseColors(
 	colorConfigs,
 	{
-		panelTitle = __( 'Color settings' ),
+		panelTitle = __( 'Color' ),
 		colorPanelProps,
 		contrastCheckers,
 		panelChildren,
@@ -58,7 +58,7 @@ export default function __experimentalUseColors(
 			textColorTargetRef = targetRef,
 		} = {},
 	} = {
-		panelTitle: __( 'Color settings' ),
+		panelTitle: __( 'Color' ),
 	},
 	deps = []
 ) {

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -55,7 +55,7 @@ export default function ColorPanel( {
 	return (
 		<InspectorControls>
 			<PanelColorGradientSettings
-				title={ __( 'Color settings' ) }
+				title={ __( 'Color' ) }
 				initialOpen={ false }
 				settings={ settings }
 			>

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -327,7 +327,7 @@ export function ColorEdit( props ) {
 				...( hasTextColorSupport( blockName )
 					? [
 							{
-								label: __( 'Text Color' ),
+								label: __( 'Text color' ),
 								onColorChange: onChangeColor( 'text' ),
 								colorValue: getColorObjectByAttributeValues(
 									colors,
@@ -340,7 +340,7 @@ export function ColorEdit( props ) {
 				...( hasBackground || hasGradient
 					? [
 							{
-								label: __( 'Background Color' ),
+								label: __( 'Background color' ),
 								onColorChange: hasBackground
 									? onChangeColor( 'background' )
 									: undefined,

--- a/packages/block-library/src/button/color-edit.js
+++ b/packages/block-library/src/button/color-edit.js
@@ -68,9 +68,7 @@ function ColorPanel( { settings, clientId, enableContrastChecking = true } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
 
-	const title = isWebPlatform
-		? __( 'Color settings' )
-		: __( 'Color Settings' );
+	const title = __( 'Color' );
 
 	useEffect( () => {
 		if ( isWebPlatform && ! enableContrastChecking ) {
@@ -209,7 +207,7 @@ function ColorEdit( props ) {
 	const settings = useMemo( () => {
 		return [
 			{
-				label: __( 'Text Color' ),
+				label: __( 'Text color' ),
 				onColorChange: onChangeColor( 'text' ),
 				colorValue: getColorObjectByAttributeValues(
 					colors,
@@ -218,7 +216,7 @@ function ColorEdit( props ) {
 				).color,
 			},
 			{
-				label: __( 'Background Color' ),
+				label: __( 'Background color' ),
 				onColorChange: onChangeColor( 'background' ),
 				colorValue: getColorObjectByAttributeValues(
 					colors,

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -160,7 +160,7 @@ function PullQuoteEdit( {
 			{ Platform.OS === 'web' && (
 				<InspectorControls>
 					<PanelColorSettings
-						title={ __( 'Color settings' ) }
+						title={ __( 'Color' ) }
 						colorSettings={ [
 							{
 								value: mainColor.color,

--- a/packages/block-library/src/separator/separator-settings.js
+++ b/packages/block-library/src/separator/separator-settings.js
@@ -7,7 +7,7 @@ import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
 const SeparatorSettings = ( { color, setColor } ) => (
 	<InspectorControls>
 		<PanelColorSettings
-			title={ __( 'Color settings' ) }
+			title={ __( 'Color' ) }
 			colorSettings={ [
 				{
 					value: color.color,

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -205,7 +205,7 @@ export function SocialLinksEdit( props ) {
 									iconBackgroundColorValue: colorValue,
 								} );
 							},
-							label: __( 'Background color' ),
+							label: __( 'Icon background color' ),
 						},
 					] }
 				/>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -181,7 +181,7 @@ export function SocialLinksEdit( props ) {
 					/>
 				</PanelBody>
 				<PanelColorSettings
-					title={ __( 'Color settings' ) }
+					title={ __( 'Color' ) }
 					colorSettings={ [
 						{
 							// Use custom attribute as fallback to prevent loss of named color selection when
@@ -205,7 +205,7 @@ export function SocialLinksEdit( props ) {
 									iconBackgroundColorValue: colorValue,
 								} );
 							},
-							label: __( 'Icon background color' ),
+							label: __( 'Background color' ),
 						},
 					] }
 				/>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -500,7 +500,7 @@ function TableEdit( {
 						/>
 					</PanelBody>
 					<PanelColorSettings
-						title={ __( 'Color settings' ) }
+						title={ __( 'Color' ) }
 						initialOpen={ false }
 						colorSettings={ [
 							{

--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -14,7 +14,7 @@ describe( 'Heading', () => {
 	const COLOR_INPUT_FIELD_SELECTOR =
 		'.components-color-palette__picker .components-text-control__input';
 	const COLOR_PANEL_TOGGLE_X_SELECTOR =
-		"//button[./span[contains(text(),'Color settings')]]";
+		"//button[./span[contains(text(),'Color')]]";
 
 	beforeEach( async () => {
 		await createNewPost();


### PR DESCRIPTION
## Description

Color panel labels are a bit of a mix across panels and even across web and mobile. This PR attempts to clean it up.

Before:

<img width="330" alt="Screenshot 2021-03-22 at 08 17 21" src="https://user-images.githubusercontent.com/1204802/111954008-c3ae7180-8ae7-11eb-82c1-458f50c2486b.png">

<img width="344" alt="Screenshot 2021-03-22 at 08 17 29" src="https://user-images.githubusercontent.com/1204802/111954016-c4df9e80-8ae7-11eb-824f-8239d5fa55ef.png">

After:

<img width="354" alt="Screenshot 2021-03-22 at 08 19 45" src="https://user-images.githubusercontent.com/1204802/111954026-c8732580-8ae7-11eb-83e5-f7dc73087ed6.png">
<img width="378" alt="Screenshot 2021-03-22 at 08 20 58" src="https://user-images.githubusercontent.com/1204802/111954031-c9a45280-8ae7-11eb-831a-06633b99ebcb.png">

The motivation here is that the "settings" part of "Color settings" is reduntant information, and that we use sentence case for labels everywhere else.

## Types of changes

- Color settings → Color
- Text Color → Text color
- Background Color → Background color
- Icon background color → Background color

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
