### PR TITLE
theme.json: Fix theme_has_support()

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -31,7 +31,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @var boolean
 	 */
-	private static $theme_has_support = null;
+	private static $theme_has_support = array();
 
 	/**
 	 * Container for data coming from the user.
@@ -503,11 +503,12 @@ class WP_Theme_JSON_Resolver {
 	 * @return boolean
 	 */
 	public static function theme_has_support() {
-		if ( ! isset( self::$theme_has_support ) ) {
-			self::$theme_has_support = (bool) self::get_file_path_from_theme( 'experimental-theme.json' );
+		$theme_slug = get_stylesheet();
+		if ( ! isset( self::$theme_has_support[ $theme_slug ] ) ) {
+			self::$theme_has_support[ $theme_slug ] = (bool) self::get_file_path_from_theme( 'experimental-theme.json' );
 		}
 
-		return self::$theme_has_support;
+		return self::$theme_has_support[ $theme_slug ];
 	}
 
 	/**

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -124,7 +124,7 @@ function _gutenberg_get_template_files( $template_type ) {
  * @return array Template.
  */
 function _gutenberg_add_template_part_area_info( $template_info ) {
-	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+	if ( WP_Theme_JSON_Resolver::theme_has_support( $template_info['slug'] ) ) {
 		$theme_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_parts();
 	}
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -124,7 +124,7 @@ function _gutenberg_get_template_files( $template_type ) {
  * @return array Template.
  */
 function _gutenberg_add_template_part_area_info( $template_info ) {
-	if ( WP_Theme_JSON_Resolver::theme_has_support( $template_info['slug'] ) ) {
+	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
 		$theme_data = WP_Theme_JSON_Resolver::get_theme_data()->get_template_parts();
 	}
 


### PR DESCRIPTION
## Description
Fixes #30478. See there for details.

## How has this been tested?
Read the explanation in #30478. Then, have a look at #30045, and verify that its unit tests are currently failing.
Check out #30045's branch (`update/wp-env-tt1-blocks-0-4-4`), and run

```
npm run test-unit-php -- /var/www/html/wp-content/plugins/gutenberg/phpunit/class-block-templates-test.php
```

It should fail.

Now cherry-pick the commits from this branch. Restart `wp-env` (in order to trigger the upgrade to TT1 Blocks v0.4.5), and run the test again.

This time, it should pass.

Maybe @Addison-Stavlo @david-szabo97 et al can come up with a simpler way to demonstrate this -- I'm not sure where (e.g. in the UI) the template part area is currently exposed (and broken by the underlying bug).

## TODO

**Note** that if you run all PHP unit tests (`npm run test-unit-php`) after cherry-picking, there's another test failure:

```
1) WP_Theme_JSON_Resolver_Test::test_translations_are_applied
Failed asserting that Array &0 (
    'palette' => Array &1 (
        0 => Array &2 (
            'slug' => 'light'
            'name' => 'Jasny'
            'color' => '#f5f7f9'
        )
        1 => Array &3 (
            'slug' => 'dark'
            'name' => 'Ciemny'
            'color' => '#000'
        )
    )
    'custom' => false
) is identical to null.

/var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-resolver-test.php:114
```

I believe that is probably a bug that is exposed by this fix (and that also needs to be addressed).

## Types of changes
Bug fix.