### PR TITLE
Change the prefix for custom templates

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -72,6 +72,8 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
 		// Is this a custom template?
+		// This check should be removed when merged in core.
+		// Instead, wp_templates should be considered valid in locate_template.
 		$is_custom_template = 0 === strpos( $current_block_template_slug, 'wp-custom-template-' );
 
 		// Don't override the template if we find a template matching the slug we look for

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -72,7 +72,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
 		// Is this a custom template?
-		$is_custom_template = 0 === strpos( $current_block_template_slug, 'custom-template-' );
+		$is_custom_template = 0 === strpos( $current_block_template_slug, 'wp-custom-template-' );
 
 		// Don't override the template if we find a template matching the slug we look for
 		// and which does not match a block template slug.

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -448,7 +448,7 @@ export function* __unstableSwitchToEditingMode( shouldCreateTemplate = false ) {
 			createBlock( 'core/post-content' ),
 		];
 		const template = {
-			slug: 'custom-template-' + uuid(),
+			slug: 'wp-custom-template-' + uuid(),
 			content: serialize( templateContent ),
 			title: 'Custom Template',
 		};


### PR DESCRIPTION
## Description

As discussed 1-on-1 with @youknowriad, this PR changes the prefix for custom templates to make it a bit more unique by adding `wp-` at the front. 
Using `custom-template-` has the potential to return some false positives in https://github.com/WordPress/gutenberg/pull/30438/commits/91b24b63f15ab721c0f52657bd93070b03496bc3#diff-b549790920c5dba823bd76cf7f7b1ef68fa0d89f9f66f3579dc9daa68767b646R75. By adding the `wp-` prefix we ensure that the template was one generated by WP and not a file called `custom-template-something`