### PR TITLE
Block Library: Add 'object-position' to allowed inline style attributes list

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -196,6 +196,8 @@ add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post
 /**
  * Update allowed inline style attributes list.
  *
+ * Note: This should be removed when the minimum required WP version is >= 5.8.
+ *
  * @param string[] $attrs Array of allowed CSS attributes.
  * @return string[] CSS attributes.
  */

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -192,3 +192,16 @@ function gutenberg_override_reusable_block_post_type_labels() {
 	);
 }
 add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post_type_labels', 10, 0 );
+
+/**
+ * Update allowed inline style attributes list.
+ *
+ * @param string[] $attrs Array of allowed CSS attributes.
+ * @return string[] CSS attributes.
+ */
+function gutenberg_safe_style_attrs( $attrs ) {
+	$attrs[] = 'object-position';
+
+	return $attrs;
+}
+add_filter( 'safe_style_css', 'gutenberg_safe_style_attrs' );


### PR DESCRIPTION
## Description
The `object-position` property, used by the Cover block, isn't in the list of allowed CSS attributes. It's removed from the content when non-admin users save a post.

Fixes #29907.

## How has this been tested?
1. Create a post with a cover block.
2. Edit it as an Author user.
3. Update cover block's focal point.
4. Save and refresh the page.
5. Editor shouldn't display the cover block in recovery mode.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
