### PR TITLE
Navigation Editor - Unification MenuSwitcher in UnselectedMenuState and Header

### DIFF
--- a/packages/edit-navigation/src/components/layout/unselected-menu-state.js
+++ b/packages/edit-navigation/src/components/layout/unselected-menu-state.js
@@ -22,7 +22,8 @@ export default function UnselectedMenuState( {
 			<Card>
 				<CardBody>
 					{ showMenuSwitcher ? (
-						<NavigableMenu>
+						// class components-dropdown-menu__menu added to unify styles with MenuSwitcher in Header
+						<NavigableMenu className="components-dropdown-menu__menu">
 							<MenuSwitcher
 								onSelectMenu={ onSelectMenu }
 								menus={ menus }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

**Edit**: the issue is that the padding used on the menu switcher is different in the x2 places the menu switcher is used within the Navigation Editor:

1. As a drop down when clicking on `Switch menu` button (top right).
2. Within the editor "canvas" (to see this creates x2 menus, select a menu then click `Delete menu` from the block settings in the right hand sidebar. You will then be asked to select a menu to editor.



<!-- Please describe what you have changed or added -->
As `MenuSwitcher` is wrapped in `DropdownMenu` in `Header`, the `components-dropdown-menu__menu` css class is added to `NavigableMenu`. In `UnselectedMenuState`the class was missing and it made the same component in these two places look slightly different - padding was missing.
In order to make it look the same we can do one of the following:
1. Create a class that would have the same, hardcoded props as  `components-dropdown-menu__menu` - this would not be a scalable solution
2. We can create a class that would inherit from `components-dropdown-menu__menu` - it would be a preferable way from my perspective, but I remember @talldan pointed scss `@extend` should be avoided
3. We can add `components-dropdown-menu__menu` directly to the `NavigableMenu` element - as it can be confusing in the code, I have added a comment to explain why this class is added there


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Navigate to Navigation Editor
2. Check the styles under `Switch Menu` in the header 
![image](https://user-images.githubusercontent.com/8398557/112849042-f8eb2e80-90a8-11eb-8caa-51bea2801278.png)
3. Compare with styles with unselected menu state, once a menu is deleted, and a user needs to choose a menu to edit
![image](https://user-images.githubusercontent.com/8398557/112849172-18825700-90a9-11eb-9b35-f7a215c64d75.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Style fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
