### PR TITLE
Navigation Link: Limit Nesting Depth to 5

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -168,7 +168,6 @@ export default function NavigationLinkEdit( {
 
 	const {
 		isAtMaxNesting,
-		isDraggingBlocks,
 		isParentOfSelectedBlock,
 		isImmediateParentOfSelectedBlock,
 		hasDescendants,
@@ -182,7 +181,6 @@ export default function NavigationLinkEdit( {
 				getClientIdsOfDescendants,
 				hasSelectedInnerBlock,
 				getSelectedBlockClientId,
-				isDraggingBlocks: _isDraggingBlocks,
 				getBlockParentsByBlockName,
 			} = select( blockEditorStore );
 
@@ -394,11 +392,11 @@ export default function NavigationLinkEdit( {
 					/>
 					{ ! isAtMaxNesting && (
 						<ToolbarButton
-						name="submenu"
-						icon={ addSubmenu }
-						title={ __( 'Add submenu' ) }
-						onClick={ insertLinkBlock }
-					/>
+							name="submenu"
+							icon={ addSubmenu }
+							title={ __( 'Add submenu' ) }
+							onClick={ insertLinkBlock }
+						/>
 					) }
 				</ToolbarGroup>
 			</BlockControls>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -192,7 +192,9 @@ export default function NavigationLinkEdit( {
 				.length;
 
 			return {
-				isAtMaxNesting : getBlockParentsByBlockName( clientId, name ).length >= MAX_NESTING,
+				isAtMaxNesting:
+					getBlockParentsByBlockName( clientId, name ).length >=
+					MAX_NESTING,
 				isParentOfSelectedBlock: hasSelectedInnerBlock(
 					clientId,
 					true

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -46,8 +46,11 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { ItemSubmenuIcon } from './icons';
+import { name } from './block.json';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/spacer' ];
+
+const MAX_NESTING = 5;
 
 /**
  * A React hook to determine if it's dragging within the target element.
@@ -164,6 +167,8 @@ export default function NavigationLinkEdit( {
 	const ref = useRef();
 
 	const {
+		isAtMaxNesting,
+		isDraggingBlocks,
 		isParentOfSelectedBlock,
 		isImmediateParentOfSelectedBlock,
 		hasDescendants,
@@ -177,6 +182,8 @@ export default function NavigationLinkEdit( {
 				getClientIdsOfDescendants,
 				hasSelectedInnerBlock,
 				getSelectedBlockClientId,
+				isDraggingBlocks: _isDraggingBlocks,
+				getBlockParentsByBlockName,
 			} = select( blockEditorStore );
 
 			const selectedBlockId = getSelectedBlockClientId();
@@ -185,6 +192,7 @@ export default function NavigationLinkEdit( {
 				.length;
 
 			return {
+				isAtMaxNesting : getBlockParentsByBlockName( clientId, name ).length >= MAX_NESTING,
 				isParentOfSelectedBlock: hasSelectedInnerBlock(
 					clientId,
 					true
@@ -382,12 +390,14 @@ export default function NavigationLinkEdit( {
 						shortcut={ displayShortcut.primary( 'k' ) }
 						onClick={ () => setIsLinkOpen( true ) }
 					/>
-					<ToolbarButton
+					{ ! isAtMaxNesting && (
+						<ToolbarButton
 						name="submenu"
 						icon={ addSubmenu }
 						title={ __( 'Add submenu' ) }
 						onClick={ insertLinkBlock }
 					/>
+					) }
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>


### PR DESCRIPTION
Closes #21691

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Removes the ability to nest submenus beyond 5 to avoid scrolling off the screen.

## How has this been tested?
Manually tested in desktop.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
When choosing a Navigation Link that isn't too nested, the submenu icon appears:
![Screen Shot 2021-03-24 at 11 59 54 AM](https://user-images.githubusercontent.com/128240/112342484-a240b780-8c98-11eb-911d-dbd9d33c1a62.png)

When choosing a Navigation Link that has reached the limit, the icon goes away:
![Screen Shot 2021-03-24 at 12 00 01 PM](https://user-images.githubusercontent.com/128240/112342562-b4baf100-8c98-11eb-96c2-4b1d11bc9259.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->

