### PR TITLE
Enable color palettes with custom color alpha support

### DIFF
--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -50,6 +50,16 @@ Whether the palette should have a clearing button or not.
 - Required: No
 - Default: true
 
+### disableAlpha
+
+Whether the custom color picker allows the selection of alpha values. Only relevant, when
+`disableCustomColors` is false. If alpha is enabled, the returned color format will be rgba
+instead of hex.
+
+- Type: `Boolean`
+- Required: No
+- Default: true
+
 
 ## Usage
 ```jsx

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -23,6 +23,7 @@ export default function ColorPalette( {
 	disableCustomColors = false,
 	onChange,
 	value,
+	disableAlpha = true,
 } ) {
 	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
 	const colorOptions = useMemo( () => {
@@ -61,8 +62,12 @@ export default function ColorPalette( {
 	const renderCustomColorPicker = () => (
 		<ColorPicker
 			color={ value }
-			onChangeComplete={ ( color ) => onChange( color.hex ) }
-			disableAlpha
+			onChangeComplete={ ( color ) =>
+				disableAlpha
+					? onChange( color.hex )
+					: onChange( tinycolor( color.rgb ).toRgbString() )
+			}
+			disableAlpha={ disableAlpha }
 		/>
 	);
 

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -39,3 +39,16 @@ export const withKnobs = () => {
 
 	return <ColorPaletteWithState colors={ colors } />;
 };
+
+export const alphaEnabled = () => {
+	const colors = [
+		object( 'Red', { name: 'red transparent', color: '#f00a' } ),
+		object( 'White', { name: 'white transparent', color: '#fff9' } ),
+		object( 'Blue', {
+			name: 'blue transparent',
+			color: 'rgba(0, 0, 255, 0.5)',
+		} ),
+	];
+
+	return <ColorPaletteWithState colors={ colors } disableAlpha={ false } />;
+};


### PR DESCRIPTION
## Description
`<ColorPicker>` component already had alpha support. Added a `disableAlpha` prop to the `<ColorPalette>` that passes the prop to the `<ColorPicker>`. Fix #27960 Fix #13045

## How has this been tested?
Tested with a custom Block that has a `<ColorPalette>` in its inspector controls and `disableAlpha={ false }`. Also tested core components that have `<ColorPalette>` still work.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
