### PR TITLE
Restore the default editor font for the non FSE themes

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -645,12 +645,12 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 		unset( $settings['styles'][ $i ] );
 	}
 
-	// Remove the default font editor styles.
-	// When Gutenberg is updated to have minimum version of WordPress 5.8
-	// This could be removed.
-	foreach ( $settings['styles'] as $j => $style ) {
-		if ( 0 === strpos( $style['css'], 'body { font-family:' ) ) {
-			unset( $settings['styles'][ $j ] );
+	// Remove the default font editor styles for FSE themes.
+	if ( gutenberg_is_fse_theme() ) {
+		foreach ( $settings['styles'] as $j => $style ) {
+			if ( 0 === strpos( $style['css'], 'body { font-family:' ) ) {
+				unset( $settings['styles'][ $j ] );
+			}
 		}
 	}
 


### PR DESCRIPTION
In Gutenberg 10.2 we removed the default font family from themes and just relies on browser defaults and the font provided by themes. It seems that this has been too disruptive for some themes, so to avoid confusing users with this change, I'm only applying it to block themes where frontend/editor parity is a bit more important.