### PR TITLE
List View: Update the hover, focus, select colors

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -445,9 +445,6 @@
 	--wp-admin-theme-color-darker-10: #{darken($color-primary, 5%)};
 	--wp-admin-theme-color-darker-20: #{darken($color-primary, 10%)};
 
-	// Lighter shades.
-	--wp-admin-theme-color-lighter-90: #{scale-color($color-primary, $lightness: 90%)};
-
 	// Focus style width.
 	// Avoid rounding issues by showing a whole 2px for 1x screens, and 1.5px on high resolution screens.
 	--wp-admin-border-width-focus: 2px;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -445,6 +445,9 @@
 	--wp-admin-theme-color-darker-10: #{darken($color-primary, 5%)};
 	--wp-admin-theme-color-darker-20: #{darken($color-primary, 10%)};
 
+	// Lighter shades.
+	--wp-admin-theme-color-lighter-90: #{scale-color($color-primary, $lightness: 90%)};
+
 	// Focus style width.
 	// Avoid rounding issues by showing a whole 2px for 1x screens, and 1.5px on high resolution screens.
 	--wp-admin-border-width-focus: 2px;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -43,7 +43,7 @@
 	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
 		// Lighten a CSS variable without introducing a new SASS variable
 		background:
-			linear-gradient(transparentize($white, 0.9), transparentize($white, 0.9)),
+			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
 			linear-gradient(var(--wp-admin-theme-color), var(--wp-admin-theme-color));
 		border-radius: 0;
 	}

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -34,7 +34,7 @@
 	&.is-selected .block-editor-block-navigation-block-contents:focus {
 		box-shadow:
 			inset 0 0 0 1px $white,
-			0 0 0 $border-width var(--wp-admin-theme-color);
+			0 0 0 $border-width-focus var(--wp-admin-theme-color);
 	}
 
 	&.is-branch-selected.is-selected .block-editor-block-navigation-block-contents {
@@ -66,7 +66,7 @@
 
 		&:hover,
 		&:focus {
-			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 		}
 		&:focus {
 			z-index: 1;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -41,7 +41,10 @@
 		border-radius: 2px 2px 0 0;
 	}
 	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
-		background: var(--wp-admin-theme-color-lighter-90);
+		// Lighten a CSS variable without introducing a new SASS variable
+		background:
+			linear-gradient(transparentize($white, 0.9), transparentize($white, 0.9)),
+			linear-gradient(var(--wp-admin-theme-color), var(--wp-admin-theme-color));
 		border-radius: 0;
 	}
 	&.is-branch-selected.is-last-of-selected-branch .block-editor-block-navigation-block-contents {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -41,7 +41,7 @@
 		border-radius: 2px 2px 0 0;
 	}
 	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
-		background: $gray-100;
+		background: var(--wp-admin-theme-color-lighter-90);
 		border-radius: 0;
 	}
 	&.is-branch-selected.is-last-of-selected-branch .block-editor-block-navigation-block-contents {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -27,11 +27,14 @@
 	// Use position relative for row animation.
 	position: relative;
 
-	&.is-selected .block-editor-block-navigation-block-contents,
-	&.is-selected:hover .block-editor-block-navigation-block-contents,
-	&.is-selected:focus .block-editor-block-navigation-block-contents {
-		background: $gray-900;
+	&.is-selected .block-editor-block-navigation-block-contents {
+		background: var(--wp-admin-theme-color);
 		color: $white;
+	}
+	&.is-selected .block-editor-block-navigation-block-contents:focus {
+		box-shadow:
+			inset 0 0 0 1px $white,
+			0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 
 	&.is-branch-selected.is-selected .block-editor-block-navigation-block-contents {
@@ -40,10 +43,6 @@
 	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
 		background: $gray-100;
 		border-radius: 0;
-
-		&:hover {
-			background: $gray-300;
-		}
 	}
 	&.is-branch-selected.is-last-of-selected-branch .block-editor-block-navigation-block-contents {
 		border-radius: 0 0 2px 2px;
@@ -65,14 +64,11 @@
 		position: relative;
 		white-space: nowrap;
 
-		&:hover {
-			background: $gray-100;
-		}
-
+		&:hover,
 		&:focus {
-			box-shadow:
-				inset 0 0 0 1px $white,
-				0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
+		}
+		&:focus {
 			z-index: 1;
 		}
 

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -34,7 +34,7 @@
 	&.is-selected .block-editor-block-navigation-block-contents:focus {
 		box-shadow:
 			inset 0 0 0 1px $white,
-			0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 
 	&.is-branch-selected.is-selected .block-editor-block-navigation-block-contents {
@@ -69,7 +69,7 @@
 
 		&:hover,
 		&:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 		&:focus {
 			z-index: 1;


### PR DESCRIPTION
## Description

This PR experiments on the List View colors, hoping to make them more clear.

## How has this been tested?

- Install a block theme such as TT1 Blocks, and open the Site Editor.
- Toggle the (persistent) List View.
- Play around with it.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/2070010/112668544-8a169700-8e56-11eb-96a1-4425bb2e663a.mp4

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
