### PR TITLE
Writing flow: fix horizontal caret placing for empty editable with placeholder

### DIFF
--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -12,6 +12,7 @@ export default function QueryPaginationNextEdit( {
 		<PlainText
 			__experimentalVersion={ 2 }
 			tagName="a"
+			style={ { display: 'inline-block' } }
 			aria-label={ __( 'Next page link' ) }
 			placeholder={ __( 'Next Page' ) }
 			value={ label }

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -12,6 +12,7 @@ export default function QueryPaginationPreviousEdit( {
 		<PlainText
 			__experimentalVersion={ 2 }
 			tagName="a"
+			style={ { display: 'inline-block' } }
 			aria-label={ __( 'Previous page link' ) }
 			placeholder={ __( 'Previous Page' ) }
 			value={ label }

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -49,6 +49,7 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 			<TagName { ...blockProps }>
 				<RichText
 					tagName="a"
+					style={ { display: 'inline-block' } }
 					aria-label={ __( 'Site title text' ) }
 					placeholder={ __( 'Write site title…' ) }
 					value={ title }

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -272,6 +272,7 @@ _Parameters_
 
 -   _container_ `Element`: Focusable element.
 -   _isReverse_ `boolean`: True for end, false for start.
+-   _mayUseScroll_ `boolean`: Whether to allow scrolling.
 
 <a name="placeCaretAtVerticalEdge" href="#placeCaretAtVerticalEdge">#</a> **placeCaretAtVerticalEdge**
 

--- a/packages/rich-text/src/component/use-inline-warning.js
+++ b/packages/rich-text/src/component/use-inline-warning.js
@@ -15,7 +15,7 @@ export function useInlineWarning( { ref } ) {
 
 			if ( computedStyle.display === 'inline' ) {
 				// eslint-disable-next-line no-console
-				console.warn( message );
+				console.error( message );
 			}
 		}
 	}, [] );

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -305,6 +305,8 @@ export function toTree( {
 						// selection. The placeholder is also not editable after
 						// all.
 						contenteditable: 'false',
+						style:
+							'pointer-events:none;user-select:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;',
 					},
 				} );
 			}


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

Attempts to fix https://github.com/WordPress/gutenberg/pull/30393#issuecomment-812022894.

Horizontal caret placement at content editable edges by the writing flow component does not work as expected when there is a placeholder. Currently we let the browser select the field's content (which includes the placeholder) and then collapse the selection either to the start or end. This seems a bit problematic since the caret can end up after the placeholder, which is technically possible, but shouldn't be allowed. The caret cannot be placed there unless programmatically done so.

To resolve the issue, I've changed `placeCaretAtHorizontalEdge` to use the same technique as `isEdge` and `placeCaretAtVerticalEdge` which is to let the browser create a `Range` that is closest to a certain point. This will completely ignore the placeholder (which is non editable and disables pointer events).

## How has this been tested?

Create a new post. Focus the title field. Press three times Enter and two times ArrowLeft. The caret should be in the first paragraph block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
