### PR TITLE
Social links, default protocol to https if not set

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -45,9 +45,10 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		)
 	);
 
-	// Add defaul https if no protocol specified. Issue: #21699
-	// The following chunk of code is taken from esc_url that is hard-coded to http://
-	// See: https://developer.wordpress.org/reference/functions/esc_url/ for details.
+	// Add default https if no protocol specified. The following chunk of code
+	// is taken from esc_url which is hard-coded to use http. This can be
+	// changed to pass the parameter in esc_url after
+	// https://core.trac.wordpress.org/ticket/52886 is in core.
 	if ( strpos( $url, ':' ) === false && ! in_array( $url[0], array( '/', '#', '?' ), true ) &&
 		! preg_match( '/^[a-z0-9-]+?\.php/i', $url ) ) {
 		$url = 'https://' . $url;

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -14,6 +14,7 @@
  *
  * @return string Rendered HTML of the referenced block.
  */
+
 function render_block_core_social_link( $attributes, $content, $block ) {
 	$open_in_new_tab = isset( $block->context['openInNewTab'] ) ? $block->context['openInNewTab'] : false;
 
@@ -44,6 +45,14 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 			'style' => block_core_social_link_get_color_styles( $block->context ),
 		)
 	);
+
+	// Add defaul https if no protocol specified. Issue: #21699
+	// The following chunk of code is taken from esc_url that is hard-coded to http://
+	// See: https://developer.wordpress.org/reference/functions/esc_url/
+	if ( strpos( $url, ':' ) === false && ! in_array( $url[0], array( '/', '#', '?' ), true ) &&
+        ! preg_match( '/^[a-z0-9-]+?\.php/i', $url ) ) {
+        $url = 'https://' . $url;
+    }
 
 	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $attribute . ' class="wp-block-social-link-anchor"> ' . $icon . '</a></li>';
 }

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -14,7 +14,6 @@
  *
  * @return string Rendered HTML of the referenced block.
  */
-
 function render_block_core_social_link( $attributes, $content, $block ) {
 	$open_in_new_tab = isset( $block->context['openInNewTab'] ) ? $block->context['openInNewTab'] : false;
 
@@ -48,11 +47,11 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 
 	// Add defaul https if no protocol specified. Issue: #21699
 	// The following chunk of code is taken from esc_url that is hard-coded to http://
-	// See: https://developer.wordpress.org/reference/functions/esc_url/
+	// See: https://developer.wordpress.org/reference/functions/esc_url/ for details.
 	if ( strpos( $url, ':' ) === false && ! in_array( $url[0], array( '/', '#', '?' ), true ) &&
-        ! preg_match( '/^[a-z0-9-]+?\.php/i', $url ) ) {
-        $url = 'https://' . $url;
-    }
+		! preg_match( '/^[a-z0-9-]+?\.php/i', $url ) ) {
+		$url = 'https://' . $url;
+	}
 
 	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $attribute . ' class="wp-block-social-link-anchor"> ' . $icon . '</a></li>';
 }


### PR DESCRIPTION
If no protocol is specified the core esc_url function will default to http:// protocol, this probably should be updated in core to allow a parameter to default to https

See: https://developer.wordpress.org/reference/functions/esc_url/

This change takes the chunk of code from esc_url that determines if needed and defaults to https if no protocol specified.

Fixes #21699


## Testing

1. Create a new post 
2. Add a social links block
3. Add multiple social link icons with and without protocols
4. Save post and check markup displayed when viewed

**Before:**
You should see `http://` protocol for links with no protocol specified 

**After:**
You should see `https://` protocol for links with no protocol specified.

Links with protocol specified will be unchanged, so `http://` entered will stay as `http://`

