### PR TITLE
Add check to avoid PHP warnings

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -649,7 +649,7 @@ class WP_Theme_JSON {
 		foreach ( $properties as $prop ) {
 			$value = self::get_property_value( $styles, $prop['value'] );
 			if ( ! empty( $value ) ) {
-				$declarations[]   = array(
+				$declarations[] = array(
 					'name'  => $prop['name'],
 					'value' => $value,
 				);
@@ -678,6 +678,9 @@ class WP_Theme_JSON {
 		$stylesheet = '';
 		foreach ( self::PRESETS_METADATA as $preset ) {
 			$values = _wp_array_get( $settings, $preset['path'], array() );
+			if ( empty( $values ) ) {
+				continue;
+			}
 			foreach ( $values as $value ) {
 				foreach ( $preset['classes'] as $class ) {
 					$stylesheet .= self::to_ruleset(
@@ -716,6 +719,9 @@ class WP_Theme_JSON {
 	private static function compute_preset_vars( $declarations, $settings ) {
 		foreach ( self::PRESETS_METADATA as $preset ) {
 			$values = _wp_array_get( $settings, $preset['path'], array() );
+			if ( empty( $values ) ) {
+				continue;
+			}
 			foreach ( $values as $value ) {
 				$declarations[] = array(
 					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . $value['slug'],


### PR DESCRIPTION
## Description

Adds an additional check before running some PHP loops that are currently throwing PHP warnings (`PHP Warning:  foreach() argument must be of type array|object, null given`)

## How has this been tested?

Tested with an FSE theme which does not have gradients defined in the JSON. It was throwing errors before, doesn't have errors after the PR.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
