### PR TITLE
RichText: fix inline display warning

### DIFF
--- a/docs/reference-guides/richtext.md
+++ b/docs/reference-guides/richtext.md
@@ -110,7 +110,7 @@ While using the RichText component a number of common issues tend to appear.
 
 In some cases the placeholder content on RichText can appear separate from the input where you would write your content. This is likely due to one of two reasons:
 
-1. You can't use an [inline HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements) as the RichText component. If your `tagName` property is using an inline element such as `span`, `a` or `code`, it needs to be changed to a [block-level element](https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements).
+1. You can't have an element with the CSS `display` property set to `inline`. You will need to set it to `inline-block` or any other value.
 2. The `position` CSS property value for the element must be set to `relative` or `absolute` within the admin. If the styles within style.css or editor.css modify the `position` property value for this element, you may see issues with how it displays.
 
 ### HTML Formatting Tags Display in the Content

--- a/packages/block-editor/src/components/editable-text/README.md
+++ b/packages/block-editor/src/components/editable-text/README.md
@@ -14,7 +14,7 @@ Renders an editable text input in which text formatting is not allowed.
 
 ### `tagName: String`
 
-*Default: `div`.* The [tag name](https://www.w3.org/TR/html51/syntax.html#tag-name) of the editable element. Elements that display inline are not supported.
+*Default: `div`.* The [tag name](https://www.w3.org/TR/html51/syntax.html#tag-name) of the editable element. Elements that display inline are not supported. Set to `inline-block` to use tag names that have `inline` as the default.
 
 ### `disableLineBreaks: Boolean`
 

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -14,7 +14,7 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 ### `tagName: String`
 
-*Default: `div`.* The [tag name](https://www.w3.org/TR/html51/syntax.html#tag-name) of the editable element. Elements that display inline are not supported.
+*Default: `div`.* The [tag name](https://www.w3.org/TR/html51/syntax.html#tag-name) of the editable element. Elements that display inline are not supported. Set to `inline-block` to use tag names that have `inline` as the default.
 
 ### `placeholder: String`
 

--- a/packages/rich-text/src/component/use-inline-warning.js
+++ b/packages/rich-text/src/component/use-inline-warning.js
@@ -3,6 +3,9 @@
  */
 import { useEffect } from '@wordpress/element';
 
+const message =
+	'RichText cannot be used with an inline container. Please use a different display property.';
+
 export function useInlineWarning( { ref } ) {
 	useEffect( () => {
 		if ( process.env.NODE_ENV === 'development' ) {
@@ -12,9 +15,7 @@ export function useInlineWarning( { ref } ) {
 
 			if ( computedStyle.display === 'inline' ) {
 				// eslint-disable-next-line no-console
-				console.warn(
-					'RichText cannot be used with an inline container. Please use a different tagName.'
-				);
+				console.warn( message );
 			}
 		}
 	}, [] );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

It's not necessary to change the tag name, only the display property.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
