### PR TITLE
Block Library - Navigation: Fix arrow inheritance, polish

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -12,9 +12,10 @@
  */
 
 // Show submenus above the sibling inserter.
-.has-child {
+.wp-block-navigation .has-child {
 	cursor: pointer;
 
+	.submenu-container,
 	.wp-block-navigation-link__container {
 		z-index: z-index(".has-child .wp-block-navigation-link__container");
 	}

--- a/packages/block-library/src/navigation-link/icons.js
+++ b/packages/block-library/src/navigation-link/icons.js
@@ -11,10 +11,6 @@ export const ItemSubmenuIcon = () => (
 		viewBox="0 0 12 12"
 		fill="none"
 	>
-		<Path
-			d="M1.50002 4L6.00002 8L10.5 4"
-			stroke="#000000"
-			strokeWidth="1.5"
-		/>
+		<Path d="M1.50002 4L6.00002 8L10.5 4" strokeWidth="1.5" />
 	</SVG>
 );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -91,7 +91,7 @@ function block_core_navigation_link_build_css_font_sizes( $context ) {
  * @return string
  */
 function block_core_navigation_link_render_submenu_icon() {
-	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke="#000000" stroke-width="1.5"></path></svg>';
+	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
 }
 
 /**

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -82,7 +82,6 @@
 
 		.submenu-container,
 		.wp-block-navigation-link__container {
-			border: 1px solid rgba(0, 0, 0, 0.15);
 			background-color: inherit;
 			color: inherit;
 			position: absolute;
@@ -115,13 +114,11 @@
 			}
 
 			@include break-medium {
-				left: 1.5em;
-
 				// Nested submenus sit to the left on large breakpoints.
 				.submenu-container,
 				.wp-block-navigation-link__container {
 					left: 100%;
-					top: -$border-width;
+					top: 0;
 
 					// Prevent the menu from disappearing when the mouse is over the gap
 					&::before {
@@ -190,5 +187,11 @@
 		// several times, so care needs to be taken.
 		background-color: #fff;
 		color: #000;
+		border: 1px solid rgba(0, 0, 0, 0.15);
+
+		.submenu-container,
+		.wp-block-navigation-link__container {
+			top: -1px;
+		}
 	}
 }

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -15,6 +15,12 @@
 		}
 	}
 
+	// Margin when justified right or space-between.
+	.wp-block-navigation__container > .wp-block-pages-list__item:last-child,
+	.wp-block-navigation__container > .wp-block-navigation-link:last-child {
+		margin-right: 0;
+	}
+
 	// Menu item link.
 	.wp-block-pages-list__item__link,
 	.wp-block-navigation-link__content {


### PR DESCRIPTION
## Description

This PR does a few things. It fixes a small regression where increased specificity of styles meant the submenu was now again overlapped by the sibling inserter. Before:

<img width="1109" alt="Screenshot 2021-03-26 at 11 36 20" src="https://user-images.githubusercontent.com/1204802/112621289-db5c6180-8e29-11eb-8421-503428d37280.png">

After:

<img width="993" alt="Screenshot 2021-03-26 at 11 39 22" src="https://user-images.githubusercontent.com/1204802/112621298-deefe880-8e29-11eb-8a36-371829bf3546.png">

It fixes an issue with a hardcoded color in the chevron SVG, which meant colors weren't inherited:
 
<img width="530" alt="Screenshot 2021-03-26 at 11 31 39" src="https://user-images.githubusercontent.com/1204802/112621380-f5963f80-8e29-11eb-8ea9-5bac442fe095.png">

After:

<img width="1065" alt="Screenshot 2021-03-26 at 11 39 30" src="https://user-images.githubusercontent.com/1204802/112621401-fa5af380-8e29-11eb-9139-2712c1d374e7.png">

It changes it so that the border on submenus is only present if you haven't defined a color. I would expect future customization options on submenu borders, (see also #29963).

It removes a left value from the submenu, which meant text did not align vertically:

<img width="946" alt="Screenshot 2021-03-26 at 11 51 02" src="https://user-images.githubusercontent.com/1204802/112621669-4f970500-8e2a-11eb-8051-c2198efab84d.png">



## How has this been tested?

Please test a navigation menu with submenus, ideally including also a page list and a bunch of pages / subpages published on your site.

Please also verify this doesn't regress anything in the navigation screen.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
