### PR TITLE
Add a custom toggler hook and use it to fix Dropdown and ad hoc toggles

### DIFF
--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -8,8 +8,6 @@ import { shallow, mount } from 'enzyme';
  */
 import { useSelect } from '@wordpress/data';
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
-import { DOWN } from '@wordpress/keycodes';
-import { Button } from '@wordpress/components';
 import { stack } from '@wordpress/icons';
 
 /**
@@ -155,7 +153,7 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	describe( 'Dropdown', () => {
+	describe( 'Dropdown .renderContent', () => {
 		beforeAll( () => {
 			useSelect.mockImplementation( () => ( {
 				possibleBlockTransformations: [
@@ -168,66 +166,19 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 				<BlockSwitcherDropdownMenu blocks={ [ headingBlock1 ] } />
 			).find( 'Dropdown' );
 
-		test( 'should dropdown exist', () => {
-			expect( getDropdown() ).toHaveLength( 1 );
-		} );
-
-		describe( '.renderToggle', () => {
-			const onToggleStub = jest.fn();
-			const mockKeyDown = {
-				preventDefault: () => {},
-				stopPropagation: () => {},
-				keyCode: DOWN,
-			};
-
-			afterEach( () => {
-				onToggleStub.mockReset();
-			} );
-
-			test( 'should simulate a keydown event, which should call onToggle and open transform toggle.', () => {
-				const toggleClosed = mount(
-					getDropdown().props().renderToggle( {
-						onToggle: onToggleStub,
-						isOpen: false,
-					} )
-				);
-				const iconButtonClosed = toggleClosed.find( Button );
-
-				iconButtonClosed.simulate( 'keydown', mockKeyDown );
-
-				expect( onToggleStub ).toHaveBeenCalledTimes( 1 );
-			} );
-
-			test( 'should simulate a click event, which should call onToggle.', () => {
-				const toggleOpen = mount(
-					getDropdown().props().renderToggle( {
-						onToggle: onToggleStub,
-						isOpen: true,
-					} )
-				);
-				const iconButtonOpen = toggleOpen.find( Button );
-
-				iconButtonOpen.simulate( 'keydown', mockKeyDown );
-
-				expect( onToggleStub ).toHaveBeenCalledTimes( 0 );
-			} );
-		} );
-
-		describe( '.renderContent', () => {
-			test( 'should create the transform items for the chosen block. A heading block will have 3 items', () => {
-				const onCloseStub = jest.fn();
-				const content = shallow(
-					<div>
-						{ getDropdown()
-							.props()
-							.renderContent( { onClose: onCloseStub } ) }
-					</div>
-				);
-				const blockList = content.find( 'BlockTransformationsMenu' );
-				expect(
-					blockList.prop( 'possibleBlockTransformations' )
-				).toHaveLength( 1 );
-			} );
+		test( 'should create the transform items for the chosen block. A heading block will have 1 item', () => {
+			const onCloseStub = jest.fn();
+			const content = shallow(
+				<div>
+					{ getDropdown()
+						.props()
+						.renderContent( { onClose: onCloseStub } ) }
+				</div>
+			);
+			const blockList = content.find( 'BlockTransformationsMenu' );
+			expect(
+				blockList.prop( 'possibleBlockTransformations' )
+			).toHaveLength( 1 );
 		} );
 	} );
 } );

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -7,17 +7,19 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useState, useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import {
 	Button,
 	ButtonGroup,
+	Dropdown,
 	KeyboardShortcuts,
 	PanelBody,
 	RangeControl,
 	TextControl,
 	ToolbarButton,
-	Popover,
+	ToolbarItem,
 } from '@wordpress/components';
+import { useMergeRefs } from '@wordpress/compose';
 import {
 	BlockControls,
 	InspectorControls,
@@ -107,76 +109,87 @@ function URLPicker( {
 	onToggleOpenInNewTab,
 	anchorRef,
 } ) {
-	const [ isURLPickerOpen, setIsURLPickerOpen ] = useState( false );
 	const urlIsSet = !! url;
 	const urlIsSetandSelected = urlIsSet && isSelected;
-	const openLinkControl = () => {
-		setIsURLPickerOpen( true );
-		return false; // prevents default behaviour for event
-	};
-	const unlinkButton = () => {
-		setAttributes( {
-			url: undefined,
-			linkTarget: undefined,
-			rel: undefined,
-		} );
-		setIsURLPickerOpen( false );
-	};
-	const linkControl = ( isURLPickerOpen || urlIsSetandSelected ) && (
-		<Popover
-			position="bottom center"
-			onClose={ () => setIsURLPickerOpen( false ) }
-			anchorRef={ anchorRef?.current }
-		>
-			<LinkControl
-				className="wp-block-navigation-link__inline-link-input"
-				value={ { url, opensInNewTab } }
-				onChange={ ( {
-					url: newURL = '',
-					opensInNewTab: newOpensInNewTab,
-				} ) => {
-					setAttributes( { url: newURL } );
 
-					if ( opensInNewTab !== newOpensInNewTab ) {
-						onToggleOpenInNewTab( newOpensInNewTab );
-					}
-				} }
+	const renderToolbarItem = ( {
+		ref: toolbarItemRef,
+		...toolbarItemProps
+	} ) => {
+		const useToggle = ( { ref: toggleRef, onToggle, onClose } ) => {
+			const onRemove = ( { type } ) => {
+				setAttributes( {
+					url: undefined,
+					linkTarget: undefined,
+					rel: undefined,
+				} );
+				if ( type === 'keydown' ) {
+					onClose();
+				}
+			};
+			const ref = useMergeRefs( [ toolbarItemRef, toggleRef ] );
+			const toggleProps = {
+				ref,
+				name: 'link',
+				...toolbarItemProps,
+				...( ! urlIsSet
+					? {
+							icon: link,
+							title: __( 'Link' ),
+							shortcut: displayShortcut.primary( 'k' ),
+					  }
+					: {
+							icon: linkOff,
+							title: __( 'Unlink' ),
+							shortcut: displayShortcut.primaryShift( 'k' ),
+							isActive: true,
+							onClick: onRemove,
+					  } ),
+			};
+			return (
+				<>
+					<ToolbarButton name="link" { ...toggleProps } />
+					<KeyboardShortcuts
+						bindGlobal
+						shortcuts={ {
+							[ rawShortcut.primary( 'k' ) ]: onToggle,
+							[ rawShortcut.primaryShift( 'k' ) ]: onRemove,
+						} }
+					/>
+				</>
+			);
+		};
+		return (
+			<Dropdown
+				autoClose={ false }
+				openOnMount={ urlIsSetandSelected }
+				position="bottom center"
+				popoverProps={ { anchorRef: anchorRef?.current } }
+				renderToggle={ useToggle }
+				renderContent={ () => (
+					<LinkControl
+						className="wp-block-navigation-link__inline-link-input"
+						value={ { url, opensInNewTab } }
+						onChange={ ( {
+							url: newURL = '',
+							opensInNewTab: newOpensInNewTab,
+						} ) => {
+							setAttributes( { url: newURL } );
+
+							if ( opensInNewTab !== newOpensInNewTab ) {
+								onToggleOpenInNewTab( newOpensInNewTab );
+							}
+						} }
+					/>
+				) }
 			/>
-		</Popover>
-	);
+		);
+	};
 	return (
 		<>
 			<BlockControls group="block">
-				{ ! urlIsSet && (
-					<ToolbarButton
-						name="link"
-						icon={ link }
-						title={ __( 'Link' ) }
-						shortcut={ displayShortcut.primary( 'k' ) }
-						onClick={ openLinkControl }
-					/>
-				) }
-				{ urlIsSetandSelected && (
-					<ToolbarButton
-						name="link"
-						icon={ linkOff }
-						title={ __( 'Unlink' ) }
-						shortcut={ displayShortcut.primaryShift( 'k' ) }
-						onClick={ unlinkButton }
-						isActive={ true }
-					/>
-				) }
+				<ToolbarItem>{ renderToolbarItem }</ToolbarItem>
 			</BlockControls>
-			{ isSelected && (
-				<KeyboardShortcuts
-					bindGlobal
-					shortcuts={ {
-						[ rawShortcut.primary( 'k' ) ]: openLinkControl,
-						[ rawShortcut.primaryShift( 'k' ) ]: unlinkButton,
-					} }
-				/>
-			) }
-			{ linkControl }
 		</>
 	);
 }

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { useState } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
 import {
 	AlignmentToolbar,
@@ -25,6 +25,7 @@ import {
 	CustomSelectControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { __experimentalUseToggler as useToggler } from '@wordpress/compose';
 import { edit } from '@wordpress/icons';
 
 export default function PostDateEdit( { attributes, context, setAttributes } ) {
@@ -38,7 +39,12 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 		'date',
 		postId
 	);
-	const [ isPickerOpen, setIsPickerOpen ] = useState( false );
+	const timeRef = useRef();
+	const {
+		togglerHandlers,
+		isOn: isPickerOpen,
+		offUnlessToggler,
+	} = useToggler();
 	const settings = __experimentalGetSettings();
 	// To know if the current time format is a 12 hour time, look for "a".
 	// Also make sure this "a" is not escaped by a "/".
@@ -49,6 +55,15 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 			.split( '' )
 			.reverse()
 			.join( '' ) // Reverse the string and test for "a" not followed by a slash.
+	);
+	const datePicker = (
+		<Popover onClose={ offUnlessToggler } anchorRef={ timeRef.current }>
+			<DateTimePicker
+				currentDate={ date }
+				onChange={ setDate }
+				is12Hour={ is12Hour }
+			/>
+		</Popover>
 	);
 	const formatOptions = Object.values( settings.formats ).map(
 		( formatOption ) => ( {
@@ -64,17 +79,9 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 	} );
 
 	let postDate = date ? (
-		<time dateTime={ dateI18n( 'c', date ) }>
+		<time dateTime={ dateI18n( 'c', date ) } ref={ timeRef }>
 			{ dateI18n( resolvedFormat, date ) }
-			{ isPickerOpen && (
-				<Popover onClose={ setIsPickerOpen.bind( null, false ) }>
-					<DateTimePicker
-						currentDate={ date }
-						onChange={ setDate }
-						is12Hour={ is12Hour }
-					/>
-				</Popover>
-			) }
+			{ isPickerOpen && datePicker }
 		</time>
 	) : (
 		__( 'No Date' )
@@ -95,13 +102,10 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 				{ date && (
 					<ToolbarGroup>
 						<ToolbarButton
+							aria-expanded={ isPickerOpen }
 							icon={ edit }
 							title={ __( 'Change Date' ) }
-							onClick={ () =>
-								setIsPickerOpen(
-									( _isPickerOpen ) => ! _isPickerOpen
-								)
-							}
+							{ ...togglerHandlers }
 						/>
 					</ToolbarGroup>
 				) }

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -10,7 +10,6 @@ import { flatMap, isEmpty, isFunction } from 'lodash';
 import { DOWN } from '@wordpress/keycodes';
 import deprecated from '@wordpress/deprecated';
 import { menu } from '@wordpress/icons';
-import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -43,7 +42,7 @@ function DropdownMenu( {
 	icon = menu,
 	label,
 	popoverProps,
-	toggleProps: { ref: togglePropsRef, ...restOfToggleProps } = {},
+	toggleProps,
 	menuProps,
 	disableOpenOnArrowDown = false,
 	text,
@@ -93,12 +92,7 @@ function DropdownMenu( {
 		<Dropdown
 			className={ classnames( 'components-dropdown-menu', className ) }
 			popoverProps={ mergedPopoverProps }
-			renderToggle={ function useDropdownMenuToggle( {
-				isOpen,
-				onToggle,
-				ref: toggleRef,
-			} ) {
-				const ref = useMergeRefs( [ togglePropsRef, toggleRef ] );
+			renderToggle={ ( { isOpen, onToggle } ) => {
 				const openOnArrowDown = ( event ) => {
 					if ( disableOpenOnArrowDown ) {
 						return;
@@ -119,15 +113,19 @@ function DropdownMenu( {
 							}
 						),
 					},
-					restOfToggleProps
+					toggleProps
 				);
 
 				return (
 					<ButtonComponent
 						{ ...mergedToggleProps }
-						ref={ ref }
 						icon={ icon }
-						onClick={ mergedToggleProps?.onClick }
+						onClick={ ( event ) => {
+							onToggle( event );
+							if ( mergedToggleProps.onClick ) {
+								mergedToggleProps.onClick( event );
+							}
+						} }
 						onKeyDown={ ( event ) => {
 							openOnArrowDown( event );
 							if ( mergedToggleProps.onKeyDown ) {
@@ -138,7 +136,7 @@ function DropdownMenu( {
 						aria-expanded={ isOpen }
 						label={ label }
 						text={ text }
-						showTooltip={ mergedToggleProps?.showTooltip ?? true }
+						showTooltip={ toggleProps?.showTooltip ?? true }
 					>
 						{ mergedToggleProps.children }
 					</ButtonComponent>

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -92,7 +92,7 @@ function DropdownMenu( {
 		<Dropdown
 			className={ classnames( 'components-dropdown-menu', className ) }
 			popoverProps={ mergedPopoverProps }
-			renderToggle={ ( { isOpen, onToggle } ) => {
+			renderToggle={ ( { isOpen, onToggle, togglerHandlers } ) => {
 				const openOnArrowDown = ( event ) => {
 					if ( disableOpenOnArrowDown ) {
 						return;
@@ -115,22 +115,24 @@ function DropdownMenu( {
 					},
 					toggleProps
 				);
+				Object.keys( togglerHandlers ).forEach( ( key ) => {
+					if ( toggleProps?.key ) {
+						mergedToggleProps[ key ] = ( event ) => {
+							togglerHandlers[ key ]( event );
+							toggleProps[ key ]( event );
+						};
+					} else {
+						mergedToggleProps[ key ] = togglerHandlers[ key ];
+					}
+				} );
 
 				return (
 					<ButtonComponent
 						{ ...mergedToggleProps }
 						icon={ icon }
-						onClick={ ( event ) => {
-							onToggle( event );
-							if ( mergedToggleProps.onClick ) {
-								mergedToggleProps.onClick( event );
-							}
-						} }
 						onKeyDown={ ( event ) => {
 							openOnArrowDown( event );
-							if ( mergedToggleProps.onKeyDown ) {
-								mergedToggleProps.onKeyDown( event );
-							}
+							mergedToggleProps.onKeyDown?.( event );
 						} }
 						aria-haspopup="true"
 						aria-expanded={ isOpen }

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -10,6 +10,7 @@ import { flatMap, isEmpty, isFunction } from 'lodash';
 import { DOWN } from '@wordpress/keycodes';
 import deprecated from '@wordpress/deprecated';
 import { menu } from '@wordpress/icons';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -42,7 +43,7 @@ function DropdownMenu( {
 	icon = menu,
 	label,
 	popoverProps,
-	toggleProps,
+	toggleProps: { ref: togglePropsRef, ...restOfToggleProps } = {},
 	menuProps,
 	disableOpenOnArrowDown = false,
 	text,
@@ -92,7 +93,12 @@ function DropdownMenu( {
 		<Dropdown
 			className={ classnames( 'components-dropdown-menu', className ) }
 			popoverProps={ mergedPopoverProps }
-			renderToggle={ ( { isOpen, onToggle } ) => {
+			renderToggle={ function useDropdownMenuToggle( {
+				isOpen,
+				onToggle,
+				ref: toggleRef,
+			} ) {
+				const ref = useMergeRefs( [ togglePropsRef, toggleRef ] );
 				const openOnArrowDown = ( event ) => {
 					if ( disableOpenOnArrowDown ) {
 						return;
@@ -113,19 +119,15 @@ function DropdownMenu( {
 							}
 						),
 					},
-					toggleProps
+					restOfToggleProps
 				);
 
 				return (
 					<ButtonComponent
 						{ ...mergedToggleProps }
+						ref={ ref }
 						icon={ icon }
-						onClick={ ( event ) => {
-							onToggle( event );
-							if ( mergedToggleProps.onClick ) {
-								mergedToggleProps.onClick( event );
-							}
-						} }
+						onClick={ mergedToggleProps?.onClick }
 						onKeyDown={ ( event ) => {
 							openOnArrowDown( event );
 							if ( mergedToggleProps.onKeyDown ) {
@@ -136,7 +138,7 @@ function DropdownMenu( {
 						aria-expanded={ isOpen }
 						label={ label }
 						text={ text }
-						showTooltip={ toggleProps?.showTooltip ?? true }
+						showTooltip={ mergedToggleProps?.showTooltip ?? true }
 					>
 						{ mergedToggleProps.children }
 					</ButtonComponent>

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { useRef, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,107 +17,69 @@ function useObservableState( initialState, onStateChange ) {
 	const [ state, setState ] = useState( initialState );
 	return [
 		state,
-		( valueOrSetter ) => {
-			let syncState;
-			if ( typeof valueOrSetter === 'function' ) {
-				setState( ( value ) => {
-					syncState = valueOrSetter( value );
-					return syncState;
-				} );
-			} else {
-				syncState = valueOrSetter;
-				setState( valueOrSetter );
-			}
+		( value ) => {
+			setState( value );
 			if ( onStateChange ) {
-				onStateChange( syncState );
+				onStateChange( value );
 			}
 		},
 	];
 }
 
 export default function Dropdown( {
-	autoClose = true,
+	renderContent,
+	renderToggle,
+	position = 'bottom right',
 	className,
 	contentClassName,
 	expandOnMobile,
-	focusOnMount,
 	headerTitle,
+	focusOnMount,
+	popoverProps,
 	onClose,
 	onToggle,
-	openOnMount = false,
-	popoverProps,
-	position = 'bottom right',
-	renderContent,
-	renderToggle,
 } ) {
 	const containerRef = useRef();
-	const toggleRef = useRef();
-	const isTogglePressed = useRef();
-	const [ isOpen, setIsOpen ] = useObservableState( openOnMount, onToggle );
+	const [ isOpen, setIsOpen ] = useObservableState( false, onToggle );
 
-	useEffect( () => {
-		// If onToggle was provided on mount, calls it with false on unmount
-		if ( onToggle ) {
-			return () => onToggle( false );
-		}
-	}, [] );
+	useEffect(
+		() => () => {
+			if ( onToggle ) {
+				onToggle( false );
+			}
+		},
+		[]
+	);
 
 	function toggle() {
-		setIsOpen( ( value ) => ! value );
+		setIsOpen( ! isOpen );
 	}
 
 	/**
-	 * Handles focus outside of the Popover to determine whether to close it.
-	 * No action is taken in case autoClose is false or if pressing the toggle
-	 * was the cause of the focus loss. The latter avoids the toggle click
-	 * event handler changing the state back to open immediately after this.
+	 * Closes the dropdown if a focus leaves the dropdown wrapper. This is
+	 * intentionally distinct from `onClose` since focus loss from the popover
+	 * is expected to occur when using the Dropdown's toggle button, in which
+	 * case the correct behavior is to keep the dropdown closed. The same applies
+	 * in case when focus is moved to the modal dialog.
 	 */
-	function onFocusOutsidePopover() {
-		if ( toggleRef.current ) {
-			if ( ! autoClose || isTogglePressed.current ) {
-				return;
-			}
-			close();
-		}
-		// The rest is only for back-compat and could be removed at some point.
-		// Attempts determination that the active element is inside Dropdown.
-		// Prone to failure in UAs that do not focus pressed button elements
-		// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus
+	function closeIfFocusOutside() {
 		const { ownerDocument } = containerRef.current;
-		if ( ! containerRef.current.contains( ownerDocument.activeElement ) ) {
+		if (
+			! containerRef.current.contains( ownerDocument.activeElement ) &&
+			! ownerDocument.activeElement.closest( '[role="dialog"]' )
+		) {
 			close();
 		}
 	}
 
 	function close() {
-		// Allows the callback to return false to cancel closing
-		const willClose = onClose?.() ?? true;
-		if ( willClose ) {
-			setIsOpen( false );
+		if ( onClose ) {
+			onClose();
 		}
+		setIsOpen( false );
 	}
 
-	const setToggleRef = useCallback( ( node ) => {
-		if ( node ) {
-			toggleRef.current = node;
-			Object.keys( toggleHandlers ).forEach( ( event ) => {
-				node.addEventListener( event, toggleHandlers[ event ] );
-			} );
-		}
-	}, [] );
-
-	const toggleHandlers = {
-		click: toggle,
-		pointerdown: () => ( isTogglePressed.current = true ),
-		pointerup: () => ( isTogglePressed.current = false ),
-	};
-
-	const args = {
-		isOpen,
-		onToggle: toggle,
-		onClose: close,
-		ref: setToggleRef,
-	};
+	const args = { isOpen, onToggle: toggle, onClose: close };
 
 	return (
 		<div
@@ -129,7 +91,7 @@ export default function Dropdown( {
 				<Popover
 					position={ position }
 					onClose={ close }
-					onFocusOutside={ onFocusOutsidePopover }
+					onFocusOutside={ closeIfFocusOutside }
 					expandOnMobile={ expandOnMobile }
 					headerTitle={ headerTitle }
 					focusOnMount={ focusOnMount }

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,69 +17,107 @@ function useObservableState( initialState, onStateChange ) {
 	const [ state, setState ] = useState( initialState );
 	return [
 		state,
-		( value ) => {
-			setState( value );
+		( valueOrSetter ) => {
+			let syncState;
+			if ( typeof valueOrSetter === 'function' ) {
+				setState( ( value ) => {
+					syncState = valueOrSetter( value );
+					return syncState;
+				} );
+			} else {
+				syncState = valueOrSetter;
+				setState( valueOrSetter );
+			}
 			if ( onStateChange ) {
-				onStateChange( value );
+				onStateChange( syncState );
 			}
 		},
 	];
 }
 
 export default function Dropdown( {
-	renderContent,
-	renderToggle,
-	position = 'bottom right',
+	autoClose = true,
 	className,
 	contentClassName,
 	expandOnMobile,
-	headerTitle,
 	focusOnMount,
-	popoverProps,
+	headerTitle,
 	onClose,
 	onToggle,
+	openOnMount = false,
+	popoverProps,
+	position = 'bottom right',
+	renderContent,
+	renderToggle,
 } ) {
 	const containerRef = useRef();
-	const [ isOpen, setIsOpen ] = useObservableState( false, onToggle );
+	const toggleRef = useRef();
+	const isTogglePressed = useRef();
+	const [ isOpen, setIsOpen ] = useObservableState( openOnMount, onToggle );
 
-	useEffect(
-		() => () => {
-			if ( onToggle ) {
-				onToggle( false );
-			}
-		},
-		[]
-	);
+	useEffect( () => {
+		// If onToggle was provided on mount, calls it with false on unmount
+		if ( onToggle ) {
+			return () => onToggle( false );
+		}
+	}, [] );
 
 	function toggle() {
-		setIsOpen( ! isOpen );
+		setIsOpen( ( value ) => ! value );
 	}
 
 	/**
-	 * Closes the dropdown if a focus leaves the dropdown wrapper. This is
-	 * intentionally distinct from `onClose` since focus loss from the popover
-	 * is expected to occur when using the Dropdown's toggle button, in which
-	 * case the correct behavior is to keep the dropdown closed. The same applies
-	 * in case when focus is moved to the modal dialog.
+	 * Handles focus outside of the Popover to determine whether to close it.
+	 * No action is taken in case autoClose is false or if pressing the toggle
+	 * was the cause of the focus loss. The latter avoids the toggle click
+	 * event handler changing the state back to open immediately after this.
 	 */
-	function closeIfFocusOutside() {
+	function onFocusOutsidePopover() {
+		if ( toggleRef.current ) {
+			if ( ! autoClose || isTogglePressed.current ) {
+				return;
+			}
+			close();
+		}
+		// The rest is only for back-compat and could be removed at some point.
+		// Attempts determination that the active element is inside Dropdown.
+		// Prone to failure in UAs that do not focus pressed button elements
+		// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus
 		const { ownerDocument } = containerRef.current;
-		if (
-			! containerRef.current.contains( ownerDocument.activeElement ) &&
-			! ownerDocument.activeElement.closest( '[role="dialog"]' )
-		) {
+		if ( ! containerRef.current.contains( ownerDocument.activeElement ) ) {
 			close();
 		}
 	}
 
 	function close() {
-		if ( onClose ) {
-			onClose();
+		// Allows the callback to return false to cancel closing
+		const willClose = onClose?.() ?? true;
+		if ( willClose ) {
+			setIsOpen( false );
 		}
-		setIsOpen( false );
 	}
 
-	const args = { isOpen, onToggle: toggle, onClose: close };
+	const setToggleRef = useCallback( ( node ) => {
+		if ( node ) {
+			toggleRef.current = node;
+			Object.keys( toggleHandlers ).forEach( ( event ) => {
+				node.addEventListener( event, toggleHandlers[ event ] );
+			} );
+		}
+	}, [] );
+
+	const toggleHandlers = {
+		click: toggle,
+		pointerdown: () => ( isTogglePressed.current = true ),
+		pointerup: () => ( isTogglePressed.current = false ),
+	};
+
+	const args = {
+		isOpen,
+		onToggle: toggle,
+		onClose: close,
+		ref: setToggleRef,
+	};
 
 	return (
 		<div
@@ -91,7 +129,7 @@ export default function Dropdown( {
 				<Popover
 					position={ position }
 					onClose={ close }
-					onFocusOutside={ closeIfFocusOutside }
+					onFocusOutside={ onFocusOutsidePopover }
 					expandOnMobile={ expandOnMobile }
 					headerTitle={ headerTitle }
 					focusOnMount={ focusOnMount }

--- a/packages/compose/src/hooks/use-toggler/index.js
+++ b/packages/compose/src/hooks/use-toggler/index.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useRef, useState } from '@wordpress/element';
+
+/**
+ * @typedef  {Object}    TogglerHookReturnValue
+ * @property {Object}    togglerHandlers   Event handlers for toggler element.
+ * @property {boolean}   isOn              State of toggler.
+ * @property {Function}  setIsOn           Sets toggler state
+ * @property {Function}  offUnlessToggler  Sets state, if toggler element is
+ *                                         not pressed, to false.
+ */
+
+/**
+ * Facilitates disclosure/toggle components. It returns state with a setter,
+ * event handlers for the toggle commponent and a function `offUnlessToggler`
+ * to be used by the disclosed component for auto-closing with deferral to the
+ * toggle component in case it was pressed.
+ *
+ * @return {TogglerHookReturnValue} State and handlers for content disclosures
+ */
+export default function useToggler() {
+	const [ isOn, setIsOn ] = useState( false );
+
+	const isTogglerPressed = useRef();
+	const togglerHandlers = useRef();
+	if ( ! togglerHandlers.current ) {
+		togglerHandlers.current = {
+			onMouseDown: () => ( isTogglerPressed.current = true ),
+			onMouseUp: () => ( isTogglerPressed.current = false ),
+			onClick: ( { currentTarget: { disabled, ariaDisabled } } ) => {
+				if ( disabled || ( ariaDisabled && ariaDisabled === 'true' ) ) {
+					return;
+				}
+				setIsOn( ( current ) => ! current );
+			},
+		};
+	}
+
+	const offUnlessToggler = useCallback(
+		() => ! isTogglerPressed.current && setIsOn( false ),
+		[]
+	);
+
+	return {
+		togglerHandlers: togglerHandlers.current,
+		isOn,
+		setIsOn,
+		offUnlessToggler,
+	};
+}

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -35,3 +35,4 @@ export { default as useDebounce } from './hooks/use-debounce';
 export { default as useThrottle } from './hooks/use-throttle';
 export { default as useMergeRefs } from './hooks/use-merge-refs';
 export { default as useRefEffect } from './hooks/use-ref-effect';
+export { default as __experimentalUseToggler } from './hooks/use-toggler';

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -24,11 +24,11 @@ export function PostVisibility() {
 						<Dropdown
 							position="bottom left"
 							contentClassName="edit-post-post-visibility__dialog"
-							renderToggle={ ( { isOpen, ref } ) => (
+							renderToggle={ ( { isOpen, onToggle } ) => (
 								<Button
-									ref={ ref }
 									aria-expanded={ isOpen }
 									className="edit-post-post-visibility__toggle"
+									onClick={ onToggle }
 									isTertiary
 								>
 									<PostVisibilityLabel />

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -24,11 +24,11 @@ export function PostVisibility() {
 						<Dropdown
 							position="bottom left"
 							contentClassName="edit-post-post-visibility__dialog"
-							renderToggle={ ( { isOpen, onToggle } ) => (
+							renderToggle={ ( { isOpen, ref } ) => (
 								<Button
+									ref={ ref }
 									aria-expanded={ isOpen }
 									className="edit-post-post-visibility__toggle"
-									onClick={ onToggle }
 									isTertiary
 								>
 									<PostVisibilityLabel />

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -24,12 +24,12 @@ export function PostVisibility() {
 						<Dropdown
 							position="bottom left"
 							contentClassName="edit-post-post-visibility__dialog"
-							renderToggle={ ( { isOpen, onToggle } ) => (
+							renderToggle={ ( { isOpen, togglerHandlers } ) => (
 								<Button
 									aria-expanded={ isOpen }
 									className="edit-post-post-visibility__toggle"
-									onClick={ onToggle }
 									isTertiary
+									{ ...togglerHandlers }
 								>
 									<PostVisibilityLabel />
 								</Button>


### PR DESCRIPTION
An alternative to #27406 coinciding more with the approach recommended here: https://github.com/WordPress/gutenberg/pull/30392#issue-604508849

## Why
The issue is toggle buttons for popovers that don't close the popover as expected. When part of a `Dropdown` component the toggle works fine in common browsers but fails in some UAs (e.g. Firefox on macOS and Safari) that do not focus button elements when pressed.

## How
A custom hook has been added that gives back handlers to ease implementor boilerplate in making toggles that work in tandem with popovers auto-closing behavior (because that should be canceled in cases that pressing the toggle was what caused the auto-close). The hook has been used to refactor `Dropdown` but the implementors of it need minor updates to get the improved toggle logic (that doesn't break on the aforementioned UAs). `DropdownMenu` has also been updated and its implementors need no changes to use the improved toggle logic. As an example of refactoring an ad hoc dropdown-like component, the `PostDate` block was updated to use the new hook for its date picker. There are various others like it that should receive similar treatment as they don't currently toggle properly even in UAs that **do** focus buttons when pressed. 

## Ongoing
If this approach gets a green light here are some things left to do:
* update remaining `Dropdown` implementors
* refactor any ad hoc toggle/popover components that have toggling issues to use the Toggler hook
* Documentation updates

## How has this been tested?
Manually in Chrome and Firefox on macOS by interacting with any of the dropdowns affected by the PR and many that are not. All is well so far.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix #29746 and new features 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
