### PR TITLE
Revert "Support drag-and-drop for submenus of navigation blocks (#24479)"

### DIFF
--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -47,6 +47,7 @@
 
 // This hides the block being dragged.
 // The effect is that the block being dragged appears to be "lifted".
-.is-dragging {
+.is-dragging.is-selected,
+.is-dragging.is-multi-selected {
 	display: none !important;
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -682,19 +682,6 @@
 	}
 }
 
-// Hide the popover block editor list while dragging.
-// Using a hacky animation to delay hiding the element.
-// It's needed because if we hide the element immediately upon dragging,
-// the dragging will end immediately since there are no elements to be dragged anymore.
-// Fortunately, we only have to keep it visible for a frame immediately after dragging,
-// after that, we can safely hide it altogether.
-@keyframes hide-during-dragging {
-	to {
-		position: fixed;
-		transform: translate(9999px, 9999px);
-	}
-}
-
 .components-popover.block-editor-block-list__block-popover {
 	z-index: z-index(".block-editor-block-list__block-popover");
 	position: absolute;
@@ -724,9 +711,6 @@
 
 	.is-dragging-components-draggable & {
 		opacity: 0;
-		// Use a minimal duration to delay hiding the element, see hide-during-dragging animation for more details.
-		// It's essential to hide the toolbar/popover so that `dragEnter` events can pass through them to the underlying elements.
-		animation: hide-during-dragging 1ms linear forwards;
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -50,12 +50,12 @@ export function useBlockClassNames( clientId ) {
 				spotlightEntityBlocks
 			);
 			return classnames( 'block-editor-block-list__block', {
-				'is-selected': isSelected && ! isDragging,
+				'is-selected': isSelected,
 				'is-highlighted': isBlockHighlighted( clientId ),
 				'is-multi-selected': isBlockMultiSelected( clientId ),
 				'is-reusable': isReusableBlock( getBlockType( name ) ),
 				'is-dragging': isDragging,
-				'has-child-selected': isAncestorOfSelectedBlock && ! isDragging,
+				'has-child-selected': isAncestorOfSelectedBlock,
 				'has-active-entity': activeEntityBlockId,
 				// Determine if there is an active entity area to spotlight.
 				'is-active-entity': activeEntityBlockId === clientId,

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -54,9 +54,7 @@
 // Styles for submenu flyout.
 .has-child {
 	&.is-selected,
-	&.has-child-selected,
-	// Show the submenu list when is dragging and drag enter the list item.
-	.is-dragging-components-draggable &.is-dragging-within {
+	&.has-child-selected {
 		> .wp-block-navigation__container {
 			opacity: 1;
 			visibility: visible;
@@ -70,17 +68,6 @@
 	opacity: 1;
 	display: flex;
 	flex-direction: column;
-}
-
-.is-dragging-components-draggable .wp-block-navigation-link > .wp-block-navigation__container {
-	// Set opacity to 1 to still be able to show the draggable chip.
-	opacity: 1;
-	visibility: hidden;
-
-	// Show the chip but hide the submenu list.
-	.block-editor-block-draggable-chip-wrapper {
-		visibility: visible;
-	}
 }
 
 /**
@@ -122,7 +109,7 @@ $colors-selector-size: 22px;
 		min-width: $colors-selector-size;
 		height: $colors-selector-size;
 		min-height: $colors-selector-size;
-		line-height: ( $colors-selector-size - 2 );
+		line-height: ($colors-selector-size - 2);
 		padding: 2px;
 
 		> svg {
@@ -265,6 +252,7 @@ $color-control-label-height: 20px;
 		margin-right: $grid-unit-15;
 		height: $button-size; // Prevents jumpiness.
 	}
+
 }
 
 // When block is vertical.


### PR DESCRIPTION
This reverts commit 748c632feccbffb51a6e3c79972a447b71211a0c.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #30177.
Unfortunately we have to revert #24479.

After a refactoring (#29186) the custom drag behaviour of the navigation link block is throwing an infinite loop error.
If we want better drag and drop behaviour in nested contexts, we could implement this in the block editor rather than the block.

## How has this been tested?

Dragging a navigation link block within the navigation block should work again.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
