### PR TITLE
CSS: Add a reset for image heights

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -52,6 +52,7 @@ figure.wp-block-image:not(.wp-block) {
 [data-align="wide"] > .wp-block-image,
 [data-align="full"] > .wp-block-image {
 	img {
+		height: auto;
 		width: 100%;
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -2,6 +2,7 @@
 	margin: 0 0 1em 0;
 
 	img {
+		height: auto;
 		max-width: 100%;
 	}
 
@@ -15,6 +16,7 @@
 
 	&.alignfull img,
 	&.alignwide img {
+		height: auto;
 		width: 100%;
 	}
 

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -67,6 +67,7 @@
 
 .wp-block-media-text__media img,
 .wp-block-media-text__media video {
+	height: auto;
 	max-width: unset;
 	width: 100%;
 	vertical-align: middle;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -19,6 +19,7 @@
 		width: 120px;
 
 		img {
+			height: auto;
 			width: 100%;
 		}
 	}
@@ -38,6 +39,7 @@
 
 	img {
 		display: block;
+		height: auto;
 		max-width: 100%;
 	}
 


### PR DESCRIPTION
## Description (updated 5/10/2021)
For all images that explicitly set widths or max-widths of 100% we should add a `height: auto` rule to prevent them from becoming stretched.

## Screenshots <!-- if applicable -->
Before:
![localhost_4759__p=435](https://user-images.githubusercontent.com/275961/136035673-9a8bb768-9cd2-4473-bcaf-ce54bee435a0.jpg)

After:
![localhost_4759__p=435 (1)](https://user-images.githubusercontent.com/275961/136035664-573c10b0-1755-42d6-b603-79adb2510af7.jpg)


## How has this been tested?
- Switch to empty theme
- Add an image to a post
- Check that the image isn't stretched in the front end
- Try setting wide and full alignments
- Also try a media and text block



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
