### PR TITLE
Load block editor assets in the navigation and widget editors

### DIFF
--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -51,7 +51,6 @@ function gutenberg_navigation_init( $hook ) {
 
 	wp_enqueue_script( 'wp-edit-navigation' );
 	wp_enqueue_style( 'wp-edit-navigation' );
-	wp_enqueue_style( 'wp-block-library' );
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-format-library' );
 	do_action( 'enqueue_block_editor_assets' );

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -56,3 +56,19 @@ function gutenberg_navigation_init( $hook ) {
 	wp_enqueue_style( 'wp-format-library' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_navigation_init' );
+
+/**
+ * Tells the script loader to load the scripts and styles of custom block on navigation editor screen.
+ *
+ * @param bool $is_block_editor_screen Current decision about loading block assets.
+ * @return bool Filtered decision about loading block assets.
+ */
+function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
+	if ( is_callable( 'get_current_screen' ) && 'gutenberg_page_gutenberg-navigation' === get_current_screen()->base ) {
+		return true;
+	}
+
+	return $is_block_editor_screen;
+}
+
+add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation_editor_load_block_editor_scripts_and_styles' );

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -54,6 +54,7 @@ function gutenberg_navigation_init( $hook ) {
 	wp_enqueue_style( 'wp-block-library' );
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-format-library' );
+	do_action( 'enqueue_block_editor_assets' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_navigation_init' );
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -70,6 +70,7 @@ function gutenberg_widgets_init( $hook ) {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-widgets' );
 	wp_enqueue_style( 'wp-format-library' );
+	do_action( 'enqueue_block_editor_assets' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
 


### PR DESCRIPTION
## Description
Fixes #21648
Fixes #28874

The `do_action( 'enqueue_block_editor_assets' );` was not being called in the widget and navigation editors.

This caused a side effect where `style.scss` styles for blocks were not displayed on those screens when the TT1-blocks theme was active.

Additionally, the navigation editor now also uses the `should_load_block_editor_scripts_and_styles` filter appropriately. This triggers some logic in core that enqueues `wp-block-library` styles and calls `do_action( 'enqueue_block_assets' )`, a slightly different action.

## How has this been tested?
### Test TT1 blocks
1. Activate TT1 blocks theme
2. Inspect block styles
3. See that style.scss styles are present.

### Test enqueueing
1. Add the following to a plugin or your theme:
```
function my_custom_format_enqueue_assets_editor() {
    die("got here");
}
add_action( 'enqueue_block_editor_assets', 'my_custom_format_enqueue_assets_editor' );
```
2. Visit /wp-admin/admin.php?page=gutenberg-navigation
3. Expect a crash

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
