### PR TITLE
Blocks: Introduce registerBlockTypeFromMetadata API

### DIFF
--- a/bin/plugin/commands/common.js
+++ b/bin/plugin/commands/common.js
@@ -116,6 +116,7 @@ function calculateVersionBumpFromChangelog(
 		if (
 			lineNormalized.startsWith( '### deprecation' ) ||
 			lineNormalized.startsWith( '### enhancement' ) ||
+			lineNormalized.startsWith( '### new api' ) ||
 			lineNormalized.startsWith( '### new feature' )
 		) {
 			versionBump = 'minor';

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -438,7 +438,7 @@ return array(
 
 ## Internationalization
 
-WordPress string discovery automatically will translate fields marked in the documentation as translatable using the `textdomain` property when specified in the `block.json` file. In that case, localized properties will be automatically wrapped in `_x` function calls on the backend of WordPress when executing `register_block_type_from_metadata`. These translations are added as an inline script to the `wp-block-library` script handle in WordPress core or to the plugin's script handle.
+WordPress string discovery system can automatically translate fields marked in this document as translatable. First, you need to set the `textdomain` property in the `block.json` file that provides block metadata.
 
 **Example:**
 
@@ -451,18 +451,39 @@ WordPress string discovery automatically will translate fields marked in the doc
 }
 ```
 
-The way `register_block_type_from_metadata` processes translatable values is roughly equivalent to:
+### PHP
+
+In PHP, localized properties will be automatically wrapped in `_x` function calls on the backend of WordPress when executing `register_block_type_from_metadata`. These translations get added as an inline script to the plugin's script handle or to the `wp-block-library` script handle in WordPress core.
+
+The way `register_block_type_from_metadata` processes translatable values is roughly equivalent to the following code snippet:
 
 ```php
 <?php
 $metadata = array(
 	'title'       => _x( 'My block', 'block title', 'my-plugin' ),
 	'description' => _x( 'My block is fantastic!', 'block description', 'my-plugin' ),
-	'keywords'    => array( _x( 'fantastic', 'block keywords', 'my-plugin' ) ),
+	'keywords'    => array( _x( 'fantastic', 'block keyword', 'my-plugin' ) ),
 );
 ```
 
 Implementation follows the existing [get_plugin_data](https://codex.wordpress.org/Function_Reference/get_plugin_data) function which parses the plugin contents to retrieve the plugin’s metadata, and it applies translations dynamically.
+
+### JavaScript
+
+In JavaScript, you need to use `registerBlockTypeFromMetadata` method from `@wordpress/blocks` package to process loaded block metadata. All localized properties get automatically wrapped in `_x` (from `@wordpress/i18n` package) function calls similar to how it works in PHP.
+
+**Example:**
+
+```js
+import { registerBlockTypeFromMetadata } from '@wordpress/blocks';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockTypeFromMetadata( metadata, {
+	edit: Edit,
+	// ...other client-side settings
+} );
+```
 
 ## Backward Compatibility
 

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -4,12 +4,11 @@
 import '@wordpress/core-data';
 import '@wordpress/block-editor';
 import {
-	registerBlockType,
+	registerBlockTypeFromMetadata,
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
 	setGroupingBlockName,
-	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
 
 /**
@@ -106,10 +105,7 @@ const registerBlock = ( block ) => {
 		return;
 	}
 	const { metadata, settings, name } = block;
-	if ( metadata ) {
-		unstable__bootstrapServerSideBlockDefinitions( { [ name ]: metadata } );
-	}
-	registerBlockType( name, settings );
+	registerBlockTypeFromMetadata( { name, ...metadata }, settings );
 };
 
 /**

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -10,6 +10,7 @@ import { sortBy } from 'lodash';
 import {
 	hasBlockSupport,
 	registerBlockType,
+	registerBlockTypeFromMetadata,
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
@@ -127,10 +128,13 @@ const registerBlock = ( block ) => {
 		return;
 	}
 	const { metadata, settings, name } = block;
-	registerBlockType( name, {
-		...metadata,
-		...settings,
-	} );
+	registerBlockTypeFromMetadata(
+		{
+			name,
+			...metadata,
+		},
+		settings
+	);
 };
 
 /**

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New API
+
+-   `registerBlockTypeFromMetadata` method can be used to register a block type using the metadata loaded from `block.json` file ([#30293](https://github.com/WordPress/gutenberg/pull/30293)).
+
 ## 8.0.0 (2021-03-17)
 
 ### Breaking Change

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -726,6 +726,7 @@ _Parameters_
 
 -   _metadata_ `Object`: Block metadata loaded from `block.json`.
 -   _metadata.name_ `string`: Block name.
+-   _metadata.textdomain_ `string`: Textdomain to use with translations.
 -   _additionalSettings_ `Object`: Additional block settings.
 
 _Returns_

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -713,6 +713,25 @@ _Returns_
 
 -   `?WPBlock`: The block, if it has been successfully registered; otherwise `undefined`.
 
+<a name="registerBlockTypeFromMetadata" href="#registerBlockTypeFromMetadata">#</a> **registerBlockTypeFromMetadata**
+
+Registers a new block provided from metadata stored in `block.json` file.
+It uses `registerBlockType` internally.
+
+_Related_
+
+-   registerBlockType
+
+_Parameters_
+
+-   _metadata_ `Object`: Block metadata loaded from `block.json`.
+-   _metadata.name_ `string`: Block name.
+-   _additionalSettings_ `Object`: Additional block settings.
+
+_Returns_
+
+-   `?WPBlock`: The block, if it has been successfully registered; otherwise `undefined`.
+
 <a name="registerBlockVariation" href="#registerBlockVariation">#</a> **registerBlockVariation**
 
 Registers a new block variation for the given block type.

--- a/packages/blocks/src/api/i18n-block.json
+++ b/packages/blocks/src/api/i18n-block.json
@@ -1,12 +1,17 @@
 {
 	"title": "block title",
 	"description": "block description",
-	"keywords": [
-		"block keyword"
-	],
+	"keywords": [ "block keyword" ],
 	"styles": [
 		{
 			"label": "block style label"
+		}
+	],
+	"variations": [
+		{
+			"title": "block variation title",
+			"description": "block variation description",
+			"keywords": [ "block variation keyword" ]
 		}
 	]
 }

--- a/packages/blocks/src/api/i18n-block.json
+++ b/packages/blocks/src/api/i18n-block.json
@@ -1,0 +1,12 @@
+{
+	"title": "block title",
+	"description": "block description",
+	"keywords": [
+		"block keyword"
+	],
+	"styles": [
+		{
+			"label": "block style label"
+		}
+	]
+}

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -108,6 +108,7 @@ export { getCategories, setCategories, updateCategory } from './categories';
 // children of another block.
 export {
 	registerBlockType,
+	registerBlockTypeFromMetadata,
 	registerBlockCollection,
 	unregisterBlockType,
 	setFreeformContentHandlerName,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -387,6 +387,7 @@ export function registerBlockTypeFromMetadata(
 	additionalSettings
 ) {
 	const allowedFields = [
+		'apiVersion',
 		'title',
 		'category',
 		'parent',
@@ -399,7 +400,7 @@ export function registerBlockTypeFromMetadata(
 		'supports',
 		'styles',
 		'example',
-		'apiVersion',
+		'variations',
 	];
 
 	const settings = pick( metadata, allowedFields );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -5,9 +5,13 @@
  */
 import {
 	camelCase,
+	isArray,
+	isEmpty,
 	isFunction,
 	isNil,
+	isObject,
 	isPlainObject,
+	isString,
 	mapKeys,
 	omit,
 	pick,
@@ -25,6 +29,7 @@ import { blockDefault } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import i18nBlockSchema from './i18n-block.json';
 import { isValidIcon, normalizeIconObject } from './utils';
 import { DEPRECATED_ENTRY_KEYS } from './constants';
 import { store as blocksStore } from '../store';
@@ -311,20 +316,72 @@ export function registerBlockType( name, settings ) {
 }
 
 /**
+ * Translates block settings provided with metadata using the i18n schema.
+ *
+ * @param {string|string[]|Object[]} settingSchema I18n schema for the block setting.
+ * @param {string|string[]|Object[]} settingValue  Value for the block setting.
+ * @param {string}                   textdomain    Textdomain to use with translations.
+ *
+ * @return {string|string[]|Object[]} Translated setting.
+ */
+function translateBlockSettingUsingI18nSchema(
+	settingSchema,
+	settingValue,
+	textdomain
+) {
+	if ( isString( settingSchema ) && isString( settingValue ) ) {
+		return settingValue + ':' + settingSchema + ':' + textdomain;
+	}
+	if (
+		isArray( settingSchema ) &&
+		! isEmpty( settingSchema ) &&
+		isArray( settingValue )
+	) {
+		return settingValue.map( ( value ) =>
+			translateBlockSettingUsingI18nSchema(
+				settingSchema[ 0 ],
+				value,
+				textdomain
+			)
+		);
+	}
+	if (
+		isObject( settingSchema ) &&
+		! isEmpty( settingSchema ) &&
+		isObject( settingValue )
+	) {
+		return Object.keys( settingValue ).reduce( ( accumulator, key ) => {
+			if ( ! settingSchema[ key ] ) {
+				accumulator[ key ] = settingValue[ key ];
+				return accumulator;
+			}
+			accumulator[ key ] = translateBlockSettingUsingI18nSchema(
+				settingSchema[ key ],
+				settingValue[ key ],
+				textdomain
+			);
+			return accumulator;
+		}, {} );
+	}
+	return settingValue;
+}
+
+/**
  * Registers a new block provided from metadata stored in `block.json` file.
  * It uses `registerBlockType` internally.
  *
  * @see registerBlockType
  *
- * @param {Object} metadata           Block metadata loaded from `block.json`.
- * @param {string} metadata.name      Block name.
- * @param {Object} additionalSettings Additional block settings.
+ * @param {Object} metadata            Block metadata loaded from `block.json`.
+ * @param {string} metadata.name       Block name.
+ * @param {string} metadata.textdomain Textdomain to use with translations.
+ * @param {Object} additionalSettings  Additional block settings.
  *
  * @return {?WPBlock} The block, if it has been successfully registered;
  *                    otherwise `undefined`.
  */
 export function registerBlockTypeFromMetadata(
-	{ name, ...metadata },
+	{ name, textdomain, ...metadata },
 	additionalSettings
 ) {
 	const allowedFields = [
@@ -343,8 +400,23 @@ export function registerBlockTypeFromMetadata(
 		'apiVersion',
 	];
 
+	const settings = pick( metadata, allowedFields );
+
+	if ( textdomain ) {
+		Object.keys( i18nBlockSchema ).forEach( ( key ) => {
+			if ( ! settings[ key ] ) {
+				return;
+			}
+			settings[ key ] = translateBlockSettingUsingI18nSchema(
+				i18nBlockSchema[ key ],
+				settings[ key ],
+				textdomain
+			);
+		} );
+	}
+
 	unstable__bootstrapServerSideBlockDefinitions( {
-		[ name ]: pick( metadata, allowedFields ),
+		[ name ]: settings,
 	} );
 
 	return registerBlockType( name, additionalSettings );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -24,6 +24,7 @@ import {
  */
 import { applyFilters } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
+import { _x } from '@wordpress/i18n';
 import { blockDefault } from '@wordpress/icons';
 
 /**
@@ -318,45 +319,46 @@ export function registerBlockType( name, settings ) {
 /**
  * Translates block settings provided with metadata using the i18n schema.
  *
- * @param {string|string[]|Object[]} settingSchema I18n schema for the block setting.
+ * @param {string|string[]|Object[]} i18nSchema    I18n schema for the block setting.
  * @param {string|string[]|Object[]} settingValue  Value for the block setting.
  * @param {string}                   textdomain    Textdomain to use with translations.
  *
  * @return {string|string[]|Object[]} Translated setting.
  */
 function translateBlockSettingUsingI18nSchema(
-	settingSchema,
+	i18nSchema,
 	settingValue,
 	textdomain
 ) {
-	if ( isString( settingSchema ) && isString( settingValue ) ) {
-		return settingValue + ':' + settingSchema + ':' + textdomain;
+	if ( isString( i18nSchema ) && isString( settingValue ) ) {
+		// eslint-disable-next-line @wordpress/i18n-no-variables, @wordpress/i18n-text-domain
+		return _x( settingValue, i18nSchema, textdomain );
 	}
 	if (
-		isArray( settingSchema ) &&
-		! isEmpty( settingSchema ) &&
+		isArray( i18nSchema ) &&
+		! isEmpty( i18nSchema ) &&
 		isArray( settingValue )
 	) {
 		return settingValue.map( ( value ) =>
 			translateBlockSettingUsingI18nSchema(
-				settingSchema[ 0 ],
+				i18nSchema[ 0 ],
 				value,
 				textdomain
 			)
 		);
 	}
 	if (
-		isObject( settingSchema ) &&
-		! isEmpty( settingSchema ) &&
+		isObject( i18nSchema ) &&
+		! isEmpty( i18nSchema ) &&
 		isObject( settingValue )
 	) {
 		return Object.keys( settingValue ).reduce( ( accumulator, key ) => {
-			if ( ! settingSchema[ key ] ) {
+			if ( ! i18nSchema[ key ] ) {
 				accumulator[ key ] = settingValue[ key ];
 				return accumulator;
 			}
 			accumulator[ key ] = translateBlockSettingUsingI18nSchema(
-				settingSchema[ key ],
+				i18nSchema[ key ],
 				settingValue[ key ],
 				textdomain
 			);

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -311,6 +311,46 @@ export function registerBlockType( name, settings ) {
 }
 
 /**
+ * Registers a new block provided from metadata stored in `block.json` file.
+ * It uses `registerBlockType` internally.
+ *
+ * @see registerBlockType
+ *
+ * @param {Object} metadata           Block metadata loaded from `block.json`.
+ * @param {string} metadata.name      Block name.
+ * @param {Object} additionalSettings Additional block settings.
+ *
+ * @return {?WPBlock} The block, if it has been successfully registered;
+ *                    otherwise `undefined`.
+ */
+export function registerBlockTypeFromMetadata(
+	{ name, ...metadata },
+	additionalSettings
+) {
+	const allowedFields = [
+		'title',
+		'category',
+		'parent',
+		'icon',
+		'description',
+		'keywords',
+		'attributes',
+		'providesContext',
+		'usesContext',
+		'supports',
+		'styles',
+		'example',
+		'apiVersion',
+	];
+
+	unstable__bootstrapServerSideBlockDefinitions( {
+		[ name ]: pick( metadata, allowedFields ),
+	} );
+
+	return registerBlockType( name, additionalSettings );
+}
+
+/**
  * Registers a new block collection to group blocks in the same namespace in the inserter.
  *
  * @param {string} namespace       The namespace to group blocks by in the inserter; corresponds to the block namespace.

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -812,6 +812,14 @@ describe( 'blocks', () => {
 					title: 'Block from metadata',
 					category: 'text',
 					icon: 'palmtree',
+					variations: [
+						{
+							name: 'variation',
+							title: 'Variation Title',
+							description: 'Variation description',
+							keywords: [ 'variation' ],
+						},
+					],
 				},
 				{
 					edit: Edit,
@@ -831,6 +839,14 @@ describe( 'blocks', () => {
 				usesContext: [],
 				supports: {},
 				styles: [],
+				variations: [
+					{
+						name: 'variation',
+						title: 'Variation Title',
+						description: 'Variation description',
+						keywords: [ 'variation' ],
+					},
+				],
 				edit: Edit,
 				save: noop,
 			} );
@@ -851,8 +867,16 @@ describe( 'blocks', () => {
 					keywords: [ 'i18n', 'metadata' ],
 					styles: [
 						{
-							name: 'i18n-metadata',
-							label: 'I18n Metadata',
+							name: 'i18n-style',
+							label: 'I18n Style Label',
+						},
+					],
+					variations: [
+						{
+							name: 'i18n-variation',
+							title: 'I18n Variation Title',
+							description: 'I18n variation description',
+							keywords: [ 'variation' ],
 						},
 					],
 					textdomain: 'test',
@@ -882,8 +906,16 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [
 					{
-						name: 'i18n-metadata',
-						label: 'I18n Metadata (translated)',
+						name: 'i18n-style',
+						label: 'I18n Style Label (translated)',
+					},
+				],
+				variations: [
+					{
+						name: 'i18n-variation',
+						title: 'I18n Variation Title (translated)',
+						description: 'I18n variation description (translated)',
+						keywords: [ 'variation (translated)' ],
 					},
 				],
 				edit: Edit,

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -17,6 +17,7 @@ import { blockDefault as blockIcon } from '@wordpress/icons';
  */
 import {
 	registerBlockType,
+	registerBlockTypeFromMetadata,
 	registerBlockCollection,
 	unregisterBlockCollection,
 	unregisterBlockType,
@@ -798,6 +799,40 @@ describe( 'blocks', () => {
 				);
 				// Only attributes of block1 are supposed to be edited by the filter thus it must differ from block2.
 				expect( block1.attributes ).not.toEqual( block2.attributes );
+			} );
+		} );
+	} );
+
+	describe( 'registerBlockTypeFromMetadata', () => {
+		test( 'registers block from metadata', () => {
+			const Edit = () => 'test';
+			const block = registerBlockTypeFromMetadata(
+				{
+					name: 'test/block-from-metadata',
+					title: 'Block from metadata',
+					category: 'text',
+					icon: 'palmtree',
+				},
+				{
+					edit: Edit,
+					save: noop,
+				}
+			);
+			expect( block ).toEqual( {
+				name: 'test/block-from-metadata',
+				title: 'Block from metadata',
+				category: 'text',
+				icon: {
+					src: 'palmtree',
+				},
+				keywords: [],
+				attributes: {},
+				providesContext: {},
+				usesContext: [],
+				supports: {},
+				styles: [],
+				edit: Edit,
+				save: noop,
 			} );
 		} );
 	} );

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -835,6 +835,50 @@ describe( 'blocks', () => {
 				save: noop,
 			} );
 		} );
+		test( 'registers block from metadata with translation', () => {
+			const Edit = () => 'test';
+			const block = registerBlockTypeFromMetadata(
+				{
+					name: 'test/block-from-metadata-i18n',
+					title: 'I18n title from metadata',
+					description: 'I18n description from metadata',
+					keywords: [ 'i18n', 'metadata' ],
+					styles: [
+						{
+							label: 'i18n-metadata',
+							title: 'I18n Metadata',
+						},
+					],
+					textdomain: 'i18n',
+					icon: 'palmtree',
+				},
+				{
+					edit: Edit,
+					save: noop,
+				}
+			);
+			expect( block ).toEqual( {
+				name: 'test/block-from-metadata-i18n',
+				title: 'I18n title from metadata',
+				description: 'I18n description from metadata',
+				icon: {
+					src: 'palmtree',
+				},
+				keywords: [ 'i18n', 'metadata' ],
+				attributes: {},
+				providesContext: {},
+				usesContext: [],
+				supports: {},
+				styles: [
+					{
+						label: 'i18n-metadata',
+						title: 'I18n Metadata',
+					},
+				],
+				edit: Edit,
+				save: noop,
+			} );
+		} );
 	} );
 
 	describe( 'registerBlockCollection()', () => {

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -8,7 +8,7 @@ import { noop, get, omit, pick } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { addFilter, removeAllFilters } from '@wordpress/hooks';
+import { addFilter, removeAllFilters, removeFilter } from '@wordpress/hooks';
 import { select } from '@wordpress/data';
 import { blockDefault as blockIcon } from '@wordpress/icons';
 
@@ -836,6 +836,12 @@ describe( 'blocks', () => {
 			} );
 		} );
 		test( 'registers block from metadata with translation', () => {
+			addFilter(
+				'i18n.gettext_with_context_test',
+				'test/mark-as-translated',
+				( value ) => value + ' (translated)'
+			);
+
 			const Edit = () => 'test';
 			const block = registerBlockTypeFromMetadata(
 				{
@@ -845,11 +851,11 @@ describe( 'blocks', () => {
 					keywords: [ 'i18n', 'metadata' ],
 					styles: [
 						{
-							label: 'i18n-metadata',
-							title: 'I18n Metadata',
+							name: 'i18n-metadata',
+							label: 'I18n Metadata',
 						},
 					],
-					textdomain: 'i18n',
+					textdomain: 'test',
 					icon: 'palmtree',
 				},
 				{
@@ -857,22 +863,27 @@ describe( 'blocks', () => {
 					save: noop,
 				}
 			);
+			removeFilter(
+				'i18n.gettext_with_context_test',
+				'test/mark-as-translated'
+			);
+
 			expect( block ).toEqual( {
 				name: 'test/block-from-metadata-i18n',
-				title: 'I18n title from metadata',
-				description: 'I18n description from metadata',
+				title: 'I18n title from metadata (translated)',
+				description: 'I18n description from metadata (translated)',
 				icon: {
 					src: 'palmtree',
 				},
-				keywords: [ 'i18n', 'metadata' ],
+				keywords: [ 'i18n (translated)', 'metadata (translated)' ],
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
 				supports: {},
 				styles: [
 					{
-						label: 'i18n-metadata',
-						title: 'I18n Metadata',
+						name: 'i18n-metadata',
+						label: 'I18n Metadata (translated)',
 					},
 				],
 				edit: Edit,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #23636.

> 1. JSON imports work only in Node.js or with webpack tool. In Gutenberg, we use a custom plugin that inlines JSON in JavaScript as a plain object. We should decide whether we add the same plugin to the shared Babel preset (`@wordpress/babel-preset-default`) distributed as part of WordPress packages.
> 2. We miss the logic that wraps translatable fields with i18n functions, it still needs to be added. In the past, there was a failed attempt to build a Babel macro that would address both points but it wasn’t as straightforward as expected. We were afraid it could be a point of bugs when not configured properly. Related PR: #16088.

This PR proposes we introduce a new API method `registerBlockTypeFromMetadata` that processes metadata loaded from `block.json` and applies translations on the fly to the corresponding fields. 

## Dev Note

In JavaScript, you can use now `registerBlockTypeFromMetadata` method from `@wordpress/blocks` package to register a  block type using the metadata loaded from `block.json` file. All localized properties get automatically wrapped in `_x` (from `@wordpress/i18n` package) function calls similar to how it works in PHP with `register_block_type_from_metadata`. The only requirement is to set the `textdomain` property in the `block.json` file.

 **Example:**

`block.json`
```json
{
	"name": "my-plugin/translatable-block",
	"title": "My translatable block",
	"description": "My block with translatable metadata",
	"keywords": [ "translatable" ],
	"textdomain": "my-plugin"
}
```

`index.js`
```js
import { registerBlockTypeFromMetadata } from '@wordpress/blocks';
import Edit from './edit';
import metadata from './block.json';

registerBlockTypeFromMetadata( metadata, {
	edit: Edit,
	// ...other client-side settings
} );
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run test-unit`


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New API.
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
