### PR TITLE
Removed before psevdo for access to buttons

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -37,6 +37,16 @@
 			}
 		}
 
+		figure::before {
+			display: none;
+		}
+
+		figure:hover {
+			box-shadow: 0 0 0 1px #fff inset, 0 0 0 3px var(--wp-admin-theme-color) inset;
+			outline: 2px solid transparent;
+			z-index: 1;
+		}
+
 		img {
 			display: block;
 			max-width: 100%;


### PR DESCRIPTION
Hello ) this is a fix to "Can't replace image in gallery block #30158" issue , I removed styles for  before pseudo element and assign styles to figure tag.