### PR TITLE
Polish the Site Logo block.

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -10,18 +10,11 @@ import { includes, pick } from 'lodash';
 import { isBlobURL } from '@wordpress/blob';
 import { useState, useRef } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
-import {
-	Notice,
-	PanelBody,
-	RangeControl,
-	ResizableBox,
-	Spinner,
-} from '@wordpress/components';
+import { Notice, ResizableBox, Spinner } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	BlockControls,
 	BlockIcon,
-	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	useBlockProps,
@@ -172,24 +165,6 @@ const SiteLogo = ( {
 
 	return (
 		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Site Logo Settings' ) }>
-					<RangeControl
-						label={ __( 'Image width' ) }
-						onChange={ ( newWidth ) =>
-							setAttributes( { width: newWidth } )
-						}
-						min={ minWidth }
-						max={ maxWidthBuffer }
-						initialPosition={ Math.min(
-							naturalWidth,
-							maxWidthBuffer
-						) }
-						value={ width || '' }
-						disabled={ ! isResizable }
-					/>
-				</PanelBody>
-			</InspectorControls>
 			<ResizableBox
 				size={ { width, height } }
 				showHandle={ isSelected }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -10,11 +10,18 @@ import { includes, pick } from 'lodash';
 import { isBlobURL } from '@wordpress/blob';
 import { useState, useRef } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
-import { Notice, ResizableBox, Spinner } from '@wordpress/components';
+import {
+	Notice,
+	PanelBody,
+	RangeControl,
+	ResizableBox,
+	Spinner,
+} from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	BlockControls,
 	BlockIcon,
+	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	useBlockProps,
@@ -165,6 +172,20 @@ const SiteLogo = ( {
 
 	return (
 		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings' ) }>
+					<RangeControl
+						label={ __( 'Image width' ) }
+						onChange={ ( newWidth ) =>
+							setAttributes( { width: newWidth } )
+						}
+						min={ minWidth }
+						max={ maxWidthBuffer }
+						value={ width || '' }
+						disabled={ ! isResizable }
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<ResizableBox
 				size={ { width, height } }
 				showHandle={ isSelected }

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -5,9 +5,24 @@
 }
 
 .wp-block-site-logo {
+	// Make the block selectable.
+	a {
+		pointer-events: none;
+	}
+
 	&.is-resized {
 		display: table;
 	}
+
+	// Provide a sane starting point for the size.
+	&:not(.is-resized) {
+		width: 120px;
+
+		img {
+			width: 100%;
+		}
+	}
+
 
 	.custom-logo-link {
 		cursor: inherit;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -40,4 +40,43 @@
 		display: block;
 		max-width: 100%;
 	}
+
+	// Placeholder improvements.
+	.components-placeholder {
+		min-height: auto;
+		height: 120px;
+		padding: $grid-unit-10;
+
+		// Massage the label.
+		.components-placeholder__label {
+			white-space: nowrap;
+		}
+
+		.components-placeholder__label .block-editor-block-icon {
+			margin-right: $grid-unit-05;
+		}
+
+		// Hide the upload button, as it's also available in the media library.
+		.components-form-file-upload {
+			display: none;
+		}
+
+		// Position the spinner.
+		.components-placeholder__preview {
+			position: absolute;
+			top: $grid-unit-05;
+			right: $grid-unit-05;
+			bottom: $grid-unit-05;
+			left: $grid-unit-05;
+			background: rgba($white, 0.8);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+
+		// Hide drag and drop text.
+		.components-drop-zone__content-text {
+			display: none;
+		}
+	}
 }

--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -15,9 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: _x( 'Site Logo', 'block title' ),
-	description: __(
-		"Allows you to define a logo to be used across your site. Once defined, changing it in one template will change it in all places where it's used as well."
-	),
+	description: __( 'Displays and enables editing of the site logo.' ),
 	icon,
 	styles: [
 		{

--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -15,7 +15,9 @@ export { metadata, name };
 
 export const settings = {
 	title: _x( 'Site Logo', 'block title' ),
-	description: __( 'Show a site logo' ),
+	description: __(
+		"Allows you to define a logo to be used across your site. Once defined, changing it in one template will change it in all places where it's used as well."
+	),
 	icon,
 	styles: [
 		{

--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -1,6 +1,15 @@
 .wp-block-site-logo {
 	line-height: 0;
 
+	a {
+		display: inline-block;
+	}
+
+	// Provide a sane starting point for the size.
+	&:not(.is-resized) img {
+		width: 120px;
+	}
+
 	.aligncenter {
 		display: table;
 	}


### PR DESCRIPTION
## Description

This PR takes a stab at a few of the items from #30406. Specifically it:

1. Improves the description in the block sidebar.
2. Sets a default (until resized) width of 120px.
3. Polishes the placeholder state to work well in the small size.

I could use advice on the description in the sidebar, is it precise enough? 

Note that for 2, I entirely removed the "Logo width" range control in the sidebar. It seemed duplicate compared to the control that exists in the canvas itself, and it was problematic insofar as it showed the image dimensions even when you hadn't explicitly set the width of the image at all (and was therefore subject to theme styles). Is there any reason to keep that control that I'm missing?

## How has this been tested?

Test inserting a site logo, test setting it, and that it looks correct in editor and frontend.

Then try resizing the site logo and check that also looks good.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
