### PR TITLE
Rich Text: Fix multi-select copy

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -40,6 +40,24 @@ exports[`Multi-block selection should copy and paste 3`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Multi-block selection should copy multiple blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Multi-block selection should cut and paste 1`] = `""`;
 
 exports[`Multi-block selection should cut and paste 2`] = `

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -574,4 +574,18 @@ describe( 'Multi-block selection', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should copy multiple blocks', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'c' );
+		await page.keyboard.press( 'ArrowUp' );
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -1060,7 +1060,10 @@ function RichText(
 
 	const copyHandler = useRefEffect( ( element ) => {
 		function onCopy( event ) {
-			if ( isCollapsed( record.current ) ) {
+			if (
+				isCollapsed( record.current ) ||
+				! element.contains( element.ownerDocument.activeElement )
+			) {
 				return;
 			}
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -19,7 +19,7 @@ import {
 	ESCAPE,
 } from '@wordpress/keycodes';
 import { getFilesFromDataTransfer } from '@wordpress/dom';
-import { useMergeRefs, useRefEffect } from '@wordpress/compose';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -41,8 +41,7 @@ import { useFormatTypes } from './use-format-types';
 import { useBoundaryStyle } from './use-boundary-style';
 import { useInlineWarning } from './use-inline-warning';
 import { insert } from '../insert';
-import { slice } from '../slice';
-import { getTextContent } from '../get-text-content';
+import { useCopyHandler } from './use-copy-handler';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -1058,40 +1057,16 @@ function RichText(
 		applyRecord( record.current );
 	}
 
-	const copyHandler = useRefEffect( ( element ) => {
-		function onCopy( event ) {
-			if (
-				isCollapsed( record.current ) ||
-				! element.contains( element.ownerDocument.activeElement )
-			) {
-				return;
-			}
-
-			const selectedRecord = slice( record.current );
-			const plainText = getTextContent( selectedRecord );
-			const html = toHTMLString( {
-				value: selectedRecord,
-				multilineTag,
-				preserveWhiteSpace,
-			} );
-			event.clipboardData.setData( 'text/plain', plainText );
-			event.clipboardData.setData( 'text/html', html );
-			event.clipboardData.setData( 'rich-text', 'true' );
-			event.preventDefault();
-		}
-
-		element.addEventListener( 'copy', onCopy );
-		return () => {
-			element.removeEventListener( 'copy', onCopy );
-		};
-	}, [] );
-
 	const editableProps = {
 		// Overridable props.
 		role: 'textbox',
 		'aria-multiline': true,
 		'aria-label': placeholder,
-		ref: useMergeRefs( [ forwardedRef, ref, copyHandler ] ),
+		ref: useMergeRefs( [
+			forwardedRef,
+			ref,
+			useCopyHandler( { record, multilineTag, preserveWhiteSpace } ),
+		] ),
 		style: defaultStyle,
 		className: 'rich-text',
 		onPaste: handlePaste,

--- a/packages/rich-text/src/component/use-copy-handler.js
+++ b/packages/rich-text/src/component/use-copy-handler.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { toHTMLString } from '../to-html-string';
+import { isCollapsed } from '../is-collapsed';
+import { slice } from '../slice';
+import { getTextContent } from '../get-text-content';
+
+export function useCopyHandler( { record, multilineTag, preserveWhiteSpace } ) {
+	return useRefEffect(
+		( element ) => {
+			function onCopy( event ) {
+				if (
+					isCollapsed( record.current ) ||
+					! element.contains( element.ownerDocument.activeElement )
+				) {
+					return;
+				}
+
+				const selectedRecord = slice( record.current );
+				const plainText = getTextContent( selectedRecord );
+				const html = toHTMLString( {
+					value: selectedRecord,
+					multilineTag,
+					preserveWhiteSpace,
+				} );
+				event.clipboardData.setData( 'text/plain', plainText );
+				event.clipboardData.setData( 'text/html', html );
+				event.clipboardData.setData( 'rich-text', 'true' );
+				event.preventDefault();
+			}
+
+			element.addEventListener( 'copy', onCopy );
+			return () => {
+				element.removeEventListener( 'copy', onCopy );
+			};
+		},
+		[ record, multilineTag, preserveWhiteSpace ]
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

There's an issue in the order in which clipboard data is set on copy and the conditions on which we set rich text data. Rich text data should not be set if the active element is outside of the rich text wrapper.

Added an e2e test because there is no coverage for this.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
