### PR TITLE
Remove path ignore configs from CI

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -2,12 +2,8 @@ name: Build Gutenberg Plugin Zip
 
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
   push:
     branches: [trunk]
-    paths-ignore:
-    - '**.md'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -2,16 +2,8 @@ name: Create Block
 
 on:
   pull_request:
-    paths:
-    - 'packages/**'
-    - '!packages/**/test/**'
-    - '!packages/**/*.md'
   push:
     branches: [trunk, wp/trunk]
-    paths:
-    - 'packages/**'
-    - '!packages/**/test/**'
-    - '!packages/**/*.md'
 
 jobs:
   checks:

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -2,14 +2,10 @@ name: End-to-End Tests
 
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
   push:
     branches:
       - trunk
       - 'wp/**'
-    paths-ignore:
-    - '**.md'
 
 jobs:
   admin:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,8 +2,6 @@ name: Performances Tests
 
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
   release:
     types: [created]
 

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -2,12 +2,8 @@ name: React Native E2E Tests (Android)
 
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
   push:
     branches: [trunk]
-    paths-ignore:
-    - '**.md'
 
 jobs:
   test:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -2,12 +2,8 @@ name: React Native E2E Tests (iOS)
 
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
   push:
     branches: [trunk]
-    paths-ignore:
-    - '**.md'
 
 jobs:
   test:


### PR DESCRIPTION
When Jobs are marked required, they can't have a "path-ignore" config in the workflow yaml file.
This PR removes this config from all of our jobs.
I think we could explore adding similar checks using actions instead in the job itself separately.