### PR TITLE
Cover block: Rename isBlogUrl to isUploadingMedia

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -240,6 +240,17 @@ function mediaPosition( { x, y } ) {
 	return `${ Math.round( x * 100 ) }% ${ Math.round( y * 100 ) }%`;
 }
 
+/**
+ * Is the URL a temporary blob URL? A blob URL is one that is used temporarily while
+ * the media (image or video) is being uploaded and will not have an id allocated yet.
+ *
+ * @param {number} id  The id of the media.
+ * @param {string} url The url of the media.
+ *
+ * @return {boolean} Is the URL a Blob URL.
+ */
+const isTemporaryMedia = ( id, url ) => ! id && isBlobURL( url );
+
 function CoverPlaceholder( {
 	hasBackground = false,
 	children,
@@ -301,7 +312,7 @@ function CoverEdit( {
 		setGradient,
 	} = __experimentalUseGradient();
 	const onSelectMedia = attributesFromMedia( setAttributes );
-	const isTemporaryImage = isBlobURL( url );
+	const isUploadingMedia = isTemporaryMedia( id, url );
 
 	const [ prevMinHeightValue, setPrevMinHeightValue ] = useState( minHeight );
 	const [ prevMinHeightUnit, setPrevMinHeightUnit ] = useState(
@@ -574,7 +585,7 @@ function CoverEdit( {
 		{
 			'is-dark-theme': isDark,
 			'has-background-dim': dimRatio !== 0,
-			'is-transient': isTemporaryImage,
+			'is-transient': isUploadingMedia,
 			'has-parallax': hasParallax,
 			'is-repeated': isRepeated,
 			[ overlayColor.class ]: overlayColor.class,
@@ -644,7 +655,7 @@ function CoverEdit( {
 						style={ mediaStyle }
 					/>
 				) }
-				{ isTemporaryImage && <Spinner /> }
+				{ isUploadingMedia && <Spinner /> }
 				<CoverPlaceholder
 					hasBackground={ hasBackground }
 					noticeUI={ noticeUI }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -301,7 +301,7 @@ function CoverEdit( {
 		setGradient,
 	} = __experimentalUseGradient();
 	const onSelectMedia = attributesFromMedia( setAttributes );
-	const isBlogUrl = isBlobURL( url );
+	const isTemporaryImage = isBlobURL( url );
 
 	const [ prevMinHeightValue, setPrevMinHeightValue ] = useState( minHeight );
 	const [ prevMinHeightUnit, setPrevMinHeightUnit ] = useState(
@@ -574,7 +574,7 @@ function CoverEdit( {
 		{
 			'is-dark-theme': isDark,
 			'has-background-dim': dimRatio !== 0,
-			'is-transient': isBlogUrl,
+			'is-transient': isTemporaryImage,
 			'has-parallax': hasParallax,
 			'is-repeated': isRepeated,
 			[ overlayColor.class ]: overlayColor.class,
@@ -644,7 +644,7 @@ function CoverEdit( {
 						style={ mediaStyle }
 					/>
 				) }
-				{ isBlogUrl && <Spinner /> }
+				{ isTemporaryImage && <Spinner /> }
 				<CoverPlaceholder
 					hasBackground={ hasBackground }
 					noticeUI={ noticeUI }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This is a tiny change to rename a constant to improve code readability.

I noticed a typo in the `isBlogUrl` constant in the Cover block, which is used to set whether or not the provided url for the cover image is a temporary image (i.e. is it a _blob_ url), and if so, render a spinner to indicate loading state.

I was a bit confused as to why we'd be looking for a _blog_ url, until I then realised it was a typo. To make it a bit clearer to folks newer to looking at the component (like me! 😀), I'm proposing we rename the constant and borrow the `isTemporaryImage` approach used in the [gallery block here](https://github.com/wordpress/gutenberg/blob/f31c35c5756091392f64c203c1e0a57c6badab8e/packages/block-library/src/gallery/gallery-image.js#L40). Happy to go with a different name if there are other ideas, of course!

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually. In the editor, I added a cover block and selected an image to upload as the background. I throttled my network speed down to slow 3G so that I could see that the spinner was rendered in my local development environment and that the `is-transient` class name was still being added to the parent div during the loading state.

## Screenshots <!-- if applicable -->

This is the loading state that I tested to ensure the rename doesn't break anything:

![image](https://user-images.githubusercontent.com/14988353/113244984-ca1bc500-9301-11eb-95bf-0ef5450ed72e.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
* Non breaking-change, just a rename of a constant to (subjectively!) improve readability.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- ~I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->~ N/A
- ~My code has proper inline documentation.~ N/A <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- ~I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal)~ (I couldn't find any that apply). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
