### PR TITLE
Simplify insertion point

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -160,22 +160,16 @@ _Returns_
 
 <a name="getBlockInsertionPoint" href="#getBlockInsertionPoint">#</a> **getBlockInsertionPoint**
 
-Returns the insertion point. This will be:
-
-1. The insertion point manually set using setInsertionPoint() or
-   showInsertionPoint(); or
-2. The point after the current block selection, if there is a selection; or
-3. The point at the end of the block list.
-
-Components like <Inserter> will default to inserting blocks at this point.
+Returns the insertion point, the index at which the new inserted block would
+be placed. Defaults to the last index.
 
 _Parameters_
 
--   _state_ `Object`: Global application state.
+-   _state_ `Object`: Editor state.
 
 _Returns_
 
--   `Object`: Insertion point object with `rootClientId` and `index`.
+-   `Object`: Insertion point object with `rootClientId`, `index`.
 
 <a name="getBlockListSettings" href="#getBlockListSettings">#</a> **getBlockListSettings**
 
@@ -853,8 +847,7 @@ _Returns_
 
 <a name="isBlockInsertionPointVisible" href="#isBlockInsertionPointVisible">#</a> **isBlockInsertionPointVisible**
 
-Whether or not the insertion point should be shown to users. This is set
-using showInsertionPoint() or hideInsertionPoint().
+Returns true if we should show the block insertion point.
 
 _Parameters_
 
@@ -862,7 +855,7 @@ _Parameters_
 
 _Returns_
 
--   `?boolean`: Whether the insertion point should be shown.
+-   `?boolean`: Whether the insertion point is visible or not.
 
 <a name="isBlockMultiSelected" href="#isBlockMultiSelected">#</a> **isBlockMultiSelected**
 
@@ -1090,7 +1083,7 @@ _Parameters_
 
 <a name="hideInsertionPoint" href="#hideInsertionPoint">#</a> **hideInsertionPoint**
 
-Hides the insertion point for users.
+Returns an action object hiding the insertion point.
 
 _Returns_
 
@@ -1406,14 +1399,13 @@ _Returns_
 
 <a name="showInsertionPoint" href="#showInsertionPoint">#</a> **showInsertionPoint**
 
-Sets the insertion point and shows it to users.
-
-Components like <Inserter> will default to inserting blocks at this point.
+Returns an action object used in signalling that the insertion point should
+be shown.
 
 _Parameters_
 
--   _rootClientId_ `?string`: Root client ID of block list in which to insert. Use `undefined` for the root block list.
--   _index_ `number`: Index at which block should be inserted.
+-   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
+-   _index_ `?number`: Index at which block should be inserted.
 
 _Returns_
 

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -38,7 +38,7 @@ import { store as blockEditorStore } from '../../../store';
  * @return {Array} Insertion Point State (rootClientID, onInsertBlocks and onToggle).
  */
 function useInsertionPoint( {
-	rootClientId,
+	rootClientId = '',
 	insertionIndex,
 	clientId,
 	isAppender,

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -49,11 +49,14 @@ function useInsertionPoint( {
 	const { destinationRootClientId, destinationIndex } = useSelect(
 		( select ) => {
 			const {
+				getSelectedBlockClientId,
+				getBlockRootClientId,
 				getBlockIndex,
 				getBlockOrder,
 			} = select( blockEditorStore );
+			const selectedBlockClientId = getSelectedBlockClientId();
 
-			const _destinationRootClientId = rootClientId;
+			let _destinationRootClientId = rootClientId;
 			let _destinationIndex;
 
 			if ( insertionIndex ) {
@@ -65,6 +68,15 @@ function useInsertionPoint( {
 					clientId,
 					_destinationRootClientId
 				);
+			} else if ( ! isAppender && selectedBlockClientId ) {
+				_destinationRootClientId = getBlockRootClientId(
+					selectedBlockClientId
+				);
+				_destinationIndex =
+					getBlockIndex(
+						selectedBlockClientId,
+						_destinationRootClientId
+					) + 1;
 			} else {
 				// Insert at the end of the list.
 				_destinationIndex = getBlockOrder( _destinationRootClientId )

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -51,38 +51,24 @@ function useInsertionPoint( {
 			const {
 				getBlockIndex,
 				getBlockOrder,
-				getBlockInsertionPoint,
 			} = select( blockEditorStore );
 
-			let _destinationRootClientId, _destinationIndex;
+			const _destinationRootClientId = rootClientId;
+			let _destinationIndex;
 
-			if ( rootClientId || insertionIndex || clientId || isAppender ) {
-				// If any of these arguments are set, we're in "manual mode"
-				// meaning the insertion point is set by the caller.
-
-				_destinationRootClientId = rootClientId;
-
-				if ( insertionIndex ) {
-					// Insert into a specific index.
-					_destinationIndex = insertionIndex;
-				} else if ( clientId ) {
-					// Insert after a specific client ID.
-					_destinationIndex = getBlockIndex(
-						clientId,
-						_destinationRootClientId
-					);
-				} else {
-					// Insert at the end of the list.
-					_destinationIndex = getBlockOrder(
-						_destinationRootClientId
-					).length;
-				}
+			if ( insertionIndex ) {
+				// Insert into a specific index.
+				_destinationIndex = insertionIndex;
+			} else if ( clientId ) {
+				// Insert after a specific client ID.
+				_destinationIndex = getBlockIndex(
+					clientId,
+					_destinationRootClientId
+				);
 			} else {
-				// Otherwise, we're in "auto mode" where the insertion point is
-				// decided by getBlockInsertionPoint().
-				const insertionPoint = getBlockInsertionPoint();
-				_destinationRootClientId = insertionPoint.rootClientId;
-				_destinationIndex = insertionPoint.index;
+				// Insert at the end of the list.
+				_destinationIndex = getBlockOrder( _destinationRootClientId )
+					.length;
 			}
 
 			return {

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -17,7 +17,6 @@ import { store as blockEditorStore } from '../../store';
 function InserterLibrary( {
 	rootClientId,
 	clientId,
-	index,
 	isAppender,
 	showInserterHelpPanel,
 	showMostUsedBlocks = false,
@@ -25,27 +24,22 @@ function InserterLibrary( {
 	onSelect = noop,
 	shouldFocusBlock = false,
 } ) {
-	const { destinationRootClientId, destinationClientId } = useSelect(
+	const destinationRootClientId = useSelect(
 		( select ) => {
-			const { getBlockRootClientId, getBlockOrder } = select(
-				blockEditorStore
+			const { getBlockRootClientId } = select( blockEditorStore );
+
+			return (
+				rootClientId || getBlockRootClientId( clientId ) || undefined
 			);
-			const _destinationRootClientId =
-				rootClientId || getBlockRootClientId( clientId ) || undefined;
-			const order = getBlockOrder( _destinationRootClientId );
-			return {
-				destinationRootClientId: _destinationRootClientId,
-				destinationClientId: clientId || order[ index ],
-			};
 		},
-		[ clientId, rootClientId, index ]
+		[ clientId, rootClientId ]
 	);
 
 	return (
 		<InserterMenu
 			onSelect={ onSelect }
 			rootClientId={ destinationRootClientId }
-			clientId={ destinationClientId }
+			clientId={ clientId }
 			isAppender={ isAppender }
 			showInserterHelpPanel={ showInserterHelpPanel }
 			showMostUsedBlocks={ showMostUsedBlocks }

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -17,6 +17,7 @@ import { store as blockEditorStore } from '../../store';
 function InserterLibrary( {
 	rootClientId,
 	clientId,
+	index,
 	isAppender,
 	showInserterHelpPanel,
 	showMostUsedBlocks = false,
@@ -24,22 +25,27 @@ function InserterLibrary( {
 	onSelect = noop,
 	shouldFocusBlock = false,
 } ) {
-	const destinationRootClientId = useSelect(
+	const { destinationRootClientId, destinationClientId } = useSelect(
 		( select ) => {
-			const { getBlockRootClientId } = select( blockEditorStore );
-
-			return (
-				rootClientId || getBlockRootClientId( clientId ) || undefined
+			const { getBlockRootClientId, getBlockOrder } = select(
+				blockEditorStore
 			);
+			const _destinationRootClientId =
+				rootClientId || getBlockRootClientId( clientId ) || undefined;
+			const order = getBlockOrder( _destinationRootClientId );
+			return {
+				destinationRootClientId: _destinationRootClientId,
+				destinationClientId: clientId || order[ index ],
+			};
 		},
-		[ clientId, rootClientId ]
+		[ clientId, rootClientId, index ]
 	);
 
 	return (
 		<InserterMenu
 			onSelect={ onSelect }
 			rootClientId={ destinationRootClientId }
-			clientId={ clientId }
+			clientId={ destinationClientId }
 			isAppender={ isAppender }
 			showInserterHelpPanel={ showInserterHelpPanel }
 			showMostUsedBlocks={ showMostUsedBlocks }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -190,6 +190,9 @@ function InserterMenu( {
 							rootClientId={ rootClientId }
 							clientId={ clientId }
 							isAppender={ isAppender }
+							__experimentalInsertionIndex={
+								__experimentalInsertionIndex
+							}
 							showBlockDirectory
 							shouldFocusBlock={ shouldFocusBlock }
 						/>

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -52,13 +52,16 @@ export default function QuickInserter( {
 		( showPatterns && patterns.length > SEARCH_THRESHOLD ) ||
 		blockTypes.length > SEARCH_THRESHOLD;
 
-	const { setInserterIsOpened, blockIndex } = useSelect(
+	const { setInserterIsOpened, insertionIndex } = useSelect(
 		( select ) => {
-			const { getSettings, getBlockIndex } = select( blockEditorStore );
+			const { getSettings, getBlockIndex, getBlockCount } = select(
+				blockEditorStore
+			);
+			const index = getBlockIndex( clientId, rootClientId );
 			return {
 				setInserterIsOpened: getSettings()
 					.__experimentalSetIsInserterOpened,
-				blockIndex: getBlockIndex( clientId, rootClientId ),
+				insertionIndex: index === -1 ? getBlockCount() : index,
 			};
 		},
 		[ clientId, rootClientId ]
@@ -73,7 +76,7 @@ export default function QuickInserter( {
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected
 	const onBrowseAll = () => {
-		setInserterIsOpened( { rootClientId, blockIndex } );
+		setInserterIsOpened( { rootClientId, insertionIndex } );
 	};
 
 	return (

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -70,13 +70,10 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
-	const { __unstableSetInsertionPoint } = useDispatch( blockEditorStore );
-
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected
 	const onBrowseAll = () => {
-		__unstableSetInsertionPoint( rootClientId, blockIndex );
-		setInserterIsOpened( true );
+		setInserterIsOpened( { rootClientId, blockIndex } );
 	};
 
 	return (

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -33,6 +33,7 @@ function InserterSearchResults( {
 	rootClientId,
 	clientId,
 	isAppender,
+	__experimentalInsertionIndex,
 	maxBlockPatterns,
 	maxBlockTypes,
 	showBlockDirectory = false,
@@ -46,6 +47,7 @@ function InserterSearchResults( {
 		rootClientId,
 		clientId,
 		isAppender,
+		insertionIndex: __experimentalInsertionIndex,
 		shouldFocusBlock,
 	} );
 	const [

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -620,34 +620,12 @@ export function* insertBlocks(
 }
 
 /**
- * Sets the insertion point without showing it to users.
+ * Returns an action object used in signalling that the insertion point should
+ * be shown.
  *
- * Components like <Inserter> will default to inserting blocks at this point.
- *
- * @param {?string} rootClientId Root client ID of block list in which to
- *                               insert. Use `undefined` for the root block
- *                               list.
- * @param {number} index         Index at which block should be inserted.
- *
- * @return {Object} Action object.
- */
-export function __unstableSetInsertionPoint( rootClientId, index ) {
-	return {
-		type: 'SET_INSERTION_POINT',
-		rootClientId,
-		index,
-	};
-}
-
-/**
- * Sets the insertion point and shows it to users.
- *
- * Components like <Inserter> will default to inserting blocks at this point.
- *
- * @param {?string} rootClientId Root client ID of block list in which to
- *                               insert. Use `undefined` for the root block
- *                               list.
- * @param {number} index         Index at which block should be inserted.
+ * @param {?string} rootClientId Optional root client ID of block list on
+ *                               which to insert.
+ * @param {?number} index        Index at which block should be inserted.
  *
  * @return {Object} Action object.
  */
@@ -660,7 +638,7 @@ export function showInsertionPoint( rootClientId, index ) {
 }
 
 /**
- * Hides the insertion point for users.
+ * Returns an action object hiding the insertion point.
  *
  * @return {Object} Action object.
  */

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1393,32 +1393,9 @@ export function blocksMode( state = {}, action ) {
 }
 
 /**
- * A helper for resetting the insertion point state.
- *
- * @param {Object} state        Current state.
- * @param {Object} action       Dispatched action.
- * @param {*}      defaultValue The default value for the reducer.
- *
- * @return {*} Either the default value if a reset is required, or the state.
- */
-function resetInsertionPoint( state, action, defaultValue ) {
-	switch ( action.type ) {
-		case 'CLEAR_SELECTED_BLOCK':
-		case 'SELECT_BLOCK':
-		case 'SELECTION_CHANGE':
-		case 'REPLACE_INNER_BLOCKS':
-		case 'INSERT_BLOCKS':
-		case 'REMOVE_BLOCKS':
-		case 'REPLACE_BLOCKS':
-			return defaultValue;
-	}
-
-	return state;
-}
-
-/**
- * Reducer returning the insertion point position, consisting of the
- * rootClientId and an index.
+ * Reducer returning the block insertion point visibility, either null if there
+ * is not an explicit insertion point assigned, or an object of its `index` and
+ * `rootClientId`.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
@@ -1427,33 +1404,15 @@ function resetInsertionPoint( state, action, defaultValue ) {
  */
 export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
-		case 'SET_INSERTION_POINT':
-		case 'SHOW_INSERTION_POINT': {
+		case 'SHOW_INSERTION_POINT':
 			const { rootClientId, index } = action;
 			return { rootClientId, index };
-		}
-	}
 
-	return resetInsertionPoint( state, action, null );
-}
-
-/**
- * Reducer returning the visibility of the insertion point.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function insertionPointVisibility( state = false, action ) {
-	switch ( action.type ) {
-		case 'SHOW_INSERTION_POINT':
-			return true;
 		case 'HIDE_INSERTION_POINT':
-			return false;
+			return null;
 	}
 
-	return resetInsertionPoint( state, action, false );
+	return state;
 }
 
 /**
@@ -1764,7 +1723,6 @@ export default combineReducers( {
 	blocksMode,
 	blockListSettings,
 	insertionPoint,
-	insertionPointVisibility,
 	template,
 	settings,
 	preferences,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1177,18 +1177,12 @@ export function isCaretWithinFormattedText( state ) {
 }
 
 /**
- * Returns the insertion point. This will be:
+ * Returns the insertion point, the index at which the new inserted block would
+ * be placed. Defaults to the last index.
  *
- * 1) The insertion point manually set using setInsertionPoint() or
- *    showInsertionPoint(); or
- * 2) The point after the current block selection, if there is a selection; or
- * 3) The point at the end of the block list.
+ * @param {Object} state Editor state.
  *
- * Components like <Inserter> will default to inserting blocks at this point.
- *
- * @param {Object} state Global application state.
- *
- * @return {Object} Insertion point object with `rootClientId` and `index`.
+ * @return {Object} Insertion point object with `rootClientId`, `index`.
  */
 export function getBlockInsertionPoint( state ) {
 	let rootClientId, index;
@@ -1214,15 +1208,14 @@ export function getBlockInsertionPoint( state ) {
 }
 
 /**
- * Whether or not the insertion point should be shown to users. This is set
- * using showInsertionPoint() or hideInsertionPoint().
+ * Returns true if we should show the block insertion point.
  *
  * @param {Object} state Global application state.
  *
- * @return {?boolean} Whether the insertion point should be shown.
+ * @return {?boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
-	return state.insertionPointVisibility;
+	return state.insertionPoint !== null;
 }
 
 /**

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -42,7 +42,6 @@ const {
 	resetBlocks,
 	selectBlock,
 	selectPreviousBlock,
-	__unstableSetInsertionPoint,
 	showInsertionPoint,
 	startMultiSelect,
 	startTyping,
@@ -741,30 +740,10 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '__unstableSetInsertionPoint', () => {
-		it( 'should return the SET_INSERTION_POINT action', () => {
-			expect( __unstableSetInsertionPoint() ).toEqual( {
-				type: 'SET_INSERTION_POINT',
-			} );
-			expect( __unstableSetInsertionPoint( 'rootClientId', 2 ) ).toEqual(
-				{
-					type: 'SET_INSERTION_POINT',
-					rootClientId: 'rootClientId',
-					index: 2,
-				}
-			);
-		} );
-	} );
-
 	describe( 'showInsertionPoint', () => {
 		it( 'should return the SHOW_INSERTION_POINT action', () => {
 			expect( showInsertionPoint() ).toEqual( {
 				type: 'SHOW_INSERTION_POINT',
-			} );
-			expect( showInsertionPoint( 'rootClientId', 2 ) ).toEqual( {
-				type: 'SHOW_INSERTION_POINT',
-				rootClientId: 'rootClientId',
-				index: 2,
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -29,7 +29,6 @@ import {
 	preferences,
 	blocksMode,
 	insertionPoint,
-	insertionPointVisibility,
 	template,
 	blockListSettings,
 	lastBlockAttributesChange,
@@ -2041,82 +2040,35 @@ describe( 'state', () => {
 	} );
 
 	describe( 'insertionPoint', () => {
-		it( 'defaults to `null`', () => {
+		it( 'should default to null', () => {
 			const state = insertionPoint( undefined, {} );
 
-			expect( state ).toEqual( null );
+			expect( state ).toBe( null );
 		} );
 
-		it.each( [ 'SET_INSERTION_POINT', 'SHOW_INSERTION_POINT' ] )(
-			'sets the insertion point on %s',
-			( type ) => {
-				const original = deepFreeze( {
-					rootClientId: 'clientId1',
-					index: 0,
-				} );
+		it( 'should set insertion point', () => {
+			const state = insertionPoint( null, {
+				type: 'SHOW_INSERTION_POINT',
+				rootClientId: 'clientId1',
+				index: 0,
+			} );
 
-				const expectedNewState = {
-					rootClientId: 'clientId2',
-					index: 1,
-				};
+			expect( state ).toEqual( {
+				rootClientId: 'clientId1',
+				index: 0,
+			} );
+		} );
 
-				const state = insertionPoint( original, {
-					type,
-					...expectedNewState,
-				} );
-
-				expect( state ).toEqual( expectedNewState );
-			}
-		);
-
-		it.each( [
-			'CLEAR_SELECTED_BLOCK',
-			'SELECT_BLOCK',
-			'REPLACE_INNER_BLOCKS',
-			'INSERT_BLOCKS',
-			'REMOVE_BLOCKS',
-			'REPLACE_BLOCKS',
-		] )( 'resets the insertion point to `null` on %s', ( type ) => {
+		it( 'should clear the insertion point', () => {
 			const original = deepFreeze( {
 				rootClientId: 'clientId1',
 				index: 0,
 			} );
 			const state = insertionPoint( original, {
-				type,
+				type: 'HIDE_INSERTION_POINT',
 			} );
 
-			expect( state ).toEqual( null );
-		} );
-	} );
-
-	describe( 'insertionPointVisibility', () => {
-		it( 'defaults to `false`', () => {
-			const state = insertionPointVisibility( undefined, {} );
-			expect( state ).toBe( false );
-		} );
-
-		it( 'shows the insertion point', () => {
-			const state = insertionPointVisibility( false, {
-				type: 'SHOW_INSERTION_POINT',
-			} );
-
-			expect( state ).toBe( true );
-		} );
-
-		it.each( [
-			'HIDE_INSERTION_POINT',
-			'CLEAR_SELECTED_BLOCK',
-			'SELECT_BLOCK',
-			'REPLACE_INNER_BLOCKS',
-			'INSERT_BLOCKS',
-			'REMOVE_BLOCKS',
-			'REPLACE_BLOCKS',
-		] )( 'sets the insertion point on %s to `false`', ( type ) => {
-			const state = insertionPointVisibility( true, {
-				type,
-			} );
-
-			expect( state ).toBe( false );
+			expect( state ).toBe( null );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2246,17 +2246,20 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isBlockInsertionPointVisible', () => {
-		it( 'should return false if insertion point is set to not show', () => {
+		it( 'should return false if no assigned insertion point', () => {
 			const state = {
-				insertionPointVisibility: false,
+				insertionPoint: null,
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
 		} );
 
-		it( 'should return true if insertion point is set to show', () => {
+		it( 'should return true if assigned insertion point', () => {
 			const state = {
-				insertionPointVisibility: true,
+				insertionPoint: {
+					rootClientId: undefined,
+					index: 5,
+				},
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( true );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -215,7 +215,9 @@ function Layout( { styles } ) {
 									rootClientId={
 										isInserterOpened?.rootClientId
 									}
-									index={ isInserterOpened?.blockIndex }
+									__experimentalInsertionIndex={
+										isInserterOpened?.insertionIndex
+									}
 								/>
 							</div>
 						</div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -216,7 +216,7 @@ function Layout( { styles } ) {
 									rootClientId={
 										isInserterOpened?.rootClientId
 									}
-									index={ isInserterOpened?.index }
+									index={ isInserterOpened?.blockIndex }
 								/>
 							</div>
 						</div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -212,7 +212,6 @@ function Layout( { styles } ) {
 									showMostUsedBlocks={ showMostUsedBlocks }
 									showInserterHelpPanel
 									shouldFocusBlock={ isMobileViewport }
-									isInserterOpened={ isInserterOpened }
 									rootClientId={
 										isInserterOpened?.rootClientId
 									}

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -86,6 +86,7 @@ function Layout( { styles } ) {
 		hasBlockSelected,
 		showMostUsedBlocks,
 		isInserterOpened,
+		insertionPoint,
 		showIconLabels,
 		hasReducedUI,
 		showBlockBreadcrumbs,
@@ -107,6 +108,9 @@ function Layout( { styles } ) {
 				'mostUsedBlocks'
 			),
 			isInserterOpened: select( editPostStore ).isInserterOpened(),
+			insertionPoint: select(
+				editPostStore
+			).__experimentalGetInsertionPoint(),
 			mode: select( editPostStore ).getEditorMode(),
 			isRichEditingEnabled: editorSettings.richEditingEnabled,
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
@@ -212,11 +216,9 @@ function Layout( { styles } ) {
 									showMostUsedBlocks={ showMostUsedBlocks }
 									showInserterHelpPanel
 									shouldFocusBlock={ isMobileViewport }
-									rootClientId={
-										isInserterOpened?.rootClientId
-									}
+									rootClientId={ insertionPoint.rootClientId }
 									__experimentalInsertionIndex={
-										isInserterOpened?.insertionIndex
+										insertionPoint.insertionIndex
 									}
 								/>
 							</div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -212,6 +212,11 @@ function Layout( { styles } ) {
 									showMostUsedBlocks={ showMostUsedBlocks }
 									showInserterHelpPanel
 									shouldFocusBlock={ isMobileViewport }
+									isInserterOpened={ isInserterOpened }
+									rootClientId={
+										isInserterOpened?.rootClientId
+									}
+									index={ isInserterOpened?.index }
 								/>
 							</div>
 						</div>

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -416,7 +416,13 @@ export function __experimentalSetPreviewDeviceType( deviceType ) {
 /**
  * Returns an action object used to open/close the inserter.
  *
- * @param {boolean} value A boolean representing whether the inserter should be opened or closed.
+ * @param {boolean|Object} value                Whether the inserter should be
+ *                                              opened (true) or closed (false).
+ *                                              To specify an insertion point,
+ *                                              use an object.
+ * @param {string}         value.rootClientId   The root client ID to insert at.
+ * @param {number}         value.insertionIndex The index to insert at.
+ *
  * @return {Object} Action object.
  */
 export function setIsInserterOpened( value ) {

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -241,10 +241,10 @@ export function deviceType( state = 'Desktop', action ) {
 /**
  * Reducer tracking whether the inserter is open.
  *
- * @param {boolean} state
- * @param {Object}  action
+ * @param {boolean|Object} state
+ * @param {Object}         action
  */
-function isInserterOpened( state = false, action ) {
+function blockInserterPanel( state = false, action ) {
 	switch ( action.type ) {
 		case 'SET_IS_INSERTER_OPENED':
 			return action.value;
@@ -278,6 +278,6 @@ export default combineReducers( {
 	publishSidebarActive,
 	removedPanels,
 	deviceType,
-	isInserterOpened,
+	blockInserterPanel,
 	isEditingTemplate,
 } );

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -324,7 +324,19 @@ export function __experimentalGetPreviewDeviceType( state ) {
  * @return {boolean} Whether the inserter is opened.
  */
 export function isInserterOpened( state ) {
-	return state.isInserterOpened;
+	return !! state.blockInserterPanel;
+}
+
+/**
+ * Get the insertion point for the inserter.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} The root client ID and index to insert at.
+ */
+export function __experimentalGetInsertionPoint( state ) {
+	const { rootClientId, insertionIndex } = state.blockInserterPanel;
+	return { rootClientId, insertionIndex };
 }
 
 /**

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -155,7 +155,7 @@ function Editor( { initialSettings } ) {
 			return (
 				<InserterSidebar
 					rootClientId={ isInserterOpen?.rootClientId }
-					index={ isInserterOpen?.blockIndex }
+					insertionIndex={ isInserterOpen?.insertionIndex }
 				/>
 			);
 		}

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -152,7 +152,12 @@ function Editor( { initialSettings } ) {
 
 	const secondarySidebar = () => {
 		if ( isInserterOpen ) {
-			return <InserterSidebar />;
+			return (
+				<InserterSidebar
+					rootClientId={ isInserterOpen?.rootClientId }
+					index={ isInserterOpen?.blockIndex }
+				/>
+			);
 		}
 		if ( isListViewOpen ) {
 			return (

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -152,12 +152,7 @@ function Editor( { initialSettings } ) {
 
 	const secondarySidebar = () => {
 		if ( isInserterOpen ) {
-			return (
-				<InserterSidebar
-					rootClientId={ isInserterOpen?.rootClientId }
-					insertionIndex={ isInserterOpen?.insertionIndex }
-				/>
-			);
+			return <InserterSidebar />;
 		}
 		if ( isListViewOpen ) {
 			return (

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
 import { close } from '@wordpress/icons';
@@ -15,8 +15,12 @@ import {
  */
 import { store as editSiteStore } from '../../store';
 
-export default function InserterSidebar( { rootClientId, insertionIndex } ) {
+export default function InserterSidebar() {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
+	const insertionPoint = useSelect(
+		( select ) => select( editSiteStore ).__experimentalGetInsertionPoint(),
+		[]
+	);
 
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
@@ -39,8 +43,10 @@ export default function InserterSidebar( { rootClientId, insertionIndex } ) {
 				<Library
 					showInserterHelpPanel
 					shouldFocusBlock={ isMobile }
-					rootClientId={ rootClientId }
-					__experimentalInsertionIndex={ insertionIndex }
+					rootClientId={ insertionPoint.rootClientId }
+					__experimentalInsertionIndex={
+						insertionPoint.insertionIndex
+					}
 				/>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -15,7 +15,7 @@ import {
  */
 import { store as editSiteStore } from '../../store';
 
-export default function InserterSidebar( { rootClientId, index } ) {
+export default function InserterSidebar( { rootClientId, insertionIndex } ) {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
 
 	const isMobile = useViewportMatch( 'medium', '<' );
@@ -40,7 +40,7 @@ export default function InserterSidebar( { rootClientId, index } ) {
 					showInserterHelpPanel
 					shouldFocusBlock={ isMobile }
 					rootClientId={ rootClientId }
-					index={ index }
+					__experimentalInsertionIndex={ insertionIndex }
 				/>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -15,7 +15,7 @@ import {
  */
 import { store as editSiteStore } from '../../store';
 
-export default function InserterSidebar() {
+export default function InserterSidebar( { rootClientId, index } ) {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
 
 	const isMobile = useViewportMatch( 'medium', '<' );
@@ -36,7 +36,12 @@ export default function InserterSidebar() {
 				/>
 			</div>
 			<div className="edit-site-editor__inserter-panel-content">
-				<Library showInserterHelpPanel shouldFocusBlock={ isMobile } />
+				<Library
+					showInserterHelpPanel
+					shouldFocusBlock={ isMobile }
+					rootClientId={ rootClientId }
+					index={ index }
+				/>
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -264,15 +264,21 @@ export function setIsNavigationPanelOpened( isOpen ) {
 }
 
 /**
- * Sets whether the block inserter panel should be open.
+ * Returns an action object used to open/close the inserter.
  *
- * @param {boolean} isOpen If true, opens the inserter. If false, closes it. It
- *                         does not toggle the state, but sets it directly.
+ * @param {boolean|Object} value                Whether the inserter should be
+ *                                              opened (true) or closed (false).
+ *                                              To specify an insertion point,
+ *                                              use an object.
+ * @param {string}         value.rootClientId   The root client ID to insert at.
+ * @param {number}         value.insertionIndex The index to insert at.
+ *
+ * @return {Object} Action object.
  */
-export function setIsInserterOpened( isOpen ) {
+export function setIsInserterOpened( value ) {
 	return {
 		type: 'SET_IS_INSERTER_OPENED',
-		isOpen,
+		value,
 	};
 }
 

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -145,12 +145,17 @@ export function navigationPanel(
 				menu: ! action.isOpen ? MENU_ROOT : state.menu, // Set menu to root when closing panel.
 				isOpen: action.isOpen,
 			};
-		case 'SET_IS_INSERTER_OPENED':
 		case 'SET_IS_LIST_VIEW_OPENED':
 			return {
 				...state,
 				menu: state.isOpen && action.isOpen ? MENU_ROOT : state.menu, // Set menu to root when closing panel.
 				isOpen: action.isOpen ? false : state.isOpen,
+			};
+		case 'SET_IS_INSERTER_OPENED':
+			return {
+				...state,
+				menu: state.isOpen && action.value ? MENU_ROOT : state.menu, // Set menu to root when closing panel.
+				isOpen: action.value ? false : state.isOpen,
 			};
 	}
 	return state;
@@ -162,8 +167,8 @@ export function navigationPanel(
  * Note: this reducer interacts with the navigation and list view panels reducers
  * to make sure that only one of the three panels is open at the same time.
  *
- * @param {Object} state Current state.
- * @param {Object} action Dispatched action.
+ * @param {boolean|Object} state  Current state.
+ * @param {Object}         action Dispatched action.
  */
 export function blockInserterPanel( state = false, action ) {
 	switch ( action.type ) {
@@ -173,7 +178,7 @@ export function blockInserterPanel( state = false, action ) {
 		case 'SET_IS_LIST_VIEW_OPENED':
 			return action.isOpen ? false : state;
 		case 'SET_IS_INSERTER_OPENED':
-			return action.isOpen;
+			return action.value;
 	}
 	return state;
 }
@@ -192,8 +197,9 @@ export function listViewPanel( state = false, action ) {
 		case 'OPEN_NAVIGATION_PANEL_TO_MENU':
 			return false;
 		case 'SET_IS_NAVIGATION_PANEL_OPENED':
-		case 'SET_IS_INSERTER_OPENED':
 			return action.isOpen ? false : state;
+		case 'SET_IS_INSERTER_OPENED':
+			return action.value ? false : state;
 		case 'SET_IS_LIST_VIEW_OPENED':
 			return action.isOpen;
 	}

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -231,7 +231,19 @@ export function isNavigationOpened( state ) {
  * @return {boolean} True if the inserter panel should be open; false if closed.
  */
 export function isInserterOpened( state ) {
-	return state.blockInserterPanel;
+	return !! state.blockInserterPanel;
+}
+
+/**
+ * Get the insertion point for the inserter.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} The root client ID and index to insert at.
+ */
+export function __experimentalGetInsertionPoint( state ) {
+	const { rootClientId, insertionIndex } = state.blockInserterPanel;
+	return { rootClientId, insertionIndex };
 }
 
 /**

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -299,7 +299,13 @@ export function setIsWidgetAreaOpen( clientId, isOpen ) {
 /**
  * Returns an action object used to open/close the inserter.
  *
- * @param {boolean} value A boolean representing whether the inserter should be opened or closed.
+ * @param {boolean|Object} value                Whether the inserter should be
+ *                                              opened (true) or closed (false).
+ *                                              To specify an insertion point,
+ *                                              use an object.
+ * @param {string}         value.rootClientId   The root client ID to insert at.
+ * @param {number}         value.insertionIndex The index to insert at.
+ *
  * @return {Object} Action object.
  */
 export function setIsInserterOpened( value ) {

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -32,10 +32,10 @@ export function widgetAreasOpenState( state = {}, action ) {
 /**
  * Reducer tracking whether the inserter is open.
  *
- * @param {boolean} state
- * @param {Object}  action
+ * @param {boolean|Object} state
+ * @param {Object}         action
  */
-function isInserterOpened( state = false, action ) {
+function blockInserterPanel( state = false, action ) {
 	switch ( action.type ) {
 		case 'SET_IS_INSERTER_OPENED':
 			return action.value;
@@ -44,6 +44,6 @@ function isInserterOpened( state = false, action ) {
 }
 
 export default combineReducers( {
-	isInserterOpened,
+	blockInserterPanel,
 	widgetAreasOpenState,
 } );

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -193,5 +193,5 @@ export const getIsWidgetAreaOpen = ( state, clientId ) => {
  * @return {boolean} Whether the inserter is opened.
  */
 export function isInserterOpened( state ) {
-	return state.isInserterOpened;
+	return !! state.blockInserterPanel;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

**Blocking** #29933 and #30285.

This PR seeks to undo some of the complexity introduced in #26443 for the insertion point. The insertion point used to be a simple visible indicator for where block will be inserted/dropped etc., but now it is also used for passing context to the main/library inserter, even when the insertion point is not visible.

This new behaviour is getting in the way when trying to use the insertion point action for other things like drop and the in-between inserter. Showing an insertion point at a different position will result in the loss of context for the main block library.

The solution I'm proposing is to pass the position data directly to the main library inserter when opening it.

It's worth noting that there's already a precedent for passing an index to the experimental `<Library>` component, which we're reusing here.

https://github.com/WordPress/gutenberg/blob/3da717b8d0ac7d7821fc6d0475695ccf3ae2829f/packages/edit-widgets/src/components/layout/interface.js#L90-L94

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
