### PR TITLE
Apply mover tweaks to navigation and widgets.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -557,7 +557,9 @@
 // Position mover arrows for both toolbars.
 .block-editor-block-contextual-toolbar,
 .edit-post-header-toolbar__block-toolbar,
-.edit-site-header-toolbar__block-toolbar {
+.edit-site-header-toolbar__block-toolbar,
+.edit-navigation-layout__block-toolbar,
+.edit-widgets-header__block-toolbar {
 
 	.block-editor-block-mover:not(.is-horizontal) {
 		// Position SVGs.


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/30242#discussion_r602123956.

This PR applies the mover positioning rules also to the navigation and widget screens:

<img width="767" alt="Screenshot 2021-03-26 at 10 30 12" src="https://user-images.githubusercontent.com/1204802/112611979-ba424380-8e1e-11eb-88bd-89d7384c5179.png">

<img width="671" alt="Screenshot 2021-03-26 at 10 30 08" src="https://user-images.githubusercontent.com/1204802/112611986-bb737080-8e1e-11eb-8b83-4a2b66687d54.png">

I couldn't see the block toolbar for widgets at all on the mobile breakpoint:

<img width="733" alt="Screenshot 2021-03-26 at 10 31 53" src="https://user-images.githubusercontent.com/1204802/112612048-c62e0580-8e1e-11eb-946e-4f9508329782.png">

But they are no worse on the desktop

<img width="499" alt="Screenshot 2021-03-26 at 10 31 58" src="https://user-images.githubusercontent.com/1204802/112612000-bd3d3400-8e1e-11eb-8aa3-d19570802f7e.png">

## How has this been tested?

Observe that mover arrows look correctly positioned on navigation screen, and if you know how to, on the widgets screen.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
