### PR TITLE
Block Library - Post Excerpt: Fix toolbar for post excerpt warning

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -63,6 +63,14 @@ function PostExcerptEditor( {
 		} ),
 	} );
 
+	if ( ! postType || ! postId ) {
+		return (
+			<div { ...blockProps}>
+				<Warning>{ __( 'Post excerpt block: no post found.' ) }</Warning>
+			</div>
+		);
+	}
+
 	return (
 		<>
 			<BlockControls>
@@ -146,11 +154,6 @@ export default function PostExcerptEdit( {
 	isSelected,
 	context,
 } ) {
-	if ( ! context.postType || ! context.postId ) {
-		return (
-			<Warning>{ __( 'Post excerpt block: no post found.' ) }</Warning>
-		);
-	}
 	return (
 		<PostExcerptEditor
 			attributes={ attributes }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -40,7 +40,7 @@ function usePostContentExcerpt( wordCount, postId, postType ) {
 	}, [ rawPostContent, wordCount ] );
 }
 
-function PostExcerptEditor( {
+export default function PostExcerptEditor( {
 	attributes: { textAlign, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
@@ -65,8 +65,10 @@ function PostExcerptEditor( {
 
 	if ( ! postType || ! postId ) {
 		return (
-			<div { ...blockProps}>
-				<Warning>{ __( 'Post excerpt block: no post found.' ) }</Warning>
+			<div { ...blockProps }>
+				<Warning>
+					{ __( 'Post excerpt block: no post found.' ) }
+				</Warning>
 			</div>
 		);
 	}
@@ -145,21 +147,5 @@ function PostExcerptEditor( {
 				) }
 			</div>
 		</>
-	);
-}
-
-export default function PostExcerptEdit( {
-	attributes,
-	setAttributes,
-	isSelected,
-	context,
-} ) {
-	return (
-		<PostExcerptEditor
-			attributes={ attributes }
-			setAttributes={ setAttributes }
-			isSelected={ isSelected }
-			context={ context }
-		/>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes https://github.com/WordPress/gutenberg/issues/30279
Moves the warning and wraps it inside a div with blockProps.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Follow the instructions in the issue.

Confirm that the warning now has a block toolbar; that the toolbar is still present when moved to top,
and that the block still works when placed in a post context for example query/loop.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
