### PR TITLE
Navigation: Replace arrow with chevron

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -39,13 +39,13 @@ import {
 	createInterpolateElement,
 } from '@wordpress/element';
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
-import { link as linkIcon } from '@wordpress/icons';
+import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import { ToolbarSubmenuIcon, ItemSubmenuIcon } from './icons';
+import { ItemSubmenuIcon } from './icons';
 
 /**
  * A React hook to determine if it's dragging within the target element.
@@ -391,7 +391,7 @@ export default function NavigationLinkEdit( {
 					/>
 					<ToolbarButton
 						name="submenu"
-						icon={ <ToolbarSubmenuIcon /> }
+						icon={ addSubmenu }
 						title={ __( 'Add submenu' ) }
 						onClick={ insertLinkBlock }
 					/>

--- a/packages/block-library/src/navigation-link/icons.js
+++ b/packages/block-library/src/navigation-link/icons.js
@@ -8,10 +8,13 @@ export const ItemSubmenuIcon = () => (
 		xmlns="http://www.w3.org/2000/svg"
 		width="12"
 		height="12"
-		viewBox="0 0 24 24"
-		transform="rotate(90)"
+		viewBox="0 0 12 12"
+		fill="none"
 	>
-		<Path d="M8 5v14l11-7z" />
-		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path
+			d="M1.50002 4L6.00002 8L10.5 4"
+			stroke="#000000"
+			strokeWidth="1.5"
+		/>
 	</SVG>
 );

--- a/packages/block-library/src/navigation-link/icons.js
+++ b/packages/block-library/src/navigation-link/icons.js
@@ -3,12 +3,6 @@
  */
 import { Path, SVG } from '@wordpress/components';
 
-export const ToolbarSubmenuIcon = () => (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24">
-		<Path d="M2 12c0 3.6 2.4 5.5 6 5.5h.5V19l3-2.5-3-2.5v2H8c-2.5 0-4.5-1.5-4.5-4s2-4.5 4.5-4.5h3.5V6H8c-3.6 0-6 2.4-6 6zm19.5-1h-8v1.5h8V11zm0 5h-8v1.5h8V16zm0-10h-8v1.5h8V6z" />
-	</SVG>
-);
-
 export const ItemSubmenuIcon = () => (
 	<SVG
 		xmlns="http://www.w3.org/2000/svg"

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -91,7 +91,7 @@ function block_core_navigation_link_build_css_font_sizes( $context ) {
  * @return string
  */
 function block_core_navigation_link_render_submenu_icon() {
-	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" transform="rotate(90)"><path d="M8 5v14l11-7z"/><path d="M0 0h24v24H0z" fill="none"/></svg>';
+	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke="#000000" stroke-width="1.5"></path></svg>';
 }
 
 /**

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -69,11 +69,7 @@
 		padding: 0.375em 1em 0.375em 0;
 
 		svg {
-			fill: currentColor;
-
-			@include break-medium {
-				transform: rotate(90deg);
-			}
+			stroke: currentColor;
 		}
 	}
 
@@ -105,6 +101,8 @@
 
 			> .wp-block-pages-list__item,
 			> .wp-block-navigation-link {
+				margin: 0;
+
 				> .wp-block-pages-list__item__link,
 				> .wp-block-navigation-link__content {
 					flex-grow: 1;
@@ -140,7 +138,7 @@
 				// Reset the submenu indicator for horizontal flyouts.
 				.wp-block-page-list__submenu-icon svg,
 				.wp-block-navigation-link__submenu-icon svg {
-					transform: rotate(0);
+					transform: rotate(-90deg);
 				}
 			}
 		}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -23,6 +23,10 @@
 		&.wp-block-navigation-link {
 			margin: 0 0.5em 0 0;
 		}
+
+		&.has-child .block-editor-block-list__block.wp-block-navigation-link {
+			margin: 0;
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -91,7 +91,7 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  * @return string
  */
 function block_core_navigation_render_submenu_icon() {
-	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" transform="rotate(90)"><path d="M8 5v14l11-7z"/><path d="M0 0h24v24H0z" fill="none"/></svg>';
+	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke="#000000" stroke-width="1.5"></path></svg>';
 }
 
 /**

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -108,7 +108,7 @@ function render_nested_page_list( $nested_pages ) {
 			wp_kses_allowed_html( 'post' )
 		) . '</a>';
 		if ( isset( $page['children'] ) ) {
-			$markup .= '<span class="wp-block-page-list__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" transform="rotate(90)"><path d="M8 5v14l11-7z"></path><path d="M0 0h24v24H0z" fill="none"></path></svg></span>';
+			$markup .= '<span class="wp-block-page-list__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke="#000000" stroke-width="1.5"></path></svg></span>';
 			$markup .= '<ul class="submenu-container">' . render_nested_page_list( $page['children'] ) . '</ul>';
 		}
 		$markup .= '</li>';

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -80,7 +80,6 @@
 
 		svg {
 			padding: 0;
-			transform: rotate(90deg);
 		}
 	}
 

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -1,5 +1,6 @@
 export { default as Icon } from './icon';
 
+export { default as addSubmenu } from './library/add-submenu';
 export { default as alignCenter } from './library/align-center';
 export { default as alignJustify } from './library/align-justify';
 export { default as alignLeft } from './library/align-left';

--- a/packages/icons/src/library/add-submenu.js
+++ b/packages/icons/src/library/add-submenu.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const addSubmenu = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M2 12c0 3.6 2.4 5.5 6 5.5h.5V19l3-2.5-3-2.5v2H8c-2.5 0-4.5-1.5-4.5-4s2-4.5 4.5-4.5h3.5V6H8c-3.6 0-6 2.4-6 6zm19.5-1h-8v1.5h8V11zm0 5h-8v1.5h8V16zm0-10h-8v1.5h8V6z" />
+	</SVG>
+);
+
+export default addSubmenu;


### PR DESCRIPTION
## Description

This PR replaces the navigation block submenu triangle with a chevron. Before:

<img width="410" alt="Screenshot 2021-03-24 at 10 35 56" src="https://user-images.githubusercontent.com/1204802/112297275-fd24df80-8c95-11eb-8b25-aa14503e236d.png">

After:

![editor](https://user-images.githubusercontent.com/1204802/112297285-001fd000-8c96-11eb-8965-0e093557224e.gif)

![frontend](https://user-images.githubusercontent.com/1204802/112297294-0150fd00-8c96-11eb-96c7-418758602fcb.gif)

Whether the triangle or the chevron is a subject of taste, hwoever the chevron brings with it a few themer benefits. Specifically, it is an SVG with two strokes and a stroke-width. Which means a theme can:

- Change the stroke-width thicker or thinner
- Remove the stroke-width and replace it with a fill, restoring it to a triangle

In that vein, the chevron SVG shape is to an extent more flexible.

## How has this been tested?

Please test navigation blocks with custom submenus, and with page list, and on the navigation screen. Verify the chevron looks right.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
