### PR TITLE
Fix non responsive embed iframes styles

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -33,6 +33,10 @@
 	iframe {
 		max-width: 100%;
 	}
+
+	&:not(.wp-has-aspect-ratio) iframe {
+		width: auto;
+	}
 }
 
 .wp-block-embed__wrapper {

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -32,10 +32,7 @@
 	// Don't allow iframe to overflow it's container.
 	iframe {
 		max-width: 100%;
-	}
-
-	&:not(.wp-has-aspect-ratio) iframe {
-		width: auto;
+		width: 100%;
 	}
 }
 


### PR DESCRIPTION
Related to #29976 

So it turns out by default browsers give iframe a width of 500px and in the editor we default to 100%  for embed iframe meaning the editor doesn't look like the frontend.

I also noticed that we have some iframe that have an "aspect ratio" applied and these are already 100% wide in both editor and frontend.

So this PR makes the width equal to `auto` (so width of its content) for iframes that don't use the aspect ratio styles.

This is an area I'm not very familiar with so I'd love some testing of different embeds producing iframe (YouTube, amazon, Spotify...) :) 