### PR TITLE
RichText: fix Space key for button and summary elements

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -18,6 +18,7 @@ import { useSelectObject } from './use-select-object';
 import { useIndentListItemOnSpace } from './use-indent-list-item-on-space';
 import { useInputAndSelection } from './use-input-and-selection';
 import { useDelete } from './use-delete';
+import { useSpace } from './use-space';
 
 export function useRichText( {
 	value = '',
@@ -198,6 +199,7 @@ export function useRichText( {
 			isSelected,
 			onSelectionChange,
 		} ),
+		useSpace(),
 		useRefEffect( () => {
 			applyFromProps();
 			didMount.current = true;

--- a/packages/rich-text/src/component/use-space.js
+++ b/packages/rich-text/src/component/use-space.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { SPACE } from '@wordpress/keycodes';
+
+/**
+ * For some elements like BUTTON and SUMMARY, the space key doesn't insert a
+ * space character in some browsers even though the element is editable. We have
+ * to manually insert a space and prevent default behaviour.
+ *
+ * DO NOT limit this behaviour to specific tag names! It would mean that this
+ * behaviour is not widely tested. If there's ever any problems, we should find
+ * a different solution entirely or remove it entirely.
+ */
+export function useSpace() {
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			// Don't insert a space if default behaviour is prevented.
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			const { keyCode, altKey, metaKey, ctrlKey } = event;
+
+			// Only consider the space key without modifiers pressed.
+			if ( keyCode !== SPACE || altKey || metaKey || ctrlKey ) {
+				return;
+			}
+
+			event.target.ownerDocument.execCommand( 'insertText', false, ' ' );
+			event.preventDefault();
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Alternative to #24558.

Currently it's not possible to use rich text with the BUTTON and SUMMARY tag names because the space key doesn't work. This PR fixes the issue.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
