### PR TITLE
Fix select all shortcut inside widget area parents

### DIFF
--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -42,8 +42,7 @@ function KeyboardShortcuts() {
 		}
 		const [ selectedParentClientId ] = getBlockParentsByBlockName(
 			selectedClientId,
-			'core/widget-area',
-			false
+			'core/widget-area'
 		);
 		return {
 			rootBlocksClientIds: getBlockOrder( selectedParentClientId ),

--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -79,7 +79,7 @@ function KeyboardShortcuts() {
 	);
 
 	useShortcut(
-		'core/block-editor/select-all',
+		'core/edit-widgets/select-all',
 		useCallback(
 			( event ) => {
 				event.preventDefault();
@@ -135,7 +135,7 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
-			name: 'core/block-editor/select-all',
+			name: 'core/edit-widgets/select-all',
 			category: 'selection',
 			description: __(
 				'Select all text when typing. Press again to select all blocks.'

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -23,8 +23,8 @@ export default function WidgetAreasBlockEditorContent( {
 	return (
 		<div className="edit-widgets-block-editor editor-styles-wrapper">
 			<EditorStyles styles={ blockEditorSettings.styles } />
-			<KeyboardShortcuts />
 			<BlockEditorKeyboardShortcuts />
+			<KeyboardShortcuts />
 			<Notices />
 			<Popover.Slot name="block-toolbar" />
 			<BlockSelectionClearer>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #28267. The "select all" functionality in the post editor assumes that there is no boundary block and so it defaults to selecting everthing. On the widgtets editor we have a widget area block that contains the blocks for that area and it makes no sense to select via Primary + A the blocks in another area.
This fix is also part of my investigation in fixing  #19102 and it may contain a way to fix that.
<!-- Please describe what you have changed or added -->

I am not happy with this implementation, but it does work. The downside is creating a memory store or hardcoding a block name for determining the container.
Alternatives would be:

- adding a `selectable` supports where by certain blocks will not be selectable and select all will only apply to their `innerBlocks`

The other place that has this problem is the site editor where select all is selecting across template parts which might not be expected, but at least there we don't have the visual and functional separation active in the widgets editor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested locally by:

1. Setting up a theme with multiple widget areas (TwentyTwentyOne has two)
2. Go to Appearance > Widgets
3. Add some widgets
4. Save
5. Click in a paragraph
6. Press CMD/Ctrl + A, observe text is selected
7. Press CMD/Ctrl + A, observe all widgets and blocks in the current widget area are selected.
8. Press CMD/Ctrl + A. observe the selection remains the same.


## Screenshots <!-- if applicable -->

N/A

## Types of changes
Added an overrride for the edit-widgets package of the 'core/block-editor/select-all' shortcut.
Updated the select all logic by remembering the first selection, finding the parent and preserving the list of the blocks in the top most widget area.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## To Do

- [ ] Write a test for multiple selection

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
