### PR TITLE
Icons: Polish media & text icons.

### DIFF
--- a/packages/icons/src/library/media-and-text.js
+++ b/packages/icons/src/library/media-and-text.js
@@ -5,7 +5,7 @@ import { Path, SVG } from '@wordpress/primitives';
 
 const mediaAndText = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M4 17h7V6H4v11zm9-10v1.5h7V7h-7zm0 5.5h7V11h-7v1.5zm0 4h7V15h-7v1.5z" />
+		<Path d="M3 18h8V6H3v12zM14 7.5V9h7V7.5h-7zm0 5.3h7v-1.5h-7v1.5zm0 3.7h7V15h-7v1.5z" />
 	</SVG>
 );
 

--- a/packages/icons/src/library/pull-left.js
+++ b/packages/icons/src/library/pull-left.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const pullLeft = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M4 18h6V6H4v12zm9-10v1.5h7V8h-7zm0 7.5h7V14h-7v1.5z" />
+		<Path d="M4 18h6V6H4v12zm9-9.5V10h7V8.5h-7zm0 7h7V14h-7v1.5z" />
 	</SVG>
 );
 

--- a/packages/icons/src/library/pull-right.js
+++ b/packages/icons/src/library/pull-right.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const pullRight = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M14 6v12h6V6h-6zM4 9.5h7V8H4v1.5zm0 6h7V14H4v1.5z" />
+		<Path d="M14 6v12h6V6h-6zM4 10h7V8.5H4V10zm0 5.5h7V14H4v1.5z" />
 	</SVG>
 );
 


### PR DESCRIPTION
## Description

The metrics and positions of the Media & Text icons were slightly off. Before:

<img width="547" alt="before" src="https://user-images.githubusercontent.com/1204802/112469493-d9cb6480-8d69-11eb-9fe5-d4b5f53225e7.png">

This PR fixes that. After:

<img width="465" alt="Screenshot 2021-03-25 at 12 57 48" src="https://user-images.githubusercontent.com/1204802/112469513-de901880-8d69-11eb-9566-c0bdfb370bfa.png">

<img width="401" alt="Screenshot 2021-03-25 at 12 48 50" src="https://user-images.githubusercontent.com/1204802/112469528-e0f27280-8d69-11eb-85ae-836c4955f980.png">
<img width="371" alt="Screenshot 2021-03-25 at 12 48 58" src="https://user-images.githubusercontent.com/1204802/112469531-e2239f80-8d69-11eb-8a96-2aa8e720534a.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
