### PR TITLE
Navigation Block: Increase importance of submenus staying open.

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -23,8 +23,9 @@
 	&.is-selected,
 	&.has-child-selected {
 		> .wp-block-navigation-link__container {
-			visibility: visible;
-			opacity: 1;
+			// We use important here because if the parent block is selected and submenus are present, they should always be visible.
+			visibility: visible !important;
+			opacity: 1 !important;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fixes #30113, or at least an aspect discovered in that ticket. 

When you create submenus, the submenus should stay visible while you're creating them.

This was not the case after you reached a certain level:

<img src="https://user-images.githubusercontent.com/1204802/112265973-b0301180-8c73-11eb-8c0e-e511d18e2ac1.gif">

This PR increases the importance of the rules to make that happen:

![fix](https://user-images.githubusercontent.com/1204802/112266951-05b8ee00-8c75-11eb-81de-9222b5a651c0.gif)

To explain in a more techinal level, you can see the rules here that are supposed to keep the submenu visible, but being overridden:

<img width="432" alt="Screenshot 2021-03-24 at 07 44 18" src="https://user-images.githubusercontent.com/1204802/112267004-18332780-8c75-11eb-8291-7165dd2baf8d.png">

The new rules make it so they do not get overridden:

<img width="383" alt="Screenshot 2021-03-24 at 07 44 08" src="https://user-images.githubusercontent.com/1204802/112267021-1f5a3580-8c75-11eb-84d0-31658f3ee32f.png">



## How has this been tested?

Please insert a navigation menu and start empty. Insert a page link, then point it to a page.

Now click the "Add submenu" button in the toolbar, and add a bunch of submenus. While you are creating this monster, observe that the monster stays visible for the whole duration.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
