### PR TITLE
Block Library - Quote: Fix the editor/frontend style parity.

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -32,7 +32,6 @@
 @import "./post-excerpt/editor.scss";
 @import "./post-author/editor.scss";
 @import "./pullquote/editor.scss";
-@import "./quote/editor.scss";
 @import "./rss/editor.scss";
 @import "./search/editor.scss";
 @import "./separator/editor.scss";

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -82,6 +82,8 @@ export default function QuoteEdit( {
 				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 					<RichText
 						identifier="citation"
+						tagName="cite"
+						display={ { style: 'inline-block' } }
 						value={ citation }
 						onChange={ ( nextCitation ) =>
 							setAttributes( {

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -83,7 +83,7 @@ export default function QuoteEdit( {
 					<RichText
 						identifier="citation"
 						tagName="cite"
-						display={ { style: 'inline-block' } }
+						style={ { display: 'inline-block' } }
 						value={ citation }
 						onChange={ ( nextCitation ) =>
 							setAttributes( {

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -83,7 +83,7 @@ export default function QuoteEdit( {
 					<RichText
 						identifier="citation"
 						tagName="cite"
-						style={ { display: 'inline-block' } }
+						style={ { display: 'block' } }
 						value={ citation }
 						onChange={ ( nextCitation ) =>
 							setAttributes( {

--- a/packages/block-library/src/quote/editor.scss
+++ b/packages/block-library/src/quote/editor.scss
@@ -1,3 +1,0 @@
-.wp-block-quote__citation {
-	font-size: $default-font-size;
-}

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -4,11 +4,9 @@
 	padding-left: 1em;
 
 	cite,
-	footer,
-	&__citation {
+	footer {
 		color: currentColor;
 		font-size: 0.8125em;
-		margin-top: 1em;
 		position: relative;
 		font-style: normal;
 	}

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -84,11 +84,17 @@ const INSERTION_INPUT_TYPES_TO_IGNORE = new Set( [
 const whiteSpace = 'pre-wrap';
 
 /**
+ * A minimum width of 1px will prevent the rich text container from collapsing
+ * to 0 width and hiding the caret. This is useful for inline containers.
+ */
+const minWidth = '1px';
+
+/**
  * Default style object for the editable element.
  *
  * @type {Object<string,string>}
  */
-const defaultStyle = { whiteSpace };
+const defaultStyle = { whiteSpace, minWidth };
 
 const EMPTY_ACTIVE_FORMATS = [];
 


### PR DESCRIPTION
Related #29976 

Removes the editor styles of the quote block and make its markup match the frontend.