### PR TITLE
Block Supports: Add border color, style and width support

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -13,11 +13,11 @@
  */
 function gutenberg_register_border_support( $block_type ) {
 	// Determine if any border related features are supported.
-	$has_border_color_support = gutenberg_has_border_support( $block_type, 'color' );
+	$has_border_color_support = gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'color' ) );
 	$has_border_support       =
-		gutenberg_has_border_support( $block_type, 'radius' ) ||
-		gutenberg_has_border_support( $block_type, 'style' ) ||
-		gutenberg_has_border_support( $block_type, 'width' ) ||
+		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ) ) ||
+		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'style' ) ) ||
+		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'width' ) ) ||
 		$has_border_color_support;
 
 	// Setup attributes and styles within that if needed.
@@ -56,31 +56,34 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	$styles  = array();
 
 	// Border radius.
-	if ( gutenberg_has_border_support( $block_type, 'radius' ) ) {
-		if ( isset( $block_attributes['style']['border']['radius'] ) ) {
-			$border_radius = (int) $block_attributes['style']['border']['radius'];
-			$styles[]      = sprintf( 'border-radius: %dpx;', $border_radius );
-		}
+	if (
+		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ) ) &&
+		isset( $block_attributes['style']['border']['radius'] )
+	) {
+		$border_radius = (int) $block_attributes['style']['border']['radius'];
+		$styles[]      = sprintf( 'border-radius: %dpx;', $border_radius );
 	}
 
 	// Border style.
-	if ( gutenberg_has_border_support( $block_type, 'style' ) ) {
-		if ( isset( $block_attributes['style']['border']['style'] ) ) {
-			$border_style = $block_attributes['style']['border']['style'];
-			$styles[]     = sprintf( 'border-style: %s;', $border_style );
-		}
+	if (
+		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'style' ) ) &&
+		isset( $block_attributes['style']['border']['style'] )
+	) {
+		$border_style = $block_attributes['style']['border']['style'];
+		$styles[]     = sprintf( 'border-style: %s;', $border_style );
 	}
 
 	// Border width.
-	if ( gutenberg_has_border_support( $block_type, 'width' ) ) {
-		if ( isset( $block_attributes['style']['border']['width'] ) ) {
-			$border_width = intval( $block_attributes['style']['border']['width'] );
-			$styles[]     = sprintf( 'border-width: %dpx;', $border_width );
-		}
+	if (
+		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'width' ) ) &&
+		isset( $block_attributes['style']['border']['width'] )
+	) {
+		$border_width = intval( $block_attributes['style']['border']['width'] );
+		$styles[]     = sprintf( 'border-width: %dpx;', $border_width );
 	}
 
 	// Border color.
-	if ( gutenberg_has_border_support( $block_type, 'color' ) ) {
+	if ( gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'color' ) ) ) {
 		$has_named_border_color  = array_key_exists( 'borderColor', $block_attributes );
 		$has_custom_border_color = isset( $block_attributes['style']['border']['color'] );
 
@@ -124,24 +127,6 @@ function gutenberg_skip_border_serialization( $block_type ) {
 	return is_array( $border_support ) &&
 		array_key_exists( '__experimentalSkipSerialization', $border_support ) &&
 		$border_support['__experimentalSkipSerialization'];
-}
-
-/**
- * Checks whether the current block type supports the feature requested.
- *
- * @param WP_Block_Type $block_type Block type to check for support.
- * @param string        $feature    Name of the feature to check support for.
- * @param mixed         $default    Fallback value for feature support, defaults to false.
- *
- * @return boolean                  Whether or not the feature is supported.
- */
-function gutenberg_has_border_support( $block_type, $feature, $default = false ) {
-	$block_support = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$block_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), $default );
-	}
-
-	return true === $block_support || ( is_array( $block_support ) && _wp_array_get( $block_support, array( $feature ), false ) );
 }
 
 // Register the block support.

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -13,12 +13,8 @@
  */
 function gutenberg_register_border_support( $block_type ) {
 	// Determine if any border related features are supported.
+	$has_border_support       = gutenberg_block_has_support( $block_type, array( '__experimentalBorder' ) );
 	$has_border_color_support = gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'color' ) );
-	$has_border_support       =
-		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ) ) ||
-		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'style' ) ) ||
-		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'width' ) ) ||
-		$has_border_color_support;
 
 	// Setup attributes and styles within that if needed.
 	if ( ! $block_type->attributes ) {

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -6,24 +6,34 @@
  */
 
 /**
- * Registers the style attribute used by the border feature if needed for block types that
- * support borders.
+ * Registers the style attribute used by the border feature if needed for block
+ * types that support borders.
  *
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_border_support( $block_type ) {
-	// Determine border related features supported.
-	// Border width, style etc can be added in the future.
-	$has_border_radius_support = gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ), false );
+	// Determine if any border related features are supported.
+	$has_border_color_support = gutenberg_has_border_support( $block_type, 'color' );
+	$has_border_support       =
+		gutenberg_has_border_support( $block_type, 'radius' ) ||
+		gutenberg_has_border_support( $block_type, 'style' ) ||
+		gutenberg_has_border_support( $block_type, 'width' ) ||
+		$has_border_color_support;
 
 	// Setup attributes and styles within that if needed.
 	if ( ! $block_type->attributes ) {
 		$block_type->attributes = array();
 	}
 
-	if ( $has_border_radius_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+	if ( $has_border_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
 		$block_type->attributes['style'] = array(
 			'type' => 'object',
+		);
+	}
+
+	if ( $has_border_color_support && ! array_key_exists( 'borderColor', $block_type->attributes ) ) {
+		$block_type->attributes['borderColor'] = array(
+			'type' => 'string',
 		);
 	}
 }
@@ -38,38 +48,100 @@ function gutenberg_register_border_support( $block_type ) {
  * @return array Border CSS classes and inline styles.
  */
 function gutenberg_apply_border_support( $block_type, $block_attributes ) {
-	$border_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), false );
-
-	if (
-		is_array( $border_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $border_support ) &&
-		$border_support['__experimentalSkipSerialization']
-	) {
+	if ( gutenberg_skip_border_serialization( $block_type ) ) {
 		return array();
 	}
 
-	// Arrays used to ease addition of further border related features in future.
-	$styles = array();
+	$classes = array();
+	$styles  = array();
 
-	// Border Radius.
-	$has_border_radius_support = gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ), false );
-	if ( $has_border_radius_support ) {
+	// Border radius.
+	if ( gutenberg_has_border_support( $block_type, 'radius' ) ) {
 		if ( isset( $block_attributes['style']['border']['radius'] ) ) {
 			$border_radius = (int) $block_attributes['style']['border']['radius'];
 			$styles[]      = sprintf( 'border-radius: %dpx;', $border_radius );
 		}
 	}
 
-	// Border width, style etc can be added here.
+	// Border style.
+	if ( gutenberg_has_border_support( $block_type, 'style' ) ) {
+		if ( isset( $block_attributes['style']['border']['style'] ) ) {
+			$border_style = $block_attributes['style']['border']['style'];
+			$styles[]     = sprintf( 'border-style: %s;', $border_style );
+		}
+	}
+
+	// Border width.
+	if ( gutenberg_has_border_support( $block_type, 'width' ) ) {
+		if ( isset( $block_attributes['style']['border']['width'] ) ) {
+			$border_width = intval( $block_attributes['style']['border']['width'] );
+			$styles[]     = sprintf( 'border-width: %dpx;', $border_width );
+		}
+	}
+
+	// Border color.
+	if ( gutenberg_has_border_support( $block_type, 'color' ) ) {
+		$has_named_border_color  = array_key_exists( 'borderColor', $block_attributes );
+		$has_custom_border_color = isset( $block_attributes['style']['border']['color'] );
+
+		if ( $has_named_border_color || $has_custom_border_color ) {
+			$classes[] = 'has-border-color';
+		}
+
+		if ( $has_named_border_color ) {
+			$classes[] = sprintf( 'has-%s-border-color', $block_attributes['borderColor'] );
+		} elseif ( $has_custom_border_color ) {
+			$border_color = $block_attributes['style']['border']['color'];
+			$styles[]     = sprintf( 'border-color: %s;', $border_color );
+		}
+	}
 
 	// Collect classes and styles.
 	$attributes = array();
+
+	if ( ! empty( $classes ) ) {
+		$attributes['class'] = implode( ' ', $classes );
+	}
 
 	if ( ! empty( $styles ) ) {
 		$attributes['style'] = implode( ' ', $styles );
 	}
 
 	return $attributes;
+}
+
+/**
+ * Checks whether serialization of the current block's border properties should
+ * occur.
+ *
+ * @param WP_Block_type $block_type       Block type.
+ *
+ * @return boolean
+ */
+function gutenberg_skip_border_serialization( $block_type ) {
+	$border_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), false );
+
+	return is_array( $border_support ) &&
+		array_key_exists( '__experimentalSkipSerialization', $border_support ) &&
+		$border_support['__experimentalSkipSerialization'];
+}
+
+/**
+ * Checks whether the current block type supports the feature requested.
+ *
+ * @param WP_Block_Type $block_type Block type to check for support.
+ * @param string        $feature    Name of the feature to check support for.
+ * @param mixed         $default    Fallback value for feature support, defaults to false.
+ *
+ * @return boolean                  Whether or not the feature is supported.
+ */
+function gutenberg_has_border_support( $block_type, $feature, $default = false ) {
+	$block_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$block_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), $default );
+	}
+
+	return true === $block_support || ( is_array( $block_support ) && _wp_array_get( $block_support, array( $feature ), false ) );
 }
 
 // Register the block support.

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -198,6 +198,10 @@ class WP_Theme_JSON {
 					'class_suffix'  => 'background-color',
 					'property_name' => 'background-color',
 				),
+				array(
+					'class_suffix'  => 'border-color',
+					'property_name' => 'border-color',
+				),
 			),
 		),
 		array(

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -171,7 +171,10 @@
 				"units": [ "px", "em", "rem", "vh", "vw" ]
 			},
 			"border": {
-				"customRadius": false
+				"customColor": false,
+				"customRadius": false,
+				"customStyle": false,
+				"customWidth": false
 			}
 		}
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -260,6 +260,7 @@ function gutenberg_global_styles_include_support_for_wp_variables( $allow_css, $
 	$allowed_preset_attributes = array(
 		'background',
 		'background-color',
+		'border-color',
 		'color',
 		'font-family',
 		'font-size',

--- a/packages/block-editor/src/components/border-style-control/index.js
+++ b/packages/block-editor/src/components/border-style-control/index.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { CustomSelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const DEFAULT_STYLE = {
+	key: 'default',
+	name: __( 'Default' ),
+	style: { borderStyle: undefined },
+};
+
+const BORDER_STYLES = [
+	DEFAULT_STYLE,
+	{
+		key: 'none',
+		name: __( 'None' ),
+		style: { borderStyle: 'none' },
+	},
+	{
+		key: 'solid',
+		name: __( 'Solid' ),
+		style: { borderStyle: 'solid' },
+	},
+	{
+		key: 'dashed',
+		name: __( 'Dashed' ),
+		style: { borderStyle: 'dashed' },
+	},
+	{
+		key: 'dotted',
+		name: __( 'Dotted' ),
+		style: { borderStyle: 'dotted' },
+	},
+];
+
+/**
+ * Control to display border style options.
+ *
+ * @param  {Object}   props          Component props.
+ * @param  {Object}   props.onChange Handler for changing border style selection.
+ * @param  {Object}   props.value    Currently selected border style value.
+ *
+ * @return {WPElement}      Custom border style select control.
+ */
+export default function BorderStyleControl( { onChange, value } ) {
+	const style = BORDER_STYLES.find( ( option ) => option.key === value );
+
+	return (
+		<fieldset className="components-border-style-control">
+			<CustomSelectControl
+				className="components-border-style-control__select"
+				label={ __( 'Border style' ) }
+				options={ BORDER_STYLES }
+				value={ style || DEFAULT_STYLE }
+				onChange={ ( { selectedItem } ) =>
+					selectedItem.key === 'default'
+						? onChange( undefined )
+						: onChange( selectedItem.key )
+				}
+			/>
+		</fieldset>
+	);
+}

--- a/packages/block-editor/src/components/border-style-control/style.scss
+++ b/packages/block-editor/src/components/border-style-control/style.scss
@@ -1,0 +1,14 @@
+.components-border-style-control__select {
+	margin-bottom: 24px;
+
+	button {
+		width: 100%;
+	}
+
+	ul {
+		li,
+		li:last-child {
+			margin: 6px;
+		}
+	}
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -32,6 +32,7 @@ export {
 	BlockVerticalAlignmentToolbar,
 	BlockVerticalAlignmentControl,
 } from './block-vertical-alignment-control';
+export { default as __experimentalBorderStyleControl } from './border-style-control';
 export { default as ButtonBlockerAppender } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';
 export { default as ColorPaletteControl } from './color-palette/control';

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -18,7 +18,7 @@ import {
 	getColorObjectByColorValue,
 } from '../components/colors';
 import useEditorFeature from '../components/use-editor-feature';
-import { hasBorderFeatureSupport } from './border';
+import { hasBorderFeatureSupport, shouldSkipSerialization } from './border';
 import { cleanEmptyObject } from './utils';
 
 const EMPTY_ARRAY = [];
@@ -129,7 +129,10 @@ function addAttributes( settings ) {
  * @return {Object}            Filtered props to apply to save element.
  */
 function addSaveProps( props, blockType, attributes ) {
-	if ( ! hasBorderFeatureSupport( 'color', blockType ) ) {
+	if (
+		! hasBorderFeatureSupport( 'color', blockType ) ||
+		shouldSkipSerialization( blockType )
+	) {
 		return props;
 	}
 
@@ -154,7 +157,10 @@ function addSaveProps( props, blockType, attributes ) {
  * @return {Object}         Filtered block settings.
  */
 function addEditProps( settings ) {
-	if ( ! hasBorderFeatureSupport( 'color', settings ) ) {
+	if (
+		! hasBorderFeatureSupport( 'color', settings ) ||
+		shouldSkipSerialization( settings )
+	) {
 		return settings;
 	}
 

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -21,6 +21,8 @@ import useEditorFeature from '../components/use-editor-feature';
 import { hasBorderFeatureSupport, shouldSkipSerialization } from './border';
 import { cleanEmptyObject } from './utils';
 
+// Defining empty array here instead of inline avoids unnecessary re-renders of
+// color control.
 const EMPTY_ARRAY = [];
 
 /**

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -59,6 +59,7 @@ export function BorderColorEdit( props ) {
 			},
 		};
 
+		// If empty slug, ensure undefined to remove attribute.
 		const newNamedColor = colorObject?.slug ? colorObject.slug : undefined;
 
 		setAttributes( {

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -20,7 +20,7 @@ import {
 	getColorObjectByAttributeValues,
 } from '../components/colors';
 import useEditorFeature from '../components/use-editor-feature';
-import { hasBorderFeatureSupport, shouldSkipSerialization } from './border';
+import { hasBorderSupport, shouldSkipSerialization } from './border';
 import { cleanEmptyObject } from './utils';
 
 // Defining empty array here instead of inline avoids unnecessary re-renders of
@@ -48,10 +48,6 @@ export function BorderColorEdit( props ) {
 
 	const disableCustomColors = ! useEditorFeature( 'color.custom' );
 	const disableCustomGradients = ! useEditorFeature( 'color.customGradient' );
-
-	if ( useIsBorderColorDisabled( props ) ) {
-		return null;
-	}
 
 	const onChangeColor = ( value ) => {
 		const colorObject = getColorObjectByColorValue( colors, value );
@@ -86,17 +82,6 @@ export function BorderColorEdit( props ) {
 }
 
 /**
- * Custom hook that checks if border color settings have been disabled.
- *
- * @param  {string} name The name of the block.
- * @return {boolean}     Whether border color setting is disabled.
- */
-export function useIsBorderColorDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useEditorFeature( 'border.customColor' );
-	return ! hasBorderFeatureSupport( 'color', blockName ) || isDisabled;
-}
-
-/**
  * Filters registered block settings, extending attributes to include
  * `borderColor` if needed.
  *
@@ -104,7 +89,7 @@ export function useIsBorderColorDisabled( { name: blockName } = {} ) {
  * @return {Object}          Updated block settings.
  */
 function addAttributes( settings ) {
-	if ( ! hasBorderFeatureSupport( 'color', settings ) ) {
+	if ( ! hasBorderSupport( settings, 'color' ) ) {
 		return settings;
 	}
 
@@ -135,7 +120,7 @@ function addAttributes( settings ) {
  */
 function addSaveProps( props, blockType, attributes ) {
 	if (
-		! hasBorderFeatureSupport( 'color', blockType ) ||
+		! hasBorderSupport( blockType, 'color' ) ||
 		shouldSkipSerialization( blockType )
 	) {
 		return props;
@@ -165,7 +150,7 @@ function addSaveProps( props, blockType, attributes ) {
  */
 function addEditProps( settings ) {
 	if (
-		! hasBorderFeatureSupport( 'color', settings ) ||
+		! hasBorderSupport( settings, 'color' ) ||
 		shouldSkipSerialization( settings )
 	) {
 		return settings;
@@ -199,7 +184,7 @@ export const withBorderColorPaletteStyles = createHigherOrderComponent(
 		const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
 
 		if (
-			! hasBorderFeatureSupport( 'color', name ) ||
+			! hasBorderSupport( name, 'color' ) ||
 			shouldSkipSerialization( name )
 		) {
 			return <BlockListBlock { ...props } />;

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -147,6 +147,8 @@ function addSaveProps( props, blockType, attributes ) {
 		[ borderColorClass ]: !! borderColorClass,
 	} );
 
+	// If we are clearing the last of the previous classes in `className`
+	// set it to `undefined` to avoid rendering empty DOM attributes.
 	props.className = newClassName ? newClassName : undefined;
 
 	return props;

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -73,6 +73,8 @@ export function BorderColorEdit( props ) {
 		<ColorGradientControl
 			label={ __( 'Border color' ) }
 			value={ borderColor || style?.border?.color }
+			colors={ colors }
+			gradients={ undefined }
 			disableCustomColors={ disableCustomColors }
 			disableCustomGradients={ disableCustomGradients }
 			onColorChange={ onChangeColor }

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -1,0 +1,197 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ColorGradientControl from '../components/colors-gradients/control';
+import {
+	getColorClassName,
+	getColorObjectByColorValue,
+} from '../components/colors';
+import useEditorFeature from '../components/use-editor-feature';
+import { BORDER_SUPPORT_KEY } from './border';
+import { cleanEmptyObject } from './utils';
+
+const BORDER_COLOR_SUPPORT_KEY = 'color';
+const EMPTY_ARRAY = [];
+
+/**
+ * Inspector control panel containing the border color related configuration.
+ *
+ * There is deliberate overlap between the colors and borders block supports
+ * relating to border color. It can be argued the border color controls could
+ * be included within either, or both, the colors and borders panels in the
+ * inspector controls. If they share the same block attributes it should not
+ * matter.
+ *
+ * @param  {Object} props Block properties.
+ * @return {WPElement}    Border color edit element.
+ */
+export function BorderColorEdit( props ) {
+	const {
+		attributes: { borderColor, style },
+		setAttributes,
+	} = props;
+	const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
+
+	const disableCustomColors = ! useEditorFeature( 'color.custom' );
+	const disableCustomGradients = ! useEditorFeature( 'color.customGradient' );
+
+	if ( useIsBorderColorDisabled( props ) ) {
+		return null;
+	}
+
+	const onChangeColor = ( value ) => {
+		const colorObject = getColorObjectByColorValue( colors, value );
+		const newStyle = {
+			...style,
+			border: {
+				...style?.border,
+				color: colorObject?.slug ? undefined : value,
+			},
+		};
+
+		const newNamedColor = colorObject?.slug ? colorObject.slug : undefined;
+
+		setAttributes( {
+			style: cleanEmptyObject( newStyle ),
+			borderColor: newNamedColor,
+		} );
+	};
+
+	return (
+		<ColorGradientControl
+			label={ __( 'Border color' ) }
+			value={ borderColor || style?.border?.color }
+			disableCustomColors={ disableCustomColors }
+			disableCustomGradients={ disableCustomGradients }
+			onColorChange={ onChangeColor }
+		/>
+	);
+}
+
+/**
+ * Determines if there is border color support.
+ *
+ * @param  {string|Object} blockType Block name or Block Type object.
+ * @return {boolean}                 Whether there is support.
+ */
+export function hasBorderColorSupport( blockType ) {
+	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
+	return !! ( true === support || support?.color );
+}
+
+/**
+ * Custom hook that checks if border color settings have been disabled.
+ *
+ * @param  {string} name The name of the block.
+ * @return {boolean}     Whether border color setting is disabled.
+ */
+export function useIsBorderColorDisabled( { name: blockName } = {} ) {
+	const isDisabled = ! useEditorFeature( 'border.customColor' );
+	return ! hasBorderColorSupport( blockName ) || isDisabled;
+}
+
+/**
+ * Filters registered block settings, extending attributes to include
+ * `borderColor` if needed.
+ *
+ * @param  {Object} settings Original block settings.
+ * @return {Object}          Updated block settings.
+ */
+function addAttributes( settings ) {
+	if ( ! hasBlockSupport( settings, BORDER_COLOR_SUPPORT_KEY ) ) {
+		return settings;
+	}
+
+	// Allow blocks to specify default value if needed.
+	if ( ! settings.attributes.borderColor ) {
+		Object.assign( settings.attributes, {
+			borderColor: {
+				type: 'string',
+			},
+		} );
+	}
+
+	return settings;
+}
+
+/**
+ * Override props assigned to save component to inject border color.
+ *
+ * @param  {Object} props      Additional props applied to save element.
+ * @param  {Object} blockType  Block type definition.
+ * @param  {Object} attributes Block's attributes
+ * @return {Object}            Filtered props to apply to save element.
+ */
+function addSaveProps( props, blockType, attributes ) {
+	if ( ! hasBlockSupport( blockType, BORDER_COLOR_SUPPORT_KEY ) ) {
+		return props;
+	}
+
+	const { borderColor, style } = attributes;
+	const borderColorClass = getColorClassName( 'border-color', borderColor );
+
+	const newClassName = classnames( props.className, {
+		'has-border-color': borderColor || style?.border?.color,
+		[ borderColorClass ]: !! borderColorClass,
+	} );
+
+	props.className = newClassName ? newClassName : undefined;
+
+	return props;
+}
+
+/**
+ * Filters the registered block settings to apply border color styles and
+ * classnames to the block edit wrapper.
+ *
+ * @param {Object} settings Original block settings.
+ * @return {Object}         Filtered block settings.
+ */
+function addEditProps( settings ) {
+	if ( ! hasBlockSupport( settings, BORDER_COLOR_SUPPORT_KEY ) ) {
+		return settings;
+	}
+
+	const existingGetEditWrapperProps = settings.getEditWrapperProps;
+	settings.getEditWrapperProps = ( attributes ) => {
+		let props = {};
+
+		if ( existingGetEditWrapperProps ) {
+			props = existingGetEditWrapperProps( attributes );
+		}
+
+		return addSaveProps( props, settings, attributes );
+	};
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/border/addAttributes',
+	addAttributes
+);
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'core/border/addSaveProps',
+	addSaveProps
+);
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/border/addEditProps',
+	addEditProps
+);

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -112,20 +112,25 @@ export function useIsBorderColorDisabled( { name: blockName } = {} ) {
  * @return {Object}          Updated block settings.
  */
 function addAttributes( settings ) {
-	if ( ! hasBlockSupport( settings, BORDER_COLOR_SUPPORT_KEY ) ) {
+	if ( ! hasBorderColorSupport( settings ) ) {
 		return settings;
 	}
 
 	// Allow blocks to specify default value if needed.
-	if ( ! settings.attributes.borderColor ) {
-		Object.assign( settings.attributes, {
+	if ( settings.attributes.borderColor ) {
+		return settings;
+	}
+
+	// Add new borderColor attribute to block settings.
+	return {
+		...settings,
+		attributes: {
+			...settings.attributes,
 			borderColor: {
 				type: 'string',
 			},
-		} );
-	}
-
-	return settings;
+		},
+	};
 }
 
 /**

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -19,10 +18,9 @@ import {
 	getColorObjectByColorValue,
 } from '../components/colors';
 import useEditorFeature from '../components/use-editor-feature';
-import { BORDER_SUPPORT_KEY } from './border';
+import { hasBorderFeatureSupport } from './border';
 import { cleanEmptyObject } from './utils';
 
-const BORDER_COLOR_SUPPORT_KEY = 'color';
 const EMPTY_ARRAY = [];
 
 /**
@@ -83,17 +81,6 @@ export function BorderColorEdit( props ) {
 }
 
 /**
- * Determines if there is border color support.
- *
- * @param  {string|Object} blockType Block name or Block Type object.
- * @return {boolean}                 Whether there is support.
- */
-export function hasBorderColorSupport( blockType ) {
-	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
-	return !! ( true === support || support?.color );
-}
-
-/**
  * Custom hook that checks if border color settings have been disabled.
  *
  * @param  {string} name The name of the block.
@@ -101,7 +88,7 @@ export function hasBorderColorSupport( blockType ) {
  */
 export function useIsBorderColorDisabled( { name: blockName } = {} ) {
 	const isDisabled = ! useEditorFeature( 'border.customColor' );
-	return ! hasBorderColorSupport( blockName ) || isDisabled;
+	return ! hasBorderFeatureSupport( 'color', blockName ) || isDisabled;
 }
 
 /**
@@ -112,7 +99,7 @@ export function useIsBorderColorDisabled( { name: blockName } = {} ) {
  * @return {Object}          Updated block settings.
  */
 function addAttributes( settings ) {
-	if ( ! hasBorderColorSupport( settings ) ) {
+	if ( ! hasBorderFeatureSupport( 'color', settings ) ) {
 		return settings;
 	}
 
@@ -142,7 +129,7 @@ function addAttributes( settings ) {
  * @return {Object}            Filtered props to apply to save element.
  */
 function addSaveProps( props, blockType, attributes ) {
-	if ( ! hasBlockSupport( blockType, BORDER_COLOR_SUPPORT_KEY ) ) {
+	if ( ! hasBorderFeatureSupport( 'color', blockType ) ) {
 		return props;
 	}
 
@@ -167,7 +154,7 @@ function addSaveProps( props, blockType, attributes ) {
  * @return {Object}         Filtered block settings.
  */
 function addEditProps( settings ) {
-	if ( ! hasBlockSupport( settings, BORDER_COLOR_SUPPORT_KEY ) ) {
+	if ( ! hasBorderFeatureSupport( 'color', settings ) ) {
 		return settings;
 	}
 

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -7,8 +7,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useEditorFeature from '../components/use-editor-feature';
-import { hasBorderFeatureSupport } from './border';
 import { cleanEmptyObject } from './utils';
 
 const MIN_BORDER_RADIUS_VALUE = 0;
@@ -25,10 +23,6 @@ export function BorderRadiusEdit( props ) {
 		attributes: { style },
 		setAttributes,
 	} = props;
-
-	if ( useIsBorderRadiusDisabled( props ) ) {
-		return null;
-	}
 
 	const onChange = ( newRadius ) => {
 		let newStyle = {
@@ -57,15 +51,4 @@ export function BorderRadiusEdit( props ) {
 			onChange={ onChange }
 		/>
 	);
-}
-
-/**
- * Custom hook that checks if border radius settings have been disabled.
- *
- * @param  {string} name The name of the block.
- * @return {boolean}                 Whether border radius setting is disabled.
- */
-export function useIsBorderRadiusDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useEditorFeature( 'border.customRadius' );
-	return ! hasBorderFeatureSupport( 'radius', blockName ) || isDisabled;
 }

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { getBlockSupport } from '@wordpress/blocks';
 import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -9,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useEditorFeature from '../components/use-editor-feature';
-import { BORDER_SUPPORT_KEY } from './border';
+import { hasBorderFeatureSupport } from './border';
 import { cleanEmptyObject } from './utils';
 
 const MIN_BORDER_RADIUS_VALUE = 0;
@@ -61,17 +60,6 @@ export function BorderRadiusEdit( props ) {
 }
 
 /**
- * Determines if there is border radius support.
- *
- * @param  {string|Object} blockType Block name or Block Type object.
- * @return {boolean}                 Whether there is support.
- */
-export function hasBorderRadiusSupport( blockType ) {
-	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
-	return !! ( true === support || support?.radius );
-}
-
-/**
  * Custom hook that checks if border radius settings have been disabled.
  *
  * @param  {string} name The name of the block.
@@ -79,5 +67,5 @@ export function hasBorderRadiusSupport( blockType ) {
  */
 export function useIsBorderRadiusDisabled( { name: blockName } = {} ) {
 	const isDisabled = ! useEditorFeature( 'border.customRadius' );
-	return ! hasBorderRadiusSupport( blockName ) || isDisabled;
+	return ! hasBorderFeatureSupport( 'radius', blockName ) || isDisabled;
 }

--- a/packages/block-editor/src/hooks/border-style.js
+++ b/packages/block-editor/src/hooks/border-style.js
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import BorderStyleControl from '../components/border-style-control';
+import useEditorFeature from '../components/use-editor-feature';
+import { BORDER_SUPPORT_KEY } from './border';
+import { cleanEmptyObject } from './utils';
+
+/**
+ * Inspector control for configuring border style property.
+ *
+ * @param  {Object} props  Block properties.
+ * @return {WPElement}     Border style edit element.
+ */
+export const BorderStyleEdit = ( props ) => {
+	const {
+		attributes: { style },
+		setAttributes,
+	} = props;
+
+	if ( useIsBorderStyleDisabled( props ) ) {
+		return null;
+	}
+
+	const onChange = ( newBorderStyle ) => {
+		const newStyleAttributes = {
+			...style,
+			border: {
+				...style?.border,
+				style: newBorderStyle,
+			},
+		};
+
+		setAttributes( { style: cleanEmptyObject( newStyleAttributes ) } );
+	};
+
+	return (
+		<BorderStyleControl
+			value={ style?.border?.style }
+			onChange={ onChange }
+		/>
+	);
+};
+
+/**
+ * Determines if there is border style support.
+ *
+ * @param  {string|Object} blockType Block name or block type object.
+ * @return {boolean}                 Whether there is support.
+ */
+export const hasBorderStyleSupport = ( blockType ) => {
+	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
+	return !! ( true === support || support?.style );
+};
+
+/**
+ * Custom hook that checks if border style settings have been disabled.
+ *
+ * @param  {string} blockName The name of the block to determine support scope.
+ * @return {boolean}          Whether or not border style is disabled.
+ */
+export const useIsBorderStyleDisabled = ( { name: blockName } = {} ) => {
+	const isDisabled = ! useEditorFeature( 'border.customStyle' );
+	return ! hasBorderStyleSupport( blockName ) || isDisabled;
+};

--- a/packages/block-editor/src/hooks/border-style.js
+++ b/packages/block-editor/src/hooks/border-style.js
@@ -1,14 +1,9 @@
 /**
- * WordPress dependencies
- */
-import { getBlockSupport } from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
 import BorderStyleControl from '../components/border-style-control';
 import useEditorFeature from '../components/use-editor-feature';
-import { BORDER_SUPPORT_KEY } from './border';
+import { hasBorderFeatureSupport } from './border';
 import { cleanEmptyObject } from './utils';
 
 /**
@@ -48,17 +43,6 @@ export const BorderStyleEdit = ( props ) => {
 };
 
 /**
- * Determines if there is border style support.
- *
- * @param  {string|Object} blockType Block name or block type object.
- * @return {boolean}                 Whether there is support.
- */
-export const hasBorderStyleSupport = ( blockType ) => {
-	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
-	return !! ( true === support || support?.style );
-};
-
-/**
  * Custom hook that checks if border style settings have been disabled.
  *
  * @param  {string} blockName The name of the block to determine support scope.
@@ -66,5 +50,5 @@ export const hasBorderStyleSupport = ( blockType ) => {
  */
 export const useIsBorderStyleDisabled = ( { name: blockName } = {} ) => {
 	const isDisabled = ! useEditorFeature( 'border.customStyle' );
-	return ! hasBorderStyleSupport( blockName ) || isDisabled;
+	return ! hasBorderFeatureSupport( 'style', blockName ) || isDisabled;
 };

--- a/packages/block-editor/src/hooks/border-style.js
+++ b/packages/block-editor/src/hooks/border-style.js
@@ -2,8 +2,6 @@
  * Internal dependencies
  */
 import BorderStyleControl from '../components/border-style-control';
-import useEditorFeature from '../components/use-editor-feature';
-import { hasBorderFeatureSupport } from './border';
 import { cleanEmptyObject } from './utils';
 
 /**
@@ -17,10 +15,6 @@ export const BorderStyleEdit = ( props ) => {
 		attributes: { style },
 		setAttributes,
 	} = props;
-
-	if ( useIsBorderStyleDisabled( props ) ) {
-		return null;
-	}
 
 	const onChange = ( newBorderStyle ) => {
 		const newStyleAttributes = {
@@ -40,15 +34,4 @@ export const BorderStyleEdit = ( props ) => {
 			onChange={ onChange }
 		/>
 	);
-};
-
-/**
- * Custom hook that checks if border style settings have been disabled.
- *
- * @param  {string} blockName The name of the block to determine support scope.
- * @return {boolean}          Whether or not border style is disabled.
- */
-export const useIsBorderStyleDisabled = ( { name: blockName } = {} ) => {
-	const isDisabled = ! useEditorFeature( 'border.customStyle' );
-	return ! hasBorderFeatureSupport( 'style', blockName ) || isDisabled;
 };

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import { RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useEditorFeature from '../components/use-editor-feature';
+import { BORDER_SUPPORT_KEY } from './border';
+import { cleanEmptyObject } from './utils';
+
+const MIN_BORDER_WIDTH = 0;
+const MAX_BORDER_WIDTH = 50;
+
+/**
+ * Inspector control for configuring border width property.
+ *
+ * @param  {Object} props  Block properties.
+ * @return {WPElement}     Border width edit element.
+ */
+export const BorderWidthEdit = ( props ) => {
+	const {
+		attributes: { style },
+		setAttributes,
+	} = props;
+
+	if ( useIsBorderWidthDisabled( props ) ) {
+		return null;
+	}
+
+	const onChange = ( newWidth ) => {
+		const newStyle = {
+			...style,
+			border: {
+				...style?.border,
+				width: newWidth,
+			},
+		};
+
+		setAttributes( { style: cleanEmptyObject( newStyle ) } );
+	};
+
+	return (
+		<RangeControl
+			value={ style?.border?.width }
+			label={ __( 'Border width' ) }
+			min={ MIN_BORDER_WIDTH }
+			max={ MAX_BORDER_WIDTH }
+			initialPosition={ 0 }
+			allowReset
+			onChange={ onChange }
+		/>
+	);
+};
+
+/**
+ * Determines if there is border width support.
+ *
+ * @param  {string|Object} blockType Block name or block type object.
+ * @return {boolean}                 Whether there is support.
+ */
+export const hasBorderWidthSupport = ( blockType ) => {
+	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
+	return !! ( true === support || support?.width );
+};
+
+/**
+ * Custom hook that checks if border width settings have been disabled.
+ *
+ * @param  {string} blockName The name of the block to determine support scope.
+ * @return {boolean}          Whether or not border width is disabled.
+ */
+export const useIsBorderWidthDisabled = ( { name: blockName } = {} ) => {
+	const isDisabled = ! useEditorFeature( 'border.customWidth' );
+	return ! hasBorderWidthSupport( blockName ) || isDisabled;
+};

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { getBlockSupport } from '@wordpress/blocks';
 import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -9,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useEditorFeature from '../components/use-editor-feature';
-import { BORDER_SUPPORT_KEY } from './border';
+import { hasBorderFeatureSupport } from './border';
 import { cleanEmptyObject } from './utils';
 
 const MIN_BORDER_WIDTH = 0;
@@ -57,17 +56,6 @@ export const BorderWidthEdit = ( props ) => {
 };
 
 /**
- * Determines if there is border width support.
- *
- * @param  {string|Object} blockType Block name or block type object.
- * @return {boolean}                 Whether there is support.
- */
-export const hasBorderWidthSupport = ( blockType ) => {
-	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
-	return !! ( true === support || support?.width );
-};
-
-/**
  * Custom hook that checks if border width settings have been disabled.
  *
  * @param  {string} blockName The name of the block to determine support scope.
@@ -75,5 +63,5 @@ export const hasBorderWidthSupport = ( blockType ) => {
  */
 export const useIsBorderWidthDisabled = ( { name: blockName } = {} ) => {
 	const isDisabled = ! useEditorFeature( 'border.customWidth' );
-	return ! hasBorderWidthSupport( blockName ) || isDisabled;
+	return ! hasBorderFeatureSupport( 'width', blockName ) || isDisabled;
 };

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -7,8 +7,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useEditorFeature from '../components/use-editor-feature';
-import { hasBorderFeatureSupport } from './border';
 import { cleanEmptyObject } from './utils';
 
 const MIN_BORDER_WIDTH = 0;
@@ -25,10 +23,6 @@ export const BorderWidthEdit = ( props ) => {
 		attributes: { style },
 		setAttributes,
 	} = props;
-
-	if ( useIsBorderWidthDisabled( props ) ) {
-		return null;
-	}
 
 	const onChange = ( newWidth ) => {
 		const newStyle = {
@@ -53,15 +47,4 @@ export const BorderWidthEdit = ( props ) => {
 			onChange={ onChange }
 		/>
 	);
-};
-
-/**
- * Custom hook that checks if border width settings have been disabled.
- *
- * @param  {string} blockName The name of the block to determine support scope.
- * @return {boolean}          Whether or not border width is disabled.
- */
-export const useIsBorderWidthDisabled = ( { name: blockName } = {} ) => {
-	const isDisabled = ! useEditorFeature( 'border.customWidth' );
-	return ! hasBorderFeatureSupport( 'width', blockName ) || isDisabled;
 };

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -60,6 +60,18 @@ export function hasBorderSupport( blockName ) {
 }
 
 /**
+ * Determines if there a specific border feature is supported.
+ *
+ * @param {string}        feature   Name of the border feature e.g.`radius`
+ * @param {string|Object} blockType Block name or block type object.
+ * @return { boolean }              Whether the border feature is supported.
+ */
+export function hasBorderFeatureSupport( feature, blockType ) {
+	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
+	return !! ( true === support || ( support && support[ feature ] ) );
+}
+
+/**
  * Determines whether there is any block support for borders e.g. border radius,
  * style, width etc.
  *

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -64,11 +64,23 @@ export function hasBorderSupport( blockName ) {
  *
  * @param {string}        feature   Name of the border feature e.g.`radius`
  * @param {string|Object} blockType Block name or block type object.
- * @return { boolean }              Whether the border feature is supported.
+ * @return {boolean}                Whether the border feature is supported.
  */
 export function hasBorderFeatureSupport( feature, blockType ) {
 	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
 	return !! ( true === support || ( support && support[ feature ] ) );
+}
+
+/**
+ * Check whether serialization of border classes and styles should be skipped.
+ *
+ * @param  {string|Object} blockType Block name or block type object.
+ * @return {boolean}                 Whether serialization of border properties should occur.
+ */
+export function shouldSkipSerialization( blockType ) {
+	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
+
+	return support?.__experimentalSkipSerialization;
 }
 
 /**

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -10,7 +10,10 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
+import { BorderColorEdit, useIsBorderColorDisabled } from './border-color';
 import { BorderRadiusEdit, useIsBorderRadiusDisabled } from './border-radius';
+import { BorderStyleEdit, useIsBorderStyleDisabled } from './border-style';
+import { BorderWidthEdit, useIsBorderWidthDisabled } from './border-width';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 
@@ -24,15 +27,18 @@ export function BorderPanel( props ) {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Border settings' ) }>
+			<PanelBody title={ __( 'Border settings' ) } initialOpen={ false }>
+				<BorderStyleEdit { ...props } />
+				<BorderWidthEdit { ...props } />
 				<BorderRadiusEdit { ...props } />
+				<BorderColorEdit { ...props } />
 			</PanelBody>
 		</InspectorControls>
 	);
 }
 
 /**
- * Determine whether there is block support for borders.
+ * Determine whether there is block support for border properties.
  *
  * @param {string} blockName Block name.
  * @return {boolean}         Whether there is support.
@@ -44,9 +50,13 @@ export function hasBorderSupport( blockName ) {
 
 	const support = getBlockSupport( blockName, BORDER_SUPPORT_KEY );
 
-	// Further border properties to be added in future iterations.
-	// e.g. support && ( support.radius || support.width || support.style )
-	return !! ( true === support || support?.radius );
+	return !! (
+		true === support ||
+		support?.color ||
+		support?.radius ||
+		support?.width ||
+		support?.style
+	);
 }
 
 /**
@@ -57,11 +67,12 @@ export function hasBorderSupport( blockName ) {
  * @return {boolean}      If border support is completely disabled.
  */
 const useIsBorderDisabled = ( props = {} ) => {
-	// Further border properties to be added in future iterations.
-	// e.g. const configs = [
-	// 		useIsBorderRadiusDisabled( props ),
-	//		useIsBorderWidthDisabled( props ),
-	// ];
-	const configs = [ useIsBorderRadiusDisabled( props ) ];
+	const configs = [
+		useIsBorderColorDisabled( props ),
+		useIsBorderRadiusDisabled( props ),
+		useIsBorderStyleDisabled( props ),
+		useIsBorderWidthDisabled( props ),
+	];
+
 	return configs.every( Boolean );
 };

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -8,4 +8,5 @@ import './generated-class-name';
 import './style';
 import './color';
 import './font-size';
+import './border-color';
 import './layout';

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -17,11 +17,19 @@ describe( 'getInlineStyles', () => {
 			getInlineStyles( {
 				color: { text: 'red', background: 'black' },
 				typography: { lineHeight: 1.5, fontSize: 10 },
-				border: { radius: 10 },
+				border: {
+					radius: 10,
+					width: 3,
+					style: 'dotted',
+					color: '#21759b',
+				},
 			} )
 		).toEqual( {
 			backgroundColor: 'black',
+			borderColor: '#21759b',
 			borderRadius: 10,
+			borderStyle: 'dotted',
+			borderWidth: 3,
 			color: 'red',
 			lineHeight: 1.5,
 			fontSize: 10,

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -27,6 +27,7 @@
 @import "./components/block-types-list/style.scss";
 @import "./components/block-variation-picker/style.scss";
 @import "./components/block-variation-transforms/style.scss";
+@import "./components/border-style-control/style.scss";
 @import "./components/button-block-appender/style.scss";
 @import "./components/colors-gradients/style.scss";
 @import "./components/contrast-checker/style.scss";

--- a/packages/edit-site/src/components/sidebar/border-panel.js
+++ b/packages/edit-site/src/components/sidebar/border-panel.js
@@ -1,0 +1,147 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalBorderStyleControl as BorderStyleControl,
+	__experimentalColorGradientControl as ColorGradientControl,
+} from '@wordpress/block-editor';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useEditorFeature } from '../editor/utils';
+
+const MIN_BORDER_RADIUS_VALUE = 0;
+const MAX_BORDER_RADIUS_VALUE = 50;
+const MIN_BORDER_WIDTH = 0;
+const MAX_BORDER_WIDTH = 50;
+
+// Defining empty array here instead of inline avoids unnecessary re-renders of
+// color control.
+const EMPTY_ARRAY = [];
+
+export function useHasBorderPanel( { supports, name } ) {
+	const controls = [
+		useHasBorderColorControl( { supports, name } ),
+		useHasBorderRadiusControl( { supports, name } ),
+		useHasBorderStyleControl( { supports, name } ),
+		useHasBorderWidthControl( { supports, name } ),
+	];
+
+	return controls.every( Boolean );
+}
+
+function useHasBorderColorControl( { supports, name } ) {
+	return (
+		useEditorFeature( 'border.customColor', name ) &&
+		supports.includes( 'borderColor' )
+	);
+}
+
+function useHasBorderRadiusControl( { supports, name } ) {
+	return (
+		useEditorFeature( 'border.customRadius', name ) &&
+		supports.includes( 'borderRadius' )
+	);
+}
+
+function useHasBorderStyleControl( { supports, name } ) {
+	return (
+		useEditorFeature( 'border.customStyle', name ) &&
+		supports.includes( 'borderStyle' )
+	);
+}
+
+function useHasBorderWidthControl( { supports, name } ) {
+	return (
+		useEditorFeature( 'border.customWidth', name ) &&
+		supports.includes( 'borderWidth' )
+	);
+}
+
+export default function BorderPanel( {
+	context: { supports, name },
+	getStyle,
+	setStyle,
+} ) {
+	// Border style.
+	const hasBorderStyle = useHasBorderStyleControl( { supports, name } );
+	const borderStyle = getStyle( name, 'borderStyle' );
+
+	// Border width.
+	const hasBorderWidth = useHasBorderWidthControl( { supports, name } );
+	const borderWidthValue = parseInt(
+		getStyle( name, 'borderWidth' ) || 0,
+		10
+	);
+
+	// Border radius.
+	const hasBorderRadius = useHasBorderRadiusControl( { supports, name } );
+	const borderRadiusValue = parseInt(
+		getStyle( name, 'borderRadius' ) || 0,
+		10
+	);
+
+	// Border color.
+	const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
+	const disableCustomColors = ! useEditorFeature( 'color.custom' );
+	const disableCustomGradients = ! useEditorFeature( 'color.customGradient' );
+	const hasBorderColor = useHasBorderColorControl( { supports, name } );
+	const borderColor = getStyle( name, 'borderColor' );
+
+	return (
+		<PanelBody title={ __( 'Border' ) } initialOpen={ true }>
+			{ hasBorderStyle && (
+				<BorderStyleControl
+					value={ borderStyle }
+					onChange={ ( value ) =>
+						setStyle( name, 'borderStyle', value )
+					}
+				/>
+			) }
+			{ hasBorderWidth && (
+				<RangeControl
+					value={ borderWidthValue }
+					label={ __( 'Border width' ) }
+					min={ MIN_BORDER_WIDTH }
+					max={ MAX_BORDER_WIDTH }
+					initialPosition={ borderWidthValue }
+					allowReset
+					onChange={ ( value ) => {
+						const widthStyle = value ? `${ value }px` : undefined;
+						setStyle( name, 'borderWidth', widthStyle );
+					} }
+				/>
+			) }
+			{ hasBorderRadius && (
+				<RangeControl
+					value={ borderRadiusValue }
+					label={ __( 'Border radius' ) }
+					min={ MIN_BORDER_RADIUS_VALUE }
+					max={ MAX_BORDER_RADIUS_VALUE }
+					initialPosition={ borderRadiusValue }
+					allowReset
+					onChange={ ( value ) => {
+						const radiusStyle = value ? `${ value }px` : undefined;
+						setStyle( name, 'borderRadius', radiusStyle );
+					} }
+				/>
+			) }
+			{ hasBorderColor && (
+				<ColorGradientControl
+					label={ __( 'Border color' ) }
+					value={ borderColor }
+					colors={ colors }
+					gradients={ undefined }
+					disableCustomColors={ disableCustomColors }
+					disableCustomGradients={ disableCustomGradients }
+					onColorChange={ ( value ) =>
+						setStyle( name, 'borderColor', value )
+					}
+				/>
+			) }
+		</PanelBody>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -29,6 +29,7 @@ import {
 	default as TypographyPanel,
 	useHasTypographyPanel,
 } from './typography-panel';
+import { default as BorderPanel, useHasBorderPanel } from './border-panel';
 import { default as ColorPanel, useHasColorPanel } from './color-panel';
 import { default as SpacingPanel, useHasSpacingPanel } from './spacing-panel';
 
@@ -40,6 +41,7 @@ function GlobalStylesPanel( {
 	getSetting,
 	setSetting,
 } ) {
+	const hasBorderPanel = useHasBorderPanel( context );
 	const hasColorPanel = useHasColorPanel( context );
 	const hasTypographyPanel = useHasTypographyPanel( context );
 	const hasSpacingPanel = useHasSpacingPanel( context );
@@ -70,6 +72,13 @@ function GlobalStylesPanel( {
 			) }
 			{ hasSpacingPanel && (
 				<SpacingPanel
+					context={ context }
+					getStyle={ getStyle }
+					setStyle={ setStyle }
+				/>
+			) }
+			{ hasBorderPanel && (
+				<BorderPanel
 					context={ context }
 					getStyle={ getStyle }
 					setStyle={ setStyle }

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -16,9 +16,9 @@ import { useEditorFeature } from '../editor/utils';
 
 export function useHasTypographyPanel( { supports, name } ) {
 	const hasLineHeight = useHasLineHeightControl( { supports, name } );
-	const hasFontAppearence = useHasAppearenceControl( { supports, name } );
+	const hasFontAppearance = useHasAppearanceControl( { supports, name } );
 	return (
-		hasLineHeight || hasFontAppearence || supports.includes( 'fontSize' )
+		hasLineHeight || hasFontAppearance || supports.includes( 'fontSize' )
 	);
 }
 
@@ -29,7 +29,7 @@ function useHasLineHeightControl( { supports, name } ) {
 	);
 }
 
-function useHasAppearenceControl( { supports, name } ) {
+function useHasAppearanceControl( { supports, name } ) {
 	const hasFontStyles =
 		useEditorFeature( 'typography.customFontStyle', name ) &&
 		supports.includes( 'fontStyle' );
@@ -57,7 +57,7 @@ export default function TypographyPanel( {
 		useEditorFeature( 'typography.customFontWeight', name ) &&
 		supports.includes( 'fontWeight' );
 	const hasLineHeightEnabled = useHasLineHeightControl( { supports, name } );
-	const hasAppearenceControl = useHasAppearenceControl( { supports, name } );
+	const hasAppearanceControl = useHasAppearanceControl( { supports, name } );
 
 	return (
 		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
@@ -88,7 +88,7 @@ export default function TypographyPanel( {
 					}
 				/>
 			) }
-			{ hasAppearenceControl && (
+			{ hasAppearanceControl && (
 				<FontAppearanceControl
 					value={ {
 						fontStyle: getStyle( name, 'fontStyle' ),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -245,11 +245,11 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}',
+			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
 			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}',
+			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(
@@ -284,11 +284,11 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			'.wp-block-group{--wp--preset--color--grey: grey;}.wp-block-group{color: red;}.wp-block-group.has-grey-color{color: grey !important;}.wp-block-group.has-grey-background-color{background-color: grey !important;}',
+			'.wp-block-group{--wp--preset--color--grey: grey;}.wp-block-group{color: red;}.wp-block-group.has-grey-color{color: grey !important;}.wp-block-group.has-grey-background-color{background-color: grey !important;}.wp-block-group.has-grey-border-color{border-color: grey !important;}',
 			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			'.wp-block-group{color: red;}.wp-block-group.has-grey-color{color: grey !important;}.wp-block-group.has-grey-background-color{background-color: grey !important;}',
+			'.wp-block-group{color: red;}.wp-block-group.has-grey-color{color: grey !important;}.wp-block-group.has-grey-background-color{background-color: grey !important;}.wp-block-group.has-grey-border-color{border-color: grey !important;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 	}
@@ -324,7 +324,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			':root{--wp--preset--color--grey: grey;}h2.wp-block-post-title{background-color: blue;color: red;font-size: 12px;line-height: 1.3;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}',
+			':root{--wp--preset--color--grey: grey;}h2.wp-block-post-title{background-color: blue;color: red;font-size: 12px;line-height: 1.3;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
 			$theme_json->get_stylesheet()
 		);
 	}


### PR DESCRIPTION
Fixes: #29616

## Description
This PR extends the border related block support to include color, style and width options.

These border options are disabled by default.

## How has this been tested?

Manually with a couple of small updates to existing unit tests.

#### Testing Instructions:

1. Enable custom border color, radius, style and width in your theme.json file.
2. Create a new post and add a group block to it
3. Select the group block and confirm the "Border settings" panel displays in the sidebar
4. Expand the "Border settings" panel and try editing each of the border properties. 
5. Confirm the block updates as expected in the editor, save and then confirm correct classes and styles on the frontend.
6. Open the Site Editor then its global styles sidebar. Switch to the "By block type" tab and expand the Group block panel.
7. Confirm that the border support features you have enabled are present. 
8. Test changing the global styles for the group block's borders.

#### Unit Tests:
- `npm run test-unit:watch packages/block-editor/src/hooks/test/style.js`
- `wp-env run phpunit "phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist /var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-test.php"`

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/60436221/112101007-b7164000-8bf1-11eb-9bb0-168af504cf15.gif" width="400" />

## Types of changes
New feature

## Next steps

- [ ] Make any required UI refinements
- [ ] Confirm approach to border color support
- [ ] Surface the border color option under the colors panel as well if desired (https://github.com/WordPress/gutenberg/issues/27331#issuecomment-793799694)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
