### PR TITLE
Do not create revisions for global styles CPT

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -468,10 +468,7 @@ class WP_Theme_JSON_Resolver {
 				'delete_others_posts'    => 'edit_theme_options',
 			),
 			'map_meta_cap' => true,
-			'supports'     => array(
-				'editor',
-				'revisions',
-			),
+			'supports'     => array( 'editor' ),
 		);
 		register_post_type( 'wp_global_styles', $args );
 	}


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/30132

## How to test

- Activate the TT1-blocks theme and go to the site editor.
- Update something in the global styles sidebar and save (e.g.: change the root background).
- Go to the database and sort the `wp_posts` table by the `post_modified` field in descending order.
- Verify that the user changes have updated the global styles CTP: `wp-global-styles-tt1-blocks` as `post_name`.
- Verify that a revision wasn't created for this change.
