### PR TITLE
Post Comments: Add some basic CSS to the post comments block

### DIFF
--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -20,5 +20,6 @@
 			"link": true
 		},
 		"lineHeight": true
-	}
+	},
+	"style": "wp-block-post-comments"
 }

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -4,17 +4,45 @@
 		list-style: none;
 		margin: 0;
 		padding: 0;
-	}
 
-	.comment-author {
-		.avatar {
-			float: left;
-			margin-right: 10px;
+		.comment {
+			font-size: 0.875em;
+			line-height: 1.8;
+			margin-bottom: 1em;
+			min-height: 2.25em;
+			padding-left: 3.25em;
+
+			p {
+				margin: 0.36em 0 1.4em;
+			}
 		}
 	}
 
+	.comment-author {
+		line-height: 1.5;
+		margin-left: -3.25em;
+
+		.avatar {
+			border-radius: 1.5em;
+			display: block;
+			float: left;
+			height: 2.5em;
+			margin-right: 0.75em;
+			width: 2.5em;
+		}
+
+		cite {
+			font-style: normal;
+		}
+	}
+
+	.comment-meta {
+		line-height: 1.5;
+		margin-left: -3.25em;
+	}
+
 	.comment-body .commentmetadata {
-		font-size: 0.8em;
+		font-size: 0.75em;
 	}
 
 	.comment-form-comment,
@@ -29,5 +57,9 @@
 	.comment-form-comment textarea {
 		box-sizing: border-box;
 		width: 100%;
+	}
+
+	.reply {
+		font-size: 0.75em;
 	}
 }

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -1,0 +1,33 @@
+
+.wp-block-post-comments {
+	.commentlist {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.comment-author {
+		.avatar {
+			float: left;
+			margin-right: 10px;
+		}
+	}
+
+	.comment-body .commentmetadata {
+		font-size: 0.8em;
+	}
+
+	.comment-form-comment,
+	.comment-form-author,
+	.comment-form-email,
+	.comment-form-url {
+		label {
+			display: block;
+		}
+	}
+
+	.comment-form-comment textarea {
+		box-sizing: border-box;
+		width: 100%;
+	}
+}

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -1,4 +1,3 @@
-
 .wp-block-post-comments {
 	.commentlist {
 		list-style: none;
@@ -6,15 +5,20 @@
 		padding: 0;
 
 		.comment {
-			font-size: 0.875em;
-			line-height: 1.8;
-			margin-bottom: 1em;
 			min-height: 2.25em;
 			padding-left: 3.25em;
 
 			p {
+				font-size: 0.875em;
+				line-height: 1.8;
 				margin: 0.36em 0 1.4em;
 			}
+		}
+
+		.children {
+			list-style: none;
+			margin: 0;
+			padding: 0;
 		}
 	}
 
@@ -61,5 +65,13 @@
 
 	.reply {
 		font-size: 0.75em;
+		margin-bottom: 1.4em;
+	}
+
+	.comment-form {
+		textarea,
+		input {
+			border: 1px solid $gray-600;
+		}
 	}
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -26,6 +26,7 @@
 @import "./page-list/style.scss";
 @import "./paragraph/style.scss";
 @import "./post-author/style.scss";
+@import "./post-comments/style.scss";
 @import "./post-comments-form/style.scss";
 @import "./post-excerpt/style.scss";
 @import "./post-title/style.scss";


### PR DESCRIPTION
## Description
This adds some basic CSS to the Post Comments block, so it doesn't look broken. Fixes https://github.com/WordPress/gutenberg/issues/26864

## How has this been tested?
- Switch to empty theme
- Add Post Comment block to a post
- Add a comment to the post
- Preview when logged in
- Preview when logged out

## Screenshots <!-- if applicable -->
<img width="936" alt="Screenshot 2021-03-30 at 16 42 14" src="https://user-images.githubusercontent.com/275961/113016985-e9d2b200-9176-11eb-9ffe-b851d3c223af.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
