### PR TITLE
Block editor: focus mode: fix opacity for inner blocks, move classes

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
 import { useRef, createContext, useState } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -30,11 +31,14 @@ export default function BlockList( { className, __experimentalLayout } ) {
 	const insertionPoint = useInsertionPoint( ref );
 	useScrollSelectionIntoView( ref );
 
-	const { isTyping, isOutlineMode } = useSelect( ( select ) => {
+	const isLargeViewport = useViewportMatch( 'medium' );
+	const { isTyping, isOutlineMode, isFocusMode } = useSelect( ( select ) => {
 		const { isTyping: _isTyping, getSettings } = select( blockEditorStore );
+		const { outlineMode, focusMode } = getSettings();
 		return {
 			isTyping: _isTyping(),
-			isOutlineMode: getSettings().outlineMode,
+			isOutlineMode: outlineMode,
+			isFocusMode: focusMode,
 		};
 	}, [] );
 
@@ -47,7 +51,11 @@ export default function BlockList( { className, __experimentalLayout } ) {
 				className={ classnames(
 					'block-editor-block-list__layout is-root-container',
 					className,
-					{ 'is-typing': isTyping, 'is-outline-mode': isOutlineMode }
+					{
+						'is-typing': isTyping,
+						'is-outline-mode': isOutlineMode,
+						'is-focus-mode': isFocusMode && isLargeViewport,
+					}
 				) }
 			>
 				<SetBlockNodes.Provider value={ setBlockNodes }>

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -193,18 +193,6 @@
 		}
 	}
 
-	// Spotlight mode.
-	&.is-focus-mode:not(.is-multi-selected) {
-		opacity: 0.5;
-		transition: opacity 0.1s linear;
-		@include reduce-motion("transition");
-
-		&:not(.is-focused) .block-editor-block-list__block,
-		&.is-focused {
-			opacity: 1;
-		}
-	}
-
 	// Active entity spotlight.
 	&.has-active-entity:not(.is-focus-mode) {
 		opacity: 0.5;
@@ -337,6 +325,21 @@
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			}
 		}
+	}
+}
+
+// Spotlight mode.
+.is-focus-mode .block-editor-block-list__block {
+	opacity: 0.5;
+	transition: opacity 0.1s linear;
+	@include reduce-motion("transition");
+
+	&.is-selected,
+	&.is-selected .block-editor-block-list__block,
+	&.is-multi-selected,
+	&.is-multi-selected .block-editor-block-list__block,
+	&.has-child-selected {
+		opacity: 1;
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -193,21 +193,6 @@
 		}
 	}
 
-	// Active entity spotlight.
-	&.has-active-entity:not(.is-focus-mode) {
-		opacity: 0.5;
-		transition: opacity 0.1s linear;
-		@include reduce-motion("transition");
-
-		&.is-active-entity,
-		&.has-child-selected,
-		&:not(.has-child-selected) .block-editor-block-list__block,
-		&.is-active-entity .block-editor-block-list__block,
-		.is-active-entity .block-editor-block-list__block {
-			opacity: 1;
-		}
-	}
-
 	/**
 	* Block styles and alignments
 	*/
@@ -341,6 +326,22 @@
 	.block-editor-block-list__block,
 	&.is-selected,
 	&.is-multi-selected {
+		opacity: 1;
+	}
+}
+
+// Active entity spotlight.
+// Disable if focus mode is active.
+.is-root-container:not(.is-focus-mode) .block-editor-block-list__block.has-active-entity {
+	opacity: 0.5;
+	transition: opacity 0.1s linear;
+	@include reduce-motion("transition");
+
+	&.is-active-entity,
+	&.has-child-selected,
+	&:not(.has-child-selected) .block-editor-block-list__block,
+	&.is-active-entity .block-editor-block-list__block,
+	.is-active-entity .block-editor-block-list__block {
 		opacity: 1;
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -328,8 +328,8 @@
 	}
 }
 
-// Spotlight mode.
-.is-focus-mode .block-editor-block-list__block {
+// Spotlight mode. Fade out blocks unless they contain a selected block.
+.is-focus-mode .block-editor-block-list__block:not(.has-child-selected) {
 	opacity: 0.5;
 	transition: opacity 0.1s linear;
 	@include reduce-motion("transition");
@@ -340,8 +340,7 @@
 	// including inner blocks, should be focused.
 	.block-editor-block-list__block,
 	&.is-selected,
-	&.is-multi-selected,
-	&.has-child-selected {
+	&.is-multi-selected {
 		opacity: 1;
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -334,10 +334,13 @@
 	transition: opacity 0.1s linear;
 	@include reduce-motion("transition");
 
+	// Nested blocks should never be faded. If the parent block is already faded
+	// out, it shouldn't be faded out more. If the parent block in not faded
+	// out, it shouldn't be faded out either because the block as a whole,
+	// including inner blocks, should be focused.
+	.block-editor-block-list__block,
 	&.is-selected,
-	&.is-selected .block-editor-block-list__block,
 	&.is-multi-selected,
-	&.is-multi-selected .block-editor-block-list__block,
 	&.has-child-selected {
 		opacity: 1;
 	}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useViewportMatch } from '@wordpress/compose';
 import { isReusableBlock, getBlockType } from '@wordpress/blocks';
 
 /**
@@ -23,7 +22,6 @@ import { store as blockEditorStore } from '../../../store';
  * @return {string} The class names.
  */
 export function useBlockClassNames( clientId ) {
-	const isLargeViewport = useViewportMatch( 'medium' );
 	return useSelect(
 		( select ) => {
 			const {
@@ -37,7 +35,6 @@ export function useBlockClassNames( clientId ) {
 				__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
 			} = select( blockEditorStore );
 			const {
-				focusMode,
 				__experimentalSpotlightEntityBlocks: spotlightEntityBlocks,
 			} = getSettings();
 			const isDragging = isBlockBeingDragged( clientId );
@@ -58,17 +55,12 @@ export function useBlockClassNames( clientId ) {
 				'is-multi-selected': isBlockMultiSelected( clientId ),
 				'is-reusable': isReusableBlock( getBlockType( name ) ),
 				'is-dragging': isDragging,
-				'is-focused':
-					focusMode &&
-					isLargeViewport &&
-					( isSelected || isAncestorOfSelectedBlock ),
-				'is-focus-mode': focusMode && isLargeViewport,
 				'has-child-selected': isAncestorOfSelectedBlock && ! isDragging,
 				'has-active-entity': activeEntityBlockId,
 				// Determine if there is an active entity area to spotlight.
 				'is-active-entity': activeEntityBlockId === clientId,
 			} );
 		},
-		[ clientId, isLargeViewport ]
+		[ clientId ]
 	);
 }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -279,7 +279,6 @@ export function ImageEdit( {
 	const classes = classnames( className, {
 		'is-transient': isBlobURL( url ),
 		'is-resized': !! width || !! height,
-		'is-focused': isSelected,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -342,7 +342,6 @@ export default function LogoEdit( {
 
 	const classes = classnames( className, {
 		'is-resized': !! width,
-		'is-focused': isSelected,
 	} );
 
 	const blockProps = useBlockProps( {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

This one is similar to #30106. It doesn't make sense for these classes that set a mode to be added to blocks. They should be added to the block editor (wrapper). Currently, `is-focus-mode` is added to every single block when focus mode is enabled.

This PR moves `is-focus-mode` to the root element of the block editor and takes advantage of the selected state classes to determine whether a block should be focussed or not, instead of creating a new `is-focused` class.

Blocks should be faded out unless:

* The parent block is already faded out.
* The block is (multi-)selected.
* The block's parent is (multi-)selected. (This we currently don't do, so if you select the cover block, the contents are still faded out.)
* One of the block's children is (multi-)selected.

## How has this been tested?

Test the above rules of spotlight mode. Select a block, select e.g. a cover block and select a block within the cover block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
