### PR TITLE
Block Library: Add option to make PostDate a link

### DIFF
--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -8,6 +8,10 @@
 		},
 		"format": {
 			"type": "string"
+		},
+		"isLink": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -18,16 +18,17 @@ import {
 import {
 	ToolbarGroup,
 	ToolbarButton,
+	ToggleControl,
 	Popover,
 	DateTimePicker,
 	PanelBody,
 	CustomSelectControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { edit } from '@wordpress/icons';
 
 export default function PostDateEdit( { attributes, context, setAttributes } ) {
-	const { textAlign, format } = attributes;
+	const { textAlign, format, isLink } = attributes;
 	const { postId, postType } = context;
 
 	const [ siteFormat ] = useEntityProp( 'root', 'site', 'date_format' );
@@ -62,6 +63,25 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 		} ),
 	} );
 
+	let postDate = date ? (
+		<time dateTime={ dateI18n( 'c', date ) }>
+			{ dateI18n( resolvedFormat, date ) }
+			{ isPickerOpen && (
+				<Popover onClose={ setIsPickerOpen.bind( null, false ) }>
+					<DateTimePicker
+						currentDate={ date }
+						onChange={ setDate }
+						is12Hour={ is12Hour }
+					/>
+				</Popover>
+			) }
+		</time>
+	) : (
+		__( 'No Date' )
+	);
+	if ( isLink && date ) {
+		postDate = <a href="#post-date-pseudo-link">{ postDate }</a>;
+	}
 	return (
 		<>
 			<BlockControls>
@@ -103,28 +123,19 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 						) }
 					/>
 				</PanelBody>
-			</InspectorControls>
-
-			<div { ...blockProps }>
-				{ date && (
-					<time dateTime={ dateI18n( 'c', date ) }>
-						{ dateI18n( resolvedFormat, date ) }
-
-						{ isPickerOpen && (
-							<Popover
-								onClose={ setIsPickerOpen.bind( null, false ) }
-							>
-								<DateTimePicker
-									currentDate={ date }
-									onChange={ setDate }
-									is12Hour={ is12Hour }
-								/>
-							</Popover>
+				<PanelBody title={ __( 'Link settings' ) }>
+					<ToggleControl
+						label={ sprintf(
+							// translators: %s: Name of the post type e.g: "post".
+							__( 'Link to %s' ),
+							postType
 						) }
-					</time>
-				) }
-				{ ! date && __( 'No Date' ) }
-			</div>
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
+						checked={ isLink }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>{ postDate }</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -18,14 +18,19 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$post_ID            = $block->context['postId'];
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+	$formatted_date     = get_the_date( isset( $attributes['format'] ) ? $attributes['format'] : '', $post_ID );
+	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+		$formatted_date = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $post_ID ), $formatted_date );
+	}
 
 	return sprintf(
 		'<div %1$s><time datetime="%2$s">%3$s</time></div>',
 		$wrapper_attributes,
-		get_the_date( 'c', $block->context['postId'] ),
-		get_the_date( isset( $attributes['format'] ) ? $attributes['format'] : '', $block->context['postId'] )
+		get_the_date( 'c', $post_ID ),
+		$formatted_date
 	);
 }
 

--- a/packages/e2e-tests/fixtures/blocks/core__post-date.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-date.json
@@ -3,7 +3,9 @@
         "clientId": "_clientId_0",
         "name": "core/post-date",
         "isValid": true,
-        "attributes": {},
+        "attributes": {
+            "isLink": false
+        },
         "innerBlocks": [],
         "originalContent": ""
     }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/30477

This PR adds a new attribute to `PostDate` block, to allow making it a link to the post/page.
<!-- Please describe what you have changed or added -->

## Testing instructions
With a block theme, add a `PostDate` block and enable the new option to make it a link, under `Link Settings` in Inspector controls.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![postDateLink](https://user-images.githubusercontent.com/16275880/113573397-c00c0600-9622-11eb-845e-b94db55e8fd1.gif)


