### PR TITLE
Add  gutenberg_supports_block_templates

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -646,7 +646,7 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 	}
 
 	// Remove the default font editor styles for FSE themes.
-	if ( gutenberg_is_fse_theme() ) {
+	if ( gutenberg_is_fse_enabled() ) {
 		foreach ( $settings['styles'] as $j => $style ) {
 			if ( 0 === strpos( $style['css'], 'body { font-family:' ) ) {
 				unset( $settings['styles'][ $j ] );
@@ -666,7 +666,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_block_editor_settings_with_fse_theme_flag( $settings ) {
-	$settings['supportsTemplateMode'] = true; // gutenberg_is_fse_theme();
+	$settings['supportsTemplateMode'] = gutenberg_is_fse_enabled();
 
 	// Enable the new layout options for themes with a theme.json file.
 	$settings['supportsLayout'] = WP_Theme_JSON_Resolver::theme_has_support();

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -646,7 +646,7 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 	}
 
 	// Remove the default font editor styles for FSE themes.
-	if ( gutenberg_is_fse_enabled() ) {
+	if ( gutenberg_supports_block_templates() ) {
 		foreach ( $settings['styles'] as $j => $style ) {
 			if ( 0 === strpos( $style['css'], 'body { font-family:' ) ) {
 				unset( $settings['styles'][ $j ] );
@@ -666,7 +666,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_block_editor_settings_with_fse_theme_flag( $settings ) {
-	$settings['supportsTemplateMode'] = gutenberg_is_fse_enabled();
+	$settings['supportsTemplateMode'] = gutenberg_supports_block_templates();
 
 	// Enable the new layout options for themes with a theme.json file.
 	$settings['supportsLayout'] = WP_Theme_JSON_Resolver::theme_has_support();

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -14,7 +14,7 @@
  * @return bool
  */
 function gutenberg_should_load_separate_block_assets() {
-	$load_separate_styles = gutenberg_is_fse_enabled();
+	$load_separate_styles = gutenberg_supports_block_templates();
 	/**
 	 * Determine if separate styles will be loaded for blocks on-render or not.
 	 *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -14,7 +14,7 @@
  * @return bool
  */
 function gutenberg_should_load_separate_block_assets() {
-	$load_separate_styles = gutenberg_is_fse_theme();
+	$load_separate_styles = gutenberg_is_fse_enabled();
 	/**
 	 * Determine if separate styles will be loaded for blocks on-render or not.
 	 *

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -39,7 +39,7 @@ function gutenberg_get_common_block_editor_settings() {
 	};
 
 	$settings = array(
-		'__unstableEnableFullSiteEditingBlocks' => true, // gutenberg_is_fse_theme(),
+		'__unstableEnableFullSiteEditingBlocks' => gutenberg_is_fse_enabled(),
 		'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
 		'disableCustomGradients'                => get_theme_support( 'disable-custom-gradients' ),
@@ -81,7 +81,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 	$image_sizes        = wp_list_pluck( $settings['imageSizes'], 'slug' );
 
 	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
-	$settings['__unstableEnableFullSiteEditingBlocks'] = true; // gutenberg_is_fse_theme();
+	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_enabled();
 
 	return $settings;
 }

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -39,7 +39,7 @@ function gutenberg_get_common_block_editor_settings() {
 	};
 
 	$settings = array(
-		'__unstableEnableFullSiteEditingBlocks' => gutenberg_is_fse_enabled(),
+		'__unstableEnableFullSiteEditingBlocks' => gutenberg_supports_block_templates(),
 		'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
 		'disableCustomGradients'                => get_theme_support( 'disable-custom-gradients' ),
@@ -81,7 +81,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 	$image_sizes        = wp_list_pluck( $settings['imageSizes'], 'slug' );
 
 	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
-	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_enabled();
+	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_supports_block_templates();
 
 	return $settings;
 }

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -21,7 +21,7 @@ function gutenberg_is_fse_theme() {
  */
 function gutenberg_is_fse_enabled() {
 	return apply_filters(
-		'fse_enabled',
+		'full_site_editing_enabled',
 		gutenberg_is_fse_theme() || ! current_theme_supports( 'disable-full-site-editing' )
 	);
 }

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -20,10 +20,7 @@ function gutenberg_is_fse_theme() {
  * @return boolean Whether the current theme is FSE-enabled or not.
  */
 function gutenberg_is_fse_enabled() {
-	return apply_filters(
-		'full_site_editing_enabled',
-		gutenberg_is_fse_theme() || ! current_theme_supports( 'disable-full-site-editing' )
-	);
+	return gutenberg_is_fse_theme() || ! current_theme_supports( 'disable-full-site-editing' );
 }
 
 /**

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -20,7 +20,7 @@ function gutenberg_is_fse_theme() {
  * @return boolean Whether the current theme is FSE-enabled or not.
  */
 function gutenberg_supports_block_templates() {
-	return gutenberg_is_fse_theme() || current_theme_supports( 'full-site-editing' );
+	return gutenberg_is_fse_theme() || current_theme_supports( 'block-templates' );
 }
 
 /**

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -15,6 +15,18 @@ function gutenberg_is_fse_theme() {
 }
 
 /**
+ * Returns whether the current theme is FSE-enabled or not.
+ *
+ * @return boolean Whether the current theme is FSE-enabled or not.
+ */
+function gutenberg_is_fse_enabled() {
+	return apply_filters(
+		'fse_enabled',
+		gutenberg_is_fse_enabled() || current_theme_supports( 'full-site-editing' );
+	)
+}
+
+/**
  * Show a notice when a Full Site Editing theme is used.
  */
 function gutenberg_full_site_editing_notice() {

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -22,8 +22,8 @@ function gutenberg_is_fse_theme() {
 function gutenberg_is_fse_enabled() {
 	return apply_filters(
 		'fse_enabled',
-		gutenberg_is_fse_enabled() || current_theme_supports( 'full-site-editing' );
-	)
+		gutenberg_is_fse_theme() || ! current_theme_supports( 'disable-full-site-editing' )
+	);
 }
 
 /**

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -20,7 +20,7 @@ function gutenberg_is_fse_theme() {
  * @return boolean Whether the current theme is FSE-enabled or not.
  */
 function gutenberg_supports_block_templates() {
-	return gutenberg_is_fse_theme() || ! current_theme_supports( 'disable-full-site-editing' );
+	return gutenberg_is_fse_theme() || current_theme_supports( 'full-site-editing' );
 }
 
 /**

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -19,7 +19,7 @@ function gutenberg_is_fse_theme() {
  *
  * @return boolean Whether the current theme is FSE-enabled or not.
  */
-function gutenberg_is_fse_enabled() {
+function gutenberg_supports_block_templates() {
 	return gutenberg_is_fse_theme() || ! current_theme_supports( 'disable-full-site-editing' );
 }
 

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -15,7 +15,7 @@
  * @return array (Maybe) modified page templates array.
  */
 function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
-	if ( ! gutenberg_is_fse_enabled() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return $templates;
 	}
 

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -15,9 +15,9 @@
  * @return array (Maybe) modified page templates array.
  */
 function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
-	/*if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_enabled() ) {
 		return $templates;
-	}*/
+	}
 
 	$block_templates = gutenberg_get_block_templates( array(), 'wp_template' );
 	foreach ( $block_templates as $template ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -9,9 +9,9 @@
  * Adds necessary filters to use 'wp_template' posts instead of theme template files.
  */
 function gutenberg_add_template_loader_filters() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_enabled() ) {
 		return;
-	} */
+	}
 
 	foreach ( gutenberg_get_template_type_slugs() as $template_type ) {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -9,7 +9,7 @@
  * Adds necessary filters to use 'wp_template' posts instead of theme template files.
  */
 function gutenberg_add_template_loader_filters() {
-	if ( ! gutenberg_is_fse_enabled() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
 	}
 

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -9,9 +9,9 @@
  * Registers block editor 'wp_template_part' post type.
  */
 function gutenberg_register_template_part_post_type() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_enabled() ) {
 		return;
-	} */
+	}
 
 	$labels = array(
 		'name'                  => __( 'Template Parts', 'gutenberg' ),
@@ -64,9 +64,9 @@ add_action( 'init', 'gutenberg_register_template_part_post_type' );
  * Registers the 'wp_template_part_area' taxonomy.
  */
 function gutenberg_register_wp_template_part_area_taxonomy() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_enabled() ) {
 		return;
-	} */
+	}
 
 	register_taxonomy(
 		'wp_template_part_area',
@@ -107,9 +107,9 @@ if ( ! defined( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED' ) ) {
  * Fixes the label of the 'wp_template_part' admin menu entry.
  */
 function gutenberg_fix_template_part_admin_menu_entry() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_enabled() ) {
 		return;
-	} */
+	}
 
 	global $submenu;
 	if ( ! isset( $submenu['themes.php'] ) ) {

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -9,7 +9,7 @@
  * Registers block editor 'wp_template_part' post type.
  */
 function gutenberg_register_template_part_post_type() {
-	if ( ! gutenberg_is_fse_enabled() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
 	}
 
@@ -64,7 +64,7 @@ add_action( 'init', 'gutenberg_register_template_part_post_type' );
  * Registers the 'wp_template_part_area' taxonomy.
  */
 function gutenberg_register_wp_template_part_area_taxonomy() {
-	if ( ! gutenberg_is_fse_enabled() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
 	}
 
@@ -107,7 +107,7 @@ if ( ! defined( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED' ) ) {
  * Fixes the label of the 'wp_template_part' admin menu entry.
  */
 function gutenberg_fix_template_part_admin_menu_entry() {
-	if ( ! gutenberg_is_fse_enabled() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
 	}
 

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -28,7 +28,7 @@ function gutenberg_get_template_paths() {
  * Registers block editor 'wp_template' post type.
  */
 function gutenberg_register_template_post_type() {
-	if ( ! gutenberg_is_fse_enabled() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
 	}
 
@@ -84,7 +84,7 @@ add_action( 'init', 'gutenberg_register_template_post_type' );
  * Registers block editor 'wp_theme' taxonomy.
  */
 function gutenberg_register_wp_theme_taxonomy() {
-	if ( ! gutenberg_is_fse_enabled() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
 	}
 
@@ -139,7 +139,7 @@ add_filter( 'user_has_cap', 'gutenberg_grant_template_caps' );
  * Fixes the label of the 'wp_template' admin menu entry.
  */
 function gutenberg_fix_template_admin_menu_entry() {
-	if ( ! gutenberg_is_fse_enabled() ) {
+	if ( ! gutenberg_supports_block_templates() ) {
 		return;
 	}
 	global $submenu;

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -28,9 +28,9 @@ function gutenberg_get_template_paths() {
  * Registers block editor 'wp_template' post type.
  */
 function gutenberg_register_template_post_type() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_enabled() ) {
 		return;
-	} */
+	}
 
 	$labels = array(
 		'name'                  => __( 'Templates', 'gutenberg' ),
@@ -84,9 +84,9 @@ add_action( 'init', 'gutenberg_register_template_post_type' );
  * Registers block editor 'wp_theme' taxonomy.
  */
 function gutenberg_register_wp_theme_taxonomy() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_enabled() ) {
 		return;
-	} */
+	}
 
 	register_taxonomy(
 		'wp_theme',
@@ -139,9 +139,9 @@ add_filter( 'user_has_cap', 'gutenberg_grant_template_caps' );
  * Fixes the label of the 'wp_template' admin menu entry.
  */
 function gutenberg_fix_template_admin_menu_entry() {
-	/* if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_enabled() ) {
 		return;
-	} */
+	}
 	global $submenu;
 	if ( ! isset( $submenu['themes.php'] ) ) {
 		return;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -198,7 +198,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	$origin = 'theme';
 	if (
 		WP_Theme_JSON_Resolver::theme_has_support() &&
-		gutenberg_is_fse_enabled()
+		gutenberg_supports_block_templates()
 	) {
 		// Only lookup for the user data if we need it.
 		$origin = 'user';
@@ -224,7 +224,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		function_exists( 'gutenberg_is_edit_site_page' ) &&
 		gutenberg_is_edit_site_page( $screen->id ) &&
 		WP_Theme_JSON_Resolver::theme_has_support() &&
-		gutenberg_is_fse_enabled()
+		gutenberg_supports_block_templates()
 	) {
 		$user_cpt_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
 		$base_styles = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get_raw_data();

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -198,7 +198,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	$origin = 'theme';
 	if (
 		WP_Theme_JSON_Resolver::theme_has_support() &&
-		gutenberg_is_fse_theme()
+		gutenberg_is_fse_enabled()
 	) {
 		// Only lookup for the user data if we need it.
 		$origin = 'user';
@@ -224,7 +224,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		function_exists( 'gutenberg_is_edit_site_page' ) &&
 		gutenberg_is_edit_site_page( $screen->id ) &&
 		WP_Theme_JSON_Resolver::theme_has_support() &&
-		gutenberg_is_fse_theme()
+		gutenberg_is_fse_enabled()
 	) {
 		$user_cpt_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
 		$base_styles = WP_Theme_JSON_Resolver::get_merged_data( $theme_support_data, 'theme' )->get_raw_data();

--- a/lib/init.php
+++ b/lib/init.php
@@ -177,3 +177,4 @@ function register_site_icon_url( $response ) {
 add_filter( 'rest_index', 'register_site_icon_url' );
 
 add_theme_support( 'widgets-block-editor' );
+add_theme_support( 'full-site-editing' );


### PR DESCRIPTION
# Description

Introduces an ` supports_block_templates` function which is filterable and also checks for a theme-support.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
