### PR TITLE
Fix adding blocks on enter in the Widgets Customizer

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -75,6 +75,8 @@ function HeadingEdit( {
 
 					if ( isOriginal ) {
 						block.clientId = clientId;
+						// Skip sanitizing attributes if it's the original block,
+						// This allows us to keep the internal attributes untouched.
 						block.attributes = newAttributes;
 					}
 

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -60,6 +60,7 @@ function HeadingEdit( {
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
 				onSplit={ ( value, isOriginal ) => {
+					let block;
 					let newAttributes = {};
 
 					if ( isOriginal || value ) {
@@ -67,12 +68,10 @@ function HeadingEdit( {
 							...attributes,
 							content: value,
 						};
+						block = createBlock( 'core/heading', newAttributes );
+					} else {
+						block = createBlock( 'core/paragraph' );
 					}
-
-					const block = createBlock(
-						'core/paragraph',
-						newAttributes
-					);
 
 					if ( isOriginal ) {
 						block.clientId = clientId;

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -60,19 +60,23 @@ function HeadingEdit( {
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
 				onSplit={ ( value, isOriginal ) => {
-					let block;
+					let newAttributes = {};
 
 					if ( isOriginal || value ) {
-						block = createBlock( 'core/heading', {
+						newAttributes = {
 							...attributes,
 							content: value,
-						} );
-					} else {
-						block = createBlock( 'core/paragraph' );
+						};
 					}
+
+					const block = createBlock(
+						'core/paragraph',
+						newAttributes
+					);
 
 					if ( isOriginal ) {
 						block.clientId = clientId;
+						block.attributes = newAttributes;
 					}
 
 					return block;

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -119,6 +119,7 @@ function ParagraphBlock( {
 
 					if ( isOriginal ) {
 						block.clientId = clientId;
+						block.attributes = newAttributes;
 					}
 
 					return block;

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -119,6 +119,8 @@ function ParagraphBlock( {
 
 					if ( isOriginal ) {
 						block.clientId = clientId;
+						// Skip sanitizing attributes if it's the original block,
+						// This allows us to keep the internal attributes untouched.
 						block.attributes = newAttributes;
 					}
 

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -71,6 +71,8 @@ function ParagraphBlock( {
 
 					if ( isOriginal ) {
 						block.clientId = clientId;
+						// Skip sanitizing attributes if it's the original block,
+						// This allows us to keep the internal attributes untouched.
 						block.attributes = newAttributes;
 					}
 

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -71,6 +71,7 @@ function ParagraphBlock( {
 
 					if ( isOriginal ) {
 						block.clientId = clientId;
+						block.attributes = newAttributes;
 					}
 
 					return block;

--- a/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-adapter.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-adapter.js
@@ -76,15 +76,18 @@ export default class SidebarAdapter {
 		}
 
 		this.subscribers.add( callback );
-	}
 
-	unsubscribe( callback ) {
-		this.subscribers.delete( callback );
+		return () => {
+			this.subscribers.delete( callback );
 
-		if ( ! this.subscribers.size ) {
-			this.setting.unbind( this._handleSettingChange );
-			this.allSettings.unbind( 'change', this._handleAllSettingsChange );
-		}
+			if ( ! this.subscribers.size ) {
+				this.setting.unbind( this._handleSettingChange );
+				this.allSettings.unbind(
+					'change',
+					this._handleAllSettingsChange
+				);
+			}
+		};
 	}
 
 	getWidgets() {

--- a/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
@@ -110,6 +110,17 @@ export default function useSidebarBlockEditor( sidebar ) {
 		widgetsToBlocks( sidebar.getWidgets() )
 	);
 
+	// Get the blocks from the store and save it back to component's states once mounted.
+	// This is necessary since that after the first onChangeBlocks fired,
+	// all the blocks in the callback are transformed once via getBlocks internally.
+	// In order to only perform referential equality check in the callback,
+	// we have to make sure the references are the same between state and store.
+	useEffect( () => {
+		const storedBlocks = select( blockEditorStore ).getBlocks( null );
+
+		setBlocks( storedBlocks );
+	}, [] );
+
 	useEffect( () => {
 		return sidebar.subscribe( ( prevWidgets, nextWidgets ) => {
 			setBlocks( ( prevBlocks ) => {

--- a/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
@@ -110,17 +110,6 @@ export default function useSidebarBlockEditor( sidebar ) {
 		widgetsToBlocks( sidebar.getWidgets() )
 	);
 
-	// Get the blocks from the store and save it back to component's states once mounted.
-	// This is necessary since that after the first onChangeBlocks fired,
-	// all the blocks in the callback are transformed once via getBlocks internally.
-	// In order to only perform referential equality check in the callback,
-	// we have to make sure the references are the same between state and store.
-	useEffect( () => {
-		const storedBlocks = select( blockEditorStore ).getBlocks( null );
-
-		setBlocks( storedBlocks );
-	}, [] );
-
 	useEffect( () => {
 		return sidebar.subscribe( ( prevWidgets, nextWidgets ) => {
 			setBlocks( ( prevBlocks ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #30268. Best reviewed with ["Hide whitespace changes"](https://github.com/WordPress/gutenberg/pull/30399/files?diff=split&w=1) enabled.

Upon pressing <kbd>Enter</kbd> on some blocks, they internally call the `onSplit` callback, which split the current block into 2 blocks and recreated them from scratch via `createBlock`. `createBlock` by default sanitizes the attributes so our beloved `__internalWidgetId` attribute is then lost. The solution I came up is to reassign the `attributes` back to the created block, since the created block should already sanitized the attributes. This technique is already being used when reassigning `clientId` if the block is proved to be the original. Even so I'm not extremely happy with the solution and it feels a little bit repetitive and fragile, but I can't think of any other solutions now.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Enable the "Widget editor in Customizer" experiment flag
2. Go to Customize -> Widgets
3. Focus on an existing block
4. Hit <kbd>Enter</kbd>
5. It should create new default paragraph block

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/113084222-2999a800-9210-11eb-8970-dd26d7df3ce4.mp4

(_There are still serious performance issues need to be fixed, but not related to this PR._)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
