### PR TITLE
Fix Backspace in content editable button in Safari

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -817,8 +817,23 @@ function RichText(
 			return;
 		}
 
-		if ( ref.current.ownerDocument.activeElement !== ref.current ) {
-			return;
+		const { ownerDocument } = ref.current;
+
+		if ( ownerDocument.activeElement !== ref.current ) {
+			const { defaultView } = ownerDocument;
+			const { anchorNode, focusNode } = defaultView.getSelection();
+
+			// Safari won't set focus on interactive editable elements, so if
+			// selection appears within the editable container, set focus and
+			// selection internally.
+			if (
+				! ref.current.contains( anchorNode ) ||
+				! ref.current.contains( focusNode )
+			) {
+				return;
+			}
+
+			ref.current.focus();
 		}
 
 		if ( event.type !== 'selectionchange' && ! isSelected ) {

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -823,16 +823,21 @@ function RichText(
 			const { defaultView } = ownerDocument;
 			const { anchorNode, focusNode } = defaultView.getSelection();
 
-			// Safari won't set focus on interactive editable elements, so if
-			// selection appears within the editable container, set focus and
-			// selection internally.
-			if (
-				! ref.current.contains( anchorNode ) ||
-				! ref.current.contains( focusNode )
-			) {
+			if ( isSelected ) {
 				return;
 			}
 
+			const isSelectionWithin =
+				ref.current.contains( anchorNode ) &&
+				ref.current.contains( focusNode );
+
+			if ( ! isSelectionWithin ) {
+				return;
+			}
+
+			// Safari won't set focus on interactive editable elements, so if
+			// selection appears within the editable container, set focus and
+			// selection internally.
 			ref.current.focus();
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

See https://github.com/WordPress/gutenberg/pull/30176/files#r601161161.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
