### PR TITLE
Reset wp admin styles for hr

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -98,4 +98,8 @@
 		line-height: revert;
 		font-weight: revert;
 	}
+
+	hr {
+		border: revert;
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
The [wp admin styles](https://github.com/WordPress/WordPress/blob/fc6e4cbe3ef1dcd3a9977272d7ddcc413acdde0d/wp-admin/css/common.css#L865-L869) are bleeding into the editor for the hr separator. This PR reverts those styles to reset them so that the editor and the frontend show the same.

## How has this been tested?
This has been tested using Empty theme and removing the block_styles support.

## Screenshots <!-- if applicable -->

**Before**:

Editor | Frontend
--- | ---
<img width="962" alt="Screenshot 2021-03-25 at 12 08 21" src="https://user-images.githubusercontent.com/3593343/112464217-80f8cd80-8d63-11eb-8fcc-f70da72ee4d0.png"> | <img width="902" alt="Screenshot 2021-03-25 at 12 13 31" src="https://user-images.githubusercontent.com/3593343/112464239-881fdb80-8d63-11eb-9770-a10f1bd398fd.png">

**After**:

Editor | Frontend
--- | ---
<img width="952" alt="Screenshot 2021-03-25 at 12 08 51" src="https://user-images.githubusercontent.com/3593343/112464216-80f8cd80-8d63-11eb-92ad-37d1cd0cba15.png"> | <img width="935" alt="Screenshot 2021-03-25 at 12 09 06" src="https://user-images.githubusercontent.com/3593343/112464215-80603700-8d63-11eb-87ed-e68fd69581f2.png">



## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
