### PR TITLE
Button block: hide link popover if not in visual edit mode

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -175,6 +175,9 @@ function ButtonEdit( props ) {
 	function onKeyDown( event ) {
 		if ( isKeyboardEvent.primary( event, 'k' ) ) {
 			startEditing( event );
+		} else if ( isKeyboardEvent.primaryShift( event, 'k' ) ) {
+			unlink();
+			richTextRef.current?.focus();
 		}
 	}
 
@@ -314,6 +317,7 @@ function ButtonEdit( props ) {
 						title={ __( 'Link' ) }
 						shortcut={ displayShortcut.primary( 'k' ) }
 						onClick={ () => setIsEditingURL( ! isEditingURL ) }
+						isActive={ isURLSet }
 					/>
 				) }
 			</BlockControls>

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -38,8 +38,8 @@ import {
 	store as blockEditorStore,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
-import { link, linkOff } from '@wordpress/icons';
+import { ENTER } from '@wordpress/keycodes';
+import { link } from '@wordpress/icons';
 import {
 	createBlock,
 	cloneBlock,
@@ -172,15 +172,6 @@ function ButtonEdit( props ) {
 
 	const TagName = tagName || 'a';
 
-	function onKeyDown( event ) {
-		if ( isKeyboardEvent.primary( event, 'k' ) ) {
-			startEditing( event );
-		} else if ( isKeyboardEvent.primaryShift( event, 'k' ) ) {
-			unlink();
-			richTextRef.current?.focus();
-		}
-	}
-
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -193,7 +184,6 @@ function ButtonEdit( props ) {
 	const richTextRef = useRef();
 	const blockProps = useBlockProps( {
 		ref: useMergeRefs( [ setPopoverAnchor, ref ] ),
-		onKeyDown,
 	} );
 	const blockEditingMode = useBlockEditingMode();
 
@@ -202,11 +192,6 @@ function ButtonEdit( props ) {
 	const opensInNewTab = linkTarget === NEW_TAB_TARGET;
 	const nofollow = !! rel?.includes( NOFOLLOW_REL );
 	const isLinkTag = 'a' === TagName;
-
-	function startEditing( event ) {
-		event.preventDefault();
-		setIsEditingURL( true );
-	}
 
 	function unlink() {
 		setAttributes( {
@@ -233,7 +218,7 @@ function ButtonEdit( props ) {
 	const useEnterRef = useEnter( { content: text, clientId } );
 	const mergedRef = useMergeRefs( [ useEnterRef, richTextRef ] );
 
-	const { lockUrlControls = false, isVisualEditMode } = useSelect(
+	const { lockUrlControls = false } = useSelect(
 		( select ) => {
 			if ( ! isSelected ) {
 				return {};
@@ -310,67 +295,53 @@ function ButtonEdit( props ) {
 						} }
 					/>
 				) }
-				{ ! isURLSet && isLinkTag && ! lockUrlControls && (
+				{ isLinkTag && ! lockUrlControls && (
 					<ToolbarButton
 						name="link"
 						icon={ link }
 						title={ __( 'Link' ) }
-						shortcut={ displayShortcut.primary( 'k' ) }
-						onClick={ startEditing }
-					/>
-				) }
-				{ isURLSet && isLinkTag && ! lockUrlControls && (
-					<ToolbarButton
-						name="link"
-						icon={ linkOff }
-						title={ __( 'Unlink' ) }
-						shortcut={ displayShortcut.primaryShift( 'k' ) }
-						onClick={ unlink }
-						isActive
+						onClick={ () => setIsEditingURL( ! isEditingURL ) }
+						isActive={ isURLSet }
 					/>
 				) }
 			</BlockControls>
-			{ isLinkTag &&
-				isSelected &&
-				isVisualEditMode &&
-				( isEditingURL || isURLSet ) &&
-				! lockUrlControls && (
-					<Popover
-						placement="bottom"
-						onClose={ () => {
-							setIsEditingURL( false );
+			{ isLinkTag && isSelected && isEditingURL && ! lockUrlControls && (
+				<Popover
+					placement="bottom"
+					onClose={ () => {
+						setIsEditingURL( false );
+						richTextRef.current?.focus();
+					} }
+					anchor={ popoverAnchor }
+					focusOnMount={ isEditingURL ? 'firstElement' : false }
+					__unstableSlotName="__unstable-block-tools-after"
+					shift
+				>
+					<LinkControl
+						value={ linkValue }
+						onChange={ ( {
+							url: newURL,
+							opensInNewTab: newOpensInNewTab,
+							nofollow: newNofollow,
+						} ) =>
+							setAttributes(
+								getUpdatedLinkAttributes( {
+									rel,
+									url: newURL,
+									opensInNewTab: newOpensInNewTab,
+									nofollow: newNofollow,
+								} )
+							)
+						}
+						onRemove={ () => {
+							unlink();
 							richTextRef.current?.focus();
 						} }
-						anchor={ popoverAnchor }
-						focusOnMount={ isEditingURL ? 'firstElement' : false }
-						__unstableSlotName="__unstable-block-tools-after"
-						shift
-					>
-						<LinkControl
-							value={ linkValue }
-							onChange={ ( {
-								url: newURL,
-								opensInNewTab: newOpensInNewTab,
-								nofollow: newNofollow,
-							} ) =>
-								setAttributes(
-									getUpdatedLinkAttributes( {
-										rel,
-										url: newURL,
-										opensInNewTab: newOpensInNewTab,
-										nofollow: newNofollow,
-									} )
-								)
-							}
-							onRemove={ () => {
-								unlink();
-								richTextRef.current?.focus();
-							} }
-							forceIsEditingLink={ isEditingURL }
-							settings={ LINK_SETTINGS }
-						/>
-					</Popover>
-				) }
+						forceIsEditingLink={ ! isURLSet }
+						settings={ LINK_SETTINGS }
+					/>
+				</Popover>
+			) }
 			<InspectorControls>
 				<WidthPanel
 					selectedWidth={ width }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -233,7 +233,7 @@ function ButtonEdit( props ) {
 	const useEnterRef = useEnter( { content: text, clientId } );
 	const mergedRef = useMergeRefs( [ useEnterRef, richTextRef ] );
 
-	const { lockUrlControls = false } = useSelect(
+	const { lockUrlControls = false, isVisualEditMode } = useSelect(
 		( select ) => {
 			if ( ! isSelected ) {
 				return {};
@@ -332,6 +332,7 @@ function ButtonEdit( props ) {
 			</BlockControls>
 			{ isLinkTag &&
 				isSelected &&
+				isVisualEditMode &&
 				( isEditingURL || isURLSet ) &&
 				! lockUrlControls && (
 					<Popover

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -38,7 +38,7 @@ import {
 	store as blockEditorStore,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { ENTER } from '@wordpress/keycodes';
+import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
 import { link } from '@wordpress/icons';
 import {
 	createBlock,
@@ -172,6 +172,12 @@ function ButtonEdit( props ) {
 
 	const TagName = tagName || 'a';
 
+	function onKeyDown( event ) {
+		if ( isKeyboardEvent.primary( event, 'k' ) ) {
+			startEditing( event );
+		}
+	}
+
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -184,6 +190,7 @@ function ButtonEdit( props ) {
 	const richTextRef = useRef();
 	const blockProps = useBlockProps( {
 		ref: useMergeRefs( [ setPopoverAnchor, ref ] ),
+		onKeyDown,
 	} );
 	const blockEditingMode = useBlockEditingMode();
 
@@ -192,6 +199,11 @@ function ButtonEdit( props ) {
 	const opensInNewTab = linkTarget === NEW_TAB_TARGET;
 	const nofollow = !! rel?.includes( NOFOLLOW_REL );
 	const isLinkTag = 'a' === TagName;
+
+	function startEditing( event ) {
+		event.preventDefault();
+		setIsEditingURL( true );
+	}
 
 	function unlink() {
 		setAttributes( {
@@ -300,8 +312,8 @@ function ButtonEdit( props ) {
 						name="link"
 						icon={ link }
 						title={ __( 'Link' ) }
+						shortcut={ displayShortcut.primary( 'k' ) }
 						onClick={ () => setIsEditingURL( ! isEditingURL ) }
-						isActive={ isURLSet }
 					/>
 				) }
 			</BlockControls>

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -104,11 +104,6 @@ test.describe( 'Buttons', () => {
 		await expect(
 			editor.canvas.locator( 'role=textbox[name="Button text"i]' )
 		).toBeFocused();
-
-		// The link control should still be visible when a URL is set.
-		await expect(
-			page.locator( 'role=link[name=/^example\\.com/]' )
-		).toBeVisible();
 	} );
 
 	test( 'appends http protocol to links added which are missing a protocol', async ( {

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -320,6 +320,7 @@ test.describe( 'Pattern Overrides', () => {
 		requestUtils,
 		editor,
 		context,
+		pageUtils,
 	} ) => {
 		const buttonName = 'Editable button';
 		const { id } = await requestUtils.createBlock( {
@@ -339,11 +340,12 @@ test.describe( 'Pattern Overrides', () => {
 			attributes: { ref: id },
 		} );
 
-		// Focus the button, open the link popup.
-		await editor.canvas
+		const button = editor.canvas
 			.getByRole( 'document', { name: 'Block: Button' } )
-			.getByRole( 'textbox', { name: 'Button text' } )
-			.focus();
+			.getByRole( 'textbox', { name: 'Button text' } );
+		// Focus the button, open the link popup.
+		await button.focus();
+		await pageUtils.pressKeys( 'Meta+k' );
 		await expect(
 			page.getByRole( 'link', { name: 'wp.org' } ).getByText( '↗' )
 		).toHaveAttribute( 'aria-label', '(opens in a new tab)' );
@@ -395,6 +397,10 @@ test.describe( 'Pattern Overrides', () => {
 			'noreferrer noopener'
 		);
 
+		// Reopen the link popup.
+		await button.focus();
+		await pageUtils.pressKeys( 'Meta+k' );
+
 		// Uncheck both checkboxes.
 		await editLinkButton.click();
 		await openInNewTabCheckbox.setChecked( false );
@@ -410,6 +416,10 @@ test.describe( 'Pattern Overrides', () => {
 		await previewPage.reload();
 		await expect( buttonLink ).toHaveAttribute( 'target', '' );
 		await expect( buttonLink ).toHaveAttribute( 'rel', '' );
+
+		// Reopen the link popup.
+		await button.focus();
+		await pageUtils.pressKeys( 'Meta+k' );
 
 		// Check only the "mark as nofollow" checkbox.
 		await editLinkButton.click();


### PR DESCRIPTION
There are two cases where the popover for the link of a Button block is visible when it shouldn't be:
1. Editing the block as HTML
2. In Select (Navigation) mode

I've not found issues reporting these but I'm betting we want to fix them. 

## How has this been tested?
In the post and site editor, by adding Button blocks with links and verifying that the link popover hides when the block is edited as HTML and also when the mode is changed to Select.

## Screenshots
### Before
https://user-images.githubusercontent.com/9000376/112248046-84307400-8c12-11eb-99d9-a37b6ef102b1.mp4

### After
https://user-images.githubusercontent.com/9000376/112248090-990d0780-8c12-11eb-9c23-45b87e689f7f.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
