### PR TITLE
Testing: Skip flaky e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -240,7 +240,8 @@ describe( 'Multi-block selection', () => {
 		expect( await getSelectedFlatIndices() ).toBe( 3 );
 	} );
 
-	it( 'should deselect with Escape', async () => {
+	// Flaky test.
+	it.skip( 'should deselect with Escape', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );

--- a/packages/react-native-editor/jest_ui_test_environment.js
+++ b/packages/react-native-editor/jest_ui_test_environment.js
@@ -23,7 +23,7 @@ class CustomEnvironment extends JSDOMEnvironment {
 	}
 
 	async teardown() {
-		await this.global.editorPage.stopDriver();
+		await this.global.editorPage?.stopDriver();
 		await super.teardown();
 	}
 }


### PR DESCRIPTION
To have more confidence in our test suite, we need to maintain a stable suite and avoid flaky tests as much as we can. So we should fix them ideally or skip them until they're made stable.

This PR takes a look at the latest commits in master and skips the tests that are flaky.

 - Selection test: see [here](https://github.com/WordPress/gutenberg/runs/2217488923) and [here](https://github.com/WordPress/gutenberg/runs/2215759130) for instance
 - React native android test: see [here](https://github.com/WordPress/gutenberg/runs/2217668201) and [here](https://github.com/WordPress/gutenberg/runs/2203647400) for instance