### PR TITLE
Global Styles: Add child theme support

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -313,7 +313,7 @@ class WP_Theme_JSON_Resolver {
 			if( is_child_theme() ) {
 				$parent_theme_json_data = self::read_json_file( self::get_file_path_from_theme( 'experimental-theme.json', get_template_directory() ) );
 				$parent_theme_json_data = self::translate( $parent_theme_json_data, wp_get_theme( get_template() )->get( 'TextDomain' ) );
-				$theme_json_data = array_merge( $parent_theme_json_data, $theme_json_data );
+				$theme_json_data = array_replace_recursive( $parent_theme_json_data, $theme_json_data );
 			}
 
 			self::$theme = new WP_Theme_JSON( $theme_json_data );


### PR DESCRIPTION
## Description
This adds support for child themes to Global Styles. When we fetch the theme.json we also check if this is a child theme. If it is then we also get the theme.json for the parent theme and merge it with the child. This will be very useful in having child themes extend the parent's theme.json file without having to declare all the same properties in the child theme.json.

## How has this been tested?
1. Use this child theme: [child.zip](https://github.com/WordPress/gutenberg/files/6190696/child.zip)
1. Make sure you also have TT1 Blocks installed.
1. Switch to the Child theme
1. Check that you see an inverted version of TT1 Blocks.

## Screenshots <!-- if applicable -->
<img width="1036" alt="Screenshot 2021-03-23 at 15 17 13" src="https://user-images.githubusercontent.com/275961/112170290-da89bc80-8bea-11eb-9e8b-0fa8b08bc416.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
