### PR TITLE
Block Library - Buttons: Add Typography support

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -65,7 +65,9 @@
 			"__experimentalSkipSerialization": true,
 			"gradients": true
 		},
+		"fontSize": true,
 		"reusable": false,
+		"__experimentalFontFamily": true,
 		"__experimentalSelector": ".wp-block-button__link"
 	},
 	"editorStyle": "wp-block-button-editor",

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -198,7 +198,6 @@ function ButtonEdit( props ) {
 		text,
 		url,
 		width,
-		fontSize,
 	} = attributes;
 	const onSetLinkRel = useCallback(
 		( value ) => {
@@ -242,7 +241,7 @@ function ButtonEdit( props ) {
 				{ ...blockProps }
 				className={ classnames( blockProps.className, {
 					[ `has-custom-width wp-block-button__width-${ width }` ]: width,
-					[ `has-custom-font-size` ]: fontSize,
+					[ `has-custom-font-size` ]: blockProps.style.fontSize,
 				} ) }
 			>
 				<RichText

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -198,6 +198,7 @@ function ButtonEdit( props ) {
 		text,
 		url,
 		width,
+		fontSize,
 	} = attributes;
 	const onSetLinkRel = useCallback(
 		( value ) => {
@@ -241,6 +242,7 @@ function ButtonEdit( props ) {
 				{ ...blockProps }
 				className={ classnames( blockProps.className, {
 					[ `has-custom-width wp-block-button__width-${ width }` ]: width,
+					[ `has-custom-font-size` ]: fontSize,
 				} ) }
 			>
 				<RichText

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -16,8 +16,10 @@ import getColorAndStyleProps from './color-props';
 export default function save( { attributes, className } ) {
 	const {
 		borderRadius,
+		fontSize,
 		linkTarget,
 		rel,
+		style,
 		text,
 		title,
 		url,
@@ -47,6 +49,7 @@ export default function save( { attributes, className } ) {
 
 	const wrapperClasses = classnames( className, {
 		[ `has-custom-width wp-block-button__width-${ width }` ]: width,
+		[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
 	} );
 
 	return (

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -43,6 +43,12 @@ $blocks-block__margin: 0.5em;
 		}
 	}
 
+	&.has-custom-font-size {
+		.wp-block-button__link {
+			font-size: inherit;
+		}
+	}
+
 	&.wp-block-button__width-25 {
 		width: calc(25% - #{ $blocks-block__margin });
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds support for font size and font family to the Button Block

## How has this been tested?
In TT1 Blocks and Twenty Twenty-One
- Editing a button in a single Post
- Editing a button in the Site Editor

## Screenshots <!-- if applicable -->

<img width="1537" alt="Screen Shot 2021-03-31 at 8 39 59 am" src="https://user-images.githubusercontent.com/1097667/113065756-b3d81100-91fc-11eb-970c-d3ddd39d2bd8.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
