### PR TITLE
Try: Flip orientation of submenus that are towards the right of the viewport

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -15,7 +15,7 @@
 		}
 	}
 
-	// Margin when justified right or space-between.
+	// Margin of right-most margin should be zero, for right aligned or justified items.
 	.wp-block-navigation__container > .wp-block-pages-list__item:last-child,
 	.wp-block-navigation__container > .wp-block-navigation-link:last-child {
 		margin-right: 0;
@@ -178,6 +178,27 @@
 			> .submenu-container {
 				visibility: visible;
 				opacity: 1;
+			}
+		}
+	}
+
+
+	// When justified space-between, open submenus leftward for last menu item.
+	// When justified right, open all submenus leftwards.
+	&.items-justified-space-between > .submenu-container > .has-child:last-child,
+	&.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
+	&.items-justified-right .has-child {
+		// First submenu.
+		.submenu-container,
+		.wp-block-navigation-link__container {
+			left: auto;
+			right: 0;
+
+			// Nested submenus.
+			.submenu-container,
+			.wp-block-navigation-link__container {
+				left: auto;
+				right: 100%;
 			}
 		}
 	}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -27,6 +27,12 @@
 		&.has-child .block-editor-block-list__block.wp-block-navigation-link {
 			margin: 0;
 		}
+
+		// Margin of right-most margin should be zero, for right aligned or justified items.
+		&.wp-block-pages-list__item:last-child,
+		&.wp-block-navigation-link:last-child {
+			margin-right: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Navigation block menus open down and to the right. Cool.

<img width="734" alt="Screenshot 2021-03-29 at 13 38 25" src="https://user-images.githubusercontent.com/1204802/112831325-11048300-9094-11eb-82dc-ac1af6716761.png">

But this is not so cool, when you're reached the right screen edge:

<img width="697" alt="Screenshot 2021-03-29 at 13 39 21" src="https://user-images.githubusercontent.com/1204802/112831419-31ccd880-9094-11eb-848f-d6521bd82c85.png">

This PR fixes that by flipping the direction a menu opens, when the menu is justified right, or for the last item when the menu is justified space-between:

![frontend](https://user-images.githubusercontent.com/1204802/112831493-4ad58980-9094-11eb-9bd8-f235568502a0.gif)


This PR pairs well with https://github.com/WordPress/gutenberg/pull/30199.

But even with both this and 30199 in place, it will be possible for a theme to make a menu that gets viewport cropped. However we shoul allow this, because:

- The develop might be aware of this, and is accommodating their CSS to fit the menu.
- We might want a separate block option that allows you to open submenus using accordions.
- We wouldn't want a situation where you ended up creating menus that first opened rightwards, then using JS measured that it bumps against the viewport and goes in the other direction, it would be too easy to lose your hover-place. By not supporting it, it encourages careful design of submenus.

## How has this been tested?

Test navigation menus justified right or space between, with a bunch of submenus.

Bonus points if you test the Page List block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
