### PR TITLE
Build: Ensure non-JS changes are processed in the watch mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24046,26 +24046,63 @@
 			"dev": true
 		},
 		"cacache": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"version": "12.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+			"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.5.1",
-				"chownr": "^1.0.1",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.1.11",
-				"lru-cache": "^4.1.1",
-				"mississippi": "^2.0.0",
+				"bluebird": "^3.5.5",
+				"chownr": "^1.1.1",
+				"figgy-pudding": "^3.5.1",
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.1.15",
+				"infer-owner": "^1.0.3",
+				"lru-cache": "^5.1.1",
+				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.2",
-				"ssri": "^5.2.4",
-				"unique-filename": "^1.1.0",
+				"rimraf": "^2.6.3",
+				"ssri": "^6.0.1",
+				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
 			},
 			"dependencies": {
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.6",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+					"dev": true
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -24073,28 +24110,18 @@
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
-					},
-					"dependencies": {
-						"glob": {
-							"version": "7.1.6",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-							"dev": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						}
 					}
 				},
 				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+					"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+					"dev": true
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true
 				}
 			}
@@ -24543,9 +24570,9 @@
 			}
 		},
 		"chownr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true
 		},
 		"chrome-trace-event": {
@@ -25811,21 +25838,46 @@
 			}
 		},
 		"copy-webpack-plugin": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.2.tgz",
-			"integrity": "sha512-zmC33E8FFSq3AbflTvqvPvBo621H36Afsxlui91d+QyZxPIuXghfnTsa1CuqiAaCPgJoSUWfTFbKJnadZpKEbQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+			"integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
 			"dev": true,
 			"requires": {
-				"cacache": "^10.0.4",
-				"find-cache-dir": "^1.0.0",
+				"cacache": "^12.0.3",
+				"find-cache-dir": "^2.1.0",
+				"glob-parent": "^3.1.0",
 				"globby": "^7.1.1",
-				"is-glob": "^4.0.0",
-				"loader-utils": "^1.1.0",
+				"is-glob": "^4.0.1",
+				"loader-utils": "^1.2.3",
 				"minimatch": "^3.0.4",
-				"p-limit": "^1.0.0",
-				"serialize-javascript": "^1.4.0"
+				"normalize-path": "^3.0.0",
+				"p-limit": "^2.2.1",
+				"schema-utils": "^1.0.0",
+				"serialize-javascript": "^4.0.0",
+				"webpack-log": "^2.0.0"
 			},
 			"dependencies": {
+				"big.js": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+					"dev": true
+				},
+				"dir-glob": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+					"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+					"dev": true,
+					"requires": {
+						"path-type": "^3.0.0"
+					}
+				},
+				"emojis-list": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+					"dev": true
+				},
 				"globby": {
 					"version": "7.1.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
@@ -25838,18 +25890,57 @@
 						"ignore": "^3.3.5",
 						"pify": "^3.0.0",
 						"slash": "^1.0.0"
-					},
-					"dependencies": {
-						"dir-glob": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-							"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-							"dev": true,
-							"requires": {
-								"path-type": "^3.0.0"
-							}
-						}
 					}
+				},
+				"is-glob": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
@@ -30896,29 +30987,88 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"make-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0"
 			},
 			"dependencies": {
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
-				"pify": {
+				"locate-path": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -41995,9 +42145,9 @@
 			}
 		},
 		"mississippi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
 			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
@@ -42006,10 +42156,22 @@
 				"flush-write-stream": "^1.0.0",
 				"from2": "^2.1.0",
 				"parallel-transform": "^1.1.0",
-				"pump": "^2.0.1",
+				"pump": "^3.0.0",
 				"pumpify": "^1.3.3",
 				"stream-each": "^1.1.0",
 				"through2": "^2.0.0"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
 			}
 		},
 		"mitt": {
@@ -50131,10 +50293,13 @@
 			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
 		},
 		"serialize-javascript": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
 		},
 		"serve-favicon": {
 			"version": "2.5.0",
@@ -51042,12 +51207,12 @@
 			}
 		},
 		"ssri": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.1"
+				"figgy-pudding": "^3.5.1"
 			}
 		},
 		"stable": {
@@ -54389,9 +54554,9 @@
 			"dev": true
 		},
 		"unique-filename": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
 			"dev": true,
 			"requires": {
 				"unique-slug": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
 		"chalk": "4.0.0",
 		"commander": "4.1.0",
 		"concurrently": "3.5.0",
-		"copy-webpack-plugin": "4.5.2",
+		"copy-webpack-plugin": "5.1.2",
 		"cross-env": "3.2.4",
 		"css-loader": "3.5.2",
 		"cssnano": "4.1.10",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -270,7 +270,7 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	].filter( Boolean ),
 	watchOptions: {
-		ignored: '!packages/*/!(src)/**/*',
+		ignored: '!packages/*/build-module/**/*',
 		aggregateTimeout: 500,
 	},
 	devtool,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Originally reported by @stokesman in https://github.com/WordPress/gutenberg/pull/27821#issuecomment-808925495 after merging #27821 (it was reverted because of the issue reported).

> This seems to have broken `npm run dev` on my end. It completes the initial build without complaint but a moment after all the normal output it prints: `wp-scripts start exited with code 0`. The `npm run dev` job is still running and the file watching is too (updated files are noted in terminal) but the build does not run again.
> 
> When I encountered this I'd just merged trunk and noticing the package(-lock).json changes, I ran `npm install`. After rebuilds wouldn't work, I tried `npm run distclean` followed by another `npm install` but it didn't change. It started working again after reverting these changes and running `npm install`.
> 

A similar issue was previously reported and this PR should also fix #22645.

> After Removing package-lock.json and node_modules then npm run dev, wp-scripts builds the files one time only and results in having this notice wp-scripts start exited with code 0 .It doesn't watch the files any more.

In addition to that, there were several reports that changes to SCSS files weren't propagate when using `npm run dev` (build in watch mode).

### Changes proposed

This PR upgrades the version of `CopyWebpackPlugin` to `5.1.2` (there are newer versions that work only with webpack 5) and updates the list of ignored files in the watch mode to resolve both issues present.

Now that `CopyWebpackPlugin` ensures we watch for changes for all files that it processes, we only need to look at changes applied to the packages in `build-module` folder (all production packages are transpiled and have this folder). 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Run `npm run dev` and make sure that changes to files are reflected in the `/build` folder. I tried changing the following files:
- any production JS file in the `packages/*/src/` folder
- `block.json` in the `block-library` package
- SCSS files for packages

## Types of changes
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
