### PR TITLE
Make the default padding match the browser's default padding

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -6,7 +6,7 @@
  */
 
 .editor-styles-wrapper {
-	padding: 10px;
+	padding: 8px;
 
 	/**
 	* The following styles revert to the browser defaults overriding the WPAdmin styles.

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -419,7 +419,7 @@ describe( 'Multi-block selection', () => {
 				},
 				{
 					// Move a bit outside the paragraph.
-					x: rect2.x - 10,
+					x: rect2.x - 5,
 					y: rect2.y + rect2.height / 2,
 				},
 			];


### PR DESCRIPTION
I considered several approaches here:

 - Making that padding 0 and adding a styles to all themes making it 0 as well.
 - Adding a padding around the canvas (like we do for tablet/mobile previews)

These options didn't feel great and I just aligned the default padding used with the "body" one, I think it's a sane default that ensures WYSIWYG for themes by default.