### PR TITLE
Block editor: move is-typing and is-outline-mode classes up the tree

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -15,12 +15,7 @@ import {
 	hasBlockSupport,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import {
-	withDispatch,
-	withSelect,
-	useDispatch,
-	useSelect,
-} from '@wordpress/data';
+import { withDispatch, withSelect, useDispatch } from '@wordpress/data';
 import { compose, pure, ifCondition } from '@wordpress/compose';
 
 /**
@@ -88,21 +83,6 @@ function BlockListBlock( {
 } ) {
 	const { removeBlock } = useDispatch( blockEditorStore );
 	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
-	const isTypingWithinBlock = useSelect(
-		( select ) => {
-			const { isTyping, hasSelectedInnerBlock } = select(
-				blockEditorStore
-			);
-			return (
-				// We only care about this prop when the block is selected
-				// Thus to avoid unnecessary rerenders we avoid updating the
-				// prop if the block is not selected.
-				( isSelected || hasSelectedInnerBlock( clientId, true ) ) &&
-				isTyping()
-			);
-		},
-		[ clientId, isSelected ]
-	);
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces
@@ -183,10 +163,7 @@ function BlockListBlock( {
 		isSelected,
 		index,
 		// The wp-block className is important for editor styles.
-		className: classnames( className, {
-			'wp-block': ! isAligned,
-			'is-typing': isTypingWithinBlock,
-		} ),
+		className: classnames( className, { 'wp-block': ! isAligned } ),
 		wrapperProps: omit( wrapperProps, [ 'data-align' ] ),
 	};
 	const memoizedValue = useMemo( () => value, Object.values( value ) );

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -30,6 +30,14 @@ export default function BlockList( { className, __experimentalLayout } ) {
 	const insertionPoint = useInsertionPoint( ref );
 	useScrollSelectionIntoView( ref );
 
+	const { isTyping, isOutlineMode } = useSelect( ( select ) => {
+		const { isTyping: _isTyping, getSettings } = select( blockEditorStore );
+		return {
+			isTyping: _isTyping(),
+			isOutlineMode: getSettings().outlineMode,
+		};
+	}, [] );
+
 	return (
 		<BlockNodes.Provider value={ blockNodes }>
 			{ insertionPoint }
@@ -38,7 +46,8 @@ export default function BlockList( { className, __experimentalLayout } ) {
 				ref={ ref }
 				className={ classnames(
 					'block-editor-block-list__layout is-root-container',
-					className
+					className,
+					{ 'is-typing': isTyping, 'is-outline-mode': isOutlineMode }
 				) }
 			>
 				<SetBlockNodes.Provider value={ setBlockNodes }>

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -193,7 +193,7 @@
 		}
 	}
 
-	&.is-outline-mode.is-selected:not(.is-typing) {
+	.is-outline-mode:not(.is-typing) &.is-selected {
 		&::after {
 			box-shadow: 0 0 0 $border-width $gray-900; // Selected not focussed
 			top: $border-width;
@@ -210,7 +210,7 @@
 		}
 	}
 
-	&.is-outline-mode.is-hovered:not(.is-typing) {
+	.is-outline-mode:not(.is-typing) &.is-hovered {
 		cursor: default;
 
 		&::after {
@@ -223,7 +223,7 @@
 		}
 	}
 
-	&.is-outline-mode.is-selected.is-hovered {
+	.is-outline-mode &.is-selected.is-hovered {
 		cursor: unset;
 	}
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -193,40 +193,6 @@
 		}
 	}
 
-	.is-outline-mode:not(.is-typing) &.is-selected {
-		&::after {
-			box-shadow: 0 0 0 $border-width $gray-900; // Selected not focussed
-			top: $border-width;
-			left: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-		}
-
-		&:focus {
-			&::after {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			}
-		}
-	}
-
-	.is-outline-mode:not(.is-typing) &.is-hovered {
-		cursor: default;
-
-		&::after {
-			top: $border-width;
-			left: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			box-shadow: 0 0 0 $border-width $gray-900;
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-		}
-	}
-
-	.is-outline-mode &.is-selected.is-hovered {
-		cursor: unset;
-	}
-
 	// Spotlight mode.
 	&.is-focus-mode:not(.is-multi-selected) {
 		opacity: 0.5;
@@ -336,6 +302,40 @@
 		.block-editor-default-block-appender .block-editor-inserter {
 			left: auto;
 			right: $grid-unit-10;
+		}
+	}
+}
+
+.is-outline-mode:not(.is-typing) .block-editor-block-list__block {
+	&.is-hovered {
+		cursor: default;
+
+		&::after {
+			top: $border-width;
+			left: $border-width;
+			right: $border-width;
+			bottom: $border-width;
+			box-shadow: 0 0 0 $border-width $gray-900;
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
+		}
+	}
+
+	&.is-selected {
+		cursor: unset;
+
+		&::after {
+			box-shadow: 0 0 0 $border-width $gray-900; // Selected not focussed
+			top: $border-width;
+			left: $border-width;
+			right: $border-width;
+			bottom: $border-width;
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
+		}
+
+		&:focus {
+			&::after {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -38,7 +38,6 @@ export function useBlockClassNames( clientId ) {
 			} = select( blockEditorStore );
 			const {
 				focusMode,
-				outlineMode,
 				__experimentalSpotlightEntityBlocks: spotlightEntityBlocks,
 			} = getSettings();
 			const isDragging = isBlockBeingDragged( clientId );
@@ -64,7 +63,6 @@ export function useBlockClassNames( clientId ) {
 					isLargeViewport &&
 					( isSelected || isAncestorOfSelectedBlock ),
 				'is-focus-mode': focusMode && isLargeViewport,
-				'is-outline-mode': outlineMode,
 				'has-child-selected': isAncestorOfSelectedBlock && ! isDragging,
 				'has-active-entity': activeEntityBlockId,
 				// Determine if there is an active entity area to spotlight.

--- a/packages/block-library/src/freeform/editor.scss
+++ b/packages/block-library/src/freeform/editor.scss
@@ -307,11 +307,10 @@ div[data-type="core/freeform"] {
 	// On mobile, toolbars go edge to edge.
 	padding: 0;
 
-	// By using the `data-type` attribute in this selector it ensures these styles only appear
-	// when the block itself is selected, without it they would also show when a parent block
-	// is selected.
-	div[data-type="core/freeform"].is-selected &,
-	div[data-type="core/freeform"].is-typing & {
+	// By using the `data-type` attribute in this selector it ensures these
+	// styles only appear when the block itself is selected, without it they
+	// would also show when a parent block is selected.
+	div[data-type="core/freeform"].is-selected & {
 		display: block;
 		border-color: $gray-900;
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

It doesn't make sense for these classes to be added to blocks. They should be added to the block editor (wrapper). Currently `is-outline-mode` is added to every single block in the whole block editor that sets this setting to true. For `is-typing`, we have an exception to only add it to the selected block because it would otherwise impact performance negatively.

## How has this been tested?

In the site editor, the outline should disappear when typing in a block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
