### PR TITLE
Public API: Remove small APIs deprecated in WordPress 5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12530,7 +12530,6 @@
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/data-controls": "file:packages/data-controls",
-				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -649,25 +649,6 @@ _Returns_
 
 -   `boolean`: Whether there is a previous edit or not.
 
-<a name="hasUploadPermissions" href="#hasUploadPermissions">#</a> **hasUploadPermissions**
-
-> **Deprecated** since 5.0. Callers should use the more generic `canUser()` selector instead of `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
-
-Returns whether the current user can upload media.
-
-Calling this may trigger an OPTIONS request to the REST API via the
-`canUser()` resolver.
-
-<https://developer.wordpress.org/rest-api/reference/>
-
-_Parameters_
-
--   _state_ `Object`: Data state.
-
-_Returns_
-
--   `boolean`: Whether or not the user can upload media. Defaults to `true` if the OPTIONS request is being made.
-
 <a name="isAutosavingEntityRecord" href="#isAutosavingEntityRecord">#</a> **isAutosavingEntityRecord**
 
 Returns true if the specified entity record is autosaving, and false otherwise.

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -31,7 +31,6 @@
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/data": "file:../data",
 		"@wordpress/data-controls": "file:../data-controls",
-		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -7,7 +7,6 @@ import { find, includes, get, hasIn, compact, uniq } from 'lodash';
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import deprecated from '@wordpress/deprecated';
 import { controls } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
 /**
@@ -284,20 +283,6 @@ export function* getEmbedPreview( url ) {
 		// Embed API 404s if the URL cannot be embedded, so we have to catch the error from the apiRequest here.
 		yield receiveEmbedPreview( url, false );
 	}
-}
-
-/**
- * Requests Upload Permissions from the REST API.
- *
- * @deprecated since 5.0. Callers should use the more generic `canUser()` selector instead of
- *            `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
- */
-export function* hasUploadPermissions() {
-	deprecated( "select( 'core' ).hasUploadPermissions()", {
-		since: '5.2',
-		alternative: "select( 'core' ).canUser( 'create', 'media' )",
-	} );
-	yield* canUser( 'create', 'media' );
 }
 
 /**

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { set, map, find, get, filter, compact, defaultTo } from 'lodash';
+import { set, map, find, get, filter, compact } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { createRegistrySelector } from '@wordpress/data';
-import deprecated from '@wordpress/deprecated';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -614,30 +613,6 @@ export function isPreviewEmbedFallback( state, url ) {
 		return false;
 	}
 	return preview.html === oEmbedLinkCheck;
-}
-
-/**
- * Returns whether the current user can upload media.
- *
- * Calling this may trigger an OPTIONS request to the REST API via the
- * `canUser()` resolver.
- *
- * https://developer.wordpress.org/rest-api/reference/
- *
- * @deprecated since 5.0. Callers should use the more generic `canUser()` selector instead of
- *             `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
- *
- * @param {Object} state Data state.
- *
- * @return {boolean} Whether or not the user can upload media. Defaults to `true` if the OPTIONS
- *                   request is being made.
- */
-export function hasUploadPermissions( state ) {
-	deprecated( "select( 'core' ).hasUploadPermissions()", {
-		since: '5.2',
-		alternative: "select( 'core' ).canUser( 'create', 'media' )",
-	} );
-	return defaultTo( canUser( state, 'create', 'media' ), true );
 }
 
 /**

--- a/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
@@ -3,7 +3,6 @@
  */
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch } from '@wordpress/data';
-import deprecated from '@wordpress/deprecated';
 import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 
 /**
@@ -41,12 +40,3 @@ function VisualEditorGlobalKeyboardShortcuts() {
 }
 
 export default VisualEditorGlobalKeyboardShortcuts;
-
-export function EditorGlobalKeyboardShortcuts() {
-	deprecated( 'EditorGlobalKeyboardShortcuts', {
-		since: '5.2',
-		alternative: 'VisualEditorGlobalKeyboardShortcuts',
-	} );
-
-	return <VisualEditorGlobalKeyboardShortcuts />;
-}

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -5,10 +5,7 @@ export * from './autocompleters';
 export { default as AutosaveMonitor } from './autosave-monitor';
 export { default as DocumentOutline } from './document-outline';
 export { default as DocumentOutlineCheck } from './document-outline/check';
-export {
-	default as VisualEditorGlobalKeyboardShortcuts,
-	EditorGlobalKeyboardShortcuts,
-} from './global-keyboard-shortcuts/visual-editor-shortcuts';
+export { default as VisualEditorGlobalKeyboardShortcuts } from './global-keyboard-shortcuts/visual-editor-shortcuts';
 export { default as TextEditorGlobalKeyboardShortcuts } from './global-keyboard-shortcuts/text-editor-shortcuts';
 export { default as EditorKeyboardShortcutsRegister } from './global-keyboard-shortcuts/register-shortcuts';
 export { default as EditorHistoryRedo } from './editor-history/redo';


### PR DESCRIPTION
This PR raises the question of how long should it take to remove deprecated JS APIs. Unlike PHP these can't be supported forever because they have an impact on users, they keep useless Kbs around that combine impact performance. 

In This PR I'm removing 5.2 deprecations which was released almost two years ago and since we had 5 major releases. 
I think removing an old API should be done carefully by thinking of the impact of each API. 

For the APIs removed in this PR particularly, I think the potential impact is negligible. 