### PR TITLE
FSE Theme Stylesheet: Add Gutenberg stylesheet filter

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -343,7 +343,7 @@ class WP_Theme_JSON_Resolver {
 	private static function get_user_data_from_custom_post_type( $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
 		$user_cpt         = array();
 		$post_type_filter = 'wp_global_styles';
-		$post_name_filter = 'wp-global-styles-' . urlencode( wp_get_theme()->get_stylesheet() );
+		$post_name_filter = 'wp-global-styles-' . urlencode( gutenberg_get_theme_stylesheet() );
 		$recent_posts     = wp_get_recent_posts(
 			array(
 				'numberposts' => 1,

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -343,7 +343,7 @@ class WP_Theme_JSON_Resolver {
 	private static function get_user_data_from_custom_post_type( $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
 		$user_cpt         = array();
 		$post_type_filter = 'wp_global_styles';
-		$post_name_filter = 'wp-global-styles-' . urlencode( gutenberg_get_theme_stylesheet() );
+		$post_name_filter = 'wp-global-styles-' . urlencode( gutenberg_get_canonical_theme_slug() );
 		$recent_posts     = wp_get_recent_posts(
 			array(
 				'numberposts' => 1,

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -155,7 +155,7 @@ function _inject_theme_attribute_in_content( $template_content ) {
 			'core/template-part' === $block['blockName'] &&
 			! isset( $block['attrs']['theme'] )
 		) {
-			$template_blocks[ $key ]['attrs']['theme'] = wp_get_theme()->get_stylesheet();
+			$template_blocks[ $key ]['attrs']['theme'] = gutenberg_get_theme_stylesheet();
 			$has_updated_content                       = true;
 		}
 	}
@@ -182,7 +182,7 @@ function _inject_theme_attribute_in_content( $template_content ) {
 function _gutenberg_build_template_result_from_file( $template_file, $template_type ) {
 	$default_template_types = gutenberg_get_default_template_types();
 	$template_content       = file_get_contents( $template_file['path'] );
-	$theme                  = wp_get_theme()->get_stylesheet();
+	$theme                  = gutenberg_get_theme_stylesheet();
 
 	$template            = new WP_Block_Template();
 	$template->id        = $theme . '//' . $template_file['slug'];
@@ -271,7 +271,7 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 			array(
 				'taxonomy' => 'wp_theme',
 				'field'    => 'name',
-				'terms'    => wp_get_theme()->get_stylesheet(),
+				'terms'    => gutenberg_get_theme_stylesheet(),
 			),
 		),
 	);
@@ -310,7 +310,7 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 		$template_files = _gutenberg_get_template_files( $template_type );
 		foreach ( $template_files as $template_file ) {
 			$is_not_custom   = false === array_search(
-				wp_get_theme()->get_stylesheet() . '//' . $template_file['slug'],
+				gutenberg_get_theme_stylesheet() . '//' . $template_file['slug'],
 				array_column( $query_result, 'id' ),
 				true
 			);
@@ -367,7 +367,7 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 		}
 	}
 
-	if ( wp_get_theme()->get_stylesheet() === $theme ) {
+	if ( gutenberg_get_theme_stylesheet() === $theme ) {
 		$template_file = _gutenberg_get_template_file( $template_type, $slug );
 		if ( null !== $template_file ) {
 			return _gutenberg_build_template_result_from_file( $template_file, $template_type );
@@ -402,7 +402,7 @@ function gutenberg_filter_wp_template_unique_post_slug( $override_slug, $slug, $
 	// term does not work in the case of new entities since is too early in
 	// the process to have been saved to the entity.  So for now we use the
 	// currently activated theme for creation.
-	$theme = wp_get_theme()->get_stylesheet();
+	$theme = gutenberg_get_theme_stylesheet();
 	$terms = get_the_terms( $post_ID, 'wp_theme' );
 	if ( $terms && ! is_wp_error( $terms ) ) {
 		$theme = $terms[0]->name;

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -155,7 +155,7 @@ function _inject_theme_attribute_in_content( $template_content ) {
 			'core/template-part' === $block['blockName'] &&
 			! isset( $block['attrs']['theme'] )
 		) {
-			$template_blocks[ $key ]['attrs']['theme'] = gutenberg_get_theme_stylesheet();
+			$template_blocks[ $key ]['attrs']['theme'] = gutenberg_get_canonical_theme_slug();
 			$has_updated_content                       = true;
 		}
 	}
@@ -182,7 +182,7 @@ function _inject_theme_attribute_in_content( $template_content ) {
 function _gutenberg_build_template_result_from_file( $template_file, $template_type ) {
 	$default_template_types = gutenberg_get_default_template_types();
 	$template_content       = file_get_contents( $template_file['path'] );
-	$theme                  = gutenberg_get_theme_stylesheet();
+	$theme                  = gutenberg_get_canonical_theme_slug();
 
 	$template            = new WP_Block_Template();
 	$template->id        = $theme . '//' . $template_file['slug'];
@@ -271,7 +271,7 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 			array(
 				'taxonomy' => 'wp_theme',
 				'field'    => 'name',
-				'terms'    => gutenberg_get_theme_stylesheet(),
+				'terms'    => gutenberg_get_canonical_theme_slug(),
 			),
 		),
 	);
@@ -310,7 +310,7 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 		$template_files = _gutenberg_get_template_files( $template_type );
 		foreach ( $template_files as $template_file ) {
 			$is_not_custom   = false === array_search(
-				gutenberg_get_theme_stylesheet() . '//' . $template_file['slug'],
+				gutenberg_get_canonical_theme_slug() . '//' . $template_file['slug'],
 				array_column( $query_result, 'id' ),
 				true
 			);
@@ -367,7 +367,7 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 		}
 	}
 
-	if ( gutenberg_get_theme_stylesheet() === $theme ) {
+	if ( gutenberg_get_canonical_theme_slug() === $theme ) {
 		$template_file = _gutenberg_get_template_file( $template_type, $slug );
 		if ( null !== $template_file ) {
 			return _gutenberg_build_template_result_from_file( $template_file, $template_type );
@@ -402,7 +402,7 @@ function gutenberg_filter_wp_template_unique_post_slug( $override_slug, $slug, $
 	// term does not work in the case of new entities since is too early in
 	// the process to have been saved to the entity.  So for now we use the
 	// currently activated theme for creation.
-	$theme = gutenberg_get_theme_stylesheet();
+	$theme = gutenberg_get_canonical_theme_slug();
 	$terms = get_the_terms( $post_ID, 'wp_theme' );
 	if ( $terms && ! is_wp_error( $terms ) ) {
 		$theme = $terms[0]->name;

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -333,7 +333,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_type   = $this->post_type;
 			$changes->post_status = 'publish';
 			$changes->tax_input   = array(
-				'wp_theme' => isset( $request['theme'] ) ? $request['content'] : gutenberg_get_theme_stylesheet(),
+				'wp_theme' => isset( $request['theme'] ) ? $request['content'] : gutenberg_get_canonical_theme_slug(),
 			);
 		} elseif ( ! $template->is_custom ) {
 			$changes->post_type   = $this->post_type;

--- a/lib/full-site-editing/class-wp-rest-templates-controller.php
+++ b/lib/full-site-editing/class-wp-rest-templates-controller.php
@@ -333,7 +333,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_type   = $this->post_type;
 			$changes->post_status = 'publish';
 			$changes->tax_input   = array(
-				'wp_theme' => isset( $request['theme'] ) ? $request['content'] : wp_get_theme()->get_stylesheet(),
+				'wp_theme' => isset( $request['theme'] ) ? $request['content'] : gutenberg_get_theme_stylesheet(),
 			);
 		} elseif ( ! $template->is_custom ) {
 			$changes->post_type   = $this->post_type;

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -166,6 +166,10 @@ function gutenberg_render_title_tag() {
 	echo '<title>' . wp_get_document_title() . '</title>' . "\n";
 }
 
+function gutenberg_get_theme_stylesheet() {
+	return apply_filters( 'gutenberg_get_theme_stylesheet', wp_get_theme()->get_stylesheet() );
+}
+
 /**
  * Returns the markup for the current template.
  */

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -138,7 +138,7 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 
 	// Find all potential templates 'wp_template' post matching the hierarchy.
 	$query     = array(
-		'theme'    => gutenberg_get_theme_stylesheet(),
+		'theme'    => gutenberg_get_canonical_theme_slug(),
 		'slug__in' => $slugs,
 	);
 	$templates = gutenberg_get_block_templates( $query );
@@ -166,8 +166,8 @@ function gutenberg_render_title_tag() {
 	echo '<title>' . wp_get_document_title() . '</title>' . "\n";
 }
 
-function gutenberg_get_theme_stylesheet() {
-	return apply_filters( 'gutenberg_get_theme_stylesheet', wp_get_theme()->get_stylesheet() );
+function gutenberg_get_canonical_theme_slug() {
+	return apply_filters( 'gutenberg_get_canonical_theme_slug', wp_get_theme()->get_stylesheet() );
 }
 
 /**

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -138,7 +138,7 @@ function gutenberg_resolve_template( $template_type, $template_hierarchy = array
 
 	// Find all potential templates 'wp_template' post matching the hierarchy.
 	$query     = array(
-		'theme'    => wp_get_theme()->get_stylesheet(),
+		'theme'    => gutenberg_get_theme_stylesheet(),
 		'slug__in' => $slugs,
 	);
 	$templates = gutenberg_get_block_templates( $query );

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -157,7 +157,7 @@ function set_unique_slug_on_create_template_part( $post_id ) {
 
 	$terms = get_the_terms( $post_id, 'wp_theme' );
 	if ( ! $terms || ! count( $terms ) ) {
-		wp_set_post_terms( $post_id, wp_get_theme()->get_stylesheet(), 'wp_theme' );
+		wp_set_post_terms( $post_id, gutenberg_get_theme_stylesheet(), 'wp_theme' );
 	}
 }
 add_action( 'save_post_wp_template_part', 'set_unique_slug_on_create_template_part' );

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -157,7 +157,7 @@ function set_unique_slug_on_create_template_part( $post_id ) {
 
 	$terms = get_the_terms( $post_id, 'wp_theme' );
 	if ( ! $terms || ! count( $terms ) ) {
-		wp_set_post_terms( $post_id, gutenberg_get_theme_stylesheet(), 'wp_theme' );
+		wp_set_post_terms( $post_id, gutenberg_get_canonical_theme_slug(), 'wp_theme' );
 	}
 }
 add_action( 'save_post_wp_template_part', 'set_unique_slug_on_create_template_part' );

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -188,7 +188,7 @@ function set_unique_slug_on_create_template( $post_id ) {
 
 	$terms = get_the_terms( $post_id, 'wp_theme' );
 	if ( ! $terms || ! count( $terms ) ) {
-		wp_set_post_terms( $post_id, gutenberg_get_theme_stylesheet(), 'wp_theme' );
+		wp_set_post_terms( $post_id, gutenberg_get_canonical_theme_slug(), 'wp_theme' );
 	}
 }
 add_action( 'save_post_wp_template', 'set_unique_slug_on_create_template' );

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -188,7 +188,7 @@ function set_unique_slug_on_create_template( $post_id ) {
 
 	$terms = get_the_terms( $post_id, 'wp_theme' );
 	if ( ! $terms || ! count( $terms ) ) {
-		wp_set_post_terms( $post_id, wp_get_theme()->get_stylesheet(), 'wp_theme' );
+		wp_set_post_terms( $post_id, gutenberg_get_theme_stylesheet(), 'wp_theme' );
 	}
 }
 add_action( 'save_post_wp_template', 'set_unique_slug_on_create_template' );

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -27,7 +27,7 @@ function render_block_core_template_part( $attributes ) {
 	} elseif (
 		isset( $attributes['slug'] ) &&
 		isset( $attributes['theme'] ) &&
-		wp_get_theme()->get_stylesheet() === $attributes['theme']
+		gutenberg_get_theme_stylesheet() === $attributes['theme']
 	) {
 		$template_part_id    = $attributes['theme'] . '//' . $attributes['slug'];
 		$template_part_query = new WP_Query(

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -27,7 +27,7 @@ function render_block_core_template_part( $attributes ) {
 	} elseif (
 		isset( $attributes['slug'] ) &&
 		isset( $attributes['theme'] ) &&
-		gutenberg_get_theme_stylesheet() === $attributes['theme']
+		gutenberg_get_canonical_theme_slug() === $attributes['theme']
 	) {
 		$template_part_id    = $attributes['theme'] . '//' . $attributes['slug'];
 		$template_part_query = new WP_Query(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Addresses https://github.com/WordPress/gutenberg/issues/30788

This PR introduces a lightweight filter that allows developers to transform the theme stylesheet that is referenced in Gutenberg. The filter would return `wp_get_theme()->get_stylesheet()` by default, and would only be used to [store the value attribute](https://github.com/WordPress/gutenberg/compare/trunk...akirk:gutenberg-get-theme-stylesheet#diff-6ca30c26729f0fb3398ad5c6b4e82d1a83bfe5bd920e4cb6deca5646d9e578bdR158) or [when comparing it](https://href.li/?https://github.com/WordPress/gutenberg/compare/trunk...akirk:gutenberg-get-theme-stylesheet#diff-6ca30c26729f0fb3398ad5c6b4e82d1a83bfe5bd920e4cb6deca5646d9e578bdR370). It would _not_ replace `get_stylesheet_directory()` for actual stylesheet loading. This change will probably require documentation ( not entirely sure yet about where the best place to document this would be ).

This hook would be particularly useful because theme stylesheet values change depending on where the stylesheet lives relative to the `wp-content/themes` directory. That is to say, a theme stylesheet that lives in a subdirectory like `wp-content/themes/test/my-theme` will have a stylesheet that looks like ` test/my-theme`, whereas one that lives in the default `wp-content/themes/my-theme` directory will look like `my-theme`. This becomes a problem during the content importing and exporting process, where one WordPress instance might have a different theme directory structure than its counterpart. 

The filter would provide developers, if they so choose, the option of working with theme stylesheets in a directory agnostic way, and would be allow them to accommodate the content importing and exporting process.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Set up a local dev environment with Gutenberg
2. Install the tt1-blocks theme in the default `wp-content/themes` folder
3. Navigate to the site editor
4. Customize a template by adding a paragraph block to the editor Document
5. Customize a template part by adding a paragraph block to a header template part
6. Save the updates
7. In `wp-admin`, navigate to Appearance > Templates and Appearance > Template Parts
8. Verify that the "Theme" column for each customized CPT is `tt1-blocks`
9. Smoke test side editor
    - Template and template part customization and persistence
    - Template and template part loading / previews in the navigation menu
    - Template part placeholder ("Choose existing" and "New template part" flows)
10. Smoke test the frontend
11. Reset the environment if possible (If using `wp-env`, run the `npx wp-env destroy` command)
12. Install the tt1-blocks theme in a subdirectory relative to `wp-content/themes`. The subdirectory can be named arbitrarily, but for testing purposes we will call it "test". The end result should look like `wp-content/themes/test/tt1-blocks` If we're using `wp-env` and a docker instance , we can accomplish this in `.wp-env.json`
```javascript
// .wp-env.json
{
	"mappings": {
		"wp-content/themes/a8c/tt1-blocks": "~/INSERT_PATH_TO_TT1_BLOCKS_HERE"
	},
        ...rest
}
```
13. Activate the tt1-blocks theme
14. Navigate to the site editor
15. Customize a template by adding a paragraph block to the editor Document.
16. Customize a template part by adding a paragraph block to a header template part.
17. Save the updates
18. In `wp-admin`, navigate to Appearance > Templates and Appearance > Template Parts
19. Verify that the "Theme" column for each customized CPT is `test-tt1-blocks`
20. Smoke test side editor
    - Template and template part customization and persistence
    - Template and template part loading / previews in the navigation menu
    - Template part placeholder ("Choose existing" and "New template part" flows)
21. Smoke test the frontend

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New Feature


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
