### PR TITLE
 Added ability to change style via store

### DIFF
--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -3,14 +3,24 @@
  */
 import { store as blocksStore } from '@wordpress/blocks';
 import { useMemo, useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import {
+	getActiveStyle,
+	replaceActiveStyle,
+} from '../../components/block-styles/utils';
+
+/**
+ * External dependencies
+ */
+
+import { find } from 'lodash';
 
 export default function DefaultStylePicker( { blockName } ) {
 	const {
@@ -38,10 +48,53 @@ export default function DefaultStylePicker( { blockName } ) {
 		],
 		[ styles ]
 	);
+
+	function selector( select ) {
+		const { getClientId } = select( blockEditorStore );
+		return {
+			getClientId: getClientId(),
+		};
+	}
+
+	const { getClientId } = useSelect( selector, [] );
+
+	const clientId = getClientId;
+
+	const selector1 = ( select ) => {
+		const { getBlock } = select( blockEditorStore );
+		const block = getBlock( clientId );
+		return {
+			className: block.attributes.className || '',
+		};
+	};
+
+	const { style, className } = useSelect( selector1, [ clientId ] );
+
+	const renderedStyles = find( style, 'isDefault' )
+		? style
+		: [
+				{
+					name: 'default',
+					label: _x( 'Default', 'block style' ),
+					isDefault: true,
+				},
+				...style,
+		  ];
+
+	const activeStyle = getActiveStyle( renderedStyles, className );
+
+	const styleClassName = replaceActiveStyle( className, activeStyle, style );
+
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
 	const selectOnChange = useCallback(
 		( blockStyle ) => {
 			onUpdatePreferredStyleVariations( blockName, blockStyle );
 		},
+		updateBlockAttributes( clientId, {
+			//	className: 'is-style-large',
+			className: styleClassName,
+		} ),
 		[ blockName, onUpdatePreferredStyleVariations ]
 	);
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1993,6 +1993,9 @@ export function isNavigationMode( state ) {
 	return state.isNavigationMode;
 }
 
+export function getClientId( state ) {
+	return state.selection.selectionEnd.clientId;
+}
 /**
  * Returns whether block moving mode is enabled.
  *


### PR DESCRIPTION
Hi ) I found out that I can not change default styles of quote via select if selected item in the block menu.
![Знімок екрана з 2021-04-04 20-28-59](https://user-images.githubusercontent.com/34488718/113516732-8f758f00-9584-11eb-8338-26747704c866.png)
As you can see text has not large font , which was selected in select menu under "Default Style" string.


I tried to get id of block from store , as it was in packages/block-editor/src/components/block-styles/index.js file but I have an error :  
![Знімок екрана з 2021-04-04 20-36-27](https://user-images.githubusercontent.com/34488718/113516890-76211280-9585-11eb-8243-7523f535c0df.png)
Please , who can help me to finish this fix ? What I've done wrong ?