### PR TITLE
Widgets Customizer: Add Legacy Widget block

### DIFF
--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -34,7 +34,8 @@ export default function PreviewIframe( { idBase, instance, isVisible } ) {
 			<iframe
 				ref={ ref }
 				className="wp-block-legacy-widget__edit-preview"
-				src={ addQueryArgs( '', {
+				src={ addQueryArgs( 'themes.php', {
+					page: 'gutenberg-widgets',
 					'legacy-widget-preview': {
 						idBase,
 						instance,

--- a/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
@@ -59,32 +59,41 @@ function blockToWidget( block, existingWidget = null ) {
 	};
 }
 
-function widgetToBlock( widget ) {
+function widgetToBlock( {
+	id,
+	idBase,
+	number,
+	instance: {
+		encoded_serialized_instance: encoded,
+		instance_hash_key: hash,
+		raw_instance: raw,
+	},
+} ) {
 	let block;
 
-	if ( widget.idBase === 'block' ) {
-		const parsedBlocks = parse( widget.instance.raw_instance.content );
+	if ( idBase === 'block' ) {
+		const parsedBlocks = parse( raw.content );
 		block = parsedBlocks.length
 			? parsedBlocks[ 0 ]
 			: createBlock( 'core/paragraph', {} );
-	} else if ( widget.number ) {
+	} else if ( number ) {
 		// Widget that extends WP_Widget.
 		block = createBlock( 'core/legacy-widget', {
-			idBase: widget.idBase,
+			idBase,
 			instance: {
-				encoded: widget.instance.encoded_serialized_instance,
-				hash: widget.instance.instance_hash_key,
-				raw: widget.instance.raw_instance,
+				encoded,
+				hash,
+				raw,
 			},
 		} );
 	} else {
 		// Widget that does not extend WP_Widget.
 		block = createBlock( 'core/legacy-widget', {
-			id: widget.id,
+			id,
 		} );
 	}
 
-	return addWidgetIdToBlock( block, widget.id );
+	return addWidgetIdToBlock( block, id );
 }
 
 function initState( sidebar ) {

--- a/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
@@ -36,7 +36,7 @@ function blockToWidget( block, existingWidget = null ) {
 					encoded_serialized_instance:
 						block.attributes.instance.encoded,
 					instance_hash_key: block.attributes.instance.hash,
-					__unstable_instance: block.attributes.instance.raw,
+					raw_instance: block.attributes.instance.raw,
 				},
 			};
 		}
@@ -48,7 +48,7 @@ function blockToWidget( block, existingWidget = null ) {
 			idBase: 'block',
 			widgetClass: 'WP_Widget_Block',
 			instance: {
-				__unstable_instance: instance,
+				raw_instance: instance,
 			},
 		};
 	}
@@ -63,9 +63,7 @@ function widgetToBlock( widget ) {
 	let block;
 
 	if ( widget.idBase === 'block' ) {
-		const parsedBlocks = parse(
-			widget.instance.__unstable_instance.content
-		);
+		const parsedBlocks = parse( widget.instance.raw_instance.content );
 		block = parsedBlocks.length
 			? parsedBlocks[ 0 ]
 			: createBlock( 'core/paragraph', {} );
@@ -76,7 +74,7 @@ function widgetToBlock( widget ) {
 			instance: {
 				encoded: widget.instance.encoded_serialized_instance,
 				hash: widget.instance.instance_hash_key,
-				raw: widget.instance.__unstable_instance,
+				raw: widget.instance.raw_instance,
 			},
 		} );
 	} else {

--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
 import {
 	registerCoreBlocks,
 	__experimentalGetCoreBlocks,
@@ -26,36 +25,10 @@ export function initialize() {
 	registerCoreBlocks( coreBlocks );
 
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks();
+		__experimentalRegisterExperimentalCoreBlocks( {
+			enableLegacyWidgetBlock: true,
+		} );
 	}
-
-	// TODO: Register legacy widgets block
-	registerBlockType( 'core/legacy-widget', {
-		title: 'Legacy Widget',
-		attributes: {
-			widgetClass: {
-				type: 'string',
-			},
-			referenceWidgetName: {
-				type: 'string',
-			},
-			name: {
-				type: 'string',
-			},
-			idBase: {
-				type: 'string',
-			},
-			number: {
-				type: 'number',
-			},
-			instance: {
-				type: 'object',
-			},
-		},
-		edit( { attributes } ) {
-			return <div>{ JSON.stringify( attributes ) }</div>;
-		},
-	} );
 
 	wp.customize.sectionConstructor.sidebar = SidebarSection;
 	wp.customize.controlConstructor.sidebar_block_editor = SidebarControl;


### PR DESCRIPTION
## Description

Closes https://github.com/WordPress/gutenberg/issues/30265.
Closes https://github.com/WordPress/gutenberg/issues/30266.

Wires up the Legacy Widget block — which was rewritten in https://github.com/WordPress/gutenberg/pull/29960 — to the Widgets Customizer and removes the `__unstable_instance` hack added in https://github.com/WordPress/gutenberg/pull/29365 in favour of a correct and more permanent solution.

## How has this been tested?

1. Enable the "Enable Widgets screen in Customizer" experiment 
2. Navigate to Appearance → Customize → Widgets
3. Legacy Widgets blocks should appear on the left with the correct settings. (If there are no legacy widgets, you'll have to add them via Appearance → Widgets right now.)
4. Updating the Legacy Widget blocks should update the preview on the right.
5. Pressing _Publish_ should save any changes on the frontend.

## Screenshots 

https://user-images.githubusercontent.com/612155/112789794-99415300-90a9-11eb-80b9-847de1575eda.mp4


## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->