### PR TITLE
List View: Update list view icon size and spacing

### DIFF
--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -60,7 +60,7 @@
 		align-items: center;
 		width: 100%;
 		height: auto;
-		padding: ($grid-unit-15 / 2);
+		padding: ($grid-unit-15 / 2) $grid-unit-15;
 		text-align: left;
 		color: $gray-900;
 		border-radius: 2px;
@@ -121,7 +121,8 @@
 
 	.block-editor-block-icon {
 		align-self: flex-start;
-		margin-right: 6px;
+		margin-right: ( $grid-unit-05 * 2.5 ); // 10px is off the 4px grid, but required for visual alignment between block name and subsequent nested icon
+		width: 20px;
 	}
 
 	.block-editor-block-navigation-block__menu-cell,


### PR DESCRIPTION
Currently the icon size and placement in list view feels a bit unbalanced compared to the general spacing of the rows and the block name.

This PR explores how things feel if we reduce the icon size a bit (20px instead of 24px) and increase the spacing a little, giving everything a bit more room the breathe:

| Before | After |
| --- | --- |
| <img width="350" alt="Screenshot 2021-04-01 at 16 07 44" src="https://user-images.githubusercontent.com/846565/113314778-8ffff280-9304-11eb-8c75-6a29eda0b753.png"> | <img width="350" alt="Screenshot 2021-04-01 at 16 08 00" src="https://user-images.githubusercontent.com/846565/113314804-955d3d00-9304-11eb-8dff-86e0096b133a.png"> |

Hopefully these changes better prepare us to accomodate future enhancements like expanding / collapsing container blocks, or block actions via ellipsis menu.

<img width="295" alt="Screenshot 2021-04-01 at 16 10 51" src="https://user-images.githubusercontent.com/846565/113315123-d9504200-9304-11eb-9d2c-6e36b1865e06.png">

cc @mtias 