### PR TITLE
File block: Make the editor markup match the frontend

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -196,17 +196,17 @@ function FileEdit( { attributes, setAttributes, noticeUI, noticeOperations } ) {
 			</BlockControls>
 			<div { ...blockProps }>
 				<div className={ 'wp-block-file__content-wrapper' }>
-					<div className="wp-block-file__textlink">
-						<RichText
-							tagName="div" // must be block-level or else cursor disappears
-							value={ fileName }
-							placeholder={ __( 'Write file name…' ) }
-							withoutInteractiveFormatting
-							onChange={ ( text ) =>
-								setAttributes( { fileName: text } )
-							}
-						/>
-					</div>
+					<RichText
+						style={ { display: 'inline-block' } }
+						tagName="a" // must be block-level or else cursor disappears
+						value={ fileName }
+						placeholder={ __( 'Write file name…' ) }
+						withoutInteractiveFormatting
+						onChange={ ( text ) =>
+							setAttributes( { fileName: text } )
+						}
+						href={ textLinkHref }
+					/>
 					{ showDownloadButton && (
 						<div
 							className={

--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -8,13 +8,8 @@
 		flex-grow: 1;
 	}
 
-	.wp-block-file__textlink {
-		display: inline-block;
+	a {
 		min-width: 1em;
-
-		&:focus {
-			box-shadow: none;
-		}
 	}
 
 	.wp-block-file__button-richtext-wrapper {


### PR DESCRIPTION
Related to #29976 

RichText doesn't allow inline elements to be used as tagName, this was the reason the file block markup didn't match the frontend in the editor. It seems that we can still keep the same markup and just set an "inline-block" display style to the RichText component.

**Testing Instructions**

Check that the file block look the same in frontend and backend.