### PR TITLE
Global Styles: Add padding server-side block support

### DIFF
--- a/lib/block-supports/align.php
+++ b/lib/block-supports/align.php
@@ -11,10 +11,7 @@
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_alignment_support( $block_type ) {
-	$has_align_support = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_align_support = _wp_array_get( $block_type->supports, array( 'align' ), false );
-	}
+	$has_align_support = gutenberg_block_has_support( $block_type, array( 'align' ), false );
 	if ( $has_align_support ) {
 		if ( ! $block_type->attributes ) {
 			$block_type->attributes = array();
@@ -40,10 +37,7 @@ function gutenberg_register_alignment_support( $block_type ) {
  */
 function gutenberg_apply_alignment_support( $block_type, $block_attributes ) {
 	$attributes        = array();
-	$has_align_support = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_align_support = _wp_array_get( $block_type->supports, array( 'align' ), false );
-	}
+	$has_align_support = gutenberg_block_has_support( $block_type, array( 'align' ), false );
 	if ( $has_align_support ) {
 		$has_block_alignment = array_key_exists( 'align', $block_attributes );
 

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -14,7 +14,7 @@
 function gutenberg_register_border_support( $block_type ) {
 	// Determine border related features supported.
 	// Border width, style etc can be added in the future.
-	$has_border_radius_support = gutenberg_has_border_support( $block_type, 'radius' );
+	$has_border_radius_support = gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ), false );
 
 	// Setup attributes and styles within that if needed.
 	if ( ! $block_type->attributes ) {
@@ -52,7 +52,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	$styles = array();
 
 	// Border Radius.
-	if ( gutenberg_has_border_support( $block_type, 'radius' ) ) {
+	$has_border_radius_support = gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ), false );
+	if ( $has_border_radius_support ) {
 		if ( isset( $block_attributes['style']['border']['radius'] ) ) {
 			$border_radius = intval( $block_attributes['style']['border']['radius'] );
 			$styles[]      = sprintf( 'border-radius: %dpx;', $border_radius );
@@ -69,24 +70,6 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	}
 
 	return $attributes;
-}
-
-/**
- * Checks whether the current block type supports the feature requested.
- *
- * @param WP_Block_Type $block_type Block type to check for support.
- * @param string        $feature    Name of the feature to check support for.
- * @param mixed         $default    Fallback value for feature support, defaults to false.
- *
- * @return boolean                  Whether or not the feature is supported.
- */
-function gutenberg_has_border_support( $block_type, $feature, $default = false ) {
-	$block_support = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$block_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), $default );
-	}
-
-	return true === $block_support || ( is_array( $block_support ) && _wp_array_get( $block_support, array( $feature ), false ) );
 }
 
 // Register the block support.

--- a/lib/block-supports/custom-classname.php
+++ b/lib/block-supports/custom-classname.php
@@ -11,10 +11,8 @@
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_custom_classname_support( $block_type ) {
-	$has_custom_classname_support = true;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_custom_classname_support = _wp_array_get( $block_type->supports, array( 'customClassName' ), true );
-	}
+	$has_custom_classname_support = gutenberg_block_has_support( $block_type, array( 'customClassName' ), true );
+
 	if ( $has_custom_classname_support ) {
 		if ( ! $block_type->attributes ) {
 			$block_type->attributes = array();
@@ -37,11 +35,8 @@ function gutenberg_register_custom_classname_support( $block_type ) {
  * @return array Block CSS classes and inline styles.
  */
 function gutenberg_apply_custom_classname_support( $block_type, $block_attributes ) {
-	$has_custom_classname_support = true;
+	$has_custom_classname_support = gutenberg_block_has_support( $block_type, array( 'customClassName' ), true );
 	$attributes                   = array();
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_custom_classname_support = _wp_array_get( $block_type->supports, array( 'customClassName' ), true );
-	}
 	if ( $has_custom_classname_support ) {
 		$has_custom_classnames = array_key_exists( 'className', $block_attributes );
 

--- a/lib/block-supports/generated-classname.php
+++ b/lib/block-supports/generated-classname.php
@@ -39,11 +39,8 @@ function gutenberg_get_block_default_classname( $block_name ) {
  * @return array Block CSS classes and inline styles.
  */
 function gutenberg_apply_generated_classname_support( $block_type ) {
-	$has_generated_classname_support = true;
 	$attributes                      = array();
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_generated_classname_support = _wp_array_get( $block_type->supports, array( 'className' ), true );
-	}
+	$has_generated_classname_support = gutenberg_block_has_support( $block_type, array( 'className' ), true );
 	if ( $has_generated_classname_support ) {
 		$block_classname = gutenberg_get_block_default_classname( $block_type->name );
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -11,10 +11,7 @@
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_layout_support( $block_type ) {
-	$support_layout = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$support_layout = _wp_array_get( $block_type->supports, array( '__experimentalLayout' ), false );
-	}
+	$support_layout = gutenberg_block_has_support( $block_type, array( '__experimentalLayout' ), false );
 	if ( $support_layout ) {
 		if ( ! $block_type->attributes ) {
 			$block_type->attributes = array();
@@ -37,10 +34,7 @@ function gutenberg_register_layout_support( $block_type ) {
  */
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$block_type     = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$support_layout = false;
-	if ( $block_type && property_exists( $block_type, 'supports' ) ) {
-		$support_layout = _wp_array_get( $block_type->supports, array( '__experimentalLayout' ), false );
-	}
+	$support_layout = gutenberg_block_has_support( $block_type, array( '__experimentalLayout' ), false );
 	if ( ! $support_layout || ! isset( $block['attrs']['layout'] ) ) {
 		return $block_content;
 	}

--- a/lib/block-supports/padding.php
+++ b/lib/block-supports/padding.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Padding block support flag.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the style block attribute for block types that support it.
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function gutenberg_register_padding_support( $block_type ) {
+	$has_padding_support = gutenberg_block_has_support( $block_type, array( 'spacing', 'padding' ), false );
+
+	// Setup attributes and styles within that if needed.
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( $has_padding_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+		$block_type->attributes['style'] = array(
+			'type' => 'object',
+		);
+	}
+}
+
+/**
+ * Add CSS classes for block padding to the incoming attributes array.
+ * This will be applied to the block markup in the front-end.
+ *
+ * @param WP_Block_Type $block_type       Block Type.
+ * @param array         $block_attributes Block attributes.
+ *
+ * @return array Block padding CSS classes and inline styles.
+ */
+function gutenberg_apply_padding_support( $block_type, $block_attributes ) {
+	$has_padding_support = gutenberg_block_has_support( $block_type, array( 'spacing', 'padding' ), false );
+	$styles              = array();
+	if ( $has_padding_support ) {
+		$padding_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'padding' ), null );
+		if ( null !== $padding_value ) {
+			foreach ( $padding_value as $key => $value ) {
+				$styles[] = sprintf( 'padding-%s: %s;', $key, $value );
+			}
+		}
+	}
+
+	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'padding',
+	array(
+		'register_attribute' => 'gutenberg_register_padding_support',
+		'apply'              => 'gutenberg_apply_padding_support',
+	)
+);

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -375,3 +375,21 @@ function gutenberg_register_theme_block_category( $categories ) {
 }
 
 add_filter( 'block_categories', 'gutenberg_register_theme_block_category' );
+
+/**
+ * Checks whether the current block type supports the feature requested.
+ *
+ * @param WP_Block_Type $block_type Block type to check for support.
+ * @param string        $feature    Name of the feature to check support for.
+ * @param mixed         $default    Fallback value for feature support, defaults to false.
+ *
+ * @return boolean                  Whether or not the feature is supported.
+ */
+function gutenberg_block_has_support( $block_type, $feature, $default = false ) {
+	$block_support = $default;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$block_support = _wp_array_get( $block_type->supports, $feature, $default );
+	}
+
+	return true === $block_support || is_array( $block_support );
+}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -387,7 +387,7 @@ add_filter( 'block_categories', 'gutenberg_register_theme_block_category' );
  */
 function gutenberg_block_has_support( $block_type, $feature, $default = false ) {
 	$block_support = $default;
-	if ( property_exists( $block_type, 'supports' ) ) {
+	if ( $block_type && property_exists( $block_type, 'supports' ) ) {
 		$block_support = _wp_array_get( $block_type->supports, $feature, $default );
 	}
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -123,3 +123,4 @@ require __DIR__ . '/block-supports/typography.php';
 require __DIR__ . '/block-supports/custom-classname.php';
 require __DIR__ . '/block-supports/border.php';
 require __DIR__ . '/block-supports/layout.php';
+require __DIR__ . '/block-supports/padding.php';


### PR DESCRIPTION
Related #28356 

This PR adds the padding block support flag server-side allowing dynamic blocks to use it. 
At the moment, it doesn't enable it for any block though (I'll leave that for you all designers to enable it on the blocks you like).

**Testing instructions**

 - Add `spacing: { padding: true }` to the `block.json` of the dynamic block where  you want to enable padding support.
 - Check that you can set padding in the editor and that it is rendered on both editor and frontend.