### PR TITLE
api-fetch: Add types to http-v1 middleware

### DIFF
--- a/packages/api-fetch/src/middlewares/http-v1.js
+++ b/packages/api-fetch/src/middlewares/http-v1.js
@@ -1,7 +1,7 @@
 /**
  * Set of HTTP methods which are eligible to be overridden.
  *
- * @type {Set}
+ * @type {Set<string>}
  */
 const OVERRIDE_METHODS = new Set( [ 'PATCH', 'PUT', 'DELETE' ] );
 
@@ -21,12 +21,9 @@ const DEFAULT_METHOD = 'GET';
  * API Fetch middleware which overrides the request method for HTTP v1
  * compatibility leveraging the REST API X-HTTP-Method-Override header.
  *
- * @param {Object}   options Fetch options.
- * @param {Function} next    [description]
- *
- * @return {*} The evaluated result of the remaining middleware chain.
+ * @type {import('../types').ApiFetchMiddleware}
  */
-function httpV1Middleware( options, next ) {
+const httpV1Middleware = ( options, next ) => {
 	const { method = DEFAULT_METHOD } = options;
 	if ( OVERRIDE_METHODS.has( method.toUpperCase() ) ) {
 		options = {
@@ -41,6 +38,6 @@ function httpV1Middleware( options, next ) {
 	}
 
 	return next( options );
-}
+};
 
 export default httpV1Middleware;

--- a/packages/api-fetch/src/types.ts
+++ b/packages/api-fetch/src/types.ts
@@ -1,4 +1,5 @@
-export interface ApiFetchRequestProps {
+export interface ApiFetchRequestProps extends RequestInit {
+	// Override headers, we only accept it as an object due to the `nonce` middleware
 	headers?: Record< string, string >;
 	path?: string;
 	url?: string;

--- a/packages/api-fetch/src/types.ts
+++ b/packages/api-fetch/src/types.ts
@@ -10,7 +10,6 @@ export interface ApiFetchRequestProps extends RequestInit {
 	data?: any;
 	namespace?: string;
 	endpoint?: string;
-	method?: string;
 }
 
 export type ApiFetchMiddleware = (

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -8,6 +8,7 @@
 		{ "path": "../url" }
 	],
 	"include": [
+		"src/middlewares/http-v1.js",
 		"src/middlewares/media-upload.js",
 		"src/middlewares/namespace-endpoint.js",
 		"src/middlewares/nonce.js",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds types to the `http-v1` middleware

No runtime changes except to turn `httpV1Middleware` into a `const` so that it can be typed using the `@type` annotation for `ApiFetchMiddleware`.

## How has this been tested?
Type check passes

## Types of changes
Non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
