### PR TITLE
In-between inserter: use useRefCallback, use showInsertionPoint

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
 import { useViewportMatch, useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -67,21 +66,14 @@ function Root( { className, children } ) {
 }
 
 export default function BlockList( { className, __experimentalLayout } ) {
-	const ref = useRef();
-
 	usePreParsePatterns();
-
 	return (
-		<>
+		<InsertionPoint>
 			<BlockPopover />
-			<InsertionPoint>
-				<Root className={ className } containerRef={ ref }>
-					<BlockListItems
-						__experimentalLayout={ __experimentalLayout }
-					/>
-				</Root>
-			</InsertionPoint>
-		</>
+			<Root className={ className }>
+				<BlockListItems __experimentalLayout={ __experimentalLayout } />
+			</Root>
+		</InsertionPoint>
 	);
 }
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -16,7 +16,7 @@ import { useViewportMatch, useMergeRefs } from '@wordpress/compose';
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import useBlockDropZone from '../use-block-drop-zone';
-import useInsertionPoint from './insertion-point';
+import InsertionPoint from './insertion-point';
 import { useInBetweenInserter } from './use-in-between-inserter';
 import BlockPopover from './block-popover';
 import { store as blockEditorStore } from '../../store';
@@ -25,7 +25,6 @@ import { LayoutProvider, defaultLayout } from './layout';
 
 export default function BlockList( { className, __experimentalLayout } ) {
 	const ref = useRef();
-	const insertionPoint = useInsertionPoint( ref );
 	usePreParsePatterns();
 
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -51,7 +50,7 @@ export default function BlockList( { className, __experimentalLayout } ) {
 
 	return (
 		<>
-			{ insertionPoint }
+			<InsertionPoint />
 			<BlockPopover />
 			<div
 				ref={ useMergeRefs( [

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -17,6 +17,7 @@ import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import useBlockDropZone from '../use-block-drop-zone';
 import useInsertionPoint from './insertion-point';
+import { useInBetweenInserter } from './use-in-between-inserter';
 import BlockPopover from './block-popover';
 import { store as blockEditorStore } from '../../store';
 import { usePreParsePatterns } from '../../utils/pre-parse-patterns';
@@ -53,7 +54,11 @@ export default function BlockList( { className, __experimentalLayout } ) {
 			{ insertionPoint }
 			<BlockPopover />
 			<div
-				ref={ useMergeRefs( [ ref, useBlockDropZone() ] ) }
+				ref={ useMergeRefs( [
+					ref,
+					useBlockDropZone(),
+					useInBetweenInserter(),
+				] ) }
 				className={ classnames(
 					'block-editor-block-list__layout is-root-container',
 					className,

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -23,10 +23,7 @@ import { store as blockEditorStore } from '../../store';
 import { usePreParsePatterns } from '../../utils/pre-parse-patterns';
 import { LayoutProvider, defaultLayout } from './layout';
 
-export default function BlockList( { className, __experimentalLayout } ) {
-	const ref = useRef();
-	usePreParsePatterns();
-
+function Root( { className, children } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const {
 		isTyping,
@@ -47,30 +44,43 @@ export default function BlockList( { className, __experimentalLayout } ) {
 			isNavigationMode: _isNavigationMode(),
 		};
 	}, [] );
+	return (
+		<div
+			ref={ useMergeRefs( [
+				useBlockDropZone(),
+				useInBetweenInserter(),
+			] ) }
+			className={ classnames(
+				'block-editor-block-list__layout is-root-container',
+				className,
+				{
+					'is-typing': isTyping,
+					'is-outline-mode': isOutlineMode,
+					'is-focus-mode': isFocusMode && isLargeViewport,
+					'is-navigate-mode': isNavigationMode,
+				}
+			) }
+		>
+			{ children }
+		</div>
+	);
+}
+
+export default function BlockList( { className, __experimentalLayout } ) {
+	const ref = useRef();
+
+	usePreParsePatterns();
 
 	return (
 		<>
-			<InsertionPoint />
 			<BlockPopover />
-			<div
-				ref={ useMergeRefs( [
-					ref,
-					useBlockDropZone(),
-					useInBetweenInserter(),
-				] ) }
-				className={ classnames(
-					'block-editor-block-list__layout is-root-container',
-					className,
-					{
-						'is-typing': isTyping,
-						'is-outline-mode': isOutlineMode,
-						'is-focus-mode': isFocusMode && isLargeViewport,
-						'is-navigate-mode': isNavigationMode,
-					}
-				) }
-			>
-				<BlockListItems __experimentalLayout={ __experimentalLayout } />
-			</div>
+			<InsertionPoint>
+				<Root className={ className } containerRef={ ref }>
+					<BlockListItems
+						__experimentalLayout={ __experimentalLayout }
+					/>
+				</Root>
+			</InsertionPoint>
 		</>
 	);
 }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -7,13 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	useState,
-	useEffect,
-	useCallback,
-	useRef,
-	useMemo,
-} from '@wordpress/element';
+import { useState, useCallback, useRef, useMemo } from '@wordpress/element';
 import { Popover } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
 
@@ -260,14 +254,13 @@ function InsertionPointPopover( {
 }
 
 export default function useInsertionPoint( ref ) {
-	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
-	const [ inserterClientId, setInserterClientId ] = useState( null );
 	const {
 		isMultiSelecting,
 		isInserterVisible,
 		selectedClientId,
 		selectedRootClientId,
+		isInserterShown,
 	} = useSelect( ( select ) => {
 		const {
 			isMultiSelecting: _isMultiSelecting,
@@ -284,110 +277,9 @@ export default function useInsertionPoint( ref ) {
 			isInserterVisible: isBlockInsertionPointVisible(),
 			selectedClientId: order[ insertionPoint.index - 1 ],
 			selectedRootClientId: insertionPoint.rootClientId,
+			isInserterShown: insertionPoint.withInserter,
 		};
 	}, [] );
-	const { getBlockListSettings } = useSelect( blockEditorStore );
-
-	const onMouseMove = useCallback(
-		( event ) => {
-			if (
-				! event.target.classList.contains(
-					'block-editor-block-list__layout'
-				)
-			) {
-				if ( isInserterShown ) {
-					setIsInserterShown( false );
-				}
-				return;
-			}
-
-			let rootClientId;
-			if ( ! event.target.classList.contains( 'is-root-container' ) ) {
-				const blockElement = !! event.target.getAttribute(
-					'data-block'
-				)
-					? event.target
-					: event.target.closest( '[data-block]' );
-				rootClientId = blockElement.getAttribute( 'data-block' );
-			}
-
-			const orientation =
-				getBlockListSettings( rootClientId )?.orientation || 'vertical';
-			const rect = event.target.getBoundingClientRect();
-			const offsetTop = event.clientY - rect.top;
-			const offsetLeft = event.clientX - rect.left;
-
-			const children = Array.from( event.target.children );
-			const nextElement = children.find( ( blockEl ) => {
-				return (
-					( blockEl.classList.contains( 'wp-block' ) &&
-						orientation === 'vertical' &&
-						blockEl.offsetTop > offsetTop ) ||
-					( blockEl.classList.contains( 'wp-block' ) &&
-						orientation === 'horizontal' &&
-						blockEl.offsetLeft > offsetLeft )
-				);
-			} );
-
-			let element = nextElement
-				? children[ children.indexOf( nextElement ) - 1 ]
-				: children[ children.length - 1 ];
-
-			if ( ! element ) {
-				return;
-			}
-
-			// The block may be in an alignment wrapper, so check the first direct
-			// child if the element has no ID.
-			if ( ! element.id ) {
-				element = element.firstElementChild;
-
-				if ( ! element ) {
-					return;
-				}
-			}
-
-			const clientId = element.id.slice( 'block-'.length );
-
-			if ( ! clientId ) {
-				return;
-			}
-
-			const elementRect = element.getBoundingClientRect();
-
-			if (
-				( orientation === 'horizontal' &&
-					( event.clientY > elementRect.bottom ||
-						event.clientY < elementRect.top ) ) ||
-				( orientation === 'vertical' &&
-					( event.clientX > elementRect.right ||
-						event.clientX < elementRect.left ) )
-			) {
-				if ( isInserterShown ) {
-					setIsInserterShown( false );
-				}
-				return;
-			}
-
-			setIsInserterShown( true );
-			setInserterClientId( clientId );
-		},
-		[ isInserterShown, setIsInserterShown, setInserterClientId ]
-	);
-
-	const enableMouseMove = ! isInserterForced && ! isMultiSelecting;
-
-	useEffect( () => {
-		if ( ! enableMouseMove ) {
-			return;
-		}
-
-		ref.current.addEventListener( 'mousemove', onMouseMove );
-
-		return () => {
-			ref.current.removeEventListener( 'mousemove', onMouseMove );
-		};
-	}, [ enableMouseMove, onMouseMove ] );
 
 	const isVisible = isInserterShown || isInserterForced || isInserterVisible;
 
@@ -395,17 +287,12 @@ export default function useInsertionPoint( ref ) {
 		! isMultiSelecting &&
 		isVisible && (
 			<InsertionPointPopover
-				clientId={
-					isInserterVisible ? selectedClientId : inserterClientId
-				}
+				clientId={ selectedClientId }
 				selectedRootClientId={ selectedRootClientId }
 				isInserterShown={ isInserterShown }
 				isInserterForced={ isInserterForced }
 				setIsInserterForced={ ( value ) => {
 					setIsInserterForced( value );
-					if ( ! value ) {
-						setIsInserterShown( value );
-					}
 				} }
 				showInsertionPoint={ isInserterVisible }
 			/>

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -253,7 +253,7 @@ function InsertionPointPopover( {
 	/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 }
 
-export default function useInsertionPoint( ref ) {
+export default function InsertionPoint( { containerRef } ) {
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
 	const {
 		isMultiSelecting,

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -271,13 +271,15 @@ export default function useInsertionPoint( ref ) {
 
 		const insertionPoint = getBlockInsertionPoint();
 		const order = getBlockOrder( insertionPoint.rootClientId );
+		const _isInserterVisible = isBlockInsertionPointVisible();
 
 		return {
 			isMultiSelecting: _isMultiSelecting(),
-			isInserterVisible: isBlockInsertionPointVisible(),
+			isInserterVisible: _isInserterVisible,
 			selectedClientId: order[ insertionPoint.index - 1 ],
 			selectedRootClientId: insertionPoint.rootClientId,
-			isInserterShown: insertionPoint.withInserter,
+			isInserterShown:
+				_isInserterVisible && insertionPoint.__unstableWithInserter,
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -107,8 +107,8 @@ export function useInBetweenInserter() {
 				}
 
 				showInsertionPoint(
-					getBlockRootClientId( clientId ),
-					getBlockIndex( clientId ),
+					rootClientId,
+					getBlockIndex( clientId, rootClientId ),
 					true
 				);
 			}

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -1,0 +1,131 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export function useInBetweenInserter() {
+	const isMultiSelecting = useSelect(
+		( select ) => select( blockEditorStore ).isMultiSelecting(),
+		[]
+	);
+	const {
+		getBlockListSettings,
+		getBlockRootClientId,
+		getBlockIndex,
+	} = useSelect( blockEditorStore );
+	const { showInsertionPoint, hideInsertionPoint } = useDispatch(
+		blockEditorStore
+	);
+	return useRefEffect(
+		( node ) => {
+			if ( isMultiSelecting ) {
+				return;
+			}
+
+			function onMouseMove( event ) {
+				if (
+					! event.target.classList.contains(
+						'block-editor-block-list__layout'
+					)
+				) {
+					hideInsertionPoint();
+					return;
+				}
+
+				let rootClientId;
+				if (
+					! event.target.classList.contains( 'is-root-container' )
+				) {
+					const blockElement = !! event.target.getAttribute(
+						'data-block'
+					)
+						? event.target
+						: event.target.closest( '[data-block]' );
+					rootClientId = blockElement.getAttribute( 'data-block' );
+				}
+
+				const orientation =
+					getBlockListSettings( rootClientId )?.orientation ||
+					'vertical';
+				const rect = event.target.getBoundingClientRect();
+				const offsetTop = event.clientY - rect.top;
+				const offsetLeft = event.clientX - rect.left;
+
+				const children = Array.from( event.target.children );
+				const nextElement = children.find( ( blockEl ) => {
+					return (
+						( blockEl.classList.contains( 'wp-block' ) &&
+							orientation === 'vertical' &&
+							blockEl.offsetTop > offsetTop ) ||
+						( blockEl.classList.contains( 'wp-block' ) &&
+							orientation === 'horizontal' &&
+							blockEl.offsetLeft > offsetLeft )
+					);
+				} );
+
+				let element = nextElement || children[ children.length - 1 ];
+
+				if ( ! element ) {
+					return;
+				}
+
+				// The block may be in an alignment wrapper, so check the first direct
+				// child if the element has no ID.
+				if ( ! element.id ) {
+					element = element.firstElementChild;
+
+					if ( ! element ) {
+						return;
+					}
+				}
+
+				const clientId = element.id.slice( 'block-'.length );
+
+				if ( ! clientId ) {
+					return;
+				}
+
+				const elementRect = element.getBoundingClientRect();
+
+				if (
+					( orientation === 'horizontal' &&
+						( event.clientY > elementRect.bottom ||
+							event.clientY < elementRect.top ) ) ||
+					( orientation === 'vertical' &&
+						( event.clientX > elementRect.right ||
+							event.clientX < elementRect.left ) )
+				) {
+					hideInsertionPoint();
+					return;
+				}
+
+				showInsertionPoint(
+					getBlockRootClientId( clientId ),
+					getBlockIndex( clientId ),
+					true
+				);
+			}
+
+			node.addEventListener( 'mousemove', onMouseMove );
+
+			return () => {
+				node.removeEventListener( 'mousemove', onMouseMove );
+			};
+		},
+		[
+			isMultiSelecting,
+			getBlockListSettings,
+			getBlockRootClientId,
+			getBlockIndex,
+			showInsertionPoint,
+			hideInsertionPoint,
+		]
+	);
+}

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -4,33 +4,39 @@
 import { useRefEffect } from '@wordpress/compose';
 
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { InsertionPointOpenRef } from './insertion-point';
 
 export function useInBetweenInserter() {
-	const isMultiSelecting = useSelect(
-		( select ) => select( blockEditorStore ).isMultiSelecting(),
-		[]
-	);
+	const openRef = useContext( InsertionPointOpenRef );
 	const {
+		getBlockInsertionPoint,
 		getBlockListSettings,
 		getBlockRootClientId,
 		getBlockIndex,
 		isBlockInsertionPointVisible,
+		isMultiSelecting,
 	} = useSelect( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } = useDispatch(
 		blockEditorStore
 	);
+
 	return useRefEffect(
 		( node ) => {
-			if ( isMultiSelecting ) {
-				return;
-			}
-
 			function onMouseMove( event ) {
+				if ( openRef.current ) {
+					return;
+				}
+
+				if ( isMultiSelecting() ) {
+					return;
+				}
+
 				if (
 					! event.target.classList.contains(
 						'block-editor-block-list__layout'
@@ -125,10 +131,13 @@ export function useInBetweenInserter() {
 			};
 		},
 		[
-			isMultiSelecting,
+			openRef,
+			getBlockInsertionPoint,
 			getBlockListSettings,
 			getBlockRootClientId,
 			getBlockIndex,
+			isBlockInsertionPointVisible,
+			isMultiSelecting,
 			showInsertionPoint,
 			hideInsertionPoint,
 		]

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -19,6 +19,7 @@ export function useInBetweenInserter() {
 		getBlockListSettings,
 		getBlockRootClientId,
 		getBlockIndex,
+		isBlockInsertionPointVisible,
 	} = useSelect( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } = useDispatch(
 		blockEditorStore
@@ -35,7 +36,9 @@ export function useInBetweenInserter() {
 						'block-editor-block-list__layout'
 					)
 				) {
-					hideInsertionPoint();
+					if ( isBlockInsertionPointVisible() ) {
+						hideInsertionPoint();
+					}
 					return;
 				}
 
@@ -102,14 +105,16 @@ export function useInBetweenInserter() {
 						( event.clientX > elementRect.right ||
 							event.clientX < elementRect.left ) )
 				) {
-					hideInsertionPoint();
+					if ( isBlockInsertionPointVisible() ) {
+						hideInsertionPoint();
+					}
 					return;
 				}
 
 				showInsertionPoint(
 					rootClientId,
 					getBlockIndex( clientId, rootClientId ),
-					true
+					{ __unstableWithInserter: true }
 				);
 			}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -630,7 +630,11 @@ export function* insertBlocks(
  *
  * @return {Object} Action object.
  */
-export function showInsertionPoint( rootClientId, index, __unstableOptions ) {
+export function showInsertionPoint(
+	rootClientId,
+	index,
+	__unstableOptions = {}
+) {
 	const { __unstableWithInserter } = __unstableOptions;
 	return {
 		type: 'SHOW_INSERTION_POINT',

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -626,14 +626,16 @@ export function* insertBlocks(
  * @param {?string} rootClientId Optional root client ID of block list on
  *                               which to insert.
  * @param {?number} index        Index at which block should be inserted.
+ * @param {boolean} withInserter Wether or not to show an inserter button.
  *
  * @return {Object} Action object.
  */
-export function showInsertionPoint( rootClientId, index ) {
+export function showInsertionPoint( rootClientId, index, withInserter ) {
 	return {
 		type: 'SHOW_INSERTION_POINT',
 		rootClientId,
 		index,
+		withInserter,
 	};
 }
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -626,16 +626,17 @@ export function* insertBlocks(
  * @param {?string} rootClientId Optional root client ID of block list on
  *                               which to insert.
  * @param {?number} index        Index at which block should be inserted.
- * @param {boolean} withInserter Wether or not to show an inserter button.
+ * @param {Object}  __unstableOptions Wether or not to show an inserter button.
  *
  * @return {Object} Action object.
  */
-export function showInsertionPoint( rootClientId, index, withInserter ) {
+export function showInsertionPoint( rootClientId, index, __unstableOptions ) {
+	const { __unstableWithInserter } = __unstableOptions;
 	return {
 		type: 'SHOW_INSERTION_POINT',
 		rootClientId,
 		index,
-		withInserter,
+		__unstableWithInserter,
 	};
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1405,8 +1405,8 @@ export function blocksMode( state = {}, action ) {
 export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
 		case 'SHOW_INSERTION_POINT':
-			const { rootClientId, index } = action;
-			return { rootClientId, index };
+			const { rootClientId, index, withInserter } = action;
+			return { rootClientId, index, withInserter };
 
 		case 'HIDE_INSERTION_POINT':
 			return null;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1405,8 +1405,8 @@ export function blocksMode( state = {}, action ) {
 export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
 		case 'SHOW_INSERTION_POINT':
-			const { rootClientId, index, withInserter } = action;
-			return { rootClientId, index, withInserter };
+			const { rootClientId, index, __unstableWithInserter } = action;
+			return { rootClientId, index, __unstableWithInserter };
 
 		case 'HIDE_INSERTION_POINT':
 			return null;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

I'm making this change to make the insertion point easier to work with for #29933 and #30153.

This PR changes the in-between inserter logic (on mouse move) to use the inserter point API instead of directly passing data to the inserter point itself. As a result, the event handler can be separated from the inserter point (just like the main inserter and drop logic is) and the insertion point only needs to look at one data point instead of merging two. We can now also use `useRefCallback`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Try the in-between inserter by moving the mouse between blocks. Click the plus icon, navigate the popover, insert a block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
