### PR TITLE
Image block: Caption toolbar is not dismissed when cropping image in place 

### DIFF
--- a/packages/block-library/src/image/image-editing/cropper.js
+++ b/packages/block-library/src/image/image-editing/cropper.js
@@ -23,6 +23,7 @@ export default function ImageCropper( {
 	clientWidth,
 	naturalHeight,
 	naturalWidth,
+	onClick,
 } ) {
 	const {
 		isInProgress,
@@ -51,6 +52,7 @@ export default function ImageCropper( {
 				width: width || clientWidth,
 				height: editedHeight,
 			} }
+			onClick={ onClick }
 		>
 			<Cropper
 				image={ editedUrl || url }

--- a/packages/block-library/src/image/image-editing/cropper.js
+++ b/packages/block-library/src/image/image-editing/cropper.js
@@ -8,12 +8,12 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { MIN_ZOOM, MAX_ZOOM } from './constants';
-
 import { useImageEditingContext } from './context';
 
 export default function ImageCropper( {
@@ -53,6 +53,9 @@ export default function ImageCropper( {
 				height: editedHeight,
 			} }
 			onClick={ onClick }
+			onKeyDown={ onClick }
+			role="img"
+			aria-label={ __( 'Image editor cropping tool' ) }
 		>
 			<Cropper
 				image={ editedUrl || url }

--- a/packages/block-library/src/image/image-editing/cropper.js
+++ b/packages/block-library/src/image/image-editing/cropper.js
@@ -23,7 +23,6 @@ export default function ImageCropper( {
 	clientWidth,
 	naturalHeight,
 	naturalWidth,
-	onClick,
 } ) {
 	const {
 		isInProgress,
@@ -52,8 +51,6 @@ export default function ImageCropper( {
 				width: width || clientWidth,
 				height: editedHeight,
 			} }
-			onClick={ onClick }
-			onKeyDown={ onClick }
 			role="img"
 			aria-label={ __( 'Image editor cropping tool' ) }
 		>

--- a/packages/block-library/src/image/image-editing/index.js
+++ b/packages/block-library/src/image/image-editing/index.js
@@ -20,6 +20,7 @@ export default function ImageEditor( {
 	clientWidth,
 	naturalHeight,
 	naturalWidth,
+	onClick,
 } ) {
 	return (
 		<>
@@ -30,6 +31,7 @@ export default function ImageEditor( {
 				clientWidth={ clientWidth }
 				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
+				onClick={ onClick }
 			/>
 			<BlockControls>
 				<ToolbarGroup>

--- a/packages/block-library/src/image/image-editing/index.js
+++ b/packages/block-library/src/image/image-editing/index.js
@@ -20,7 +20,6 @@ export default function ImageEditor( {
 	clientWidth,
 	naturalHeight,
 	naturalWidth,
-	onClick,
 } ) {
 	return (
 		<>
@@ -31,7 +30,6 @@ export default function ImageEditor( {
 				clientWidth={ clientWidth }
 				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
-				onClick={ onClick }
 			/>
 			<BlockControls>
 				<ToolbarGroup>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -211,7 +211,6 @@ export default function Image( {
 
 	function onImageClick() {
 		if ( captionFocused ) {
-			captionRef.current.blur();
 			setCaptionFocused( false );
 		}
 	}
@@ -455,7 +454,6 @@ export default function Image( {
 				clientWidth={ clientWidth }
 				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
-				onClick={ onImageClick }
 			/>
 		);
 	} else if ( ! isResizable || ! imageWidthWithinContainer ) {
@@ -542,6 +540,13 @@ export default function Image( {
 		);
 	}
 
+	function onCaptionBlur() {
+		if ( captionFocused ) {
+			captionRef.current.blur();
+			setCaptionFocused( false );
+		}
+	}
+
 	return (
 		<ImageEditingProvider
 			id={ id }
@@ -559,6 +564,7 @@ export default function Image( {
 			{ img }
 			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 				<RichText
+					onBlur={ onCaptionBlur }
 					ref={ captionRef }
 					tagName="figcaption"
 					aria-label={ __( 'Image caption text' ) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -211,6 +211,7 @@ export default function Image( {
 
 	function onImageClick() {
 		if ( captionFocused ) {
+			captionRef.current.blur();
 			setCaptionFocused( false );
 		}
 	}
@@ -454,6 +455,7 @@ export default function Image( {
 				clientWidth={ clientWidth }
 				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
+				onClick={ onImageClick }
 			/>
 		);
 	} else if ( ! isResizable || ! imageWidthWithinContainer ) {


### PR DESCRIPTION
## Description

When editing an image caption, clicking on the image itself dismisses the caption toolbar. This is normal and expected.

However, when we click on the image's caption field while _cropping an image in place_, we can't dismiss the toolbar without cancelling image crop mode. 

Furthermore the caption field refuses to yield focus. 🤷 

This PR passes an `onBlur` handler down to the RichText package, and blurs the caption field when the field loses focus. 

This needs to be tested in conjunction with https://github.com/WordPress/gutenberg/pull/30587 as the RichText package doesn't currently handle an onBlur callback

We're also blurring away from the caption field when the caption field loses focus.

Resolves https://github.com/WordPress/gutenberg/issues/30334

Also remarked upon in https://github.com/WordPress/gutenberg/issues/23350#issuecomment-647741685

## How has this been tested?
Manually on desktop and a mobile emulator.

#### Testing

1. Check out this PR and also https://github.com/WordPress/gutenberg/pull/30587
2. Select an image in the editor
3. Click the crop button in the toolbar
4. Check that the caption toolbar is dismissed

The caption toolbar should now disappear and the caption field should lose focus. 

## Screenshots 

#### Before 
![Mar-31-2021 22-17-26](https://user-images.githubusercontent.com/6458278/113136410-0c47f680-926f-11eb-9558-a9e9220db3d3.gif)


#### After
![Mar-31-2021 22-13-47](https://user-images.githubusercontent.com/6458278/113136839-8e381f80-926f-11eb-867e-0d8779e39719.gif)


## Types of changes
This is a minor bugfix for an existing block (image).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
