### PR TITLE
Block Library: Fix fullwide regression.

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -17,10 +17,11 @@
 	line-height: initial;
 	color: initial;
 
-	// For full-wide blocks, we compensate for these 10px.
+	// For full-wide blocks, we compensate for the base padding.
+	// These margins should match the padding value above.
 	.block-editor-block-list__layout.is-root-container > .wp-block[data-align="full"] {
-		margin-left: -10px;
-		margin-right: -10px;
+		margin-left: -8px;
+		margin-right: -8px;
 	}
 
 	.wp-align-wrapper {


### PR DESCRIPTION
## Description

This is a tiny one. In the smallest of oversights, we forgot a negative margin when we changed the default editor canvas padding. This caused a horizontal scrollbar for fullwide blocks.

Before:

<img width="1270" alt="Screenshot 2021-04-06 at 09 35 23" src="https://user-images.githubusercontent.com/1204802/113675694-ecc02c00-96bb-11eb-9f02-cb7a9663be96.png">

After:

<img width="1270" alt="Screenshot 2021-04-06 at 09 37 17" src="https://user-images.githubusercontent.com/1204802/113675707-ef228600-96bb-11eb-8673-636a0a437b69.png">

## How has this been tested?

Test the demo content, or just fullwide blocks, in a theme that uses truly full-wide images, such as TwentyTwentyOne or TwentyTwenty

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
