### PR TITLE
Try: Darker canvas color.

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -7,6 +7,7 @@ $black: #000;			// Use only when you truly need pure black. For UI, use $gray-90
 $gray-900: #1e1e1e;
 $gray-700: #757575;		// Meets 4.6:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
+$gray-500: #bbb;
 $gray-400: #ccc;
 $gray-300: #ddd;		// Used for most borders.
 $gray-200: #e0e0e0;		// Used sparingly for light borders.

--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -67,6 +67,7 @@ export default function useResizeCanvas(
 					minHeight: height,
 					maxHeight: height,
 					overflowY: 'auto',
+					borderRadius: '2px',
 				};
 			default:
 				return null;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -87,7 +87,7 @@
 }
 
 .edit-post-layout .interface-interface-skeleton__content {
-	background-color: $gray-400;
+	background-color: $gray-500;
 }
 
 .edit-post-layout__inserter-panel {


### PR DESCRIPTION
## Description

Alternative to https://github.com/WordPress/gutenberg/pull/30275

To make the contrast between canvas and preview clearer, this adds a darker color and a border radius. Before:

<img width="1811" alt="Screenshot 2021-03-26 at 09 46 24" src="https://user-images.githubusercontent.com/1204802/112607734-c972c280-8e19-11eb-9b3b-b65ce4fc6361.png">

After:

<img width="1811" alt="Screenshot 2021-03-26 at 09 56 14" src="https://user-images.githubusercontent.com/1204802/112607754-cc6db300-8e19-11eb-8c59-b3107032185f.png">

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
