### PR TITLE
Fix regression with multi select style.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -39,6 +39,7 @@
  * Cross-Block Selection
  */
 
+// Note to developers refactoring this. Please test navigation mode and multi selection also.
 .block-editor-block-list__layout {
 	position: relative;
 
@@ -85,6 +86,7 @@
 		box-shadow: 0 0 0 1px $gray-600;
 	}
 
+	.block-editor-block-list__block.is-multi-selected::after,
 	.is-navigate-mode & .block-editor-block-list__block.is-selected::after,
 	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -39,7 +39,8 @@
  * Cross-Block Selection
  */
 
-// Note to developers refactoring this. Please test navigation mode and multi selection also.
+// Note to developers refactoring this, please test navigation mode, and
+// multi selection and hovering the block switcher to highlight the block.
 .block-editor-block-list__layout {
 	position: relative;
 
@@ -86,6 +87,7 @@
 		box-shadow: 0 0 0 1px $gray-600;
 	}
 
+	.block-editor-block-list__block.is-highlighted::after,
 	.block-editor-block-list__block.is-multi-selected::after,
 	.is-navigate-mode & .block-editor-block-list__block.is-selected::after,
 	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected {


### PR DESCRIPTION
## Description

The multi select style regressed recently. This PR fixes it.

Before:

<img width="815" alt="Screenshot 2021-03-23 at 09 38 26" src="https://user-images.githubusercontent.com/1204802/112117953-2ffaa500-8bbc-11eb-9506-23d2637197e5.png">


After:

<img width="829" alt="Screenshot 2021-03-23 at 09 42 03" src="https://user-images.githubusercontent.com/1204802/112117946-2cffb480-8bbc-11eb-9db7-a606ab0c5d48.png">


Followup to https://github.com/WordPress/gutenberg/pull/30126.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
