### PR TITLE
Fix Backspace in content editable button in Safari

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-event-handlers.js
@@ -98,6 +98,24 @@ export function useEventHandlers( clientId ) {
 					return;
 				}
 
+				// In Safari, when interactive content editable element is
+				// focused, the browser assign the block element as the target
+				// and active element in the document while the active element
+				// should be the content editable container. Check the selection
+				// to make sure it is not within a text field.
+				const {
+					ownerDocument: { defaultView },
+				} = target;
+				let { focusNode } = defaultView.getSelection();
+
+				if ( focusNode.nodeType !== focusNode.ELEMENT_NODE ) {
+					focusNode = focusNode.parentElement;
+				}
+
+				if ( isTextField( focusNode ) ) {
+					return;
+				}
+
 				event.preventDefault();
 
 				if ( keyCode === ENTER ) {

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -233,7 +233,8 @@ Undocumented declaration.
 <a name="isTextField" href="#isTextField">#</a> **isTextField**
 
 Check whether the given element is a text field, where text field is defined
-by the ability to select within the input, or that it is contenteditable.
+by the ability to select within the input, or that it is contenteditable or
+within a contenteditable container.
 
 See: <https://html.spec.whatwg.org/#textFieldSelection>
 

--- a/packages/dom/src/dom/is-text-field.js
+++ b/packages/dom/src/dom/is-text-field.js
@@ -1,6 +1,7 @@
 /**
  * Check whether the given element is a text field, where text field is defined
- * by the ability to select within the input, or that it is contenteditable.
+ * by the ability to select within the input, or that it is contenteditable or
+ * within a contenteditable container.
  *
  * See: https://html.spec.whatwg.org/#textFieldSelection
  *
@@ -9,7 +10,7 @@
  * @return {boolean} True if the element is an text field, false if not.
  */
 export default function isTextField( element ) {
-	const { nodeName, contentEditable } = element;
+	const { nodeName } = element;
 	const nonTextInputs = [
 		'button',
 		'checkbox',
@@ -25,6 +26,6 @@ export default function isTextField( element ) {
 	return (
 		( nodeName === 'INPUT' && ! nonTextInputs.includes( element.type ) ) ||
 		nodeName === 'TEXTAREA' ||
-		contentEditable === 'true'
+		!! element.closest( '[contenteditable]' )
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

See https://github.com/WordPress/gutenberg/pull/30176/files#r601161161.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
