### PR TITLE
Add do_block_template_part function

### DIFF
--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -222,7 +222,7 @@ function gutenberg_do_block_template_part( $part ) {
  *
  * @return void
  */
-function gutenberg_do_block_template_part_header() {
+function gutenberg_do_block_header_area() {
 	gutenberg_do_block_template_part( 'header' );
 }
 
@@ -231,6 +231,6 @@ function gutenberg_do_block_template_part_header() {
  *
  * @return void
  */
-function gutenberg_do_block_template_part_footer() {
+function gutenberg_do_block_footer_area() {
 	gutenberg_do_block_template_part( 'footer' );
 }

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -216,3 +216,21 @@ function gutenberg_do_block_template_part( $part ) {
 	}
 	echo do_blocks( $template_part->content );
 }
+
+/**
+ * Print the header template-part.
+ *
+ * @return void
+ */
+function gutenberg_do_block_template_part_header() {
+	gutenberg_do_block_template_part( 'header' );
+}
+
+/**
+ * Print the footer template-part.
+ *
+ * @return void
+ */
+function gutenberg_do_block_template_part_footer() {
+	gutenberg_do_block_template_part( 'footer' );
+}

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -201,3 +201,18 @@ function gutenberg_filter_template_part_area( $type ) {
 	trigger_error( $warning_message, E_USER_NOTICE );
 	return WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 }
+
+/**
+ * Print a template-part.
+ *
+ * @param string $part The template-part to print. Use "header" or "footer".
+ *
+ * @return void
+ */
+function gutenberg_do_block_template_part( $part ) {
+	$template_part = gutenberg_get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
+	if ( ! $template_part || empty( $template_part->content ) ) {
+		return;
+	}
+	echo do_blocks( $template_part->content );
+}

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -209,7 +209,7 @@ function gutenberg_filter_template_part_area( $type ) {
  *
  * @return void
  */
-function gutenberg_do_block_template_part( $part ) {
+function gutenberg_block_template_part( $part ) {
 	$template_part = gutenberg_get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
 	if ( ! $template_part || empty( $template_part->content ) ) {
 		return;
@@ -222,8 +222,8 @@ function gutenberg_do_block_template_part( $part ) {
  *
  * @return void
  */
-function gutenberg_do_block_header_area() {
-	gutenberg_do_block_template_part( 'header' );
+function gutenberg_block_header_area() {
+	gutenberg_block_template_part( 'header' );
 }
 
 /**
@@ -231,6 +231,6 @@ function gutenberg_do_block_header_area() {
  *
  * @return void
  */
-function gutenberg_do_block_footer_area() {
-	gutenberg_do_block_template_part( 'footer' );
+function gutenberg_block_footer_area() {
+	gutenberg_block_template_part( 'footer' );
 }


### PR DESCRIPTION
## Description

Adds a `gutenberg_do_block_template_part()` function. This can be used by classic (non-FSE) themes that want to use a block template for their header and/or footer.

## How has this been tested?
* Use the twentytwentyone theme
* Copy the [`block-template-parts/header.html` file from the TT1-Blocks theme](https://github.com/WordPress/theme-experiments/blob/master/tt1-blocks/block-template-parts/header.html) to twentytwentyone
* In the theme's `header.php` file replace this line: `<?php get_template_part( 'template-parts/header/site-header' ); ?>` with this: `<?php gutenberg_block_header_area(); ?>`

Your theme will now use the block-template instead of the PHP template for the header.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

cc @mtias 