### PR TITLE
Site Editor: Add 'area' selection to convert to template part flow.

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -97,7 +97,7 @@ function gutenberg_edit_site_init( $hook ) {
 			'postsPerPage'                         => get_option( 'posts_per_page' ),
 			'styles'                               => gutenberg_get_editor_styles(),
 			'defaultTemplateTypes'                 => gutenberg_get_indexed_default_template_types(),
-			'defaultTemplatePartAreas'			   => gutenberg_get_allowed_template_part_areas(),
+			'defaultTemplatePartAreas'             => gutenberg_get_allowed_template_part_areas(),
 			'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
 			'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 		)

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -97,6 +97,7 @@ function gutenberg_edit_site_init( $hook ) {
 			'postsPerPage'                         => get_option( 'posts_per_page' ),
 			'styles'                               => gutenberg_get_editor_styles(),
 			'defaultTemplateTypes'                 => gutenberg_get_indexed_default_template_types(),
+			'defaultTemplatePartAreas'			   => gutenberg_get_allowed_template_part_areas(),
 			'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
 			'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 		)

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -171,23 +171,23 @@ function gutenberg_get_allowed_template_part_areas() {
 	$default_area_definitions = array(
 		array(
 			'area'        => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
-			'label'       => __( 'General' ),
+			'label'       => __( 'General', 'gutenberg' ),
 			'description' => __(
-				'General templates often perform a specific role like displaying post content, and are not tied to any particular area.'
+				'General templates often perform a specific role like displaying post content, and are not tied to any particular area.', 'gutenberg'
 			),
 		),
 		array(
 			'area'        => WP_TEMPLATE_PART_AREA_HEADER,
-			'label'       => __( 'Header' ),
+			'label'       => __( 'Header', 'gutenberg' ),
 			'description' => __(
-				'The Header template defines a page area that typically contains a title, logo, and main navigation.'
+				'The Header template defines a page area that typically contains a title, logo, and main navigation.', 'gutenberg'
 			),
 		),
 		array(
 			'area'        => WP_TEMPLATE_PART_AREA_FOOTER,
-			'label'       => __( 'Footer' ),
+			'label'       => __( 'Footer', 'gutenberg' ),
 			'description' => __(
-				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.'
+				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.', 'gutenberg'
 			),
 		),
 	);

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -173,21 +173,24 @@ function gutenberg_get_allowed_template_part_areas() {
 			'area'        => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
 			'label'       => __( 'General', 'gutenberg' ),
 			'description' => __(
-				'General templates often perform a specific role like displaying post content, and are not tied to any particular area.', 'gutenberg'
+				'General templates often perform a specific role like displaying post content, and are not tied to any particular area.',
+				'gutenberg'
 			),
 		),
 		array(
 			'area'        => WP_TEMPLATE_PART_AREA_HEADER,
 			'label'       => __( 'Header', 'gutenberg' ),
 			'description' => __(
-				'The Header template defines a page area that typically contains a title, logo, and main navigation.', 'gutenberg'
+				'The Header template defines a page area that typically contains a title, logo, and main navigation.',
+				'gutenberg'
 			),
 		),
 		array(
 			'area'        => WP_TEMPLATE_PART_AREA_FOOTER,
 			'label'       => __( 'Footer', 'gutenberg' ),
 			'description' => __(
-				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.', 'gutenberg'
+				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.',
+				'gutenberg'
 			),
 		),
 	);

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -168,19 +168,36 @@ add_action( 'save_post_wp_template_part', 'set_unique_slug_on_create_template_pa
  * @return array The supported template part area values.
  */
 function gutenberg_get_allowed_template_part_areas() {
-	$default_area_values = array(
-		WP_TEMPLATE_PART_AREA_HEADER,
-		WP_TEMPLATE_PART_AREA_FOOTER,
-		WP_TEMPLATE_PART_AREA_SIDEBAR,
-		WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
+	$default_area_definitions = array(
+		array(
+			'area'        => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
+			'label'       => __( 'General' ),
+			'description' => __(
+				'General templates often perform a specific role like displaying post content, and are not tied to any particular area.'
+			),
+		),
+		array(
+			'area'        => WP_TEMPLATE_PART_AREA_HEADER,
+			'label'       => __( 'Header' ),
+			'description' => __(
+				'The Header template defines a page area that typically contains a title, logo, and main navigation.'
+			),
+		),
+		array(
+			'area'        => WP_TEMPLATE_PART_AREA_FOOTER,
+			'label'       => __( 'Footer' ),
+			'description' => __(
+				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.'
+			),
+		),
 	);
 
 	/**
 	 * Filters the list of allowed template part area values.
 	 *
-	 * @param array $default_area_values An array of supported area values.
+	 * @param array $default_areas An array of supported area objects.
 	 */
-	return apply_filters( 'default_wp_template_part_areas', $default_area_values );
+	return apply_filters( 'default_wp_template_part_areas', $default_area_definitions );
 }
 
 /**
@@ -192,7 +209,13 @@ function gutenberg_get_allowed_template_part_areas() {
  * @return string Input if supported, else the uncategorized value.
  */
 function gutenberg_filter_template_part_area( $type ) {
-	if ( in_array( $type, gutenberg_get_allowed_template_part_areas(), true ) ) {
+	$allowed_areas = array_map(
+		function ( $item ) {
+			return $item['area'];
+		},
+		gutenberg_get_allowed_template_part_areas()
+	);
+	if ( in_array( $type, $allowed_areas, true ) ) {
 		return $type;
 	}
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -17,10 +17,13 @@ import {
 	ComplementaryArea,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import { EntitiesSavedStates, UnsavedChangesWarning } from '@wordpress/editor';
+import {
+	EntitiesSavedStates,
+	UnsavedChangesWarning,
+	store as editorStore,
+} from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { PluginArea } from '@wordpress/plugins';
-
 /**
  * Internal dependencies
  */
@@ -86,7 +89,7 @@ function Editor( { initialSettings } ) {
 			isNavigationOpen: isNavigationOpened(),
 		};
 	}, [] );
-	const { updateEditorSettings } = useDispatch( 'core/editor' );
+	const { updateEditorSettings } = useDispatch( editorStore );
 	const { setPage, setIsInserterOpened, updateSettings } = useDispatch(
 		editSiteStore
 	);
@@ -98,10 +101,13 @@ function Editor( { initialSettings } ) {
 	// so that they can be selected with core/editor selectors in any editor.
 	// This is needed because edit-site doesn't initialize with EditorProvider,
 	// which internally uses updateEditorSettings as well.
-	const { defaultTemplateTypes } = settings;
+	const { defaultTemplateTypes, defaultTemplatePartAreas } = settings;
 	useEffect( () => {
-		updateEditorSettings( { defaultTemplateTypes } );
-	}, [ defaultTemplateTypes ] );
+		updateEditorSettings( {
+			defaultTemplateTypes,
+			defaultTemplatePartAreas,
+		} );
+	}, [ defaultTemplateTypes, defaultTemplatePartAreas ] );
 
 	const [
 		isEntitiesSavedStatesOpen,

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -18,9 +18,11 @@ import {
 	BaseControl,
 	Flex,
 	FlexItem,
+	FlexBlock,
 	Button,
 	Modal,
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 
 import { createBlock, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
@@ -29,6 +31,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 
 export default function ConvertToTemplatePart( { clientIds, blocks } ) {
+	const instanceId = useInstanceId( ConvertToTemplatePart );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ title, setTitle ] = useState( '' );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
@@ -95,18 +98,45 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 									value={ title }
 									onChange={ setTitle }
 								/>
-								<BaseControl className="edit-site-template-part-converter__area-control">
+								<label
+									className="edit-site-template-part-converter__area-control-label"
+									htmlFor={ `edit-site-template-part-converter__area-control-${ instanceId }` }
+								>
+									{ __( 'Area' ) }
+								</label>
+								<BaseControl
+									className="edit-site-template-part-converter__area-control"
+									id={ `edit-site-template-part-converter__area-control-${ instanceId }` }
+								>
 									{ AREA_OPTIONS.map(
-										( { icon, label, value } ) => (
+										( {
+											icon,
+											label,
+											value,
+											description,
+										} ) => (
 											<Button
 												key={ label }
 												onClick={ () =>
 													setArea( value )
 												}
 												disabled={ area === value }
+												className="edit-site-template-part-converter__area-button"
 											>
-												<Icon icon={ icon } />
-												{ label }
+												<Flex
+													align="start"
+													justify="start"
+												>
+													<FlexItem>
+														<Icon icon={ icon } />
+													</FlexItem>
+													<FlexBlock>
+														{ label }
+														<div>
+															{ description }
+														</div>
+													</FlexBlock>
+												</Flex>
 											</Button>
 										)
 									) }

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -138,7 +138,9 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 													</FlexBlock>
 													{ area === value && (
 														<FlexItem>
-															<Icon icon={ check } />
+															<Icon
+																icon={ check }
+															/>
 														</FlexItem>
 													) }
 												</Flex>

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -136,6 +136,11 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 															{ description }
 														</div>
 													</FlexBlock>
+													{ area === value && (
+														<FlexItem>
+															<Icon icon={ check } />
+														</FlexItem>
+													) }
 												</Flex>
 											</Button>
 										)
@@ -171,8 +176,16 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	);
 }
 
-import { footer, header, layout } from '@wordpress/icons';
+import { footer, header, layout, check } from '@wordpress/icons';
 const AREA_OPTIONS = [
+	{
+		description: __(
+			'General templates often perform a specific role like displaying post content, and are not tied to any particular area.'
+		),
+		icon: layout,
+		label: __( 'General' ),
+		value: 'uncategorized',
+	},
 	{
 		description: __(
 			'The Header template defines a page area that typically contains a title, logo, and main navigation.'
@@ -188,13 +201,5 @@ const AREA_OPTIONS = [
 		icon: footer,
 		label: __( 'Footer' ),
 		value: 'footer',
-	},
-	{
-		description: __(
-			'General templates often perform a specific role like displaying post content, and are not tied to any particular area.'
-		),
-		icon: layout,
-		label: __( 'General' ),
-		value: 'uncategorized',
 	},
 ];

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -13,12 +13,15 @@ import {
 } from '@wordpress/block-editor';
 import {
 	MenuItem,
+	Icon,
 	TextControl,
+	BaseControl,
 	Flex,
 	FlexItem,
 	Button,
 	Modal,
 } from '@wordpress/components';
+
 import { createBlock, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -31,6 +34,7 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
+	const [ area, setArea ] = useState( 'uncategorized' );
 
 	const onConvert = async ( templatePartTitle ) => {
 		const defaultTitle = __( 'Untitled Template Part' );
@@ -41,6 +45,7 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 				slug: kebabCase( templatePartTitle || defaultTitle ),
 				title: templatePartTitle || defaultTitle,
 				content: serialize( blocks ),
+				area,
 			}
 		);
 		replaceBlocks(
@@ -90,6 +95,22 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 									value={ title }
 									onChange={ setTitle }
 								/>
+								<BaseControl className="edit-site-template-part-converter__area-control">
+									{ AREA_OPTIONS.map(
+										( { icon, label, value } ) => (
+											<Button
+												key={ label }
+												onClick={ () =>
+													setArea( value )
+												}
+												disabled={ area === value }
+											>
+												<Icon icon={ icon } />
+												{ label }
+											</Button>
+										)
+									) }
+								</BaseControl>
 								<Flex
 									className="edit-site-template-part-converter__convert-modal-actions"
 									justify="flex-end"
@@ -119,3 +140,31 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 		</BlockSettingsMenuControls>
 	);
 }
+
+import { footer, header, layout } from '@wordpress/icons';
+const AREA_OPTIONS = [
+	{
+		description: __(
+			'The Header template defines a page area that typically contains a title, logo, and main navigation.'
+		),
+		icon: header,
+		label: __( 'Header' ),
+		value: 'header',
+	},
+	{
+		description: __(
+			'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.'
+		),
+		icon: footer,
+		label: __( 'Footer' ),
+		value: 'footer',
+	},
+	{
+		description: __(
+			'General templates often perform a specific role like displaying post content, and are not tied to any particular area.'
+		),
+		icon: layout,
+		label: __( 'General' ),
+		value: 'uncategorized',
+	},
+];

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { kebabCase } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -15,12 +16,14 @@ import {
 	MenuItem,
 	Icon,
 	TextControl,
-	BaseControl,
 	Flex,
 	FlexItem,
 	FlexBlock,
 	Button,
 	Modal,
+	__unstableComposite as Composite,
+	__unstableCompositeItem as CompositeItem,
+	__unstableUseCompositeState as useCompositeState,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 
@@ -38,6 +41,7 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ area, setArea ] = useState( 'uncategorized' );
+	const composite = useCompositeState();
 
 	const onConvert = async ( templatePartTitle ) => {
 		const defaultTitle = __( 'Untitled Template Part' );
@@ -104,9 +108,11 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 								>
 									{ __( 'Area' ) }
 								</label>
-								<BaseControl
+								<Composite
 									className="edit-site-template-part-converter__area-control"
 									id={ `edit-site-template-part-converter__area-control-${ instanceId }` }
+									role="listbox"
+									{ ...composite }
 								>
 									{ AREA_OPTIONS.map(
 										( {
@@ -115,13 +121,21 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 											value,
 											description,
 										} ) => (
-											<Button
+											<CompositeItem
+												role="option"
+												as={ Button }
 												key={ label }
 												onClick={ () =>
 													setArea( value )
 												}
-												disabled={ area === value }
-												className="edit-site-template-part-converter__area-button"
+												className={ classnames(
+													'edit-site-template-part-converter__area-button',
+													{
+														'is-selected':
+															area === value,
+													}
+												) }
+												{ ...composite }
 											>
 												<Flex
 													align="start"
@@ -144,10 +158,10 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 														</FlexItem>
 													) }
 												</Flex>
-											</Button>
+											</CompositeItem>
 										)
 									) }
-								</BaseControl>
+								</Composite>
 								<Flex
 									className="edit-site-template-part-converter__convert-modal-actions"
 									justify="flex-end"

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -15,6 +15,7 @@ import {
 import {
 	MenuItem,
 	Icon,
+	BaseControl,
 	TextControl,
 	Flex,
 	FlexItem,
@@ -102,66 +103,72 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 									value={ title }
 									onChange={ setTitle }
 								/>
-								<label
-									className="edit-site-template-part-converter__area-control-label"
-									htmlFor={ `edit-site-template-part-converter__area-control-${ instanceId }` }
+								<BaseControl
+									label={ __( 'Area' ) }
+									id={ `edit-site-template-part-converter__area-base-control-${ instanceId }` }
+									className="edit-site-template-part-converter__area-base-control"
 								>
-									{ __( 'Area' ) }
-								</label>
-								<Composite
-									className="edit-site-template-part-converter__area-control"
-									id={ `edit-site-template-part-converter__area-control-${ instanceId }` }
-									role="listbox"
-									{ ...composite }
-								>
-									{ AREA_OPTIONS.map(
-										( {
-											icon,
-											label,
-											value,
-											description,
-										} ) => (
-											<CompositeItem
-												role="option"
-												as={ Button }
-												key={ label }
-												onClick={ () =>
-													setArea( value )
-												}
-												className={ classnames(
-													'edit-site-template-part-converter__area-button',
-													{
-														'is-selected':
-															area === value,
+									<Composite
+										className="edit-site-template-part-converter__area-composite"
+										role="group"
+										{ ...composite }
+									>
+										{ AREA_OPTIONS.map(
+											( {
+												icon,
+												label,
+												value,
+												description,
+											} ) => (
+												<CompositeItem
+													role="radio"
+													as={ Button }
+													key={ label }
+													onClick={ () =>
+														setArea( value )
 													}
-												) }
-												{ ...composite }
-											>
-												<Flex
-													align="start"
-													justify="start"
+													className={ classnames(
+														'edit-site-template-part-converter__area-button',
+														{
+															'is-selected':
+																area === value,
+														}
+													) }
+													aria-checked={
+														area === value
+													}
+													{ ...composite }
 												>
-													<FlexItem>
-														<Icon icon={ icon } />
-													</FlexItem>
-													<FlexBlock>
-														{ label }
-														<div>
-															{ description }
-														</div>
-													</FlexBlock>
-													{ area === value && (
+													<Flex
+														align="start"
+														justify="start"
+													>
 														<FlexItem>
 															<Icon
-																icon={ check }
+																icon={ icon }
 															/>
 														</FlexItem>
-													) }
-												</Flex>
-											</CompositeItem>
-										)
-									) }
-								</Composite>
+														<FlexBlock>
+															{ label }
+															<div>
+																{ description }
+															</div>
+														</FlexBlock>
+														{ area === value && (
+															<FlexItem>
+																<Icon
+																	icon={
+																		check
+																	}
+																/>
+															</FlexItem>
+														) }
+													</Flex>
+												</CompositeItem>
+											)
+										) }
+									</Composite>
+								</BaseControl>
 								<Flex
 									className="edit-site-template-part-converter__convert-modal-actions"
 									justify="flex-end"

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	BlockSettingsMenuControls,
 	store as blockEditorStore,
@@ -33,6 +33,8 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as editorStore } from '@wordpress/editor';
+import { check } from '@wordpress/icons';
 
 export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	const instanceId = useInstanceId( ConvertToTemplatePart );
@@ -43,6 +45,12 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ area, setArea ] = useState( 'uncategorized' );
 	const composite = useCompositeState();
+
+	const templatePartAreas = useSelect(
+		( select ) =>
+			select( editorStore ).__experimentalGetDefaultTemplatePartAreas(),
+		[]
+	);
 
 	const onConvert = async ( templatePartTitle ) => {
 		const defaultTitle = __( 'Untitled Template Part' );
@@ -111,13 +119,14 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 									<Composite
 										className="edit-site-template-part-converter__area-composite"
 										role="group"
+										aria-label={ __( 'Area' ) }
 										{ ...composite }
 									>
-										{ AREA_OPTIONS.map(
+										{ templatePartAreas.map(
 											( {
 												icon,
 												label,
-												value,
+												area: value,
 												description,
 											} ) => (
 												<CompositeItem
@@ -198,31 +207,3 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 		</BlockSettingsMenuControls>
 	);
 }
-
-import { footer, header, layout, check } from '@wordpress/icons';
-const AREA_OPTIONS = [
-	{
-		description: __(
-			'General templates often perform a specific role like displaying post content, and are not tied to any particular area.'
-		),
-		icon: layout,
-		label: __( 'General' ),
-		value: 'uncategorized',
-	},
-	{
-		description: __(
-			'The Header template defines a page area that typically contains a title, logo, and main navigation.'
-		),
-		icon: header,
-		label: __( 'Header' ),
-		value: 'header',
-	},
-	{
-		description: __(
-			'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.'
-		),
-		icon: footer,
-		label: __( 'Footer' ),
-		value: 'footer',
-	},
-];

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -113,12 +113,13 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 								/>
 								<BaseControl
 									label={ __( 'Area' ) }
-									id={ `edit-site-template-part-converter__area-base-control-${ instanceId }` }
+									id={ `edit-site-template-part-converter__area-selection-${ instanceId }` }
 									className="edit-site-template-part-converter__area-base-control"
 								>
 									<Composite
 										className="edit-site-template-part-converter__area-composite"
 										role="group"
+										id={ `edit-site-template-part-converter__area-selection-${ instanceId }` }
 										aria-label={ __( 'Area' ) }
 										{ ...composite }
 									>

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { kebabCase } from 'lodash';
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -22,12 +21,10 @@ import {
 	FlexBlock,
 	Button,
 	Modal,
-	__unstableComposite as Composite,
-	__unstableCompositeItem as CompositeItem,
-	__unstableUseCompositeState as useCompositeState,
+	__experimentalRadioGroup as RadioGroup,
+	__experimentalRadio as Radio,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-
 import { createBlock, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -44,7 +41,6 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ area, setArea ] = useState( 'uncategorized' );
-	const composite = useCompositeState();
 
 	const templatePartAreas = useSelect(
 		( select ) =>
@@ -116,12 +112,12 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 									id={ `edit-site-template-part-converter__area-selection-${ instanceId }` }
 									className="edit-site-template-part-converter__area-base-control"
 								>
-									<Composite
-										className="edit-site-template-part-converter__area-composite"
-										role="group"
+									<RadioGroup
+										label={ __( 'Area' ) }
+										className="edit-site-template-part-converter__area-radio-group"
 										id={ `edit-site-template-part-converter__area-selection-${ instanceId }` }
-										aria-label={ __( 'Area' ) }
-										{ ...composite }
+										onChange={ setArea }
+										checked={ area }
 									>
 										{ templatePartAreas.map(
 											( {
@@ -130,24 +126,10 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 												area: value,
 												description,
 											} ) => (
-												<CompositeItem
-													role="radio"
-													as={ Button }
+												<Radio
 													key={ label }
-													onClick={ () =>
-														setArea( value )
-													}
-													className={ classnames(
-														'edit-site-template-part-converter__area-button',
-														{
-															'is-selected':
-																area === value,
-														}
-													) }
-													aria-checked={
-														area === value
-													}
-													{ ...composite }
+													value={ value }
+													className="edit-site-template-part-converter__area-radio"
 												>
 													<Flex
 														align="start"
@@ -164,20 +146,22 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 																{ description }
 															</div>
 														</FlexBlock>
-														{ area === value && (
-															<FlexItem>
+
+														<FlexItem className="edit-site-template-part-converter__checkbox">
+															{ area ===
+																value && (
 																<Icon
 																	icon={
 																		check
 																	}
 																/>
-															</FlexItem>
-														) }
+															) }
+														</FlexItem>
 													</Flex>
-												</CompositeItem>
+												</Radio>
 											)
 										) }
-									</Composite>
+									</RadioGroup>
 								</BaseControl>
 								<Flex
 									className="edit-site-template-part-converter__convert-modal-actions"

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -6,3 +6,59 @@
 .edit-site-template-part-converter__convert-modal-actions {
 	padding-top: $grid-unit-15;
 }
+
+.edit-site-template-part-converter__area-control-label {
+	display: block;
+	margin: $grid-unit-20 0 $grid-unit-10;
+}
+
+.edit-site-template-part-converter__area-control {
+	width: 100%;
+
+	.components-base-control__field {
+		border: $border-width solid $gray-700;
+		border-radius: 2px;
+	}
+
+	.edit-site-template-part-converter__area-button {
+		display: block;
+		width: 100%;
+		height: 100%;
+		text-align: left;
+		padding: $grid-unit-15;
+
+		border-bottom: $border-width solid $gray-500;
+		border-radius: 0;
+
+		&:last-of-type {
+			border: none;
+		}
+
+		&:disabled {
+			background: $gray-900;
+			color: $white;
+			opacity: 1;
+		}
+
+		.components-flex__block {
+			padding-top: $grid-unit-05;
+
+			@include break-small {
+				max-width: 320px;
+			}
+
+			div {
+				padding-top: $grid-unit-05;
+
+				font-size: $helptext-font-size;
+			}
+		}
+
+		&:not(:hover),
+		&:disabled {
+			.components-flex__block div {
+				color: $gray-600;
+			}
+		}
+	}
+}

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -27,7 +27,7 @@
 		text-align: left;
 		padding: $grid-unit-15;
 
-		border-bottom: $border-width solid $gray-500;
+		border-bottom: $border-width solid $gray-700;
 		border-radius: 0;
 
 		&:last-of-type {
@@ -35,8 +35,6 @@
 		}
 
 		&:disabled {
-			background: $gray-900;
-			color: $white;
 			opacity: 1;
 		}
 

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -34,8 +34,14 @@
 			border: none;
 		}
 
+		&:not(:hover),
 		&:disabled {
 			opacity: 1;
+			color: $gray-900;
+
+			.components-flex__block div {
+				color: $gray-600;
+			}
 		}
 
 		.components-flex__block {
@@ -47,15 +53,7 @@
 
 			div {
 				padding-top: $grid-unit-05;
-
 				font-size: $helptext-font-size;
-			}
-		}
-
-		&:not(:hover),
-		&:disabled {
-			.components-flex__block div {
-				color: $gray-600;
 			}
 		}
 	}

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -14,11 +14,8 @@
 
 .edit-site-template-part-converter__area-control {
 	width: 100%;
-
-	.components-base-control__field {
-		border: $border-width solid $gray-700;
-		border-radius: 2px;
-	}
+	border: $border-width solid $gray-700;
+	border-radius: 2px;
 
 	.edit-site-template-part-converter__area-button {
 		display: block;
@@ -30,14 +27,19 @@
 		border-bottom: $border-width solid $gray-700;
 		border-radius: 0;
 
+		&:focus {
+			border-bottom: $border-width solid $white;
+		}
+
 		&:last-of-type {
 			border: none;
 		}
 
 		&:not(:hover),
-		&:disabled {
+		&.is-selected {
 			opacity: 1;
 			color: $gray-900;
+			cursor: auto;
 
 			.components-flex__block div {
 				color: $gray-600;

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -1,5 +1,11 @@
 .edit-site-template-part-converter__modal {
 	z-index: z-index(".edit-site-template-part-converter__modal");
+
+	.components-modal__frame {
+		@include break-small {
+			max-width: 500px;
+		}
+	}
 }
 
 
@@ -12,32 +18,41 @@
 	cursor: auto;
 }
 
-.edit-site-template-part-converter__area-composite {
+.edit-site-template-part-converter__area-radio-group {
 	width: 100%;
 	border: $border-width solid $gray-700;
 	border-radius: 2px;
 
-	.edit-site-template-part-converter__area-button {
+	.components-button.edit-site-template-part-converter__area-radio {
 		display: block;
 		width: 100%;
 		height: 100%;
 		text-align: left;
 		padding: $grid-unit-15;
 
-		border-bottom: $border-width solid $gray-700;
-		border-radius: 0;
+		&,
+		&.is-secondary:hover,
+		&.is-primary:hover {
+			margin: 0;
+			background-color: inherit;
+			border-bottom: $border-width solid $gray-700;
+			border-radius: 0;
 
-		&:focus {
-			border-bottom: $border-width solid $white;
-		}
+			&:not(:focus) {
+				box-shadow: none;
+			}
 
-		&:last-of-type {
-			border: none;
+			&:focus {
+				border-bottom: $border-width solid $white;
+			}
+
+			&:last-of-type {
+				border-bottom: none;
+			}
 		}
 
 		&:not(:hover),
-		&.is-selected {
-			opacity: 1;
+		&[aria-checked="true"] {
 			color: $gray-900;
 			cursor: auto;
 
@@ -48,15 +63,17 @@
 
 		.components-flex__block {
 			padding-top: $grid-unit-05;
-
-			@include break-small {
-				max-width: 320px;
-			}
+			white-space: normal;
 
 			div {
 				padding-top: $grid-unit-05;
 				font-size: $helptext-font-size;
 			}
+		}
+
+		.edit-site-template-part-converter__checkbox {
+			margin-left: auto;
+			min-width: $grid-unit-30;
 		}
 	}
 }

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -7,12 +7,12 @@
 	padding-top: $grid-unit-15;
 }
 
-.edit-site-template-part-converter__area-control-label {
-	display: block;
+.edit-site-template-part-converter__area-base-control .components-base-control__label {
 	margin: $grid-unit-20 0 $grid-unit-10;
+	cursor: auto;
 }
 
-.edit-site-template-part-converter__area-control {
+.edit-site-template-part-converter__area-composite {
 	width: 100%;
 	border: $border-width solid $gray-700;
 	border-radius: 2px;

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1672,6 +1672,24 @@ export function __experimentalGetDefaultTemplateTypes( state ) {
 }
 
 /**
+ * Returns the default template part areas.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Array} The template part areas.
+ */
+export const __experimentalGetDefaultTemplatePartAreas = createSelector(
+	( state ) => {
+		const areas = getEditorSettings( state )?.defaultTemplatePartAreas;
+		const areasWithIcons = areas?.map( ( item ) => {
+			return { ...item, icon: getIconByArea( item.area ) };
+		} );
+		return areasWithIcons;
+	},
+	( state ) => [ getEditorSettings( state )?.defaultTemplatePartAreas ]
+);
+
+/**
  * Returns a default template type searched by slug.
  *
  * @param {Object} state Global application state.
@@ -1706,11 +1724,7 @@ export function __experimentalGetTemplateInfo( state, template ) {
 
 	const templateTitle = isString( title ) ? title : title?.rendered;
 	const templateDescription = isString( excerpt ) ? excerpt : excerpt?.raw;
-	const iconsByArea = {
-		footer,
-		header,
-	};
-	const templateIcon = iconsByArea[ area ] || layout;
+	const templateIcon = getIconByArea( area );
 
 	return {
 		title:
@@ -1720,4 +1734,12 @@ export function __experimentalGetTemplateInfo( state, template ) {
 		description: templateDescription || defaultDescription,
 		icon: templateIcon,
 	};
+}
+
+function getIconByArea( area ) {
+	const iconsByArea = {
+		footer,
+		header,
+	};
+	return iconsByArea[ area ] || layout;
 }

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -27,7 +27,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { createRegistrySelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { Platform } from '@wordpress/element';
-import { layout, header, footer } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -41,6 +40,7 @@ import {
 } from './constants';
 import { getPostRawValue } from './reducer';
 import { cleanForSlug } from '../utils/url';
+import { getTemplatePartIconByArea } from './utils/get-template-part-icon';
 
 /**
  * Shared reference to an empty object for cases where it is important to avoid
@@ -1681,10 +1681,9 @@ export function __experimentalGetDefaultTemplateTypes( state ) {
 export const __experimentalGetDefaultTemplatePartAreas = createSelector(
 	( state ) => {
 		const areas = getEditorSettings( state )?.defaultTemplatePartAreas;
-		const areasWithIcons = areas?.map( ( item ) => {
+		return areas?.map( ( item ) => {
 			return { ...item, icon: getTemplatePartIconByArea( item.area ) };
 		} );
-		return areasWithIcons;
 	},
 	( state ) => [ getEditorSettings( state )?.defaultTemplatePartAreas ]
 );
@@ -1734,19 +1733,4 @@ export function __experimentalGetTemplateInfo( state, template ) {
 		description: templateDescription || defaultDescription,
 		icon: templateIcon,
 	};
-}
-
-/**
- * Helper function to find the corresponding icon for a template part's 'area'.
- *
- * @param {string} area The value of the template part 'area' tax term.
- *
- * @return {Object} The corresponding icon.
- */
-function getTemplatePartIconByArea( area ) {
-	const iconsByArea = {
-		footer,
-		header,
-	};
-	return iconsByArea[ area ] || layout;
 }

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1682,7 +1682,7 @@ export const __experimentalGetDefaultTemplatePartAreas = createSelector(
 	( state ) => {
 		const areas = getEditorSettings( state )?.defaultTemplatePartAreas;
 		const areasWithIcons = areas?.map( ( item ) => {
-			return { ...item, icon: getIconByArea( item.area ) };
+			return { ...item, icon: getTemplatePartIconByArea( item.area ) };
 		} );
 		return areasWithIcons;
 	},
@@ -1724,7 +1724,7 @@ export function __experimentalGetTemplateInfo( state, template ) {
 
 	const templateTitle = isString( title ) ? title : title?.rendered;
 	const templateDescription = isString( excerpt ) ? excerpt : excerpt?.raw;
-	const templateIcon = getIconByArea( area );
+	const templateIcon = getTemplatePartIconByArea( area );
 
 	return {
 		title:
@@ -1736,7 +1736,14 @@ export function __experimentalGetTemplateInfo( state, template ) {
 	};
 }
 
-function getIconByArea( area ) {
+/**
+ * Helper function to find the corresponding icon for a template part's 'area'.
+ *
+ * @param {string} area The value of the template part 'area' tax term.
+ *
+ * @return {Object} The corresponding icon.
+ */
+function getTemplatePartIconByArea( area ) {
 	const iconsByArea = {
 		footer,
 		header,

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -172,6 +172,7 @@ const {
 	__experimentalGetDefaultTemplateType,
 	__experimentalGetDefaultTemplateTypes,
 	__experimentalGetTemplateInfo,
+	__experimentalGetDefaultTemplatePartAreas,
 } = selectors;
 
 const defaultTemplateTypes = [
@@ -184,6 +185,19 @@ const defaultTemplateTypes = [
 		title: '404 (Not Found)',
 		description: 'Applied when content cannot be found',
 		slug: '404',
+	},
+];
+
+const defaultTemplatePartAreas = [
+	{
+		area: 'header',
+		label: 'Header',
+		description: 'Some description of a header',
+	},
+	{
+		area: 'footer',
+		label: 'Footer',
+		description: 'Some description of a footer',
 	},
 ];
 
@@ -2801,6 +2815,32 @@ describe( 'selectors', () => {
 			expect(
 				__experimentalGetDefaultTemplateTypes( state )
 			).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( '__experimentalGetDefaultTemplatePartAreas', () => {
+		const state = { editorSettings: { defaultTemplatePartAreas } };
+
+		it( 'returns undefined if there are no default template part areas', () => {
+			const emptyState = { editorSettings: {} };
+			expect(
+				__experimentalGetDefaultTemplatePartAreas( emptyState )
+			).toBeUndefined();
+		} );
+
+		it( 'returns a list of default template part areas if present in state', () => {
+			expect(
+				__experimentalGetDefaultTemplatePartAreas( state )
+			).toHaveLength( 2 );
+		} );
+
+		it( 'assigns an icon to each area', () => {
+			const templatePartAreas = __experimentalGetDefaultTemplatePartAreas(
+				state
+			);
+			templatePartAreas.forEach( ( area ) =>
+				expect( area.icon ).not.toBeNull()
+			);
 		} );
 	} );
 

--- a/packages/editor/src/store/utils/get-template-part-icon.js
+++ b/packages/editor/src/store/utils/get-template-part-icon.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { layout, header, footer } from '@wordpress/icons';
+
+/**
+ * Helper function to find the corresponding icon for a template part's 'area'.
+ *
+ * @param {string} area The value of the template part 'area' tax term.
+ *
+ * @return {Object} The corresponding icon.
+ */
+export function getTemplatePartIconByArea( area ) {
+	const iconsByArea = {
+		footer,
+		header,
+	};
+	return iconsByArea[ area ] || layout;
+}

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -66,12 +66,12 @@ class Block_Templates_Test extends WP_UnitTestCase {
 					get_stylesheet(),
 				),
 				'wp_template_part_area' => array(
-					WP_TEMPLATE_PART_AREA_SIDEBAR,
+					WP_TEMPLATE_PART_AREA_HEADER,
 				),
 			),
 		);
 		self::$template_part_post = self::factory()->post->create_and_get( $template_part_args );
-		wp_set_post_terms( self::$template_part_post->ID, WP_TEMPLATE_PART_AREA_SIDEBAR, 'wp_template_part_area' );
+		wp_set_post_terms( self::$template_part_post->ID, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
 		wp_set_post_terms( self::$template_part_post->ID, get_stylesheet(), 'wp_theme' );
 	}
 
@@ -114,7 +114,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'header', $template_part->title );
 		$this->assertEquals( '', $template_part->description );
 		$this->assertEquals( 'wp_template_part', $template_part->type );
-		$this->assertEquals( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
+		$this->assertEquals( 'header', $template_part->area );
 	}
 
 	function test_gutenberg_build_template_result_from_post() {
@@ -147,7 +147,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'My Template Part', $template_part->title );
 		$this->assertEquals( 'Description of my template part', $template_part->description );
 		$this->assertEquals( 'wp_template_part', $template_part->type );
-		$this->assertEquals( WP_TEMPLATE_PART_AREA_SIDEBAR, $template_part->area );
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
 	}
 
 	function test_inject_theme_attribute_in_content() {
@@ -228,7 +228,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $template->status );
 		$this->assertEquals( 'custom', $template->source );
 		$this->assertEquals( 'wp_template_part', $template->type );
-		$this->assertEquals( WP_TEMPLATE_PART_AREA_SIDEBAR, $template->area );
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_HEADER, $template->area );
 	}
 
 	/**
@@ -263,7 +263,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template' ), $template_ids );
 
 		// Filter template part by area.
-		$templates    = gutenberg_get_block_templates( array( 'area' => WP_TEMPLATE_PART_AREA_SIDEBAR ), 'wp_template_part' );
+		$templates    = gutenberg_get_block_templates( array( 'area' => WP_TEMPLATE_PART_AREA_HEADER ), 'wp_template_part' );
 		$template_ids = get_template_ids( $templates );
 		// TODO - update following array result once tt1-blocks theme.json is updated for area info.
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template_part' ), $template_ids );

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -114,7 +114,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'header', $template_part->title );
 		$this->assertEquals( '', $template_part->description );
 		$this->assertEquals( 'wp_template_part', $template_part->type );
-		$this->assertEquals( 'header', $template_part->area );
+		$this->assertEquals( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
 	}
 
 	function test_gutenberg_build_template_result_from_post() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Attempts to resolve https://github.com/WordPress/gutenberg/issues/29222 - by adding selection for 'area' in this modal per design suggestion https://github.com/WordPress/gutenberg/issues/29222#issuecomment-791381586 (update to https://github.com/WordPress/gutenberg/pull/30395#issuecomment-810897861)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

To Test:
1. Load the Site Editor (must have a block based theme such as tt1-blocks activated).
2. Select an/some existing blocks in the editor (or create new ones).
3. On the block toolbar, click the ellipsis menu and select the "Convert to Template Part" option.
4. A modal should appear to name the template part and select its area (this area selection is what has been added in this PR).  
5. Create the template part and verify its block variation corresponds to the area selected in step 4.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
