### PR TITLE
Fix snackbar list component blocking clicks to UI it overlaps

### DIFF
--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -10,6 +10,7 @@
 	max-width: 600px;
 	box-sizing: border-box;
 	cursor: pointer;
+	pointer-events: auto;
 
 	@include break-small() {
 		width: fit-content;

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -10,6 +10,9 @@
 	max-width: 600px;
 	box-sizing: border-box;
 	cursor: pointer;
+
+	// Re-enable pointer events, which are disabled by the
+	// .components-snackbar-list styles.
 	pointer-events: auto;
 
 	@include break-small() {
@@ -78,6 +81,11 @@
 	z-index: z-index(".components-snackbar-list");
 	width: 100%;
 	box-sizing: border-box;
+
+	// Disable pointer events, so that clicking this area
+	// outside of an individual notice still allows the UI
+	// underneath to be clicked.
+	pointer-events: none;
 }
 
 .components-snackbar-list__notice-container {

--- a/packages/edit-navigation/src/components/notices/style.scss
+++ b/packages/edit-navigation/src/components/notices/style.scss
@@ -2,7 +2,6 @@
 	position: fixed;
 	bottom: 20px;
 	margin-left: 20px;
-	pointer-events: none;
 }
 
 .edit-navigation-notices__notice-list {

--- a/packages/edit-navigation/src/components/notices/style.scss
+++ b/packages/edit-navigation/src/components/notices/style.scss
@@ -2,6 +2,7 @@
 	position: fixed;
 	bottom: 20px;
 	margin-left: 20px;
+	pointer-events: none;
 }
 
 .edit-navigation-notices__notice-list {

--- a/packages/editor/src/components/editor-notices/style.scss
+++ b/packages/editor/src/components/editor-notices/style.scss
@@ -32,10 +32,3 @@
 		}
 	}
 }
-
-.components-editor-notices__snackbar {
-	width: 100%;
-	@include break-medium() {
-		width: fit-content;
-	}
-}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closes https://github.com/WordPress/gutenberg/issues/30319

Only notices themselves should react to events, not their containers. In order to fix the problem once for all, I have changed pointer-events so notices background will never affect anything beneath. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Navigate to Navigation Editor
2. Select menu
3. Click on `save` button multiple times to generate a lot of notices
4. Click on the sidebar to check if it responds
5. Click on the notice itself to verify it will receive an event

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/8398557/113009088-ee4b9a80-9177-11eb-89c9-fe620cb514bd.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
