### PR TITLE
Navigation: Save theme location on button click

### DIFF
--- a/packages/edit-navigation/src/components/name-editor/index.js
+++ b/packages/edit-navigation/src/components/name-editor/index.js
@@ -9,6 +9,7 @@ import { useEffect, useRef, useContext } from '@wordpress/element';
 import { TextControl } from '@wordpress/components';
 import {
 	IsMenuNameControlFocusedContext,
+	untitledMenu,
 	useMenuEntity,
 	useSelectedMenuData,
 } from '../../hooks';
@@ -19,7 +20,14 @@ export function NameEditor() {
 	);
 
 	const { menuId } = useSelectedMenuData();
-	const { editMenuName, editedMenuName } = useMenuEntity( menuId );
+	const { editedMenu, editMenuEntityRecord, menuEntityData } = useMenuEntity(
+		menuId
+	);
+	const editedMenuName = menuId && editedMenu.name;
+
+	const editMenuName = ( name = untitledMenu ) =>
+		editMenuEntityRecord( ...menuEntityData, { name } );
+
 	const inputRef = useRef();
 	useEffect( () => {
 		if ( isMenuNameEditFocused ) inputRef.current.focus();

--- a/packages/edit-navigation/src/hooks/use-menu-entity.js
+++ b/packages/edit-navigation/src/hooks/use-menu-entity.js
@@ -7,8 +7,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { MENU_KIND, MENU_POST_TYPE } from '../constants';
 
-import { untitledMenu } from './index';
-
 export default function useMenuEntity( menuId ) {
 	const { editEntityRecord } = useDispatch( 'core' );
 
@@ -20,13 +18,9 @@ export default function useMenuEntity( menuId ) {
 		[ menuId ]
 	);
 
-	const editedMenuName = menuId && editedMenu.name;
-
-	const editMenuName = ( name = untitledMenu ) =>
-		editEntityRecord( ...menuEntityData, { name } );
-
 	return {
-		editedMenuName,
-		editMenuName,
+		editedMenu,
+		menuEntityData,
+		editMenuEntityRecord: editEntityRecord,
 	};
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closing https://github.com/WordPress/gutenberg/issues/30139
Advances https://github.com/WordPress/gutenberg/issues/30307

All menage location settings (in sidebar and modal window) are saved upon clicking the `save` button placed in the header.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Navigate to `Navigation`
2. Select menu
3. Change something in manage location settings
4. See it will not be saved after refresh
5. Change something in manage location settings one more time
6. Click on the `save` button
7. See the change is saved now

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Inconsistency fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
