### PR TITLE
Testing: Remove cache `restore-keys`.

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -122,10 +122,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: Build Gutenberg plugin ZIP file
               run: ./bin/build-plugin-zip.sh

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -30,10 +30,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: npm install, build, format and lint
               run: |

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -34,10 +34,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: Npm install and build
               run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -27,10 +27,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: Npm install
               run: |

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -26,8 +26,6 @@ jobs:
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-npm-
 
             - run: npm ci
 
@@ -36,7 +34,6 @@ jobs:
               with:
                   path: ~/.gradle/caches
                   key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-                  restore-keys: ${{ runner.os }}-gradle
 
             - uses: reactivecircus/android-emulator-runner@d2799957d660add41c61a5103e2fbb9e2889eb73 # v2.15.0
               with:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -26,8 +26,6 @@ jobs:
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-npm-
 
             - run: npm ci
 
@@ -51,11 +49,6 @@ jobs:
                       ~/.cocoapods/repos/trunk
                       packages/react-native-editor/ios/vendor
                   key: ${{ runner.os }}-pods-${{ hashFiles('packages/react-native-editor/ios/Gemfile.lock') }}-${{ hashFiles('packages/react-native-editor/ios/Podfile.lock') }}-${{ hashFiles('package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pods-${{ hashFiles('packages/react-native-editor/ios/Gemfile.lock') }}-${{ hashFiles('packages/react-native-editor/ios/Podfile.lock') }}-${{ hashFiles('package-lock.json') }}
-                      ${{ runner.os }}-pods-${{ hashFiles('packages/react-native-editor/ios/Gemfile.lock') }}-${{ hashFiles('packages/react-native-editor/ios/Podfile.lock') }}-
-                      ${{ runner.os }}-pods-${{ hashFiles('packages/react-native-editor/ios/Gemfile.lock') }}-
-                      ${{ runner.os }}-pods-
 
             - name: Bundle iOS
               run: npm run native test:e2e:bundle:ios

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -29,10 +29,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: Npm install and build
               # A "full" install is executed, since `npm ci` does not always exit

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -27,10 +27,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: Install Dependencies
               run: npm ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -34,10 +34,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: Npm install and build
               # It's not necessary to run the full build, since Jest can interpret
@@ -74,10 +70,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: Npm install and build
               run: |
@@ -121,10 +113,6 @@ jobs:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
 
             - name: Npm install and build
               # It's not necessary to run the full build, since Jest can interpret

--- a/package-lock.json
+++ b/package-lock.json
@@ -50106,9 +50106,9 @@
 			}
 		},
 		"sass": {
-			"version": "1.26.11",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.26.11.tgz",
-			"integrity": "sha512-W1l/+vjGjIamsJ6OnTe0K37U2DBO/dgsv2Z4c89XQ8ZOO6l/VwkqwLSqoYzJeJs6CLuGSTRWc91GbQFL3lvrvw==",
+			"version": "1.26.12",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.26.12.tgz",
+			"integrity": "sha512-hmSwtBOWoS9zwe0yAS+QmaseVCUELiGV22gXHDR7+9stEsVuEuxfY1GhC8XmUpC+Ir3Hwq7NxSUNbnmkznnF7g==",
 			"dev": true,
 			"requires": {
 				"chokidar": ">=2.0.0 <4.0.0"

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
 		"react-test-renderer": "16.13.1",
 		"rimraf": "3.0.2",
 		"rtlcss": "2.6.2",
-		"sass": "1.26.11",
+		"sass": "1.26.12",
 		"sass-loader": "8.0.2",
 		"semver": "7.3.2",
 		"simple-git": "^2.35.0",


### PR DESCRIPTION
## Description

While specifying backup `restore-keys` is great in theory, it results in cache snowballing because of lax matching. Over time, multiple versions of dependencies will be included in the cache.

For example, if the package-lock.json file is updated, the cache will not be matched. However, the `${{ runner.os }}-build-${{ env.cache-name }}-` restore key will match and restore the previous cache before installing the new dependencies and saving the cache.

In WordPress Core, limiting cache restoration to an exact key match only resulted in a ~40% decrease in overall cache size.

Detailed blog post about this issue: https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/.
Related Core ticket: https://core.trac.wordpress.org/ticket/52660.

## How this is being tested
- Made a commit removing restore keys (won't see benefits of this change because the lock file has not changed).
- Observed cache sizes: iOS & Android E2E testing: 593MB, every other workflow: 635MB or 2% savings.
- Make a minor change to dependencies to change the cache key.
- Observed cache sizes: iOS & Android E2E testing: 586MB, every other workflow: 599MB or ~6% savings.

## Checklist:
- [x] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
