### PR TITLE
Block Support: Add configurable sides and margins to spacing support

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -119,7 +119,7 @@ class WP_Theme_JSON {
 				'text'       => null,
 			),
 			'spacing'    => array(
-				'margin' => array(
+				'margin'  => array(
 					'top'    => null,
 					'right'  => null,
 					'bottom' => null,
@@ -158,6 +158,7 @@ class WP_Theme_JSON {
 			),
 			'spacing'    => array(
 				'customPadding' => null,
+				'customMargin'  => null,
 				'units'         => null,
 			),
 			'typography' => array(
@@ -315,7 +316,7 @@ class WP_Theme_JSON {
 			'value'   => array( 'typography', 'lineHeight' ),
 			'support' => array( 'lineHeight' ),
 		),
-		'margin'                  => array(
+		'margin'                   => array(
 			'value'      => array( 'spacing', 'margin' ),
 			'support'    => array( 'spacing', 'margin' ),
 			'properties' => array( 'top', 'right', 'bottom', 'left' ),

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -119,6 +119,12 @@ class WP_Theme_JSON {
 				'text'       => null,
 			),
 			'spacing'    => array(
+				'margin' => array(
+					'top'    => null,
+					'right'  => null,
+					'bottom' => null,
+					'left'   => null,
+				),
 				'padding' => array(
 					'top'    => null,
 					'right'  => null,
@@ -308,6 +314,11 @@ class WP_Theme_JSON {
 		'lineHeight'               => array(
 			'value'   => array( 'typography', 'lineHeight' ),
 			'support' => array( 'lineHeight' ),
+		),
+		'margin'                  => array(
+			'value'      => array( 'spacing', 'margin' ),
+			'support'    => array( 'spacing', 'margin' ),
+			'properties' => array( 'top', 'right', 'bottom', 'left' ),
 		),
 		'padding'                  => array(
 			'value'      => array( 'spacing', 'padding' ),

--- a/packages/block-editor/src/components/spacing-panel-control/index.js
+++ b/packages/block-editor/src/components/spacing-panel-control/index.js
@@ -12,8 +12,11 @@ import useEditorFeature from '../use-editor-feature';
 
 export default function SpacingPanelControl( { children, ...props } ) {
 	const isSpacingEnabled = useEditorFeature( 'spacing.customPadding' );
+	const isMarginEnabled = useEditorFeature( 'spacing.customMargin' );
 
-	if ( ! isSpacingEnabled ) return null;
+	if ( ! isSpacingEnabled && ! isMarginEnabled ) {
+		return null;
+	}
 
 	return (
 		<InspectorControls { ...props }>

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -15,35 +15,34 @@ import { cleanEmptyObject } from './utils';
 import { useCustomUnits } from '../components/unit-control';
 
 /**
- * Determines if there is padding support.
+ * Determines if there is margin support.
  *
  * @param  {string|Object} blockType Block name or Block Type object.
  * @return {boolean}                 Whether there is support.
  */
-const hasPaddingSupport = ( blockType ) => {
+const hasMarginSupport = ( blockType ) => {
 	const support = getBlockSupport( blockType, SPACING_SUPPORT_KEY );
-	return !! ( true === support || support?.padding );
+	return !! ( true === support || support?.margin );
 };
 
 /**
- * Custom hook that checks if padding settings have been disabled.
+ * Custom hook that checks if margin settings have been disabled.
  *
  * @param  {string} name The name of the block.
- * @return {boolean}                 Whether padding setting is disabled.
+ * @return {boolean}     Whether margin setting is disabled.
  */
-export function useIsPaddingDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useEditorFeature( 'spacing.customPadding' );
-	return ! hasPaddingSupport( blockName ) || isDisabled;
+export function useIsMarginDisabled( { name: blockName } = {} ) {
+	const isDisabled = ! useEditorFeature( 'spacing.customMargin' );
+	return ! hasMarginSupport( blockName ) || isDisabled;
 }
 
 /**
- * Inspector control panel containing the padding related configuration
+ * Inspector control panel containing the margin related configuration
  *
- * @param {Object} props
- *
- * @return {WPElement} Padding edit element.
+ * @param  {Object} props Block props.
+ * @return {WPElement}    Margin edit element.
  */
-export function PaddingEdit( props ) {
+export function MarginEdit( props ) {
 	const {
 		name: blockName,
 		attributes: { style },
@@ -51,9 +50,9 @@ export function PaddingEdit( props ) {
 	} = props;
 
 	const units = useCustomUnits();
-	const sides = useCustomSides( blockName, 'padding' );
+	const sides = useCustomSides( blockName, 'margin' );
 
-	if ( ! hasPaddingSupport( blockName ) ) {
+	if ( ! hasMarginSupport( blockName ) ) {
 		return null;
 	}
 
@@ -62,7 +61,7 @@ export function PaddingEdit( props ) {
 			...style,
 			spacing: {
 				...style?.spacing,
-				padding: next,
+				margin: next,
 			},
 		};
 
@@ -75,7 +74,7 @@ export function PaddingEdit( props ) {
 		const newStyle = {
 			...style,
 			visualizers: {
-				padding: next,
+				margin: next,
 			},
 		};
 
@@ -88,10 +87,10 @@ export function PaddingEdit( props ) {
 		web: (
 			<>
 				<BoxControl
-					values={ style?.spacing?.padding }
+					values={ style?.spacing?.margin }
 					onChange={ onChange }
 					onChangeShowVisualizer={ onChangeShowVisualizer }
-					label={ __( 'Padding' ) }
+					label={ __( 'Margin' ) }
 					sides={ sides }
 					units={ units }
 				/>

--- a/packages/block-editor/src/hooks/spacing.js
+++ b/packages/block-editor/src/hooks/spacing.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import { Platform } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { PaddingEdit, useIsPaddingDisabled } from './padding';
+import { MarginEdit, useIsMarginDisabled } from './margin';
+import SpacingPanelControl from '../components/spacing-panel-control';
+
+export const SPACING_SUPPORT_KEY = 'spacing';
+
+/**
+ * Inspector controls for spacing support.
+ *
+ * @param  {Object} props Block props.
+ * @return {WPElement}    Inspector controls for spacing support features.
+ */
+export function SpacingPanel( props ) {
+	const isDisabled = useIsSpacingDisabled( props );
+	const isSupported = hasSpacingSupport( props.name );
+
+	if ( isDisabled || ! isSupported ) {
+		return null;
+	}
+
+	return (
+		<SpacingPanelControl key="spacing">
+			<PaddingEdit { ...props } />
+			<MarginEdit { ...props } />
+		</SpacingPanelControl>
+	);
+}
+
+/**
+ * Determine whether there is block support for padding or margins.
+ *
+ * @param {string} blockName Block name.
+ * @return {boolean}         Whether there is support.
+ */
+export function hasSpacingSupport( blockName ) {
+	if ( Platform.OS !== 'web' ) {
+		return false;
+	}
+
+	const support = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
+
+	return !! ( true === support || support?.padding || support?.margin );
+}
+
+/**
+ * Determines whether spacing support has been disabled.
+ *
+ * @param  {Object} props Block properties.
+ * @return {boolean}      If spacing support is completely disabled.
+ */
+const useIsSpacingDisabled = ( props = {} ) => {
+	const paddingDisabled = useIsPaddingDisabled( props );
+	const marginDisabled = useIsMarginDisabled( props );
+
+	return paddingDisabled && marginDisabled;
+};
+
+/**
+ * Custom hook to retrieve which padding/margin is supported
+ * e.g. top, right, bottom or left.
+ *
+ * Sides are opted into by default. It is only if a specific side is set to
+ * false that it is omitted.
+ *
+ * @param  {string} blockName Block name.
+ * @param  {string} feature   The feature custom sides relate to e.g. padding or margins.
+ * @return {Object}           Sides supporting custom margin.
+ */
+export function useCustomSides( blockName, feature ) {
+	const support = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
+
+	// Return empty config when setting is boolean as theme isn't setting
+	// arbitrary sides.
+	if ( typeof support[ feature ] === 'boolean' ) {
+		return {};
+	}
+
+	return support[ feature ];
+}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -18,9 +18,8 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
+import { SPACING_SUPPORT_KEY, SpacingPanel } from './spacing';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
-import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
-import SpacingPanelControl from '../components/spacing-panel-control';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -119,7 +118,7 @@ export function addSaveProps( props, blockType, attributes ) {
 }
 
 /**
- * Filters registered block settings to extand the block edit wrapper
+ * Filters registered block settings to extend the block edit wrapper
  * to apply the desired styles and classnames properly.
  *
  * @param  {Object} settings Original block settings
@@ -152,23 +151,12 @@ export function addEditProps( settings ) {
  */
 export const withBlockControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const { name: blockName } = props;
-
-		const hasSpacingSupport = hasBlockSupport(
-			blockName,
-			SPACING_SUPPORT_KEY
-		);
-
 		return [
 			<TypographyPanel key="typography" { ...props } />,
 			<BorderPanel key="border" { ...props } />,
 			<ColorEdit key="colors" { ...props } />,
 			<BlockEdit key="edit" { ...props } />,
-			hasSpacingSupport && (
-				<SpacingPanelControl key="spacing">
-					<PaddingEdit { ...props } />
-				</SpacingPanelControl>
-			),
+			<SpacingPanel key="spacing" { ...props } />,
 		];
 	},
 	'withToolbarControls'

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -18,6 +18,10 @@ describe( 'getInlineStyles', () => {
 				color: { text: 'red', background: 'black' },
 				typography: { lineHeight: 1.5, fontSize: 10 },
 				border: { radius: 10 },
+				spacing: {
+					padding: { top: '10px' },
+					margin: { bottom: '15px' },
+				},
 			} )
 		).toEqual( {
 			backgroundColor: 'black',
@@ -25,6 +29,8 @@ describe( 'getInlineStyles', () => {
 			color: 'red',
 			lineHeight: 1.5,
 			fontSize: 10,
+			marginBottom: '15px',
+			paddingTop: '10px',
 		} );
 	} );
 } );

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -53,6 +53,11 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		value: [ 'typography', 'lineHeight' ],
 		support: [ 'lineHeight' ],
 	},
+	margin: {
+		value: [ 'spacing', 'margin' ],
+		support: [ 'spacing', 'margin' ],
+		properties: [ 'top', 'right', 'bottom', 'left' ],
+	},
 	padding: {
 		value: [ 'spacing', 'padding' ],
 		support: [ 'spacing', 'padding' ],

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -52,12 +52,20 @@ export default function BoxControl( {
 	values: valuesProp,
 	units,
 	sides,
+	resetToInitialValues = false,
 } ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
 	} );
 	const inputValues = values || DEFAULT_VALUES;
 	const hasInitialValue = isValuesDefined( valuesProp );
+
+	// Determine which values the reset button should apply.
+	// Global styles generally prefer to reset to the initial value likely
+	// coming from a theme.
+	const resetValues = useRef(
+		resetToInitialValues && valuesProp ? valuesProp : DEFAULT_VALUES
+	);
 
 	const [ isDirty, setIsDirty ] = useState( hasInitialValue );
 	const [ isLinked, setIsLinked ] = useState(
@@ -93,10 +101,8 @@ export default function BoxControl( {
 	};
 
 	const handleOnReset = () => {
-		const initialValues = DEFAULT_VALUES;
-
-		onChange( initialValues );
-		setValues( initialValues );
+		onChange( resetValues.current );
+		setValues( resetValues.current );
 		setIsDirty( false );
 	};
 

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -6,17 +6,31 @@ import {
 	__experimentalBoxControl as BoxControl,
 	PanelBody,
 } from '@wordpress/components';
+import { getBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { useEditorFeature } from '../editor/utils';
 
-export function useHasSpacingPanel( { supports, name } ) {
+export function useHasSpacingPanel( context ) {
+	const hasPadding = useHasPadding( context );
+	const hasMargin = useHasMargin( context );
+
+	return hasPadding || hasMargin;
+}
+
+function useHasPadding( { name, supports } ) {
 	return (
 		useEditorFeature( 'spacing.customPadding', name ) &&
 		supports.includes( 'padding' )
 	);
+}
+
+function useHasMargin( { name, supports } ) {
+	const settings = useEditorFeature( 'spacing.customMargin', name );
+
+	return settings && supports.includes( 'margin' );
 }
 
 function filterUnitsWithSettings( settings = [], units = [] ) {
@@ -35,29 +49,77 @@ function useCustomUnits( { units, contextName } ) {
 	return usedUnits.length === 0 ? false : usedUnits;
 }
 
-export default function SpacingPanel( {
-	context: { name },
-	getStyle,
-	setStyle,
-} ) {
+function useCustomSides( blockName, feature ) {
+	const support = getBlockSupport( blockName, 'spacing' );
+
+	// Return empty config when setting is boolean as theme isn't setting
+	// arbitrary sides.
+	if ( typeof support[ feature ] === 'boolean' ) {
+		return {};
+	}
+
+	return support[ feature ];
+}
+
+function filterValuesBySides( values, sides ) {
+	if ( Object.entries( sides ).length === 0 ) {
+		// If no custom side configuration all sides are opted into by default.
+		return values;
+	}
+
+	// Only include sides opted into within filtered values.
+	return Object.keys( sides )
+		.filter( ( side ) => sides[ side ] )
+		.reduce(
+			( filtered, side ) => ( { ...filtered, [ side ]: values[ side ] } ),
+			{}
+		);
+}
+
+export default function SpacingPanel( { context, getStyle, setStyle } ) {
+	const { name } = context;
+	const showPaddingControl = useHasPadding( context );
+	const showMarginControl = useHasMargin( context );
 	const units = useCustomUnits( { contextName: name } );
+
 	const paddingValues = getStyle( name, 'padding' );
-	const setPaddingValues = ( { top, right, bottom, left } ) => {
-		setStyle( name, 'padding', {
-			top: top || paddingValues?.top,
-			right: right || paddingValues?.right,
-			bottom: bottom || paddingValues?.bottom,
-			left: left || paddingValues?.left,
-		} );
+	const paddingSides = useCustomSides( name, 'padding' );
+
+	const setPaddingValues = ( newPaddingValues ) => {
+		const padding = filterValuesBySides( newPaddingValues, paddingSides );
+		setStyle( name, 'padding', padding );
 	};
+
+	const marginValues = getStyle( name, 'margin' );
+	const marginSides = useCustomSides( name, 'margin' );
+
+	const setMarginValues = ( newMarginValues ) => {
+		const margin = filterValuesBySides( newMarginValues, marginSides );
+		setStyle( name, 'margin', margin );
+	};
+
 	return (
 		<PanelBody title={ __( 'Spacing' ) }>
-			<BoxControl
-				values={ paddingValues }
-				onChange={ setPaddingValues }
-				label={ __( 'Padding' ) }
-				units={ units }
-			/>
+			{ showPaddingControl && (
+				<BoxControl
+					values={ paddingValues }
+					onChange={ setPaddingValues }
+					label={ __( 'Padding' ) }
+					sides={ paddingSides }
+					units={ units }
+					resetToInitialValues
+				/>
+			) }
+			{ showMarginControl && (
+				<BoxControl
+					values={ marginValues }
+					onChange={ setMarginValues }
+					label={ __( 'Margin' ) }
+					sides={ marginSides }
+					units={ units }
+					resetToInitialValues
+				/>
+			) }
 		</PanelBody>
 	);
 }


### PR DESCRIPTION
## Description
- Add block support for margins under the spacing feature
- Leverages the modified `BoxControl` from #29363 to allow arbitrary sides to be configured


_Branched from #29363 which should be close to being able to land_


## How has this been tested?

Simple unit test for spacing inline styles: 
`npm run test-unit:watch packages/block-editor/src/hooks/test/style.js`

Manually.

#### Test Setup

1. Enable spacing controls for individual blocks. In your theme.json set both `customMargin` and `customPadding` under `settings.defaults.spacing` to true ( [gist](https://gist.github.com/8e642152e04361f0cfad1d44f10e628f) )
    <img width="250" alt="Screen Shot 2021-03-29 at 6 13 08 pm" src="https://user-images.githubusercontent.com/60436221/112806998-bb8f9c80-90ba-11eb-9603-5dda5d3d14ca.png">
2. In the group block's `block.json` file, opt into padding support. 
    Then configure support for only top/bottom margins ( [gist](https://gist.github.com/42baddd8cc2c707420059669269c74e8) ).
    <img width="250" alt="Screen Shot 2021-03-29 at 6 19 22 pm" src="https://user-images.githubusercontent.com/60436221/112807559-656f2900-90bb-11eb-86a1-737df4e35c3b.png">
3. If you want to see dual visualizers (one for padding and another for margins) you can update the group block's edit component as per this [gist](https://gist.github.com/aaronrobertshaw/f7dd05121cc7cf3fa488410310988427).

#### Test Instructions - Block Support
1. After checking out this PR and completing the setup above. Create a new post, add a group block and set a background color on it.
2. Select the block and confirm that a Spacing panel is displayed in the Inspector Controls.
3. Within the spacing controls, check that the padding controls still allow editing every side
4. Ensure the spacing margin controls only allow setting the top/bottom margins specified in the setup config
5. The `BoxControl` icon for margins should reflect the configured sides as well.
6. If you've setup the second visualizer, ensure it reflects changes.
7. Spacing the block with some padding and margins.
8. Ensure those choices are saved correctly and rendered on the frontend.

#### Test Instructions - Global Styles
1. Undo the change to your theme.json from Test Setup step 1.
2. Add new configuration to your theme.json settings specifically for the `core/group` block context ( [gist](https://gist.github.com/563540daeb3e5ca90bb8b01bbaa593c4) )
    <img width="340" alt="Screen Shot 2021-04-07 at 3 53 21 pm" src="https://user-images.githubusercontent.com/60436221/113817293-773a8580-97b9-11eb-96dd-d4d06015b219.png">
3. Ensure you have a block based theme active. Then open the Site Editor.
4. Confirm there are no spacing controls under "Root" in the Global Styles sidebar.
5. Switch to the "By Block Type" tab in the Global Styles sidebar.
6. Expand the Cover block and you should only see the padding controls.
7. Expand the Group block and you should see both padding and margin controls. The margin controls should reflect the sides you've configured via the group block.json file.

## Screenshots <!-- if applicable -->
<img width="500" src="https://user-images.githubusercontent.com/60436221/112808648-8d12c100-90bc-11eb-8591-3a9140cb6449.gif" />

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
