### PR TITLE
Navigation component: Align item text to the left/right

### DIFF
--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -14,7 +14,7 @@ import { isRTL } from '@wordpress/i18n';
 import { G2, UI } from '../../utils/colors-values';
 import Button from '../../button';
 import Text from '../../text';
-import { reduceMotion, space } from '../../utils';
+import { reduceMotion, space, rtl } from '../../utils';
 
 export const NavigationUI = styled.div`
 	width: 100%;
@@ -163,6 +163,7 @@ export const ItemBaseUI = styled.li`
 		width: 100%;
 		color: ${ G2.lightGray.ui };
 		padding: ${ space( 1 ) } ${ space( 2 ) }; /* 8px 16px */
+		${ rtl( { textAlign: 'left' }, { textAlign: 'right' } ) }
 
 		&:hover,
 		&:focus:not( [aria-disabled='true'] ):active,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes https://github.com/WordPress/gutenberg/issues/30059

## How has this been tested?
1. Open site editor
2. Open browsing sidebar (W menu)
3. Make sure long texts are aligned to the left in LTR mode, right in RTL mode


## Screenshots <!-- if applicable -->
Before
![image](https://user-images.githubusercontent.com/2256104/111972877-34f91f00-8afe-11eb-817e-d50faa0ead45.png)

After
![image](https://user-images.githubusercontent.com/2256104/111972913-404c4a80-8afe-11eb-99f4-2aa9f19ab8dd.png)

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
