### PR TITLE
Navigation editor - fix for manage theme locations data lost when menu is deselected 

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/index.js
+++ b/packages/edit-navigation/src/components/inspector-additions/index.js
@@ -23,6 +23,9 @@ export default function InspectorAdditions( {
 	isManageLocationsModalOpen,
 	closeManageLocationsModal,
 	openManageLocationsModal,
+	menuLocations,
+	assignMenuToLocation,
+	toggleMenuLocationAssignment,
 } ) {
 	const selectedBlock = useSelect(
 		( select ) => select( 'core/block-editor' ).getSelectedBlock(),
@@ -45,6 +48,11 @@ export default function InspectorAdditions( {
 			</PanelBody>
 			<PanelBody title={ __( 'Theme locations' ) }>
 				<ManageLocations
+					menuLocations={ menuLocations }
+					assignMenuToLocation={ assignMenuToLocation }
+					toggleMenuLocationAssignment={
+						toggleMenuLocationAssignment
+					}
 					menus={ menus }
 					selectedMenuId={ menuId }
 					onSelectMenu={ onSelectMenu }

--- a/packages/edit-navigation/src/components/inspector-additions/manage-locations.js
+++ b/packages/edit-navigation/src/components/inspector-additions/manage-locations.js
@@ -10,11 +10,6 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { useMenuLocations } from '../../hooks';
-
 export default function ManageLocations( {
 	onSelectMenu,
 	isModalOpen,
@@ -22,13 +17,10 @@ export default function ManageLocations( {
 	closeModal,
 	menus,
 	selectedMenuId,
+	menuLocations,
+	assignMenuToLocation,
+	toggleMenuLocationAssignment,
 } ) {
-	const {
-		menuLocations,
-		assignMenuToLocation,
-		toggleMenuLocationAssignment,
-	} = useMenuLocations();
-
 	if ( ! menuLocations ) {
 		return <Spinner />;
 	}

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -37,6 +37,7 @@ import {
 	useNavigationEditor,
 	useNavigationBlockEditor,
 	useMenuNotifications,
+	useMenuLocations,
 } from '../../hooks';
 import ErrorBoundary from '../error-boundary';
 import NavigationEditorShortcuts from './shortcuts';
@@ -110,6 +111,12 @@ export default function Layout( { blockEditorSettings } ) {
 	}, [] );
 
 	useMenuNotifications( selectedMenuId );
+
+	const {
+		menuLocations,
+		assignMenuToLocation,
+		toggleMenuLocationAssignment,
+	} = useMenuLocations();
 
 	const hasMenus = !! menus?.length;
 	const hasPermanentSidebar = isLargeViewport && hasMenus;
@@ -204,6 +211,15 @@ export default function Layout( { blockEditorSettings } ) {
 															blocks={ blocks }
 														/>
 														<InspectorAdditions
+															menuLocations={
+																menuLocations
+															}
+															assignMenuToLocation={
+																assignMenuToLocation
+															}
+															toggleMenuLocationAssignment={
+																toggleMenuLocationAssignment
+															}
 															isManageLocationsModalOpen={
 																isManageLocationsModalOpen
 															}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closes https://github.com/WordPress/gutenberg/issues/30424

When the menu was deselected and then selected again, theme management data was lost. In order to fix this behavior I have moved the useMenuLocations hook to layout

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to Navigation Editor
2. Select menu (add at least one if you don't have any)
3. Make a change in a sidebar - change a anything in theme locations
4. Click on the background
5. Select the block
6. See the changes persist

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
