### PR TITLE
Site editor: Switch to proper settings tab based on the selection

### DIFF
--- a/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
@@ -6,6 +6,7 @@ import {
 	activateTheme,
 	getAllBlocks,
 	selectBlockByClientId,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -93,6 +94,29 @@ describe( 'Settings sidebar', () => {
 			await toggleSidebar();
 
 			expect( await getActiveTabLabel() ).toEqual( 'Block (selected)' );
+		} );
+	} );
+
+	describe( 'Tab switch based on selection', () => {
+		it( 'should switch to block tab if we select a block, when Template is selected', async () => {
+			await toggleSidebar();
+			expect( await getActiveTabLabel() ).toEqual(
+				'Template (selected)'
+			);
+			// By inserting the block is also selected.
+			await insertBlock( 'Heading' );
+			expect( await getActiveTabLabel() ).toEqual( 'Block (selected)' );
+		} );
+		it( 'should switch to Template tab when a block was selected and we select the Template', async () => {
+			await insertBlock( 'Heading' );
+			await toggleSidebar();
+			expect( await getActiveTabLabel() ).toEqual( 'Block (selected)' );
+			await page.evaluate( () => {
+				wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
+			} );
+			expect( await getActiveTabLabel() ).toEqual(
+				'Template (selected)'
+			);
 		} );
 	} );
 } );

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -53,7 +53,6 @@ export function SidebarComplementaryAreaFills() {
 			enableComplementaryArea( STORE_NAME, SIDEBAR_TEMPLATE );
 		}
 	}, [ hasBlockSelection, isEditorSidebarOpened ] );
-	// TODO check why this is needed (when we have GS sidebar selected)..
 	let sidebarName = sidebar;
 	if ( ! isEditorSidebarOpened ) {
 		sidebarName = hasBlockSelection ? SIDEBAR_BLOCK : SIDEBAR_TEMPLATE;

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -4,7 +4,8 @@
 import { createSlotFill, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { cog, typography } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
@@ -24,23 +25,39 @@ const { Slot: InspectorSlot, Fill: InspectorFill } = createSlotFill(
 export const SidebarInspectorFill = InspectorFill;
 
 export function SidebarComplementaryAreaFills() {
-	const { sidebarName } = useSelect( ( select ) => {
-		let sidebar = select( interfaceStore ).getActiveComplementaryArea(
-			STORE_NAME
-		);
-
-		if ( ! [ SIDEBAR_BLOCK, SIDEBAR_TEMPLATE ].includes( sidebar ) ) {
-			sidebar = SIDEBAR_TEMPLATE;
-			if ( select( blockEditorStore ).getBlockSelectionStart() ) {
-				sidebar = SIDEBAR_BLOCK;
-			}
+	const { sidebar, isEditorSidebarOpened, hasBlockSelection } = useSelect(
+		( select ) => {
+			const _sidebar = select(
+				interfaceStore
+			).getActiveComplementaryArea( STORE_NAME );
+			const _isEditorSidebarOpened = [
+				SIDEBAR_BLOCK,
+				SIDEBAR_TEMPLATE,
+			].includes( _sidebar );
+			return {
+				sidebar: _sidebar,
+				isEditorSidebarOpened: _isEditorSidebarOpened,
+				hasBlockSelection: !! select(
+					blockEditorStore
+				).getBlockSelectionStart(),
+			};
+		},
+		[]
+	);
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	useEffect( () => {
+		if ( ! isEditorSidebarOpened ) return;
+		if ( hasBlockSelection ) {
+			enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
+		} else {
+			enableComplementaryArea( STORE_NAME, SIDEBAR_TEMPLATE );
 		}
-
-		return {
-			sidebarName: sidebar,
-		};
-	} );
-
+	}, [ hasBlockSelection, isEditorSidebarOpened ] );
+	// TODO check why this is needed (when we have GS sidebar selected)..
+	let sidebarName = sidebar;
+	if ( ! isEditorSidebarOpened ) {
+		sidebarName = hasBlockSelection ? SIDEBAR_BLOCK : SIDEBAR_TEMPLATE;
+	}
 	return (
 		<>
 			<DefaultSidebar


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/29620

In `site-editor` selecting a block does not switch to the block tab in Sidebar controls. This PR resolves this.
<!-- Please describe what you have changed or added -->

## Testing instructions
1. With a block theme go to `site-editor`
2. Open `Settings` sidebar
3. Select blocks and the `template` (click on the canvas) in combinations to observe the tab switch.

## Screenshots <!-- if applicable -->
![select](https://user-images.githubusercontent.com/16275880/113038981-d4be4900-919f-11eb-8992-666131348c37.gif)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
