### PR TITLE
i18n: Add `resetLocaleData` method

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add new `resetLocaleData` method to reset the existing Tannin locale data.
+
 ## 3.19.0 (2021-03-17)
 
 ### Enhancements

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add new argument to `setLocaleData` to specify whether the locale data should be merged with or replace the existing data for the text domain.
+
 ## 3.19.0 (2021-03-17)
 
 ### Enhancements

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- Add new argument to `setLocaleData` to specify whether the locale data should be merged with or replace the existing data for the text domain.
-
 ## 3.19.0 (2021-03-17)
 
 ### Enhancements

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -88,6 +88,20 @@ _Returns_
 
 -   `boolean`: Whether locale is RTL.
 
+<a name="resetLocaleData" href="#resetLocaleData">#</a> **resetLocaleData**
+
+Resets all current Tannin instance locale data and sets the specified
+locale data for the domain. Accepts data in a Jed-formatted JSON object shape.
+
+_Related_
+
+-   <http://messageformat.github.io/Jed/>
+
+_Parameters_
+
+-   _data_ `[LocaleData]`: Locale data configuration.
+-   _domain_ `[string]`: Domain for which configuration applies.
+
 <a name="setLocaleData" href="#setLocaleData">#</a> **setLocaleData**
 
 Merges locale data into the Tannin instance by domain. Accepts data in a

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -101,6 +101,7 @@ _Parameters_
 
 -   _data_ `[LocaleData]`: Locale data configuration.
 -   _domain_ `[string]`: Domain for which configuration applies.
+-   _shouldMerge_ `[boolean]`: Whether the locale data should be merged with or replace the existing locale data for the text domain.
 
 <a name="sprintf" href="#sprintf">#</a> **sprintf**
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -101,7 +101,6 @@ _Parameters_
 
 -   _data_ `[LocaleData]`: Locale data configuration.
 -   _domain_ `[string]`: Domain for which configuration applies.
--   _shouldMerge_ `[boolean]`: Whether the locale data should be merged with or replace the existing locale data for the text domain.
 
 <a name="sprintf" href="#sprintf">#</a> **sprintf**
 

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -44,6 +44,14 @@ const I18N_HOOK_REGEXP = /^i18n\.(n?gettext|has_translation)(_|$)/;
  *
  * @see http://messageformat.github.io/Jed/
  */
+/**
+ * @typedef {(data?: LocaleData, domain?: string) => void} ResetLocaleData
+ *
+ * Resets all current Tannin instance locale data and sets the specified
+ * locale data for the domain. Accepts data in a Jed-formatted JSON object shape.
+ *
+ * @see http://messageformat.github.io/Jed/
+ */
 /** @typedef {() => void} SubscribeCallback */
 /** @typedef {() => void} UnsubscribeCallback */
 /**
@@ -106,18 +114,20 @@ const I18N_HOOK_REGEXP = /^i18n\.(n?gettext|has_translation)(_|$)/;
  * An i18n instance
  *
  * @typedef I18n
- * @property {GetLocaleData} getLocaleData Returns locale data by domain in a Jed-formatted JSON object shape.
- * @property {SetLocaleData} setLocaleData Merges locale data into the Tannin instance by domain. Accepts data in a
- *                                         Jed-formatted JSON object shape.
- * @property {Subscribe} subscribe         Subscribes to changes of Tannin locale data.
- * @property {__} __                       Retrieve the translation of text.
- * @property {_x} _x                       Retrieve translated string with gettext context.
- * @property {_n} _n                       Translates and retrieves the singular or plural form based on the supplied
- *                                         number.
- * @property {_nx} _nx                     Translates and retrieves the singular or plural form based on the supplied
- *                                         number, with gettext context.
- * @property {IsRtl} isRTL                 Check if current locale is RTL.
- * @property {HasTranslation} hasTranslation Check if there is a translation for a given string.
+ * @property {GetLocaleData} getLocaleData     Returns locale data by domain in a Jed-formatted JSON object shape.
+ * @property {SetLocaleData} setLocaleData     Merges locale data into the Tannin instance by domain. Accepts data in a
+ *                                             Jed-formatted JSON object shape.
+ * @property {ResetLocaleData} resetLocaleData Resets all current Tannin instance locale data and sets the specified
+ *                                             locale data for the domain. Accepts data in a Jed-formatted JSON object shape.
+ * @property {Subscribe} subscribe             Subscribes to changes of Tannin locale data.
+ * @property {__} __                           Retrieve the translation of text.
+ * @property {_x} _x                           Retrieve translated string with gettext context.
+ * @property {_n} _n                           Translates and retrieves the singular or plural form based on the supplied
+ *                                             number.
+ * @property {_nx} _nx                         Translates and retrieves the singular or plural form based on the supplied
+ *                                             number, with gettext context.
+ * @property {IsRtl} isRTL                     Check if current locale is RTL.
+ * @property {HasTranslation} hasTranslation   Check if there is a translation for a given string.
  */
 
 /**
@@ -179,6 +189,14 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 	const setLocaleData = ( data, domain ) => {
 		doSetLocaleData( data, domain );
 		notifyListeners();
+	};
+
+	/** @type {SetLocaleData} */
+	const resetLocaleData = ( data, domain ) => {
+		// Reset all current Tannin locale data .
+		tannin.data = {};
+
+		setLocaleData( data, domain );
 	};
 
 	/**
@@ -435,6 +453,7 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 	return {
 		getLocaleData,
 		setLocaleData,
+		resetLocaleData,
 		subscribe,
 		__,
 		_x,

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -37,7 +37,7 @@ const I18N_HOOK_REGEXP = /^i18n\.(n?gettext|has_translation)(_|$)/;
  * @see http://messageformat.github.io/Jed/
  */
 /**
- * @typedef {(data?: LocaleData, domain?: string) => void} SetLocaleData
+ * @typedef {(data?: LocaleData, domain?: string, shouldMerge?: boolean) => void} SetLocaleData
  *
  * Merges locale data into the Tannin instance by domain. Accepts data in a
  * Jed-formatted JSON object shape.
@@ -158,9 +158,19 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 
 	/**
 	 * @param {LocaleData} [data]
-	 * @param {string} [domain]
+	 * @param {string}     [domain]
+	 * @param {boolean}    [shouldMerge]
 	 */
-	const doSetLocaleData = ( data, domain = 'default' ) => {
+	const doSetLocaleData = (
+		data,
+		domain = 'default',
+		shouldMerge = true
+	) => {
+		if ( ! shouldMerge ) {
+			// Remove the existing locale data for the specified domain.
+			delete tannin.data[ domain ];
+		}
+
 		tannin.data[ domain ] = {
 			...DEFAULT_LOCALE_DATA,
 			...tannin.data[ domain ],
@@ -176,8 +186,8 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 	};
 
 	/** @type {SetLocaleData} */
-	const setLocaleData = ( data, domain ) => {
-		doSetLocaleData( data, domain );
+	const setLocaleData = ( data, domain, shouldMerge ) => {
+		doSetLocaleData( data, domain, shouldMerge );
 		notifyListeners();
 	};
 
@@ -415,7 +425,7 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 	};
 
 	if ( initialData ) {
-		setLocaleData( initialData, initialDomain );
+		setLocaleData( initialData, initialDomain, true );
 	}
 
 	if ( hooks ) {

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -193,8 +193,11 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 
 	/** @type {ResetLocaleData} */
 	const resetLocaleData = ( data, domain ) => {
-		// Reset all current Tannin locale data .
+		// Reset all current Tannin locale data.
 		tannin.data = {};
+
+		// Reset cached plural forms functions cache.
+		tannin.pluralForms = {};
 
 		setLocaleData( data, domain );
 	};

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -37,7 +37,7 @@ const I18N_HOOK_REGEXP = /^i18n\.(n?gettext|has_translation)(_|$)/;
  * @see http://messageformat.github.io/Jed/
  */
 /**
- * @typedef {(data?: LocaleData, domain?: string, shouldMerge?: boolean) => void} SetLocaleData
+ * @typedef {(data?: LocaleData, domain?: string) => void} SetLocaleData
  *
  * Merges locale data into the Tannin instance by domain. Accepts data in a
  * Jed-formatted JSON object shape.
@@ -158,19 +158,9 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 
 	/**
 	 * @param {LocaleData} [data]
-	 * @param {string}     [domain]
-	 * @param {boolean}    [shouldMerge]
+	 * @param {string} [domain]
 	 */
-	const doSetLocaleData = (
-		data,
-		domain = 'default',
-		shouldMerge = true
-	) => {
-		if ( ! shouldMerge ) {
-			// Remove the existing locale data for the specified domain.
-			delete tannin.data[ domain ];
-		}
-
+	const doSetLocaleData = ( data, domain = 'default' ) => {
 		tannin.data[ domain ] = {
 			...DEFAULT_LOCALE_DATA,
 			...tannin.data[ domain ],
@@ -186,8 +176,8 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 	};
 
 	/** @type {SetLocaleData} */
-	const setLocaleData = ( data, domain, shouldMerge ) => {
-		doSetLocaleData( data, domain, shouldMerge );
+	const setLocaleData = ( data, domain ) => {
+		doSetLocaleData( data, domain );
 		notifyListeners();
 	};
 
@@ -425,7 +415,7 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 	};
 
 	if ( initialData ) {
-		setLocaleData( initialData, initialDomain, true );
+		setLocaleData( initialData, initialDomain );
 	}
 
 	if ( hooks ) {

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -191,7 +191,7 @@ export const createI18n = ( initialData, initialDomain, hooks ) => {
 		notifyListeners();
 	};
 
-	/** @type {SetLocaleData} */
+	/** @type {ResetLocaleData} */
 	const resetLocaleData = ( data, domain ) => {
 		// Reset all current Tannin locale data .
 		tannin.data = {};

--- a/packages/i18n/src/default-i18n.js
+++ b/packages/i18n/src/default-i18n.js
@@ -48,6 +48,17 @@ export const getLocaleData = i18n.getLocaleData.bind( i18n );
 export const setLocaleData = i18n.setLocaleData.bind( i18n );
 
 /**
+ * Resets all current Tannin instance locale data and sets the specified
+ * locale data for the domain. Accepts data in a Jed-formatted JSON object shape.
+ *
+ * @see http://messageformat.github.io/Jed/
+ *
+ * @param {LocaleData} [data]   Locale data configuration.
+ * @param {string}     [domain] Domain for which configuration applies.
+ */
+export const resetLocaleData = i18n.resetLocaleData.bind( i18n );
+
+/**
  * Subscribes to changes of locale data
  *
  * @param {SubscribeCallback} callback Subscription callback

--- a/packages/i18n/src/default-i18n.js
+++ b/packages/i18n/src/default-i18n.js
@@ -42,8 +42,9 @@ export const getLocaleData = i18n.getLocaleData.bind( i18n );
  *
  * @see http://messageformat.github.io/Jed/
  *
- * @param {LocaleData} [data]   Locale data configuration.
- * @param {string}     [domain] Domain for which configuration applies.
+ * @param {LocaleData} [data]        Locale data configuration.
+ * @param {string}     [domain]      Domain for which configuration applies.
+ * @param {boolean}    [shouldMerge] Whether the locale data should be merged with or replace the existing locale data for the text domain.
  */
 export const setLocaleData = i18n.setLocaleData.bind( i18n );
 

--- a/packages/i18n/src/default-i18n.js
+++ b/packages/i18n/src/default-i18n.js
@@ -42,9 +42,8 @@ export const getLocaleData = i18n.getLocaleData.bind( i18n );
  *
  * @see http://messageformat.github.io/Jed/
  *
- * @param {LocaleData} [data]        Locale data configuration.
- * @param {string}     [domain]      Domain for which configuration applies.
- * @param {boolean}    [shouldMerge] Whether the locale data should be merged with or replace the existing locale data for the text domain.
+ * @param {LocaleData} [data]   Locale data configuration.
+ * @param {string}     [domain] Domain for which configuration applies.
  */
 export const setLocaleData = i18n.setLocaleData.bind( i18n );
 

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -3,6 +3,7 @@ export * from './create-i18n';
 export {
 	default as defaultI18n,
 	setLocaleData,
+	resetLocaleData,
 	getLocaleData,
 	subscribe,
 	__,

--- a/packages/i18n/src/test/create-i18n.js
+++ b/packages/i18n/src/test/create-i18n.js
@@ -139,44 +139,6 @@ describe( 'createI18n', () => {
 	} );
 
 	describe( 'setLocaleData', () => {
-		it( 'merge the new and the existing locale data as a default behavior', () => {
-			const locale = createTestLocale();
-			locale.setLocaleData(
-				{ 'new string': [ 'new string translated' ] },
-				'test_domain'
-			);
-			expect( locale.__( 'new string', 'test_domain' ) ).toBe(
-				'new string translated'
-			);
-			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'bonjour' );
-		} );
-
-		it( 'replace the existing locale data for the specified text domain', () => {
-			const locale = createTestLocale();
-			locale.setLocaleData( additionalLocaleData, 'test_domain2' );
-
-			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'bonjour' );
-			expect( locale.__( 'cheeseburger', 'test_domain2' ) ).toBe(
-				'hamburger au fromage'
-			);
-
-			locale.setLocaleData(
-				{
-					'new string': [ 'new string translated' ],
-				},
-				'test_domain',
-				false
-			);
-
-			expect( locale.__( 'new string', 'test_domain' ) ).toBe(
-				'new string translated'
-			);
-			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'hello' );
-			expect( locale.__( 'cheeseburger', 'test_domain2' ) ).toBe(
-				'hamburger au fromage'
-			);
-		} );
-
 		it( 'supports omitted plural forms expression', () => {
 			const locale = createTestLocaleWithAdditionalData();
 			locale.setLocaleData(

--- a/packages/i18n/src/test/create-i18n.js
+++ b/packages/i18n/src/test/create-i18n.js
@@ -139,6 +139,44 @@ describe( 'createI18n', () => {
 	} );
 
 	describe( 'setLocaleData', () => {
+		it( 'merge the new and the existing locale data as a default behavior', () => {
+			const locale = createTestLocale();
+			locale.setLocaleData(
+				{ 'new string': [ 'new string translated' ] },
+				'test_domain'
+			);
+			expect( locale.__( 'new string', 'test_domain' ) ).toBe(
+				'new string translated'
+			);
+			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'bonjour' );
+		} );
+
+		it( 'replace the existing locale data for the specified text domain', () => {
+			const locale = createTestLocale();
+			locale.setLocaleData( additionalLocaleData, 'test_domain2' );
+
+			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'bonjour' );
+			expect( locale.__( 'cheeseburger', 'test_domain2' ) ).toBe(
+				'hamburger au fromage'
+			);
+
+			locale.setLocaleData(
+				{
+					'new string': [ 'new string translated' ],
+				},
+				'test_domain',
+				false
+			);
+
+			expect( locale.__( 'new string', 'test_domain' ) ).toBe(
+				'new string translated'
+			);
+			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'hello' );
+			expect( locale.__( 'cheeseburger', 'test_domain2' ) ).toBe(
+				'hamburger au fromage'
+			);
+		} );
+
 		it( 'supports omitted plural forms expression', () => {
 			const locale = createTestLocaleWithAdditionalData();
 			locale.setLocaleData(

--- a/packages/i18n/src/test/create-i18n.js
+++ b/packages/i18n/src/test/create-i18n.js
@@ -216,6 +216,63 @@ describe( 'createI18n', () => {
 			locale.resetLocaleData( additionalLocaleData, 'test_domain2' );
 			expect( locale.__( '%d cat', 'test_domain2' ) ).toBe( '%d chat' );
 		} );
+
+		it( 'reset the plural forms function cache', () => {
+			const locale = createI18n( {}, 'test_domain' );
+
+			// Call `_n` to get the plural forms function cached.
+			locale._n( 'singular', 'plural', 1, 'test_domain' );
+
+			// Reset the locale data and provide custom plural forms function.
+			locale.resetLocaleData(
+				{
+					'': {
+						domain: 'test_domain',
+						lang: 'aa',
+						plural_forms:
+							'nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;',
+					},
+					singular: [
+						'translated',
+						'translated_plural_1',
+						'translated_plural_2',
+					],
+				},
+				'test_domain'
+			);
+
+			expect( locale._n( 'singular', 'plural', 1, 'test_domain' ) ).toBe(
+				'translated'
+			);
+			expect( locale._n( 'singular', 'plural', 2, 'test_domain' ) ).toBe(
+				'translated_plural_1'
+			);
+			expect( locale._n( 'singular', 'plural', 3, 'test_domain' ) ).toBe(
+				'translated_plural_2'
+			);
+
+			// Reset the locale data and fallback to the defualt plural forms function.
+			locale.resetLocaleData(
+				{
+					singular: [
+						'translated',
+						'translated_plural_1',
+						'translated_plural_2',
+					],
+				},
+				'test_domain'
+			);
+
+			expect( locale._n( 'singular', 'plural', 1, 'test_domain' ) ).toBe(
+				'translated'
+			);
+			expect( locale._n( 'singular', 'plural', 2, 'test_domain' ) ).toBe(
+				'translated_plural_1'
+			);
+			expect( locale._n( 'singular', 'plural', 3, 'test_domain' ) ).toBe(
+				'translated_plural_1'
+			);
+		} );
 	} );
 } );
 

--- a/packages/i18n/src/test/create-i18n.js
+++ b/packages/i18n/src/test/create-i18n.js
@@ -194,6 +194,29 @@ describe( 'createI18n', () => {
 			} );
 		} );
 	} );
+
+	describe( 'resetLocaleData', () => {
+		it( 'reset the locale data', () => {
+			const locale = createTestLocale();
+			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'bonjour' );
+
+			locale.resetLocaleData();
+			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'hello' );
+		} );
+
+		it( 'reset the current locale data and set new locale data for the specified domain', () => {
+			const locale = createTestLocale();
+			expect( locale.__( 'hello', 'test_domain' ) ).toBe( 'bonjour' );
+
+			locale.resetLocaleData( additionalLocaleData );
+			expect( locale.__( 'cheeseburger' ) ).toBe(
+				'hamburger au fromage'
+			);
+
+			locale.resetLocaleData( additionalLocaleData, 'test_domain2' );
+			expect( locale.__( '%d cat', 'test_domain2' ) ).toBe( '%d chat' );
+		} );
+	} );
 } );
 
 describe( 'i18n filters', () => {


### PR DESCRIPTION
## Description
Currently, it's not possible to reset the locale data of a `@wordpress/i18n` instance. The `setLocaleData` method that is supposed to be used to modify the data, would only merge the new and the existing data and wouldn't allow to reset the data that has already been loaded to the instance.

This PR adds new `resetLocaleData` method to the @wordpress/i18n instance that resets all current Tannin instance locale data and sets the new locale data for specified the domain.

## How has this been tested?
* Existing unit tests pass.
* Added new tests that should cover `resetLocaleData` funcitonality.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
