### PR TITLE
RichText: Always show placholder on focus

### DIFF
--- a/packages/block-editor/src/components/block-navigation/editor.js
+++ b/packages/block-editor/src/components/block-navigation/editor.js
@@ -16,7 +16,6 @@ export default function BlockNavigationEditor( { value, onChange } ) {
 				value={ value }
 				onChange={ onChange }
 				placeholder={ __( 'Navigation item' ) }
-				keepPlaceholderOnFocus
 				withoutInteractiveFormatting
 				allowedFormats={ [
 					'core/bold',

--- a/packages/block-editor/src/components/editable-text/README.md
+++ b/packages/block-editor/src/components/editable-text/README.md
@@ -25,10 +25,6 @@ Renders an editable text input in which text formatting is not allowed.
 *Optional.* Placeholder text to show when the field is empty, similar to the
   [`input` and `textarea` attribute of the same name](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/HTML5_updates#The_placeholder_attribute).
 
-### `keepPlaceholderOnFocus: Boolean`
-
-*Optional.* Show placeholder even when selected/focused, as long as there is no content.
-
 ### `onSplit( value: String ): Function`
 
 *Optional.* Called when the content can be split, where `value` is a piece of content being split off. Here you should create a new block with that content and return it. Note that you also need to provide `onReplace` in order for this to take any effect.

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -21,10 +21,6 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 *Optional.* Placeholder text to show when the field is empty, similar to the
   [`input` and `textarea` attribute of the same name](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/HTML5_updates#The_placeholder_attribute).
 
-### `keepPlaceholderOnFocus: Boolean`
-
-*Optional.* Show placeholder even when selected/focused, as long as there is no content.
-
 ### `multiline: Boolean | String`
 
 *Optional.* By default, a line break will be inserted on <kbd>Enter</kbd>. If the editable field can contain multiple paragraphs, this property can be set to create new paragraphs on <kbd>Enter</kbd>.

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -125,7 +125,6 @@ function RichTextWrapper(
 		autocompleters,
 		onReplace,
 		placeholder,
-		keepPlaceholderOnFocus,
 		allowedFormats,
 		formattingControls,
 		withoutInteractiveFormatting,
@@ -690,10 +689,7 @@ function RichTextWrapper(
 								className={ classnames(
 									classes,
 									props.className,
-									editableProps.className,
-									{
-										'keep-placeholder-on-focus': keepPlaceholderOnFocus,
-									}
+									editableProps.className
 								) }
 								aria-autocomplete={
 									listBoxId ? 'list' : undefined

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -21,10 +21,6 @@
 		[data-rich-text-format-boundary] {
 			border-radius: 2px;
 		}
-
-		&:not(.keep-placeholder-on-focus) [data-rich-text-placeholder]::after {
-			display: none;
-		}
 	}
 }
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -450,7 +450,6 @@ export default function NavigationLinkEdit( {
 							}
 							aria-label={ __( 'Navigation link text' ) }
 							placeholder={ itemLabelPlaceholder }
-							keepPlaceholderOnFocus
 							withoutInteractiveFormatting
 							allowedFormats={ [
 								'core/bold',

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -50,10 +50,6 @@
 		min-width: 20px;
 	}
 
-	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus)[data-rich-text-placeholder]::after {
-		display: inline-block;
-	}
-
 	.block-list-appender {
 		margin-top: $grid-unit-20;
 		// The right margin should be set to auto, so as to not shift layout in flex containers.

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -64,7 +64,6 @@ export default function PostNavigationLinkEdit( {
 					onChange={ ( newLabel ) =>
 						setAttributes( { label: newLabel } )
 					}
-					keepPlaceholderOnFocus
 				/>
 			</div>
 		</>

--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -15,7 +15,6 @@ export default function QueryPaginationNextEdit( {
 			aria-label={ __( 'Next page link' ) }
 			placeholder={ __( 'Next Page' ) }
 			value={ label }
-			keepPlaceholderOnFocus
 			onChange={ ( newLabel ) => setAttributes( { label: newLabel } ) }
 			{ ...useBlockProps() }
 		/>

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -15,7 +15,6 @@ export default function QueryPaginationPreviousEdit( {
 			aria-label={ __( 'Previous page link' ) }
 			placeholder={ __( 'Previous Page' ) }
 			value={ label }
-			keepPlaceholderOnFocus
 			onChange={ ( newLabel ) => setAttributes( { label: newLabel } ) }
 			{ ...useBlockProps() }
 		/>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Always show placeholders when RichText is empty, also on focus. Previously we would remove the placeholder on focus, unless the block wants to keep it (usually to make sure the text field doesn't collapse for inline elements).

This would make the behaviour more consistent.

It's worth noting that HTML `input` elements that have `placeholder` specified also keep it on focus.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
