### PR TITLE
Interim dual license license of future contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
 
+<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions must be made under that dual-license: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
+
 ## Description
 <!-- Please describe what you have changed or added -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
 
-<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are now dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
+<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
 
 ## Description
 <!-- Please describe what you have changed or added -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
 
-<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions must be made under that dual-license: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
+<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are now dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
 
 ## Description
 <!-- Please describe what you have changed or added -->

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -43,7 +43,7 @@ and
 ### Dual License 
 
 **We are currently in the process of changing Gutenberg’s software license from
-GPL (or later) to a dual license: GPL (or later) and MPL.**
+GPL to a dual license: GPL and MPL.**
 
 **This process involves two independent steps (1) obtaining permission for dual
 licensing from contributors of already contributed Gutenberg code and (2)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## Gutenberg
 
-    Copyright 2011-2021 by the contributors
+    Copyright 2016-2021 by the contributors
 
 **License for Contributions (on and after April 15, 2021)**
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -78,7 +78,7 @@ License” to the following:**
 
 ## Full Text of Referenced Licenses
 
-1. [GNU General Public License, Version 2](#gnu-general_public_license-version-2)
+1. [GNU General Public License, Version 2](#gnu-general-public-license-version-2)
 2. [Mozilla Public License, Version 2.0](#mozilla-public-license-version-20)
 
 ## GNU General Public License, Version 2

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,9 +11,11 @@ the GNU General Public License as published by the Free Software Foundation;
 either version 2 of the License or (at your option) any later version (the “GPL”)
 and the Mozilla Public License, Version 2.0 (the “MPL”). 
 
-**Project License (as of April 15, 2021)**
+**Project License**
 
-The Gutenberg project is free software; you can redistribute it and/or modify it
+The Gutenberg project license is not affected by the License for Contributions (as 
+discussed in the [Dual License section](#dual-license) below). The Gutenberg project 
+continues to be free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the Free
 Software Foundation; either version 2 of the License or (at your option) any
 later version (the “GPL”). 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
     Copyright 2011-2021 by the contributors
 
-**License for Contributions (on and after March __, 2021)**
+**License for Contributions (on and after April 15, 2021)**
 
 All code contributed to the Gutenberg project is dual-licensed, 
 and released under both of the following licenses: 
@@ -11,7 +11,7 @@ the GNU General Public License as published by the Free Software Foundation;
 either version 2 of the License or (at your option) any later version (the “GPL”)
 and the Mozilla Public License Version 2.0 (the “MPL”). 
 
-**Project License (as of March __, 2021)**
+**Project License (as of April 15, 2021)**
 
 The Gutenberg project is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the Free
@@ -27,19 +27,19 @@ GPLv2 (or later) to a dual license: GPLv2 (or later) and MPLv2.**
 **This process involves two independent steps (1) obtaining permission for dual
 licensing from contributors of already contributed Gutenberg code and (2)
 dual licensing of all contributions to Gutenberg that are made on or after
-March XX, 2021.**
+April 15, 2021.**
 
 **For part (1): We’re reaching out to everyone who has contributed code, prior
-to March XX, 2021, and asking that they agree to dual license their
+to April 15, 2021, and asking that they agree to dual license their
 contribution to the project. We expect this process to be completed by
 mid-year, 2021.**
 
 **For part (2): We have changed the license for contributed code to this
-repository to make clear that all contributions on or after March XX, 2021
+repository to make clear that all contributions on or after April 15, 2021
 will be made under the dual-license.**
 
 **When we have received all necessary rights and permissions to dual license
-the pre-March 2021 code of the Gutenberg project (Part 1 above), you will
+the pre-April 15, 2021 code of the Gutenberg project (Part 1 above), you will
 have the option to use and distribute all of the Gutenberg project under
 either the GPL or MPL license. At this time we will change the “Project
 License” to the following:**

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,20 +1,57 @@
-### WordPress - Web publishing software
+## Gutenberg
 
     Copyright 2011-2021 by the contributors
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
+**License for Contributions (on and after March __, 2021)**
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+All code contributed to the Gutenberg project is dual-licensed, 
+and released under both of the following licenses: 
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+the GNU General Public License as published by the Free Software Foundation; 
+either version 2 of the License or (at your option) any later version (the “GPL”)
+and the Mozilla Public License Version 2.0 (the “MPL”). 
+
+**Project License (as of March __, 2021)**
+
+The Gutenberg project is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 2 of the License or (at your option) any
+later version (the “GPL”). 
+
+
+### Dual License 
+
+**We are currently in the process of changing Gutenberg’s software license from
+GPLv2 (or later) to a dual license: GPLv2 (or later) and MPLv2.**
+
+**This process involves two independent steps (1) obtaining permission for dual
+licensing from contributors of already contributed Gutenberg code and (2)
+dual licensing of all contributions to Gutenberg that are made on or after
+March XX, 2021.**
+
+**For part (1): We’re reaching out to everyone who has contributed code, prior
+to March XX, 2021, and asking that they agree to dual license their
+contribution to the project. We expect this process to be completed by
+mid-year, 2021.**
+
+**For part (2): We have changed the license for contributed code to this
+repository to make clear that all contributions on or after March XX, 2021
+will be made under the dual-license.**
+
+**When we have received all necessary rights and permissions to dual license
+the pre-March 2021 code of the Gutenberg project (Part 1 above), you will
+have the option to use and distribute all of the Gutenberg project under
+either the GPL or MPL license. At this time we will change the “Project
+License” to the following:**
+ 
+    The Gutenberg project is free software; you can redistribute it and/or modify
+    it under the terms of either of the following licenses: 
+
+        1. the GNU General Public License as published by the Free Software Foundation;
+           either version 2 of the License or (at your option) any later version (the
+           “GPL”) OR
+       
+        2. the Mozilla Public License Version 2.0 (the “MPL”).
 
 This program incorporates work covered by the following copyright and
 permission notices:
@@ -36,6 +73,13 @@ and
     WordPress is released under the GPL
 
 ---
+
+## Referenced Licenses
+
+1. [GNU General Public License, Version 2](#gnu-general_public_license-version-2)
+2. [Mozilla Public License Version 2.0](#mozilla-public-license-version-20)
+
+## GNU GENERAL PUBLIC LICENSE, VERSION 2
 
 ### GNU GENERAL PUBLIC LICENSE
 
@@ -398,3 +442,359 @@ applications with the library. If this is what you want to do, use the
 [GNU Lesser General Public
 License](http://www.gnu.org/licenses/lgpl.html) instead of this
 License.
+
+---
+## Mozilla Public License Version 2.0
+
+### 1. Definitions
+
+**1.1. “Contributor”**
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+**1.2. “Contributor Version”**
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+**1.3. “Contribution”**
+    means Covered Software of a particular Contributor.
+
+**1.4. “Covered Software”**
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+**1.5. “Incompatible With Secondary Licenses”**
+    means
+
+* **(a)** that the initial Contributor has attached the notice described
+    in Exhibit B to the Covered Software; or
+* **(b)** that the Covered Software was made available under the terms of
+    version 1.1 or earlier of the License, but not also under the
+    terms of a Secondary License.
+
+**1.6. “Executable Form”**
+    means any form of the work other than Source Code Form.
+
+**1.7. “Larger Work”**
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+**1.8. “License”**
+    means this document.
+
+**1.9. “Licensable”**
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+**1.10. “Modifications”**
+    means any of the following:
+
+* **(a)** any file in Source Code Form that results from an addition to,
+    deletion from, or modification of the contents of Covered
+    Software; or
+* **(b)** any new file in Source Code Form that contains any Covered
+    Software.
+
+**1.11. “Patent Claims” of a Contributor**
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+**1.12. “Secondary License”**
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+**1.13. “Source Code Form”**
+    means the form of the work preferred for making modifications.
+
+**1.14. “You” (or “Your”)**
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, “You” includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, “control” means **(a)** the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or **(b)** ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+
+### 2. License Grants and Conditions
+
+#### 2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+* **(a)** under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+* **(b)** under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+#### 2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+#### 2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+* **(a)** for any code that a Contributor has removed from Covered Software;
+    or
+* **(b)** for infringements caused by: **(i)** Your and any other third party's
+    modifications of Covered Software, or **(ii)** the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+* **(c)** under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+#### 2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+#### 2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+#### 2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+#### 2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+
+### 3. Responsibilities
+
+#### 3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+#### 3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+* **(a)** such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+* **(b)** You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+#### 3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+#### 3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+#### 3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+
+### 4. Inability to Comply Due to Statute or Regulation
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: **(a)** comply with
+the terms of this License to the maximum extent possible; and **(b)**
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+
+### 5. Termination
+
+**5.1.** The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated **(a)** provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and **(b)** on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+**5.2.** If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+**5.3.** In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+
+### 6. Disclaimer of Warranty
+
+> Covered Software is provided under this License on an “as is”
+> basis, without warranty of any kind, either expressed, implied, or
+> statutory, including, without limitation, warranties that the
+> Covered Software is free of defects, merchantable, fit for a
+> particular purpose or non-infringing. The entire risk as to the
+> quality and performance of the Covered Software is with You.
+> Should any Covered Software prove defective in any respect, You
+> (not any Contributor) assume the cost of any necessary servicing,
+> repair, or correction. This disclaimer of warranty constitutes an
+> essential part of this License. No use of any Covered Software is
+> authorized under this License except under this disclaimer.
+
+### 7. Limitation of Liability
+
+> Under no circumstances and under no legal theory, whether tort
+> (including negligence), contract, or otherwise, shall any
+> Contributor, or anyone who distributes Covered Software as
+> permitted above, be liable to You for any direct, indirect,
+> special, incidental, or consequential damages of any character
+> including, without limitation, damages for lost profits, loss of
+> goodwill, work stoppage, computer failure or malfunction, or any
+> and all other commercial damages or losses, even if such party
+> shall have been informed of the possibility of such damages. This
+> limitation of liability shall not apply to liability for death or
+> personal injury resulting from such party's negligence to the
+> extent applicable law prohibits such limitation. Some
+> jurisdictions do not allow the exclusion or limitation of
+> incidental or consequential damages, so this exclusion and
+> limitation may not apply to You.
+
+
+### 8. Litigation
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+
+### 9. Miscellaneous
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+
+### 10. Versions of the License
+
+#### 10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+#### 10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+#### 10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+#### 10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+## Exhibit A - Source Code Form License Notice
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+## Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+    This Source Code Form is "Incompatible With Secondary Licenses", as
+    defined by the Mozilla Public License, v. 2.0.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -18,6 +18,25 @@ under the terms of the GNU General Public License as published by the Free
 Software Foundation; either version 2 of the License or (at your option) any
 later version (the “GPL”). 
 
+This program incorporates work covered by the following copyright and
+permission notices:
+
+    b2 is (c) 2001, 2002 Michel Valdrighi - m@tidakada.com -
+    http://tidakada.com
+
+    Wherever third party code has been used, credit has been given in the code's
+    comments.
+
+    b2 is released under the GPL
+
+and
+
+    WordPress - Web publishing software
+
+    Copyright 2003-2010 by the contributors
+
+    WordPress is released under the GPL
+
 
 ### Dual License 
 
@@ -52,25 +71,6 @@ License” to the following:**
            “GPL”) OR
        
         2. the Mozilla Public License Version 2.0 (the “MPL”).
-
-This program incorporates work covered by the following copyright and
-permission notices:
-
-    b2 is (c) 2001, 2002 Michel Valdrighi - m@tidakada.com -
-    http://tidakada.com
-
-    Wherever third party code has been used, credit has been given in the code's
-    comments.
-
-    b2 is released under the GPL
-
-and
-
-    WordPress - Web publishing software
-
-    Copyright 2003-2010 by the contributors
-
-    WordPress is released under the GPL
 
 ---
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,7 +9,7 @@ and released under both of the following licenses:
 
 the GNU General Public License as published by the Free Software Foundation; 
 either version 2 of the License or (at your option) any later version (the “GPL”)
-and the Mozilla Public License Version 2.0 (the “MPL”). 
+and the Mozilla Public License, Version 2.0 (the “MPL”). 
 
 **Project License (as of April 15, 2021)**
 
@@ -22,7 +22,7 @@ later version (the “GPL”).
 ### Dual License 
 
 **We are currently in the process of changing Gutenberg’s software license from
-GPLv2 (or later) to a dual license: GPLv2 (or later) and MPLv2.**
+GPL (or later) to a dual license: GPL (or later) and MPL.**
 
 **This process involves two independent steps (1) obtaining permission for dual
 licensing from contributors of already contributed Gutenberg code and (2)
@@ -74,12 +74,12 @@ and
 
 ---
 
-## Referenced Licenses
+## Full Text of Referenced Licenses
 
 1. [GNU General Public License, Version 2](#gnu-general_public_license-version-2)
-2. [Mozilla Public License Version 2.0](#mozilla-public-license-version-20)
+2. [Mozilla Public License, Version 2.0](#mozilla-public-license-version-20)
 
-## GNU GENERAL PUBLIC LICENSE, VERSION 2
+## GNU General Public License, Version 2
 
 ### GNU GENERAL PUBLIC LICENSE
 
@@ -444,7 +444,7 @@ License](http://www.gnu.org/licenses/lgpl.html) instead of this
 License.
 
 ---
-## Mozilla Public License Version 2.0
+## Mozilla Public License, Version 2.0
 
 ### 1. Definitions
 


### PR DESCRIPTION
## Description
As part of the process to transition Gutenberg to be dual-licensed under both the Mozilla Public License and the GPL, we are updating Gutenberg’s license to dual-license future contributions but leaving the project as a whole licensed under the GPL while we obtain permission to relicense past Gutenberg contributions. More information is available on the Make blog: [Dual-Licensing Gutenberg: Next Steps](https://make.wordpress.org/core/2021/03/05/dual-licensing-gutenberg-next-steps/).

## How has this been tested?
N/A

## Types of changes
Documentation

## Checklist:

- [N/A] My code is tested.
- [N/A] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
