### PR TITLE
Block Editor: Show only the allowed patterns from top level blocks

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -9,26 +9,16 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import BlockPreview from '../block-preview';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
-import { store as blockEditorStore } from '../../store';
 
 function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 	const instanceId = useInstanceId( BlockPattern );
-	const { name, viewportWidth } = pattern;
-	const parsedPattern = useSelect(
-		( select ) =>
-			select( blockEditorStore ).__experimentalGetParsedPattern( name ),
-		[ name ]
-	);
-	// If pattern is not found or containes not allowed blocks do not render it.
-	if ( ! parsedPattern ) return null;
-	const { blocks } = parsedPattern;
+	const { viewportWidth, blocks } = pattern;
 	const descriptionId = `block-editor-block-patterns-list__item-description-${ instanceId }`;
 	return (
 		<InserterDraggableBlocks isEnabled={ isDraggable } blocks={ blocks }>

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -19,15 +19,17 @@ import InserterDraggableBlocks from '../inserter-draggable-blocks';
 import { store as blockEditorStore } from '../../store';
 
 function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
+	const instanceId = useInstanceId( BlockPattern );
 	const { name, viewportWidth } = pattern;
-	const { blocks } = useSelect(
+	const parsedPattern = useSelect(
 		( select ) =>
 			select( blockEditorStore ).__experimentalGetParsedPattern( name ),
 		[ name ]
 	);
-	const instanceId = useInstanceId( BlockPattern );
+	// If pattern is not found or containes not allowed blocks do not render it.
+	if ( ! parsedPattern ) return null;
+	const { blocks } = parsedPattern;
 	const descriptionId = `block-editor-block-patterns-list__item-description-${ instanceId }`;
-
 	return (
 		<InserterDraggableBlocks isEnabled={ isDraggable } blocks={ blocks }>
 			{ ( { draggable, onDragStart, onDragEnd } ) => (

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -9,17 +9,25 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import BlockPreview from '../block-preview';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
+import { store as blockEditorStore } from '../../store';
 
 function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
+	const { name, viewportWidth } = pattern;
+	const { blocks } = useSelect(
+		( select ) =>
+			select( blockEditorStore ).__experimentalGetParsedPattern( name ),
+		[ name ]
+	);
 	const instanceId = useInstanceId( BlockPattern );
-	const { viewportWidth, blocks } = pattern;
 	const descriptionId = `block-editor-block-patterns-list__item-description-${ instanceId }`;
+
 	return (
 		<InserterDraggableBlocks isEnabled={ isDraggable } blocks={ blocks }>
 			{ ( { draggable, onDragStart, onDragEnd } ) => (

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1798,27 +1798,12 @@ export const __experimentalGetParsedPattern = createSelector(
 		if ( ! pattern ) {
 			return null;
 		}
-		const parsedBlocks = parse( pattern.content );
-		// Check if pattern consists of `allowedBlockTypes`.
-		const { allowedBlockTypes } = state.settings;
-		if (
-			( typeof allowedBlockTypes === 'boolean' && ! allowedBlockTypes ) ||
-			( Array.isArray( allowedBlockTypes ) &&
-				parsedBlocks.some(
-					( { name } ) => ! allowedBlockTypes.includes( name )
-				) )
-		) {
-			return null;
-		}
 		return {
 			...pattern,
-			blocks: parsedBlocks,
+			blocks: parse( pattern.content ),
 		};
 	},
-	( state ) => [
-		state.settings.__experimentalBlockPatterns,
-		state.settings.allowedBlockTypes,
-	]
+	( state ) => [ state.settings.__experimentalBlockPatterns ]
 );
 
 /**
@@ -1832,16 +1817,9 @@ export const __experimentalGetParsedPattern = createSelector(
 export const __experimentalGetAllowedPatterns = createSelector(
 	( state, rootClientId = null ) => {
 		const patterns = state.settings.__experimentalBlockPatterns;
-		if ( ! rootClientId ) {
-			return patterns;
-		}
-
-		const parsedPatterns = patterns.reduce( ( accumulator, { name } ) => {
-			const parsedPattern = __experimentalGetParsedPattern( state, name );
-			if ( parsedPattern ) accumulator.push( parsedPattern );
-			return accumulator;
-		}, [] );
-
+		const parsedPatterns = patterns.map( ( { name } ) =>
+			__experimentalGetParsedPattern( state, name )
+		);
 		const patternsAllowed = filter( parsedPatterns, ( { blocks } ) =>
 			blocks.every( ( { name } ) =>
 				canInsertBlockType( state, name, rootClientId )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Partially fixes: https://github.com/WordPress/gutenberg/issues/23275

Currently patterns don't take into account the `allowed_block_types` which can result in showing block patterns in the Inserter and by clicking one the following happens:
1. Nothing is inserted because `allowed_block_types` is checked during insertion
2. A notice that the pattern was inserted is shown, while that's not the case.

This is not a complete solution due to performance implications of pattern parsing for various actions. Ideally we need to find a performant way to recurse through all inner blocks of a block and check if the block is allowed or if is unregistered. For now we check the top level blocks of a pattern.

<!-- Please describe what you have changed or added -->

## Testing instructions
1. Set just a few `allowed_block_types` in php
```
function test_allowed_block_types( $allowed_block_types, $post ) {
    return array( 'core/paragraph', 'core/heading', 'core/image' );
}
add_filter( 'allowed_block_types', 'test_allowed_block_types', 10, 2 );
```
2. Open the Inserter in `patterns` tab and observe the proper results

