### PR TITLE
Page List: add ability to convert to navigation links

### DIFF
--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, ButtonGroup, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { createBlock as create } from '@wordpress/blocks';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+const PAGE_FIELDS = [ 'id', 'title', 'link', 'type', 'parent' ];
+const FETCH_ALL_PAGES = -1;
+
+export const convertSelectedBlockToNavigationLinks = ( {
+	pages,
+	clientId,
+	replaceBlock,
+	createBlock,
+} ) => () => {
+	//TODO: handle resolving state
+	//TODO: test performance for lots of pages
+	//TODO: add related aria-labels
+	if ( ! pages ) {
+		return;
+	}
+
+	const linkMap = {};
+	const navigationLinks = [];
+
+	pages.forEach( ( { id, title, link: url, type, parent } ) => {
+		// See if a placeholder exists. This is created if children appear before parents in list
+		const innerBlocks = linkMap[ id ]?.innerBlocks ?? [];
+		linkMap[ id ] = createBlock(
+			'core/navigation-link',
+			{
+				id,
+				label: title.rendered, //TODO: raw or rendered?
+				url,
+				type,
+				kind: 'post-type',
+			},
+			innerBlocks
+		);
+
+		if ( ! parent ) {
+			navigationLinks.push( linkMap[ id ] );
+		} else {
+			if ( ! linkMap[ parent ] ) {
+				// Use a placeholder if the child appears before parent in list
+				linkMap[ parent ] = { innerBlocks: [] };
+			}
+			const parentLinkInnerBlocks = linkMap[ parent ].innerBlocks;
+			parentLinkInnerBlocks.push( linkMap[ id ] );
+		}
+	} );
+
+	replaceBlock( clientId, navigationLinks );
+};
+
+export default function ConvertToLinksModal( { onClose, clientId } ) {
+	const pages = useSelect(
+		( select ) => {
+			const { getPages } = select( coreDataStore );
+			return getPages( {
+				per_page: FETCH_ALL_PAGES,
+				_fields: PAGE_FIELDS,
+				orderby: 'menu_order',
+			} );
+		},
+		[ clientId ]
+	);
+	const { replaceBlock } = useDispatch( blockEditorStore );
+
+	return (
+		<Modal
+			closeLabel={ __( 'Close' ) }
+			onRequestClose={ onClose }
+			title={ __( 'Convert to Links' ) }
+			className={ 'wp-block-page-list-modal' }
+		>
+			<p>
+				{ __(
+					'To edit this navigation menu, convert it to single page links. This allows you to add re-order, remove items, or edit their labels.'
+				) }
+			</p>
+			<p>
+				{ __(
+					"Note: if you add new pages to your site, you'll need to add them to your navigation menu."
+				) }
+			</p>
+			<ButtonGroup className={ 'wp-block-page-list-modal-buttons' }>
+				<Button isSecondary onClick={ onClose }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					isPrimary
+					onClick={ convertSelectedBlockToNavigationLinks( {
+						pages,
+						replaceBlock,
+						clientId,
+						createBlock: create,
+					} ) }
+				>
+					{ __( 'Convert' ) }
+				</Button>
+			</ButtonGroup>
+		</Modal>
+	);
+}

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -3,6 +3,7 @@
  */
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { createBlock as create } from '@wordpress/blocks';
@@ -16,6 +17,7 @@ export const convertSelectedBlockToNavigationLinks = ( {
 	clientId,
 	replaceBlock,
 	createBlock,
+	setIsConverting,
 } ) => () => {
 	if ( ! pages ) {
 		return;
@@ -23,7 +25,7 @@ export const convertSelectedBlockToNavigationLinks = ( {
 
 	const linkMap = {};
 	const navigationLinks = [];
-
+	setIsConverting( true );
 	pages.forEach( ( { id, title, link: url, type, parent } ) => {
 		// See if a placeholder exists. This is created if children appear before parents in list
 		const innerBlocks = linkMap[ id ]?.innerBlocks ?? [];
@@ -52,9 +54,11 @@ export const convertSelectedBlockToNavigationLinks = ( {
 	} );
 
 	replaceBlock( clientId, navigationLinks );
+	setIsConverting( false );
 };
 
 export default function ConvertToLinksModal( { onClose, clientId } ) {
+	const [ isConverting, setIsConverting ] = useState( false );
 	const { pages, pagesFinished } = useSelect(
 		( select ) => {
 			const { getEntityRecords, hasFinishedResolution } = select(
@@ -104,12 +108,14 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 				</Button>
 				<Button
 					isPrimary
-					disabled={ ! pagesFinished }
+					isBusy={ isConverting }
+					disabled={ ! pagesFinished || isConverting }
 					onClick={ convertSelectedBlockToNavigationLinks( {
 						pages,
 						replaceBlock,
 						clientId,
 						createBlock: create,
+						setIsConverting,
 					} ) }
 				>
 					{ __( 'Convert' ) }

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -91,8 +91,9 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 			onRequestClose={ onClose }
 			title={ __( 'Convert to links' ) }
 			className={ 'wp-block-page-list-modal' }
+			aria={ { describedby: 'wp-block-page-list-modal__description' } }
 		>
-			<p>
+			<p id={ 'wp-block-page-list-modal__description' }>
 				{ __(
 					'To edit this navigation menu, convert it to single page links. This allows you to add re-order, remove items, or edit their labels.'
 				) }

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button, ButtonGroup, Modal } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
@@ -75,7 +75,7 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 		<Modal
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onClose }
-			title={ __( 'Convert to Links' ) }
+			title={ __( 'Convert to links' ) }
 			className={ 'wp-block-page-list-modal' }
 		>
 			<p>
@@ -88,8 +88,8 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 					"Note: if you add new pages to your site, you'll need to add them to your navigation menu."
 				) }
 			</p>
-			<ButtonGroup className={ 'wp-block-page-list-modal-buttons' }>
-				<Button isSecondary onClick={ onClose }>
+			<div className="wp-block-page-list-modal-buttons">
+				<Button isTertiary onClick={ onClose }>
 					{ __( 'Cancel' ) }
 				</Button>
 				<Button
@@ -103,7 +103,7 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 				>
 					{ __( 'Convert' ) }
 				</Button>
-			</ButtonGroup>
+			</div>
 		</Modal>
 	);
 }

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -21,10 +21,16 @@
 	}
 }
 
+// Modal that shows conversion option.
+.wp-block-page-list-modal {
+	max-width: 400px;
+}
+
 .wp-block-page-list-modal-buttons {
 	display: flex;
 	justify-content: flex-end;
-	> button {
-		margin: $grid-unit-10;
+
+	.components-button {
+		margin-left: $grid-unit-15;
 	}
 }

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -20,3 +20,11 @@
 		margin: 0.5em;
 	}
 }
+
+.wp-block-page-list-modal-buttons {
+	display: flex;
+	justify-content: flex-end;
+	> button {
+		margin: $grid-unit-10;
+	}
+}

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -150,12 +150,10 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$block_id++;
 
 	// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby values is resolved,
-	// update 'sort_column' to 'menu_order, post_title'.
-	//
-	// Sorting by both menu_order and post_title ensures a stable sort. Otherwise with pages that have
-	// the same menu_order value, we can see different ordering depending on how DB queries are constructed
-	// internally. For example we might see a different order when a limit is set to <499 versus >= 500
-	//
+	// update 'sort_column' to 'menu_order, post_title'. Sorting by both menu_order and post_title ensures a stable sort.
+	// Otherwise with pages that have the same menu_order value, we can see different ordering depending on how DB
+	// queries are constructed internally. For example we might see a different order when a limit is set to <499
+	// versus >= 500
 	$all_pages = get_pages( array( 'sort_column' => 'menu_order', 'order' => 'asc' ) );
 
 	$top_level_pages = array();

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -153,8 +153,13 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	// update 'sort_column' to 'menu_order, post_title'. Sorting by both menu_order and post_title ensures a stable sort.
 	// Otherwise with pages that have the same menu_order value, we can see different ordering depending on how DB
 	// queries are constructed internally. For example we might see a different order when a limit is set to <499
-	// versus >= 500
-	$all_pages = get_pages( array( 'sort_column' => 'menu_order', 'order' => 'asc' ) );
+	// versus >= 500.
+	$all_pages = get_pages(
+		array(
+			'sort_column' => 'menu_order',
+			'order'       => 'asc',
+		)
+	);
 
 	$top_level_pages = array();
 

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -149,7 +149,14 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	static $block_id = 0;
 	$block_id++;
 
-	$all_pages = get_pages( array( 'sort_column' => 'menu_order' ) );
+	// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby values is resolved,
+	// update 'sort_column' to 'menu_order, post_title'.
+	//
+	// Sorting by both menu_order and post_title ensures a stable sort. Otherwise with pages that have
+	// the same menu_order value, we can see different ordering depending on how DB queries are constructed
+	// internally. For example we might see a different order when a limit is set to <499 versus >= 500
+	//
+	$all_pages = get_pages( array( 'sort_column' => 'menu_order', 'order' => 'asc' ) );
 
 	$top_level_pages = array();
 

--- a/packages/block-library/src/page-list/test/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/test/convert-to-links-modal.js
@@ -1,0 +1,399 @@
+/**
+ * Internal dependencies
+ */
+import { convertSelectedBlockToNavigationLinks } from '../convert-to-links-modal';
+
+describe( 'page list convert to links', () => {
+	describe( 'convertSelectedBlockToNavigationLinks', () => {
+		it( 'Can create submenus', () => {
+			const pages = [
+				{
+					title: {
+						raw: 'Sample Page',
+						rendered: 'Sample Page',
+					},
+					id: 2,
+					parent: 0,
+					link: 'http://wordpress.local/sample-page/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'About',
+						rendered: 'About',
+					},
+					id: 34,
+					parent: 0,
+					link: 'http://wordpress.local/about/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Contact Page',
+						rendered: 'Contact Page',
+					},
+					id: 37,
+					parent: 0,
+					link: 'http://wordpress.local/contact-page/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test',
+						rendered: 'Test',
+					},
+					id: 229,
+					parent: 0,
+					link: 'http://wordpress.local/test/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'About Sub 1',
+						rendered: 'About Sub 1',
+					},
+					id: 738,
+					parent: 34,
+					link: 'http://wordpress.local/about/about-sub-1/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'About Sub 2',
+						rendered: 'About Sub 2',
+					},
+					id: 740,
+					parent: 34,
+					link: 'http://wordpress.local/about/about-sub-2/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test Sub',
+						rendered: 'Test Sub',
+					},
+					id: 742,
+					parent: 229,
+					link: 'http://wordpress.local/test/test-sub/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test Sub Sub',
+						rendered: 'Test Sub Sub',
+					},
+					id: 744,
+					parent: 742,
+					link: 'http://wordpress.local/test/test-sub/test-sub-sub/',
+					type: 'page',
+				},
+			];
+			const replaceBlock = jest.fn();
+			const createBlock = jest.fn(
+				( name, attributes, innerBlocks ) => ( {
+					name,
+					attributes,
+					innerBlocks,
+				} )
+			);
+			const convertLinks = convertSelectedBlockToNavigationLinks( {
+				pages,
+				clientId: 'testId',
+				replaceBlock,
+				createBlock,
+			} );
+			convertLinks();
+			expect( replaceBlock.mock.calls?.[ 0 ]?.[ 1 ] ).toEqual( [
+				{
+					attributes: {
+						id: 2,
+						kind: 'post-type',
+						label: 'Sample Page',
+						type: 'page',
+						url: 'http://wordpress.local/sample-page/',
+					},
+					innerBlocks: [],
+					name: 'core/navigation-link',
+				},
+				{
+					attributes: {
+						id: 34,
+						kind: 'post-type',
+						label: 'About',
+						type: 'page',
+						url: 'http://wordpress.local/about/',
+					},
+					innerBlocks: [
+						{
+							attributes: {
+								id: 738,
+								kind: 'post-type',
+								label: 'About Sub 1',
+								type: 'page',
+								url:
+									'http://wordpress.local/about/about-sub-1/',
+							},
+							innerBlocks: [],
+							name: 'core/navigation-link',
+						},
+						{
+							attributes: {
+								id: 740,
+								kind: 'post-type',
+								label: 'About Sub 2',
+								type: 'page',
+								url:
+									'http://wordpress.local/about/about-sub-2/',
+							},
+							innerBlocks: [],
+							name: 'core/navigation-link',
+						},
+					],
+					name: 'core/navigation-link',
+				},
+				{
+					attributes: {
+						id: 37,
+						kind: 'post-type',
+						label: 'Contact Page',
+						type: 'page',
+						url: 'http://wordpress.local/contact-page/',
+					},
+					innerBlocks: [],
+					name: 'core/navigation-link',
+				},
+				{
+					attributes: {
+						id: 229,
+						kind: 'post-type',
+						label: 'Test',
+						type: 'page',
+						url: 'http://wordpress.local/test/',
+					},
+					innerBlocks: [
+						{
+							attributes: {
+								id: 742,
+								kind: 'post-type',
+								label: 'Test Sub',
+								type: 'page',
+								url: 'http://wordpress.local/test/test-sub/',
+							},
+							innerBlocks: [
+								{
+									attributes: {
+										id: 744,
+										kind: 'post-type',
+										label: 'Test Sub Sub',
+										type: 'page',
+										url:
+											'http://wordpress.local/test/test-sub/test-sub-sub/',
+									},
+									innerBlocks: [],
+									name: 'core/navigation-link',
+								},
+							],
+							name: 'core/navigation-link',
+						},
+					],
+					name: 'core/navigation-link',
+				},
+			] );
+		} );
+		it( 'Can create submenus, when children appear before parents', () => {
+			const pages = [
+				{
+					title: {
+						raw: 'About Sub 1',
+						rendered: 'About Sub 1',
+					},
+					id: 738,
+					parent: 34,
+					link: 'http://wordpress.local/about/about-sub-1/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'About Sub 2',
+						rendered: 'About Sub 2',
+					},
+					id: 740,
+					parent: 34,
+					link: 'http://wordpress.local/about/about-sub-2/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test Sub Sub',
+						rendered: 'Test Sub Sub',
+					},
+					id: 744,
+					parent: 742,
+					link: 'http://wordpress.local/test/test-sub/test-sub-sub/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test Sub',
+						rendered: 'Test Sub',
+					},
+					id: 742,
+					parent: 229,
+					link: 'http://wordpress.local/test/test-sub/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Sample Page',
+						rendered: 'Sample Page',
+					},
+					id: 2,
+					parent: 0,
+					link: 'http://wordpress.local/sample-page/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'About',
+						rendered: 'About',
+					},
+					id: 34,
+					parent: 0,
+					link: 'http://wordpress.local/about/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Contact Page',
+						rendered: 'Contact Page',
+					},
+					id: 37,
+					parent: 0,
+					link: 'http://wordpress.local/contact-page/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test',
+						rendered: 'Test',
+					},
+					id: 229,
+					parent: 0,
+					link: 'http://wordpress.local/test/',
+					type: 'page',
+				},
+			];
+			const replaceBlock = jest.fn();
+			const createBlock = jest.fn(
+				( name, attributes, innerBlocks ) => ( {
+					name,
+					attributes,
+					innerBlocks,
+				} )
+			);
+			const convertLinks = convertSelectedBlockToNavigationLinks( {
+				pages,
+				clientId: 'testId',
+				replaceBlock,
+				createBlock,
+			} );
+			convertLinks();
+			expect( replaceBlock.mock.calls?.[ 0 ]?.[ 1 ] ).toEqual( [
+				{
+					attributes: {
+						id: 2,
+						kind: 'post-type',
+						label: 'Sample Page',
+						type: 'page',
+						url: 'http://wordpress.local/sample-page/',
+					},
+					innerBlocks: [],
+					name: 'core/navigation-link',
+				},
+				{
+					attributes: {
+						id: 34,
+						kind: 'post-type',
+						label: 'About',
+						type: 'page',
+						url: 'http://wordpress.local/about/',
+					},
+					innerBlocks: [
+						{
+							attributes: {
+								id: 738,
+								kind: 'post-type',
+								label: 'About Sub 1',
+								type: 'page',
+								url:
+									'http://wordpress.local/about/about-sub-1/',
+							},
+							innerBlocks: [],
+							name: 'core/navigation-link',
+						},
+						{
+							attributes: {
+								id: 740,
+								kind: 'post-type',
+								label: 'About Sub 2',
+								type: 'page',
+								url:
+									'http://wordpress.local/about/about-sub-2/',
+							},
+							innerBlocks: [],
+							name: 'core/navigation-link',
+						},
+					],
+					name: 'core/navigation-link',
+				},
+				{
+					attributes: {
+						id: 37,
+						kind: 'post-type',
+						label: 'Contact Page',
+						type: 'page',
+						url: 'http://wordpress.local/contact-page/',
+					},
+					innerBlocks: [],
+					name: 'core/navigation-link',
+				},
+				{
+					attributes: {
+						id: 229,
+						kind: 'post-type',
+						label: 'Test',
+						type: 'page',
+						url: 'http://wordpress.local/test/',
+					},
+					innerBlocks: [
+						{
+							attributes: {
+								id: 742,
+								kind: 'post-type',
+								label: 'Test Sub',
+								type: 'page',
+								url: 'http://wordpress.local/test/test-sub/',
+							},
+							innerBlocks: [
+								{
+									attributes: {
+										id: 744,
+										kind: 'post-type',
+										label: 'Test Sub Sub',
+										type: 'page',
+										url:
+											'http://wordpress.local/test/test-sub/test-sub-sub/',
+									},
+									innerBlocks: [],
+									name: 'core/navigation-link',
+								},
+							],
+							name: 'core/navigation-link',
+						},
+					],
+					name: 'core/navigation-link',
+				},
+			] );
+		} );
+	} );
+} );

--- a/packages/block-library/src/page-list/test/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/test/convert-to-links-modal.js
@@ -96,11 +96,13 @@ describe( 'page list convert to links', () => {
 					innerBlocks,
 				} )
 			);
+			const setIsConverting = jest.fn();
 			const convertLinks = convertSelectedBlockToNavigationLinks( {
 				pages,
 				clientId: 'testId',
 				replaceBlock,
 				createBlock,
+				setIsConverting,
 			} );
 			convertLinks();
 			expect( replaceBlock.mock.calls?.[ 0 ]?.[ 1 ] ).toEqual( [
@@ -291,11 +293,13 @@ describe( 'page list convert to links', () => {
 					innerBlocks,
 				} )
 			);
+			const setIsConverting = jest.fn();
 			const convertLinks = convertSelectedBlockToNavigationLinks( {
 				pages,
 				clientId: 'testId',
 				replaceBlock,
 				createBlock,
+				setIsConverting,
 			} );
 			convertLinks();
 			expect( replaceBlock.mock.calls?.[ 0 ]?.[ 1 ] ).toEqual( [

--- a/packages/block-library/src/page-list/test/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/test/convert-to-links-modal.js
@@ -96,13 +96,11 @@ describe( 'page list convert to links', () => {
 					innerBlocks,
 				} )
 			);
-			const setIsConverting = jest.fn();
 			const convertLinks = convertSelectedBlockToNavigationLinks( {
 				pages,
 				clientId: 'testId',
 				replaceBlock,
 				createBlock,
-				setIsConverting,
 			} );
 			convertLinks();
 			expect( replaceBlock.mock.calls?.[ 0 ]?.[ 1 ] ).toEqual( [
@@ -293,13 +291,11 @@ describe( 'page list convert to links', () => {
 					innerBlocks,
 				} )
 			);
-			const setIsConverting = jest.fn();
 			const convertLinks = convertSelectedBlockToNavigationLinks( {
 				pages,
 				clientId: 'testId',
 				replaceBlock,
 				createBlock,
-				setIsConverting,
 			} );
 			convertLinks();
 			expect( replaceBlock.mock.calls?.[ 0 ]?.[ 1 ] ).toEqual( [

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -93,6 +93,13 @@ export const defaultEntities = [
 		label: __( 'Comment' ),
 	},
 	{
+		name: 'page',
+		kind: 'root',
+		baseURL: '/wp/v2/pages',
+		plural: 'pages',
+		label: __( 'Pages' ),
+	},
+	{
 		name: 'menu',
 		kind: 'root',
 		baseURL: '/__experimental/menus',

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -93,13 +93,6 @@ export const defaultEntities = [
 		label: __( 'Comment' ),
 	},
 	{
-		name: 'page',
-		kind: 'root',
-		baseURL: '/wp/v2/pages',
-		plural: 'pages',
-		label: __( 'Pages' ),
-	},
-	{
 		name: 'menu',
 		kind: 'root',
 		baseURL: '/__experimental/menus',


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/29437.

This PR allows the Page List block to be converted to single menu items, so those can be reordered, deleted or tweaked at will.

https://user-images.githubusercontent.com/1270189/113763666-cb1c7000-96ce-11eb-80b8-515c1c9f87fb.mp4

### Implementation Notes of Interest

This is the straightforward approach specific to the page list. Folks have also expressed a desire to remove the usage of `<ServerSideRender />` but let's leave that for a follow up.

#### Problems reserved for follow up PRs:
- Navigation Links has **severe performance issues** when testing with not that many links, for example 200ish links or so will be very noticeable on a fast laptop. I think it'd be ideal to profile this in an immediate follow up for some wins likely in innerblocks.
-  I can't get REST API queries to match `get_pages( array( 'sort_column' => 'menu_order' ) )` when using `orderby: menu_order`. This is noticeable when results are > 100 (meaning we have multiple fetches). I suspect this might be a more general issue. Let me know if folks spot the right combination.
- This duplicates some of the page fetching/sorting logic. Which by its nature allows for drift between the PHP callback and client implementation. (This is probably okay?)

### Testing Instructions

On a site with < 100 pages:
- Visit the post or site editor
- Add a navigation block
- Click on "Add all Pages"
- Clicking on the page list "Edit" is visible
- The dialog appears
- Clicking on "Convert to links" transforms the menu to using Navigation Links

On a site with > 100 pages:
- Visit the post or site editor
- Add a navigation block
- Click on "Add all Pages"
- Clicking on the page list "Edit" is **not visible**

Add a page list directly into the page
- Clicking on the page list "Edit" is **not visible**

### The Problem

When you create a navigation menu and press "Add all pages", you get the Page List preinserted. This block stays in sync with pages you create or delete on your website, and is likely a good default experience for most people.

Every once in a while, you need a more curated experience:

* You want to delete a page
* Edit the label of a page link
* Change the order of pages