### PR TITLE
Clear floats for blocks that do not share the same layout container

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -67,6 +67,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 				max-width: <?php echo $content_size ? $content_size : $wide_size; ?>;
 				margin-left: auto;
 				margin-right: auto;
+				overflow: auto;
 			}
 
 			<?php echo '.wp-container-' . $id; ?> > .alignwide {

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -68,7 +68,6 @@ export function LayoutStyle( { selector, layout = {} } ) {
 			float: right;
 			margin-left: 2em;
 		}
-
 	`;
 
 	return <style>{ style }</style>;

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -45,6 +45,7 @@ export function LayoutStyle( { selector, layout = {} } ) {
 					max-width: ${ contentSize ?? wideSize };
 					margin-left: auto;
 					margin-right: auto;
+					overflow: auto;
 				}
 
 				${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
@@ -67,6 +68,7 @@ export function LayoutStyle( { selector, layout = {} } ) {
 			float: right;
 			margin-left: 2em;
 		}
+
 	`;
 
 	return <style>{ style }</style>;


### PR DESCRIPTION
The new layout + alignments system is more declarative and context specific. 

Now that these new powers exist, does it make sense like for floats to only apply to blocks that share the same layout context?

This PR clears the floats per layout container for templates that are using the new alignments system. I am not sure about the approach, but adding `overflow: auto;` to the container was the simplest I could think of. I chose to not target the `:after` element to clear the floats because the block-list component makes extensive use of it.

What do you think?

Before | After (using emptytheme)
-------- | --------
<img width="965" alt="Screen Shot 2021-03-22 at 5 49 47 PM" src="https://user-images.githubusercontent.com/5375500/112064223-db095100-8b1f-11eb-8b38-727869e9204f.png"> | <img width="970" alt="Screen Shot 2021-03-22 at 5 41 00 PM" src="https://user-images.githubusercontent.com/5375500/112064261-ea889a00-8b1f-11eb-8591-a99d47a4c750.png">

**To Test**
- Activate emptytheme
- Add [this content](https://pastebin.com/xepVGA11) to a post