### PR TITLE
Writing Flow: Fix copy pasting non textual blocks

### DIFF
--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -115,7 +115,7 @@ export function useClipboardHandler() {
 				}
 			}
 
-			if ( ! node.contains( event.target ) ) {
+			if ( ! node.contains( event.target.ownerDocument.activeElement ) ) {
 				return;
 			}
 
@@ -156,14 +156,14 @@ export function useClipboardHandler() {
 			}
 		}
 
-		node.addEventListener( 'copy', handler );
-		node.addEventListener( 'cut', handler );
-		node.addEventListener( 'paste', handler );
+		node.ownerDocument.addEventListener( 'copy', handler );
+		node.ownerDocument.addEventListener( 'cut', handler );
+		node.ownerDocument.addEventListener( 'paste', handler );
 
 		return () => {
-			node.removeEventListener( 'copy', handler );
-			node.removeEventListener( 'cut', handler );
-			node.removeEventListener( 'paste', handler );
+			node.ownerDocument.removeEventListener( 'copy', handler );
+			node.ownerDocument.removeEventListener( 'cut', handler );
+			node.ownerDocument.removeEventListener( 'paste', handler );
 		};
 	}, [] );
 }

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
@@ -24,6 +24,22 @@ exports[`Copy/cut/paste of whole blocks should copy and paste individual blocks 
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Copy/cut/paste of whole blocks should copy blocks when non textual elements are focused  (image, spacer) 1`] = `
+"<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;
+
+exports[`Copy/cut/paste of whole blocks should copy blocks when non textual elements are focused  (image, spacer) 2`] = `
+"<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;
+
 exports[`Copy/cut/paste of whole blocks should cut and paste individual blocks 1`] = `
 "<!-- wp:paragraph -->
 <p>2</p>

--- a/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
@@ -31,6 +31,17 @@ describe( 'Copy/cut/paste of whole blocks', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should copy blocks when non textual elements are focused  (image, spacer)', async () => {
+		await insertBlock( 'Spacer' );
+		// At this point the spacer wrapper should be focused.
+		await pressKeyWithModifier( 'primary', 'c' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await clickBlockAppender();
+		await pressKeyWithModifier( 'primary', 'v' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'should cut and paste individual blocks', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Yet another unique string.' );


### PR DESCRIPTION
If you insert an image, or a spacer and click on it then try to copy it using "cmd + c", you'll notice in trunk that it's not copied (at least not consistently) depending on what element of the block is focused.

This PR fixes that bug.