### PR TITLE
Fix template hierarchy for custom, user-generated templates

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -71,9 +71,16 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	foreach ( $templates as $template_item ) {
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
+		// Is this a custom template?
+		$is_custom_template = 0 === strpos( $current_block_template_slug, 'custom-template-' );
+
 		// Don't override the template if we find a template matching the slug we look for
 		// and which does not match a block template slug.
-		if ( $current_template_slug !== $current_block_template_slug && $current_template_slug === $template_item_slug ) {
+		if (
+			! $is_custom_template &&
+			$current_template_slug !== $current_block_template_slug &&
+			$current_template_slug === $template_item_slug
+		) {
 			return $template;
 		}
 	}


### PR DESCRIPTION
## Description

Fixes the template hierarchy issue for user-generated templates in https://github.com/WordPress/gutenberg/pull/30438

## How has this been tested?
Tested in the twentytwentyone & twentytwenty themes

## Types of changes

Added a check for custom templates. These should not be getting overridden.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
