### PR TITLE
Site Editor (Experiment): Automatically open the sidebar to the appropriate template sub-menu

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
@@ -51,6 +51,12 @@ export const TEMPLATES_NEW_OPTIONS = [
 	'index',
 ];
 
+export const TEMPLATE_OVERRIDES = {
+	singular: [ 'single', 'page' ],
+	index: [ 'archive', '404', 'search', 'singular', 'home' ],
+	home: [ 'front-page' ],
+};
+
 export const MENU_ROOT = 'root';
 export const MENU_CONTENT_CATEGORIES = 'content-categories';
 export const MENU_CONTENT_PAGES = 'content-pages';

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
@@ -25,64 +25,15 @@ import {
 	MENU_TEMPLATES_PAGES,
 	MENU_TEMPLATES_POSTS,
 	MENU_TEMPLATES_UNUSED,
-	TEMPLATES_GENERAL,
-	TEMPLATES_PAGES_PREFIXES,
-	TEMPLATES_POSTS_PREFIXES,
-	TEMPLATES_TOP_LEVEL,
 } from '../constants';
 import NewTemplateDropdown from '../new-template-dropdown';
 import TemplateNavigationItem from '../template-navigation-item';
 import SearchResults from '../search-results';
 import TemplatesSubMenu from './templates-sub';
-import { isTemplateSuperseded } from '../template-hierarchy';
-
-function getTemplateLocation( template ) {
-	const { slug } = template;
-
-	const isTopLevelTemplate = TEMPLATES_TOP_LEVEL.includes( slug );
-	if ( isTopLevelTemplate ) {
-		return MENU_TEMPLATES;
-	}
-
-	const isGeneralTemplate = TEMPLATES_GENERAL.includes( slug );
-	if ( isGeneralTemplate ) {
-		return MENU_TEMPLATES_GENERAL;
-	}
-
-	const isPostsTemplate = TEMPLATES_POSTS_PREFIXES.some( ( prefix ) =>
-		slug.startsWith( prefix )
-	);
-	if ( isPostsTemplate ) {
-		return MENU_TEMPLATES_POSTS;
-	}
-
-	const isPagesTemplate = TEMPLATES_PAGES_PREFIXES.some( ( prefix ) =>
-		slug.startsWith( prefix )
-	);
-	if ( isPagesTemplate ) {
-		return MENU_TEMPLATES_PAGES;
-	}
-
-	return MENU_TEMPLATES_GENERAL;
-}
-
-function getUnusedTemplates( templates, showOnFront ) {
-	const unusedTemplates = [];
-
-	const templateSlugs = map( templates, 'slug' );
-	const supersededTemplates = templates.filter( ( { slug } ) =>
-		isTemplateSuperseded( slug, templateSlugs, showOnFront )
-	);
-
-	return [ ...supersededTemplates, ...unusedTemplates ];
-}
-
-function getTemplatesLocationMap( templates ) {
-	return templates.reduce( ( obj, template ) => {
-		obj[ template.slug ] = getTemplateLocation( template );
-		return obj;
-	}, {} );
-}
+import {
+	getTemplatesLocationMap,
+	getUnusedTemplates,
+} from '../template-hierarchy';
 
 export default function TemplatesMenu() {
 	const [ search, setSearch ] = useState( '' );

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-hierarchy.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-hierarchy.js
@@ -65,14 +65,12 @@ export function getTemplateLocation( slug ) {
 }
 
 export function getUnusedTemplates( templates, showOnFront ) {
-	const unusedTemplates = [];
-
 	const templateSlugs = map( templates, 'slug' );
 	const supersededTemplates = templates.filter( ( { slug } ) =>
 		isTemplateSuperseded( slug, templateSlugs, showOnFront )
 	);
 
-	return [ ...supersededTemplates, ...unusedTemplates ];
+	return supersededTemplates;
 }
 
 export function getTemplatesLocationMap( templates ) {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-hierarchy.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-hierarchy.js
@@ -1,8 +1,22 @@
-const TEMPLATE_OVERRIDES = {
-	singular: [ 'single', 'page' ],
-	index: [ 'archive', '404', 'search', 'singular', 'home' ],
-	home: [ 'front-page' ],
-};
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	MENU_TEMPLATES,
+	MENU_TEMPLATES_GENERAL,
+	MENU_TEMPLATES_PAGES,
+	MENU_TEMPLATES_POSTS,
+	TEMPLATE_OVERRIDES,
+	TEMPLATES_GENERAL,
+	TEMPLATES_PAGES_PREFIXES,
+	TEMPLATES_POSTS_PREFIXES,
+	TEMPLATES_TOP_LEVEL,
+} from './constants';
 
 export function isTemplateSuperseded( slug, existingSlugs, showOnFront ) {
 	if ( ! TEMPLATE_OVERRIDES[ slug ] ) {
@@ -20,4 +34,50 @@ export function isTemplateSuperseded( slug, existingSlugs, showOnFront ) {
 			existingSlugs.includes( overrideSlug ) ||
 			isTemplateSuperseded( overrideSlug, existingSlugs, showOnFront )
 	);
+}
+
+export function getTemplateLocation( slug ) {
+	const isTopLevelTemplate = TEMPLATES_TOP_LEVEL.includes( slug );
+	if ( isTopLevelTemplate ) {
+		return MENU_TEMPLATES;
+	}
+
+	const isGeneralTemplate = TEMPLATES_GENERAL.includes( slug );
+	if ( isGeneralTemplate ) {
+		return MENU_TEMPLATES_GENERAL;
+	}
+
+	const isPostsTemplate = TEMPLATES_POSTS_PREFIXES.some( ( prefix ) =>
+		slug.startsWith( prefix )
+	);
+	if ( isPostsTemplate ) {
+		return MENU_TEMPLATES_POSTS;
+	}
+
+	const isPagesTemplate = TEMPLATES_PAGES_PREFIXES.some( ( prefix ) =>
+		slug.startsWith( prefix )
+	);
+	if ( isPagesTemplate ) {
+		return MENU_TEMPLATES_PAGES;
+	}
+
+	return MENU_TEMPLATES_GENERAL;
+}
+
+export function getUnusedTemplates( templates, showOnFront ) {
+	const unusedTemplates = [];
+
+	const templateSlugs = map( templates, 'slug' );
+	const supersededTemplates = templates.filter( ( { slug } ) =>
+		isTemplateSuperseded( slug, templateSlugs, showOnFront )
+	);
+
+	return [ ...supersededTemplates, ...unusedTemplates ];
+}
+
+export function getTemplatesLocationMap( templates ) {
+	return templates.reduce( ( obj, template ) => {
+		obj[ template.slug ] = getTemplateLocation( template.slug );
+		return obj;
+	}, {} );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Follow up to #26964

The previous PR only took care of Template Parts, as they are arguably easier to handle.
Their sub-menu location is explicitly contained by their post objects, so there's not much to figure out.

Templates locations, on the other hand, depend on other templates as well.
While most commonly templates will belong to a precise location as defined in the Navigation Panel constants, at times a template might be _superseded_ by another (e.g. `front-page` supersedes `home`), and end up grouped in their own "Unused" sub-menu.

Most of the groundwork was already laid down in #28291, by creating specific helper functions for the menu rendering.

This PR takes those functions and moves them into the `template-hierarchy.js` utilities file, to share them with the `getCurrentTemplateNavigationPanelSubMenu` selector introduced in the previous PR.

_NOTE: I'm not overly happy with how I've handled this move, and I think I can do better._

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
