### PR TITLE
Search Block: Add border radius support using skip serialization feature

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -34,6 +34,10 @@
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],
+		"__experimentalBorder": {
+			"radius": true,
+			"__experimentalSkipSerialization": true
+		},
 		"html": false
 	},
 	"editorStyle": "wp-block-search-editor",

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -313,16 +313,16 @@ export default function SearchEdit( {
 	);
 
 	const getWrapperStyles = () => {
-		if ( 'button-inside' !== buttonPosition || ! style?.border?.radius ) {
-			return undefined;
+		if ( 'button-inside' === buttonPosition && style?.border?.radius ) {
+			// We have button inside wrapper and a border radius value to apply.
+			// Add default padding so we don't get "fat" corners.
+			const outerRadius =
+				parseInt( style?.border?.radius, 10 ) + DEFAULT_INNER_PADDING;
+
+			return { borderRadius: `${ outerRadius }px` };
 		}
 
-		// We have button inside wrapper and a border radius value to apply.
-		// Add default padding so we don't get "fat" corners.
-		const outerRadius =
-			parseInt( style?.border?.radius, 10 ) + DEFAULT_INNER_PADDING;
-
-		return { borderRadius: `${ outerRadius }px` };
+		return undefined;
 	};
 
 	const blockProps = useBlockProps( {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -48,6 +48,10 @@ import {
 	MIN_WIDTH_UNIT,
 } from './utils.js';
 
+// Used to calculate border radius adjustment to avoid "fat" corners when
+// button is placed inside wrapper.
+const DEFAULT_INNER_PADDING = 4;
+
 export default function SearchEdit( {
 	className,
 	attributes,
@@ -65,8 +69,10 @@ export default function SearchEdit( {
 		buttonText,
 		buttonPosition,
 		buttonUseIcon,
+		style,
 	} = attributes;
 
+	const borderRadius = style?.border?.radius;
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 
@@ -122,6 +128,7 @@ export default function SearchEdit( {
 		return (
 			<input
 				className="wp-block-search__input"
+				style={ { borderRadius } }
 				aria-label={ __( 'Optional placeholder text' ) }
 				// We hide the placeholder field's placeholder when there is a value. This
 				// stops screen readers from reading the placeholder field's placeholder
@@ -144,12 +151,14 @@ export default function SearchEdit( {
 					<Button
 						icon={ search }
 						className="wp-block-search__button"
+						style={ { borderRadius } }
 					/>
 				) }
 
 				{ ! buttonUseIcon && (
 					<RichText
 						className="wp-block-search__button"
+						style={ { borderRadius } }
 						aria-label={ __( 'Button text' ) }
 						placeholder={ __( 'Add button text…' ) }
 						withoutInteractiveFormatting
@@ -303,6 +312,19 @@ export default function SearchEdit( {
 		</>
 	);
 
+	const getWrapperStyles = () => {
+		if ( 'button-inside' !== buttonPosition || ! style?.border?.radius ) {
+			return undefined;
+		}
+
+		// We have button inside wrapper and a border radius value to apply.
+		// Add default padding so we don't get "fat" corners.
+		const outerRadius =
+			parseInt( style?.border?.radius, 10 ) + DEFAULT_INNER_PADDING;
+
+		return { borderRadius: `${ outerRadius }px` };
+	};
+
 	const blockProps = useBlockProps( {
 		className: getBlockClassNames(),
 	} );
@@ -327,6 +349,7 @@ export default function SearchEdit( {
 					width: `${ width }${ widthUnit }`,
 				} }
 				className="wp-block-search__inside-wrapper"
+				style={ getWrapperStyles() }
 				minWidth={ MIN_WIDTH }
 				enable={ getResizableSides() }
 				onResizeStart={ ( event, direction, elt ) => {

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -56,11 +56,11 @@ function render_block_core_search( $attributes ) {
 
 	if ( $show_input ) {
 		$input_markup = sprintf(
-			'<input type="search" id="%s" class="wp-block-search__input"%s name="s" value="%s" placeholder="%s" required />',
+			'<input type="search" id="%s" class="wp-block-search__input" name="s" value="%s" placeholder="%s" %s required />',
 			$input_id,
-			$inline_styles['shared'],
 			esc_attr( get_search_query() ),
-			esc_attr( $attributes['placeholder'] )
+			esc_attr( $attributes['placeholder'] ),
+			$inline_styles['shared']
 		);
 	}
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -36,7 +36,7 @@ function render_block_core_search( $attributes ) {
 	$label_markup    = '';
 	$input_markup    = '';
 	$button_markup   = '';
-	$width_styles    = '';
+	$inline_styles   = styles_for_block_core_search( $attributes );
 
 	if ( $show_label ) {
 		if ( ! empty( $attributes['label'] ) ) {
@@ -56,8 +56,9 @@ function render_block_core_search( $attributes ) {
 
 	if ( $show_input ) {
 		$input_markup = sprintf(
-			'<input type="search" id="%s" class="wp-block-search__input" name="s" value="%s" placeholder="%s" required />',
+			'<input type="search" id="%s" class="wp-block-search__input"%s name="s" value="%s" placeholder="%s" required />',
 			$input_id,
+			$inline_styles['shared'],
 			esc_attr( get_search_query() ),
 			esc_attr( $attributes['placeholder'] )
 		);
@@ -80,20 +81,16 @@ function render_block_core_search( $attributes ) {
 		}
 
 		$button_markup = sprintf(
-			'<button type="submit" class="wp-block-search__button ' . $button_classes . '">%s</button>',
+			'<button type="submit" class="wp-block-search__button %s"%s>%s</button>',
+			$button_classes,
+			$inline_styles['shared'],
 			$button_internal_markup
 		);
 	}
 
-	if ( ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] ) ) {
-		if ( ! empty( $attributes['buttonPosition'] ) && 'button-only' !== $attributes['buttonPosition'] ) {
-			$width_styles = ' style="width: ' . $attributes['width'] . $attributes['widthUnit'] . ';"';
-		}
-	}
-
 	$field_markup       = sprintf(
 		'<div class="wp-block-search__inside-wrapper"%s>%s</div>',
-		$width_styles,
+		$inline_styles['wrapper'],
 		$input_markup . $button_markup
 	);
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
@@ -158,4 +155,59 @@ function classnames_for_block_core_search( $attributes ) {
 	}
 
 	return implode( ' ', $classnames );
+}
+
+/**
+ * Builds an array of inline styles for the search block.
+ *
+ * The result will contain one entry for shared styles such as those for the
+ * inner input or button and a second for the inner wrapper should the block
+ * be positioning the button "inside".
+ *
+ * @param  array $attributes The block attributes.
+ *
+ * @return array Style HTML attribute.
+ */
+function styles_for_block_core_search( $attributes ) {
+	$shared_styles  = array();
+	$wrapper_styles = array();
+
+	// Add width styles.
+	$has_width   = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
+	$button_only = ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'];
+
+	if ( $has_width && ! $button_only ) {
+		$wrapper_styles[] = sprintf(
+			'width: %d%s;',
+			esc_attr( $attributes['width'] ),
+			esc_attr( $attributes['widthUnit'] )
+		);
+	}
+
+	// Add border radius styles.
+	$has_border_radius = ! empty( $attributes['style']['border']['radius'] );
+
+	if ( $has_border_radius ) {
+		// Shared style for button and input radius values.
+		$border_radius   = $attributes['style']['border']['radius'];
+		$shared_styles[] = sprintf( 'border-radius: %spx;', esc_attr( $border_radius ) );
+
+		// Apply wrapper border radius if button placed inside.
+		$button_inside = ! empty( $attributes['buttonPosition'] ) &&
+			'button-inside' === $attributes['buttonPosition'];
+
+		if ( $button_inside ) {
+			// We adjust the border radius value for the outer wrapper element
+			// to make it visually consistent with the radius applied to inner
+			// elements.
+			$default_padding  = 4;
+			$adjusted_radius  = $border_radius + $default_padding;
+			$wrapper_styles[] = sprintf( 'border-radius: %dpx;', esc_attr( $adjusted_radius ) );
+		}
+	}
+
+	return array(
+		'shared'  => ! empty( $shared_styles ) ? sprintf( ' style="%s"', implode( ' ', $shared_styles ) ) : '',
+		'wrapper' => ! empty( $wrapper_styles ) ? sprintf( ' style="%s"', implode( ' ', $wrapper_styles ) ) : '',
+	);
 }


### PR DESCRIPTION
## Description
Opts into border radius block support for the Search block. 

The changes also include using the new `__experimentalSkipSerialization` block support feature. This allows finer grained control over where and how the border radius values are applied. 

In the Search block's specific use case, we can adjust the inner wrapper's border radius so that it remains visually consistent with the radii of the input and button when the button is placed inside it.

For comparison purposes this has been created in a separate PR so it is easier to compare with the previous approach (https://github.com/WordPress/gutenberg/pull/27664) and evaluate how the new `__experimentalSkipSerialization` affected this use case.

## How has this been tested?
Manually.

### Setup
1. Checkout this PR
2. Edit your theme.json file an enable `settings.defaults.border.customRadius` by setting it to true.
<img width="603" alt="Screen Shot 2021-03-26 at 9 08 29 am" src="https://user-images.githubusercontent.com/60436221/112554874-dc35c900-8e12-11eb-8c7c-b3440422a1ac.png">


### Testing Instructions
1. Create a new post, add a search block and select it
2. In the inspector panel, drag the border radius slider and confirm the block updates as expected
3. Update the radius via the input field and confirm that change is reflected
4. Confirm the border radius reset button works
5. Try setting various border radius values with different layout options selected e.g. button inside, no button etc.
6. Switch the block to position the button inside and set a non-zero border radius
7. Open dev tools and confirm:
    - Inner input and button have the border radius you set
    - The inner wrapper has an adjust border radius (the radius set + default padding i.e. 4px)
8. Save post and confirm border radius displays correctly on frontend

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/60436221/112451517-53327980-8da1-11eb-901d-b81881340939.gif" width="400" />

## Types of changes
New feature. Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
