### PR TITLE
Fix padding issues with nav screen.

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -25,7 +25,8 @@
 		font-family: $default-font;
 	}
 
-	.wp-block-navigation-link {
+	// Increase specificity.
+	.wp-block-navigation .wp-block-navigation-link {
 		display: block;
 
 		// Show submenus on click.
@@ -59,8 +60,8 @@
 
 	.wp-block-navigation-link__label,
 	.wp-block-navigation-link__placeholder-text {
-		padding: $grid-unit-15;
-		padding-left: $grid-unit-30;
+		padding: $grid-unit-05;
+		padding-left: $grid-unit-10;
 	}
 
 	.wp-block-navigation-link__label {

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -49,7 +49,6 @@
 	}
 
 	.wp-block-navigation-link__content {
-		padding: 0;
 		margin-bottom: 6px;
 		border-radius: $radius-block-ui;
 


### PR DESCRIPTION
## Description

https://github.com/WordPress/gutenberg/pull/29975 increased the specificity of a few rules, which meant some padding rules now took effect in the navigation screen. That caused this:

![before](https://user-images.githubusercontent.com/1204802/112300030-b84e7800-8c98-11eb-8da0-b85d132a6380.gif)

This PR fixes that by tweaking an extra padding value, and by restoring specificity:

![after](https://user-images.githubusercontent.com/1204802/112300172-d5834680-8c98-11eb-86e6-f02a34e05aa3.gif)

## How has this been tested?

Please test menu items and submenu items on the navigation screen.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
