### PR TITLE
Block Library - Query: Use a WordPress loop for the query block

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -14,6 +14,10 @@
  * @return string Returns the filtered post content of the current post.
  */
 function render_block_core_post_content( $attributes, $content, $block ) {
+	if ( ! in_the_loop() ) {
+		the_post();
+	}
+
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -14,7 +14,6 @@
  * @return string Returns the filtered post content of the current post.
  */
 function render_block_core_post_content( $attributes, $content, $block ) {
-
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -14,12 +14,13 @@
  * @return string Returns the filtered post content of the current post.
  */
 function render_block_core_post_content( $attributes, $content, $block ) {
-	if ( ! in_the_loop() ) {
-		the_post();
-	}
 
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
+	}
+
+	if ( ! in_the_loop() ) {
+		the_post();
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -43,34 +43,34 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		}
 	}
 
-	if ( $query->have_posts() ) {
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+	if ( ! $query->have_posts() ) {
+		return '';
+	}
 
-		$content = '';
-		while ( $query->have_posts() ) :
-			$query->the_post();
-			$block_content = (
-				new WP_Block(
-					$block->parsed_block,
-					array(
-						'postType' => get_post_type(),
-						'postId'   => get_the_ID(),
-					)
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+
+	$content = '';
+	while ( $query->have_posts() ) {
+		$query->the_post();
+		$block_content = (
+			new WP_Block(
+				$block->parsed_block,
+				array(
+					'postType' => get_post_type(),
+					'postId'   => get_the_ID(),
 				)
-			)->render( array( 'dynamic' => false ) );
-			$content      .= "<li>{$block_content}</li>";
-		endwhile;
-
-		return sprintf(
-			'<ul %1$s>%2$s</ul>',
-			$wrapper_attributes,
-			$content
-		);
+			)
+		)->render( array( 'dynamic' => false ) );
+		$content      .= "<li>{$block_content}</li>";
 	}
 
 	wp_reset_postdata();
 
-	return '';
+	return sprintf(
+		'<ul %1$s>%2$s</ul>',
+		$wrapper_attributes,
+		$content
+	);
 }
 
 /**

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -47,7 +47,8 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
 
 		$content = '';
-		while ( $query->have_posts() ) : $query->the_post();
+		while ( $query->have_posts() ) :
+			$query->the_post();
 			$block_content = (
 				new WP_Block(
 					$block->parsed_block,

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -18,26 +18,23 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : filter_var( $_GET[ $page_key ], FILTER_VALIDATE_INT );
 
-	$query = construct_wp_query_args( $block, $page );
+	$query_args = construct_wp_query_args( $block, $page );
 	// Override the custom query with the global query if needed.
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {
 		global $wp_query;
 		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
 			// Unset `offset` because if is set, $wp_query overrides/ignores the paged parameter and breaks pagination.
-			unset( $query['offset'] );
-			$query = wp_parse_args( $wp_query->query_vars, $query );
+			unset( $query_args['offset'] );
+			$query_args = wp_parse_args( $wp_query->query_vars, $query_args );
 
-			if ( empty( $query['post_type'] ) && is_singular() ) {
-				$query['post_type'] = get_post_type( get_the_ID() );
+			if ( empty( $query_args['post_type'] ) && is_singular() ) {
+				$query_args['post_type'] = get_post_type( get_the_ID() );
 			}
 		}
 	}
 
-	$posts = get_posts( $query );
-	if ( empty( $posts ) ) {
-		return '';
-	}
+	$query = new WP_Query( $query_args );
 
 	$classnames = '';
 	if ( isset( $block->context['layout'] ) && isset( $block->context['query'] ) ) {
@@ -46,27 +43,33 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		}
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+	if ( $query->have_posts() ) {
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
 
-	$content = '';
-	foreach ( $posts as $post ) {
-		$block_content = (
-			new WP_Block(
-				$block->parsed_block,
-				array(
-					'postType' => $post->post_type,
-					'postId'   => $post->ID,
+		$content = '';
+		while ( $query->have_posts() ) : $query->the_post();
+			$block_content = (
+				new WP_Block(
+					$block->parsed_block,
+					array(
+						'postType' => get_post_type(),
+						'postId'   => get_the_ID(),
+					)
 				)
-			)
-		)->render( array( 'dynamic' => false ) );
-		$content      .= "<li>{$block_content}</li>";
+			)->render( array( 'dynamic' => false ) );
+			$content      .= "<li>{$block_content}</li>";
+		endwhile;
+
+		return sprintf(
+			'<ul %1$s>%2$s</ul>',
+			$wrapper_attributes,
+			$content
+		);
 	}
 
-	return sprintf(
-		'<ul %1$s>%2$s</ul>',
-		$wrapper_attributes,
-		$content
-	);
+	wp_reset_postdata();
+
+	return '';
 }
 
 /**

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -36,15 +36,15 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 
 	$query = new WP_Query( $query_args );
 
+	if ( ! $query->have_posts() ) {
+		return '';
+	}
+
 	$classnames = '';
 	if ( isset( $block->context['layout'] ) && isset( $block->context['query'] ) ) {
 		if ( isset( $block->context['layout']['type'] ) && 'flex' === $block->context['layout']['type'] ) {
 			$classnames = "is-flex-container columns-{$block->context['layout']['columns']}";
 		}
-	}
-
-	if ( ! $query->have_posts() ) {
-		return '';
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );


### PR DESCRIPTION
## Description
This PR changes the implementation of the query-loop block a bit.
Prior to this PR, we were running `get_posts()` to get the list of posts, and then ran these through a `foreach` loop.
With this PR, we are running a `WP_Query` and then the results of that go through a standard Loop (see [WP loop docs](https://developer.wordpress.org/themes/basics/the-loop/#creating-secondary-queries-and-loops) for details).

The benefit of this tweak is that now WordPress functions and hooks work as expected, without breaking backwards-compatibility.

## WooCommerce compatibility

This is not limited to WooCommerce, it applies to any and all plugins hooking in WP to change the way their templates are displayed. Until they transition to an FSE structure they need to remain functional, and with this PR they work.

## How has this been tested?

Tested with an FSE theme:
* Single posts using a template that had a query-loop and inside it the content.
* Single posts with no loop, just the content.
* Post categories
* WooCommerce product categories
* WooCommerce single product

In all cases the frontend was showing what was expected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

cc @ntsekouras 