### PR TITLE
Try: Add site icon and name to the publish flow

### DIFF
--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { wordpress } from '@wordpress/icons';
+import { filterURLForDisplay } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ function PostPublishPanelPrepublish( { children } ) {
 		hasPublishAction,
 		siteIconUrl,
 		siteTitle,
+		siteHome,
 	} = useSelect( ( select ) => {
 		const { isResolving } = select( 'core/data' );
 		const { getCurrentPost, isEditedPostBeingScheduled } = select(
@@ -51,6 +53,7 @@ function PostPublishPanelPrepublish( { children } ) {
 			] ),
 			siteIconUrl: siteData.site_icon_url,
 			siteTitle: siteData.name,
+			siteHome: filterURLForDisplay( siteData.home ),
 		};
 	}, [] );
 
@@ -97,7 +100,10 @@ function PostPublishPanelPrepublish( { children } ) {
 			<p>{ prePublishBodyText }</p>
 			<div className="components-site-card">
 				{ siteIcon }
-				<span className="components-site-name">{ siteTitle }</span>
+				<div className="components-site-info">
+					<span className="components-site-name">{ siteTitle }</span>
+					<span className="components-site-home">{ siteHome }</span>
+				</div>
 			</div>
 			{ hasPublishAction && (
 				<>

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -57,7 +57,9 @@ function PostPublishPanelPrepublish( { children } ) {
 		};
 	}, [] );
 
-	let siteIcon = <Icon size="36px" icon={ wordpress } />;
+	let siteIcon = (
+		<Icon className="components-site-icon" size="36px" icon={ wordpress } />
+	);
 
 	if ( siteIconUrl ) {
 		siteIcon = (

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -33,6 +33,24 @@
 	}
 }
 
+.components-site-card {
+	display: flex;
+	align-items: center;
+	margin: 16px 0;
+}
+
+.components-site-icon {
+	border: none;
+	border-radius: 2px;
+	height: 42px;
+	width: 42px;
+}
+
+.components-site-name {
+	font-size: 14px;
+	margin-left: 16px;
+}
+
 .editor-post-publish-panel__header-publish-button,
 .editor-post-publish-panel__header-cancel-button {
 	flex-grow: 1;

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -36,15 +36,17 @@
 .components-site-card {
 	display: flex;
 	align-items: center;
-	margin: 16px 0;
+	margin: $grid-unit-20 0;
 }
 
 .components-site-icon {
 	border: none;
-	border-radius: 2px;
-	height: 42px;
-	width: 42px;
-	margin-right: 16px;
+	border-radius: $radius-block-ui;
+	margin-right: $grid-unit-15;
+
+	// Same size as in the Site menu.
+	height: 36px;
+	width: 36px;
 }
 
 .components-site-name {
@@ -54,6 +56,8 @@
 
 .components-site-home {
 	display: block;
+	color: $gray-700;
+	font-size: $helptext-font-size;
 }
 
 .editor-post-publish-panel__header-publish-button,

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -44,11 +44,16 @@
 	border-radius: 2px;
 	height: 42px;
 	width: 42px;
+	margin-right: 16px;
 }
 
 .components-site-name {
+	display: block;
 	font-size: 14px;
-	margin-left: 16px;
+}
+
+.components-site-home {
+	display: block;
 }
 
 .editor-post-publish-panel__header-publish-button,

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -104,7 +104,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
   <div
     className="editor-post-publish-panel__content"
   >
-    <WithSelect(PostPublishPanelPrepublish) />
+    <PostPublishPanelPrepublish />
   </div>
   <div
     className="editor-post-publish-panel__footer"
@@ -144,7 +144,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
   <div
     className="editor-post-publish-panel__content"
   >
-    <WithSelect(PostPublishPanelPrepublish) />
+    <PostPublishPanelPrepublish />
   </div>
   <div
     className="editor-post-publish-panel__footer"


### PR DESCRIPTION
This aims to improve the clarity of the "are you ready to publish" by including the site icon and name so that it's clear in certain cases where are you publishing to (full-screen, mobile web, etc).

![image](https://user-images.githubusercontent.com/548849/112468237-4c3b4500-8d68-11eb-8864-09b943da5a9c.png)

