### PR TITLE
[RNMobile] Add buttons slot to floating toolbar

### DIFF
--- a/packages/block-editor/src/components/floating-toolbar/buttons.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/buttons.native.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Children } from '@wordpress/element';
+import { createSlotFill, Toolbar } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
+
+const { Fill, Slot } = createSlotFill( 'FloatingToolbarButtons' );
+
+const FloatingToolbarButtons = ( { children } ) => (
+	<Fill>
+		<Toolbar passedStyle={ styles.toolbarButtons }>
+			{ Children.count( children ) > 0 && (
+				<View style={ styles.pipeButtons } />
+			) }
+			{ children }
+		</Toolbar>
+	</Fill>
+);
+
+FloatingToolbarButtons.Slot = Slot;
+
+export default FloatingToolbarButtons;

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import styles from './styles.scss';
 import NavigateUpSVG from './nav-up-icon';
+import FloatingToolbarButtons from './buttons';
 import BlockSelectionButton from '../block-list/block-selection-button.native';
 import { store as blockEditorStore } from '../../store';
 
@@ -96,10 +97,13 @@ const FloatingToolbar = ( {
 				<BlockSelectionButton
 					clientId={ blockSelectionButtonClientId }
 				/>
+				<FloatingToolbarButtons.Slot />
 			</Animated.View>
 		)
 	);
 };
+
+export { default as FloatingToolbarButtons } from './buttons';
 
 export default compose( [
 	withSelect( ( select ) => {

--- a/packages/block-editor/src/components/floating-toolbar/styles.native.scss
+++ b/packages/block-editor/src/components/floating-toolbar/styles.native.scss
@@ -32,10 +32,27 @@
 	height: $mobile-floating-toolbar-height;
 }
 
+.toolbarButtons {
+	border-left-width: 0;
+	padding-left: 4;
+	padding-right: 8;
+	height: $mobile-floating-toolbar-height;
+	align-items: center;
+}
+
 .pipe {
 	margin-top: auto;
 	margin-bottom: auto;
 	margin-left: 2px;
+	height: 28px;
+	width: 1px;
+	background-color: #e9eff3;
+	opacity: 0.4;
+}
+
+.pipeButtons {
+	left: -1px;
+	position: absolute;
 	height: 28px;
 	width: 1px;
 	background-color: #e9eff3;

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -58,7 +58,10 @@ export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
 export { useBlockProps } from './block-list/use-block-props';
 export { Block as __experimentalBlock } from './block-list/block-wrapper';
-export { default as FloatingToolbar } from './floating-toolbar';
+export {
+	default as FloatingToolbar,
+	FloatingToolbarButtons,
+} from './floating-toolbar';
 
 // State Related Components
 export { default as BlockEditorProvider } from './provider';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Add a slot in the floating toolbar to allow blocks to add their own buttons.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
There's no block yet using it so for testing this it's required to add code manually.
1. Add the following code to the [Group block](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/group/edit.native.js):

Import `FloatingToolbarButtons` in [this line](https://github.com/WordPress/gutenberg/blob/19a45f136e43ff4ddb8ed78a3e0daa2f6a901ddd/packages/block-library/src/group/edit.native.js#L16):
```
import {
	InnerBlocks,
	FloatingToolbarButtons,
	store as blockEditorStore,
} from '@wordpress/block-editor';
```

Add the floating bar buttons after [this line](https://github.com/WordPress/gutenberg/blob/19a45f136e43ff4ddb8ed78a3e0daa2f6a901ddd/packages/block-library/src/group/edit.native.js#L92):
```
<FloatingToolbarButtons>
	<ToolbarButton
		title={ 'plus' }
		onClick={ () => console.log( 'plus' ) }
		icon={ require( '@wordpress/icons' ).plus }
	/>
	<ToolbarButton
		title={ 'minus' }
		onClick={ () => console.log( 'minus' ) }
		icon={ require( '@wordpress/icons' ).minus }
	/>
</FloatingToolbarButtons>
```
2. Open a post
3. Add the following HTML code:
```
<!-- wp:group -->
<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:code -->
<pre class="wp-block-code"><code></code></pre>
<!-- /wp:code --></div></div>
<!-- /wp:group -->
```
4. Select the Group block
5. Observe that the plus and minus icon buttons are displayed in the floating toolbar
6. Tap on both of them
7. Check that each of them printed a log in the console
8. Tap on the inner Code block
9. Observe that the buttons are still displayed in the floating toolbar

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/14905380/112668309-a6b6cd00-8e5e-11eb-895e-71d2718ec43d.mp4



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
