### PR TITLE
wp-env: Edit PHP config from .wp-env.json

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -390,6 +390,7 @@ You can customize the WordPress installation, plugins and themes that the develo
 | `"port"`       | `integer`      | `8888` (`8889` for the tests instance) | The primary port number to use for the installation. You'll access the instance through the port: 'http://localhost:8888'.       |
 | `"config"`     | `Object`       | See below.                             | Mapping of wp-config.php constants to their desired values.                                                                      |
 | `"mappings"`   | `Object`       | `"{}"`                                 | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                                   |
+| `"phpConfig"`  | `Object`       | See below.                             | PHP configuration directives.                                                                                                    |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
@@ -404,7 +405,7 @@ Several types of strings can be passed into the `core`, `plugins`, `themes`, and
 
 Remote sources will be downloaded into a temporary directory located in `~/.wp-env`.
 
-Additionally, the key `env` is available to override any of the above options on an individual-environment basis. For example, take the following `.wp-env.json` file:
+Additionally, the key `env` is available to override any of the above options on an individual-environment basis (except `phpConfig`). For example, take the following `.wp-env.json` file:
 
 ```json
 {
@@ -423,7 +424,7 @@ Additionally, the key `env` is available to override any of the above options on
 			},
 			"port": 3000
 		}
-	}
+	}
 }
 ```
 
@@ -432,6 +433,28 @@ On the development instance, `cwd` will be mapped as a plugin, `one-theme` will 
 On the tests instance, `cwd` is still mapped as a plugin, but no theme is mapped. Additionally, while KEY_2 is still set to false, KEY_1 is overridden and set to false. 3000 overrides the default port as well.
 
 This gives you a lot of power to change the options applicable to each environment.
+
+Custom `php.ini` directives can be specified using `phpConfig`. For example this configuration:
+
+```json
+{
+	"phpConfig": {
+		"memory_limit": "512M",
+		"post_max_size": "512M",
+		"upload_max_filesize": "512M"
+	}
+}
+```
+
+Will become these `php.ini` directives:
+
+```
+memory_limit=512M
+post_max_size=512M
+upload_max_filesize=512M
+```
+
+By default, `phpConfig` defines the directives needed to increase the maximum size of files that can be uploaded.
 
 ## .wp-env.override.json
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -424,7 +424,7 @@ Additionally, the key `env` is available to override any of the above options on
 			},
 			"port": 3000
 		}
-	}
+	}
 }
 ```
 

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -27,6 +27,7 @@ const md5 = require( '../md5' );
  * @property {Object.<string, WPServiceConfig>} env                     Specific config for different environments.
  * @property {boolean}                          debug                   True if debug mode is enabled.
  * @property {string}                           phpVersion              Version of PHP to use in the environments, of the format 0.0.
+ * @property {Object} phpConfig PHP configuration key value pairs.
  */
 
 /**
@@ -92,6 +93,10 @@ module.exports = async function readConfig( configPath ) {
 				port: 8889,
 			},
 		},
+		phpConfig: {
+			post_max_size: '500M',
+			upload_max_filesize: '500M',
+		},
 	};
 
 	// The specified base configuration from .wp-env.json or from the local
@@ -110,9 +115,7 @@ module.exports = async function readConfig( configPath ) {
 	const detectedLocalConfig =
 		Object.keys( { ...baseConfig, ...overrideConfig } ).length > 0;
 
-	// A quick validation before merging on a service by service level allows us
-	// to check the root configuration options and provide more helpful errors.
-	validateConfig(
+	const resolvedConfig = validateConfig(
 		mergeWpServiceConfigs( [
 			defaultConfiguration,
 			baseConfig,
@@ -174,6 +177,7 @@ module.exports = async function readConfig( configPath ) {
 		workDirectoryPath,
 		detectedLocalConfig,
 		env,
+		phpConfig: resolvedConfig.phpConfig,
 	} );
 };
 

--- a/packages/env/lib/config/test/__snapshots__/config.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config.js.snap
@@ -51,6 +51,10 @@ Object {
     },
   },
   "name": ".",
+  "phpConfig": Object {
+    "post_max_size": "500M",
+    "upload_max_filesize": "500M",
+  },
 }
 `;
 

--- a/packages/env/lib/config/validate-config.js
+++ b/packages/env/lib/config/validate-config.js
@@ -83,6 +83,12 @@ function validateConfig( config, envLocation ) {
 		);
 	}
 
+	if ( typeof config.phpConfig !== 'object' ) {
+		throw new ValidationError(
+			'Invalid .wp-env.json: "phpConfig" must be an object.'
+		);
+	}
+
 	return config;
 }
 


### PR DESCRIPTION
## Description
Closes #28703 and #29430. This PR makes it possible to add PHP configuration directives by editing `.wp-env.json`. It sets PHP max upload file size to `500MB` up from the default `1MB` or `2MB` which is very annoying to work with. Additional reasoning about this change is provided in #28703.

I couldn't figure out if there's an automated way to format comments properly. Does that have to be done manually?

## How has this been tested?

Manually. Run `wp-env start` and see that the PHP upload limit is 500 MB or examine PHP directives directly.

## Types of changes

New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
