### PR TITLE
GitHub Actions: Add task to comment on PRs with gutenberg.run link.

### DIFF
--- a/packages/project-management-automation/README.md
+++ b/packages/project-management-automation/README.md
@@ -5,6 +5,7 @@ This is a [GitHub Action](https://help.github.com/en/categories/automating-your-
 - [First Time Contributor](https://github.com/WordPress/gutenberg/tree/HEAD/packages/project-management-automation/lib/tasks/first-time-contributor): Adds the "First Time Contributor" label to pull requests merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if necessary for release notes credit.
 - [Add Milestone](https://github.com/WordPress/gutenberg/tree/HEAD/packages/project-management-automation/lib/tasks/add-milestone): Assigns the plugin release milestone to a pull request once it is merged.
 - [Assign Fixed Issues](https://github.com/WordPress/gutenberg/tree/HEAD/packages/project-management-automation/lib/tasks/assign-fixed-issues): Adds assignee for issues which are marked to be "Fixed" by a pull request, and adds the "In Progress" label.
+- [PR Preview Link](https://github.com/WordPress/gutenberg/tree/HEAD/packages/project-management-automation/lib/tasks/pr-preview-link): Adds a comment to new PRs with a link to `http://gutenberg.run/{pr number}`, to make testing easy.
 
 # Installation and usage
 

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -11,6 +11,7 @@ const assignFixedIssues = require( './tasks/assign-fixed-issues' );
 const firstTimeContributorAccountLink = require( './tasks/first-time-contributor-account-link' );
 const firstTimeContributorLabel = require( './tasks/first-time-contributor-label' );
 const addMilestone = require( './tasks/add-milestone' );
+const prPreviewLink = require( './tasks/pr-preview-link' );
 const debug = require( './debug' );
 
 /**
@@ -38,6 +39,11 @@ const automations = [
 		event: 'pull_request_target',
 		action: 'opened',
 		task: assignFixedIssues,
+	},
+	{
+		event: 'pull_request_target',
+		action: 'opened',
+		task: prPreviewLink,
 	},
 	{
 		event: 'pull_request_target',

--- a/packages/project-management-automation/lib/tasks/pr-preview-link/README.md
+++ b/packages/project-management-automation/lib/tasks/pr-preview-link/README.md
@@ -1,0 +1,9 @@
+PR Preview Link
+===
+
+Adds a comment to new PRs with a link to `http://gutenberg.run/{pr number}`.
+
+
+## Rationale
+
+Preview sites make PRs much easier to test, especially for folks who don't have a dev environment setup.

--- a/packages/project-management-automation/lib/tasks/pr-preview-link/index.js
+++ b/packages/project-management-automation/lib/tasks/pr-preview-link/index.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+const debug = require( '../../debug' );
+
+/** @typedef {import('@actions/github').GitHub} GitHub */
+/** @typedef {import('@octokit/webhooks').WebhookPayloadPullRequest} WebhookPayloadPullRequest */
+
+/**
+ * Adds a comment to new PRs with a link to the corresponding gutenberg.run preview site.
+ *
+ * @param {WebhookPayloadPullRequest} payload Pull request event payload.
+ * @param {GitHub}                    octokit Initialized Octokit REST client.
+ */
+async function prPreviewLink( payload, octokit ) {
+	const repo = payload.repository.name;
+	const owner = payload.repository.owner.login;
+	const pullRequestNumber = payload.pull_request.number;
+
+	debug( 'pr-preview-link: Adding comment to PR.' );
+
+	await octokit.issues.createComment( {
+		owner,
+		repo,
+		issue_number: pullRequestNumber,
+		body:
+			'Preview site for this PR: http://gutenberg.run/' +
+			pullRequestNumber,
+	} );
+}
+
+module.exports = prPreviewLink;

--- a/packages/project-management-automation/lib/tasks/pr-preview-link/test/index.js
+++ b/packages/project-management-automation/lib/tasks/pr-preview-link/test/index.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import prPreviewLink from '../';
+
+describe( 'prPreviewLink', () => {
+	const payload = {
+		repository: {
+			owner: {
+				login: 'WordPress',
+			},
+			name: 'gutenberg',
+		},
+		pull_request: {
+			number: 123,
+		},
+	};
+
+	it( 'adds the adds a comment with a link to the gutenberg.run preview site', async () => {
+		const octokit = {
+			repos: {
+				listCommits: jest.fn( () =>
+					Promise.resolve( {
+						data: [],
+					} )
+				),
+			},
+			issues: {
+				createComment: jest.fn(),
+			},
+		};
+
+		const expectedComment = `Preview site for this PR: http://gutenberg.run/123`;
+
+		await prPreviewLink( payload, octokit );
+
+		expect( octokit.issues.createComment ).toHaveBeenCalledWith( {
+			owner: 'WordPress',
+			repo: 'gutenberg',
+			issue_number: 123,
+			body: expectedComment,
+		} );
+	} );
+} );

--- a/packages/project-management-automation/lib/tasks/pr-preview-link/test/index.js
+++ b/packages/project-management-automation/lib/tasks/pr-preview-link/test/index.js
@@ -18,13 +18,6 @@ describe( 'prPreviewLink', () => {
 
 	it( 'adds the adds a comment with a link to the gutenberg.run preview site', async () => {
 		const octokit = {
-			repos: {
-				listCommits: jest.fn( () =>
-					Promise.resolve( {
-						data: [],
-					} )
-				),
-			},
 			issues: {
 				createComment: jest.fn(),
 			},


### PR DESCRIPTION
## Description

This adds a new workflow that will create a comment on new PRs, with a link to a gutenberg.run preview site.

<img width="943" alt="Screen Shot 2021-03-15 at 4 39 47 PM" src="https://user-images.githubusercontent.com/484068/112175684-aeebdf80-8bb4-11eb-92c0-f96747862044.png">

[Gutenberg.run](https://github.com/aduth/gutenberg.run/) automatically creates functioning WordPress sites that run the version of Gutenberg from a PR's branch. The sites are accessible to anybody, making testing much easier for many people.

For example, http://gutenberg.run/30255 


## How has this been tested?

I committed these changes to `trunk` on my fork, and then opened test PRs against my fork. It'd probably also work to open a test PR against https://github.com/iandunn/gutenberg/tree/add/pr-preview-site-workflow.

I also created a unit test.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
