### PR TITLE
Site Editor: Run inject and remove theme attribute recursively

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -152,8 +152,8 @@ function _flatten_blocks( &$blocks ) {
 		$queue[] = &$block;
 	}
 
-	while ( count($queue) > 0 ) {
-		$block        = &$queue[ 0 ];
+	while ( count( $queue ) > 0 ) {
+		$block = &$queue[0];
 		array_shift( $queue );
 		$all_blocks[] = &$block;
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -145,7 +145,7 @@ function _gutenberg_add_template_part_area_info( $template_info ) {
  *
  * @return array block references to the passed blocks and their inner blocks.
  */
-function _get_blocks_recursive( &$blocks ) {
+function _flatten_blocks( &$blocks ) {
 	$all_blocks = array();
 	$queue      = array();
 	foreach ( $blocks as &$block ) {
@@ -179,7 +179,7 @@ function _inject_theme_attribute_in_content( $template_content ) {
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );
 
-	$blocks = _get_blocks_recursive( $template_blocks );
+	$blocks = _flatten_blocks( $template_blocks );
 	foreach ( $blocks as &$block ) {
 		if (
 			'core/template-part' === $block['blockName'] &&

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -138,6 +138,35 @@ function _gutenberg_add_template_part_area_info( $template_info ) {
 }
 
 /**
+ * Returns an array containing the references of
+ * the passed blocks and their inner blocks.
+ *
+ * @param array $blocks array of blocks.
+ *
+ * @return array block references to the passed blocks and their inner blocks.
+ */
+function _get_blocks_recursive( &$blocks ) {
+	$all_blocks = array();
+	$queue      = array();
+	foreach ( $blocks as &$block ) {
+		$queue[] = &$block;
+	}
+
+	for ( $i = 0; $i < count( $queue ); $i++ ) {
+		$block        = &$queue[ $i ];
+		$all_blocks[] = &$block;
+
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			foreach ( $block['innerBlocks'] as &$inner_block ) {
+				$queue[] = &$inner_block;
+			}
+		}
+	}
+
+	return $all_blocks;
+}
+
+/**
  * Parses wp_template content and injects the current theme's
  * stylesheet as a theme attribute into each wp_template_part
  *
@@ -150,18 +179,19 @@ function _inject_theme_attribute_in_content( $template_content ) {
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );
 
-	foreach ( $template_blocks as $key => $block ) {
+	$blocks = _get_blocks_recursive( $template_blocks );
+	foreach ( $blocks as &$block ) {
 		if (
 			'core/template-part' === $block['blockName'] &&
 			! isset( $block['attrs']['theme'] )
 		) {
-			$template_blocks[ $key ]['attrs']['theme'] = wp_get_theme()->get_stylesheet();
-			$has_updated_content                       = true;
+			$block['attrs']['theme'] = wp_get_theme()->get_stylesheet();
+			$has_updated_content     = true;
 		}
 	}
 
 	if ( $has_updated_content ) {
-		foreach ( $template_blocks as $block ) {
+		foreach ( $template_blocks as &$block ) {
 			$new_content .= serialize_block( $block );
 		}
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -152,8 +152,9 @@ function _flatten_blocks( &$blocks ) {
 		$queue[] = &$block;
 	}
 
-	for ( $i = 0; $i < count( $queue ); $i++ ) {
-		$block        = &$queue[ $i ];
+	while ( count($queue) > 0 ) {
+		$block        = &$queue[ 0 ];
+		array_shift( $queue );
 		$all_blocks[] = &$block;
 
 		if ( ! empty( $block['innerBlocks'] ) ) {

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -18,9 +18,10 @@ function _remove_theme_attribute_from_content( $template_content ) {
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );
 
-	foreach ( $template_blocks as $key => $block ) {
+	$blocks = _get_blocks_recursive( $template_blocks );
+	foreach ( $blocks as $key => $block ) {
 		if ( 'core/template-part' === $block['blockName'] && isset( $block['attrs']['theme'] ) ) {
-			unset( $template_blocks[ $key ]['attrs']['theme'] );
+			unset( $blocks[ $key ]['attrs']['theme'] );
 			$has_updated_content = true;
 		}
 	}

--- a/lib/full-site-editing/edit-site-export.php
+++ b/lib/full-site-editing/edit-site-export.php
@@ -18,7 +18,7 @@ function _remove_theme_attribute_from_content( $template_content ) {
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );
 
-	$blocks = _get_blocks_recursive( $template_blocks );
+	$blocks = _flatten_blocks( $template_blocks );
 	foreach ( $blocks as $key => $block ) {
 		if ( 'core/template-part' === $block['blockName'] && isset( $block['attrs']['theme'] ) ) {
 			unset( $blocks[ $key ]['attrs']['theme'] );

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -60,7 +60,7 @@ function render_block_core_template_part( $attributes ) {
 			// render the corresponding file content.
 			$template_part_file_path = get_stylesheet_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
 			if ( 0 === validate_file( $attributes['slug'] ) && file_exists( $template_part_file_path ) ) {
-				$content = file_get_contents( $template_part_file_path );
+				$content = _inject_theme_attribute_in_content( file_get_contents( $template_part_file_path ) );
 			}
 		}
 	}

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -284,22 +284,22 @@ class Block_Templates_Test extends WP_UnitTestCase {
 	 * Should flatten nested blocks
 	 */
 	function test_flatten_blocks() {
-		$content_template_part_inside_group  = '<!-- wp:group --><!-- wp:template-part {"slug":"header"} /--><!-- /wp:group -->';
-		$blocks   = parse_blocks( $content_template_part_inside_group );
-		$actual   = _flatten_blocks( $blocks );
-		$expected = array( $blocks[0], $blocks[0]['innerBlocks'][0] );
+		$content_template_part_inside_group = '<!-- wp:group --><!-- wp:template-part {"slug":"header"} /--><!-- /wp:group -->';
+		$blocks                             = parse_blocks( $content_template_part_inside_group );
+		$actual                             = _flatten_blocks( $blocks );
+		$expected                           = array( $blocks[0], $blocks[0]['innerBlocks'][0] );
 		$this->assertEquals( $expected, $actual );
 
-		$content_template_part_inside_group_inside_group  = '<!-- wp:group --><!-- wp:group --><!-- wp:template-part {"slug":"header"} /--><!-- /wp:group --><!-- /wp:group -->';
+		$content_template_part_inside_group_inside_group = '<!-- wp:group --><!-- wp:group --><!-- wp:template-part {"slug":"header"} /--><!-- /wp:group --><!-- /wp:group -->';
 		$blocks   = parse_blocks( $content_template_part_inside_group_inside_group );
 		$actual   = _flatten_blocks( $blocks );
 		$expected = array( $blocks[0], $blocks[0]['innerBlocks'][0], $blocks[0]['innerBlocks'][0]['innerBlocks'][0] );
 		$this->assertEquals( $expected, $actual );
 
-		$content_without_inner_blocks  = '<!-- wp:group /-->';
-		$blocks   = parse_blocks( $content_without_inner_blocks );
-		$actual   = _flatten_blocks( $blocks );
-		$expected = array( $blocks[0] );
+		$content_without_inner_blocks = '<!-- wp:group /-->';
+		$blocks                       = parse_blocks( $content_without_inner_blocks );
+		$actual                       = _flatten_blocks( $blocks );
+		$expected                     = array( $blocks[0] );
 		$this->assertEquals( $expected, $actual );
 	}
 }

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -284,20 +284,20 @@ class Block_Templates_Test extends WP_UnitTestCase {
 	 * Should flatten nested blocks
 	 */
 	function test_flatten_blocks() {
-		$content  = '<!-- wp:group --><!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /--><!-- /wp:group -->';
-		$blocks   = parse_blocks( $content );
+		$content_template_part_inside_group  = '<!-- wp:group --><!-- wp:template-part {"slug":"header"} /--><!-- /wp:group -->';
+		$blocks   = parse_blocks( $content_template_part_inside_group );
 		$actual   = _flatten_blocks( $blocks );
 		$expected = array( $blocks[0], $blocks[0]['innerBlocks'][0] );
 		$this->assertEquals( $expected, $actual );
 
-		$content  = '<!-- wp:group --><!-- wp:group --><!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /--><!-- /wp:group --><!-- /wp:group -->';
-		$blocks   = parse_blocks( $content );
+		$content_template_part_inside_group_inside_group  = '<!-- wp:group --><!-- wp:group --><!-- wp:template-part {"slug":"header"} /--><!-- /wp:group --><!-- /wp:group -->';
+		$blocks   = parse_blocks( $content_template_part_inside_group_inside_group );
 		$actual   = _flatten_blocks( $blocks );
 		$expected = array( $blocks[0], $blocks[0]['innerBlocks'][0], $blocks[0]['innerBlocks'][0]['innerBlocks'][0] );
 		$this->assertEquals( $expected, $actual );
 
-		$content  = '<!-- wp:group /-->';
-		$blocks   = parse_blocks( $content );
+		$content_without_inner_blocks  = '<!-- wp:group /-->';
+		$blocks   = parse_blocks( $content_without_inner_blocks );
 		$actual   = _flatten_blocks( $blocks );
 		$expected = array( $blocks[0] );
 		$this->assertEquals( $expected, $actual );

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -279,4 +279,27 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		// TODO - update following array result once tt1-blocks theme.json is updated for area info.
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template_part' ), $template_ids );
 	}
+
+	/**
+	 * Should flatten nested blocks
+	 */
+	function test_flatten_blocks() {
+		$content  = '<!-- wp:group --><!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /--><!-- /wp:group -->';
+		$blocks   = parse_blocks( $content );
+		$actual   = _flatten_blocks( $blocks );
+		$expected = array( $blocks[0], $blocks[0]['innerBlocks'][0] );
+		$this->assertEquals( $expected, $actual );
+
+		$content  = '<!-- wp:group --><!-- wp:group --><!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /--><!-- /wp:group --><!-- /wp:group -->';
+		$blocks   = parse_blocks( $content );
+		$actual   = _flatten_blocks( $blocks );
+		$expected = array( $blocks[0], $blocks[0]['innerBlocks'][0], $blocks[0]['innerBlocks'][0]['innerBlocks'][0] );
+		$this->assertEquals( $expected, $actual );
+
+		$content  = '<!-- wp:group /-->';
+		$blocks   = parse_blocks( $content );
+		$actual   = _flatten_blocks( $blocks );
+		$expected = array( $blocks[0] );
+		$this->assertEquals( $expected, $actual );
+	}
 }

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -163,6 +163,17 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals( $expected, $template_content );
 
+		$content_without_theme_attribute_nested = '<!-- wp:group --><!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /--><!-- /wp:group -->';
+		$template_content                       = _inject_theme_attribute_in_content(
+			$content_without_theme_attribute_nested,
+			$theme
+		);
+		$expected                               = sprintf(
+			'<!-- wp:group --><!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /--><!-- /wp:group -->',
+			get_stylesheet()
+		);
+		$this->assertEquals( $expected, $template_content );
+
 		// Does not inject theme when there is an existing theme attribute.
 		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->';
 		$template_content                      = _inject_theme_attribute_in_content(

--- a/phpunit/class-edit-site-export-test.php
+++ b/phpunit/class-edit-site-export-test.php
@@ -7,15 +7,20 @@
 
 class Edit_Site_Export_Test extends WP_UnitTestCase {
 	function test_remove_theme_attribute_from_content() {
-		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full","tagName":"header","className":"site-header"} /-->';
-		$template_content                = _remove_theme_attribute_from_content( $content_without_theme_attribute );
-		$expected                        = '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->';
+		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full","tagName":"header","className":"site-header"} /-->';
+		$template_content                      = _remove_theme_attribute_from_content( $content_with_existing_theme_attribute );
+		$expected                              = '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->';
+		$this->assertEquals( $expected, $template_content );
+
+		$content_with_existing_theme_attribute_nested = '<!-- wp:group --><!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full","tagName":"header","className":"site-header"} /--><!-- /wp:group -->';
+		$template_content                             = _remove_theme_attribute_from_content( $content_with_existing_theme_attribute_nested );
+		$expected                                     = '<!-- wp:group --><!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /--><!-- /wp:group -->';
 		$this->assertEquals( $expected, $template_content );
 
 		// Does not modify content when there is no existing theme attribute.
-		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->';
-		$template_content                      = _remove_theme_attribute_from_content( $content_with_existing_theme_attribute );
-		$this->assertEquals( $content_with_existing_theme_attribute, $template_content );
+		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->';
+		$template_content                = _remove_theme_attribute_from_content( $content_without_theme_attribute );
+		$this->assertEquals( $content_without_theme_attribute, $template_content );
 
 		// Does not remove theme when there is no template part.
 		$content_with_no_template_part = '<!-- wp:post-content /-->';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

Fixes #28814 

## Description
`_inject_theme_attribute_in_content` and `_remove_theme_attribute_from_content` didn't take nested template parts into account. This PR adjusts these functions to walk through all the nested blocks as well.

## How has this been tested?
You can use the following block template theme file:

```html
<!-- wp:group -->
<div class="wp-block-group">
  <!-- wp:group -->
  <div class="wp-block-group">
    <!-- wp:group -->
    <div class="wp-block-group">
      <!-- wp:group -->
      <div class="wp-block-group">
        <!-- wp:group -->
        <div class="wp-block-group">
          <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->
        </div>
        <!-- /wp:group -->
      </div>
      <!-- /wp:group -->
    </div>
    <!-- /wp:group -->
  </div>
  <!-- /wp:group -->
</div>
<!-- /wp:group -->
```

1. Open wp-admin
2. Enable a theme that you have access to
3. Add the template above to `block-templates` directory
4. Open site editor
5. Open the template you created/modified in step 3
6. Make sure template part loads


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
