### PR TITLE
Blocks: add experimental dynamic block transform endpoint

### DIFF
--- a/lib/class-wp-rest-block-transform-controller.php
+++ b/lib/class-wp-rest-block-transform-controller.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Block Transform REST API: WP_REST_Block_Transform_Controller class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since ?.?.0
+ */
+
+/**
+ * Controller which provides REST endpoint for transforming a block.
+ *
+ * @since ?.?.?
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_Block_Transform_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructs the controller.
+	 *
+	 * @since ?.?.?
+	 */
+	public function __construct() {
+		$this->namespace = '__experimental';
+		$this->rest_base = 'block-transform';
+	}
+
+	/**
+	 * Registers the necessary REST API routes, one for each dynamic block that has a transform callback.
+	 *
+	 * @since ?.?.?
+	 *
+	 * @see register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<name>[a-z0-9-]+/[a-z0-9-]+)',
+			array(
+				'args'   => array(
+					'name' => array(
+						'description' => __( 'Unique registered name for the block.', 'gutenberg' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => array( WP_REST_Server::READABLE, WP_REST_Server::CREATABLE ),
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context'    => $this->get_context_param( array( 'default' => 'view' ) ),
+						'attributes' => array(
+							'description'       => __( 'Attributes for the block.', 'gutenberg' ),
+							'type'              => 'object',
+							'default'           => array(),
+							'validate_callback' => static function ( $value, $request ) {
+								$block = WP_Block_Type_Registry::get_instance()->get_registered( $request['name'] );
+
+								if ( ! $block ) {
+									// This will get rejected in ::get_item().
+									return true;
+								}
+
+								$schema = array(
+									'type'                 => 'object',
+									'properties'           => $block->get_attributes(),
+									'additionalProperties' => false,
+								);
+
+								return rest_validate_value_from_schema( $value, $schema );
+							},
+							'sanitize_callback' => static function ( $value, $request ) {
+								$block = WP_Block_Type_Registry::get_instance()->get_registered( $request['name'] );
+
+								if ( ! $block ) {
+									// This will get rejected in ::get_item().
+									return true;
+								}
+
+								$schema = array(
+									'type'                 => 'object',
+									'properties'           => $block->get_attributes(),
+									'additionalProperties' => false,
+								);
+
+								return rest_sanitize_value_from_schema( $value, $schema );
+							},
+						),
+						'post_id'    => array(
+							'description' => __( 'ID of the post context.', 'gutenberg' ),
+							'type'        => 'integer',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to read blocks.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 *
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 * @since ?.?.?
+	 */
+	public function get_item_permissions_check( $request ) {
+		global $post;
+
+		$post_id = isset( $request['post_id'] ) ? (int) $request['post_id'] : 0;
+
+		if ( 0 < $post_id ) {
+			$post = get_post( $post_id );
+
+			if ( ! $post || ! current_user_can( 'edit_post', $post->ID ) ) {
+				return new WP_Error(
+					'block_cannot_read',
+					__( 'Sorry, you are not allowed to read blocks of this post.', 'gutenberg' ),
+					array(
+						'status' => rest_authorization_required_code(),
+					)
+				);
+			}
+		} else {
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return new WP_Error(
+					'block_cannot_read',
+					__( 'Sorry, you are not allowed to read blocks as this user.', 'gutenberg' ),
+					array(
+						'status' => rest_authorization_required_code(),
+					)
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns block output from block's registered transform_callback.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 * @since ?.?.?
+	 */
+	public function get_item( $request ) {
+		global $post;
+
+		$post_id = isset( $request['post_id'] ) ? (int) $request['post_id'] : 0;
+
+		if ( 0 < $post_id ) {
+			$post = get_post( $post_id );
+
+			// Set up postdata since this will be needed if post_id was set.
+			setup_postdata( $post );
+		}
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$registered = $registry->get_registered( $request['name'] );
+
+		$registered_is_null           = null === $registered;
+		$block_api_supports_transform = method_exists( $registered, 'has_dynamic_transform' );
+
+		if ( $registered_is_null || ! $block_api_supports_transform || ! $registered->has_dynamic_transform() ) {
+			return new WP_Error(
+				'block_invalid',
+				__( 'No block transform found.', 'gutenberg' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		$attributes = $request->get_param( 'attributes' );
+
+		// Create an array representation simulating the output of parse_blocks.
+		$block              = array(
+			'blockName'    => $request['name'],
+			'attrs'        => $attributes,
+			'innerHTML'    => '',
+			'innerContent' => array(),
+		);
+		$transform_block_to = '';
+		if ( isset( $request['to'] ) ) {
+			$transform_block_to = $request['to'];
+		}
+		// Render using transform_block to ensure all relevant filters are used.
+		$data = array(
+			'serialized' => transform_block( $block, $transform_block_to ),
+		);
+
+		return rest_ensure_response( $data );
+	}
+
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -70,6 +70,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		require_once __DIR__ . '/class-wp-rest-url-details-controller.php';
 	}
 
+	if ( ! class_exists( 'WP_REST_Block_Transform_Controller' ) ) {
+		require_once __DIR__ . '/class-wp-rest-block-transform-controller.php';
+	}
+
 	require __DIR__ . '/rest-api.php';
 }
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -23,6 +23,15 @@ function gutenberg_register_url_details_routes() {
 add_action( 'rest_api_init', 'gutenberg_register_url_details_routes' );
 
 /**
+ * Registers the block transform REST API routes.
+ */
+function gutenberg_register_block_transform_routes() {
+	$block_transform_controller = new WP_REST_Block_Transform_Controller();
+	$block_transform_controller->register_routes();
+}
+add_filter( 'rest_api_init', 'gutenberg_register_block_transform_routes' );
+
+/**
  * Registers the block pattern directory.
  */
 function gutenberg_register_rest_pattern_directory() {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -203,6 +203,51 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	);
 }
 
+/**
+ * Transforms the `core/page-list` block on server.
+ *
+ * @param string $to         The block to transform to.
+ * @param array  $attributes The block attributes.
+ * @param array  $content    The saved content.
+ * @param array  $block       The parsed block.
+ *
+ * @return array[] Returns the transformed blocks.
+ */
+function transform_block_core_page_list( $to, $attributes, $content, $block ) {
+
+	// TODO: a single callback, with a $to parameter OR a keyed array of transform callbacks?
+	// TODO: we need some create_block helpers, should be equivalent to what parse_block generates
+	// TODO: support sub-menus.
+
+	if ( 'core/navigation-link' === $to ) {
+
+		$all_pages = get_pages( array( 'sort_column' => 'menu_order' ) );
+
+		$top_level_pages = array();
+
+		foreach ( (array) $all_pages as $page ) {
+			if ( ! $page->post_parent ) {
+				$top_level_pages[] = array(
+					'blockName'    => 'core/navigation-link',
+					'attrs'        => array(
+						'label' => $page->post_title,
+						'url'   => get_permalink( $page->ID ),
+						'id'    => $page->ID,
+						'type'  => 'page',
+						'kind'  => 'post-type',
+					),
+					'innerBlocks'  => array(),
+					'innerHTML'    => '',
+					'innerContent' => array(),
+				);
+			}
+		}
+
+		return $top_level_pages;
+	}
+	return array();
+}
+
 	/**
 	 * Registers the `core/pages` block on server.
 	 */
@@ -210,7 +255,8 @@ function register_block_core_page_list() {
 	register_block_type_from_metadata(
 		__DIR__ . '/page-list',
 		array(
-			'render_callback' => 'render_block_core_page_list',
+			'render_callback'    => 'render_block_core_page_list',
+			'transform_callback' => 'transform_block_core_page_list',
 		)
 	);
 }


### PR DESCRIPTION
WIP for https://github.com/WordPress/gutenberg/issues/29437, needs https://github.com/WordPress/wordpress-develop/pull/1138 to test locally

```js
// Example call in console:

wp.apiFetch( { path: '/__experimental/block-transform/core/page-list?to=core/navigation-link' } ).then( ( data ) => { 
    console.log( data )
} );
```
<img width="1129" alt="Screen Shot 2021-03-29 at 1 39 12 PM" src="https://user-images.githubusercontent.com/1270189/112897293-48732f80-9094-11eb-9cf7-f45ec2095c04.png">

Exploration Notes:

- The block transformation APIs expect transforms to be relatively quick. Supporting any async transforms will require a lot of API surface area to update. So this approach isn't particularly viable.
- I didn't really suss out folks having a need to transform other dynamic blocks yet which is another point to pause on this approach.
- There were a few use cases of wanting to build up blocks on the server. A helper like `create_blocks` might be useful. I saw a few spots where we mimicked output of `parse_blocks`
- I need to explore this, but it may be interesting to allow `render_callback` to return blocks.

Next:

- Is a PageList refactor viable?

