### PR TITLE
Block Library: Update placeholder text across blocks

### DIFF
--- a/packages/block-editor/src/components/caption/index.native.js
+++ b/packages/block-editor/src/components/caption/index.native.js
@@ -18,7 +18,7 @@ const Caption = ( {
 	onBlur,
 	onChange,
 	onFocus,
-	placeholder = __( 'Write caption…' ),
+	placeholder = __( 'Add caption' ),
 	placeholderTextColor,
 	shouldDisplay = true,
 	style,

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -188,7 +188,7 @@ function AudioEdit( {
 					<RichText
 						tagName="figcaption"
 						aria-label={ __( 'Audio caption text' ) }
-						placeholder={ __( 'Write caption…' ) }
+						placeholder={ __( 'Add caption' ) }
 						value={ caption }
 						onChange={ ( value ) =>
 							setAttributes( { caption: value } )

--- a/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
@@ -121,7 +121,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
           onResponderTerminationRequest={[Function]}
           onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-          placeholder="Write caption…"
+          placeholder="Add caption"
           placeholderTextColor="gray"
           style={
             Object {
@@ -291,7 +291,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
           onResponderTerminationRequest={[Function]}
           onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-          placeholder="Write caption…"
+          placeholder="Add caption"
           placeholderTextColor="gray"
           style={
             Object {

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -140,7 +140,7 @@ class EmbedPreview extends Component {
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
 						tagName="figcaption"
-						placeholder={ __( 'Write caption…' ) }
+						placeholder={ __( 'Add caption' ) }
 						value={ caption }
 						onChange={ onCaptionChange }
 						inlineToolbar

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -281,9 +281,7 @@ class GalleryImage extends Component {
 					<RichText
 						tagName="figcaption"
 						aria-label={ __( 'Image caption text' ) }
-						placeholder={
-							isSelected ? __( 'Write caption…' ) : null
-						}
+						placeholder={ isSelected ? __( 'Add caption' ) : null }
 						value={ caption }
 						isSelected={ this.state.captionSelected }
 						onChange={ ( newCaption ) =>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -287,9 +287,7 @@ class GalleryImage extends Component {
 									onChange={ this.onCaptionChange }
 									onFocus={ this.onSelectCaption }
 									placeholder={
-										isSelected
-											? __( 'Write caption…' )
-											: null
+										isSelected ? __( 'Add caption' ) : null
 									}
 									placeholderTextColor={
 										captionPlaceholderStyle.color

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -80,7 +80,7 @@ function HeadingEdit( {
 				onReplace={ onReplace }
 				onRemove={ () => onReplace( [] ) }
 				aria-label={ __( 'Heading text' ) }
-				placeholder={ placeholder || __( 'Write heading…' ) }
+				placeholder={ placeholder || __( 'Heading' ) }
 				textAlign={ textAlign }
 				{ ...blockProps }
 			/>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -560,7 +560,7 @@ export default function Image( {
 					ref={ captionRef }
 					tagName="figcaption"
 					aria-label={ __( 'Image caption text' ) }
-					placeholder={ __( 'Write caption…' ) }
+					placeholder={ __( 'Add caption' ) }
 					value={ caption }
 					unstableOnFocus={ onFocusCaption }
 					onChange={ ( value ) =>

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -155,7 +155,7 @@ export default function ListEdit( {
 				}
 				value={ values }
 				aria-label={ __( 'List text' ) }
-				placeholder={ __( 'Write list…' ) }
+				placeholder={ __( 'List' ) }
 				onMerge={ mergeBlocks }
 				onSplit={ ( value ) =>
 					createBlock( name, { ...attributes, values: value } )

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -127,7 +127,7 @@ function PullQuoteEdit( {
 						aria-label={ __( 'Pullquote text' ) }
 						placeholder={
 							// translators: placeholder text used for the quote
-							__( 'Write quote…' )
+							__( 'Add quote' )
 						}
 						textAlign="center"
 					/>
@@ -138,7 +138,7 @@ function PullQuoteEdit( {
 							aria-label={ __( 'Pullquote citation text' ) }
 							placeholder={
 								// translators: placeholder text used for the citation
-								__( 'Write citation…' )
+								__( 'Add citation' )
 							}
 							onChange={ ( nextCitation ) =>
 								setAttributes( {

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -65,7 +65,7 @@ export default function QuoteEdit( {
 					aria-label={ __( 'Quote text' ) }
 					placeholder={
 						// translators: placeholder text used for the quote
-						__( 'Write quote…' )
+						__( 'Add quote' )
 					}
 					onReplace={ onReplace }
 					onSplit={ ( piece ) =>
@@ -94,7 +94,7 @@ export default function QuoteEdit( {
 						aria-label={ __( 'Quote citation text' ) }
 						placeholder={
 							// translators: placeholder text used for the citation
-							__( 'Write citation…' )
+							__( 'Add citation' )
 						}
 						className="wp-block-quote__citation"
 						textAlign={ align }

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -528,7 +528,7 @@ function TableEdit( {
 				<RichText
 					tagName="figcaption"
 					aria-label={ __( 'Table caption text' ) }
-					placeholder={ __( 'Write caption…' ) }
+					placeholder={ __( 'Add caption' ) }
 					value={ caption }
 					onChange={ ( value ) =>
 						setAttributes( { caption: value } )

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -239,7 +239,7 @@ function VideoEdit( {
 					<RichText
 						tagName="figcaption"
 						aria-label={ __( 'Video caption text' ) }
-						placeholder={ __( 'Write caption…' ) }
+						placeholder={ __( 'Add caption' ) }
 						value={ caption }
 						onChange={ ( value ) =>
 							setAttributes( { caption: value } )


### PR DESCRIPTION
Related #29611 and #30393.

This change updates the placeholder rich-text fields we use across blocks to favor more concise wording and remove the trailing ellipsis. It works better alongside the new persistent placeholder text until the user types.

Placeholder states are an important part of onboarding users to blocks and should encourage clarity and guidance.