### PR TITLE
Fix navigation screen font.

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -16,6 +16,9 @@
 		margin: 0;
 		font-size: 15px;
 		padding: $grid-unit-15;
+
+		// This is the default font that is going to be used in the content of the areas (blocks).
+		font-family: $default-font;
 	}
 
 	.wp-block-navigation-link {


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/30034#issuecomment-803947613. Pairs well with #30084.

This PR explicitly sets system fonts for navigation block items in the navigation screen. Before:

<img width="540" alt="Screenshot 2021-03-22 at 11 34 57" src="https://user-images.githubusercontent.com/1204802/111977476-0fbadf80-8b03-11eb-9427-c1f79bfbfd6c.png">

After:

<img width="534" alt="Screenshot 2021-03-22 at 11 36 38" src="https://user-images.githubusercontent.com/1204802/111977482-1184a300-8b03-11eb-8cba-9a7c13c11369.png">


## How has this been tested?

Use "Empty Theme" and test a navigation menu in the navigation screen. You should see system fonts.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
