### PR TITLE
Add a box shadow arround the responsive previews

### DIFF
--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -52,7 +52,7 @@ export default function useResizeCanvas(
 		return deviceWidth < actualWidth ? deviceWidth : actualWidth;
 	};
 
-	const marginValue = () => ( window.innerHeight < 800 ? 36 : 72 );
+	const marginValue = () => ( window.innerHeight < 800 ? 18 : 36 );
 
 	const contentInlineStyles = ( device ) => {
 		const height = device === 'Mobile' ? '768px' : '1024px';
@@ -67,6 +67,7 @@ export default function useResizeCanvas(
 					minHeight: height,
 					maxHeight: height,
 					overflowY: 'auto',
+					boxShadow: '0 1px 6px rgba(0, 0, 0, 0.4)',
 				};
 			default:
 				return null;


### PR DESCRIPTION
Just a small detail that always felt off to me, not sure how you feel about that.

<img width="1440" alt="Capture d’écran 2021-03-26 à 8 19 30 AM" src="https://user-images.githubusercontent.com/272444/112596497-2f584d80-8e0c-11eb-91a7-6f891669c0ea.png">
