### PR TITLE
Site editor: Add allowedMimeTypes to site editor settings to fix media upload behaviour and error state

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -49,6 +49,7 @@ function gutenberg_get_common_block_editor_settings() {
 		'imageSizes'                            => $available_image_sizes,
 		'isRTL'                                 => is_rtl(),
 		'maxUploadFileSize'                     => $max_upload_size,
+		'allowedMimeTypes'                      => get_allowed_mime_types(),
 	);
 
 	$color_palette = current( (array) get_theme_support( 'editor-color-palette' ) );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
In the `mediaUpload` function (for example, used by the upload buttons in the Cover block), there is a check for the current allowed mime types (from the WordPress end), which is then fed into the `uploadMedia` function which will trigger an error before attempting to upload the file (e.g. [here is the error](https://github.com/andrewserong/gutenberg/blob/8afed75c6f2daa2624b0f91781aa4bee163d4e93/packages/media-utils/src/utils/upload-media.js#L128-L128) for mime type not allowed for user).

However, currently in the new Site Editor, we're not loading the allowed mime types as part of the server rendered initial state, which means that the list allowed mime types passed in to uploadMedia is empty (`wpAllowedMimeTypes`), resulting in the editor attempting to upload the file and then failing at the server end.

This one-line change adds in `allowedMimeTypes` to the server rendered initial state, using the same approach as is used for the post and page editors (from [this line](https://github.com/wordpress/wordpress/blob/6d42a2110346a19a9874a3121e40b1e472b2cbd4/wp-admin/edit-form-blocks.php#L324) in core).

The result after this change is that if a user uploads a file that isn't allowed (testing with an `svg` file is a convenient way to do it), then we report the error back to the user immediately (along with the filename), instead of displaying a flicker of the file attempting to be uploaded.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually in the site editor. Add a cover block and attempt to upload an SVG image as the background image.

For testing, I used this image: https://upload.wikimedia.org/wikipedia/commons/2/20/WordPress_logo.svg

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![media-upload-mime-types-before-sml](https://user-images.githubusercontent.com/14988353/113252532-b2e3d400-930f-11eb-8702-5c4ec9e156c0.gif) | ![media-upload-mime-types-after-sml](https://user-images.githubusercontent.com/14988353/113252561-bb3c0f00-930f-11eb-9eb4-29c5cbb72117.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested. (Manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] ~My code follows the accessibility standards.~ N/A <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] ~I've tested my changes with keyboard and screen readers.~ N/A <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] ~My code has proper inline documentation.~ N/A <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] ~I've included developer documentation if appropriate.~ N/A <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).~ N/A <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
