### PR TITLE
Gallery block refactor: make invalid file type errors consistent

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -224,10 +224,12 @@ function GalleryEdit( props ) {
 			: selectedImages;
 
 		if ( ! imageArray.every( isValidFileType ) ) {
+			noticeOperations.removeAllNotices();
 			noticeOperations.createErrorNotice(
 				__(
 					'If uploading to a gallery all files need to be image formats'
-				)
+				),
+				{ id: 'gallery-upload-invalid-file' }
 			);
 		}
 
@@ -244,7 +246,7 @@ function GalleryEdit( props ) {
 			} );
 
 		// Because we are reusing existing innerImage blocks any reordering
-		// done in the media libary will be lost so we need to reapply that ordering
+		// done in the media library will be lost so we need to reapply that ordering
 		// once the new image blocks are merged in with existing.
 		const newOrderMap = processedImages.reduce(
 			( result, image, index ) => (

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -200,6 +200,12 @@ function GalleryEdit( props ) {
 		};
 	}
 
+	function isValidFileType( file ) {
+		return ALLOWED_MEDIA_TYPES.some(
+			( mediaType ) => file.type?.indexOf( mediaType ) === 0
+		);
+	}
+
 	function updateImages( selectedImages ) {
 		const newFileUploads =
 			Object.prototype.toString.call( selectedImages ) ===
@@ -217,11 +223,7 @@ function GalleryEdit( props ) {
 			  } )
 			: selectedImages;
 
-		if (
-			imageArray.some(
-				( image ) => image.type?.indexOf( 'image/' ) !== 0
-			)
-		) {
+		if ( ! imageArray.every( isValidFileType ) ) {
 			noticeOperations.createErrorNotice(
 				__(
 					'If uploading to a gallery all files need to be image formats'
@@ -230,9 +232,7 @@ function GalleryEdit( props ) {
 		}
 
 		const processedImages = imageArray
-			.filter(
-				( file ) => file.url || file.type?.indexOf( 'image/' ) === 0
-			)
+			.filter( ( file ) => file.url || isValidFileType( file ) )
 			.map( ( file ) => {
 				if ( ! file.url ) {
 					return pickRelevantMediaFiles( {

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -217,6 +217,18 @@ function GalleryEdit( props ) {
 			  } )
 			: selectedImages;
 
+		if (
+			imageArray.some(
+				( image ) => image.type?.indexOf( 'image/' ) !== 0
+			)
+		) {
+			noticeOperations.createErrorNotice(
+				__(
+					'If uploading to a gallery all files need to be image formats'
+				)
+			);
+		}
+
 		const processedImages = imageArray
 			.filter(
 				( file ) => file.url || file.type?.indexOf( 'image/' ) === 0

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -131,7 +131,7 @@ const transforms = {
 			},
 		},
 		{
-			// Note: when dragging and dropping multiple files onto a gallery this overrrides the
+			// Note: when dragging and dropping multiple files onto a gallery this overrides the
 			// gallery transform in order to add new images to the gallery instead of
 			// creating a new gallery.
 			type: 'files',
@@ -145,7 +145,8 @@ const transforms = {
 					createErrorNotice(
 						__(
 							'If uploading to a gallery all files need to be image formats'
-						)
+						),
+						{ id: 'gallery-transform-invalid-file' }
 					);
 				}
 				return every(

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -141,15 +141,11 @@ const transforms = {
 						( file ) => file.type.indexOf( 'image/' ) !== 0
 					)
 				) {
-					const { createWarningNotice } = dispatch( noticesStore );
-					createWarningNotice(
+					const { createErrorNotice } = dispatch( noticesStore );
+					createErrorNotice(
 						__(
 							'If uploading to a gallery all files need to be image formats'
-						),
-						{
-							id: 'image-upload-format-warning',
-							type: 'snackbar',
-						}
+						)
 					);
 				}
 				return every(


### PR DESCRIPTION
## Description
Fixes: #29997

Invalid file type warnings were not showing when invalid files were dragged onto an empty gallery placeholder, and the ones that show when dragging invalid files into populated gallery were black snackbars, but similar warnings on the Image block are red error notices.

## Testing
Check out PR
Turn on gallery refactor experiment
Add an empty gallery and try dragging an invalid file type onto the placeholder and check that red error notice appears
Try dragging multiple files with one invalid and check valid files upload but error notice still shown
Drag invalid file into populated gallery and check the error notice shows

## Screenshots 
![type-error](https://user-images.githubusercontent.com/3629020/113068257-71bdc800-921a-11eb-8b75-9ff41404ba90.gif)
