### PR TITLE
Fix query loop margin.

### DIFF
--- a/packages/block-library/src/query-loop/editor.scss
+++ b/packages/block-library/src/query-loop/editor.scss
@@ -1,5 +1,6 @@
 .wp-block.wp-block-query-loop {
 	max-width: 100%;
 	padding-left: 0;
+	margin-left: 0;
 	list-style: none;
 }

--- a/packages/block-library/src/query-loop/editor.scss
+++ b/packages/block-library/src/query-loop/editor.scss
@@ -1,5 +1,4 @@
 .wp-block.wp-block-query-loop {
-	max-width: 100%;
 	padding-left: 0;
 	margin-left: 0;
 	list-style: none;

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -1,7 +1,3 @@
-.editor-styles-wrapper .wp-block.wp-block-query {
-	max-width: 100%;
-}
-
 .block-library-query-toolbar__popover .components-popover__content {
 	min-width: 230px;
 }


### PR DESCRIPTION
## Description

There's an extra margin on the Query loop block, which probably shouldn't be there. This PR zeroes it out.

Before:

<img width="1503" alt="Screenshot 2021-03-22 at 09 37 54" src="https://user-images.githubusercontent.com/1204802/111962404-8ac7ca00-8af2-11eb-8b1b-1bab994e5408.png">

After:

<img width="1506" alt="Screenshot 2021-03-22 at 09 38 46" src="https://user-images.githubusercontent.com/1204802/111962414-8dc2ba80-8af2-11eb-9ed8-1ab51707845a.png">

The margin has almost certainly appeared recently as a result of many of the refactors of the editor styles. Meaning, the margin was zeroed out somewhere else.

## How has this been tested?

- Use a minimalist block theme such as "Empty Theme" from https://github.com/WordPress/theme-experiments
- Test the Index template in the site editro
- Note how there's extra margin left of the query block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
