### PR TITLE
Prevent the columns block from having a width > 100%

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -1,6 +1,7 @@
 .wp-block-columns {
 	display: flex;
 	margin-bottom: 1.75em;
+	box-sizing: border-box;
 
 	// Responsiveness: Allow wrapping on mobile.
 	flex-wrap: wrap;


### PR DESCRIPTION
Related to #29976 

columns block with colors have a padding and that padding was causing the columns to break out of their container in the frontend. the border-box style fixes that.