### PR TITLE
Fix popover toggle buttons

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -517,7 +517,7 @@ export default function NavigationLinkEdit( {
 	} );
 
 	if ( ! url ) {
-		blockProps.onClick = () => setIsLinkOpen( true );
+		blockProps.onClick = () => setIsLinkOpen( ( value ) => ! value );
 	}
 
 	// Always use overlay colors for submenus
@@ -590,17 +590,23 @@ export default function NavigationLinkEdit( {
 			missingText = __( 'Add link' );
 	}
 
+	const toggleButtonRef = useRef();
+
 	return (
 		<Fragment>
 			<BlockControls>
 				<ToolbarGroup>
-					<ToolbarButton
-						name="link"
-						icon={ linkIcon }
-						title={ __( 'Link' ) }
-						shortcut={ displayShortcut.primary( 'k' ) }
-						onClick={ () => setIsLinkOpen( true ) }
-					/>
+					<div tabIndex={ -1 } ref={ toggleButtonRef }>
+						<ToolbarButton
+							name="link"
+							icon={ linkIcon }
+							title={ __( 'Link' ) }
+							shortcut={ displayShortcut.primary( 'k' ) }
+							onClick={ () =>
+								setIsLinkOpen( ( value ) => ! value )
+							}
+						/>
+					</div>
 					{ ! isAtMaxNesting && (
 						<ToolbarButton
 							name="submenu"
@@ -689,7 +695,29 @@ export default function NavigationLinkEdit( {
 					{ isLinkOpen && (
 						<Popover
 							position="bottom center"
-							onClose={ () => setIsLinkOpen( false ) }
+							onClose={ () => {
+								const {
+									ownerDocument,
+								} = toggleButtonRef.current;
+
+								if (
+									// When clicking the toggle button, focus
+									// will either move to the button or the
+									// focusable div (Safari) so do not handle
+									// closing the popover because the toggle
+									// will handle it. Focus should remain on
+									// the toggle button.
+									toggleButtonRef.current.contains(
+										ownerDocument.activeElement
+									) ||
+									listItemRef.current ===
+										ownerDocument.activeElement
+								) {
+									return;
+								}
+
+								setIsLinkOpen( false );
+							} }
 							anchorRef={ listItemRef.current }
 						>
 							<LinkControl


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Alternative to #27406.

I don't think there's a need to introduce another prop and public API to the Popover component. When `onClose` is called, we can check if the active element is the toggle button and let the toggle button handle closing instead. The Popover component should not concern itself with toggle buttons and what controls it.

Ideally this should only be implemented once with a drop down or toggleable popover component instead of needing to handle this in different places.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
