### PR TITLE
Fix error in site-editor when presets are null

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -39,11 +39,13 @@ function getBlockPresetsDeclarations( blockPresets = {} ) {
 		PRESET_METADATA,
 		( declarations, { path, valueKey, cssVarInfix } ) => {
 			const preset = get( blockPresets, path, [] );
-			preset.forEach( ( value ) => {
-				declarations.push(
-					`--wp--preset--${ cssVarInfix }--${ value.slug }: ${ value[ valueKey ] }`
-				);
-			} );
+			if ( preset ) {
+				preset.forEach( ( value ) => {
+					declarations.push(
+						`--wp--preset--${ cssVarInfix }--${ value.slug }: ${ value[ valueKey ] }`
+					);
+				} );
+			}
 			return declarations;
 		},
 		[]
@@ -66,13 +68,15 @@ function getBlockPresetClasses( blockSelector, blockPresets = {} ) {
 			}
 			classes.forEach( ( { classSuffix, propertyName } ) => {
 				const presets = get( blockPresets, path, [] );
-				presets.forEach( ( preset ) => {
-					const slug = preset.slug;
-					const value = preset[ valueKey ];
-					const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;
-					const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
-					declarations += `${ selectorToUse } {${ propertyName }: ${ value };}`;
-				} );
+				if ( presets ) {
+					presets.forEach( ( preset ) => {
+						const slug = preset.slug;
+						const value = preset[ valueKey ];
+						const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;
+						const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
+						declarations += `${ selectorToUse } {${ propertyName }: ${ value };}`;
+					} );
+				}
 			} );
 			return declarations;
 		},


### PR DESCRIPTION
## Description
In an FSE theme if some things are missing from theme.json, the site-editor crashes with an error `TypeError: can't access property "forEach", preset is null`. After fixing that there's a 2nd error for `presets`. This PR fixes these 2 so the site-editor can continue loading if the theme doesn't have everything under the sun.

To replicate the issue remove the gradients from TT1-blocks' theme.json.

## How has this been tested?
Tested with an FSE theme that is missing gradients definitions in theme.json

## Types of changes
Added a check to only run the loops if `preset` & `presets` are not null.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
