### PR TITLE
Block Library: Revert column-gap property for spacing between custom-sized buttons

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -61,34 +61,6 @@ $blocks-block__margin: 0.5em;
 	}
 }
 
-// If the browser supports column-gap, use that instead of the margins above.
-@supports ( column-gap: #{ $blocks-block__margin } ) {
-	.wp-block-buttons > .wp-block-button {
-		// Added .wp-block specificity needed to override the default button margin.
-		&.wp-block,
-		&.has-custom-width {
-			margin-right: 0;
-		}
-
-		&.wp-block-button__width-25 {
-			width: calc(25% - #{ $blocks-block__margin * 0.75 });
-		}
-
-		&.wp-block-button__width-50 {
-			width: calc(50% - #{ $blocks-block__margin * 0.5 });
-		}
-
-		&.wp-block-button__width-75 {
-			width: calc(75% - #{ $blocks-block__margin * 0.25 });
-		}
-
-		&.wp-block-button__width-100 {
-			width: auto;
-			flex-basis: 100%;
-		}
-	}
-}
-
 // the first selector is required for old buttons markup
 .wp-block-button.is-style-squared,
 .wp-block-button__link.wp-block-button.is-style-squared {

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -5,7 +5,6 @@ $blocks-block__margin: 0.5em;
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	column-gap: $blocks-block__margin;
 
 	&.is-vertical {
 		flex-direction: column;


### PR DESCRIPTION
This reverts the changes from #29165, commit 069aa44883e151d35c785968c44b00edcc5c6f17.

In testing, we overlooked an issue where Safari's [partial support](https://caniuse.com/?search=column-gap) of the `gap`/`column-gap` property provides an inaccurate response to the `@supports` query. Safari will say that it supports those properties, but in reality it only supports them for `grid`, not for `flexbox`. We need to use them with flexbox here. 😞 

I tried some workarounds, but I couldn't find something that worked. In the meantime, I think it's best to just revert this to stop the regression in button spacing for Safari. We can try another approach later. 

More reading on the topic: 
https://github.com/w3c/csswg-drafts/issues/3559
https://ishadeed.com/article/flexbox-gap/


## Screenshots (in Safari) <!-- if applicable -->

Before|After
---|---
![Screen Shot 2021-04-01 at 9 06 29 AM](https://user-images.githubusercontent.com/1202812/113301713-4ea02080-92cd-11eb-910d-72303eea597a.png)|![Screen Shot 2021-04-01 at 9 27 15 AM](https://user-images.githubusercontent.com/1202812/113301714-4f38b700-92cd-11eb-84c4-f2af5217b113.png)

