### PR TITLE
Widget block: Handle when $instance is empty and use str_replace instead of sprintf

### DIFF
--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -38,7 +38,7 @@ class WP_Widget_Block extends WP_Widget {
 	 */
 	public function __construct() {
 		$widget_ops  = array(
-			'classname'                   => '%s', // Set dynamically in widget().
+			'classname'                   => 'widget_block',
 			'description'                 => __( 'Gutenberg block.', 'gutenberg' ),
 			'customize_selective_refresh' => true,
 		);
@@ -64,7 +64,11 @@ class WP_Widget_Block extends WP_Widget {
 	public function widget( $args, $instance ) {
 		$instance = wp_parse_args( $instance, $this->default_instance );
 
-		echo sprintf( $args['before_widget'], $this->get_dynamic_classname( $instance['content'] ) );
+		echo str_replace(
+			'widget_block',
+			$this->get_dynamic_classname( $instance['content'] ),
+			$args['before_widget']
+		);
 
 		// Handle embeds for block widgets.
 		//

--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -62,7 +62,10 @@ class WP_Widget_Block extends WP_Widget {
 	 * @global WP_Post $post Global post object.
 	 */
 	public function widget( $args, $instance ) {
-		echo sprintf( $args['before_widget'], $this->get_dynamic_classname( $instance ) );
+		$instance = wp_parse_args( $instance, $this->default_instance );
+
+		echo sprintf( $args['before_widget'], $this->get_dynamic_classname( $instance['content'] ) );
+
 		// Handle embeds for block widgets.
 		//
 		// When this feature is added to core it may need to be implemented
@@ -94,12 +97,12 @@ class WP_Widget_Block extends WP_Widget {
 	 *
 	 * @since 9.3.0
 	 *
-	 * @param array $instance Settings for the current block widget instance.
+	 * @param array $content The HTML content of the current block widget.
 	 *
 	 * @return string The classname to use in the block widget's container HTML.
 	 */
-	private function get_dynamic_classname( $instance ) {
-		$blocks = parse_blocks( $instance['content'] );
+	private function get_dynamic_classname( $content ) {
+		$blocks = parse_blocks( $content );
 
 		$block_name = isset( $blocks[0] ) ? $blocks[0]['blockName'] : null;
 


### PR DESCRIPTION
Fixes two small bugs in `WP_Widget_Block`.

### Handle when `$instance` is empty

c6953ec8dbe70ce1f3ce1f32da1c8618e293172f

When you add a widget to a sidebar and then save it, `$instance` is an empty array by default. Therefore our code which assumes the presence of `$instance['content']` is not correct. We didn't notice because this scenario doesn't come up when using the new widgets screen.

This fixes the following bug:

1. Enable the Block editor in Customizer experiment. 
2. Go to Appearance → Customizer and add a new block.
3. There should be no error in the DevTools console.

### Use `str_replace` instead of `sprintf`

8f0ef4020264fdeca9166e38a8d7dcdda616a120

We dynamically replace the widget block's classname during render so that some level of backwards compatibility can be obtained. See https://github.com/WordPress/gutenberg/pull/26375. We were doing this by setting the class name to `%s` and calling `sprintf` on it in `widget()`. The problem with this, though, is that lots of code paths access `$widget['classname']` directly without ever aclling `widget()`.

This fixes the following bug:

1. Make a REST API request to `/wp/v2/widget-types/block`
2. The `classname` property should be `"widget_block"`, not `"%s"`.