### PR TITLE
[RNMobile] Refactor: Simplify media flow redux migration

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -136,7 +136,13 @@ function InserterMenu( {
 
 			addLastBlockInserted( newBlock.clientId );
 
-			insertBlock( newBlock, insertionIndex, destinationRootClientId );
+			insertBlock(
+				newBlock,
+				insertionIndex,
+				destinationRootClientId,
+				true,
+				{ source: 'inserter_menu' }
+			);
 		},
 		[ insertBlock, destinationRootClientId, insertionIndex ]
 	);

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -538,6 +538,7 @@ export function* moveBlockToPosition(
  * @param {?number} index            Index at which block should be inserted.
  * @param {?string} rootClientId     Optional root client ID of block list on which to insert.
  * @param {?boolean} updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to true.
+ * @param {?Object} meta             Optional Meta values to be passed to the action object.
  *
  * @return {Object} Action object.
  */
@@ -545,9 +546,17 @@ export function insertBlock(
 	block,
 	index,
 	rootClientId,
-	updateSelection = true
+	updateSelection = true,
+	meta
 ) {
-	return insertBlocks( [ block ], index, rootClientId, updateSelection );
+	return insertBlocks(
+		[ block ],
+		index,
+		rootClientId,
+		updateSelection,
+		0,
+		meta
+	);
 }
 
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1747,7 +1747,7 @@ export function lastBlockInserted( state = {}, action ) {
 
 			return { clientId, source };
 		case 'RESET_BLOCKS':
-			return null;
+			return {};
 	}
 	return state;
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1737,11 +1737,17 @@ export function highlightedBlock( state, action ) {
  */
 export function lastBlockInserted( state = {}, action ) {
 	switch ( action.type ) {
-		case 'ADD_LAST_BLOCK_INSERTED':
-			return { ...state, clientId: action.clientId };
+		case 'INSERT_BLOCKS':
+			if ( ! action.updateSelection || ! action.blocks.length ) {
+				return state;
+			}
 
-		case 'CLEAR_LAST_BLOCK_INSERTED':
-			return {};
+			const clientId = action.blocks[ 0 ].clientId;
+			const source = action.meta?.source;
+
+			return { clientId, source };
+		case 'RESET_BLOCKS':
+			return null;
 	}
 	return state;
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -43,15 +43,6 @@ import { Platform } from '@wordpress/element';
  *                                 text value. See `wp.richText.create`.
  */
 
-/**
- * Last block selected object.
- *
- * @typedef {Object} WPLastBlockInserted
- *
- * @property {string}   clientId	Block client ID.
- * @property {string}   source      The source from where it was inserted.
- */
-
 // Module constants
 const MILLISECONDS_PER_HOUR = 3600 * 1000;
 const MILLISECONDS_PER_DAY = 24 * 3600 * 1000;
@@ -2098,19 +2089,14 @@ export const __experimentalGetActiveBlockIdByBlockNames = createSelector(
  * Tells if the block with the passed clientId was just inserted.
  *
  * @param {Object} state Global application state.
- * @param {Object} clientId client id of the block.
- * @return {boolean} If the client id exists within the lastBlockInserted state then the block was just inserted.
+ * @param {Object} clientId Client Id of the block.
+ * @param {boolean} source Insertion source of the block.
+ * @return {boolean} True if the block matches the last block inserted from the specified source.
  */
-export function wasBlockJustInserted( state, clientId ) {
-	return state.lastBlockInserted.clientId === clientId;
-}
-
-/**
- * Returns the last block inserted. If multiple blocks were inserted it returns the first item.
- *
- * @param {Object} state Global application state.
- * @return {?WPLastBlockInserted} Last inserted block.
- */
-export function getLastBlockInserted( state ) {
-	return state.lastBlockInserted;
+export function wasBlockJustInserted( state, clientId, source ) {
+	const { lastBlockInserted } = state;
+	return (
+		lastBlockInserted.clientId === clientId &&
+		lastBlockInserted.source === source
+	);
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -43,6 +43,15 @@ import { Platform } from '@wordpress/element';
  *                                 text value. See `wp.richText.create`.
  */
 
+/**
+ * Last block selected object.
+ *
+ * @typedef {Object} WPLastBlockInserted
+ *
+ * @property {string}   clientId	Block client ID.
+ * @property {string}   source      The source from where it was inserted.
+ */
+
 // Module constants
 const MILLISECONDS_PER_HOUR = 3600 * 1000;
 const MILLISECONDS_PER_DAY = 24 * 3600 * 1000;
@@ -2094,4 +2103,14 @@ export const __experimentalGetActiveBlockIdByBlockNames = createSelector(
  */
 export function wasBlockJustInserted( state, clientId ) {
 	return state.lastBlockInserted.clientId === clientId;
+}
+
+/**
+ * Returns the last block inserted. If multiple blocks were inserted it returns the first item.
+ *
+ * @param {Object} state Global application state.
+ * @return {?WPLastBlockInserted} Last inserted block.
+ */
+export function getLastBlockInserted( state ) {
+	return state.lastBlockInserted;
 }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -109,7 +109,6 @@ function GalleryEdit( props ) {
 			mediaUpload: settings.mediaUpload,
 			getMedia: select( coreStore ).getMedia,
 			wasBlockJustInserted:
-				!! lastBlockInserted &&
 				lastBlockInserted.clientId === clientId &&
 				lastBlockInserted.source === 'inserter_menu',
 		};

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -100,17 +100,14 @@ function GalleryEdit( props ) {
 		wasBlockJustInserted,
 	} = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
-		const lastBlockInserted = select(
-			blockEditorStore
-		).getLastBlockInserted();
 
 		return {
 			imageSizes: settings.imageSizes,
 			mediaUpload: settings.mediaUpload,
 			getMedia: select( coreStore ).getMedia,
-			wasBlockJustInserted:
-				lastBlockInserted.clientId === clientId &&
-				lastBlockInserted.source === 'inserter_menu',
+			wasBlockJustInserted: select(
+				blockEditorStore
+			).wasBlockJustInserted( clientId, 'inserter_menu' ),
 		};
 	} );
 

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -589,7 +589,6 @@ export default compose( [
 
 		const lastBlockInserted = getLastBlockInserted();
 		const wasBlockJustInserted =
-			!! lastBlockInserted &&
 			lastBlockInserted.clientId === clientId &&
 			lastBlockInserted.source === 'inserter_menu';
 

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -567,7 +567,7 @@ export class ImageEdit extends Component {
 export default compose( [
 	withSelect( ( select, props ) => {
 		const { getMedia } = select( coreStore );
-		const { getSettings, getLastBlockInserted } = select(
+		const { getSettings, wasBlockJustInserted } = select(
 			blockEditorStore
 		);
 		const {
@@ -587,15 +587,13 @@ export default compose( [
 				url &&
 				! hasQueryArg( url, 'w' ) );
 
-		const lastBlockInserted = getLastBlockInserted();
-		const wasBlockJustInserted =
-			lastBlockInserted.clientId === clientId &&
-			lastBlockInserted.source === 'inserter_menu';
-
 		return {
 			image: shouldGetMedia ? getMedia( id ) : null,
 			imageSizes,
-			wasBlockJustInserted,
+			wasBlockJustInserted: wasBlockJustInserted(
+				clientId,
+				'inserter_menu'
+			),
 		};
 	} ),
 	withPreferredColorScheme,

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -42,7 +42,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { getProtocol, hasQueryArg } from '@wordpress/url';
 import { doAction, hasAction } from '@wordpress/hooks';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import {
 	image as placeholderIcon,
 	textColor,
@@ -468,7 +468,7 @@ export class ImageEdit extends Component {
 						icon={ this.getPlaceholderIcon() }
 						onFocus={ this.props.onFocus }
 						autoOpenMediaUpload={
-							isSelected && ! url && wasBlockJustInserted()
+							isSelected && ! url && wasBlockJustInserted
 						}
 					/>
 				</View>
@@ -567,10 +567,13 @@ export class ImageEdit extends Component {
 export default compose( [
 	withSelect( ( select, props ) => {
 		const { getMedia } = select( coreStore );
-		const { getSettings } = select( blockEditorStore );
+		const { getSettings, getLastBlockInserted } = select(
+			blockEditorStore
+		);
 		const {
 			attributes: { id, url },
 			isSelected,
+			clientId,
 		} = props;
 		const { imageSizes } = getSettings();
 		const isNotFileUrl = id && getProtocol( url ) !== 'file:';
@@ -583,25 +586,17 @@ export default compose( [
 				isNotFileUrl &&
 				url &&
 				! hasQueryArg( url, 'w' ) );
+
+		const lastBlockInserted = getLastBlockInserted();
+		const wasBlockJustInserted =
+			!! lastBlockInserted &&
+			lastBlockInserted.clientId === clientId &&
+			lastBlockInserted.source === 'inserter_menu';
+
 		return {
 			image: shouldGetMedia ? getMedia( id ) : null,
 			imageSizes,
-		};
-	} ),
-	withDispatch( ( dispatch, { clientId }, { select } ) => {
-		return {
-			wasBlockJustInserted() {
-				const { clearLastBlockInserted } = dispatch( blockEditorStore );
-				const { wasBlockJustInserted } = select( blockEditorStore );
-
-				const result = wasBlockJustInserted( clientId );
-
-				if ( result ) {
-					clearLastBlockInserted();
-					return true;
-				}
-				return false;
-			},
+			wasBlockJustInserted,
 		};
 	} ),
 	withPreferredColorScheme,

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -372,15 +372,11 @@ class VideoEdit extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { clientId } ) => {
-		const { wasBlockJustInserted } = select( blockEditorStore );
-
-		return {
-			wasBlockJustInserted: wasBlockJustInserted(
-				clientId,
-				'inserter_menu'
-			),
-		};
-	} ),
+	withSelect( ( select, { clientId } ) => ( {
+		wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted(
+			clientId,
+			'inserter_menu'
+		),
+	} ) ),
 	withPreferredColorScheme,
 ] )( VideoEdit );

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -36,7 +36,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { isURL, getProtocol } from '@wordpress/url';
 import { doAction, hasAction } from '@wordpress/hooks';
 import { video as SvgIcon, replace } from '@wordpress/icons';
-import { withDispatch } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -229,7 +229,7 @@ class VideoEdit extends Component {
 						icon={ this.getIcon( ICON_TYPE.PLACEHOLDER ) }
 						onFocus={ this.props.onFocus }
 						autoOpenMediaUpload={
-							isSelected && ! src && wasBlockJustInserted()
+							isSelected && ! src && wasBlockJustInserted
 						}
 					/>
 				</View>
@@ -372,20 +372,17 @@ class VideoEdit extends Component {
 }
 
 export default compose( [
-	withDispatch( ( dispatch, { clientId }, { select } ) => {
+	withSelect( ( select, { clientId } ) => {
+		const { getLastBlockInserted } = select( blockEditorStore );
+
+		const lastBlockInserted = getLastBlockInserted();
+		const wasBlockJustInserted =
+			!! lastBlockInserted &&
+			lastBlockInserted.clientId === clientId &&
+			lastBlockInserted.source === 'inserter_menu';
+
 		return {
-			wasBlockJustInserted() {
-				const { clearLastBlockInserted } = dispatch( blockEditorStore );
-				const { wasBlockJustInserted } = select( blockEditorStore );
-
-				const result = wasBlockJustInserted( clientId );
-
-				if ( result ) {
-					clearLastBlockInserted();
-					return true;
-				}
-				return false;
-			},
+			wasBlockJustInserted,
 		};
 	} ),
 	withPreferredColorScheme,

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -373,15 +373,13 @@ class VideoEdit extends Component {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getLastBlockInserted } = select( blockEditorStore );
-
-		const lastBlockInserted = getLastBlockInserted();
-		const wasBlockJustInserted =
-			lastBlockInserted.clientId === clientId &&
-			lastBlockInserted.source === 'inserter_menu';
+		const { wasBlockJustInserted } = select( blockEditorStore );
 
 		return {
-			wasBlockJustInserted,
+			wasBlockJustInserted: wasBlockJustInserted(
+				clientId,
+				'inserter_menu'
+			),
 		};
 	} ),
 	withPreferredColorScheme,

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -377,7 +377,6 @@ export default compose( [
 
 		const lastBlockInserted = getLastBlockInserted();
 		const wasBlockJustInserted =
-			!! lastBlockInserted &&
 			lastBlockInserted.clientId === clientId &&
 			lastBlockInserted.source === 'inserter_menu';
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR refactors the [Simplify media flow redux store changes PR](https://github.com/WordPress/gutenberg/pull/30123) and changes the way the last block inserted is calculated.

The idea is that when a block is inserted via the inserter menu, we include a source param (`inserter_menu`) as part of the meta data. This way we can know where the last block was inserted from and in this case, we can display the media picker when it was inserted from the inserter menu.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested the different blocks that use media (`image`, `gallery` and `video`).

1. Insert the block
2. Observe that the media picker **is displayed**
3. Insert another block
4. Observe that the media picker **is displayed**
5. Undo all the actions and redo them
6. Observe that the media picker **is not displayed**
7. Duplicate a block
8. Observe that the media picker **is not displayed**
9. Copy a block and insert it via the inserter menu
10. Observe that the media picker **is displayed**

## Screenshots <!-- if applicable -->

<details><summary><strong>Gallery block</strong></summary>

https://user-images.githubusercontent.com/14905380/112467796-c6b79500-8d67-11eb-868e-3bcecf6747c7.mp4

</details>

<details><summary><strong>Image block</strong></summary>

https://user-images.githubusercontent.com/14905380/112467808-ca4b1c00-8d67-11eb-8016-a01e9805bbe3.mp4

</details>

<details><summary><strong>Video block</strong></summary>

https://user-images.githubusercontent.com/14905380/112467813-cae3b280-8d67-11eb-8458-2790e0630577.mp4

</details>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
N/A

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
