### PR TITLE
Use a default sans serif font for the widget screen

### DIFF
--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -1,5 +1,7 @@
 .wp-block[data-type="core/widget-area"] {
 	max-width: $widget-area-width;
+	margin-left: auto;
+	margin-right: auto;
 
 	.components-panel__body > .components-panel__body-title {
 		font-family: $default-font;

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -1,6 +1,9 @@
 .edit-widgets-block-editor {
 	position: relative;
 
+	// This is the default font that is going to be used in the content of the areas (blocks).
+	font-family: $default-font;
+
 	// The button element easily inherits styles that are meant for the editor style.
 	// These rules enhance the specificity to reduce that inheritance.
 	// This is copied from edit-post/src/components/style.scss but without the padding.


### PR DESCRIPTION
Follow up to #30034 

Now that the block editor resets the font used to the browser default instead of just relying on WPAdmin inheritance, we need to adapt it in the widgets editor if we want to keep the serif font there.

In the post editor and site editor we just rely on the browser default or the theme provided styles.