### PR TITLE
PHP Coding Standards fixes

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -201,7 +201,7 @@ class WP_Theme_JSON_Resolver {
 					if ( is_null( $array_to_translate ) ) {
 						continue;
 					}
-					$translated_array   = self::translate_theme_json_chunk( $array_to_translate, $key, $context, $domain );
+					$translated_array = self::translate_theme_json_chunk( $array_to_translate, $key, $context, $domain );
 					gutenberg_experimental_set( $theme_json['settings'][ $setting_key ], $path, $translated_array );
 				}
 			} else {
@@ -209,7 +209,7 @@ class WP_Theme_JSON_Resolver {
 				if ( is_null( $array_to_translate ) ) {
 					continue;
 				}
-				$translated_array   = self::translate_theme_json_chunk( $array_to_translate, $key, $context, $domain );
+				$translated_array = self::translate_theme_json_chunk( $array_to_translate, $key, $context, $domain );
 				gutenberg_experimental_set( $theme_json, $path, $translated_array );
 			}
 		}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -649,7 +649,7 @@ class WP_Theme_JSON {
 		foreach ( $properties as $prop ) {
 			$value = self::get_property_value( $styles, $prop['value'] );
 			if ( ! empty( $value ) ) {
-				$declarations[]   = array(
+				$declarations[] = array(
 					'name'  => $prop['name'],
 					'value' => $value,
 				);

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -80,7 +80,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 	$image_default_size = get_option( 'image_default_size', 'large' );
 	$image_sizes        = wp_list_pluck( $settings['imageSizes'], 'slug' );
 
-	$settings['imageDefaultSize'] = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
+	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_theme();
 
 	return $settings;


### PR DESCRIPTION
## Description

A simple PR fixing some phpcs warnings I was getting.

## How has this been tested?
No tests necessary.

## Types of changes
Spacing/alignment changes (whitespace)

## Checklist:
- [-] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
