### PR TITLE
Components: Add extra specific CSS

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/style.scss
+++ b/packages/block-editor/src/components/block-variation-picker/style.scss
@@ -17,6 +17,7 @@
 	}
 }
 
+
 .block-editor-block-variation-picker__variations.block-editor-block-variation-picker__variations {
 	display: flex;
 	justify-content: flex-start;
@@ -34,13 +35,18 @@
 		width: 75px;
 		text-align: center;
 
-		button {
+		button,
+		// Ideally not needed but this overrides the high specificity of the buttons in the canvas that can be affected by themes.
+		.editor-styles-wrapper & button.components-button.components-button {
 			display: inline-flex;
 			margin-right: 0;
 		}
 	}
 
-	.block-editor-block-variation-picker__variation {
+
+	.block-editor-block-variation-picker__variation,
+	// Ideally not needed but this overrides the high specificity of the buttons in the canvas that can be affected by themes.
+	.editor-styles-wrapper & .block-editor-block-variation-picker__variation.components-button.components-button {
 		padding: $grid-unit-10;
 	}
 

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -1,4 +1,6 @@
-.block-editor-button-block-appender {
+.block-editor-button-block-appender,
+// Ideally not needed but this overrides the high specificity of the buttons in the canvas that can be affected by themes.
+.editor-styles-wrapper .block-editor-button-block-appender.components-button.components-button {
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/packages/block-library/src/freeform/editor.scss
+++ b/packages/block-library/src/freeform/editor.scss
@@ -269,6 +269,14 @@ div[data-type="core/freeform"] {
 
 // mce global styles: the toolbars may get appended to <body>
 .mce-toolbar-grp {
+	.mce-toolbar .mce-btn button {
+		all: revert;
+		border: none;
+		background: none;
+		padding: 2px 3px;
+		cursor: pointer;
+	}
+
 	// Not sure why this is necessary, there seems to be a skin file that
 	// overrides this upstream.
 	.mce-btn.mce-active button,

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -173,7 +173,9 @@ $color-control-label-height: 20px;
 	}
 }
 
-.wp-block-navigation .block-editor-button-block-appender {
+.wp-block-navigation .block-editor-button-block-appender,
+// Ideally not needed but this overrides the high specificity of the buttons in the canvas that can be affected by themes.
+.editor-styles-wrapper .wp-block-navigation .block-editor-button-block-appender.components-button.components-button {
 	justify-content: flex-start;
 }
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,21 +1,42 @@
+.block-editor-block-list__layout input.components-button,
+.block-editor-block-list__layout button.components-button,
 .components-button {
-	display: inline-flex;
-	text-decoration: none;
-	font-weight: normal;
-	font-size: $default-font-size;
-	margin: 0;
-	border: 0;
-	cursor: pointer;
-	-webkit-appearance: none;
+	align-items: center;
 	background: none;
+	border: 0;
+	border-radius: $radius-block-ui;
+	box-sizing: border-box;
+	box-shadow: revert;
+	color: $gray-900;
+	cursor: pointer;
+	display: inline-flex;
+	font-family: $default-font;
+	font-size: $default-font-size;
+	font-style: normal;
+	font-weight: normal;
+	height: $button-size;
+	letter-spacing: normal;
+	line-height: normal;
+	min-height: revert;
+	min-width: revert;
+	margin: 0;
+	max-height: revert;
+	max-width: revert;
+	opacity: 1;
+	padding: 6px 12px;
+	stroke: revert;
+	text-align: revert;
+	text-decoration: none;
+	text-indent: 0;
+	text-shadow: revert;
+	text-transform: revert;
 	transition: box-shadow 0.1s linear;
 	@include reduce-motion("transition");
-	height: $button-size;
-	align-items: center;
-	box-sizing: border-box;
-	padding: 6px 12px;
-	border-radius: $radius-block-ui;
-	color: $gray-900;
+	vertical-align: revert;
+	width: revert;
+	-webkit-appearance: none;
+	word-break: revert;
+	word-spacing: revert;
 
 	&[aria-expanded="true"],
 	&:hover {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,5 +1,8 @@
-.block-editor-block-list__layout input.components-button,
-.block-editor-block-list__layout button.components-button,
+// These two first selectors shouldn't be needed ideally,
+// but they are useful in case theme styles conflict with Button styles
+// For example inside the image block placeholder.
+.editor-styles-wrapper input.components-button,
+.editor-styles-wrapper button.components-button,
 .components-button {
 	align-items: center;
 	background: none;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,8 +1,8 @@
 // These two first selectors shouldn't be needed ideally,
 // but they are useful in case theme styles conflict with Button styles
 // For example inside the image block placeholder.
-.editor-styles-wrapper input.components-button,
-.editor-styles-wrapper button.components-button,
+.editor-styles-wrapper input.components-button.components-button,
+.editor-styles-wrapper button.components-button.components-button,
 .components-button {
 	align-items: center;
 	background: none;

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -55,7 +55,12 @@ $color-palette-circle-spacing: 12px;
 	background: url('data:image/svg+xml,%3Csvg width="28" height="28" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M6 8V6H4v2h2zM8 8V6h2v2H8zM10 16H8v-2h2v2zM12 16v-2h2v2h-2zM12 18v-2h-2v2H8v2h2v-2h2zM14 18v2h-2v-2h2zM16 18h-2v-2h2v2z" fill="%23555D65"/%3E%3Cpath fill-rule="evenodd" clip-rule="evenodd" d="M18 18h2v-2h-2v-2h2v-2h-2v-2h2V8h-2v2h-2V8h-2v2h2v2h-2v2h2v2h2v2zm-2-4v-2h2v2h-2z" fill="%23555D65"/%3E%3Cpath d="M18 18v2h-2v-2h2z" fill="%23555D65"/%3E%3Cpath fill-rule="evenodd" clip-rule="evenodd" d="M8 10V8H6v2H4v2h2v2H4v2h2v2H4v2h2v2H4v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v-2h-2v-2h2v-2h-2v-2h2v-2h-2v-2h2V8h-2V6h2V4h-2v2h-2V4h-2v2h-2V4h-2v2h-2V4h-2v2h2v2h-2v2H8zm0 2v-2H6v2h2zm2 0v-2h2v2h-2zm0 2v-2H8v2H6v2h2v2H6v2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h-2v-2h2v-2h-2v-2h2v-2h-2v-2h2V8h-2V6h-2v2h-2V6h-2v2h-2v2h2v2h-2v2h-2z" fill="%23555D65"/%3E%3Cpath fill-rule="evenodd" clip-rule="evenodd" d="M4 0H2v2H0v2h2v2H0v2h2v2H0v2h2v2H0v2h2v2H0v2h2v2H0v2h2v2H0v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v-2h-2v-2h2v-2h-2v-2h2v-2h-2v-2h2v-2h-2v-2h2V8h-2V6h2V4h-2V2h2V0h-2v2h-2V0h-2v2h-2V0h-2v2h-2V0h-2v2h-2V0h-2v2H8V0H6v2H4V0zm0 4V2H2v2h2zm2 0V2h2v2H6zm0 2V4H4v2H2v2h2v2H2v2h2v2H2v2h2v2H2v2h2v2H2v2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h2v2h2v-2h-2v-2h2v-2h-2v-2h2v-2h-2v-2h2v-2h-2v-2h2V8h-2V6h2V4h-2V2h-2v2h-2V2h-2v2h-2V2h-2v2h-2V2h-2v2H8v2H6z" fill="%23555D65"/%3E%3C/svg%3E');
 }
 
-.components-circular-option-picker__option {
+
+.components-circular-option-picker__option,
+// This selector shouldn't be needed ideally,
+// but because theme styles can conflict with Button styles
+// the default button styles have higher specificity
+.editor-styles-wrapper button.components-circular-option-picker__option.components-button.components-button {
 	display: inline-block;
 	vertical-align: top;
 	height: 100%;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -96,7 +96,7 @@
 	width: 50%;
 }
 
-.components-placeholder__fieldset .components-button {
+.block-editor-block-list__layout .components-placeholder__fieldset button.components-button {
 	margin-right: $grid-unit-15;
 	margin-bottom: $grid-unit-15; // If buttons wrap we need vertical space between.
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -96,7 +96,11 @@
 	width: 50%;
 }
 
-.block-editor-block-list__layout .components-placeholder__fieldset button.components-button {
+.components-placeholder__fieldset button.components-button,
+// This selector shouldn't be needed ideally,
+// but they are useful in case theme styles conflict with Button styles
+// For example inside the image block placeholder.
+.editor-styles-wrapper .components-placeholder__fieldset button.components-button {
 	margin-right: $grid-unit-15;
 	margin-bottom: $grid-unit-15; // If buttons wrap we need vertical space between.
 

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -1,20 +1,5 @@
 .edit-post-visual-editor {
 	position: relative;
-
-	// The button element easily inherits styles that are meant for the editor style.
-	// These rules enhance the specificity to reduce that inheritance.
-	// This is duplicated in edit-site.
-	& .components-button {
-		font-family: $default-font;
-		font-size: $default-font-size;
-		padding: 6px 12px;
-
-		&.is-tertiary,
-		&.has-icon {
-			padding: 6px;
-		}
-	}
-
 	flex: 1 1 auto;
 
 	// In IE11 flex-basis: 100% cause a bug where the metaboxes area overlap with the content area.


### PR DESCRIPTION
closes #10178 

## Description
Adds extra specific CSS to component buttons so that themes don't override it.

## How has this been tested?
- Checkout this PR: https://github.com/WordPress/theme-experiments/pull/240
- Switch to empty theme
- Check that the block inserter and buttons on placeholders still look correct

## Screenshots <!-- if applicable -->
<img width="813" alt="Screenshot 2021-03-24 at 17 25 43" src="https://user-images.githubusercontent.com/275961/112355853-f910b600-8cc5-11eb-8f2d-952ec40e07e8.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
