### PR TITLE
Fix drop zone callback add/remove cycle

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -305,10 +305,10 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 	] );
 
 	// Optimization. Each callback returned from useOnBlockDrop should be a
-	// stable reference so that upstream in the DropZoneProvider it isn't
-	// constantly unregistered and re-registered. These callbacks all primarily
-	// use the setter from `useState`, delegating the handling of the drop
-	// event to an effect.
+	// stable reference so that upstream in the useDropZone it isn't constantly
+	// unregistered and re-registered. These callbacks all primarily use the
+	// setter from `useState`, and delegate the handling of the drop event to
+	// an effect.
 	return {
 		onDrop: useCallback(
 			( event ) => {

--- a/packages/block-editor/src/components/use-on-block-drop/test/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/test/index.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { parseDropEvent, onFilesDrop, onHTMLDrop, onBlockDrop } from '..';
+import {
+	parseDropEvent,
+	handleFilesDrop,
+	handleHTMLDrop,
+	handleBlockDrop,
+} from '..';
 /**
  * WordPress dependencies
  */
@@ -92,7 +97,7 @@ describe( 'parseDropEvent', () => {
 	} );
 } );
 
-describe( 'onBlockDrop', () => {
+describe( 'handleBlockDrop', () => {
 	it( 'does nothing if the event is not a block type drop', () => {
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
@@ -100,24 +105,18 @@ describe( 'onBlockDrop', () => {
 		const getClientIdsOfDescendants = noop;
 		const moveBlocksToPosition = jest.fn();
 
-		const event = {
-			dataTransfer: {
-				getData() {
-					return JSON.stringify( {
-						type: 'not-a-block-type-drop',
-					} );
-				},
-			},
+		const dropData = {
+			type: 'not-a-block-type-drop',
 		};
 
-		const eventHandler = onBlockDrop(
+		handleBlockDrop(
+			dropData,
 			targetRootClientId,
 			targetBlockIndex,
 			getBlockIndex,
 			getClientIdsOfDescendants,
 			moveBlocksToPosition
 		);
-		eventHandler( event );
 
 		expect( moveBlocksToPosition ).not.toHaveBeenCalled();
 	} );
@@ -130,27 +129,21 @@ describe( 'onBlockDrop', () => {
 		const getClientIdsOfDescendants = noop;
 		const moveBlocksToPosition = jest.fn();
 
-		const event = {
-			dataTransfer: {
-				getData() {
-					return JSON.stringify( {
-						type: 'block',
-						// Target and source root client id is the same.
-						srcRootClientId: targetRootClientId,
-						srcClientIds: [ '2' ],
-					} );
-				},
-			},
+		const dropData = {
+			type: 'block',
+			// Target and source root client id is the same.
+			srcRootClientId: targetRootClientId,
+			srcClientIds: [ '2' ],
 		};
 
-		const eventHandler = onBlockDrop(
+		handleBlockDrop(
+			dropData,
 			targetRootClientId,
 			targetBlockIndex,
 			getBlockIndex,
 			getClientIdsOfDescendants,
 			moveBlocksToPosition
 		);
-		eventHandler( event );
 
 		expect( moveBlocksToPosition ).not.toHaveBeenCalled();
 	} );
@@ -162,27 +155,21 @@ describe( 'onBlockDrop', () => {
 		const getClientIdsOfDescendants = noop;
 		const moveBlocksToPosition = jest.fn();
 
-		const event = {
-			dataTransfer: {
-				getData() {
-					return JSON.stringify( {
-						type: 'block',
-						srcRootClientId: '0',
-						// The dragged block is being dropped as a child of itself.
-						srcClientIds: [ targetRootClientId ],
-					} );
-				},
-			},
+		const dropData = {
+			type: 'block',
+			srcRootClientId: '0',
+			// The dragged block is being dropped as a child of itself.
+			srcClientIds: [ targetRootClientId ],
 		};
 
-		const eventHandler = onBlockDrop(
+		handleBlockDrop(
+			dropData,
 			targetRootClientId,
 			targetBlockIndex,
 			getBlockIndex,
 			getClientIdsOfDescendants,
 			moveBlocksToPosition
 		);
-		eventHandler( event );
 
 		expect( moveBlocksToPosition ).not.toHaveBeenCalled();
 	} );
@@ -197,26 +184,20 @@ describe( 'onBlockDrop', () => {
 		] );
 		const moveBlocksToPosition = jest.fn();
 
-		const event = {
-			dataTransfer: {
-				getData() {
-					return JSON.stringify( {
-						type: 'block',
-						srcRootClientId: '0',
-						srcClientIds: [ '5' ],
-					} );
-				},
-			},
+		const dropData = {
+			type: 'block',
+			srcRootClientId: '0',
+			srcClientIds: [ '5' ],
 		};
 
-		const eventHandler = onBlockDrop(
+		handleBlockDrop(
+			dropData,
 			targetRootClientId,
 			targetBlockIndex,
 			getBlockIndex,
 			getClientIdsOfDescendants,
 			moveBlocksToPosition
 		);
-		eventHandler( event );
 
 		expect( moveBlocksToPosition ).not.toHaveBeenCalled();
 	} );
@@ -230,26 +211,20 @@ describe( 'onBlockDrop', () => {
 		const getClientIdsOfDescendants = () => [];
 		const moveBlocksToPosition = jest.fn();
 
-		const event = {
-			dataTransfer: {
-				getData() {
-					return JSON.stringify( {
-						type: 'block',
-						srcRootClientId: sourceRootClientId,
-						srcClientIds: sourceClientIds,
-					} );
-				},
-			},
+		const dropData = {
+			type: 'block',
+			srcRootClientId: sourceRootClientId,
+			srcClientIds: sourceClientIds,
 		};
 
-		const eventHandler = onBlockDrop(
+		handleBlockDrop(
+			dropData,
 			targetRootClientId,
 			targetBlockIndex,
 			getBlockIndex,
 			getClientIdsOfDescendants,
 			moveBlocksToPosition
 		);
-		eventHandler( event );
 
 		expect( moveBlocksToPosition ).toHaveBeenCalledWith(
 			sourceClientIds,
@@ -269,29 +244,23 @@ describe( 'onBlockDrop', () => {
 		const getClientIdsOfDescendants = () => [];
 		const moveBlocksToPosition = jest.fn();
 
-		const event = {
-			dataTransfer: {
-				getData() {
-					return JSON.stringify( {
-						type: 'block',
-						srcRootClientId: sourceRootClientId,
-						// The dragged block is being dropped as a child of itself.
-						srcClientIds: sourceClientIds,
-					} );
-				},
-			},
+		const dropData = {
+			type: 'block',
+			srcRootClientId: sourceRootClientId,
+			// The dragged block is being dropped as a child of itself.
+			srcClientIds: sourceClientIds,
 		};
 
 		const insertIndex = targetBlockIndex - sourceClientIds.length;
 
-		const eventHandler = onBlockDrop(
+		handleBlockDrop(
+			dropData,
 			targetRootClientId,
 			targetBlockIndex,
 			getBlockIndex,
 			getClientIdsOfDescendants,
 			moveBlocksToPosition
 		);
-		eventHandler( event );
 
 		expect( moveBlocksToPosition ).toHaveBeenCalledWith(
 			sourceClientIds,
@@ -302,7 +271,7 @@ describe( 'onBlockDrop', () => {
 	} );
 } );
 
-describe( 'onFilesDrop', () => {
+describe( 'handleFilesDrop', () => {
 	it( 'does nothing if hasUploadPermissions is false', () => {
 		const updateBlockAttributes = jest.fn();
 		const canInsertBlockType = noop;
@@ -311,7 +280,8 @@ describe( 'onFilesDrop', () => {
 		const targetBlockIndex = 0;
 		const uploadPermissions = false;
 
-		const onFileDropHandler = onFilesDrop(
+		handleFilesDrop(
+			[],
 			targetRootClientId,
 			targetBlockIndex,
 			uploadPermissions,
@@ -319,7 +289,6 @@ describe( 'onFilesDrop', () => {
 			canInsertBlockType,
 			insertBlocks
 		);
-		onFileDropHandler();
 
 		expect( findTransform ).not.toHaveBeenCalled();
 		expect( insertBlocks ).not.toHaveBeenCalled();
@@ -336,7 +305,8 @@ describe( 'onFilesDrop', () => {
 		const targetBlockIndex = 0;
 		const uploadPermissions = true;
 
-		const onFileDropHandler = onFilesDrop(
+		handleFilesDrop(
+			[],
 			targetRootClientId,
 			targetBlockIndex,
 			uploadPermissions,
@@ -344,7 +314,6 @@ describe( 'onFilesDrop', () => {
 			canInsertBlockType,
 			insertBlocks
 		);
-		onFileDropHandler();
 
 		expect( findTransform ).toHaveBeenCalled();
 		expect( insertBlocks ).not.toHaveBeenCalled();
@@ -363,8 +332,10 @@ describe( 'onFilesDrop', () => {
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
 		const uploadPermissions = true;
+		const files = [ 'test' ];
 
-		const onFileDropHandler = onFilesDrop(
+		handleFilesDrop(
+			files,
 			targetRootClientId,
 			targetBlockIndex,
 			uploadPermissions,
@@ -372,8 +343,6 @@ describe( 'onFilesDrop', () => {
 			canInsertBlockType,
 			insertBlocks
 		);
-		const files = 'test';
-		onFileDropHandler( files );
 
 		expect( findTransform ).toHaveBeenCalled();
 		expect( transformation.transform ).toHaveBeenCalledWith(
@@ -388,20 +357,20 @@ describe( 'onFilesDrop', () => {
 	} );
 } );
 
-describe( 'onHTMLDrop', () => {
+describe( 'handleHTMLDrop', () => {
 	it( 'does nothing if the HTML cannot be converted into blocks', () => {
 		pasteHandler.mockImplementation( () => [] );
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
 		const insertBlocks = jest.fn();
+		const HTML = '';
 
-		const eventHandler = onHTMLDrop(
+		handleHTMLDrop(
+			HTML,
 			targetRootClientId,
 			targetBlockIndex,
 			insertBlocks
 		);
-		eventHandler();
-
 		expect( insertBlocks ).not.toHaveBeenCalled();
 	} );
 
@@ -411,13 +380,14 @@ describe( 'onHTMLDrop', () => {
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
 		const insertBlocks = jest.fn();
+		const HTML = 'HTML content does not affect the test';
 
-		const eventHandler = onHTMLDrop(
+		handleHTMLDrop(
+			HTML,
 			targetRootClientId,
 			targetBlockIndex,
 			insertBlocks
 		);
-		eventHandler();
 
 		expect( insertBlocks ).toHaveBeenCalledWith(
 			blocks,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
`useDropZone` can end up in a constant cycle of adding and removing dropzone callbacks if the event handlers passed to it aren't stable. It uses and effect for adding and removing, with dependencies on the callbacks:
https://github.com/WordPress/gutenberg/blob/c62ccd80c7c6abb85740cf8745439029bf0f4d35/packages/components/src/drop-zone/index.js#L30-L53

This seems to have been a problem for a while with the callbacks returned from `useOnBlockDrop`, which doesn't use `useCallback` and even if it did, the callbacks would still be unstable every time the `targetRootClientId` and `targetBlockIndex` change while dragging to different areas on a page:
https://github.com/WordPress/gutenberg/blob/c62ccd80c7c6abb85740cf8745439029bf0f4d35/packages/block-editor/src/components/use-on-block-drop/index.js#L243-L264

The change in this PR makes it so that the callbacks returned from `useOnBlockDrop` are stable by using minimising what the callbacks it returns do. The callbacks now set state for the data returned from the drop event, and a separate effect handles the actual dropping.

This may lead to some performance benefits, but I think it mainly solves and issue where sometimes the dropzone target indicator can flicker between two separate dropzones (e.g. if there's another drop zone for nested blocks).

## How has this been tested?
Not sure what options there are for automated testing for this kind of change

To reproduce the original issue
1. Add some console logging before `dropZones.add` (https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/drop-zone/index.js#L41) and `dropZones.remove` (https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/drop-zone/index.js#L43).
2. Do a build, open the editor, and test dragging and dropping of blocks, files, and HTML (drag a link)

In this branch: In this branch the console logs happen infrequently.
In `trunk`: console logging happens lots, even when not dragging and dropping 😬 

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
