### PR TITLE
Gutenberg Plugin: Remove deprecations planned for 10.3 release

### DIFF
--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Passing a tuple of components with `as` prop to `ActionItem.Slot` component is no longer supported. Please pass a component with `as` prop instead ([#30417](https://github.com/WordPress/gutenberg/pull/30417)).
+
 ## 1.1.0 (2021-03-17)
 
 ### Deprecations

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { isArray, isEmpty, noop } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { ButtonGroup, Button, Slot, Fill } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 import { Children } from '@wordpress/element';
 
 function ActionItemSlot( {
@@ -17,18 +16,6 @@ function ActionItemSlot( {
 	bubblesVirtually,
 	...props
 } ) {
-	if ( isArray( Component ) ) {
-		deprecated(
-			'Passing a tuple of components with `as` prop to `ActionItem.Slot` component',
-			{
-				since: '10.2',
-				plugin: 'Gutenberg',
-				alternative: 'a component with `as` prop',
-				version: '10.3',
-			}
-		);
-		Component = Component[ 0 ];
-	}
 	return (
 		<Slot
 			name={ name }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR removes deprecations planned for the plugin release v10.3. It will fix failing CI workflows that perform checks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
