### PR TITLE
Workflows: Use Gutenberg token for version bump, changelog commits

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+          token: ${{ secrets.GUTENBERG_TOKEN }}
 
       - name: Compute old and new version
         id: get_version

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
         with:
           ref: ${{ matrix.branch }}
+          token: ${{ secrets.GUTENBERG_TOKEN }}
 
       - name: Update the Changelog to include the release notes
         run: |


### PR DESCRIPTION
## Description

When @gziolo attempted running the [release workflow](https://github.com/WordPress/gutenberg/actions/workflows/build-plugin-zip.yml) to create the 10.3.0 RC earlier today, the [workflow](https://github.com/WordPress/gutenberg/actions/runs/682992391) errored:

<img width="1170" alt="Screen Shot 2021-03-24 at 13 47 34" src="https://user-images.githubusercontent.com/96308/112379344-5584cd00-8ce8-11eb-93b5-b0d0f93a396c.png">

After a short [discussion](https://wordpress.slack.com/archives/C02QB2JS7/p1616590871284100) in #core-editor, @youknowriad, Grzegorz, and I concluded that the problem is probably that we're protecting `trunk` against direct pushes from anyone, except for members of the `gutenberg-core` team. (I probably didn't catch this error while developing the new workflow (#28138) since I was testing it in my [personal fork](https://github.com/ockham/gutenberg/), where I didn't have branch protection for `trunk` enabled.)

In our GitHub Actions (GHA) workflows however, we're using the default `GITHUB_TOKEN` provided by GitHub for some default permissions for a given repository. Those permissions do not include pushing to a protected branch. In fact, there are a number of github.community threads ([e.g.](https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/40)) asking for that behavior to be allowed -- so far to no avail. The suggested workaround is to create a Personal Access Token for a user that has those permissions, store it in a (repository-level) secret, and use that in GHA workflows in order to vest them with those permissions.

Since we don't want to couple that Personal Access Token (PAT) with any one individual, I've created a [new GitHub user account ](https://github.com/gutenbergplugin), added it to the `WordPress/gutenberg` repo, added it to the list of users and teams that are allowed to push to `trunk`, and created a new PAT that we can use in our workflows.

I've then created a repository-level secret called `GUTENBERG_TOKEN`, and set it to that PAT.

The final step is then to use this token in any of our GHA jobs that attempt to push to `trunk`. It should be sufficient to pass them as `token` argument to the [`actions/checkout` action](https://github.com/actions/checkout), since it's then persisted it the local git config (and used for all `git` commands run by the job 🤞 ), and only destroyed after the job ends.

## How has this been tested?
We could test this by running it in a fork again, this time enabling branch protection for `trunk`. Furthermore, we'd need to add an repository-level secret called `GUTENBERG_TOKEN` that contains a Personal Access Token.

Or maybe we'll just merge this, delete the `release/10.3` branch, and try kicking off the release process again 😬  Worst thing that happens is that we create another `release/10.3` branch with another version bump commit before the workflow chokes 🤷‍♂️ 