### PR TITLE
Allow creating custom block templates in classic themes

### DIFF
--- a/docs/how-to-guides/themes/block-based-themes.md
+++ b/docs/how-to-guides/themes/block-based-themes.md
@@ -124,6 +124,16 @@ As we're still early in the process, the number of blocks specifically dedicated
 
 One of the most important aspects of themes (if not the most important) is the styling. While initially you'll be able to provide styles and enqueue them using the same hooks themes have always used, the [Global Styles](/docs/how-to-guides/themes/theme-json.md) effort will provide a scaffolding for adding many theme styles in the future.
 
+## Classic Themes
+
+Users of classic themes can also build custom block templates and use theme in their Pages and Custom Post Types that supports Page Templates.
+
+Theme authors can opt-out of this feature by removing the `block-templates` theme support in their `functions.php` file.
+
+```php
+remove_theme_support( 'block-templates' );
+```
+
 ## Resources
 
 -   [Full Site Editing](https://github.com/WordPress/gutenberg/labels/%5BFeature%5D%20Full%20Site%20Editing) label.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -666,7 +666,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_block_editor_settings_with_fse_theme_flag( $settings ) {
-	$settings['isFSETheme'] = gutenberg_is_fse_theme();
+	$settings['supportsTemplateMode'] = true; // gutenberg_is_fse_theme();
 
 	// Enable the new layout options for themes with a theme.json file.
 	$settings['supportsLayout'] = WP_Theme_JSON_Resolver::theme_has_support();

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -646,7 +646,7 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 	}
 
 	// Remove the default font editor styles for FSE themes.
-	if ( gutenberg_is_fse_theme() ) {
+	if ( gutenberg_supports_block_templates() ) {
 		foreach ( $settings['styles'] as $j => $style ) {
 			if ( 0 === strpos( $style['css'], 'body { font-family:' ) ) {
 				unset( $settings['styles'][ $j ] );
@@ -666,7 +666,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_block_editor_settings_with_fse_theme_flag( $settings ) {
-	$settings['supportsTemplateMode'] = true; // gutenberg_is_fse_theme();
+	$settings['supportsTemplateMode'] = gutenberg_supports_block_templates();
 
 	// Enable the new layout options for themes with a theme.json file.
 	$settings['supportsLayout'] = WP_Theme_JSON_Resolver::theme_has_support();

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -14,7 +14,7 @@
  * @return bool
  */
 function gutenberg_should_load_separate_block_assets() {
-	$load_separate_styles = gutenberg_is_fse_theme();
+	$load_separate_styles = gutenberg_supports_block_templates();
 	/**
 	 * Determine if separate styles will be loaded for blocks on-render or not.
 	 *

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -39,7 +39,7 @@ function gutenberg_get_common_block_editor_settings() {
 	};
 
 	$settings = array(
-		'__unstableEnableFullSiteEditingBlocks' => gutenberg_is_fse_theme(),
+		'__unstableEnableFullSiteEditingBlocks' => true, // gutenberg_is_fse_theme(),
 		'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
 		'disableCustomGradients'                => get_theme_support( 'disable-custom-gradients' ),
@@ -81,7 +81,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 	$image_sizes        = wp_list_pluck( $settings['imageSizes'], 'slug' );
 
 	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
-	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_theme();
+	$settings['__unstableEnableFullSiteEditingBlocks'] = true; // gutenberg_is_fse_theme();
 
 	return $settings;
 }

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -39,7 +39,7 @@ function gutenberg_get_common_block_editor_settings() {
 	};
 
 	$settings = array(
-		'__unstableEnableFullSiteEditingBlocks' => true, // gutenberg_is_fse_theme(),
+		'__unstableEnableFullSiteEditingBlocks' => gutenberg_supports_block_templates(),
 		'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
 		'disableCustomGradients'                => get_theme_support( 'disable-custom-gradients' ),
@@ -81,7 +81,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 	$image_sizes        = wp_list_pluck( $settings['imageSizes'], 'slug' );
 
 	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
-	$settings['__unstableEnableFullSiteEditingBlocks'] = true; // gutenberg_is_fse_theme();
+	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_supports_block_templates();
 
 	return $settings;
 }

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -15,6 +15,15 @@ function gutenberg_is_fse_theme() {
 }
 
 /**
+ * Returns whether the current theme is FSE-enabled or not.
+ *
+ * @return boolean Whether the current theme is FSE-enabled or not.
+ */
+function gutenberg_supports_block_templates() {
+	return gutenberg_is_fse_theme() || current_theme_supports( 'block-templates' );
+}
+
+/**
  * Show a notice when a Full Site Editing theme is used.
  */
 function gutenberg_full_site_editing_notice() {

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -15,22 +15,16 @@
  * @return array (Maybe) modified page templates array.
  */
 function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
-	if ( ! gutenberg_is_fse_theme() ) {
+	/*if ( ! gutenberg_is_fse_theme() ) {
 		return $templates;
+	}*/
+
+	$block_templates = gutenberg_get_block_templates( array(), 'wp_template' );
+	foreach ( $block_templates as $template ) {
+		// TODO: exclude templates that are not concerned by the current post type.
+		$templates[ $template->slug ] = $template->title;
 	}
 
-	$data             = WP_Theme_JSON_Resolver::get_theme_data()->get_custom_templates();
-	$custom_templates = array();
-	if ( isset( $data ) ) {
-		foreach ( $data  as $key => $template ) {
-			if ( ( ! isset( $template['postTypes'] ) && 'page' === $post_type ) ||
-				( isset( $template['postTypes'] ) && in_array( $post_type, $template['postTypes'], true ) )
-			) {
-				$custom_templates[ $key ] = $template['title'];
-			}
-		}
-	}
-
-	return $custom_templates;
+	return $templates;
 }
 add_filter( 'theme_templates', 'gutenberg_load_block_page_templates', 10, 4 );

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -15,9 +15,9 @@
  * @return array (Maybe) modified page templates array.
  */
 function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
-	/*if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return $templates;
-	}*/
+	}
 
 	$block_templates = gutenberg_get_block_templates( array(), 'wp_template' );
 	foreach ( $block_templates as $template ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -9,9 +9,9 @@
  * Adds necessary filters to use 'wp_template' posts instead of theme template files.
  */
 function gutenberg_add_template_loader_filters() {
-	if ( ! gutenberg_is_fse_theme() ) {
+	/* if ( ! gutenberg_is_fse_theme() ) {
 		return;
-	}
+	} */
 
 	foreach ( gutenberg_get_template_type_slugs() as $template_type ) {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
@@ -66,7 +66,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	$current_template = gutenberg_resolve_template( $type, $templates );
 
 	// Allow falling back to a PHP template if it has a higher priority than the block template.
-	$current_template_slug       = basename( $template, '.php' );
+	/* $current_template_slug       = basename( $template, '.php' );
 	$current_block_template_slug = is_object( $current_template ) ? $current_template->slug : false;
 	foreach ( $templates as $template_item ) {
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
@@ -76,7 +76,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 		if ( $current_template_slug !== $current_block_template_slug && $current_template_slug === $template_item_slug ) {
 			return $template;
 		}
-	}
+	} */
 
 	if ( $current_template ) {
 		if ( empty( $current_template->content ) && is_user_logged_in() ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -71,9 +71,16 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	foreach ( $templates as $template_item ) {
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
+		// Is this a custom template?
+		$is_custom_template = 0 === strpos( $current_block_template_slug, 'custom-template-' );
+
 		// Don't override the template if we find a template matching the slug we look for
 		// and which does not match a block template slug.
-		if ( $current_template_slug !== $current_block_template_slug && $current_template_slug === $template_item_slug ) {
+		if (
+			! $is_custom_template &&
+			$current_template_slug !== $current_block_template_slug &&
+			$current_template_slug === $template_item_slug
+		) {
 			return $template;
 		}
 	}

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -9,9 +9,9 @@
  * Adds necessary filters to use 'wp_template' posts instead of theme template files.
  */
 function gutenberg_add_template_loader_filters() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
-	} */
+	}
 
 	foreach ( gutenberg_get_template_type_slugs() as $template_type ) {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -66,7 +66,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	$current_template = gutenberg_resolve_template( $type, $templates );
 
 	// Allow falling back to a PHP template if it has a higher priority than the block template.
-	/* $current_template_slug       = basename( $template, '.php' );
+	$current_template_slug       = basename( $template, '.php' );
 	$current_block_template_slug = is_object( $current_template ) ? $current_template->slug : false;
 	foreach ( $templates as $template_item ) {
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
@@ -76,7 +76,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 		if ( $current_template_slug !== $current_block_template_slug && $current_template_slug === $template_item_slug ) {
 			return $template;
 		}
-	} */
+	}
 
 	if ( $current_template ) {
 		if ( empty( $current_template->content ) && is_user_logged_in() ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -72,7 +72,9 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
 		// Is this a custom template?
-		$is_custom_template = 0 === strpos( $current_block_template_slug, 'custom-template-' );
+		// This check should be removed when merged in core.
+		// Instead, wp_templates should be considered valid in locate_template.
+		$is_custom_template = 0 === strpos( $current_block_template_slug, 'wp-custom-template-' );
 
 		// Don't override the template if we find a template matching the slug we look for
 		// and which does not match a block template slug.

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -9,9 +9,9 @@
  * Registers block editor 'wp_template_part' post type.
  */
 function gutenberg_register_template_part_post_type() {
-	if ( ! gutenberg_is_fse_theme() ) {
+	/* if ( ! gutenberg_is_fse_theme() ) {
 		return;
-	}
+	} */
 
 	$labels = array(
 		'name'                  => __( 'Template Parts', 'gutenberg' ),
@@ -64,9 +64,9 @@ add_action( 'init', 'gutenberg_register_template_part_post_type' );
  * Registers the 'wp_template_part_area' taxonomy.
  */
 function gutenberg_register_wp_template_part_area_taxonomy() {
-	if ( ! gutenberg_is_fse_theme() ) {
+	/* if ( ! gutenberg_is_fse_theme() ) {
 		return;
-	}
+	} */
 
 	register_taxonomy(
 		'wp_template_part_area',
@@ -107,9 +107,9 @@ if ( ! defined( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED' ) ) {
  * Fixes the label of the 'wp_template_part' admin menu entry.
  */
 function gutenberg_fix_template_part_admin_menu_entry() {
-	if ( ! gutenberg_is_fse_theme() ) {
+	/* if ( ! gutenberg_is_fse_theme() ) {
 		return;
-	}
+	} */
 
 	global $submenu;
 	if ( ! isset( $submenu['themes.php'] ) ) {

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -9,9 +9,9 @@
  * Registers block editor 'wp_template_part' post type.
  */
 function gutenberg_register_template_part_post_type() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
-	} */
+	}
 
 	$labels = array(
 		'name'                  => __( 'Template Parts', 'gutenberg' ),
@@ -64,9 +64,9 @@ add_action( 'init', 'gutenberg_register_template_part_post_type' );
  * Registers the 'wp_template_part_area' taxonomy.
  */
 function gutenberg_register_wp_template_part_area_taxonomy() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
-	} */
+	}
 
 	register_taxonomy(
 		'wp_template_part_area',
@@ -107,9 +107,9 @@ if ( ! defined( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED' ) ) {
  * Fixes the label of the 'wp_template_part' admin menu entry.
  */
 function gutenberg_fix_template_part_admin_menu_entry() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
-	} */
+	}
 
 	global $submenu;
 	if ( ! isset( $submenu['themes.php'] ) ) {

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -28,9 +28,9 @@ function gutenberg_get_template_paths() {
  * Registers block editor 'wp_template' post type.
  */
 function gutenberg_register_template_post_type() {
-	if ( ! gutenberg_is_fse_theme() ) {
+	/* if ( ! gutenberg_is_fse_theme() ) {
 		return;
-	}
+	} */
 
 	$labels = array(
 		'name'                  => __( 'Templates', 'gutenberg' ),
@@ -84,9 +84,9 @@ add_action( 'init', 'gutenberg_register_template_post_type' );
  * Registers block editor 'wp_theme' taxonomy.
  */
 function gutenberg_register_wp_theme_taxonomy() {
-	if ( ! gutenberg_is_fse_theme() ) {
+	/* if ( ! gutenberg_is_fse_theme() ) {
 		return;
-	}
+	} */
 
 	register_taxonomy(
 		'wp_theme',
@@ -139,9 +139,9 @@ add_filter( 'user_has_cap', 'gutenberg_grant_template_caps' );
  * Fixes the label of the 'wp_template' admin menu entry.
  */
 function gutenberg_fix_template_admin_menu_entry() {
-	if ( ! gutenberg_is_fse_theme() ) {
+	/* if ( ! gutenberg_is_fse_theme() ) {
 		return;
-	}
+	} */
 	global $submenu;
 	if ( ! isset( $submenu['themes.php'] ) ) {
 		return;

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -28,9 +28,9 @@ function gutenberg_get_template_paths() {
  * Registers block editor 'wp_template' post type.
  */
 function gutenberg_register_template_post_type() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
-	} */
+	}
 
 	$labels = array(
 		'name'                  => __( 'Templates', 'gutenberg' ),
@@ -84,9 +84,9 @@ add_action( 'init', 'gutenberg_register_template_post_type' );
  * Registers block editor 'wp_theme' taxonomy.
  */
 function gutenberg_register_wp_theme_taxonomy() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
-	} */
+	}
 
 	register_taxonomy(
 		'wp_theme',
@@ -139,9 +139,9 @@ add_filter( 'user_has_cap', 'gutenberg_grant_template_caps' );
  * Fixes the label of the 'wp_template' admin menu entry.
  */
 function gutenberg_fix_template_admin_menu_entry() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
-	} */
+	}
 	global $submenu;
 	if ( ! isset( $submenu['themes.php'] ) ) {
 		return;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -198,7 +198,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	$origin = 'theme';
 	if (
 		WP_Theme_JSON_Resolver::theme_has_support() &&
-		gutenberg_is_fse_theme()
+		gutenberg_supports_block_templates()
 	) {
 		// Only lookup for the user data if we need it.
 		$origin = 'user';
@@ -224,7 +224,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		function_exists( 'gutenberg_is_edit_site_page' ) &&
 		gutenberg_is_edit_site_page( $screen->id ) &&
 		WP_Theme_JSON_Resolver::theme_has_support() &&
-		gutenberg_is_fse_theme()
+		gutenberg_supports_block_templates()
 	) {
 		$user_cpt_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
 		$base_styles = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get_raw_data();

--- a/lib/init.php
+++ b/lib/init.php
@@ -177,4 +177,4 @@ function register_site_icon_url( $response ) {
 add_filter( 'rest_index', 'register_site_icon_url' );
 
 add_theme_support( 'widgets-block-editor' );
-add_theme_support( 'full-site-editing' );
+add_theme_support( 'block-templates' );

--- a/lib/init.php
+++ b/lib/init.php
@@ -177,3 +177,4 @@ function register_site_icon_url( $response ) {
 add_filter( 'rest_index', 'register_site_icon_url' );
 
 add_theme_support( 'widgets-block-editor' );
+add_theme_support( 'full-site-editing' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12783,7 +12783,8 @@
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
 				"memize": "^1.1.0",
-				"rememo": "^3.0.0"
+				"rememo": "^3.0.0",
+				"uuid": "8.3.0"
 			}
 		},
 		"@wordpress/edit-site": {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -385,13 +385,18 @@ export function* __experimentalGetTemplateForLink( link ) {
 	// Ideally this should be using an apiFetch call
 	// We could potentially do so by adding a "filter" to the `wp_template` end point.
 	// Also it seems the returned object is not a regular REST API post type.
-	const template = yield regularFetch(
-		addQueryArgs( link, {
-			'_wp-find-template': true,
-		} )
-	);
+	let template;
+	try {
+		template = yield regularFetch(
+			addQueryArgs( link, {
+				'_wp-find-template': true,
+			} )
+		);
+	} catch ( e ) {
+		// For non-FSE themes, it is possible that this request returns an error.
+	}
 
-	if ( template === null ) {
+	if ( ! template ) {
 		return;
 	}
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -415,3 +415,12 @@ export function* __experimentalGetTemplateForLink( link ) {
 		} );
 	}
 }
+
+__experimentalGetTemplateForLink.shouldInvalidate = ( action ) => {
+	return (
+		( action.type === 'RECEIVE_ITEMS' || action.type === 'REMOVE_ITEMS' ) &&
+		action.invalidateCache &&
+		action.kind === 'postType' &&
+		action.name === 'wp_template'
+	);
+};

--- a/packages/e2e-test-utils/src/preview.js
+++ b/packages/e2e-test-utils/src/preview.js
@@ -14,6 +14,9 @@ import { last } from 'lodash';
 export async function openPreviewPage( editorPage = page ) {
 	let openTabs = await browser.pages();
 	const expectedTabsCount = openTabs.length + 1;
+	await page.waitForSelector(
+		'.block-editor-post-preview__button-toggle:not([disabled])'
+	);
 	await editorPage.click( '.block-editor-post-preview__button-toggle' );
 	await editorPage.waitForSelector(
 		'.edit-post-header-preview__button-external'

--- a/packages/e2e-tests/specs/experiments/__snapshots__/post-editor-template-mode.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/post-editor-template-mode.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Post Editor Template mode Allow creating custom block templates in classic themes 1`] = `
+"<h2 class=\\"wp-block-post-title\\">Another FSE Post</h2>
+
+<div class=\\"entry-content wp-block-post-content\\">
+<p>Hello World</p>
+</div>
+
+
+<p>Just a random paragraph added to the template</p>
+"
+`;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/post-editor-template-mode.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/post-editor-template-mode.test.js.snap
@@ -1,7 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Post Editor Template mode Allow creating custom block templates in classic themes 1`] = `
-"<h2 class=\\"wp-block-post-title\\">Another FSE Post</h2>
+"<h1 class=\\"wp-block-site-title\\"><a href=\\"http://localhost:8889\\" rel=\\"home\\">gutenberg</a></h1>
+
+<p class=\\"wp-block-site-tagline\\">Just another WordPress site</p>
+
+
+<hr class=\\"wp-block-separator\\">
+
+
+<h2 class=\\"wp-block-post-title\\">Another FSE Post</h2>
 
 <div class=\\"entry-content wp-block-post-content\\">
 <p>Hello World</p>

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -52,7 +52,8 @@
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.19",
 		"memize": "^1.1.0",
-		"rememo": "^3.0.0"
+		"rememo": "^3.0.0",
+		"uuid": "8.3.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -3,8 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -13,15 +11,12 @@ import { store as editPostStore } from '../../../store';
 
 function TemplateTitle() {
 	const { template, isEditing } = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( editorStore );
-		const { __experimentalGetTemplateForLink } = select( coreStore );
-		const { isEditingTemplate } = select( editPostStore );
-		const link = getEditedPostAttribute( 'link' );
+		const { isEditingTemplate, getEditedPostTemplate } = select(
+			editPostStore
+		);
 		const _isEditing = isEditingTemplate();
 		return {
-			template: _isEditing
-				? __experimentalGetTemplateForLink( link )
-				: null,
+			template: _isEditing ? getEditedPostTemplate() : null,
 			isEditing: _isEditing,
 		};
 	}, [] );

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -14,48 +14,33 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editPostStore } from '../../../store';
 
 function PostTemplate() {
-	const {
-		template,
-		isEditing,
-		supportsTemplateMode,
-		isResolvingTemplate,
-	} = useSelect( ( select ) => {
-		const {
-			getEditedPostAttribute,
-			getCurrentPostType,
-			getCurrentPost,
-		} = select( editorStore );
-		const {
-			__experimentalGetTemplateForLink,
-			getPostType,
-			isResolving,
-		} = select( coreStore );
-		const { isEditingTemplate } = select( editPostStore );
-		const link = getEditedPostAttribute( 'link' );
-		const _supportsTemplateMode = select( editorStore ).getEditorSettings()
-			.supportsTemplateMode;
-		const isViewable =
-			getPostType( getCurrentPostType() )?.viewable ?? false;
+	const { template, isEditing, supportsTemplateMode } = useSelect(
+		( select ) => {
+			const { getCurrentPostType } = select( editorStore );
+			const { getPostType } = select( coreStore );
+			const { isEditingTemplate, getEditedPostTemplate } = select(
+				editPostStore
+			);
+			const _supportsTemplateMode = select(
+				editorStore
+			).getEditorSettings().supportsTemplateMode;
+			const isViewable =
+				getPostType( getCurrentPostType() )?.viewable ?? false;
 
-		return {
-			template:
-				supportsTemplateMode &&
-				isViewable &&
-				link &&
-				getCurrentPost().status !== 'auto-draft'
-					? __experimentalGetTemplateForLink( link )
-					: null,
-			isEditing: isEditingTemplate(),
-			supportsTemplateMode: _supportsTemplateMode,
-			isResolvingTemplate: isResolving(
-				'__experimentalGetTemplateForLink',
-				[ link ]
-			),
-		};
-	}, [] );
+			return {
+				template:
+					supportsTemplateMode &&
+					isViewable &&
+					getEditedPostTemplate(),
+				isEditing: isEditingTemplate(),
+				supportsTemplateMode: _supportsTemplateMode,
+			};
+		},
+		[]
+	);
 	const { __unstableSwitchToEditingMode } = useDispatch( editPostStore );
 
-	if ( ! supportsTemplateMode || isResolvingTemplate ) {
+	if ( ! supportsTemplateMode ) {
 		return null;
 	}
 
@@ -106,7 +91,7 @@ function PostTemplate() {
 			) }
 			{ isEditing && (
 				<span className="edit-post-post-template__value">
-					{ template.slug }
+					{ template?.slug }
 				</span>
 			) }
 		</PanelRow>

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -108,6 +108,9 @@ function PostTemplate() {
 							event.preventDefault();
 							const defaultTitle = __( 'Custom Template' );
 							const templateContent = [
+								createBlock( 'core/site-title' ),
+								createBlock( 'core/site-tagline' ),
+								createBlock( 'core/separator' ),
 								createBlock( 'core/post-title' ),
 								createBlock( 'core/post-content' ),
 							];

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -101,6 +101,7 @@ function PostTemplate() {
 						setIsModalOpen( false );
 						setTitle( '' );
 					} }
+					overlayClassName="edit-post-post-template__modal"
 				>
 					<form
 						onSubmit={ ( event ) => {

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -6,7 +6,7 @@ import { kebabCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	PanelRow,
 	Button,
@@ -16,7 +16,7 @@ import {
 	FlexItem,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createInterpolateElement, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -63,42 +63,30 @@ function PostTemplate() {
 		<PanelRow className="edit-post-post-template">
 			<span>{ __( 'Template' ) }</span>
 			{ ! isEditing && (
-				<span className="edit-post-post-template__value">
-					{ !! template &&
-						createInterpolateElement(
-							sprintf(
-								/* translators: 1: Template name. */
-								__( '%s (<a>Edit</a>)' ),
-								template.slug
-							),
-							{
-								a: (
-									<Button
-										isLink
-										onClick={ () =>
-											__unstableSwitchToTemplateMode()
-										}
-									>
-										{ __( 'Edit' ) }
-									</Button>
-								),
-							}
+				<div className="edit-post-post-template__value">
+					<div>
+						{ !! template && template?.title?.raw }
+						{ !! template &&
+							! template?.title?.raw &&
+							template.slug }
+						{ ! template && __( 'Default' ) }
+					</div>
+					<div className="edit-post-post-template__actions">
+						{ !! template && (
+							<Button
+								isLink
+								onClick={ () =>
+									__unstableSwitchToTemplateMode()
+								}
+							>
+								{ __( 'Edit' ) }
+							</Button>
 						) }
-					{ ! template &&
-						createInterpolateElement(
-							__( 'Default (<create />)' ),
-							{
-								create: (
-									<Button
-										isLink
-										onClick={ () => setIsModalOpen( true ) }
-									>
-										{ __( 'Create custom template' ) }
-									</Button>
-								),
-							}
-						) }
-				</span>
+						<Button isLink onClick={ () => setIsModalOpen( true ) }>
+							{ __( 'New' ) }
+						</Button>
+					</div>
+				</div>
 			) }
 			{ isEditing && (
 				<span className="edit-post-post-template__value">

--- a/packages/edit-post/src/components/sidebar/post-template/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-template/style.scss
@@ -11,3 +11,7 @@
 .edit-post-post-template__value {
 	padding-left: 6px;
 }
+
+.edit-post-post-template__modal-actions {
+	padding-top: $grid-unit-15;
+}

--- a/packages/edit-post/src/components/sidebar/post-template/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-template/style.scss
@@ -1,6 +1,7 @@
 .edit-post-post-template {
 	width: 100%;
 	justify-content: left;
+	align-items: baseline;
 
 	span {
 		display: block;
@@ -14,4 +15,12 @@
 
 .edit-post-post-template__modal-actions {
 	padding-top: $grid-unit-15;
+}
+
+.edit-post-post-template__actions {
+	margin-top: $grid-unit-10;
+
+	button:not(:last-child) {
+		margin-right: $grid-unit-10;
+	}
 }

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -56,14 +56,12 @@ function Editor( {
 			getPreference,
 			__experimentalGetPreviewDeviceType,
 			isEditingTemplate,
+			getEditedPostTemplate,
 		} = select( editPostStore );
-		const {
-			getEntityRecord,
-			__experimentalGetTemplateForLink,
-			getPostType,
-			getEntityRecords,
-		} = select( 'core' );
-		const { getEditorSettings, getCurrentPost } = select( 'core/editor' );
+		const { getEntityRecord, getPostType, getEntityRecords } = select(
+			'core'
+		);
+		const { getEditorSettings } = select( 'core/editor' );
 		const { getBlockTypes } = select( blocksStore );
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			postType
@@ -100,11 +98,8 @@ function Editor( {
 			keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
 			isTemplateMode: isEditingTemplate(),
 			template:
-				supportsTemplateMode &&
-				isViewable &&
-				postObject &&
-				getCurrentPost().status !== 'auto-draft'
-					? __experimentalGetTemplateForLink( postObject.link )
+				supportsTemplateMode && isViewable
+					? getEditedPostTemplate()
 					: null,
 			post: postObject,
 		};

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -79,7 +79,7 @@ function Editor( {
 		} else {
 			postObject = getEntityRecord( 'postType', postType, postId );
 		}
-		const isFSETheme = getEditorSettings().isFSETheme;
+		const supportsTemplateMode = getEditorSettings().supportsTemplateMode;
 		const isViewable = getPostType( postType )?.viewable ?? false;
 
 		return {
@@ -100,7 +100,7 @@ function Editor( {
 			keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
 			isTemplateMode: isEditingTemplate(),
 			template:
-				isFSETheme &&
+				supportsTemplateMode &&
 				isViewable &&
 				postObject &&
 				getCurrentPost().status !== 'auto-draft'

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { v4 as uuid } from 'uuid';
 import { castArray, reduce } from 'lodash';
 
 /**
@@ -13,7 +12,6 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { controls, dispatch, select, subscribe } from '@wordpress/data';
 import { speak } from '@wordpress/a11y';
 import { store as noticesStore } from '@wordpress/notices';
-import { createBlock, serialize } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -441,17 +439,13 @@ export function setIsEditingTemplate( value ) {
 	};
 }
 
-export function* __unstableSwitchToEditingMode( shouldCreateTemplate = false ) {
-	if ( shouldCreateTemplate ) {
-		const templateContent = [
-			createBlock( 'core/post-title' ),
-			createBlock( 'core/post-content' ),
-		];
-		const template = {
-			slug: 'wp-custom-template-' + uuid(),
-			content: serialize( templateContent ),
-			title: 'Custom Template',
-		};
+/**
+ * Potentially create a block based template and switches to the template mode.
+ *
+ * @param {Object?} template template to create and assign before switching.
+ */
+export function* __unstableSwitchToTemplateMode( template ) {
+	if ( !! template ) {
 		const savedTemplate = yield controls.dispatch(
 			coreStore,
 			'saveEntityRecord',
@@ -475,7 +469,7 @@ export function* __unstableSwitchToEditingMode( shouldCreateTemplate = false ) {
 
 	yield setIsEditingTemplate( true );
 
-	const message = shouldCreateTemplate
+	const message = !! template
 		? __( "Custom template created. You're in template mode now." )
 		: __(
 				'Editing template. Changes made here affect all posts and pages that use the template.'

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -448,7 +448,7 @@ export function* __unstableSwitchToEditingMode( shouldCreateTemplate = false ) {
 			createBlock( 'core/post-content' ),
 		];
 		const template = {
-			slug: 'custom-template-' + uuid(),
+			slug: 'wp-custom-template-' + uuid(),
 			content: serialize( templateContent ),
 			title: 'Custom Template',
 		};

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -9,6 +9,8 @@ import { get, includes, some, flatten, values } from 'lodash';
  */
 import { createRegistrySelector } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 /**
  * Returns the current editing mode.
  *
@@ -335,3 +337,30 @@ export function isInserterOpened( state ) {
 export function isEditingTemplate( state ) {
 	return state.isEditingTemplate;
 }
+
+/**
+ * Retrieves the template of the currently edited post.
+ *
+ * @return {Object?} Post Template.
+ */
+export const getEditedPostTemplate = createRegistrySelector(
+	( select ) => () => {
+		const currentTemplate = select( editorStore ).getEditedPostAttribute(
+			'template'
+		);
+		if ( currentTemplate ) {
+			return select( coreStore )
+				.getEntityRecords( 'postType', 'wp_template' )
+				?.find( ( template ) => template.slug === currentTemplate );
+		}
+
+		const post = select( editorStore ).getCurrentPost();
+		if ( post.link && post.status !== 'auto-draft' ) {
+			return select( coreStore ).__experimentalGetTemplateForLink(
+				post.link
+			);
+		}
+
+		return null;
+	}
+);


### PR DESCRIPTION
The idea of this PR is to allow creating custom block templates (starting blank) for a given page in classic themes. It's a way for classic themes to enable some FSE features without any change.

**How to test it**

It's very rough at the moment, more a POC, but here's how  you do  it:

 - Create  a new page
 - Save it
 - you'll notice on the Document sidebar, a "Create custom template" link
 - Once you click that link a custom block template is created and attached to the page.
 - By default that template Is composed by just two blocks (post title and post content) but you can edit as you wish
 - Apply the changes and publish

Now, on the frontend, your page is using its own custom template and not the regular `page.php` or `singular.php` that comes from the theme itself.

**Notes**

This PR can be seen as a migration strategy for classic themes, it highlights a few things in terms of code/architecture:

 - The is_fse_theme checks become less important as this blurs the line between classic and FSE themes, the whole FSE infrastructure (template post type, template resolution, template API) need to be available for classic themes too.
 - In terms of design it's very rough at the moment, we need to improve that. I'm looking at you designers :P @jasmussen @jameskoster 
 - All FSE blocks become available for classic themes with this PR, this means if we ship this to Core, we need to make some good decisions about which FSE blocks are considered stable.
 - Right  now, it's enable for all classic themes by default, we might want to introduce a theme support flag for it to make it opt-in.

**Todo**

 - [x] Allow setting titles when creating custom templates.
 - [x] Improve the design a bit.
 - [x] Write an e2e test.
 - [x] Add some documentation.
 - [x] Theme support flag.