### PR TITLE
Fix minor styling issues with nav editor

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -5,6 +5,10 @@
 	max-width: $navigation-editor-width;
 	margin: auto;
 
+	.editor-styles-wrapper {
+		padding: 0;
+	}
+
 	.components-spinner {
 		display: block;
 		margin: $grid-unit-15 auto;

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -70,7 +70,7 @@ export default function Header( {
 						popoverProps={ {
 							className:
 								'edit-navigation-header__menu-switcher-dropdown',
-							position: 'bottom left',
+							position: 'bottom center',
 						} }
 					>
 						{ ( { onClose } ) => (

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -25,8 +25,12 @@
 .edit-navigation-header__actions {
 	display: flex;
 
-	> .components-dropdown {
-		margin-right: $grid-unit-15;
+	> .components-dropdown,
+	> .components-button,
+	> .interface-pinned-items .components-button {
+		&:not(:last-child) {
+			margin-right: $grid-unit-15;
+		}
 	}
 }
 

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -65,6 +65,11 @@
 }
 
 .edit-navigation-layout__block-toolbar {
+	// Make the fixed toolbar appear in a similar position to the floating toolbar.
+	// Take the spacing for the floating toolbar, then subtract the toolbar height and
+	// the gap between the content area and the toolbar.
+	margin-top: $navigation-editor-spacing-top - $block-toolbar-height - $grid-unit-15;
+
 	.block-editor-block-toolbar {
 		background: $white;
 		border: $border-width solid $gray-900;

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -76,6 +76,7 @@
 		border-radius: $radius-block-ui;
 		max-width: $navigation-editor-width;
 		margin: auto;
+		overflow-y: hidden;
 	}
 
 	.components-toolbar,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR fixes a few separate minor styling issues in the nav editor:
- Removes a 10px margin on the `editor-styles-wrapper` which appeared recently—this brings the floating toolbar back in line with the editable block area (bb209cc)
- On mobile viewports, a new 'cog' icon to toggle the inspector is present, but this wasn't spaced correctly from the Save button (as the PR that added the spacing happened in parallel). This is now fixed in this PR. (4bbeb67)
- The recently added fixed block toolbar had slightly different spacing from the header compared to the floating toolbar. This has now been adjusted to match (8dd6da5)
- On very narrow screens, the fixed block toolbar shows a vertical scrollbar. This is now fixed. (c771f0a)
- The Switch Menu dropdown wasn't opening to the center of the button. (6136557).

## How has this been tested?
1. Open the nav editor and test the things above

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
