### PR TITLE
Navigation Block: De-emphasize "Link" block.

### DIFF
--- a/packages/block-library/src/navigation-link/fallback-variations.js
+++ b/packages/block-library/src/navigation-link/fallback-variations.js
@@ -17,8 +17,8 @@ const fallbackVariations = [
 	{
 		name: 'link',
 		isDefault: true,
-		title: __( 'Link' ),
-		description: __( 'A link to a URL.' ),
+		title: __( 'Custom Link' ),
+		description: __( 'A link to a custom URL.' ),
 		attributes: {},
 	},
 	{

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -19,7 +19,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Link', 'block title' ),
+	title: _x( 'Custom Link', 'block title' ),
 
 	icon: linkIcon,
 

--- a/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
+++ b/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
@@ -13,7 +13,7 @@ Object {
       "isActive": [Function],
       "isDefault": true,
       "name": "link",
-      "title": "Link",
+      "title": "Custom Link",
     },
     Object {
       "attributes": Object {
@@ -107,7 +107,7 @@ Object {
       </SVG>,
       "isActive": [Function],
       "name": "link",
-      "title": "Link",
+      "title": "Custom Link",
     },
     Object {
       "attributes": Object {

--- a/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
+++ b/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
@@ -9,7 +9,7 @@ Object {
   "variations": Array [
     Object {
       "attributes": Object {},
-      "description": "A link to a URL.",
+      "description": "A link to a custom URL.",
       "isActive": [Function],
       "isDefault": true,
       "name": "link",
@@ -96,7 +96,7 @@ Object {
   "variations": Array [
     Object {
       "attributes": Object {},
-      "description": "A link to a URL.",
+      "description": "A link to a custom URL.",
       "icon": <SVG
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/block-library/src/navigation-link/test/hooks.js
+++ b/packages/block-library/src/navigation-link/test/hooks.js
@@ -46,8 +46,8 @@ describe( 'hooks', () => {
 					variations: [
 						{
 							name: 'link',
-							title: __( 'Link' ),
-							description: __( 'A link to a URL.' ),
+							title: __( 'Custom Link' ),
+							description: __( 'A link to a custom URL.' ),
 							attributes: {},
 						},
 						{

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -323,7 +323,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the Editor's "Content" region as otherwise it picks up on
 			// block previews.
 			const navBlockItemsLength = await page.$$eval(
-				'[aria-label="Editor content"][role="region"] li[aria-label="Block: Link"]',
+				'[aria-label="Editor content"][role="region"] li[aria-label="Block: Custom Link"]',
 				( els ) => els.length
 			);
 

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -248,7 +248,7 @@ async function addLinkBlock() {
 	await page.click( '.wp-block-navigation .block-list-appender' );
 
 	const [ linkButton ] = await page.$x(
-		"//*[contains(@class, 'block-editor-inserter__quick-inserter')]//*[text()='Link']"
+		"//*[contains(@class, 'block-editor-inserter__quick-inserter')]//*[text()='Custom Link']"
 	);
 	await linkButton.click();
 }

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -352,10 +352,8 @@ describe( 'Navigation editor', () => {
 		);
 		await appender.click();
 
-		// Must be an exact match to the word 'Link' as other
-		// variations also contain the word 'Link'.
 		const linkInserterItem = await page.waitForXPath(
-			'//button[@role="option"]//span[.="Link"]'
+			'//button[@role="option"]//span[.="Custom Link"]'
 		);
 		await linkInserterItem.click();
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -302,7 +302,7 @@ describe( 'Navigation editor', () => {
 
 		// Select a link block with nested links in a submenu.
 		const parentLinkXPath =
-			'//li[@aria-label="Block: Link" and contains(.,"WordPress.org")]';
+			'//li[@aria-label="Block: Custom Link" and contains(.,"WordPress.org")]';
 		const linkBlock = await page.waitForXPath( parentLinkXPath );
 		await linkBlock.click();
 
@@ -311,7 +311,7 @@ describe( 'Navigation editor', () => {
 		// Submenus are hidden using `visibility: hidden` and shown using
 		// `visibility: visible` so the visible/hidden options must be used
 		// when selecting the elements.
-		const submenuLinkXPath = `${ parentLinkXPath }//li[@aria-label="Block: Link"]`;
+		const submenuLinkXPath = `${ parentLinkXPath }//li[@aria-label="Block: Custom Link"]`;
 		const submenuLinkVisible = await page.waitForXPath( submenuLinkXPath, {
 			visible: true,
 		} );


### PR DESCRIPTION
## Description

One thing recent rounds of FSE testing has surfaced, is that when you create a navigation menu and start empty, people seem to very commonly be choosing the "Link" block to insert their navigation links, when in nearly all cases the "Page Link" block would've been a better choice, actually suggesting pages on your site to link to.

This PR renames "Link" to "Custom Link", to de-emphasize it. Before:

<img width="558" alt="Screenshot 2021-03-24 at 09 37 30" src="https://user-images.githubusercontent.com/1204802/112280867-bc24cf00-8c85-11eb-833a-f7ed6c2eaa38.png">

After:

<img width="558" alt="Screenshot 2021-03-24 at 09 43 29" src="https://user-images.githubusercontent.com/1204802/112280879-be872900-8c85-11eb-981a-1cd0df29ed90.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
