### PR TITLE
Add a margin block support and enable in group block

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -65,8 +65,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		?>
 			<?php echo '.wp-container-' . $id; ?> > * {
 				max-width: <?php echo $content_size ? $content_size : $wide_size; ?>;
-				margin-left: auto;
-				margin-right: auto;
+				margin-left: auto !important;
+				margin-right: auto !important;
 			}
 
 			<?php echo '.wp-container-' . $id; ?> > .alignwide {

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -106,6 +106,12 @@ class WP_Theme_JSON {
 					'bottom' => null,
 					'left'   => null,
 				),
+				'margin' => array(
+					'top'    => null,
+					'right'  => null,
+					'bottom' => null,
+					'left'   => null,
+				),
 			),
 			'typography' => array(
 				'fontFamily'     => null,
@@ -133,6 +139,7 @@ class WP_Theme_JSON {
 			),
 			'spacing'    => array(
 				'customPadding' => null,
+				'customMargin'  => null,
 				'units'         => null,
 			),
 			'typography' => array(
@@ -279,6 +286,10 @@ class WP_Theme_JSON {
 		),
 		'padding'                  => array(
 			'value'      => array( 'spacing', 'padding' ),
+			'properties' => array( 'top', 'right', 'bottom', 'left' ),
+		),
+		'margin'                   => array(
+			'value'      => array( 'spacing', 'margin' ),
 			'properties' => array( 'top', 'right', 'bottom', 'left' ),
 		),
 		'text-decoration'          => array(

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -168,6 +168,7 @@
 			},
 			"spacing": {
 				"customPadding": false,
+				"customMargin": false,
 				"units": [ "px", "em", "rem", "vh", "vw" ]
 			},
 			"border": {

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -43,8 +43,8 @@ export function LayoutStyle( { selector, layout = {} } ) {
 			? `
 				${ appendSelectors( selector, '> *' ) } {
 					max-width: ${ contentSize ?? wideSize };
-					margin-left: auto;
-					margin-right: auto;
+					margin-left: auto !important;
+					margin-right: auto  !important;
 				}
 
 				${ appendSelectors( selector, '> [data-align="wide"]' ) }  {

--- a/packages/block-editor/src/components/spacing-panel-control/index.js
+++ b/packages/block-editor/src/components/spacing-panel-control/index.js
@@ -11,9 +11,10 @@ import InspectorControls from '../inspector-controls';
 import useEditorFeature from '../use-editor-feature';
 
 export default function SpacingPanelControl( { children, ...props } ) {
-	const isSpacingEnabled = useEditorFeature( 'spacing.customPadding' );
+	const supportsPadding = useEditorFeature( 'spacing.customPadding' );
+	const supportsMargin = useEditorFeature( 'spacing.customMargin' );
 
-	if ( ! isSpacingEnabled ) return null;
+	if ( ! supportsMargin && ! supportsPadding ) return null;
 
 	return (
 		<InspectorControls { ...props }>

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -13,31 +13,31 @@ import { cleanEmptyObject } from './utils';
 import { useCustomUnits } from '../components/unit-control';
 import useEditorFeature from '../components/use-editor-feature';
 
-export const SPACING_SUPPORT_KEY = 'spacing';
+const SPACING_SUPPORT_KEY = 'spacing';
 
-const hasPaddingSupport = ( blockName ) => {
+const hasMarginSupport = ( blockName ) => {
 	const spacingSupport = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
-	return spacingSupport && spacingSupport.padding !== false;
+	return spacingSupport && spacingSupport.margin !== false;
 };
 
 /**
- * Inspector control panel containing the padding related configuration
+ * Inspector control panel containing the margin related configuration
  *
  * @param {Object} props
  *
- * @return {WPElement} Padding edit element.
+ * @return {WPElement} Margin edit element.
  */
-export function PaddingEdit( props ) {
+export function MarginEdit( props ) {
 	const {
 		name: blockName,
 		attributes: { style },
 		setAttributes,
 	} = props;
 
-	const supportsPadding = useEditorFeature( 'spacing.customPadding' );
+	const supportsMargin = useEditorFeature( 'spacing.customMargin' );
 	const units = useCustomUnits();
 
-	if ( ! supportsPadding || ! hasPaddingSupport( blockName ) ) {
+	if ( ! supportsMargin || ! hasMarginSupport( blockName ) ) {
 		return null;
 	}
 
@@ -46,7 +46,7 @@ export function PaddingEdit( props ) {
 			...style,
 			spacing: {
 				...style?.spacing,
-				padding: next,
+				margin: next,
 			},
 		};
 
@@ -60,7 +60,7 @@ export function PaddingEdit( props ) {
 			...style,
 			visualizers: {
 				...style?.visualizers,
-				padding: next,
+				margin: next,
 			},
 		};
 
@@ -73,10 +73,10 @@ export function PaddingEdit( props ) {
 		web: (
 			<>
 				<BoxControl
-					values={ style?.spacing?.padding }
+					values={ style?.spacing?.margin }
 					onChange={ onChange }
 					onChangeShowVisualizer={ onChangeShowVisualizer }
-					label={ __( 'Padding' ) }
+					label={ __( 'Margin' ) }
 					units={ units }
 				/>
 			</>

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -21,6 +21,7 @@ import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
 import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
+import { MarginEdit } from './margin';
 import SpacingPanelControl from '../components/spacing-panel-control';
 
 const styleSupportKeys = [
@@ -188,6 +189,7 @@ export const withBlockControls = createHigherOrderComponent(
 			hasSpacingSupport && (
 				<SpacingPanelControl key="spacing">
 					<PaddingEdit { ...props } />
+					<MarginEdit { ...props } />
 				</SpacingPanelControl>
 			),
 		];

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -20,7 +20,8 @@
 			"link": true
 		},
 		"spacing": {
-			"padding": true
+			"padding": true,
+			"margin": true
 		},
 		"__experimentalBorder": {
 			"color": true,

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -70,6 +70,11 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		support: [ 'spacing', 'padding' ],
 		properties: [ 'top', 'right', 'bottom', 'left' ],
 	},
+	margin: {
+		value: [ 'spacing', 'margin' ],
+		support: [ 'spacing', 'margin' ],
+		properties: [ 'top', 'right', 'bottom', 'left' ],
+	},
 	textDecoration: {
 		value: [ 'typography', 'textDecoration' ],
 		support: [ '__experimentalTextDecoration' ],


### PR DESCRIPTION
Related #28356 

This PR adds margin support to the Group block and a margin block support. At the moment, it's more a POC to see where we take this. Here are some open questions:

 - Should we allow setting "margin: auto" in the controls, I lean toward **no** personally since this seems more something the alignment should do.
 - At the current stage of the PR, if you apply a margin to a block, it overrides the "margin: auto" applied by the alignment (layout), the only way to solve that is to use `!important` for these. I think it's a decent solution for this use-case but would love thoughts on this.

with this PR, you'll also be able to set "margin" styles in theme.json for blocks.

**Testing instructions**

- To enable this, you need to add `spacing.customMargin: true` to your theme.json config.