### PR TITLE
add post-classes in the loop

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -61,7 +61,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 				)
 			)
 		)->render( array( 'dynamic' => false ) );
-		$content      .= '<li class="' . esc_attr( implode( ' ', get_post_class() ) ) . '">' . $block_content . '</li>';
+		$post_classes  = esc_attr( implode( ' ', get_post_class( 'wp-block-post' ) ) );
+		$content      .= '<li class="' . $post_classes . '">' . $block_content . '</li>';
 	}
 
 	wp_reset_postdata();

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -61,7 +61,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 				)
 			)
 		)->render( array( 'dynamic' => false ) );
-		$content      .= "<li>{$block_content}</li>";
+		$content      .= '<li class="' . esc_attr( implode( ' ', get_post_class() ) ) . '">' . $block_content . '</li>';
 	}
 
 	wp_reset_postdata();


### PR DESCRIPTION
## Description
This PR adds post-classes in the loop.
See https://github.com/WordPress/gutenberg/issues/29308 for details.

I'm still not convinced we should do this... It feels too noisy. Over the years a lot of classes were added to these, so a random post would look something like this:
```html
<li class="post-1944 post type-post status-publish format-standard hentry category-uncategorized">
```
Things like `post`, `type-post`, `status-publish`, `hentry` and possibly others too, don't make a lot of sense in an FSE context where queries are built by users... 🤔 

## How has this been tested?

Tested in an FSE theme and made sure that posts inside a loop get the post-classes they previously had in classic themes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->


cc @justintadlock