### PR TITLE
Global Styles: Use "Custom Styles" title to signal there are global styles changes in the saving panel of the site editor

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -472,6 +472,7 @@ class WP_Theme_JSON_Resolver {
 			),
 			'map_meta_cap' => true,
 			'supports'     => array(
+				'title',
 				'editor',
 				'revisions',
 			),

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -362,6 +362,7 @@ class WP_Theme_JSON_Resolver {
 				array(
 					'post_content' => '{}',
 					'post_status'  => 'publish',
+					'post_title'   => __( 'Custom Styles' ),
 					'post_type'    => $post_type_filter,
 					'post_name'    => $post_name_filter,
 				),


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/30232 

Types of changes:

-  Add support for title to the CustomPostType used to store user styles in the site editor.
- Add the "Custom Styles" title to the post.

## How to test

- Go to the site editor and make some changes in the global styles sidebar.
- Click "Update design".
- Verify that the opened sidebar includes a panel titled "Global Styles" and the label content is "Custom Styles".

![Captura de ecrã de 2021-04-06 10-22-37](https://user-images.githubusercontent.com/583546/113681634-7bd04280-96c2-11eb-8c98-93d44618b5ef.png)

Note this requires that you don't have a previous CPT for global styles. One way to make sure the existing data is deleted is by pasting this code in some file that is executed in the site editor (for example, in the class-wp-theme-json-resolver.php):

```php
add_filter( 'init', function() {
	$gs_cpts = get_posts( array( 'post_type' => 'wp_global_styles', 'numberposts' => -1 ) );
	foreach ( $gs_cpts as $cpt ) {
		wp_delete_post( $cpt->ID, true );
	}
} );
```
