### PR TITLE
Remove obsolete editor styles for List block.

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -21,7 +21,6 @@
 @import "./image/editor.scss";
 @import "./latest-comments/editor.scss";
 @import "./latest-posts/editor.scss";
-@import "./list/editor.scss";
 @import "./media-text/editor.scss";
 @import "./more/editor.scss";
 @import "./navigation/editor.scss";

--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -1,7 +1,0 @@
-// Extra specificity required to override default editor styles, which are
-// loaded after core block styles. If the load order changes, this rule can be
-// removed. See https://github.com/WordPress/gutenberg/issues/24011.
-ol.has-background.has-background,
-ul.has-background.has-background {
-	padding: $block-bg-padding--v $block-bg-padding--h;
-}


### PR DESCRIPTION
## Description
Thanks to #30034, the editor styles introduced in #21387 for the List block can now be removed since the normal block styles in the block's `style.scss` will take precedence as expected.

## Testing instructions.
Make sure the List block color controls still work in the editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
