### PR TITLE
Fix mover position.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -556,7 +556,8 @@
 
 // Position mover arrows for both toolbars.
 .block-editor-block-contextual-toolbar,
-.edit-post-header-toolbar__block-toolbar {
+.edit-post-header-toolbar__block-toolbar,
+.edit-site-header-toolbar__block-toolbar {
 
 	.block-editor-block-mover:not(.is-horizontal) {
 		// Position SVGs.
@@ -568,12 +569,14 @@
 			}
 		}
 
-		.block-editor-block-mover-button.is-up-button svg {
-			top: 5px;
-		}
+		@include break-small() {
+			.block-editor-block-mover-button.is-up-button svg {
+				top: 5px;
+			}
 
-		.block-editor-block-mover-button.is-down-button svg {
-			bottom: 5px;
+			.block-editor-block-mover-button.is-down-button svg {
+				bottom: 5px;
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -30,6 +30,12 @@
 	}
 
 	.block-editor-block-mover-button {
+		&.block-editor-block-mover-button {
+			padding-right: 0;
+			padding-left: 0;
+			min-width: $button-size;
+		}
+
 		@include break-small() {
 			// The !important modifier should be removed when https://github.com/WordPress/gutenberg/issues/24898 refactors the spacing grid.
 			height: $block-toolbar-height/2;


### PR DESCRIPTION
## Description

The movers were not positioned right:

<img width="715" alt="Screenshot 2021-03-25 at 13 02 51" src="https://user-images.githubusercontent.com/1204802/112470950-9245d800-8d6b-11eb-971e-cc170ee3a267.png">

This PR fixes that, and an issue for the site editor:

<img width="330" alt="Screenshot 2021-03-25 at 13 06 48" src="https://user-images.githubusercontent.com/1204802/112470964-97a32280-8d6b-11eb-9ebb-c5c4ad856d9e.png">

<img width="323" alt="Screenshot 2021-03-25 at 13 09 06" src="https://user-images.githubusercontent.com/1204802/112470976-996ce600-8d6b-11eb-8645-40687440a03b.png">

## How has this been tested?

Please test the mover control in post and site editor, mobile and desktop, top toolbar on and off, and verify it all looks good.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
