### PR TITLE
Global Styles: Make theme.json extensible

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -57,7 +57,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @return array Contents that adhere to the theme.json schema.
 	 */
-	private static function read_json_file( $file_path ) {
+	public static function read_json_file( $file_path ) {
 		$config = array();
 		if ( $file_path ) {
 			$decoded_file = json_decode(
@@ -309,6 +309,7 @@ class WP_Theme_JSON_Resolver {
 	public static function get_theme_data( $theme_support_data = array() ) {
 		if ( null === self::$theme ) {
 			$theme_json_data = self::read_json_file( self::get_file_path_from_theme( 'experimental-theme.json' ) );
+			$theme_json_data = apply_filters( 'theme_json_data', $theme_json_data );
 			$theme_json_data = self::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
 			self::$theme     = new WP_Theme_JSON( $theme_json_data );
 		}


### PR DESCRIPTION
## Description
Make it possible to filter the theme.json file provided by the theme, so themes can do other things with it, like generate the values on the server.

This is an alternative approach to https://github.com/WordPress/gutenberg/pull/30147.

## How has this been tested?
1. Use this child theme: [child.zip](https://github.com/WordPress/gutenberg/files/6207982/child.zip)
1. Make sure you also have TT1 Blocks installed.
1. Switch to the Child theme
1. Check that you see an inverted version of TT1 Blocks.

## Screenshots
<img width="813" alt="Screenshot 2021-03-25 at 21 34 27" src="https://user-images.githubusercontent.com/275961/112547115-3c485300-8db2-11eb-8fa2-2958f6119cf9.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
