### PR TITLE
Nav Block: Show justification controls for vertical variant

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -30,10 +30,6 @@
 		"showSubmenuIcon": {
 			"type": "boolean",
 			"default": true
-		},
-		"showJustifyControls": {
-			"type": "boolean",
-			"default": true
 		}
 	},
 	"providesContext": {
@@ -44,7 +40,6 @@
 		"fontSize": "fontSize",
 		"customFontSize": "customFontSize",
 		"showSubmenuIcon": "showSubmenuIcon",
-		"showJustifyControls": "showJustifyControls",
 		"style": "style",
 		"orientation": "orientation"
 	},

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -30,6 +30,10 @@
 		"showSubmenuIcon": {
 			"type": "boolean",
 			"default": true
+		},
+		"showJustifyControls": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"providesContext": {
@@ -40,6 +44,7 @@
 		"fontSize": "fontSize",
 		"customFontSize": "customFontSize",
 		"showSubmenuIcon": "showSubmenuIcon",
+		"showJustifyControls": "showJustifyControls",
 		"style": "style",
 		"orientation": "orientation"
 	},

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -53,6 +53,7 @@ function Navigation( {
 	updateInnerBlocks,
 	className,
 	hasSubmenuIndicatorSetting = true,
+	hasItemJustificationControls = true,
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -119,7 +120,7 @@ function Navigation( {
 	return (
 		<>
 			<BlockControls>
-				{ attributes.showJustifyControls && (
+				{ hasItemJustificationControls && (
 					<JustifyToolbar
 						value={ attributes.itemsJustification }
 						allowedControls={ justifyAllowedControls }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -53,7 +53,6 @@ function Navigation( {
 	updateInnerBlocks,
 	className,
 	hasSubmenuIndicatorSetting = true,
-	hasItemJustificationControls = attributes.orientation === 'horizontal',
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -112,21 +111,25 @@ function Navigation( {
 		);
 	}
 
+	const justifyAllowedControls =
+		attributes.orientation === 'vertical'
+			? [ 'left', 'center', 'right' ]
+			: [ 'left', 'center', 'right', 'space-between' ];
+
 	return (
 		<>
 			<BlockControls>
-				{ hasItemJustificationControls && (
-					<JustifyToolbar
-						value={ attributes.itemsJustification }
-						onChange={ ( value ) =>
-							setAttributes( { itemsJustification: value } )
-						}
-						popoverProps={ {
-							position: 'bottom right',
-							isAlternate: true,
-						} }
-					/>
-				) }
+				<JustifyToolbar
+					value={ attributes.itemsJustification }
+					allowedControls={ justifyAllowedControls }
+					onChange={ ( value ) =>
+						setAttributes( { itemsJustification: value } )
+					}
+					popoverProps={ {
+						position: 'bottom right',
+						isAlternate: true,
+					} }
+				/>
 				<ToolbarGroup>{ navigatorToolbarButton }</ToolbarGroup>
 			</BlockControls>
 			{ navigatorModal }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -119,17 +119,19 @@ function Navigation( {
 	return (
 		<>
 			<BlockControls>
-				<JustifyToolbar
-					value={ attributes.itemsJustification }
-					allowedControls={ justifyAllowedControls }
-					onChange={ ( value ) =>
-						setAttributes( { itemsJustification: value } )
-					}
-					popoverProps={ {
-						position: 'bottom right',
-						isAlternate: true,
-					} }
-				/>
+				{ attributes.showJustifyControls && (
+					<JustifyToolbar
+						value={ attributes.itemsJustification }
+						allowedControls={ justifyAllowedControls }
+						onChange={ ( value ) =>
+							setAttributes( { itemsJustification: value } )
+						}
+						popoverProps={ {
+							position: 'bottom right',
+							isAlternate: true,
+						} }
+					/>
+				) }
 				<ToolbarGroup>{ navigatorToolbarButton }</ToolbarGroup>
 			</BlockControls>
 			{ navigatorModal }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -24,6 +24,7 @@
 	flex-wrap: wrap;
 
 	// Vertical layout
+	// TODO: What to todo here?
 	.is-vertical & {
 		display: block;
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -25,6 +25,7 @@
 
 	// Vertical layout
 	.is-vertical & {
+		display: block;
 		flex-direction: column;
 		align-items: flex-start;
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -50,4 +50,10 @@
 
 .is-vertical.items-justified-right > ul {
 	align-items: flex-end;
+
+	.wp-block-navigation-link,
+	.wp-block-pages-list__item {
+		margin-right: 0;
+		justify-content: flex-end;
+	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -24,9 +24,9 @@
 	flex-wrap: wrap;
 
 	// Vertical layout
-	// TODO: What to todo here?
 	.is-vertical & {
-		display: block;
+		flex-direction: column;
+		align-items: flex-start;
 	}
 }
 
@@ -41,4 +41,13 @@
 
 .items-justified-space-between > ul {
 	justify-content: space-between;
+}
+
+// Vertical justification.
+.is-vertical.items-justified-center > ul {
+	align-items: center;
+}
+
+.is-vertical.items-justified-right > ul {
+	align-items: flex-end;
 }


### PR DESCRIPTION
## Description

- Enable justify content controls to show for both horiz and vert variants
- Filter out space-between from vertical controls
 
Closes #29459 

## How has this been tested?

1. Add Navigation block (vertical)
2. Confirm the left-center-right controls show and work as expected
3. Confirm the space-between controls do not show
4. Test Navigation block (horizontal) space-between shows and no regression

## Screenshots 

See comments below.