### PR TITLE
Fix navigation mode focus.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -61,7 +61,7 @@
 			right: $border-width;
 
 			// Everything else.
-			box-shadow: 0 0 0 $border-width $gray-900;
+			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 
 			// Windows High Contrast mode will show this outline.
@@ -85,6 +85,7 @@
 		box-shadow: 0 0 0 1px $gray-600;
 	}
 
+	.is-navigate-mode & .block-editor-block-list__block.is-selected::after,
 	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		outline: var(--wp-admin-border-width-focus) solid transparent;


### PR DESCRIPTION
## Description

The focus style for selected blocks in navigation mode regressed recently. This PR fixes it.

Before:

<img width="781" alt="Screenshot 2021-03-23 at 08 44 50" src="https://user-images.githubusercontent.com/1204802/112112315-a942c980-8bb5-11eb-800c-bf3a8ac7ed2e.png">

After:

<img width="789" alt="Screenshot 2021-03-23 at 08 54 58" src="https://user-images.githubusercontent.com/1204802/112112321-aba52380-8bb5-11eb-9e64-cda611206e1b.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
