### PR TITLE
dom: Add types to phrasing-content

### DIFF
--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -114,11 +114,11 @@ _Related_
 
 _Parameters_
 
--   _context_ `string`: Set to "paste" to exclude invisible elements and sensitive data.
+-   _context_ `[string]`: Set to "paste" to exclude invisible elements and sensitive data.
 
 _Returns_
 
--   `Object`: Schema.
+-   `Partial<ContentSchema>`: Schema.
 
 <a name="getRectangleFromRange" href="#getRectangleFromRange">#</a> **getRectangleFromRange**
 
@@ -220,7 +220,7 @@ _Related_
 
 _Parameters_
 
--   _node_ `Element`: The node to test.
+-   _node_ `Node`: The node to test.
 
 _Returns_
 
@@ -228,7 +228,13 @@ _Returns_
 
 <a name="isTextContent" href="#isTextContent">#</a> **isTextContent**
 
-Undocumented declaration.
+_Parameters_
+
+-   _node_ `Node`: 
+
+_Returns_
+
+-   `boolean`: Node is text content
 
 <a name="isTextField" href="#isTextField">#</a> **isTextField**
 

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -10,9 +10,21 @@ import { omit, without } from 'lodash';
  */
 
 /**
+ * @typedef {Record<string,SemanticElementDefinition>} ContentSchema
+ */
+
+/**
+ * @typedef SemanticElementDefinition
+ * @property {string[]} [attributes] Content attributes
+ * @property {ContentSchema} [children] Content attributes
+ */
+
+/**
  * All text-level semantic elements.
  *
  * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html
+ *
+ * @type {ContentSchema}
  */
 const textContentSchema = {
 	strong: {},
@@ -60,6 +72,8 @@ without( Object.keys( textContentSchema ), '#text', 'br' ).forEach( ( tag ) => {
  * Embedded content elements.
  *
  * @see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#embedded-content-0
+ *
+ * @type {ContentSchema}
  */
 const embeddedContentSchema = {
 	audio: {
@@ -127,10 +141,10 @@ const phrasingContentSchema = {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content
  *
- * @param {string} context Set to "paste" to exclude invisible elements and
+ * @param {string} [context] Set to "paste" to exclude invisible elements and
  *                         sensitive data.
  *
- * @return {Object} Schema.
+ * @return {Partial<ContentSchema>} Schema.
  */
 export function getPhrasingContentSchema( context ) {
 	if ( context !== 'paste' ) {
@@ -162,7 +176,7 @@ export function getPhrasingContentSchema( context ) {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content
  *
- * @param {Element} node The node to test.
+ * @param {Node} node The node to test.
  *
  * @return {boolean} True if phrasing content, false if not.
  */
@@ -171,6 +185,10 @@ export function isPhrasingContent( node ) {
 	return getPhrasingContentSchema().hasOwnProperty( tag ) || tag === 'span';
 }
 
+/**
+ * @param {Node} node
+ * @return {boolean} Node is text content
+ */
 export function isTextContent( node ) {
 	const tag = node.nodeName.toLowerCase();
 	return textContentSchema.hasOwnProperty( tag ) || tag === 'span';

--- a/packages/dom/tsconfig.json
+++ b/packages/dom/tsconfig.json
@@ -7,6 +7,7 @@
 	"include": [
 		"src/data-transfer.js",
 		"src/focusable.js",
+		"src/phrasing-content.js",
 		"src/tabbable.js",
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds types to `phrasing-content.js` based on #29220 (Thanks @sirreal !!!)

## How has this been tested?
Type check passes. No runtime changes.

## Types of changes
Non breaking changes, just adding types.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
