### PR TITLE
Update the save button label

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -9,7 +9,6 @@ import { some } from 'lodash';
 import { useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useViewportMatch } from '@wordpress/compose';
 
 export default function SaveButton( { openEntitiesSavedStates } ) {
 	const { isDirty, isSaving } = useSelect( ( select ) => {
@@ -27,7 +26,6 @@ export default function SaveButton( { openEntitiesSavedStates } ) {
 	} );
 
 	const disabled = ! isDirty || isSaving;
-	const isMobile = useViewportMatch( 'medium', '<' );
 
 	return (
 		<>
@@ -39,7 +37,7 @@ export default function SaveButton( { openEntitiesSavedStates } ) {
 				isBusy={ isSaving }
 				onClick={ disabled ? undefined : openEntitiesSavedStates }
 			>
-				{ isMobile ? __( 'Update' ) : __( 'Update Design' ) }
+				{ __( 'Save' ) }
 			</Button>
 		</>
 	);


### PR DESCRIPTION
In the Site Editor, the save button in the top bar currently reads "Update design" on larger screens, and "Update" on small screens.

I am proposing that we make this label more generic in order to account for the myriad of different types of changes a user might make in this context. Updating a template part area definition, renaming a reusable block, editing the content of a post / page, changing your homepage settings... these exercises do not strictly qualify as "design" in my opinion.

A simple "Save" label could be more appropriate. What do y'all think?

<img width="1540" alt="Screenshot 2021-04-01 at 10 07 42" src="https://user-images.githubusercontent.com/846565/113271164-21a23c80-92d2-11eb-8b0a-1e31e51e2399.png">
