### PR TITLE
Try: Force stacked top toolbar.

### DIFF
--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -31,7 +31,7 @@
 	}
 }
 
-.edit-post-header__settings,
+.edit-post-header__toolbar-settings,
 .edit-site-header__actions {
 	@include break-small () {
 		.editor-post-preview {
@@ -44,23 +44,23 @@
 .edit-post-header.has-reduced-ui {
 	@include break-small() {
 		// Apply transition to first two buttons.
-		.edit-post-header__settings .editor-post-save-draft,
-		.edit-post-header__settings .editor-post-saved-state,
-		.edit-post-header__settings .block-editor-post-preview__button-toggle {
+		.edit-post-header__toolbar-settings .editor-post-save-draft,
+		.edit-post-header__toolbar-settings .editor-post-saved-state,
+		.edit-post-header__toolbar-settings .block-editor-post-preview__button-toggle {
 			transition: opacity 0.1s linear;
 			@include reduce-motion("transition");
 		}
 
 		// Zero out opacity unless hovered.
 		&:not(:hover) {
-			.edit-post-header__settings .editor-post-save-draft,
-			.edit-post-header__settings .editor-post-saved-state,
-			.edit-post-header__settings .block-editor-post-preview__button-toggle {
+			.edit-post-header__toolbar-settings .editor-post-save-draft,
+			.edit-post-header__toolbar-settings .editor-post-saved-state,
+			.edit-post-header__toolbar-settings .block-editor-post-preview__button-toggle {
 				opacity: 0;
 			}
 
 			// ... or opened.
-			.edit-post-header__settings .block-editor-post-preview__button-toggle.is-opened {
+			.edit-post-header__toolbar-settings .block-editor-post-preview__button-toggle.is-opened {
 				opacity: 1;
 			}
 		}

--- a/packages/e2e-test-utils/src/ensure-sidebar-opened.js
+++ b/packages/e2e-test-utils/src/ensure-sidebar-opened.js
@@ -11,7 +11,7 @@ export async function ensureSidebarOpened() {
 		return page.$eval( '.edit-post-sidebar', () => {} );
 	} catch ( error ) {
 		return page.click(
-			'.edit-post-header__settings [aria-label="Settings"]'
+			'.edit-post-header__toolbar-settings [aria-label="Settings"]'
 		);
 	}
 }

--- a/packages/e2e-test-utils/src/open-document-settings-sidebar.js
+++ b/packages/e2e-test-utils/src/open-document-settings-sidebar.js
@@ -3,7 +3,7 @@
  */
 export async function openDocumentSettingsSidebar() {
 	const openButton = await page.$(
-		'.edit-post-header__settings button[aria-label="Settings"][aria-expanded="false"]'
+		'.edit-post-header__toolbar-settings button[aria-label="Settings"][aria-expanded="false"]'
 	);
 
 	if ( openButton ) {

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -1,16 +1,10 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import {
-	BlockToolbar,
 	NavigableToolbar,
 	BlockNavigationDropdown,
 	ToolSelector,
@@ -40,14 +34,11 @@ function HeaderToolbar() {
 	const inserterButton = useRef();
 	const { setIsInserterOpened } = useDispatch( editPostStore );
 	const {
-		hasFixedToolbar,
 		isInserterEnabled,
 		isInserterOpened,
 		isTextModeEnabled,
-		previewDeviceType,
 		showIconLabels,
 		isNavigationTool,
-		isTemplateMode,
 	} = useSelect( ( select ) => {
 		const {
 			hasInserterItems,
@@ -84,14 +75,8 @@ function HeaderToolbar() {
 	const isSmallViewport = useViewportMatch( 'small', '<' );
 	const { setNavigationMode } = useDispatch( 'core/block-editor' );
 
-	const displayBlockToolbar =
-		! isLargeViewport || previewDeviceType !== 'Desktop' || hasFixedToolbar;
-
-	const toolbarAriaLabel = displayBlockToolbar
-		? /* translators: accessibility text for the editor toolbar when Top Toolbar is on */
-		  __( 'Document and block tools' )
-		: /* translators: accessibility text for the editor toolbar when Top Toolbar is off */
-		  __( 'Document tools' );
+	/* translators: accessibility text for the editor toolbar when Top Toolbar is off */
+	const toolbarAriaLabel = __( 'Document tools' );
 
 	const onSwitchMode = ( mode ) => {
 		setNavigationMode( mode === 'edit' ? false : true );
@@ -220,19 +205,6 @@ characters. */
 			</div>
 
 			<TemplateTitle />
-
-			{ displayBlockToolbar && (
-				<div
-					className={ classnames(
-						'edit-post-header-toolbar__block-toolbar',
-						{
-							'is-pushed-down': isTemplateMode,
-						}
-					) }
-				>
-					<BlockToolbar hideDragHandle />
-				</div>
-			) }
 		</NavigableToolbar>
 	);
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -94,10 +94,7 @@
 
 // Block toolbar when fixed to the top of the screen.
 .edit-post-header__block-toolbar {
-	&:empty {
-		display: none;
-	}
-
+	height: $block-toolbar-height;
 	.block-editor-block-toolbar .components-toolbar-group,
 	.block-editor-block-toolbar .components-toolbar {
 		border-top: none;

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -92,31 +92,6 @@
 	}
 }
 
-// Block toolbar when fixed to the top of the screen.
-.edit-post-header__block-toolbar {
-	height: $block-toolbar-height;
-	.block-editor-block-toolbar .components-toolbar-group,
-	.block-editor-block-toolbar .components-toolbar {
-		border-top: none;
-		border-bottom: none;
-	}
-
-	.is-sidebar-opened & {
-		display: none;
-	}
-
-	.block-editor-block-toolbar__block-parent-selector-wrapper {
-		display: none;
-	}
-
-	@include break-medium {
-		.is-sidebar-opened & {
-			display: block;
-			right: $sidebar-width;
-		}
-	}
-}
-
 .edit-post-header-toolbar .edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle.has-icon {
 	margin-right: $grid-unit-10;
 	// Special dimensions for this button.

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -93,15 +93,7 @@
 }
 
 // Block toolbar when fixed to the top of the screen.
-.edit-post-header-toolbar__block-toolbar {
-	// Stack toolbar below Editor Bar.
-	position: absolute;
-	top: $header-height + $border-width;
-	left: 0;
-	right: 0;
-	background: $white;
-	border-bottom: $border-width solid $gray-300;
-
+.edit-post-header__block-toolbar {
 	&:empty {
 		display: none;
 	}
@@ -124,32 +116,6 @@
 		.is-sidebar-opened & {
 			display: block;
 			right: $sidebar-width;
-		}
-	}
-
-	// Move toolbar into top Editor Bar.
-	@include break-wide {
-		&:not(.is-pushed-down) {
-			position: static;
-			left: auto;
-			right: auto;
-			background: none;
-			border-bottom: none;
-
-			.is-sidebar-opened & {
-				right: auto;
-			}
-
-			.block-editor-block-toolbar {
-				border-left: $border-width solid $gray-300;
-			}
-
-			.block-editor-block-toolbar .components-toolbar-group,
-			.block-editor-block-toolbar .components-toolbar {
-				$top-toolbar-padding: ($header-height - $grid-unit-60) / 2;
-				height: $header-height;
-				padding: $top-toolbar-padding 0;
-			}
 		}
 	}
 }
@@ -176,24 +142,5 @@
 
 	.edit-post-header-toolbar__left > * + * {
 		margin-left: $grid-unit-10;
-	}
-
-	// Always display block toolbar under main toolbar when text labels are visible
-	.edit-post-header-toolbar__block-toolbar {
-		@include break-wide {
-			position: absolute;
-			top: $header-height + $border-width;
-			left: 0;
-			right: 0;
-			border-bottom: $border-width solid $gray-300;
-			padding: 0;
-			background-color: $white;
-
-			.block-editor-block-toolbar .components-toolbar-group,
-			.block-editor-block-toolbar .components-toolbar {
-				height: auto;
-				padding: 0;
-			}
-		}
 	}
 }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -10,7 +10,6 @@ import { PostSavedState, PostPreviewButton } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
-import { BlockToolbar } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -25,9 +24,6 @@ import { store as editPostStore } from '../../store';
 
 function Header( { setEntitiesSavedStatesCallback } ) {
 	const {
-		hasFixedToolbar,
-		previewDeviceType,
-		isTemplateMode,
 		hasActiveMetaboxes,
 		isPublishSidebarOpened,
 		isSaving,
@@ -49,9 +45,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		} ),
 		[]
 	);
-
-	const displayBlockToolbar =
-		! isLargeViewport || previewDeviceType !== 'Desktop' || hasFixedToolbar;
 
 	const isLargeViewport = useViewportMatch( 'large' );
 
@@ -104,16 +97,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 					) }
 				</div>
 			</div>
-
-			{ displayBlockToolbar && (
-				<div
-					className={ classnames( 'edit-post-header__block-toolbar', {
-						'is-pushed-down': isTemplateMode,
-					} ) }
-				>
-					<BlockToolbar hideDragHandle />
-				</div>
-			) }
 		</div>
 	);
 }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -10,6 +10,7 @@ import { PostSavedState, PostPreviewButton } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
+import { BlockToolbar } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -24,6 +25,9 @@ import { store as editPostStore } from '../../store';
 
 function Header( { setEntitiesSavedStatesCallback } ) {
 	const {
+		hasFixedToolbar,
+		previewDeviceType,
+		isTemplateMode,
 		hasActiveMetaboxes,
 		isPublishSidebarOpened,
 		isSaving,
@@ -46,6 +50,9 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		[]
 	);
 
+	const displayBlockToolbar =
+		! isLargeViewport || previewDeviceType !== 'Desktop' || hasFixedToolbar;
+
 	const isLargeViewport = useViewportMatch( 'large' );
 
 	const classes = classnames( 'edit-post-header', {
@@ -54,47 +61,59 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 
 	return (
 		<div className={ classes }>
-			<MainDashboardButton.Slot>
-				<FullscreenModeClose />
-			</MainDashboardButton.Slot>
 			<div className="edit-post-header__toolbar">
-				<HeaderToolbar />
-			</div>
-			<div className="edit-post-header__settings">
-				{ ! isPublishSidebarOpened && (
-					// This button isn't completely hidden by the publish sidebar.
-					// We can't hide the whole toolbar when the publish sidebar is open because
-					// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
-					// We track that DOM node to return focus to the PostPublishButtonOrToggle
-					// when the publish sidebar has been closed.
-					<PostSavedState
+				<MainDashboardButton.Slot>
+					<FullscreenModeClose />
+				</MainDashboardButton.Slot>
+				<div className="edit-post-header__toolbar-actions">
+					<HeaderToolbar />
+				</div>
+				<div className="edit-post-header__toolbar-settings">
+					{ ! isPublishSidebarOpened && (
+						// This button isn't completely hidden by the publish sidebar.
+						// We can't hide the whole toolbar when the publish sidebar is open because
+						// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
+						// We track that DOM node to return focus to the PostPublishButtonOrToggle
+						// when the publish sidebar has been closed.
+						<PostSavedState
+							forceIsDirty={ hasActiveMetaboxes }
+							forceIsSaving={ isSaving }
+							showIconLabels={ showIconLabels }
+						/>
+					) }
+					<DevicePreview />
+					<PostPreviewButton
+						forceIsAutosaveable={ hasActiveMetaboxes }
+						forcePreviewLink={ isSaving ? null : undefined }
+					/>
+					<PostPublishButtonOrToggle
 						forceIsDirty={ hasActiveMetaboxes }
 						forceIsSaving={ isSaving }
-						showIconLabels={ showIconLabels }
+						setEntitiesSavedStatesCallback={
+							setEntitiesSavedStatesCallback
+						}
 					/>
-				) }
-				<DevicePreview />
-				<PostPreviewButton
-					forceIsAutosaveable={ hasActiveMetaboxes }
-					forcePreviewLink={ isSaving ? null : undefined }
-				/>
-				<PostPublishButtonOrToggle
-					forceIsDirty={ hasActiveMetaboxes }
-					forceIsSaving={ isSaving }
-					setEntitiesSavedStatesCallback={
-						setEntitiesSavedStatesCallback
-					}
-				/>
-				{ ( isLargeViewport || ! showIconLabels ) && (
-					<>
-						<PinnedItems.Slot scope="core/edit-post" />
+					{ ( isLargeViewport || ! showIconLabels ) && (
+						<>
+							<PinnedItems.Slot scope="core/edit-post" />
+							<MoreMenu showIconLabels={ showIconLabels } />
+						</>
+					) }
+					{ showIconLabels && ! isLargeViewport && (
 						<MoreMenu showIconLabels={ showIconLabels } />
-					</>
-				) }
-				{ showIconLabels && ! isLargeViewport && (
-					<MoreMenu showIconLabels={ showIconLabels } />
-				) }
+					) }
+				</div>
 			</div>
+
+			{ displayBlockToolbar && (
+				<div
+					className={ classnames( 'edit-post-header__block-toolbar', {
+						'is-pushed-down': isTemplateMode,
+					} ) }
+				>
+					<BlockToolbar hideDragHandle />
+				</div>
+			) }
 		</div>
 	);
 }

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -1,4 +1,7 @@
+// This CSS is largely copied for the site editor (.edit-site-header).
+// Please keep them in sync.
 .edit-post-header {
+	min-height: $header-height;
 	background: $white;
 	display: flex;
 	justify-content: flex-start;
@@ -9,12 +12,6 @@
 	// Make toolbar sticky on larger breakpoints
 	@include break-zoomed-in {
 		flex-wrap: nowrap;
-	}
-
-	// Set height of toolbar depending on fixed toolbar toggle.
-	height: $header-height;
-	.has-fixed-toolbar & {
-		height: $header-height + $block-toolbar-height;
 	}
 
 	// Some browsers, most notably IE11, honor an older version of the flexbox spec
@@ -45,6 +42,7 @@
 
 .edit-post-header__toolbar {
 	height: $header-height;
+	justify-content: space-between;
 	border-bottom: $border-width solid $gray-300;
 }
 

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -1,15 +1,20 @@
 .edit-post-header {
-	height: $header-height;
 	background: $white;
 	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
+	justify-content: flex-start;
+	flex-direction: column;
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
 
 	// Make toolbar sticky on larger breakpoints
 	@include break-zoomed-in {
 		flex-wrap: nowrap;
+	}
+
+	// Set height of toolbar depending on fixed toolbar toggle.
+	height: $header-height;
+	.has-fixed-toolbar & {
+		height: $header-height + $block-toolbar-height;
 	}
 
 	// Some browsers, most notably IE11, honor an older version of the flexbox spec
@@ -21,7 +26,7 @@
 	// and IE11 is adding space between it and our last real child, shifting righthand UI elements
 	// to the left. For a workaround, we change the flex order to move the undesired spacing to the middle
 	// where it is no longer noticeable.
-	> .edit-post-header__settings {
+	> .edit-post-header__toolbar-settings {
 		order: 1;
 
 		// Restore default order for all other browsers
@@ -31,7 +36,23 @@
 	}
 }
 
+// Make both the default header toolbar and the toggled top toolbar be full-width.
+.edit-post-header__toolbar,
+.edit-post-header__block-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+}
+
 .edit-post-header__toolbar {
+	height: $header-height;
+	border-bottom: $border-width solid $gray-300;
+}
+
+.edit-post-header__block-toolbar {
+	height: $block-toolbar-height;
+}
+
+.edit-post-header__toolbar-actions {
 	display: flex;
 	flex-grow: 1;
 
@@ -44,7 +65,7 @@
 	}
 }
 
-.edit-post-header__settings {
+.edit-post-header__toolbar-settings {
 	display: inline-flex;
 	align-items: center;
 	flex-wrap: wrap;

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -34,20 +34,11 @@
 }
 
 // Make both the default header toolbar and the toggled top toolbar be full-width.
-.edit-post-header__toolbar,
-.edit-post-header__block-toolbar {
+.edit-post-header__toolbar {
 	display: flex;
 	flex-wrap: wrap;
-}
-
-.edit-post-header__toolbar {
 	height: $header-height;
 	justify-content: space-between;
-	border-bottom: $border-width solid $gray-300;
-}
-
-.edit-post-header__block-toolbar {
-	height: $block-toolbar-height;
 }
 
 .edit-post-header__toolbar-actions {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -16,6 +16,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockBreadcrumb,
+	BlockToolbar,
 	__experimentalLibrary as Library,
 } from '@wordpress/block-editor';
 import {
@@ -74,6 +75,7 @@ const interfaceLabels = {
 function Layout( { styles } ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
+	const isLargeViewport = useViewportMatch( 'large' );
 	const {
 		openGeneralSidebar,
 		closeGeneralSidebar,
@@ -94,12 +96,16 @@ function Layout( { styles } ) {
 		showIconLabels,
 		hasReducedUI,
 		showBlockBreadcrumbs,
+		previewDeviceType,
 	} = useSelect( ( select ) => {
 		const editorSettings = select( 'core/editor' ).getEditorSettings();
 		return {
 			hasFixedToolbar: select( editPostStore ).isFeatureActive(
 				'fixedToolbar'
 			),
+			previewDeviceType: select(
+				editPostStore
+			).__experimentalGetPreviewDeviceType(),
 			sidebarIsOpened: !! (
 				select( interfaceStore ).getActiveComplementaryArea(
 					editPostStore.name
@@ -136,7 +142,6 @@ function Layout( { styles } ) {
 	}, [] );
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,
-		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 		'show-icon-labels': showIconLabels,
 	} );
@@ -176,6 +181,8 @@ function Layout( { styles } ) {
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 	} );
+	const displayStickyBlockToolbar =
+		! isLargeViewport || previewDeviceType !== 'Desktop' || hasFixedToolbar;
 
 	return (
 		<>
@@ -247,6 +254,11 @@ function Layout( { styles } ) {
 				}
 				content={
 					<>
+						{ displayStickyBlockToolbar && (
+							<div className="edit-post-layout__sticky-block-toolbar">
+								<BlockToolbar hideDragHandle />
+							</div>
+						) }
 						<EditorNotices />
 						{ ( mode === 'text' || ! isRichEditingEnabled ) && (
 							<TextEditor />

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -115,3 +115,11 @@
 		height: 100%;
 	}
 }
+
+.edit-post-layout__sticky-block-toolbar:not(:empty) {
+	position: sticky;
+	z-index: 10000;
+	top: 0;
+	background: $white;
+	border-bottom: 1px solid $gray-300;
+}

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -88,8 +88,8 @@ export default function Header( { openEntitiesSavedStates } ) {
 
 	return (
 		<div className="edit-site-header">
-			<div className="edit-site-header_start">
-				<div className="edit-site-header__toolbar">
+			<div className="edit-site-header__toolbar">
+				<div className="edit-site-header__toolbar-actions">
 					<Button
 						ref={ inserterButton }
 						isPrimary
@@ -130,15 +130,8 @@ export default function Header( { openEntitiesSavedStates } ) {
 							/>
 						</>
 					) }
-					{ displayBlockToolbar && (
-						<div className="edit-site-header-toolbar__block-toolbar">
-							<BlockToolbar hideDragHandle />
-						</div>
-					) }
 				</div>
-			</div>
 
-			<div className="edit-site-header_center">
 				{ 'wp_template' === templateType && (
 					<DocumentActions
 						entityTitle={ entityTitle }
@@ -152,15 +145,14 @@ export default function Header( { openEntitiesSavedStates } ) {
 						) }
 					</DocumentActions>
 				) }
+
 				{ 'wp_template_part' === templateType && (
 					<DocumentActions
 						entityTitle={ entityTitle }
 						entityLabel="template part"
 					/>
 				) }
-			</div>
 
-			<div className="edit-site-header_end">
 				<div className="edit-site-header__actions">
 					<PreviewOptions
 						deviceType={ deviceType }
@@ -173,6 +165,12 @@ export default function Header( { openEntitiesSavedStates } ) {
 					<MoreMenu />
 				</div>
 			</div>
+
+			{ displayBlockToolbar && (
+				<div className="edit-site-header-toolbar__block-toolbar">
+					<BlockToolbar hideDragHandle />
+				</div>
+			) }
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -1,39 +1,25 @@
-$header-toolbar-min-width: 335px;
-
+// This CSS is largely copied for the post editor (.edit-post-header).
+// Please keep them in sync.
 .edit-site-header {
-	align-items: center;
+	min-height: $header-height;
 	background-color: $white;
 	display: flex;
-	height: $header-height;
-	box-sizing: border-box;
-	width: 100%;
-	justify-content: space-between;
+	justify-content: flex-start;
+	flex-direction: column;
+	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
+	max-width: 100vw;
 
+	// Make toolbar sticky on larger breakpoints
+	@include break-zoomed-in {
+		flex-wrap: nowrap;
+	}
+
+	// Add transition for the menu.
 	body.is-fullscreen-mode & {
 		padding-left: 60px;
 		transition: padding-left 20ms linear;
 		transition-delay: 80ms;
 		@include reduce-motion("transition");
-	}
-
-	.edit-site-header_start,
-	.edit-site-header_end {
-		display: flex;
-	}
-
-	.edit-site-header_center {
-		display: flex;
-		align-items: center;
-		height: 100%;
-		// Flex items will, by default, refuse to shrink below a minimum
-		// intrinsic width. In order to shrink this flexbox item, and
-		// subsequently truncate child text, we set an explicit min-width.
-		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
-		min-width: 0;
-	}
-
-	.edit-site-header_end {
-		justify-content: flex-end;
 	}
 }
 
@@ -60,7 +46,24 @@ body.is-navigation-sidebar-open {
 	}
 }
 
+// Make both the default header toolbar and the toggled top toolbar be full-width.
+.edit-site-header__toolbar,
+.edit-site-header__block-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+}
+
 .edit-site-header__toolbar {
+	height: $header-height;
+	justify-content: space-between;
+	border-bottom: $border-width solid $gray-300;
+}
+
+.edit-site-header__block-toolbar {
+	height: $block-toolbar-height;
+}
+
+.edit-site-header__toolbar-actions {
 	display: flex;
 	align-items: center;
 	padding-left: $grid-unit-10;
@@ -165,57 +168,17 @@ body.is-navigation-sidebar-open {
 
 // Block toolbar when fixed to the top of the screen.
 .edit-site-header-toolbar__block-toolbar {
-	// Stack toolbar below Editor Bar.
-	position: absolute;
-	top: $header-height + $border-width;
-	left: 0;
-	right: 0;
-	background: $white;
-	border-bottom: $border-width solid $gray-300;
-
-	&:empty {
-		display: none;
-	}
-
+	height: $block-toolbar-height;
 	.block-editor-block-toolbar .components-toolbar-group,
 	.block-editor-block-toolbar .components-toolbar {
 		border-top: none;
 		border-bottom: none;
 	}
 
-	.is-sidebar-opened & {
-		display: none;
-	}
-
 	@include break-medium {
 		.is-sidebar-opened & {
 			display: block;
 			right: $sidebar-width;
-		}
-	}
-
-	// Move toolbar into top Editor Bar.
-	@include break-wide {
-		padding-left: $grid-unit-10;
-		position: static;
-		left: auto;
-		right: auto;
-		background: none;
-		border-bottom: none;
-
-		.is-sidebar-opened & {
-			right: auto;
-		}
-
-		.block-editor-block-toolbar {
-			border-left: $border-width solid $gray-300;
-		}
-
-		.block-editor-block-toolbar .components-toolbar-group,
-		.block-editor-block-toolbar .components-toolbar {
-			$top-toolbar-padding: ( $header-height - $grid-unit-60 ) / 2;
-			height: $header-height;
-			padding: $top-toolbar-padding 0;
 		}
 	}
 }

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -36,32 +36,23 @@ export default function PostTitle() {
 		clearSelectedBlock,
 		insertBlocks,
 	} = useDispatch( 'core/block-editor' );
-	const {
-		isCleanNewPost,
-		title,
-		placeholder,
-		isFocusMode,
-		hasFixedToolbar,
-	} = useSelect( ( select ) => {
-		const {
-			getEditedPostAttribute,
-			isCleanNewPost: _isCleanNewPost,
-		} = select( 'core/editor' );
-		const { getSettings } = select( 'core/block-editor' );
-		const {
-			titlePlaceholder,
-			focusMode,
-			hasFixedToolbar: _hasFixedToolbar,
-		} = getSettings();
+	const { isCleanNewPost, title, placeholder, isFocusMode } = useSelect(
+		( select ) => {
+			const {
+				getEditedPostAttribute,
+				isCleanNewPost: _isCleanNewPost,
+			} = select( 'core/editor' );
+			const { getSettings } = select( 'core/block-editor' );
+			const { titlePlaceholder, focusMode } = getSettings();
 
-		return {
-			isCleanNewPost: _isCleanNewPost(),
-			title: getEditedPostAttribute( 'title' ),
-			placeholder: titlePlaceholder,
-			isFocusMode: focusMode,
-			hasFixedToolbar: _hasFixedToolbar,
-		};
-	} );
+			return {
+				isCleanNewPost: _isCleanNewPost(),
+				title: getEditedPostAttribute( 'title' ),
+				placeholder: titlePlaceholder,
+				isFocusMode: focusMode,
+			};
+		}
+	);
 
 	useEffect( () => {
 		if ( ! ref.current ) {
@@ -169,7 +160,6 @@ export default function PostTitle() {
 		{
 			'is-selected': isSelected,
 			'is-focus-mode': isFocusMode,
-			'has-fixed-toolbar': hasFixedToolbar,
 		}
 	);
 	const decodedPlaceholder = decodeEntities( placeholder );

--- a/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
@@ -28,7 +28,7 @@
 }
 
 /* Move the block toolbar to the top */
-.edit-post-header-toolbar__block-toolbar {
+.edit-post-header__block-toolbar {
     top: 0px;
 }
 

--- a/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
@@ -28,10 +28,6 @@
 }
 
 /* Move the block toolbar to the top */
-.edit-post-header__block-toolbar {
-    top: 0px;
-}
-
 .interface-interface-skeleton {
     top: 0px;
 }


### PR DESCRIPTION
## Description

When the "Top Toolbar" option is enabled, the block toolbar is integrated into the main toolbar but only on wide breakpoints. This very often breaks the responsive layout, as the toolbars are arbitrary in width:

<img width="1035" alt="Screenshot 2021-03-25 at 10 39 40" src="https://user-images.githubusercontent.com/1204802/112460536-4d1ba900-8d5f-11eb-95a3-8a407450e721.png">

On smaller viewports, the block toolbar is stacked, which makes the tab-order mismatch the visual order:

![weird](https://user-images.githubusercontent.com/1204802/112460645-6b81a480-8d5f-11eb-8eba-edf6e8413d7b.gif)

Because of how the stacked toolbar was implemented, it was an absolutely positioned overlay which covered content. This was mitigated in the post editor, because the "Title" block most commonly made room for the top toolbar to cover content, but in the site editor, this is problematic:

<img width="1106" alt="Screenshot 2021-03-25 at 11 45 15" src="https://user-images.githubusercontent.com/1204802/112460908-b0a5d680-8d5f-11eb-9b73-ea66e058c6b5.png">

This PR fixes that by forcing the top toolbar to be stacked always:

<img width="1084" alt="Screenshot 2021-03-25 at 11 40 53" src="https://user-images.githubusercontent.com/1204802/112460948-b996a800-8d5f-11eb-93da-a3739eedad96.png">

This has a number of benefits:

- Never covers content.
- Stays in place consistently.
- Vastly simplified CSS.
- Tab order matches the visual order.

![new tab order](https://user-images.githubusercontent.com/1204802/112461162-f6629f00-8d5f-11eb-9a46-47a39a77bc1c.gif)

Note, this PR is still a work in progress:

- The markup/CSS had a fair bit of surgery and needs a sanity check
- The specific behavior of responsive with and without the top toolbar needs to be tested well and probably have a few tweaks
- It changes a few mobile native files, that needs to be sanity checked
- I need to look at the left padding on the site editor, and how the left menu animates in. 

But for now, I'd like your thoughts and reviews:

## How has this been tested?

Please test the post and site editor on mobile, without the top toolbar option enabled — it should still be stacked.

Please test the post and site editor on any viewport width, _with_ the top toolbar option enabled.

Verify that the top toolbar always stays stacked, tabs well, works as intended, and neer covers content.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
