### PR TITLE
Make the navigation placeholder clearer.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -276,6 +276,31 @@ $color-control-label-height: 20px;
 		margin-right: $grid-unit-15;
 		height: $button-size; // Prevents jumpiness.
 	}
+
+	// Block title
+	.wp-block-navigation-placeholder__actions__indicator {
+		margin-right: $grid-unit-15;
+		padding: ($grid-unit-15 / 2) 0;
+		align-items: center;
+		justify-content: flex-start;
+		display: none;
+
+		// line up with the icon in the toolbar.
+		margin-left: $grid-unit-05 + $border-width;
+
+		svg {
+			margin-right: $grid-unit-05;
+		}
+
+		.is-vertical & {
+			margin-bottom: $grid-unit-05;
+			margin-left: 0;
+		}
+
+		@include break-small {
+			display: inline-flex;
+		}
+	}
 }
 
 // When block is vertical.
@@ -296,8 +321,14 @@ $color-control-label-height: 20px;
 	font-size: $default-font-size;
 
 	.components-button.components-dropdown-menu__toggle.has-icon {
-		padding: ($grid-unit-15 / 2) $grid-unit-15;
+		padding: ($grid-unit-15 / 2) $grid-unit-05 ($grid-unit-15 / 2) $grid-unit-15;
 		display: flex;
 		flex-direction: row-reverse; // This puts the chevron, which is hidden from screen readers, on the right.
+	}
+
+	// Margins.
+	.components-dropdown,
+	> .components-button {
+		margin-right: $grid-unit-15;
 	}
 }

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -22,7 +22,7 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { chevronDown } from '@wordpress/icons';
+import { navigation, chevronDown, Icon } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -212,6 +212,10 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 		}
 	}, [ isCreatingFromMenu, hasResolvedMenuItems ] );
 
+	const toggleProps = {
+		isPrimary: true,
+		className: 'wp-block-navigation-placeholder__actions__dropdown',
+	};
 	return (
 		<div className="wp-block-navigation-placeholder">
 			<PlaceholderPreview />
@@ -227,11 +231,14 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 						ref={ ref }
 						className="wp-block-navigation-placeholder__actions"
 					>
+						<div className="wp-block-navigation-placeholder__actions__indicator">
+							<Icon icon={ navigation } /> { __( 'Navigation' ) }
+						</div>
 						{ hasMenus ? (
 							<DropdownMenu
 								text={ __( 'Existing menu' ) }
 								icon={ chevronDown }
-								className="wp-block-navigation-placeholder__actions__dropdown"
+								toggleProps={ toggleProps }
 							>
 								{ ( { onClose } ) => (
 									<MenuGroup>
@@ -256,11 +263,15 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 							</DropdownMenu>
 						) : undefined }
 						{ hasPages ? (
-							<Button onClick={ onCreateAllPages }>
+							<Button
+								isPrimary={ hasMenus ? false : true }
+								isTertiary={ hasMenus ? true : false }
+								onClick={ onCreateAllPages }
+							>
 								{ __( 'Add all pages' ) }
 							</Button>
 						) : undefined }
-						<Button onClick={ onCreateEmptyMenu }>
+						<Button isTertiary onClick={ onCreateEmptyMenu }>
 							{ __( 'Start empty' ) }
 						</Button>
 					</div>


### PR DESCRIPTION
## Description

Fixes #30257.

This PR makes the navigation block placeholder clearer, and the buttons more clickable. Before:

<img width="786" alt="Screenshot 2021-03-26 at 09 41 57" src="https://user-images.githubusercontent.com/1204802/112605367-86afeb00-8e17-11eb-9080-8c40498a533c.png">

After:

<img width="756" alt="Screenshot 2021-03-26 at 09 40 16" src="https://user-images.githubusercontent.com/1204802/112605380-89aadb80-8e17-11eb-82d2-a9ad3b7fff14.png">

If no existing menu is present, the "Add all pages" button is primary:

<img width="762" alt="Screenshot 2021-03-26 at 09 39 49" src="https://user-images.githubusercontent.com/1204802/112605416-93344380-8e17-11eb-9b25-9ee3dd5da876.png">

This is the button that you should nearly always be using, so that your pages stay in sync and are added/removed automatically.

## How has this been tested?

Please test horizontal and vertical navigation blocks on desktop and small viewports, verify things look right.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
