### PR TITLE
Blocks: Ensure theme category is only added when not provided

### DIFF
--- a/docs/getting-started/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/getting-started/tutorials/create-block/submitting-to-block-directory.md
@@ -60,6 +60,7 @@ The Block Editor allows you to indicate the category your block belongs in, maki
 -   media
 -   design
 -   widgets
+-   theme
 -   embed
 
 [Read more about categories.](/docs/reference-guides/block-api/block-metadata.md#category)

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -128,6 +128,7 @@ The core provided categories are:
 -   media
 -   design
 -   widgets
+-   theme
 -   embed
 
 Plugins and Themes can also register [custom block categories](/docs/reference-guides/filters/block-filters.md#managing-block-categories).

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -60,6 +60,7 @@ The core provided categories are:
 -   media
 -   design
 -   widgets
+-   theme
 -   embed
 
 ```js
@@ -225,8 +226,6 @@ example: {
 -   **Type:** `Object[]`
 
 Similarly to how the block's style variations can be declared, a block type can define block variations that the user can pick from. The difference is that, rather than changing only the visual appearance, this field provides a way to apply initial custom attributes and inner blocks at the time when a block is inserted. See the [Block Variations API](/docs/reference-guides/block-api/block-variations.md) for more details.
-
-
 
 #### supports (optional)
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -347,11 +347,26 @@ add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
 
 /**
  * Filters the default block categories array to add a new one for themes.
- * Should be removed and turned into a core.trac ticket for merge.
  *
- * @param array $categories The list of default block categories.
+ * This can be removed when plugin support requires WordPress 5.8.0+.
+ *
+ * @see https://core.trac.wordpress.org/ticket/52883
+ *
+ * @param array[] $categories The list of default block categories.
+ *
+ * @return array[] Filtered block categories.
  */
 function gutenberg_register_theme_block_category( $categories ) {
+	foreach ( $categories as $category ) {
+		// Skip when the category is already set in WordPress core.
+		if (
+			isset( $category['slug'] ) &&
+			'theme' === $category['slug']
+		) {
+			return $categories;
+		}
+	}
+
 	$categories[] = array(
 		'slug'  => 'theme',
 		'title' => _x( 'Theme', 'block category', 'gutenberg' ),

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Scaffolded plugin requires WordPress 5.7 now ([#29757](https://github.com/WordPress/gutenberg/pull/29757)).
 
+### New Features
+
+-   Add new `theme` category to select for the block type ([#30089](https://github.com/WordPress/gutenberg/pull/30089)).
+
 ## 2.1.0 (2021-03-17)
 
 ### New Features

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -177,7 +177,7 @@ The following configurable variables are used with the template files. Template 
 -   `title` (no default) - a display title for your block.
 -   `description` (no default) - a short description for your block.
 -   `dashicon` (no default) - an icon property thats makes it easier to identify a block, see https://developer.wordpress.org/resource/dashicons/.
--   `category` (default: `'widgets'`) - blocks are grouped into categories to help users browse and discover them. The categories provided by core are `text`, `media`, `design`, `widgets`, and `embed`.
+-   `category` (default: `'widgets'`) - blocks are grouped into categories to help users browse and discover them. The categories provided by core are `text`, `media`, `design`, `widgets`, `theme`, and `embed`.
 -   `attributes` (no default) - see https://developer.wordpress.org/block-editor/developers/block-api/block-attributes/.
 -   `supports` (no default) - optional block extended support features, see https://developer.wordpress.org/block-editor/developers/block-api/block-supports/.
 -   `author` (default: `'The WordPress Contributors'`)

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -70,7 +70,7 @@ const category = {
 	type: 'list',
 	name: 'category',
 	message: 'The category name to help users browse and discover your block:',
-	choices: [ 'text', 'media', 'design', 'widgets', 'embed' ],
+	choices: [ 'text', 'media', 'design', 'widgets', 'theme', 'embed' ],
 };
 
 const author = {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Follow-up for #30020.

This PR ensures `theme` category is only added when not provided for the block type categories. It also adds the new category in several places in the documentation.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

The category in the inserter should look like before:

![image](https://user-images.githubusercontent.com/548849/111785380-d2651080-88bc-11eb-8da2-69a1c314e43b.png)

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
