### PR TITLE
Fix alignment issue on the nav screen manage locations buttons

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/style.scss
+++ b/packages/edit-navigation/src/components/inspector-additions/style.scss
@@ -21,6 +21,7 @@
 
 .edit-navigation-manage-locations__menu-entry {
 	display: flex;
+	align-items: end;
 	margin-bottom: $grid-unit-15;
 	margin-top: $grid-unit-15;
 	.components-custom-select-control,
@@ -29,6 +30,7 @@
 	}
 	button {
 		height: 100%;
+		margin-bottom: 8px;
 	}
 }
 


### PR DESCRIPTION
## Description
Fixes #30331.

Fix alignment issue on the nav screen manage locations buttons.

## Screenshots

Before
![manage-locations-buttons-before](https://user-images.githubusercontent.com/33403964/113277788-02f37400-92d9-11eb-8e3d-9c73f3e60f16.png)

After
![manage-locations-buttons-after](https://user-images.githubusercontent.com/33403964/113277811-08e95500-92d9-11eb-94af-0aa71c8050e8.png)


## Types of changes
CSS changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [NA] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [NA] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [NA] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [NA] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
