### PR TITLE
Try: Increase specificity of horizontal block margins.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -12,7 +12,11 @@
 
 	// Add a little left margin when used horizontally.
 	// The right margin should be set to auto, so as to not shift layout in flex containers.
-	margin: 0 auto 0 $grid-unit-10;
+	// This needs specificity for non-block-themes.
+	&,
+	.edit-post-layout:not(.supports-layout) & {
+		margin: 0 auto 0 $grid-unit-10;
+	}
 
 	// ... unless it's the only child.
 	&:first-child {

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -8,20 +8,27 @@ $blocks-block__margin: 0.5em;
 
 .wp-block-buttons {
 	> .wp-block {
-		// Override editor auto block margins.
-		margin-left: 0;
-		margin-top: $blocks-block__margin;
-		margin-right: $blocks-block__margin;
+
+		&,
+		.edit-post-layout:not(.supports-layout) & {
+			// Override editor auto block margins.
+			margin-left: 0;
+			margin-top: $blocks-block__margin;
+			margin-right: $blocks-block__margin;
+		}
 	}
+
 	> .block-list-appender {
 		display: inline-flex;
 		align-items: center;
 	}
+
 	&.is-vertical {
 		> .block-list-appender .block-list-appender__toggle {
 			justify-content: flex-start;
 		}
 	}
+
 	> .wp-block-button {
 		&:focus {
 			box-shadow: none;


### PR DESCRIPTION
## Description

A recent PR scoped the automatic left and right margins for `.wp-block` to themes that do not _support layout_. This is great because those left/right margins wreak havoc. See #29335. 

However in doing so, the `:not` selector ended up adding specificity to the rule. That means _theme_ rules that try to override those rules now fail in doing so. I don't know any good solution to this problem, other than adding additional specificity for those rules.

It also had the side-effect of adding auto margins for some block styles. Specifically, it centered blocks inside flex containers, like Social Links, Navigation, and Buttons (auto margins in flex containers usually results in centered or space-between like layouts):

<img width="1358" alt="Screenshot 2021-03-29 at 12 24 45" src="https://user-images.githubusercontent.com/1204802/112825960-a69c1480-908c-11eb-9de9-014af8650e1e.png">

<img width="987" alt="Screenshot 2021-03-29 at 12 25 36" src="https://user-images.githubusercontent.com/1204802/112825966-aa2f9b80-908c-11eb-80c7-03f68319ec58.png">

This PR fixes that by escalating the specificity for those blocks:

<img width="988" alt="Screenshot 2021-03-29 at 12 34 26" src="https://user-images.githubusercontent.com/1204802/112826014-b9aee480-908c-11eb-9eae-d7eb36651394.png">

<img width="930" alt="Screenshot 2021-03-29 at 12 34 34" src="https://user-images.githubusercontent.com/1204802/112826016-bae01180-908c-11eb-9bef-c41ab53a6309.png">

<img width="1023" alt="Screenshot 2021-03-29 at 12 37 39" src="https://user-images.githubusercontent.com/1204802/112826019-bd426b80-908c-11eb-9667-9cb74fbe4f22.png">

Finally, the higher specificity margin rules hid a bug in TwentyTwentyOne, where a blanket top-margin rule would cause a staircase effect on the Buttons block. Before this PR (note, the buttons block does not have space-between applied):

<img width="994" alt="Screenshot 2021-03-29 at 12 47 26" src="https://user-images.githubusercontent.com/1204802/112826294-16aa9a80-908d-11eb-8467-ccfca3bf33fd.png">

After this PR:

<img width="964" alt="Screenshot 2021-03-29 at 12 47 36" src="https://user-images.githubusercontent.com/1204802/112826327-20cc9900-908d-11eb-9cb1-b1968453b29e.png">

Note that the space-between effect has been fixed, and theme margins now affect the block. But they just affect the buttons block wrongly by targetting first-child and last-child rules, assuming they are in a vertical sequence:

<img width="503" alt="Screenshot 2021-03-29 at 12 38 06" src="https://user-images.githubusercontent.com/1204802/112826412-40fc5800-908d-11eb-8110-8503b21c44f1.png">

<img width="491" alt="Screenshot 2021-03-29 at 12 38 13" src="https://user-images.githubusercontent.com/1204802/112826424-42c61b80-908d-11eb-9c7e-942fe0da90f1.png">

TwentyTwenty does not have this problem:

<img width="1004" alt="Screenshot 2021-03-29 at 12 39 08" src="https://user-images.githubusercontent.com/1204802/112826463-49ed2980-908d-11eb-8296-305c18f566fb.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
