### PR TITLE
Flex component - add 'direction' prop.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13294,6 +13294,7 @@
 				"@babel/runtime": "^7.13.10",
 				"@emotion/core": "^10.1.1",
 				"@emotion/css": "^10.0.22",
+				"@emotion/is-prop-valid": "^1.1.0",
 				"@emotion/native": "^10.0.22",
 				"@emotion/styled": "^10.0.23",
 				"@wordpress/a11y": "file:packages/a11y",
@@ -13331,6 +13332,21 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.2",
 				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"@emotion/is-prop-valid": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz",
+					"integrity": "sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4"
+					}
+				},
+				"@emotion/memoize": {
+					"version": "0.7.5",
+					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+					"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+				}
 			}
 		},
 		"@wordpress/compose": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,6 +29,7 @@
 		"@babel/runtime": "^7.13.10",
 		"@emotion/core": "^10.1.1",
 		"@emotion/css": "^10.0.22",
+		"@emotion/is-prop-valid": "^1.1.0",
 		"@emotion/native": "^10.0.22",
 		"@emotion/styled": "^10.0.23",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/components/src/flex/README.md
+++ b/packages/components/src/flex/README.md
@@ -81,14 +81,6 @@ Determines the spacing in between children components. The `gap` value is a mult
 -   Required: No
 -   Default: `2`
 
-### isReversed
-
-Reverses the render order of children components.
-
--   Type: `Boolean`
--   Required: No
--   Default: `false`
-
 ### justify
 
 Horizontally aligns children components using the CSS [`justify-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) property.

--- a/packages/components/src/flex/README.md
+++ b/packages/components/src/flex/README.md
@@ -96,3 +96,11 @@ Horizontally aligns children components using the CSS [`justify-content`](https:
 -   Type: `String`
 -   Required: No
 -   Default: `space-between`
+
+### direction
+
+Determines the flex direction using the CSS [`flex-direction`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction) property.
+
+-   Type: `String`
+-   Required: No
+-   Default: `row`

--- a/packages/components/src/flex/index.js
+++ b/packages/components/src/flex/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -19,12 +20,13 @@ export { default as FlexItem } from './item';
 
 /* eslint-disable jsdoc/valid-types */
 /**
+ * @typedef {import('react').CSSProperties['flexDirection'] | 'row' | 'column' | 'row-reverse' | 'column-reverse'} FlexDirection
  * @typedef OwnProps
  * @property {import('react').CSSProperties['alignItems'] | 'top' | 'bottom'} [align='center'] Sets align-items. Top and bottom are shorthand for flex-start and flex-end respectively.
  * @property {number} [gap=2] Determines the spacing in between children components. The `gap` value is a multiplier to the base value of `4`.
  * @property {import('react').CSSProperties['justifyContent'] | 'left' | 'right'} [justify='space-between']          * Sets jusifty-content. Left and right are shorthand for flex-start and flex-end respectively, not the actual CSS value.
  * @property {boolean} [isReversed=false] Reversed the flex direction.
- * @property {import('react').CSSProperties['flexDirection'] | 'row' | 'column'} [direction='row'] Sets the flex-direction property.
+ * @property {FlexDirection} [direction='row'] Sets the flex-direction property.
  */
 /* eslint-enable jsdoc/valid-types */
 
@@ -34,38 +36,46 @@ export { default as FlexItem } from './item';
  * @param {Props} props
  * @param {import('react').Ref<HTMLDivElement>} ref
  */
-function FlexComponent(
-	{
+function FlexComponent( props, ref ) {
+	const direction = useDirection( props );
+	const {
 		align = 'center',
 		className,
 		gap = 2,
 		justify = 'space-between',
-		isReversed = false,
-		direction = 'row',
-		...props
-	},
-	ref
-) {
-	const classes = classnames( 'components-flex', className );
+		...otherProps
+	} = props;
 
-	const reversed = isReversed || direction.includes( '-reverse' );
-	const simplifiedDirection = direction.includes( '-reverse' )
-		? direction.slice( 0, -8 )
-		: direction;
+	const classes = classnames( 'components-flex', className );
 
 	return (
 		<BaseFlex
-			{ ...props }
+			{ ...otherProps }
 			align={ align }
 			className={ classes }
 			ref={ ref }
 			gap={ gap }
 			justify={ justify }
-			isReversed={ reversed }
-			// @ts-ignore
-			direction={ simplifiedDirection }
+			direction={ direction }
 		/>
 	);
+}
+
+/**
+ * @param {Props} props
+ */
+function useDirection( { isReversed, direction = 'row' } ) {
+	if ( typeof isReversed !== 'undefined' ) {
+		deprecated( 'Flex isReversed', {
+			alternative: 'Flex direction="row-reverse"',
+		} );
+		if ( isReversed ) {
+			return 'row-reverse';
+		}
+		return 'row';
+	}
+
+	return direction;
 }
 
 export const Flex = withNextFlex( forwardRef( FlexComponent ) );

--- a/packages/components/src/flex/index.js
+++ b/packages/components/src/flex/index.js
@@ -36,15 +36,19 @@ export { default as FlexItem } from './item';
  * @param {Props} props
  * @param {import('react').Ref<HTMLDivElement>} ref
  */
-function FlexComponent( props, ref ) {
-	const direction = useDirection( props );
-	const {
+function FlexComponent(
+	{
 		align = 'center',
 		className,
 		gap = 2,
 		justify = 'space-between',
+		isReversed,
+		direction: directionProp,
 		...otherProps
-	} = props;
+	},
+	ref
+) {
+	const direction = useDirection( { isReversed, direction: directionProp } );
 
 	const classes = classnames( 'components-flex', className );
 

--- a/packages/components/src/flex/index.js
+++ b/packages/components/src/flex/index.js
@@ -49,7 +49,6 @@ function FlexComponent(
 	ref
 ) {
 	const direction = useDirection( { isReversed, direction: directionProp } );
-
 	const classes = classnames( 'components-flex', className );
 
 	return (

--- a/packages/components/src/flex/index.js
+++ b/packages/components/src/flex/index.js
@@ -24,6 +24,7 @@ export { default as FlexItem } from './item';
  * @property {number} [gap=2] Determines the spacing in between children components. The `gap` value is a multiplier to the base value of `4`.
  * @property {import('react').CSSProperties['justifyContent'] | 'left' | 'right'} [justify='space-between']          * Sets jusifty-content. Left and right are shorthand for flex-start and flex-end respectively, not the actual CSS value.
  * @property {boolean} [isReversed=false] Reversed the flex direction.
+ * @property {import('react').CSSProperties['flexDirection'] | 'row' | 'column'} [direction='row'] Sets the flex-direction property.
  */
 /* eslint-enable jsdoc/valid-types */
 
@@ -40,11 +41,17 @@ function FlexComponent(
 		gap = 2,
 		justify = 'space-between',
 		isReversed = false,
+		direction = 'row',
 		...props
 	},
 	ref
 ) {
 	const classes = classnames( 'components-flex', className );
+
+	const reversed = isReversed || direction.includes( '-reverse' );
+	const simplifiedDirection = direction.includes( '-reverse' )
+		? direction.slice( 0, -8 )
+		: direction;
 
 	return (
 		<BaseFlex
@@ -54,7 +61,9 @@ function FlexComponent(
 			ref={ ref }
 			gap={ gap }
 			justify={ justify }
-			isReversed={ isReversed }
+			isReversed={ reversed }
+			// @ts-ignore
+			direction={ simplifiedDirection }
 		/>
 	);
 }

--- a/packages/components/src/flex/next.js
+++ b/packages/components/src/flex/next.js
@@ -18,10 +18,8 @@ const FlexItem =
  * @param {import('./index').Props} props Current props.
  * @return {import('../ui/flex/types').FlexProps} Next props.
  */
-const flexAdapter = ( { isReversed, ...restProps } ) => ( {
-	// There's no equivalent for `direction` on the original component so we can just translate `isReversed` to it
-	direction: isReversed ? 'row-reverse' : 'row',
-	...restProps,
+const flexAdapter = ( props ) => ( {
+	...props,
 	// There's an HTML attribute named `wrap` that will exist in `restProps` so we need to set it to undefined so the default behavior of the next component takes over
 	wrap: undefined,
 } );

--- a/packages/components/src/flex/styles/flex-styles.js
+++ b/packages/components/src/flex/styles/flex-styles.js
@@ -3,6 +3,7 @@
  */
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import isPropValid from '@emotion/is-prop-valid';
 
 /**
  * @param {import('..').OwnProps} props
@@ -87,7 +88,9 @@ const directionStyles = ( { direction } ) => {
 	`;
 };
 
-export const Flex = styled.div`
+export const Flex = styled( 'div', {
+	shouldForwardProp: ( prop ) => isPropValid( prop ) && prop !== 'direction',
+} )`
 	box-sizing: border-box;
 	display: flex;
 	width: 100%;

--- a/packages/components/src/flex/styles/flex-styles.js
+++ b/packages/components/src/flex/styles/flex-styles.js
@@ -48,10 +48,14 @@ const justifyStyle = ( { justify, isReversed } ) => {
 /**
  * @param {import('..').OwnProps} Props
  */
-const gapStyle = ( { gap, isReversed } ) => {
+const gapStyle = ( { gap, isReversed, direction } ) => {
+	const isVertical = direction === 'column';
 	const base = 4;
 	const value = typeof gap === 'number' ? base * gap : base;
-	const dir = isReversed ? 'left' : 'right';
+	let dir = isReversed ? 'left' : 'right';
+	if ( isVertical ) {
+		dir = isReversed ? 'top' : 'bottom';
+	}
 	const margin = `margin-${ dir }`;
 
 	return css`
@@ -68,11 +72,11 @@ const gapStyle = ( { gap, isReversed } ) => {
 /**
  * @param {import('..').OwnProps} props
  */
-const reversedStyles = ( { isReversed } ) => {
-	if ( ! isReversed ) return '';
+const directionStyles = ( { direction, isReversed } ) => {
+	const directionValue = isReversed ? `${ direction }-reverse` : direction;
 
 	return css`
-		flex-direction: row-reverse;
+		flex-direction: ${ directionValue };
 	`;
 };
 
@@ -83,7 +87,7 @@ export const Flex = styled.div`
 
 	${ alignStyle }
 	${ justifyStyle }
-	${ reversedStyles }
+	${ directionStyles }
 	${ gapStyle }
 `;
 

--- a/packages/components/src/flex/styles/flex-styles.js
+++ b/packages/components/src/flex/styles/flex-styles.js
@@ -48,14 +48,10 @@ const justifyStyle = ( { justify, isReversed } ) => {
 /**
  * @param {import('..').OwnProps} Props
  */
-const gapStyle = ( { gap, isReversed, direction } ) => {
-	const isVertical = direction === 'column';
+const gapStyle = ( { gap, direction } ) => {
 	const base = 4;
 	const value = typeof gap === 'number' ? base * gap : base;
-	let dir = isReversed ? 'left' : 'right';
-	if ( isVertical ) {
-		dir = isReversed ? 'top' : 'bottom';
-	}
+	const dir = getMarginDirection( direction );
 	const margin = `margin-${ dir }`;
 
 	return css`
@@ -70,13 +66,24 @@ const gapStyle = ( { gap, isReversed, direction } ) => {
 };
 
 /**
+ * @param {import('..').FlexDirection} direction
+ * @return {string} margin direction
+ */
+function getMarginDirection( direction ) {
+	const isVertical = direction?.includes( 'column' );
+	const isReversed = direction?.includes( '-reverse' );
+	if ( isVertical ) {
+		return isReversed ? 'top' : 'bottom';
+	}
+	return isReversed ? 'left' : 'right';
+}
+
+/**
  * @param {import('..').OwnProps} props
  */
-const directionStyles = ( { direction, isReversed } ) => {
-	const directionValue = isReversed ? `${ direction }-reverse` : direction;
-
+const directionStyles = ( { direction } ) => {
 	return css`
-		flex-direction: ${ directionValue };
+		flex-direction: ${ direction };
 	`;
 };
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
I noticed this neat `Flex` component and went to use it in a vertical/column direction.  It seems that currently the  vertical orientation (`flex-direction: column`) is not supported.  This PR attempts to add this functionality.

This is slightly odd since the currently existing `isReversed` function sets the `flex-direction` css property by assuming row.  Lets consider deprecating `isReversed` in favor of `direction`.  If the `isReversed` prop is present, a deprecation warning is thrown and the component has the same behavior as it previously did.  Otherwise, we go with the new `direction` prop defaulting to 'row'.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Test the component with the deprecated `isReversed` prop and ensure their are no regressions.
Test the component with the new `direction` prop and ensure settings work as expected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
