### PR TITLE
Fix Navigation Link block constantly updating its inner block list settings

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -47,6 +47,8 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { ItemSubmenuIcon } from './icons';
 
+const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/spacer' ];
+
 /**
  * A React hook to determine if it's dragging within the target element.
  *
@@ -320,7 +322,7 @@ export default function NavigationLinkEdit( {
 			} ),
 		},
 		{
-			allowedBlocks: [ 'core/navigation-link', 'core/spacer' ],
+			allowedBlocks: ALLOWED_BLOCKS,
 			renderAppender:
 				( isSelected && hasDescendants ) ||
 				( isImmediateParentOfSelectedBlock &&


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
This takes us a step closer to fixing the root cause of https://github.com/WordPress/gutenberg/issues/30177

The underlying cause is that `useNestedSettingsUpdate` performs a shallow equality check before updating a block list's settings.

This combined with the way navigation link was passing through a new array for `allowedBlocks` on every render, causing the settings to update, resulted in a cascading render. 

This was compounded for some reason when using the `isDraggingBlocks` selector. Still not entirely sure why that would be, but I'll continue looking into that. It might be that updating the block list settings is causing the inner blocks to re-render, which is also causing the action that updates the dragged blocks to trigger 🤷‍♂️ .

This first step tidies up the nav link block. It might also be worth changing the way `useNestedSettingsUpdate` checks for equality. Some of the props may need more than just shallow equality.

## How has this been tested?
1. Check out this code
2. Revert https://github.com/WordPress/gutenberg/pull/30219 (`git revert 19fa71b`)
3. Dragging a navigation link should work.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
