### PR TITLE
Check for allowed blocks recursively in patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13205,6 +13205,7 @@
 				"@babel/runtime": "^7.13.10",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/blob": "file:packages/blob",
+				"@wordpress/block-serialization-default-parser": "file:packages/block-serialization-default-parser",
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -34,6 +34,7 @@
 		"@babel/runtime": "^7.13.10",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/blob": "file:../blob",
+		"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",

--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { cloneBlock } from '@wordpress/blocks';
 import {
 	VisuallyHidden,
@@ -108,12 +108,7 @@ function BlockPattern( { pattern, onSelect, composite } ) {
 }
 
 function BlockPatternSlide( { className, pattern } ) {
-	const { name, title, description } = pattern;
-	const { blocks } = useSelect(
-		( _select ) =>
-			_select( blockEditorStore ).__experimentalGetParsedPattern( name ),
-		[ name ]
-	);
+	const { blocks, title, description } = pattern;
 	const descriptionId = useInstanceId(
 		BlockPatternSlide,
 		'block-editor-block-pattern-setup-list__item-description'

--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { select, useDispatch, useSelect } from '@wordpress/data';
 import { cloneBlock } from '@wordpress/blocks';
 import {
 	VisuallyHidden,
@@ -72,7 +72,12 @@ const SetupContent = ( {
 
 function BlockPattern( { pattern, onSelect, composite } ) {
 	const baseClassName = 'block-editor-block-pattern-setup-list';
-	const { blocks, title, description, viewportWidth = 700 } = pattern;
+	const { name, title, description, viewportWidth = 700 } = pattern;
+	const { blocks } = useSelect(
+		( _select ) =>
+			_select( blockEditorStore ).__experimentalGetParsedPattern( name ),
+		[ name ]
+	);
 	const descriptionId = useInstanceId(
 		BlockPattern,
 		`${ baseClassName }__item-description`
@@ -108,7 +113,12 @@ function BlockPattern( { pattern, onSelect, composite } ) {
 }
 
 function BlockPatternSlide( { className, pattern } ) {
-	const { blocks, title, description } = pattern;
+	const { name, title, description } = pattern;
+	const { blocks } = useSelect(
+		( _select ) =>
+			_select( blockEditorStore ).__experimentalGetParsedPattern( name ),
+		[ name ]
+	);
 	const descriptionId = useInstanceId(
 		BlockPatternSlide,
 		'block-editor-block-pattern-setup-list__item-description'
@@ -168,7 +178,12 @@ const BlockPatternSetup = ( {
 					setActiveSlide( ( active ) => active - 1 );
 				} }
 				onBlockPatternSelect={ () => {
-					onPatternSelectCallback( patterns[ activeSlide ].blocks );
+					const { blocks } = select(
+						blockEditorStore
+					).__experimentalGetAllowedPatterns(
+						patterns[ activeSlide ].name
+					);
+					onPatternSelectCallback( blocks );
 				} }
 				onStartBlank={ () => {
 					setShowBlank( true );

--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -180,7 +180,7 @@ const BlockPatternSetup = ( {
 				onBlockPatternSelect={ () => {
 					const { blocks } = select(
 						blockEditorStore
-					).__experimentalGetAllowedPatterns(
+					).__experimentalGetParsedPattern(
 						patterns[ activeSlide ].name
 					);
 					onPatternSelectCallback( blocks );

--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { select, useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { cloneBlock } from '@wordpress/blocks';
 import {
 	VisuallyHidden,
@@ -72,12 +72,7 @@ const SetupContent = ( {
 
 function BlockPattern( { pattern, onSelect, composite } ) {
 	const baseClassName = 'block-editor-block-pattern-setup-list';
-	const { name, title, description, viewportWidth = 700 } = pattern;
-	const { blocks } = useSelect(
-		( _select ) =>
-			_select( blockEditorStore ).__experimentalGetParsedPattern( name ),
-		[ name ]
-	);
+	const { blocks, title, description, viewportWidth = 700 } = pattern;
 	const descriptionId = useInstanceId(
 		BlockPattern,
 		`${ baseClassName }__item-description`
@@ -178,12 +173,7 @@ const BlockPatternSetup = ( {
 					setActiveSlide( ( active ) => active - 1 );
 				} }
 				onBlockPatternSelect={ () => {
-					const { blocks } = select(
-						blockEditorStore
-					).__experimentalGetParsedPattern(
-						patterns[ activeSlide ].name
-					);
-					onPatternSelectCallback( blocks );
+					onPatternSelectCallback( patterns[ activeSlide ].blocks );
 				} }
 				onStartBlank={ () => {
 					setShowBlank( true );

--- a/packages/block-editor/src/components/block-pattern-setup/use-patterns-setup.js
+++ b/packages/block-editor/src/components/block-pattern-setup/use-patterns-setup.js
@@ -14,17 +14,23 @@ function usePatternsSetup( clientId, blockName, filterPatternsFn ) {
 			const {
 				getBlockRootClientId,
 				__experimentalGetPatternsByBlockTypes,
+				__experimentalGetParsedPattern,
 				__experimentalGetAllowedPatterns,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
+			let patterns = [];
 			if ( filterPatternsFn ) {
-				return __experimentalGetAllowedPatterns( rootClientId ).filter(
-					filterPatternsFn
+				patterns = __experimentalGetAllowedPatterns(
+					rootClientId
+				).filter( filterPatternsFn );
+			} else {
+				patterns = __experimentalGetPatternsByBlockTypes(
+					blockName,
+					rootClientId
 				);
 			}
-			return __experimentalGetPatternsByBlockTypes(
-				blockName,
-				rootClientId
+			return patterns.map( ( { name } ) =>
+				__experimentalGetParsedPattern( name )
 			);
 		},
 		[ clientId, blockName, filterPatternsFn ]

--- a/packages/block-editor/src/components/block-switcher/use-transformed-patterns.js
+++ b/packages/block-editor/src/components/block-switcher/use-transformed-patterns.js
@@ -3,11 +3,13 @@
  */
 import { useMemo } from '@wordpress/element';
 import { cloneBlock } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getMatchingBlockByName, getRetainedBlockAttributes } from './utils';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Mutate the matched block's attributes by getting
@@ -94,9 +96,19 @@ export const getPatternTransformedBlocks = (
  */
 // TODO tests
 const useTransformedPatterns = ( patterns, selectedBlocks ) => {
+	const parsedPatterns = useSelect(
+		( select ) =>
+			patterns.map( ( { name } ) =>
+				select( blockEditorStore ).__experimentalGetParsedPattern(
+					name
+				)
+			),
+		[ patterns ]
+	);
+
 	return useMemo(
 		() =>
-			patterns.reduce( ( accumulator, _pattern ) => {
+			parsedPatterns.reduce( ( accumulator, _pattern ) => {
 				const transformedBlocks = getPatternTransformedBlocks(
 					selectedBlocks,
 					_pattern.blocks
@@ -109,7 +121,7 @@ const useTransformedPatterns = ( patterns, selectedBlocks ) => {
 				}
 				return accumulator;
 			}, [] ),
-		[ patterns, selectedBlocks ]
+		[ parsedPatterns, selectedBlocks ]
 	);
 };
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1796,6 +1796,10 @@ export const __experimentalGetParsedPattern = createSelector(
 
 		const blocks = parse( pattern.content );
 		const isAllowed = ( () => {
+			if ( isBoolean( allowedBlockTypes ) ) {
+				return allowedBlockTypes;
+			}
+
 			const blocksQueue = [ ...blocks ];
 			while ( blocksQueue.length > 0 ) {
 				const block = blocksQueue.shift();

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1811,7 +1811,7 @@ export const __experimentalGetParsedPattern = createSelector(
 				if ( ! isBlockAllowedInEditor ) {
 					return false;
 				}
-				block.blocks?.forEach( ( innerBlock ) => {
+				block.innerBlocks?.forEach( ( innerBlock ) => {
 					blocksQueue.push( innerBlock );
 				} );
 			}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1827,7 +1827,6 @@ export const __experimentalGetParsedPattern = createSelector(
 	( state ) => [
 		state.settings.__experimentalBlockPatterns,
 		state.settings.allowedBlockTypes,
-		state.settings.templateLock,
 	]
 );
 
@@ -1842,7 +1841,6 @@ export const __experimentalGetAvailableParsedPatterns = createSelector(
 	( state ) => [
 		state.settings.__experimentalBlockPatterns,
 		state.settings.allowedBlockTypes,
-		state.settings.templateLock,
 	]
 );
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1824,7 +1824,11 @@ export const __experimentalGetParsedPattern = createSelector(
 			isAllowed,
 		};
 	},
-	( state ) => [ state.settings.__experimentalBlockPatterns ]
+	( state ) => [
+		state.settings.__experimentalBlockPatterns,
+		state.settings.allowedBlockTypes,
+		state.settings.templateLock,
+	]
 );
 
 export const __experimentalGetAvailableParsedPatterns = createSelector(

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1826,7 +1826,7 @@ export const __experimentalGetParsedPattern = createSelector(
 	( state ) => [ state.settings.__experimentalBlockPatterns ]
 );
 
-export const __experimentalGetAvailableStageOneParsedPatterns = createSelector(
+const __experimentalGetAllAllowedPatterns = createSelector(
 	( state ) => {
 		const patterns = state.settings.__experimentalBlockPatterns;
 		const { allowedBlockTypes } = getSettings( state );
@@ -1860,7 +1860,7 @@ export const __experimentalGetAvailableStageOneParsedPatterns = createSelector(
  */
 export const __experimentalGetAllowedPatterns = createSelector(
 	( state, rootClientId = null ) => {
-		const availableParsedPatterns = __experimentalGetAvailableStageOneParsedPatterns(
+		const availableParsedPatterns = __experimentalGetAllAllowedPatterns(
 			state
 		);
 		const patternsAllowed = filter(

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1830,19 +1830,17 @@ const __experimentalGetAllAllowedPatterns = createSelector(
 	( state ) => {
 		const patterns = state.settings.__experimentalBlockPatterns;
 		const { allowedBlockTypes } = getSettings( state );
-		return patterns
-			.map( ( pattern ) => ( {
-				...pattern,
-				stageOneBlocks: stageOneParse( pattern.content ),
-			} ) )
-			.filter( ( { stageOneBlocks } ) => {
-				const isAllowed = checkAllowListRecursive(
-					stageOneBlocks,
-					allowedBlockTypes
-				);
-
-				return isAllowed;
-			} );
+		const parsedPatterns = patterns.map( ( pattern ) => ( {
+			...pattern,
+			// We use the Stage I parser here for performance reasons.
+			// Since we only need the structure of the parsed content,
+			// Stage I parsing is enough here.
+			stageOneBlocks: stageOneParse( pattern.content ),
+		} ) );
+		const allowedPatterns = parsedPatterns.filter( ( { stageOneBlocks } ) =>
+			checkAllowListRecursive( stageOneBlocks, allowedBlockTypes )
+		);
+		return allowedPatterns;
 	},
 	( state ) => [
 		state.settings.__experimentalBlockPatterns,

--- a/packages/e2e-tests/plugins/allowed-patterns-disable-blocks.php
+++ b/packages/e2e-tests/plugins/allowed-patterns-disable-blocks.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Allowed Patterns Disable Blocks
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-allowed-patterns-disable-blocks
+ */
+
+/**
+ * Restrict the allowed blocks in the editor.
+ *
+ * @param  Array   $allowed_block_types An array of strings containing the previously allowed blocks.
+ * @param  WP_Post $post                The current post object.
+ * @return Array                        An array of strings containing the new allowed blocks after the filter is applied.
+ */
+function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
+	if ( 'post' !== $post->post_type ) {
+		return $allowed_block_types;
+	}
+	return array( 'core/heading', 'core/columns', 'core/column', 'core/image', 'core/spacer' );
+}
+
+add_filter( 'allowed_block_types', 'my_plugin_allowed_block_types', 10, 2 );

--- a/packages/e2e-tests/plugins/allowed-patterns.php
+++ b/packages/e2e-tests/plugins/allowed-patterns.php
@@ -11,9 +11,6 @@ register_block_pattern(
 	'test-allowed-patterns/lone-heading',
 	array(
 		'title'   => 'Test: Single heading',
-		'scope'   => array(
-			'inserter' => true,
-		),
 		'content' => '<!-- wp:heading --><h2>Hello!</h2><!-- /wp:heading -->',
 	)
 );
@@ -22,9 +19,6 @@ register_block_pattern(
 	'test-allowed-patterns/lone-paragraph',
 	array(
 		'title'   => 'Test: Single paragraph',
-		'scope'   => array(
-			'inserter' => true,
-		),
 		'content' => '<!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph -->',
 	)
 );
@@ -33,9 +27,6 @@ register_block_pattern(
 	'test-allowed-patterns/paragraph-inside-group',
 	array(
 		'title'   => 'Test: Paragraph inside group',
-		'scope'   => array(
-			'inserter' => true,
-		),
 		'content' => '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph --></div><!-- /wp:group -->',
 	)
 );

--- a/packages/e2e-tests/plugins/allowed-patterns.php
+++ b/packages/e2e-tests/plugins/allowed-patterns.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Allowed Patterns
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-allowed-patterns
+ */
+
+register_block_pattern(
+	'test-allowed-patterns/lone-heading',
+	array(
+		'title'   => 'Test: Single heading',
+		'scope'   => array(
+			'inserter' => true,
+		),
+		'content' => '<!-- wp:heading --><h2>Hello!</h2><!-- /wp:heading -->',
+	)
+);
+
+register_block_pattern(
+	'test-allowed-patterns/lone-paragraph',
+	array(
+		'title'   => 'Test: Single paragraph',
+		'scope'   => array(
+			'inserter' => true,
+		),
+		'content' => '<!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph -->',
+	)
+);
+
+register_block_pattern(
+	'test-allowed-patterns/paragraph-inside-group',
+	array(
+		'title'   => 'Test: Paragraph inside group',
+		'scope'   => array(
+			'inserter' => true,
+		),
+		'content' => '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph --></div><!-- /wp:group -->',
+	)
+);

--- a/packages/e2e-tests/specs/editor/various/allowed-patterns.test.js
+++ b/packages/e2e-tests/specs/editor/various/allowed-patterns.test.js
@@ -9,7 +9,7 @@ import {
 	toggleGlobalBlockInserter,
 } from '@wordpress/e2e-test-utils';
 
-const checkPatternExistance = async ( name, available = true ) => {
+const checkPatternExistence = async ( name, available = true ) => {
 	await searchForPattern( name );
 	const patternElement = await page.waitForXPath(
 		`//div[@role = 'option']//div[contains(text(), '${ name }')]`,
@@ -38,7 +38,7 @@ describe( 'Allowed Patterns', () => {
 	describe( 'Disable blocks plugin disabled', () => {
 		for ( const [ patternName ] of TEST_PATTERNS ) {
 			it( `should show test pattern "${ patternName }"`, async () => {
-				expect( await checkPatternExistance( patternName, true ) ).toBe(
+				expect( await checkPatternExistence( patternName, true ) ).toBe(
 					true
 				);
 			} );
@@ -63,7 +63,7 @@ describe( 'Allowed Patterns', () => {
 				shouldBeAvailable ? '' : ' not'
 			} show test "pattern ${ patternName }"`, async () => {
 				expect(
-					await checkPatternExistance(
+					await checkPatternExistence(
 						patternName,
 						shouldBeAvailable
 					)

--- a/packages/e2e-tests/specs/editor/various/allowed-patterns.test.js
+++ b/packages/e2e-tests/specs/editor/various/allowed-patterns.test.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	searchForPattern,
+	toggleGlobalBlockInserter,
+} from '@wordpress/e2e-test-utils';
+
+const isPatternAvailable = async ( name ) => {
+	await searchForPattern( name );
+	const elements = await page.$x(
+		`//div[@role = 'option']//div[contains(text(), '${ name }')]`
+	);
+	const patternExists = elements.length > 0;
+	await toggleGlobalBlockInserter();
+	return patternExists;
+};
+
+const TEST_PATTERNS = [
+	[ 'Test: Single heading', false ],
+	[ 'Test: Single paragraph', true ],
+	[ 'Test: Paragraph inside group', true ],
+];
+
+describe( 'Allowed Patterns', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-allowed-patterns' );
+	} );
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-allowed-patterns' );
+	} );
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	describe( 'Disable blocks plugin disabled', () => {
+		it( 'should show test patterns', async () => {
+			for ( const [ patternName ] of TEST_PATTERNS ) {
+				expect( await isPatternAvailable( patternName ) ).toBe( true );
+			}
+		} );
+	} );
+
+	describe( 'Disable blocks plugin enabled', () => {
+		beforeAll( async () => {
+			await activatePlugin(
+				'gutenberg-test-allowed-patterns-disable-blocks'
+			);
+		} );
+		afterAll( async () => {
+			await deactivatePlugin(
+				'gutenberg-test-allowed-patterns-disable-blocks'
+			);
+		} );
+
+		it( 'should not show test patterns', async () => {
+			for ( const [ patternName, shouldBeAvailable ] of TEST_PATTERNS ) {
+				expect( await isPatternAvailable( patternName ) ).toBe(
+					shouldBeAvailable
+				);
+			}
+		} );
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/various/allowed-patterns.test.js
+++ b/packages/e2e-tests/specs/editor/various/allowed-patterns.test.js
@@ -20,9 +20,9 @@ const isPatternAvailable = async ( name ) => {
 };
 
 const TEST_PATTERNS = [
-	[ 'Test: Single heading', false ],
-	[ 'Test: Single paragraph', true ],
-	[ 'Test: Paragraph inside group', true ],
+	[ 'Test: Single heading', true ],
+	[ 'Test: Single paragraph', false ],
+	[ 'Test: Paragraph inside group', false ],
 ];
 
 describe( 'Allowed Patterns', () => {
@@ -37,11 +37,11 @@ describe( 'Allowed Patterns', () => {
 	} );
 
 	describe( 'Disable blocks plugin disabled', () => {
-		it( 'should show test patterns', async () => {
-			for ( const [ patternName ] of TEST_PATTERNS ) {
+		for ( const [ patternName ] of TEST_PATTERNS ) {
+			it( `should show test pattern "${ patternName }"`, async () => {
 				expect( await isPatternAvailable( patternName ) ).toBe( true );
-			}
-		} );
+			} );
+		}
 	} );
 
 	describe( 'Disable blocks plugin enabled', () => {
@@ -56,12 +56,14 @@ describe( 'Allowed Patterns', () => {
 			);
 		} );
 
-		it( 'should not show test patterns', async () => {
-			for ( const [ patternName, shouldBeAvailable ] of TEST_PATTERNS ) {
+		for ( const [ patternName, shouldBeAvailable ] of TEST_PATTERNS ) {
+			it( `should${
+				shouldBeAvailable ? '' : ' not'
+			} show test "pattern ${ patternName }"`, async () => {
 				expect( await isPatternAvailable( patternName ) ).toBe(
 					shouldBeAvailable
 				);
-			}
-		} );
+			} );
+		}
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
Fixes https://github.com/WordPress/gutenberg/issues/23275

## Description
Currently, patterns show up in the inserter even if they contain a block that's not on the allowed blocks list. Blocks aren't checked recursively in the patterns, only top level blocks. Even though they show up, we can't insert them since the blocks are disallowed. This PR checks recursively for disallowed blocks.

A new (private) selector is introduced: `getAllAllowedPatterns`. This intermediary function memoizes the available allowed patterns. This is used to avoid iterating over patterns that contain disallowed blocks and to avoid parsing all the patterns every time we call the `__experimentalGetAllowedPatterns` with a different `clientId`.

We use "Stage I" parser here for performance reasons. See 
https://github.com/WordPress/gutenberg/pull/30366#issuecomment-814225001
https://github.com/WordPress/gutenberg/pull/30366#issuecomment-832720472


**Why don't we use `canInsertBlockType` instead of `checkAllowListRecursive`?**
Recursively checking all blocks with `canInsertBlockType` every time we select a different block would have a huge performance impact. That's why we only check top level blocks with `canInsertBlockType` and the nested ones with `checkAllowListRecursive`.

## How has this been tested?
1. Open Post Editor
2. Open global inserter -> Patterns
3. Search for "Contact Information" pattern
4. Make sure it shows up
5. Open settings dropdown -> Block Manager
6. Now disable "Social Icons" block 
7. Open global inserter -> Patterns
8. Search for "Contact Information" pattern
9. Make sure it doesn't show up anymore

## Types of changes
Bug Fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
