### PR TITLE
Block Library: Delete sitelogo option when custom logo does not exist or was removed.

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -74,6 +74,8 @@ function override_custom_logo_theme_mod( $custom_logo ) {
  * @return string The custom logo.
  */
 function sync_site_logo_to_theme_mod( $custom_logo ) {
+	// Delete the option when the custom logo does not exist or was removed.
+	// This step ensures the option stays in sync.
 	if ( empty( $custom_logo ) ) {
 		delete_option( 'sitelogo' );
 	} else {

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -74,7 +74,9 @@ function override_custom_logo_theme_mod( $custom_logo ) {
  * @return string The custom logo.
  */
 function sync_site_logo_to_theme_mod( $custom_logo ) {
-	if ( $custom_logo ) {
+	if ( empty( $custom_logo ) ) {
+		delete_option( 'sitelogo' );
+	} else {
 		update_option( 'sitelogo', $custom_logo );
 	}
 	return $custom_logo;


### PR DESCRIPTION
## Description
Closes #30152 

This PR deletes the `'sitelogo'` option when it's removed.

Currently, the option is not updated unless there is a custom logo. In the `gutenberg_override_custom_logo_theme_mod` callback, the option is the default when it exists causing the previously saved logo to render.

This PR adds a delete option circuit: when the custom logo theme mod is removed or doesn't exist (i.e. is 0 or `'0'`), the`'sitelogo'` option is deleted.

## How has this been tested?

Steps:

1. Go to Appearance > Customize > Site Identity
2. Add a logo by "Select logo" and walking through the steps to add it
3. Publish
4. View in the front-end. Logo appears.
5. Remove the logo
6. Publish
7. View in the front-end. Logo does not appear.

## Screenshots 

Before this PR

![30152-before](https://user-images.githubusercontent.com/7284611/113211653-5f07bb00-923b-11eb-8c55-850da677e486.gif)

After applying the PR:

![30152-after](https://user-images.githubusercontent.com/7284611/113211686-6cbd4080-923b-11eb-99f6-734d4aba6db8.gif)

## Types of changes

- Adds a conditional check to delete the option

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
