### PR TITLE
Prevent overlapping button blocks in the frontend

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -15,6 +15,7 @@ $blocks-block__margin: 0.5em;
 	text-align: center;
 	text-decoration: none;
 	overflow-wrap: break-word;
+	box-sizing: border-box;
 
 	&:hover,
 	&:focus,


### PR DESCRIPTION
Related to #29976 

If you set custom widths for button blocks, you'll notice that in the frontend the blocks overlap. This is because of the missing box-sizing style.