### PR TITLE
Widgets: Fix warning when widgets block editor is disabled

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -280,7 +280,6 @@ function gutenberg_set_show_instance_in_rest_on_core_widgets() {
 	global $wp_widget_factory;
 
 	$core_widgets = array(
-		'WP_Widget_Block',
 		'WP_Widget_Pages',
 		'WP_Widget_Calendar',
 		'WP_Widget_Archives',
@@ -301,7 +300,9 @@ function gutenberg_set_show_instance_in_rest_on_core_widgets() {
 	);
 
 	foreach ( $core_widgets as $widget ) {
-		$wp_widget_factory->widgets[ $widget ]->show_instance_in_rest = true;
+		if ( isset( $wp_widget_factory->widgets[ $widget ] ) ) {
+			$wp_widget_factory->widgets[ $widget ]->show_instance_in_rest = true;
+		}
 	}
 }
 add_action( 'widgets_init', 'gutenberg_set_show_instance_in_rest_on_core_widgets' );


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/30305.

If a core widget is unregistered then it will not be in `$wp_widgets_factory→widgets` which causes a PHP warning.

We also don't need to set `show_instance_in_rest` on `WP_Widget_Block` since it already declares this.

## How has this been tested?
1. Comment out `add_theme_support( 'widgets-block-editor' );` in `lib/init.php`.
2. Load WP Admin.
3. There is not a PHP warning.


## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
