### PR TITLE
[RNMobile] Search Block: Unit Tests

### DIFF
--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -219,7 +219,7 @@ export default function SearchEdit( {
 						onFocus();
 					} }
 					onBlur={ () => setIsPlaceholderSelected( false ) }
-					placeholderTextColor={ placeholderStyle.color }
+					placeholderTextColor={ placeholderStyle?.color }
 				/>
 			</View>
 		);
@@ -271,7 +271,9 @@ export default function SearchEdit( {
 							onBlur={ () => {
 								setIsButtonSelected( false );
 							} }
-							selectionColor={ styles.richTextButtonCursor.color }
+							selectionColor={
+								styles.richTextButtonCursor?.color
+							}
 						/>
 					</View>
 				) }
@@ -318,7 +320,7 @@ export default function SearchEdit( {
 						onBlur={ () => {
 							setIsLabelSelected( false );
 						} }
-						selectionColor={ styles.richTextButtonCursor.color }
+						selectionColor={ styles.richTextButtonCursor?.color }
 					/>
 				</View>
 			) }

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -1,5 +1,172 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Search block renders block with button inside option 1`] = `
+<View
+  accessibilityElementsHidden={true}
+  className="wp-block-search__button-inside wp-block-search__text-button"
+  importantForAccessibility="no-hide-descendants"
+>
+  <View
+    accessibilityHint="Double tap to edit label text"
+    accessibilityLabel="Search block label. Current text is Search"
+    accessibilityRole="none"
+    accessible={true}
+  >
+    <View>
+      <RCTAztecView
+        accessible={true}
+        activeFormats={Array []}
+        blockType={
+          Object {
+            "tag": "p",
+          }
+        }
+        disableEditingMenu={false}
+        focusable={true}
+        fontFamily="serif"
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
+        onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
+        onStartShouldSetResponder={[Function]}
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        style={
+          Object {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
+          }
+        }
+        text={
+          Object {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "text": "<p >Search</p>",
+          }
+        }
+        triggerKeyCodes={Array []}
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityHint="Double tap to edit placeholder text"
+      accessibilityLabel="Search input field. No custom placeholder set"
+      accessibilityRole="none"
+      accessible={true}
+    >
+      <TextInput
+        allowFontScaling={true}
+        className="wp-block-search__input"
+        ellipsizeMode="tail"
+        fontFamily="serif"
+        isSelected={true}
+        label={null}
+        numberOfLines={1}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="Optional placeholder…"
+        rejectResponderTermination={true}
+        scrollEnabled={false}
+        style={
+          Array [
+            undefined,
+            false,
+          ]
+        }
+        underlineColorAndroid="transparent"
+      />
+    </View>
+    <View>
+      <View
+        accessibilityHint="Double tap to edit button text"
+        accessibilityLabel="Search button. Current button text is Search Button"
+        accessibilityRole="none"
+        accessible={true}
+      >
+        <View>
+          <RCTAztecView
+            accessible={true}
+            activeFormats={Array []}
+            blockType={
+              Object {
+                "tag": "p",
+              }
+            }
+            disableEditingMenu={false}
+            focusable={true}
+            fontFamily="serif"
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={75}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onSelectionChange={[Function]}
+            onStartShouldSetResponder={[Function]}
+            placeholder=""
+            placeholderTextColor="gray"
+            style={
+              Object {
+                "backgroundColor": undefined,
+                "maxWidth": undefined,
+                "minHeight": 0,
+              }
+            }
+            text={
+              Object {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "text": "<p >Search Button</p>",
+              }
+            }
+            textAlign="center"
+            triggerKeyCodes={Array []}
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`Search block renders block with icon button option 1`] = `
 <View
   accessibilityElementsHidden={true}

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Search block options renders block with button inside option 1`] = `
+exports[`Search Block renders block with button inside option 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__button-inside wp-block-search__text-button"
@@ -167,7 +167,7 @@ exports[`Search block options renders block with button inside option 1`] = `
 </View>
 `;
 
-exports[`Search block options renders block with icon button option 1`] = `
+exports[`Search Block renders block with icon button option matches snapshot 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__button-outside wp-block-search__icon-button"
@@ -275,7 +275,7 @@ exports[`Search block options renders block with icon button option 1`] = `
 </View>
 `;
 
-exports[`Search block options renders block with label hidden 1`] = `
+exports[`Search Block renders block with label hidden matches snapshot 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__button-outside wp-block-search__text-button"
@@ -384,7 +384,174 @@ exports[`Search block options renders block with label hidden 1`] = `
 </View>
 `;
 
-exports[`Search block options renders block with no-button option 1`] = `
+exports[`Search Block renders with default configuration matches snapshot 1`] = `
+<View
+  accessibilityElementsHidden={true}
+  className="wp-block-search__button-outside wp-block-search__text-button"
+  importantForAccessibility="no-hide-descendants"
+>
+  <View
+    accessibilityHint="Double tap to edit label text"
+    accessibilityLabel="Search block label. Current text is Search"
+    accessibilityRole="none"
+    accessible={true}
+  >
+    <View>
+      <RCTAztecView
+        accessible={true}
+        activeFormats={Array []}
+        blockType={
+          Object {
+            "tag": "p",
+          }
+        }
+        disableEditingMenu={false}
+        focusable={true}
+        fontFamily="serif"
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
+        onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
+        onStartShouldSetResponder={[Function]}
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        style={
+          Object {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
+          }
+        }
+        text={
+          Object {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "text": "<p >Search</p>",
+          }
+        }
+        triggerKeyCodes={Array []}
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        undefined,
+        false,
+      ]
+    }
+  >
+    <View
+      accessibilityHint="Double tap to edit placeholder text"
+      accessibilityLabel="Search input field. No custom placeholder set"
+      accessibilityRole="none"
+      accessible={true}
+    >
+      <TextInput
+        allowFontScaling={true}
+        className="wp-block-search__input"
+        ellipsizeMode="tail"
+        fontFamily="serif"
+        isSelected={true}
+        label={null}
+        numberOfLines={1}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="Optional placeholder…"
+        rejectResponderTermination={true}
+        scrollEnabled={false}
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }
+        underlineColorAndroid="transparent"
+      />
+    </View>
+    <View>
+      <View
+        accessibilityHint="Double tap to edit button text"
+        accessibilityLabel="Search button. Current button text is Search Button"
+        accessibilityRole="none"
+        accessible={true}
+      >
+        <View>
+          <RCTAztecView
+            accessible={true}
+            activeFormats={Array []}
+            blockType={
+              Object {
+                "tag": "p",
+              }
+            }
+            disableEditingMenu={false}
+            focusable={true}
+            fontFamily="serif"
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={75}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onSelectionChange={[Function]}
+            onStartShouldSetResponder={[Function]}
+            placeholder=""
+            placeholderTextColor="gray"
+            style={
+              Object {
+                "backgroundColor": undefined,
+                "maxWidth": undefined,
+                "minHeight": 0,
+              }
+            }
+            text={
+              Object {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "text": "<p >Search Button</p>",
+              }
+            }
+            textAlign="center"
+            triggerKeyCodes={Array []}
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Search Block renders with no-button option matches snapshot 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__no-button"
@@ -476,173 +643,6 @@ exports[`Search block options renders block with no-button option 1`] = `
       }
       underlineColorAndroid="transparent"
     />
-  </View>
-</View>
-`;
-
-exports[`Search block options renders default block configuration 1`] = `
-<View
-  accessibilityElementsHidden={true}
-  className="wp-block-search__button-outside wp-block-search__text-button"
-  importantForAccessibility="no-hide-descendants"
->
-  <View
-    accessibilityHint="Double tap to edit label text"
-    accessibilityLabel="Search block label. Current text is Search"
-    accessibilityRole="none"
-    accessible={true}
-  >
-    <View>
-      <RCTAztecView
-        accessible={true}
-        activeFormats={Array []}
-        blockType={
-          Object {
-            "tag": "p",
-          }
-        }
-        disableEditingMenu={false}
-        focusable={true}
-        fontFamily="serif"
-        isMultiline={false}
-        maxImagesWidth={200}
-        onBackspace={[Function]}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onContentSizeChange={[Function]}
-        onEnter={[Function]}
-        onFocus={[Function]}
-        onHTMLContentWithCursor={[Function]}
-        onKeyDown={[Function]}
-        onPaste={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onSelectionChange={[Function]}
-        onStartShouldSetResponder={[Function]}
-        placeholder="Add label…"
-        placeholderTextColor="gray"
-        style={
-          Object {
-            "backgroundColor": undefined,
-            "maxWidth": undefined,
-            "minHeight": 0,
-          }
-        }
-        text={
-          Object {
-            "eventCount": undefined,
-            "linkTextColor": undefined,
-            "selection": null,
-            "text": "<p >Search</p>",
-          }
-        }
-        triggerKeyCodes={Array []}
-      />
-    </View>
-  </View>
-  <View
-    style={
-      Array [
-        undefined,
-        false,
-      ]
-    }
-  >
-    <View
-      accessibilityHint="Double tap to edit placeholder text"
-      accessibilityLabel="Search input field. No custom placeholder set"
-      accessibilityRole="none"
-      accessible={true}
-    >
-      <TextInput
-        allowFontScaling={true}
-        className="wp-block-search__input"
-        ellipsizeMode="tail"
-        fontFamily="serif"
-        isSelected={true}
-        label={null}
-        numberOfLines={1}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder="Optional placeholder…"
-        rejectResponderTermination={true}
-        scrollEnabled={false}
-        style={
-          Array [
-            undefined,
-            undefined,
-          ]
-        }
-        underlineColorAndroid="transparent"
-      />
-    </View>
-    <View>
-      <View
-        accessibilityHint="Double tap to edit button text"
-        accessibilityLabel="Search button. Current button text is Search Button"
-        accessibilityRole="none"
-        accessible={true}
-      >
-        <View>
-          <RCTAztecView
-            accessible={true}
-            activeFormats={Array []}
-            blockType={
-              Object {
-                "tag": "p",
-              }
-            }
-            disableEditingMenu={false}
-            focusable={true}
-            fontFamily="serif"
-            isMultiline={false}
-            maxImagesWidth={200}
-            minWidth={75}
-            onBackspace={[Function]}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
-            onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onSelectionChange={[Function]}
-            onStartShouldSetResponder={[Function]}
-            placeholder=""
-            placeholderTextColor="gray"
-            style={
-              Object {
-                "backgroundColor": undefined,
-                "maxWidth": undefined,
-                "minHeight": 0,
-              }
-            }
-            text={
-              Object {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "text": "<p >Search Button</p>",
-              }
-            }
-            textAlign="center"
-            triggerKeyCodes={Array []}
-          />
-        </View>
-      </View>
-    </View>
   </View>
 </View>
 `;

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -1,0 +1,481 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Search block renders block with icon button option 1`] = `
+<View
+  accessibilityElementsHidden={true}
+  className="wp-block-search__button-outside wp-block-search__icon-button"
+  importantForAccessibility="no-hide-descendants"
+>
+  <View
+    accessibilityHint="Double tap to edit label text"
+    accessibilityLabel="Search block label. Current text is Search"
+    accessibilityRole="none"
+    accessible={true}
+  >
+    <View>
+      <RCTAztecView
+        accessible={true}
+        activeFormats={Array []}
+        blockType={
+          Object {
+            "tag": "p",
+          }
+        }
+        disableEditingMenu={false}
+        focusable={true}
+        fontFamily="serif"
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
+        onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
+        onStartShouldSetResponder={[Function]}
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        style={
+          Object {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
+          }
+        }
+        text={
+          Object {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "text": "<p >Search</p>",
+          }
+        }
+        triggerKeyCodes={Array []}
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        undefined,
+        false,
+      ]
+    }
+  >
+    <View
+      accessibilityHint="Double tap to edit placeholder text"
+      accessibilityLabel="Search input field. No custom placeholder set"
+      accessibilityRole="none"
+      accessible={true}
+    >
+      <TextInput
+        allowFontScaling={true}
+        className="wp-block-search__input"
+        ellipsizeMode="tail"
+        fontFamily="serif"
+        isSelected={true}
+        label={null}
+        numberOfLines={1}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="Optional placeholder…"
+        rejectResponderTermination={true}
+        scrollEnabled={false}
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }
+        underlineColorAndroid="transparent"
+      />
+    </View>
+    <View>
+      Svg
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Search block renders block with label hidden 1`] = `
+<View
+  accessibilityElementsHidden={true}
+  className="wp-block-search__button-outside wp-block-search__text-button"
+  importantForAccessibility="no-hide-descendants"
+>
+  <View
+    style={
+      Array [
+        undefined,
+        false,
+      ]
+    }
+  >
+    <View
+      accessibilityHint="Double tap to edit placeholder text"
+      accessibilityLabel="Search input field. No custom placeholder set"
+      accessibilityRole="none"
+      accessible={true}
+    >
+      <TextInput
+        allowFontScaling={true}
+        className="wp-block-search__input"
+        ellipsizeMode="tail"
+        fontFamily="serif"
+        isSelected={true}
+        label={null}
+        numberOfLines={1}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="Optional placeholder…"
+        rejectResponderTermination={true}
+        scrollEnabled={false}
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }
+        underlineColorAndroid="transparent"
+      />
+    </View>
+    <View>
+      <View
+        accessibilityHint="Double tap to edit button text"
+        accessibilityLabel="Search button. Current button text is Search Button"
+        accessibilityRole="none"
+        accessible={true}
+      >
+        <View>
+          <RCTAztecView
+            accessible={true}
+            activeFormats={Array []}
+            blockType={
+              Object {
+                "tag": "p",
+              }
+            }
+            disableEditingMenu={false}
+            focusable={true}
+            fontFamily="serif"
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={75}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onSelectionChange={[Function]}
+            onStartShouldSetResponder={[Function]}
+            placeholder=""
+            placeholderTextColor="gray"
+            style={
+              Object {
+                "backgroundColor": undefined,
+                "maxWidth": undefined,
+                "minHeight": 0,
+              }
+            }
+            text={
+              Object {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "text": "<p >Search Button</p>",
+              }
+            }
+            textAlign="center"
+            triggerKeyCodes={Array []}
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Search block renders block with no-button option 1`] = `
+<View
+  accessibilityElementsHidden={true}
+  className="wp-block-search__no-button"
+  importantForAccessibility="no-hide-descendants"
+>
+  <View
+    accessibilityHint="Double tap to edit label text"
+    accessibilityLabel="Search block label. Current text is Search"
+    accessibilityRole="none"
+    accessible={true}
+  >
+    <View>
+      <RCTAztecView
+        accessible={true}
+        activeFormats={Array []}
+        blockType={
+          Object {
+            "tag": "p",
+          }
+        }
+        disableEditingMenu={false}
+        focusable={true}
+        fontFamily="serif"
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
+        onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
+        onStartShouldSetResponder={[Function]}
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        style={
+          Object {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
+          }
+        }
+        text={
+          Object {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "text": "<p >Search</p>",
+          }
+        }
+        triggerKeyCodes={Array []}
+      />
+    </View>
+  </View>
+  <View
+    accessibilityHint="Double tap to edit placeholder text"
+    accessibilityLabel="Search input field. No custom placeholder set"
+    accessibilityRole="none"
+    accessible={true}
+  >
+    <TextInput
+      allowFontScaling={true}
+      className="wp-block-search__input"
+      ellipsizeMode="tail"
+      fontFamily="serif"
+      isSelected={true}
+      label={null}
+      numberOfLines={1}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder="Optional placeholder…"
+      rejectResponderTermination={true}
+      scrollEnabled={false}
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </View>
+</View>
+`;
+
+exports[`Search block renders default block configuration 1`] = `
+<View
+  accessibilityElementsHidden={true}
+  className="wp-block-search__button-outside wp-block-search__text-button"
+  importantForAccessibility="no-hide-descendants"
+>
+  <View
+    accessibilityHint="Double tap to edit label text"
+    accessibilityLabel="Search block label. Current text is Search"
+    accessibilityRole="none"
+    accessible={true}
+  >
+    <View>
+      <RCTAztecView
+        accessible={true}
+        activeFormats={Array []}
+        blockType={
+          Object {
+            "tag": "p",
+          }
+        }
+        disableEditingMenu={false}
+        focusable={true}
+        fontFamily="serif"
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
+        onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
+        onStartShouldSetResponder={[Function]}
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        style={
+          Object {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
+          }
+        }
+        text={
+          Object {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "text": "<p >Search</p>",
+          }
+        }
+        triggerKeyCodes={Array []}
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        undefined,
+        false,
+      ]
+    }
+  >
+    <View
+      accessibilityHint="Double tap to edit placeholder text"
+      accessibilityLabel="Search input field. No custom placeholder set"
+      accessibilityRole="none"
+      accessible={true}
+    >
+      <TextInput
+        allowFontScaling={true}
+        className="wp-block-search__input"
+        ellipsizeMode="tail"
+        fontFamily="serif"
+        isSelected={true}
+        label={null}
+        numberOfLines={1}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="Optional placeholder…"
+        rejectResponderTermination={true}
+        scrollEnabled={false}
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }
+        underlineColorAndroid="transparent"
+      />
+    </View>
+    <View>
+      <View
+        accessibilityHint="Double tap to edit button text"
+        accessibilityLabel="Search button. Current button text is Search Button"
+        accessibilityRole="none"
+        accessible={true}
+      >
+        <View>
+          <RCTAztecView
+            accessible={true}
+            activeFormats={Array []}
+            blockType={
+              Object {
+                "tag": "p",
+              }
+            }
+            disableEditingMenu={false}
+            focusable={true}
+            fontFamily="serif"
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={75}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onSelectionChange={[Function]}
+            onStartShouldSetResponder={[Function]}
+            placeholder=""
+            placeholderTextColor="gray"
+            style={
+              Object {
+                "backgroundColor": undefined,
+                "maxWidth": undefined,
+                "minHeight": 0,
+              }
+            }
+            text={
+              Object {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "text": "<p >Search Button</p>",
+              }
+            }
+            textAlign="center"
+            triggerKeyCodes={Array []}
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Search block renders block with button inside option 1`] = `
+exports[`Search block options renders block with button inside option 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__button-inside wp-block-search__text-button"
@@ -167,7 +167,7 @@ exports[`Search block renders block with button inside option 1`] = `
 </View>
 `;
 
-exports[`Search block renders block with icon button option 1`] = `
+exports[`Search block options renders block with icon button option 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__button-outside wp-block-search__icon-button"
@@ -275,7 +275,7 @@ exports[`Search block renders block with icon button option 1`] = `
 </View>
 `;
 
-exports[`Search block renders block with label hidden 1`] = `
+exports[`Search block options renders block with label hidden 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__button-outside wp-block-search__text-button"
@@ -384,7 +384,7 @@ exports[`Search block renders block with label hidden 1`] = `
 </View>
 `;
 
-exports[`Search block renders block with no-button option 1`] = `
+exports[`Search block options renders block with no-button option 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__no-button"
@@ -480,7 +480,7 @@ exports[`Search block renders block with no-button option 1`] = `
 </View>
 `;
 
-exports[`Search block renders default block configuration 1`] = `
+exports[`Search block options renders default block configuration 1`] = `
 <View
   accessibilityElementsHidden={true}
   className="wp-block-search__button-outside wp-block-search__text-button"

--- a/packages/block-library/src/search/test/edit.native.js
+++ b/packages/block-library/src/search/test/edit.native.js
@@ -52,150 +52,108 @@ const hasComponent = ( instance, className ) => {
 	return components.length !== 0;
 };
 
-describe( 'Search block options', () => {
-	it( 'renders block without crashing', () => {
+describe( 'Search Block', () => {
+	it( 'renders without crashing', () => {
 		const component = getTestComponent();
 		const rendered = component.toJSON();
 		expect( rendered ).toBeTruthy();
 	} );
 
-	it( 'renders default block configuration', () => {
+	describe( 'renders with default configuration', () => {
 		const component = getTestComponent();
 		const instance = component.root;
 
-		// Verify the label element of the search block exists and
-		// label text is set.
-		const label = getLabel( instance );
-		expect( label ).toBeTruthy();
-		expect( label.props.value ).toBe( 'Search' );
+		it( 'label is visible and text is properly set', () => {
+			// Verify the label element of the search block exists and
+			// label text is set.
+			const label = getLabel( instance );
+			expect( label ).toBeTruthy();
+			expect( label.props.value ).toBe( 'Search' );
+		} );
 
-		// Verify the button element of the search block exists and
-		// button text is set.
-		const button = getButton( instance );
-		expect( button ).toBeTruthy();
-		expect( button.props.value ).toBe( 'Search Button' );
+		it( 'button is visible and text is properly set', () => {
+			// Verify the button element of the search block exists and
+			// button text is set.
+			const button = getButton( instance );
+			expect( button ).toBeTruthy();
+			expect( button.props.value ).toBe( 'Search Button' );
+		} );
 
-		// Verify the search input element of the search block exists
-		// and the placeholder text is set.
-		const searchInput = getSearchInput( instance );
-		expect( searchInput ).toBeTruthy();
-		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
+		it( 'search input is visible and placeholder text is properly set', () => {
+			// Verify the search input element of the search block exists
+			// and the placeholder text is set.
+			const searchInput = getSearchInput( instance );
+			expect( searchInput ).toBeTruthy();
+			expect( searchInput.props.placeholder ).toBe(
+				'Optional placeholder…'
+			);
+		} );
 
-		// Verify toMatchSnapshot
-		const rendered = component.toJSON();
-		expect( rendered ).toMatchSnapshot();
+		it( 'matches snapshot', () => {
+			const rendered = component.toJSON();
+			expect( rendered ).toMatchSnapshot();
+		} );
 	} );
 
-	it( 'renders block with no-button option', () => {
+	describe( 'renders with no-button option', () => {
 		const component = getTestComponent( {
 			buttonPosition: 'no-button',
 		} );
 		const instance = component.root;
 
-		// Verify the label element of the search block exists and
-		// label text is set.
-		const label = getLabel( instance );
-		expect( label ).toBeTruthy();
-		expect( label.props.value ).toBe( 'Search' );
+		it( 'verify button element has not been rendered', () => {
+			expect(
+				hasComponent( instance, 'wp-block-search__button' )
+			).toEqual( false );
+		} );
 
-		// Verify the button element has not been rendered.
-		expect( hasComponent( instance, 'wp-block-search__button' ) ).toEqual(
-			false
-		);
-
-		// Verify the search input element of the search block exists
-		// and the placeholder text is set.
-		const searchInput = getSearchInput( instance );
-		expect( searchInput ).toBeTruthy();
-		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
-
-		// Verify toMatchSnapshot
-		const rendered = component.toJSON();
-		expect( rendered ).toMatchSnapshot();
+		it( 'matches snapshot', () => {
+			const rendered = component.toJSON();
+			expect( rendered ).toMatchSnapshot();
+		} );
 	} );
 
-	it( 'renders block with icon button option', () => {
+	describe( 'renders block with icon button option', () => {
 		const component = getTestComponent( {
 			buttonUseIcon: true,
 		} );
 		const instance = component.root;
 
-		// Verify the label element of the search block exists and
-		// label text is set.
-		const label = getLabel( instance );
-		expect( label ).toBeTruthy();
-		expect( label.props.value ).toBe( 'Search' );
+		it( 'search button uses icon', () => {
+			const button = instance.findByType( Icon );
+			expect( button ).toBeTruthy();
+		} );
 
-		// Verify the button element of the search block exists and
-		// is rendered with an icon.
-		const button = instance.findByType( Icon );
-		expect( button ).toBeTruthy();
-
-		// Verify the search input element of the search block exists
-		// and the placeholder text is set.
-		const searchInput = getSearchInput( instance );
-		expect( searchInput ).toBeTruthy();
-		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
-
-		// Verify toMatchSnapshot
-		const rendered = component.toJSON();
-		expect( rendered ).toMatchSnapshot();
+		it( 'matches snapshot', () => {
+			const rendered = component.toJSON();
+			expect( rendered ).toMatchSnapshot();
+		} );
 	} );
 
 	it( 'renders block with button inside option', () => {
 		const component = getTestComponent( {
 			buttonPosition: 'button-inside',
 		} );
-		const instance = component.root;
 
-		// Verify the label element of the search block exists and
-		// label text is set.
-		const label = getLabel( instance );
-		expect( label ).toBeTruthy();
-		expect( label.props.value ).toBe( 'Search' );
-
-		// Verify the button element of the search block exists and
-		// button text is set.
-		const button = getButton( instance );
-		expect( button ).toBeTruthy();
-		expect( button.props.value ).toBe( 'Search Button' );
-
-		// Verify the search input element of the search block exists
-		// and the placeholder text is set.
-		const searchInput = getSearchInput( instance );
-		expect( searchInput ).toBeTruthy();
-		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
-
-		// Verify toMatchSnapshot
 		const rendered = component.toJSON();
 		expect( rendered ).toMatchSnapshot();
 	} );
 
-	it( 'renders block with label hidden', () => {
+	describe( 'renders block with label hidden', () => {
 		const component = getTestComponent( {
 			showLabel: false,
 		} );
 		const instance = component.root;
 
-		// Verify the label has not been rendered.
-		expect( hasComponent( instance, 'wp-block-search__label' ) ).toEqual(
-			false
-		);
+		it( 'verify label has not been rendered', () => {
+			expect(
+				hasComponent( instance, 'wp-block-search__label' )
+			).toEqual( false );
+		} );
 
-		// Verify the button element of the search block exists and
-		// button text is set.
-		const button = getButton( instance );
-		expect( button ).toBeTruthy();
-		expect( button.props.value ).toBe( 'Search Button' );
-
-		// Verify the search input element of the search block exists
-		// and the placeholder text is set.
-		const searchInput = getSearchInput( instance );
-		expect( searchInput ).toBeTruthy();
-		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
-
-		// Verify toMatchSnapshot
-		const rendered = component.toJSON();
-		expect( rendered ).toMatchSnapshot();
+		it( 'matches snapshot', () => {
+			const rendered = component.toJSON();
+			expect( rendered ).toMatchSnapshot();
+		} );
 	} );
 } );

--- a/packages/block-library/src/search/test/edit.native.js
+++ b/packages/block-library/src/search/test/edit.native.js
@@ -146,6 +146,38 @@ describe( 'Search block', () => {
 		expect( rendered ).toMatchSnapshot();
 	} );
 
+	it( 'renders block with button inside option', () => {
+		const component = getTestComponent( {
+			label: 'Search',
+			buttonText: 'Search Button',
+			buttonPosition: 'button-inside',
+			showLabel: true,
+		} );
+		const instance = component.root;
+
+		// Verify the label element of the search block exists and
+		// label text is set.
+		const label = getLabel( instance );
+		expect( label ).toBeTruthy();
+		expect( label.props.value ).toBe( 'Search' );
+
+		// Verify the button element of the search block exists and
+		// button text is set.
+		const button = getButton( instance );
+		expect( button ).toBeTruthy();
+		expect( button.props.value ).toBe( 'Search Button' );
+
+		// Verify the search input element of the search block exists
+		// and the placeholder text is set.
+		const searchInput = getSearchInput( instance );
+		expect( searchInput ).toBeTruthy();
+		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
+
+		// Verify toMatchSnapshot
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+
 	it( 'renders block with label hidden', () => {
 		const component = getTestComponent( {
 			label: 'Search',

--- a/packages/block-library/src/search/test/edit.native.js
+++ b/packages/block-library/src/search/test/edit.native.js
@@ -13,11 +13,17 @@ import { Icon } from '@wordpress/components';
  */
 import SearchEdit from '../edit.native.js';
 
-const setAttributes = jest.fn();
+const defaultAttributes = {
+	label: 'Search',
+	buttonText: 'Search Button',
+	buttonPosition: 'button-outside',
+	showLabel: true,
+};
 
 const getTestComponent = ( attributes = {} ) => {
+	const finalAttrs = { ...defaultAttributes, ...attributes };
 	return renderer.create(
-		<SearchEdit attributes={ attributes } setAttributes={ jest.fn() } />
+		<SearchEdit attributes={ finalAttrs } setAttributes={ jest.fn() } />
 	);
 };
 
@@ -46,7 +52,7 @@ const hasComponent = ( instance, className ) => {
 	return components.length !== 0;
 };
 
-describe( 'Search block', () => {
+describe( 'Search block options', () => {
 	it( 'renders block without crashing', () => {
 		const component = getTestComponent();
 		const rendered = component.toJSON();
@@ -54,12 +60,7 @@ describe( 'Search block', () => {
 	} );
 
 	it( 'renders default block configuration', () => {
-		const component = getTestComponent( {
-			label: 'Search',
-			buttonText: 'Search Button',
-			buttonPosition: 'button-outside',
-			showLabel: true,
-		} );
+		const component = getTestComponent();
 		const instance = component.root;
 
 		// Verify the label element of the search block exists and
@@ -87,9 +88,7 @@ describe( 'Search block', () => {
 
 	it( 'renders block with no-button option', () => {
 		const component = getTestComponent( {
-			label: 'Search',
 			buttonPosition: 'no-button',
-			showLabel: true,
 		} );
 		const instance = component.root;
 
@@ -117,10 +116,7 @@ describe( 'Search block', () => {
 
 	it( 'renders block with icon button option', () => {
 		const component = getTestComponent( {
-			label: 'Search',
 			buttonUseIcon: true,
-			showLabel: true,
-			buttonPosition: 'button-outside',
 		} );
 		const instance = component.root;
 
@@ -148,10 +144,7 @@ describe( 'Search block', () => {
 
 	it( 'renders block with button inside option', () => {
 		const component = getTestComponent( {
-			label: 'Search',
-			buttonText: 'Search Button',
 			buttonPosition: 'button-inside',
-			showLabel: true,
 		} );
 		const instance = component.root;
 
@@ -180,9 +173,6 @@ describe( 'Search block', () => {
 
 	it( 'renders block with label hidden', () => {
 		const component = getTestComponent( {
-			label: 'Search',
-			buttonText: 'Search Button',
-			buttonPosition: 'button-outside',
 			showLabel: false,
 		} );
 		const instance = component.root;

--- a/packages/block-library/src/search/test/edit.native.js
+++ b/packages/block-library/src/search/test/edit.native.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+
+/**
+ * WordPress dependencies
+ */
+import { Icon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import SearchEdit from '../edit.native.js';
+
+const setAttributes = jest.fn();
+
+const getTestComponent = ( attributes = {} ) => {
+	return renderer.create(
+		<SearchEdit attributes={ attributes } setAttributes={ jest.fn() } />
+	);
+};
+
+const getLabel = ( instance ) => {
+	return instance.findByProps( {
+		className: 'wp-block-search__label',
+	} );
+};
+
+const getButton = ( instance ) => {
+	return instance.findByProps( {
+		className: 'wp-block-search__button',
+	} );
+};
+
+const getSearchInput = ( instance ) => {
+	return instance.findByProps( {
+		className: 'wp-block-search__input',
+	} );
+};
+
+const hasComponent = ( instance, className ) => {
+	const components = instance.findAllByProps( {
+		className,
+	} );
+	return components.length !== 0;
+};
+
+describe( 'Search block', () => {
+	it( 'renders block without crashing', () => {
+		const component = getTestComponent();
+		const rendered = component.toJSON();
+		expect( rendered ).toBeTruthy();
+	} );
+
+	it( 'renders default block configuration', () => {
+		const component = getTestComponent( {
+			label: 'Search',
+			buttonText: 'Search Button',
+			buttonPosition: 'button-outside',
+			showLabel: true,
+		} );
+		const instance = component.root;
+
+		// Verify the label element of the search block exists and
+		// label text is set.
+		const label = getLabel( instance );
+		expect( label ).toBeTruthy();
+		expect( label.props.value ).toBe( 'Search' );
+
+		// Verify the button element of the search block exists and
+		// button text is set.
+		const button = getButton( instance );
+		expect( button ).toBeTruthy();
+		expect( button.props.value ).toBe( 'Search Button' );
+
+		// Verify the search input element of the search block exists
+		// and the placeholder text is set.
+		const searchInput = getSearchInput( instance );
+		expect( searchInput ).toBeTruthy();
+		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
+
+		// Verify toMatchSnapshot
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+
+	it( 'renders block with no-button option', () => {
+		const component = getTestComponent( {
+			label: 'Search',
+			buttonPosition: 'no-button',
+			showLabel: true,
+		} );
+		const instance = component.root;
+
+		// Verify the label element of the search block exists and
+		// label text is set.
+		const label = getLabel( instance );
+		expect( label ).toBeTruthy();
+		expect( label.props.value ).toBe( 'Search' );
+
+		// Verify the button element has not been rendered.
+		expect( hasComponent( instance, 'wp-block-search__button' ) ).toEqual(
+			false
+		);
+
+		// Verify the search input element of the search block exists
+		// and the placeholder text is set.
+		const searchInput = getSearchInput( instance );
+		expect( searchInput ).toBeTruthy();
+		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
+
+		// Verify toMatchSnapshot
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+
+	it( 'renders block with icon button option', () => {
+		const component = getTestComponent( {
+			label: 'Search',
+			buttonUseIcon: true,
+			showLabel: true,
+			buttonPosition: 'button-outside',
+		} );
+		const instance = component.root;
+
+		// Verify the label element of the search block exists and
+		// label text is set.
+		const label = getLabel( instance );
+		expect( label ).toBeTruthy();
+		expect( label.props.value ).toBe( 'Search' );
+
+		// Verify the button element of the search block exists and
+		// is rendered with an icon.
+		const button = instance.findByType( Icon );
+		expect( button ).toBeTruthy();
+
+		// Verify the search input element of the search block exists
+		// and the placeholder text is set.
+		const searchInput = getSearchInput( instance );
+		expect( searchInput ).toBeTruthy();
+		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
+
+		// Verify toMatchSnapshot
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+
+	it( 'renders block with label hidden', () => {
+		const component = getTestComponent( {
+			label: 'Search',
+			buttonText: 'Search Button',
+			buttonPosition: 'button-outside',
+			showLabel: false,
+		} );
+		const instance = component.root;
+
+		// Verify the label has not been rendered.
+		expect( hasComponent( instance, 'wp-block-search__label' ) ).toEqual(
+			false
+		);
+
+		// Verify the button element of the search block exists and
+		// button text is set.
+		const button = getButton( instance );
+		expect( button ).toBeTruthy();
+		expect( button.props.value ).toBe( 'Search Button' );
+
+		// Verify the search input element of the search block exists
+		// and the placeholder text is set.
+		const searchInput = getSearchInput( instance );
+		expect( searchInput ).toBeTruthy();
+		expect( searchInput.props.placeholder ).toBe( 'Optional placeholder…' );
+
+		// Verify toMatchSnapshot
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
**gutenberg-mobile PR**: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3210

## Description
<!-- Please describe what you have changed or added -->
This PR adds unit tests for the Search Block that cover the following scenarios:
- Renders without crashing
- Snapshot check: Default block configuration (`{ label: 'Search', buttonText: 'Search Button', buttonPosition: 'button-outside', showLabel: true }`)
- Snapshot check: No Search button (`buttonPosition: 'no-button'`)
- Snapshot check: Search button uses icon only (`buttonUseIcon: true`)
- Snapshot check: Search button inside search input field (`buttonPosition: 'button-inside'`)
- Snapshot check: Search label hidden (`showLabel: false`)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Run the following from command-line: 
```
npm run test-unit:native -- packages/block-library/src/search/test/edit.native.js
```

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
No breaking changes. The Search block is still in `devMode` only so these test should not effect production. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
