### PR TITLE
Update design of the resize handles

### DIFF
--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -23,9 +23,9 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	content: "";
 	width: $resize-handler-size;
 	height: $resize-handler-size;
-	border: 2px solid $white;
+	border: 2px solid var(--wp-admin-theme-color);
 	border-radius: 50%;
-	background: var(--wp-admin-theme-color);
+	background: $white;
 	cursor: inherit;
 	position: absolute;
 	top: calc(50% - #{ceil($resize-handler-size / 2)});
@@ -35,25 +35,18 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 // This is the "visible" resize handle for side handles - the line
 .components-resizable-box__side-handle::before {
 	display: block;
+	border-radius: 2px;
 	content: "";
-	width: 7px;
-	height: 7px;
-	border: 2px solid $white;
+	width: 3px;
+	height: 3px;
 	background: var(--wp-admin-theme-color);
 	cursor: inherit;
 	position: absolute;
-	top: calc(50% - 4px);
-	right: calc(50% - 4px);
+	top: calc(50% - 1px);
+	right: calc(50% - 1px);
 	transition: transform 0.1s ease-in;
 	@include reduce-motion("transition");
 	opacity: 0;
-}
-
-.is-dark-theme {
-	.components-resizable-box__side-handle::before,
-	.components-resizable-box__handle::after {
-		border-color: $gray-300;
-	}
 }
 
 // Show corner handles on top of side handles so they can be used


### PR DESCRIPTION
This modifies the visual appearance of the handles to be the inverse of what they are now. Instead of the white halo it uses a white background and leaves the primary color for the outline.

Before:

<img width="782" alt="Screenshot 2021-03-28 at 20 22 24" src="https://user-images.githubusercontent.com/548849/112828069-81f56c00-908f-11eb-95be-dd2fdb18c6fa.png">


After:

![image](https://user-images.githubusercontent.com/548849/112827866-3773ef80-908f-11eb-88ac-096a65876634.png)

It also simplifies a bit the hover treatment. I think we need to revisit the hover effect in general but I didn't remove it because it can have an impact on the image block since the bounding box includes the caption.

![image](https://user-images.githubusercontent.com/548849/112828048-799d3100-908f-11eb-883f-ddc557f9262a.png)

