### PR TITLE
dom: Add types progressively to dom modules

### DIFF
--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -24,7 +24,7 @@ _Parameters_
 
 _Returns_
 
--   `?DOMRect`: The rectangle.
+-   `DOMRect | null`: The rectangle.
 
 <a name="documentHasSelection" href="#documentHasSelection">#</a> **documentHasSelection**
 

--- a/packages/dom/src/dom/caret-range-from-point.js
+++ b/packages/dom/src/dom/caret-range-from-point.js
@@ -8,7 +8,7 @@
  * @param {number}   x    Horizontal position within the current viewport.
  * @param {number}   y    Vertical position within the current viewport.
  *
- * @return {?Range} The best range for the given point.
+ * @return {Range | null} The best range for the given point.
  */
 export default function caretRangeFromPoint( doc, x, y ) {
 	if ( doc.caretRangeFromPoint ) {

--- a/packages/dom/src/dom/compute-caret-rect.js
+++ b/packages/dom/src/dom/compute-caret-rect.js
@@ -2,20 +2,22 @@
  * Internal dependencies
  */
 import getRectangleFromRange from './get-rectangle-from-range';
+import { assertIsDefined } from '../utils/assert-is-defined';
 
 /**
  * Get the rectangle for the selection in a container.
  *
  * @param {Window} win The window of the selection.
  *
- * @return {?DOMRect} The rectangle.
+ * @return {DOMRect | null} The rectangle.
  */
 export default function computeCaretRect( win ) {
 	const selection = win.getSelection();
+	assertIsDefined( selection );
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
 	if ( ! range ) {
-		return;
+		return null;
 	}
 
 	return getRectangleFromRange( range );

--- a/packages/dom/src/dom/compute-caret-rect.js
+++ b/packages/dom/src/dom/compute-caret-rect.js
@@ -13,7 +13,7 @@ import { assertIsDefined } from '../utils/assert-is-defined';
  */
 export default function computeCaretRect( win ) {
 	const selection = win.getSelection();
-	assertIsDefined( selection );
+	assertIsDefined( selection, 'selection' );
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
 	if ( ! range ) {

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -24,12 +24,12 @@ export default function getRectangleFromRange( range ) {
 	// Correct invalid "BR" ranges. The cannot contain any children.
 	if ( startContainer.nodeName === 'BR' ) {
 		const { parentNode } = startContainer;
-		assertIsDefined( parentNode );
+		assertIsDefined( parentNode, 'parentNode' );
 		const index = /** @type {Node[]} */ ( Array.from(
 			parentNode.childNodes
 		) ).indexOf( startContainer );
 
-		assertIsDefined( ownerDocument );
+		assertIsDefined( ownerDocument, 'ownerDocument' );
 		range = ownerDocument.createRange();
 		range.setStart( parentNode, index );
 		range.setEnd( parentNode, index );
@@ -43,13 +43,13 @@ export default function getRectangleFromRange( range ) {
 	//
 	// See: https://stackoverflow.com/a/6847328/995445
 	if ( ! rect ) {
-		assertIsDefined( ownerDocument );
+		assertIsDefined( ownerDocument, 'ownerDocument' );
 		const padNode = ownerDocument.createTextNode( '\u200b' );
-		assertIsDefined( padNode.parentNode );
 		// Do not modify the live range.
 		range = range.cloneRange();
 		range.insertNode( padNode );
 		rect = range.getClientRects()[ 0 ];
+		assertIsDefined( padNode.parentNode, 'padNode.parentNode' );
 		padNode.parentNode.removeChild( padNode );
 	}
 

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import { assertIsDefined } from '../utils/assert-is-defined';
+
+/**
  * Get the rectangle of a given Range.
  *
  * @param {Range} range The range.
@@ -15,13 +20,15 @@ export default function getRectangleFromRange( range ) {
 
 	const { startContainer } = range;
 	const { ownerDocument } = startContainer;
+	assertIsDefined( ownerDocument );
 
 	// Correct invalid "BR" ranges. The cannot contain any children.
 	if ( startContainer.nodeName === 'BR' ) {
 		const { parentNode } = startContainer;
-		const index = Array.from( parentNode.childNodes ).indexOf(
-			startContainer
-		);
+		assertIsDefined( parentNode );
+		const index = /** @type {Node[]} */ ( Array.from(
+			parentNode.childNodes
+		) ).indexOf( startContainer );
 
 		range = ownerDocument.createRange();
 		range.setStart( parentNode, index );
@@ -37,6 +44,7 @@ export default function getRectangleFromRange( range ) {
 	// See: https://stackoverflow.com/a/6847328/995445
 	if ( ! rect ) {
 		const padNode = ownerDocument.createTextNode( '\u200b' );
+		assertIsDefined( padNode.parentNode );
 		// Do not modify the live range.
 		range = range.cloneRange();
 		range.insertNode( padNode );

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -20,7 +20,6 @@ export default function getRectangleFromRange( range ) {
 
 	const { startContainer } = range;
 	const { ownerDocument } = startContainer;
-	assertIsDefined( ownerDocument );
 
 	// Correct invalid "BR" ranges. The cannot contain any children.
 	if ( startContainer.nodeName === 'BR' ) {
@@ -30,6 +29,7 @@ export default function getRectangleFromRange( range ) {
 			parentNode.childNodes
 		) ).indexOf( startContainer );
 
+		assertIsDefined( ownerDocument );
 		range = ownerDocument.createRange();
 		range.setStart( parentNode, index );
 		range.setEnd( parentNode, index );
@@ -43,6 +43,7 @@ export default function getRectangleFromRange( range ) {
 	//
 	// See: https://stackoverflow.com/a/6847328/995445
 	if ( ! rect ) {
+		assertIsDefined( ownerDocument );
 		const padNode = ownerDocument.createTextNode( '\u200b' );
 		assertIsDefined( padNode.parentNode );
 		// Do not modify the live range.

--- a/packages/dom/src/test/utils.js
+++ b/packages/dom/src/test/utils.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { assertIsDefined } from '../utils/assert-is-defined';
+
+describe( 'assertIsDefined', () => {
+	it( 'should throw if the variable is null', () => {
+		expect( () => assertIsDefined( null ) ).toThrow(
+			"Expected 'val' to be defined, but received null"
+		);
+	} );
+
+	it( 'should throw if the variable is undefined', () => {
+		expect( () => assertIsDefined( undefined ) ).toThrow(
+			"Expected 'val' to be defined, but received undefined"
+		);
+	} );
+
+	it.each( [ 0, '', NaN, -0, 1, new String(), {}, [], false, Infinity ] )(
+		'should not throw if the value is %s',
+		( val ) => {
+			expect( () => assertIsDefined( val ) ).not.toThrow();
+		}
+	);
+} );

--- a/packages/dom/src/test/utils.js
+++ b/packages/dom/src/test/utils.js
@@ -5,13 +5,13 @@ import { assertIsDefined } from '../utils/assert-is-defined';
 
 describe( 'assertIsDefined', () => {
 	it( 'should throw if the variable is null', () => {
-		expect( () => assertIsDefined( null ) ).toThrow(
+		expect( () => assertIsDefined( null, 'val' ) ).toThrow(
 			"Expected 'val' to be defined, but received null"
 		);
 	} );
 
 	it( 'should throw if the variable is undefined', () => {
-		expect( () => assertIsDefined( undefined ) ).toThrow(
+		expect( () => assertIsDefined( undefined, 'val' ) ).toThrow(
 			"Expected 'val' to be defined, but received undefined"
 		);
 	} );
@@ -19,7 +19,7 @@ describe( 'assertIsDefined', () => {
 	it.each( [ 0, '', NaN, -0, 1, new String(), {}, [], false, Infinity ] )(
 		'should not throw if the value is %s',
 		( val ) => {
-			expect( () => assertIsDefined( val ) ).not.toThrow();
+			expect( () => assertIsDefined( val, 'val' ) ).not.toThrow();
 		}
 	);
 } );

--- a/packages/dom/src/utils/assert-is-defined.ts
+++ b/packages/dom/src/utils/assert-is-defined.ts
@@ -1,0 +1,9 @@
+export function assertIsDefined< T >(
+	val: T
+): asserts val is NonNullable< T > {
+	if ( val === undefined || val === null ) {
+		throw new Error(
+			`Expected 'val' to be defined, but received ${ val }`
+		);
+	}
+}

--- a/packages/dom/src/utils/assert-is-defined.ts
+++ b/packages/dom/src/utils/assert-is-defined.ts
@@ -1,9 +1,10 @@
 export function assertIsDefined< T >(
-	val: T
+	val: T,
+	name: string
 ): asserts val is NonNullable< T > {
 	if ( val === undefined || val === null ) {
 		throw new Error(
-			`Expected 'val' to be defined, but received ${ val }`
+			`Expected '${ name }' to be defined, but received ${ val }`
 		);
 	}
 }

--- a/packages/dom/tsconfig.json
+++ b/packages/dom/tsconfig.json
@@ -6,6 +6,10 @@
 	},
 	"include": [
 		"src/data-transfer.js",
+		"src/dom/caret-range-from-point.js",
+		"src/dom/compute-caret-rect.js",
+		"src/dom/get-rectangle-from-range.js",
+		"src/utils/**/*",
 		"src/focusable.js",
 		"src/phrasing-content.js",
 		"src/tabbable.js",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds more types to `dom` progressively, starting with just three modules.

Also adds helper that @sirreal suggested, `assertIsDefined` which covers the various null cases we were seeing without adding null checks everywhere. These null checks _are necessary_ and the original code did not handle them, which is dangerous.

## How has this been tested?
Unit tests pass and type checks pass.

## Types of changes
Adds types and fixes unhandle null checks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
