### PR TITLE
Testing: Include NodeJS version in the cache key

### DIFF
--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Cache node modules
               uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
               env:
-                  cache-name: cache-node-modules
+                  cache-name: cache-node-modules-${{ matrix.node }}
               with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Cache node modules
               uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
               env:
-                  cache-name: cache-node-modules
+                  cache-name: cache-node-modules-${{ matrix.node }}
               with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm


### PR DESCRIPTION
## Description

When multiple versions of NodeJS are tested, the version being used should be included in the cache key to avoid any potential issues with combinations of dependencies and NodeJS versions.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
