### PR TITLE
Fix experimental link color support flag

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -158,7 +158,9 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
-	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
+	if (
+		! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
+		! WP_Theme_JSON_Resolver::theme_has_support() ) {
 		return;
 	}
 
@@ -231,7 +233,10 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $base_styles;
-	} elseif ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+	} elseif (
+		WP_Theme_JSON_Resolver::theme_has_support() ||
+		get_theme_support( 'experimental-link-color' ) // link color support needs the presets CSS variables regardless of the presence of theme.json file.
+	) {
 		// STEP 3 - ADD STYLES IF THEME HAS SUPPORT
 		//
 		// If we are in a block editor context, but not in edit-site,


### PR DESCRIPTION
closes #29535

Theme authors used to be able to use the `experimental-link-color` support flag and have their theme support custom link colors in different paragraphs. A later refactoring broke the link color presets which should be fixed in this PR.
