### PR TITLE
Components: Fix Post Publishing Popover moving when certain dates are clicked

### DIFF
--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -172,6 +172,12 @@ The class that will be added with `components-panel__row`. to the classes of the
 -   Type: `String`
 -   Required: No
 
+##### Ref
+
+PanelRow accepts a forwarded ref that will be added to the wrapper div. Usage:
+
+`<PanelRow className="edit-post-post-schedule" ref={ anchorRef }>`
+
 ---
 
 #### PanelHeader

--- a/packages/components/src/panel/row.js
+++ b/packages/components/src/panel/row.js
@@ -3,10 +3,18 @@
  */
 import classnames from 'classnames';
 
-function PanelRow( { className, children } ) {
-	const classes = classnames( 'components-panel__row', className );
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
 
-	return <div className={ classes }>{ children }</div>;
-}
+const PanelRow = forwardRef( ( { className, children }, ref ) => (
+	<div
+		className={ classnames( 'components-panel__row', className ) }
+		ref={ ref }
+	>
+		{ children }
+	</div>
+) );
 
 export default PanelRow;

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
 import {
 	PostSchedule as PostScheduleForm,
 	PostScheduleLabel,
@@ -10,11 +11,14 @@ import {
 } from '@wordpress/editor';
 
 export function PostSchedule() {
+	const anchorRef = useRef();
+
 	return (
 		<PostScheduleCheck>
-			<PanelRow className="edit-post-post-schedule">
+			<PanelRow className="edit-post-post-schedule" ref={ anchorRef }>
 				<span>{ __( 'Publish' ) }</span>
 				<Dropdown
+					popoverProps={ { anchorRef: anchorRef.current } }
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
 					renderToggle={ ( { onToggle, isOpen } ) => (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix Post Publishing popover glitch by changing the popover anchor ref to the containing div (`PanelRow`). Requires changing `PanelRow` to accept a forwarding ref.

Alternatively, we can change `PanelRow` to accept a ref as a prop and include the [`forwardRef()` wrapper](https://reactjs.org/docs/forwarding-refs.html) in `PostSchedule` instead.

Fixes #29899

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Add or edit a post.
- Open the Post Publishing popover by clicking on the publish date or "Immediately."
- Click on various dates in the picker and confirm that the popover does not move or change position.
- Regression: check that other instances of the `PanelRow` component function correctly and don't require a ref.

## Screenshots <!-- if applicable -->

![popovernotmoving](https://user-images.githubusercontent.com/1689238/112659440-c6cc9900-8e2a-11eb-9e8d-0e6fcade61aa.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix:
- Changes the `PanelRow` component to accept a forwarding ref
- Creates a ref in `PostSchedule` and assigns it to `PanelRow`
- Passes the ref to `Dropdown` as an anchor ref and popover prop

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
