### PR TITLE
Polish navigation editor menu settings styles

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
+++ b/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { CheckboxControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function AutoAddPages( { menuId } ) {
@@ -22,7 +22,7 @@ export default function AutoAddPages( { menuId } ) {
 	const { saveMenu } = useDispatch( 'core' );
 
 	return (
-		<CheckboxControl
+		<ToggleControl
 			label={ __( 'Automatically add new top-level pages' ) }
 			checked={ autoAddPages ?? false }
 			onChange={ ( newAutoAddPages ) => {

--- a/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
+++ b/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { PanelBody, CheckboxControl } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function AutoAddPages( { menuId } ) {
@@ -22,18 +22,16 @@ export default function AutoAddPages( { menuId } ) {
 	const { saveMenu } = useDispatch( 'core' );
 
 	return (
-		<PanelBody>
-			<CheckboxControl
-				label={ __( 'Automatically add new top-level pages' ) }
-				checked={ autoAddPages ?? false }
-				onChange={ ( newAutoAddPages ) => {
-					setAutoAddPages( newAutoAddPages );
-					saveMenu( {
-						...menu,
-						auto_add: newAutoAddPages,
-					} );
-				} }
-			/>
-		</PanelBody>
+		<CheckboxControl
+			label={ __( 'Automatically add new top-level pages' ) }
+			checked={ autoAddPages ?? false }
+			onChange={ ( newAutoAddPages ) => {
+				setAutoAddPages( newAutoAddPages );
+				saveMenu( {
+					...menu,
+					auto_add: newAutoAddPages,
+				} );
+			} }
+		/>
 	);
 }

--- a/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
+++ b/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
@@ -6,7 +6,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { PanelBody, CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function AutoAddPagesPanel( { menuId } ) {
+export default function AutoAddPages( { menuId } ) {
 	const menu = useSelect( ( select ) => select( 'core' ).getMenu( menuId ), [
 		menuId,
 	] );

--- a/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
+++ b/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
@@ -23,7 +23,10 @@ export default function AutoAddPages( { menuId } ) {
 
 	return (
 		<ToggleControl
-			label={ __( 'Automatically add new top-level pages' ) }
+			label={ __( 'Automatically pages' ) }
+			help={ __(
+				'Automatically add published top-level pages to this menu.'
+			) }
 			checked={ autoAddPages ?? false }
 			onChange={ ( newAutoAddPages ) => {
 				setAutoAddPages( newAutoAddPages );

--- a/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
+++ b/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
@@ -23,7 +23,7 @@ export default function AutoAddPages( { menuId } ) {
 
 	return (
 		<ToggleControl
-			label={ __( 'Automatically pages' ) }
+			label={ __( 'Add new pages' ) }
 			help={ __(
 				'Automatically add published top-level pages to this menu.'
 			) }

--- a/packages/edit-navigation/src/components/inspector-additions/delete-menu.js
+++ b/packages/edit-navigation/src/components/inspector-additions/delete-menu.js
@@ -7,7 +7,8 @@ import { __ } from '@wordpress/i18n';
 export default function DeleteMenu( { onDeleteMenu } ) {
 	return (
 		<Button
-			isLink
+			className="edit-navigation-inspector-additions__delete-menu-button"
+			isTertiary
 			isDestructive
 			onClick={ () => {
 				if (

--- a/packages/edit-navigation/src/components/inspector-additions/delete-menu.js
+++ b/packages/edit-navigation/src/components/inspector-additions/delete-menu.js
@@ -1,30 +1,26 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function DeleteMenu( { onDeleteMenu } ) {
 	return (
-		<PanelBody className="edit-navigation-inspector-additions__delete-menu-panel">
-			<Button
-				isLink
-				isDestructive
-				onClick={ () => {
-					if (
-						// eslint-disable-next-line no-alert
-						window.confirm(
-							__(
-								'Are you sure you want to delete this navigation?'
-							)
-						)
-					) {
-						onDeleteMenu();
-					}
-				} }
-			>
-				{ __( 'Delete menu' ) }
-			</Button>
-		</PanelBody>
+		<Button
+			isLink
+			isDestructive
+			onClick={ () => {
+				if (
+					// eslint-disable-next-line no-alert
+					window.confirm(
+						__( 'Are you sure you want to delete this navigation?' )
+					)
+				) {
+					onDeleteMenu();
+				}
+			} }
+		>
+			{ __( 'Delete menu' ) }
+		</Button>
 	);
 }

--- a/packages/edit-navigation/src/components/inspector-additions/delete-menu.js
+++ b/packages/edit-navigation/src/components/inspector-additions/delete-menu.js
@@ -4,7 +4,7 @@
 import { PanelBody, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function DeleteMenuPanel( { onDeleteMenu } ) {
+export default function DeleteMenu( { onDeleteMenu } ) {
 	return (
 		<PanelBody className="edit-navigation-inspector-additions__delete-menu-panel">
 			<Button

--- a/packages/edit-navigation/src/components/inspector-additions/index.js
+++ b/packages/edit-navigation/src/components/inspector-additions/index.js
@@ -7,8 +7,8 @@ import { InspectorControls } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import AutoAddPagesPanel from './auto-add-pages-panel';
-import DeleteMenuPanel from './delete-menu-panel';
+import AutoAddPages from './auto-add-pages';
+import DeleteMenu from './delete-menu';
 import ManageLocations from './manage-locations';
 import { NameEditor } from '../name-editor';
 import { PanelBody } from '@wordpress/components';
@@ -36,8 +36,8 @@ export default function InspectorAdditions( {
 		<InspectorControls>
 			<PanelBody title={ __( 'Menu settings' ) }>
 				<NameEditor />
-				<AutoAddPagesPanel menuId={ menuId } />
-				<DeleteMenuPanel onDeleteMenu={ onDeleteMenu } />
+				<AutoAddPages menuId={ menuId } />
+				<DeleteMenu onDeleteMenu={ onDeleteMenu } />
 			</PanelBody>
 			<PanelBody title={ __( 'Theme locations' ) }>
 				<ManageLocations

--- a/packages/edit-navigation/src/components/inspector-additions/style.scss
+++ b/packages/edit-navigation/src/components/inspector-additions/style.scss
@@ -1,5 +1,6 @@
-.edit-navigation-inspector-additions__delete-menu-panel {
-	text-align: center;
+.edit-navigation-inspector-additions__delete-menu-button {
+	width: 100%;
+	justify-content: center;
 }
 
 .edit-navigation-manage-locations__modal {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Updates the nav editor's menu settings styles to more closely match those in the design:
https://github.com/WordPress/gutenberg/issues/28864#issuecomment-780083954

There are a couple of small differences (help text for the toggle control https://github.com/WordPress/gutenberg/pull/30025#issuecomment-803781818, missing submit button on the name input https://github.com/WordPress/gutenberg/pull/29012#issuecomment-785308585), but they won't be tackled in this PR, I'm considering them outside the scope.

## How has this been tested?
1. Open the navigation editor
2. Create a menu
3. Select the navigation block and look at the inspector
4. Try the options—everything should still work.

## Screenshots <!-- if applicable -->
### Before
<img width="276" alt="Screenshot 2021-03-24 at 2 12 58 pm" src="https://user-images.githubusercontent.com/677833/112263953-108e7580-8cab-11eb-8a18-234f0848a1bd.png">

### After
<img width="277" alt="Screenshot 2021-03-24 at 2 02 14 pm" src="https://user-images.githubusercontent.com/677833/112263860-ef2d8980-8caa-11eb-89d7-c9e30f4899e1.png">

## Types of changes
Polish
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
