### PR TITLE
Fix Template Part Alignments behavior

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -68,6 +68,10 @@ export function useFocusFirstElement( clientId ) {
 			return;
 		}
 
+		if ( ! ref.current ) {
+			return;
+		}
+
 		const { ownerDocument } = ref.current;
 
 		// Focus is captured by the wrapper node, so while focus transition

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -164,17 +164,19 @@ export const withDataAlign = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const { name, attributes } = props;
 		const { align } = attributes;
+		const blockAllowedAlignments = getValidAlignments(
+			getBlockSupport( name, 'align' ),
+			hasBlockSupport( name, 'alignWide', true )
+		);
+		const validAlignments = useAvailableAlignments(
+			blockAllowedAlignments
+		);
 
 		// If an alignment is not assigned, there's no need to go through the
 		// effort to validate or assign its value.
 		if ( align === undefined ) {
 			return <BlockListBlock { ...props } />;
 		}
-
-		const validAlignments = getValidAlignments(
-			getBlockSupport( name, 'align' ),
-			hasBlockSupport( name, 'alignWide', true )
-		);
 
 		let wrapperProps = props.wrapperProps;
 		if ( validAlignments.includes( align ) ) {

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -14,13 +14,11 @@ import {
 	getBlockType,
 	hasBlockSupport,
 } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { BlockControls, BlockAlignmentControl } from '../components';
-import { store as blockEditorStore } from '../store';
 import useAvailableAlignments from '../components/block-alignment-control/use-available-alignments';
 
 /**
@@ -166,10 +164,6 @@ export const withDataAlign = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const { name, attributes } = props;
 		const { align } = attributes;
-		const hasWideEnabled = useSelect(
-			( select ) => !! select( blockEditorStore ).getSettings().alignWide,
-			[]
-		);
 
 		// If an alignment is not assigned, there's no need to go through the
 		// effort to validate or assign its value.
@@ -179,8 +173,7 @@ export const withDataAlign = createHigherOrderComponent(
 
 		const validAlignments = getValidAlignments(
 			getBlockSupport( name, 'align' ),
-			hasBlockSupport( name, 'alignWide', true ),
-			hasWideEnabled
+			hasBlockSupport( name, 'alignWide', true )
 		);
 
 		let wrapperProps = props.wrapperProps;

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -76,7 +76,7 @@ export default function TemplatePartEdit( {
 
 	const blockProps = useBlockProps();
 	const isPlaceholder = ! slug;
-	const isEntityAvailable = ! isPlaceholder && ! isMissing;
+	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
 	const TagName = tagName || getTagBasedOnArea( area );
 
 	// We don't want to render a missing state if we have any inner blocks.

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -114,51 +114,57 @@ export default function TemplatePartEdit( {
 				isEntityAvailable={ isEntityAvailable }
 				templatePartId={ templatePartId }
 			/>
-			<TagName { ...blockProps }>
-				{ isPlaceholder && (
+			{ isPlaceholder && (
+				<TagName { ...blockProps }>
 					<TemplatePartPlaceholder
 						area={ attributes.area }
 						setAttributes={ setAttributes }
 						innerBlocks={ innerBlocks }
 					/>
-				) }
-				{ isEntityAvailable && (
-					<BlockControls>
-						<ToolbarGroup className="wp-block-template-part__block-control-group">
-							<Dropdown
-								className="wp-block-template-part__preview-dropdown-button"
-								contentClassName="wp-block-template-part__preview-dropdown-content"
-								position="bottom right left"
-								renderToggle={ ( { isOpen, onToggle } ) => (
-									<ToolbarButton
-										aria-expanded={ isOpen }
-										onClick={ onToggle }
-										// Disable when open to prevent odd FireFox bug causing reopening.
-										// As noted in https://github.com/WordPress/gutenberg/pull/24990#issuecomment-689094119 .
-										disabled={ isOpen }
-									>
-										{ __( 'Replace' ) }
-									</ToolbarButton>
-								) }
-								renderContent={ ( { onClose } ) => (
-									<TemplatePartSelection
-										setAttributes={ setAttributes }
-										onClose={ onClose }
-									/>
-								) }
-							/>
-						</ToolbarGroup>
-					</BlockControls>
-				) }
-				{ isEntityAvailable && (
-					<TemplatePartInnerBlocks
-						postId={ templatePartId }
-						hasInnerBlocks={ innerBlocks.length > 0 }
-						layout={ layout }
-					/>
-				) }
-				{ ! isPlaceholder && ! isResolved && <Spinner /> }
-			</TagName>
+				</TagName>
+			) }
+			{ isEntityAvailable && (
+				<BlockControls>
+					<ToolbarGroup className="wp-block-template-part__block-control-group">
+						<Dropdown
+							className="wp-block-template-part__preview-dropdown-button"
+							contentClassName="wp-block-template-part__preview-dropdown-content"
+							position="bottom right left"
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<ToolbarButton
+									aria-expanded={ isOpen }
+									onClick={ onToggle }
+									// Disable when open to prevent odd FireFox bug causing reopening.
+									// As noted in https://github.com/WordPress/gutenberg/pull/24990#issuecomment-689094119 .
+									disabled={ isOpen }
+								>
+									{ __( 'Replace' ) }
+								</ToolbarButton>
+							) }
+							renderContent={ ( { onClose } ) => (
+								<TemplatePartSelection
+									setAttributes={ setAttributes }
+									onClose={ onClose }
+								/>
+							) }
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
+			{ isEntityAvailable && (
+				<TemplatePartInnerBlocks
+					tagName={ TagName }
+					blockProps={ blockProps }
+					postId={ templatePartId }
+					hasInnerBlocks={ innerBlocks.length > 0 }
+					layout={ layout }
+				/>
+			) }
+			{ ! isPlaceholder && ! isResolved && (
+				<TagName { ...blockProps }>
+					<Spinner />
+				</TagName>
+			) }
 		</RecursionProvider>
 	);
 }

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -14,6 +14,8 @@ export default function TemplatePartInnerBlocks( {
 	postId: id,
 	hasInnerBlocks,
 	layout,
+	tagName: TagName,
+	blockProps,
 } ) {
 	const themeSupportsLayout = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
@@ -31,21 +33,18 @@ export default function TemplatePartInnerBlocks( {
 		'wp_template_part',
 		{ id }
 	);
-	const innerBlocksProps = useInnerBlocksProps(
-		{},
-		{
-			value: blocks,
-			onInput,
-			onChange,
-			renderAppender: hasInnerBlocks
-				? undefined
-				: InnerBlocks.ButtonBlockAppender,
-			__experimentalLayout: {
-				type: 'default',
-				// Find a way to inject this in the support flag code (hooks).
-				alignments: themeSupportsLayout ? alignments : undefined,
-			},
-		}
-	);
-	return <div { ...innerBlocksProps } />;
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		value: blocks,
+		onInput,
+		onChange,
+		renderAppender: hasInnerBlocks
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
+		__experimentalLayout: {
+			type: 'default',
+			// Find a way to inject this in the support flag code (hooks).
+			alignments: themeSupportsLayout ? alignments : undefined,
+		},
+	} );
+	return <TagName { ...innerBlocksProps } />;
 }

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -36,8 +36,8 @@ const createTemplatePart = async (
 	await createNewButton.click();
 	await page.waitForSelector(
 		isNested
-			? '.wp-block-template-part .wp-block-template-part .block-editor-block-list__layout'
-			: '.wp-block-template-part .block-editor-block-list__layout'
+			? '.wp-block-template-part .wp-block-template-part.block-editor-block-list__layout'
+			: '.wp-block-template-part.block-editor-block-list__layout'
 	);
 	await openDocumentSettingsSidebar();
 
@@ -204,7 +204,7 @@ describe( 'Multi-entity editor states', () => {
 
 			// Wait for site editor to load.
 			await canvas().waitForSelector(
-				'.wp-block-template-part .block-editor-block-list__layout'
+				'.wp-block-template-part.block-editor-block-list__layout'
 			);
 
 			// Our custom template shows up in the "Templates > General" menu; let's use it.

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -20,7 +20,7 @@ describe( 'Multi-entity save flow', () => {
 	const checkboxInputSelector = '.components-checkbox-control__input';
 	const entitiesSaveSelector = '.editor-entities-saved-states__save-button';
 	const templatePartSelector = '*[data-type="core/template-part"]';
-	const activatedTemplatePartSelector = `${ templatePartSelector } .block-editor-block-list__layout`;
+	const activatedTemplatePartSelector = `${ templatePartSelector }.block-editor-block-list__layout`;
 	const savePanelSelector = '.entities-saved-states__panel';
 	const closePanelButtonSelector =
 		'.editor-post-publish-panel__header-cancel-button button';

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -165,7 +165,9 @@ describe( 'Template Part', () => {
 		} );
 
 		it( 'Should convert selected block to template part', async () => {
-			await canvas().waitForSelector( '.wp-block-template-part' );
+			await canvas().waitForSelector(
+				'.wp-block-template-part.block-editor-block-list__layout'
+			);
 			const initialTemplateParts = await canvas().$$(
 				'.wp-block-template-part'
 			);
@@ -203,7 +205,9 @@ describe( 'Template Part', () => {
 		} );
 
 		it( 'Should convert multiple selected blocks to template part', async () => {
-			await canvas().waitForSelector( '.wp-block-template-part' );
+			await canvas().waitForSelector(
+				'.wp-block-template-part.block-editor-block-list__layout'
+			);
 			const initialTemplateParts = await canvas().$$(
 				'.wp-block-template-part'
 			);

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -262,7 +262,7 @@ describe( 'Template Part', () => {
 			'.editor-entities-saved-states__save-button';
 		const savePostSelector = '.editor-post-publish-button__button';
 		const templatePartSelector = '*[data-type="core/template-part"]';
-		const activatedTemplatePartSelector = `${ templatePartSelector } .block-editor-block-list__layout`;
+		const activatedTemplatePartSelector = `${ templatePartSelector }.block-editor-block-list__layout`;
 		const testContentSelector = `//p[contains(., "${ testContent }")]`;
 		const createNewButtonSelector =
 			'//button[contains(text(), "New template part")]';


### PR DESCRIPTION
In #30077 we added the layout config for template parts, it was working well in the frontend but not the editor for a couple reasons.

 - The data-aligned was not applied
 - The styles didn't match the markup because the block had two wrappers.

this PR fixes both issues.