### PR TITLE
Remove button from forbidden elements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -176,7 +176,6 @@ module.exports = {
 					'error',
 					{
 						forbid: [
-							[ 'button', 'Button' ],
 							[ 'circle', 'Circle' ],
 							[ 'g', 'G' ],
 							[ 'path', 'Path' ],

--- a/packages/customize-widgets/src/components/inspector/index.js
+++ b/packages/customize-widgets/src/components/inspector/index.js
@@ -21,8 +21,7 @@ function InspectorSectionMeta( { closeInspector, inspectorTitleId } ) {
 	return (
 		<div className="customize-section-description-container section-meta">
 			<div className="customize-section-title">
-				{ /* Disable reason: We want to use the exiting style of the back button. */ }
-				<button // eslint-disable-line react/forbid-elements
+				<button
 					type="button"
 					className="customize-section-back"
 					tabIndex="0"


### PR DESCRIPTION
Button is a UI component and it shouldn't be used in blocks. Instead, in blocks, we need to use "button" in order to match the frontend output of the block. So instead of the Button component what we really need is a Button "primitive" in order to be mobile compatible. For now, I'm removing the eslint rule as it's just causing more issues than it solves, we can restore it once we have a Button primitive.