### PR TITLE
RichText: fix arrow navigation around emoji

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -48,6 +48,12 @@ exports[`RichText should make bold after split and merge 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should navigate arround emoji 1`] = `
+"<!-- wp:paragraph -->
+<p>1🍓</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should not format text after code backtick 1`] = `
 "<!-- wp:paragraph -->
 <p>A <code>backtick</code> and more.</p>

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -415,4 +415,16 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should navigate arround emoji', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '🍓' );
+		// Only one press on arrow left should be required to move in front of
+		// the emoji.
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.type( '1' );
+
+		// Expect '1🍓'.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -216,6 +216,7 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.up( 'Shift' );
 		await pressKeyWithModifier( 'primary', 'i' );
 		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -216,7 +216,6 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.up( 'Shift' );
 		await pressKeyWithModifier( 'primary', 'i' );
 		await page.keyboard.press( 'ArrowLeft' );
-		await page.keyboard.press( 'ArrowLeft' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -605,9 +605,6 @@ function RichText(
 			return;
 		}
 
-		// In all other cases, prevent default behaviour.
-		event.preventDefault();
-
 		const formatsBefore = formats[ start - 1 ] || EMPTY_ACTIVE_FORMATS;
 		const formatsAfter = formats[ start ] || EMPTY_ACTIVE_FORMATS;
 
@@ -650,30 +647,22 @@ function RichText(
 			}
 		}
 
-		if ( newActiveFormatsLength !== currentActiveFormats.length ) {
-			const newActiveFormats = source.slice( 0, newActiveFormatsLength );
-			const newValue = {
-				...record.current,
-				activeFormats: newActiveFormats,
-			};
-			record.current = newValue;
-			applyRecord( newValue );
-			setActiveFormats( newActiveFormats );
+		if ( newActiveFormatsLength === currentActiveFormats.length ) {
+			record.current._newActiveFormats = isReverse
+				? formatsBefore
+				: formatsAfter;
 			return;
 		}
 
-		const newPos = start + ( isReverse ? -1 : 1 );
-		const newActiveFormats = isReverse ? formatsBefore : formatsAfter;
+		event.preventDefault();
+
+		const newActiveFormats = source.slice( 0, newActiveFormatsLength );
 		const newValue = {
 			...record.current,
-			start: newPos,
-			end: newPos,
 			activeFormats: newActiveFormats,
 		};
-
 		record.current = newValue;
 		applyRecord( newValue );
-		onSelectionChange( newPos, newPos );
 		setActiveFormats( newActiveFormats );
 	}
 
@@ -860,8 +849,10 @@ function RichText(
 			...oldRecord,
 			start,
 			end,
-			// Allow `getActiveFormats` to get new `activeFormats`.
-			activeFormats: undefined,
+			// _newActiveFormats may be set on arrow key navigation to control
+			// the right boundary position. If undefined, getActiveFormats will
+			// give the active formats according to the browser.
+			activeFormats: oldRecord._newActiveFormats,
 		};
 
 		const newActiveFormats = getActiveFormats(

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -853,6 +853,7 @@ function RichText(
 			// the right boundary position. If undefined, getActiveFormats will
 			// give the active formats according to the browser.
 			activeFormats: oldRecord._newActiveFormats,
+			_newActiveFormats: undefined,
 		};
 
 		const newActiveFormats = getActiveFormats(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #27202.

The problem is that we're handling (simple) arrow key navigation ourselves. We should only handle it when navigating around format boundaries and otherwise let the browser do its thing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
See #27202.
## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
