### PR TITLE
Handbook: Rename, changed URL Link

### DIFF
--- a/docs/explanations/architecture/README.md
+++ b/docs/explanations/architecture/README.md
@@ -10,4 +10,4 @@ Let’s look at the big picture and the architectural and UX principles of the b
 - What are the decision decisions behind the Data Module?
 - [Why is Puppeteer the tool of choice for end-to-end tests?](/docs/explanations/architecture/automated-testing.md)
 - [What's the difference between the different editor packages? What's the purpose of each package?](/docs/explanations/architecture/modularity.md#whats-the-difference-between-the-different-editor-packages-whats-the-purpose-of-each-package)
-- [Template and template parts flows](/docs/explanations/architecture/fse-templates.md)
+- [Template and template parts flows](/docs/explanations/architecture/full-site-editing-templates.md)


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description

`fse-templates.md` seems to be `full-site-editing-templates.md`. This fixes the link, which hopefully fixes the site generation.

## How has this been tested?

* Navigating to https://developer.wordpress.org/block-editor/explanations/architecture/full-site-editing-templates/
* Checking with the internet archive (looks like they have no record of the link name).

## Screenshots <!-- if applicable -->

## Types of changes

Documentation edit (single part of single file).

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

(Note: None of the above apply, but 🤷 deleting felt less easy than ticking).