### PR TITLE
Restore the inner div of the group block in the editor for classic themes

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -34,17 +34,22 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 			? [ 'wide', 'full' ]
 			: [ 'left', 'center', 'right' ];
 	const blockProps = useBlockProps();
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		templateLock,
-		renderAppender: hasInnerBlocks
-			? undefined
-			: InnerBlocks.ButtonBlockAppender,
-		__experimentalLayout: {
-			type: 'default',
-			// Find a way to inject this in the support flag code (hooks).
-			alignments: themeSupportsLayout ? alignments : undefined,
-		},
-	} );
+	const innerBlocksProps = useInnerBlocksProps(
+		themeSupportsLayout
+			? blockProps
+			: { className: 'wp-block-group__inner-container' },
+		{
+			templateLock,
+			renderAppender: hasInnerBlocks
+				? undefined
+				: InnerBlocks.ButtonBlockAppender,
+			__experimentalLayout: {
+				type: 'default',
+				// Find a way to inject this in the support flag code (hooks).
+				alignments: themeSupportsLayout ? alignments : undefined,
+			},
+		}
+	);
 
 	return (
 		<>
@@ -66,7 +71,14 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 					}
 				/>
 			</InspectorAdvancedControls>
-			<TagName { ...innerBlocksProps } />
+			{ themeSupportsLayout && <TagName { ...innerBlocksProps } /> }
+			{ /* Ideally this is not needed but it's there for backward compatibility reason
+				to keep this div for themes that might rely on its presence */ }
+			{ ! themeSupportsLayout && (
+				<TagName { ...blockProps }>
+					<div { ...innerBlocksProps } />
+				</TagName>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
closes #30443 

In Gutenberg 10.3 we introduced the layout config  #29335 and removed the useless inner div for group blocks. Some themes used to rely on that div for their styles so we decided to keep it in the frontend. The issue is that the breakage for these themes in the editor might be important. This PR restores the div in the editor as well for these themes.