### PR TITLE
Show the active block variation's icon in Select mode

### DIFF
--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -37,6 +37,7 @@ import BlockTitle from '../block-title';
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 import BlockDraggable from '../block-draggable';
+import useBlockDisplayInformation from '../use-block-display-information';
 
 /**
  * Returns true if the user is using windows.
@@ -92,17 +93,15 @@ function selector( select ) {
  * @return {WPComponent} The component to be rendered.
  */
 function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
+	const blockInformation = useBlockDisplayInformation( clientId );
 	const selected = useSelect(
 		( select ) => {
 			const {
 				__unstableGetBlockWithoutInnerBlocks,
 				getBlockIndex,
-				getBlockName,
 				hasBlockMovingClientId,
 				getBlockListSettings,
 			} = select( blockEditorStore );
-			const blockName = getBlockName( clientId );
-			const blockType = getBlockType( blockName );
 			const index = getBlockIndex( clientId, rootClientId );
 			const { name, attributes } = __unstableGetBlockWithoutInnerBlocks(
 				clientId
@@ -114,19 +113,11 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 				attributes,
 				blockMovingMode,
 				orientation: getBlockListSettings( rootClientId )?.orientation,
-				icon: blockType.icon,
 			};
 		},
 		[ clientId, rootClientId ]
 	);
-	const {
-		index,
-		name,
-		attributes,
-		blockMovingMode,
-		orientation,
-		icon,
-	} = selected;
+	const { index, name, attributes, blockMovingMode, orientation } = selected;
 	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
 
@@ -280,7 +271,7 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 				className="block-editor-block-list__block-selection-button__content"
 			>
 				<FlexItem>
-					<BlockIcon icon={ icon } showColors />
+					<BlockIcon icon={ blockInformation?.icon } showColors />
 				</FlexItem>
 				<FlexItem>
 					<BlockDraggable clientIds={ [ clientId ] }>

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.js
@@ -15,17 +15,18 @@ import { View, Text, TouchableOpacity } from 'react-native';
  * Internal dependencies
  */
 import BlockTitle from '../block-title';
+import useBlockDisplayInformation from '../use-block-display-information';
 import SubdirectorSVG from './subdirectory-icon';
 import { store as blockEditorStore } from '../../store';
 import styles from './block-selection-button.scss';
 
 const BlockSelectionButton = ( {
 	clientId,
-	blockIcon,
 	rootClientId,
 	rootBlockIcon,
 	isRTL,
 } ) => {
+	const blockInformation = useBlockDisplayInformation( clientId );
 	return (
 		<View
 			style={ [
@@ -59,7 +60,7 @@ const BlockSelectionButton = ( {
 					] }
 				<Icon
 					size={ 24 }
-					icon={ blockIcon.src }
+					icon={ blockInformation?.icon?.src }
 					fill={ styles.icon.color }
 				/>
 				<Text
@@ -80,18 +81,10 @@ export default compose( [
 		const { getBlockRootClientId, getBlockName, getSettings } = select(
 			blockEditorStore
 		);
-
-		const blockName = getBlockName( clientId );
-		const blockType = getBlockType( blockName );
-		const blockIcon = blockType ? blockType.icon : {};
-
 		const rootClientId = getBlockRootClientId( clientId );
 
 		if ( ! rootClientId ) {
-			return {
-				clientId,
-				blockIcon,
-			};
+			return { clientId };
 		}
 		const rootBlockName = getBlockName( rootClientId );
 		const rootBlockType = getBlockType( rootBlockName );
@@ -99,7 +92,6 @@ export default compose( [
 
 		return {
 			clientId,
-			blockIcon,
 			rootClientId,
 			rootBlockIcon,
 			isRTL: getSettings().isRTL,


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/30138

Currently in `select` mode the displayed icon was from the block type. Now it uses `useBlockDisplayInformation` hook to take into account an active block variation.
<!-- Please describe what you have changed or added -->

## Screenshots <!-- if applicable -->
![selectMode](https://user-images.githubusercontent.com/16275880/112152304-d2318180-8bea-11eb-93dc-21f6af15e767.gif)

I could use some testing from someone of the native app team :) 
