### PR TITLE
Site Editor: Load block-editor scripts & styles

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -121,3 +121,16 @@ function gutenberg_menu_order( $menu_order ) {
 	}
 	return $menu_order;
 }
+
+/**
+ * Tells the script loader to load the scripts and styles of custom block on site editor screen.
+ *
+ * @param bool $is_block_editor_screen Current decision about loading block assets.
+ * @return bool Filtered decision about loading block assets.
+ */
+function gutenberg_site_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
+	return ( is_callable( 'get_current_screen' ) && 'toplevel_page_gutenberg-edit-site' === get_current_screen()->base )
+		? true
+		: $is_block_editor_screen;
+}
+add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_site_editor_load_block_editor_scripts_and_styles' );


### PR DESCRIPTION
## Description
Fixes #27962 

## How has this been tested?

Tested with the TT1-blocks theme.
Added this snippet in a PHP file:
```php
add_action( 'after_setup_theme', function() {
	register_block_style(
		'core/columns',
		array(
			'name'         => 'test',
			'label'        => __( 'test' ),
			'inline_style' => '.is-style-test {border:1px solid red;}',
		)
	);
} );
```
Before: The block-style did not apply in the site-editor screen.
After: It works.

## Types of changes

We already use the `should_load_block_editor_scripts_and_styles` filter to add assets in the widget and navigation screens, but it was missing in the site-editor.
This PR just adds the filter for that screen.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
