### PR TITLE
Editor: Use getAuthors for 'showCombobox' check

### DIFF
--- a/packages/editor/src/components/post-author/index.js
+++ b/packages/editor/src/components/post-author/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -13,10 +14,7 @@ const minimumUsersForCombobox = 25;
 
 function PostAuthor() {
 	const showCombobox = useSelect( ( select ) => {
-		const authors = select( 'core' ).getUsers( {
-			who: 'authors',
-			per_page: minimumUsersForCombobox + 1,
-		} );
+		const authors = select( coreStore ).getAuthors();
 		return authors?.length >= minimumUsersForCombobox;
 	}, [] );
 

--- a/packages/editor/src/components/post-author/index.js
+++ b/packages/editor/src/components/post-author/index.js
@@ -14,6 +14,7 @@ const minimumUsersForCombobox = 25;
 
 function PostAuthor() {
 	const showCombobox = useSelect( ( select ) => {
+		// Not using `getUsers()` because it requires `list_users` capability.
 		const authors = select( coreStore ).getAuthors();
 		return authors?.length >= minimumUsersForCombobox;
 	}, [] );


### PR DESCRIPTION
## Description
The `getUsers` automatically adds `context=edit` which requires for the current user to have `list_users` capability.

Fixes #29845.

## How has this been tested?
Test A:
1. Create/edit a post with an editor role.
2. You should not see `403 Forbidden` error in the browser console for this endpoint - `https://<site_url>/wp-json/wp/v2/users?who=authors&per_page=26&context=edit&_locale=user`.

Test B:
1. Generate authors - `wp user generate --role=editor --count=50`
2. Create/edit a post with an editor role.
3. You should see the Combobox component for author selection. 

Cleanup: `wp user delete $(wp user list --role=editor --field=ID)`.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
