### PR TITLE
Widgets: Don't use deprecated widget_class property

### DIFF
--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -405,6 +405,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 					'description' => __( 'Whether the widget supports multiple instances', 'gutenberg' ),
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
 				),
 				'classname'                   => array(
 					'description' => __( 'Class name', 'gutenberg' ),

--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -235,8 +235,11 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		$widgets = array();
 
 		foreach ( $wp_registered_widgets as $widget ) {
-			$parsed_id    = gutenberg_parse_widget_id( $widget['id'] );
-			$widget['id'] = $parsed_id['id_base'];
+			$parsed_id     = gutenberg_parse_widget_id( $widget['id'] );
+			$widget_object = gutenberg_get_widget_object( $parsed_id['id_base'] );
+
+			$widget['id']       = $parsed_id['id_base'];
+			$widget['is_multi'] = (bool) $widget_object;
 
 			unset( $widget['callback'] );
 
@@ -251,7 +254,6 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			$widget['classname'] = ltrim( $classname, '_' );
 
 			// Backwards compatibility. TODO: Remove.
-			$widget_object = gutenberg_get_widget_object( $parsed_id['id_base'] );
 			if ( $widget_object ) {
 				$widget['option_name']  = $widget_object->option_name;
 				$widget['widget_class'] = get_class( $widget_object );
@@ -301,6 +303,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		$extra_fields = array(
 			'name',
 			'description',
+			'is_multi',
 			'classname',
 			'widget_class',
 			'option_name',
@@ -396,6 +399,11 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 					'description' => __( 'Description of the widget.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'is_multi'                    => array(
+					'description' => __( 'Whether the widget supports multiple instances', 'gutenberg' ),
+					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'classname'                   => array(

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -59,7 +59,7 @@ function gutenberg_widgets_init( $hook ) {
 			'preload_paths'   => array(
 				array( '/wp/v2/media', 'OPTIONS' ),
 				'/wp/v2/sidebars?context=edit&per_page=-1',
-				'/wp/v2/widgets?context=edit&per_page=-1',
+				'/wp/v2/widgets?context=edit&per_page=-1&_embed=about',
 			),
 			'editor_settings' => $settings,
 		)

--- a/packages/block-library/src/legacy-widget/edit/widget-type-selector.js
+++ b/packages/block-library/src/legacy-widget/edit/widget-type-selector.js
@@ -43,8 +43,7 @@ export default function WidgetTypeSelector( { selectedId, onSelect } ) {
 					);
 					onSelect( {
 						selectedId: selected.id,
-						// TODO: Don't use widget_class.
-						isMulti: !! selected.widget_class,
+						isMulti: selected.is_multi,
 					} );
 				} else {
 					onSelect( { selectedId: null } );

--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -537,7 +537,7 @@ async function saveWidgets() {
 
 async function getSerializedWidgetAreas() {
 	const widgets = await page.evaluate( () =>
-		wp.data.select( 'core' ).getWidgets()
+		wp.data.select( 'core' ).getWidgets( { _embed: 'about' } )
 	);
 
 	const serializedWidgetAreas = mapValues(

--- a/packages/edit-widgets/src/register-legacy-widget-variations.js
+++ b/packages/edit-widgets/src/register-legacy-widget-variations.js
@@ -20,8 +20,7 @@ export default function registerLegacyWidgetVariations( settings ) {
 					name: widgetType.id,
 					title: widgetType.name,
 					description: widgetType.description,
-					// TODO: Don't use widget_class.
-					attributes: widgetType.widget_class
+					attributes: widgetType.is_multi
 						? {
 								idBase: widgetType.id,
 								instance: {},

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -26,8 +26,7 @@ export function transformWidgetToBlock( widget ) {
 	}
 
 	let attributes;
-	// TODO: Don't use widget_class.
-	if ( widget.widget_class ) {
+	if ( widget._embedded.about[ 0 ].is_multi ) {
 		attributes = {
 			idBase: widget.id_base,
 			instance: widget.instance,

--- a/packages/edit-widgets/src/store/utils.js
+++ b/packages/edit-widgets/src/store/utils.js
@@ -54,6 +54,7 @@ export function buildWidgetAreasQuery() {
 export function buildWidgetsQuery() {
 	return {
 		per_page: -1,
+		_embed: 'about',
 	};
 }
 

--- a/phpunit/class-rest-widget-types-controller-test.php
+++ b/phpunit/class-rest-widget-types-controller-test.php
@@ -161,12 +161,13 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 7, $properties );
+		$this->assertCount( 8, $properties );
 
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'option_name', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
+		$this->assertArrayHasKey( 'is_multi', $properties );
 		$this->assertArrayHasKey( 'classname', $properties );
 		$this->assertArrayHasKey( 'customize_selective_refresh', $properties );
 		$this->assertArrayHasKey( 'widget_class', $properties );
@@ -242,6 +243,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 			'control_options',
 			'widget_options',
 			'widget_class',
+			'is_multi',
 		);
 
 		foreach ( $extra_fields as $extra_field ) {


### PR DESCRIPTION
## Description

Follows https://github.com/WordPress/gutenberg/pull/29649 and https://github.com/WordPress/gutenberg/pull/29960.

Removes usage of the deprecated `widget.widget_class` and `widgetType.widget_class` REST API properties in favour of a new `widgetType.is_multi` property which denotes whether or not the widget type supports multiple instances.

## How has this been tested?

1. Navigate to Appearance → Widgets.
2. Check that updating and saving Legacy Widget and non Legacy Widget blocks works.
3. Enable Legacy Widget block variations for core widgets by adding `hiddenIds = [];` after `packages/edit-widgets/src/register-legacy-widget-variations.js:11`.
4. Open the inserter, search for a core widget (e.g. Search), insert it, check that it can be saved.
5. Enable support for core widgets in the Legacy Widget block by adding `hiddenIds = [];` after `packages/block-library/src/legacy-widget/edit/widget-type-selector.js:14`.
6. Insert a Legacy Widget block, select a core widget (e.g. Search), insert it, check that it can be saved.

## Types of changes
Code quality.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->