### PR TITLE
Navigation Editor - save add new pages on save button

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
+++ b/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
@@ -1,17 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function AutoAddPages( { menuId } ) {
+/**
+ * Internal dependencies
+ */
+import { useMenuEntity } from '../../hooks';
+
+export default function AutoAddPages( {
+	menuId,
+	autoAddPages,
+	setAutoAddPages,
+} ) {
 	const menu = useSelect( ( select ) => select( 'core' ).getMenu( menuId ), [
 		menuId,
 	] );
-
-	const [ autoAddPages, setAutoAddPages ] = useState( null );
 
 	useEffect( () => {
 		if ( autoAddPages === null && menu ) {
@@ -19,7 +26,7 @@ export default function AutoAddPages( { menuId } ) {
 		}
 	}, [ autoAddPages, menu ] );
 
-	const { saveMenu } = useDispatch( 'core' );
+	const { editMenuEntityRecord, menuEntityData } = useMenuEntity( menuId );
 
 	return (
 		<ToggleControl
@@ -30,8 +37,7 @@ export default function AutoAddPages( { menuId } ) {
 			checked={ autoAddPages ?? false }
 			onChange={ ( newAutoAddPages ) => {
 				setAutoAddPages( newAutoAddPages );
-				saveMenu( {
-					...menu,
+				editMenuEntityRecord( ...menuEntityData, {
 					auto_add: newAutoAddPages,
 				} );
 			} }

--- a/packages/edit-navigation/src/components/inspector-additions/index.js
+++ b/packages/edit-navigation/src/components/inspector-additions/index.js
@@ -23,6 +23,8 @@ export default function InspectorAdditions( {
 	isManageLocationsModalOpen,
 	closeManageLocationsModal,
 	openManageLocationsModal,
+	autoAddPages,
+	setAutoAddPages,
 } ) {
 	const selectedBlock = useSelect(
 		( select ) => select( 'core/block-editor' ).getSelectedBlock(),
@@ -37,7 +39,11 @@ export default function InspectorAdditions( {
 		<InspectorControls>
 			<PanelBody title={ __( 'Menu settings' ) }>
 				<NameEditor />
-				<AutoAddPages menuId={ menuId } />
+				<AutoAddPages
+					menuId={ menuId }
+					autoAddPages={ autoAddPages }
+					setAutoAddPages={ setAutoAddPages }
+				/>
 				<DeleteMenu
 					onDeleteMenu={ onDeleteMenu }
 					isMenuBeingDeleted={ isMenuBeingDeleted }

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -60,6 +60,7 @@ const interfaceLabels = {
 export default function Layout( { blockEditorSettings } ) {
 	const contentAreaRef = useBlockSelectionClearer();
 	const isLargeViewport = useViewportMatch( 'medium' );
+	const [ autoAddPages, setAutoAddPages ] = useState( null );
 	const [ isMenuNameControlFocused, setIsMenuNameControlFocused ] = useState(
 		false
 	);
@@ -204,6 +205,12 @@ export default function Layout( { blockEditorSettings } ) {
 															blocks={ blocks }
 														/>
 														<InspectorAdditions
+															autoAddPages={
+																autoAddPages
+															}
+															setAutoAddPages={
+																setAutoAddPages
+															}
 															isManageLocationsModalOpen={
 																isManageLocationsModalOpen
 															}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Closes https://github.com/WordPress/gutenberg/issues/30425

Currently all but `add new pages` config in the side bar are saved on the save button. This PR adds saving on button click to `add new pages` toggle.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to Navigation Editor
2. Select menu (add at least one if you don't have any)
3. toggle `add new pages`
4. refresh the page
5. see the change did not persist
6. toggle `add new pages`
7. click on the Save button
8. see the change has been saved


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancment

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
