### PR TITLE
Optimistically continue with empty data when user data for global styles is not a JSON

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -389,7 +389,7 @@ class WP_Theme_JSON_Resolver {
 			$json_decoding_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_decoding_error ) {
 				error_log( 'Error when decoding user schema: ' . json_last_error_msg() );
-				return $config;
+				return new WP_Theme_JSON( $config );
 			}
 
 			// Very important to verify if the flag isGlobalStylesUserThemeJSON is true.

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -143,7 +143,17 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 	const contexts = useMemo( () => getContexts( blockTypes ), [ blockTypes ] );
 
 	const { userStyles, mergedStyles } = useMemo( () => {
-		let newUserStyles = content ? JSON.parse( content ) : EMPTY_CONTENT;
+		let newUserStyles;
+		try {
+			newUserStyles = content ? JSON.parse( content ) : EMPTY_CONTENT;
+		} catch ( e ) {
+			/* eslint-disable no-console */
+			console.error( 'User data is not JSON' );
+			console.error( e );
+			/* eslint-enable no-console */
+			newUserStyles = EMPTY_CONTENT;
+		}
+
 		// It is very important to verify if the flag isGlobalStylesUserThemeJSON is true.
 		// If it is not true the content was not escaped and is not safe.
 		if ( ! newUserStyles.isGlobalStylesUserThemeJSON ) {


### PR DESCRIPTION
We store user data in the database as a JSON. If, for any reason, the data is corrupted and no longer is in a JSON format, there's an error that prevent the front-end, and editors from loading.

This PR fixes that by logging the error but continuing assuming user data is empty, both in the server and client (site-editor).

## How to test

- Using the `trunk` branch and tt1-blocks theme, load the site editor and make some changes via the global styles sidebar (ex: set the background color to red). This makes sure there's a CPT holding user data in the database.
- Load this PR.
- Go to the database and edit the CPT for the user data that matches the theme in use (`post_name = wp-global-styles-tt1-blocks`). Edit the contents of the `post_content` so it's not a JSON: for example, substitute them by the string `this is not a json`.
- Go to the front-end of the site, verify that it works (without the user data changes).
- Go to the editors (post, site) and verify that they load (without the user data changes).

Before this PR the front-end and editor will show an error and won't load.
