### PR TITLE
Move nav mode exit from writing flow to block props

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -27,6 +27,7 @@ import { useBlockDefaultClassName } from './use-block-default-class-name';
 import { useBlockCustomClassName } from './use-block-custom-class-name';
 import { useBlockMovingModeClassNames } from './use-block-moving-mode-class-names';
 import { useEventHandlers } from './use-event-handlers';
+import { useNavModeExit } from './use-nav-mode-exit';
 import { useBlockNodes } from './use-block-nodes';
 import { store as blockEditorStore } from '../../../store';
 
@@ -103,6 +104,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		useFocusFirstElement( clientId ),
 		useBlockNodes( clientId ),
 		useEventHandlers( clientId ),
+		useNavModeExit( clientId ),
 		useIsHovered(),
 		useMovingAnimation( {
 			isSelected: isPartOfSelection,

--- a/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useRefEffect } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+/**
+ * Allows navigation mode to be exited by clicking in the selected block.
+ *
+ * @param {string} clientId Block client ID.
+ */
+export function useNavModeExit( clientId ) {
+	const isEnabled = useSelect( ( select ) => {
+		const { isNavigationMode, isBlockSelected } = select(
+			blockEditorStore
+		);
+		return isNavigationMode() && isBlockSelected( clientId );
+	}, [] );
+	const { setNavigationMode } = useDispatch( blockEditorStore );
+
+	return useRefEffect(
+		( node ) => {
+			if ( ! isEnabled ) {
+				return;
+			}
+
+			function onMouseDown() {
+				setNavigationMode( false );
+			}
+
+			node.addEventListener( 'mousedown', onMouseDown );
+
+			return () => {
+				node.addEventListener( 'mousedown', onMouseDown );
+			};
+		},
+		[ isEnabled ]
+	);
+}

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -32,12 +32,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	isInSameBlock,
-	isInsideRootBlock,
-	getBlockDOMNode,
-	getBlockClientId,
-} from '../../utils/dom';
+import { isInSameBlock, getBlockClientId } from '../../utils/dom';
 import FocusCapture from './focus-capture';
 import useMultiSelection from './use-multi-selection';
 import { store as blockEditorStore } from '../../store';
@@ -243,20 +238,6 @@ export default function WritingFlow( { children } ) {
 
 	function onMouseDown( event ) {
 		verticalRect.current = null;
-
-		const { ownerDocument } = event.target;
-
-		// Clicking inside a selected block should exit navigation mode and block moving mode.
-		if (
-			isNavigationMode &&
-			selectedBlockClientId &&
-			isInsideRootBlock(
-				getBlockDOMNode( selectedBlockClientId, ownerDocument ),
-				event.target
-			)
-		) {
-			setNavigationMode( false );
-		}
 
 		// Multi-select blocks when Shift+clicking.
 		if (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

This logic belongs in a block ref callback. Gets rid of another `getBlockDOMNode`. Also worth noting that navigation mode logic is part of the block breadcrumb component and not the writing flow component, so this navigation logic is out of place.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Enter navigation mode and click in the selected block. This should exit navigation mode.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
