### PR TITLE
Template Part: Add a theme slug to nested template parts

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -137,6 +137,19 @@ function _gutenberg_add_template_part_area_info( $template_info ) {
 	return $template_info;
 }
 
+function get_inner_blocks_recursive( $blocks, $result = array() ) {
+	global $result;
+	foreach ( $blocks as $key => $block ) {
+		if ( $block['innerBlocks'] ) {
+			get_inner_blocks_recursive( $block['innerBlocks'], $result );
+		} else {
+			$result[] = $block;
+		}
+	}
+
+	return $result;
+}
+
 /**
  * Parses wp_template content and injects the current theme's
  * stylesheet as a theme attribute into each wp_template_part
@@ -148,9 +161,11 @@ function _gutenberg_add_template_part_area_info( $template_info ) {
 function _inject_theme_attribute_in_content( $template_content ) {
 	$has_updated_content = false;
 	$new_content         = '';
-	$template_blocks     = parse_blocks( $template_content );
+	$top_level_template_blocks = parse_blocks( $template_content );
+	$template_blocks = get_inner_blocks_recursive( $top_level_template_blocks );
 
 	foreach ( $template_blocks as $key => $block ) {
+
 		if (
 			'core/template-part' === $block['blockName'] &&
 			! isset( $block['attrs']['theme'] )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix for https://github.com/WordPress/gutenberg/issues/28814

In order to add the theme slug to all the blocks we need to parse the inner blocks as well as the top level ones.

I don't think is the nicest way to do it, but hopefully it gives a good starting point for others to iterate on.

## How has this been tested?
Using Mayland Blocks: https://github.com/Automattic/themes/pull/3592


## Types of changes
Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
