### PR TITLE
Navigation: add src/navigation-link/index to side effect whitelist

### DIFF
--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -23,7 +23,8 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
-		"src/**/*.scss"
+		"src/**/*.scss",
+		"src/navigation-link/index.js"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.13.10",

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -90,7 +90,7 @@ export const settings = {
 	],
 };
 
-// ensure that we import and use this from hooks.js, so code is not shaken out in final build.
+// importing this file includes side effects. This is whitelisted in block-library/package.json under sideEffects
 addFilter(
 	'blocks.registerBlockType',
 	'core/navigation-link',


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/30117 this adds the navigation-link to the side-effect whitelist, so our block hook will not be shaken out of the final build. Previously we were seeing expected behavior in the development build `npm run dev` but not when using `npm run build`

### Testing Instructions

#### WP 5.7
| missing hook | no regressions |
|-----|-----|
| <img width="1314" alt="Screen Shot 2021-03-23 at 1 35 52 PM" src="https://user-images.githubusercontent.com/1270189/112214669-b45d2000-8bdc-11eb-8cbd-8ab5f9f6461b.png"> | <img width="1314" alt="5 7-after" src="https://user-images.githubusercontent.com/1270189/112214372-56c8d380-8bdc-11eb-879e-b1f1c9659a16.png"> | 

- Make sure your local instance is on WP 5.7 or below
- Checkout this branch `npm run build` and enable the gutenberg plugin. Note use the **build** and not  **dev** command.
- Add a navigation block
- Add a navigation link
Expected: all fallback variations appear: (link, post link, page link, category, tag)

#### WP Latest 
| missing hook | no regression |
|-----|-----|
| <img width="1216" alt="before-latest" src="https://user-images.githubusercontent.com/1270189/112214201-297c2580-8bdc-11eb-805b-eb8b6ee32271.png"> | <img width="1294" alt="after-latest" src="https://user-images.githubusercontent.com/1270189/112214288-431d6d00-8bdc-11eb-857f-c0fb429143f4.png"> | 

- Make sure your local instance is on WP latest
- Checkout this branch `npm run build` and enable the gutenberg plugin. Note use the **build** and not  **dev** command.
- Add a navigation block
- Add a navigation link
Expected: variations appear (including custom variations from plugins). Each variation has the correct icon. Note that when using custom variations, there's a new post label that plugin authors have not had a chance to add:

To see the right labels, we can edit the plugin and add `item_link` and `item_link_description` to the taxonomy or post-type definition.

<img width="944" alt="109557321-cbe93300-7a8c-11eb-87d5-e7c169b88581" src="https://user-images.githubusercontent.com/1270189/111481243-fcb5a300-86ef-11eb-961f-958e08d70d3d.png">