### PR TITLE
Show the label for archives block dropdown

### DIFF
--- a/packages/block-library/src/archives/editor.scss
+++ b/packages/block-library/src/archives/editor.scss
@@ -1,9 +1,3 @@
 ul.wp-block-archives {
 	padding-left: 2.5em;
 }
-
-.wp-block-archives-dropdown {
-	label {
-		display: block;
-	}
-}

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -60,7 +60,7 @@ function render_block_core_archives( $attributes ) {
 
 		$label = esc_html( $label );
 
-		$block_content = '<label class="screen-reader-text" for="' . $dropdown_id . '">' . $title . '</label>
+		$block_content = '<label for="' . $dropdown_id . '">' . $title . '</label>
 	<select id="' . $dropdown_id . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
 	<option value="">' . $label . '</option>' . $archives . '</select>';
 

--- a/packages/block-library/src/archives/style.scss
+++ b/packages/block-library/src/archives/style.scss
@@ -1,7 +1,3 @@
-ul.wp-block-archives {
-	padding-left: 2.5em;
-}
-
 .wp-block-archives-dropdown {
 	label {
 		display: block;

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -3,6 +3,7 @@
 	display: none;
 }
 
+@import "./archives/style.scss";
 @import "./audio/style.scss";
 @import "./button/style.scss";
 @import "./buttons/style.scss";


### PR DESCRIPTION
## Description
Follow up #11219 that has been closed.

This PR shows the label markup for the archives block when the dropdown option is selected.

Fixes #11002.

## How has this been tested?
- I've checked on the default themes if the label for the archives block shows correctly on the editor and on frontend.

## Screenshots <!-- if applicable -->
Editor before
<img width="337" alt="image" src="https://user-images.githubusercontent.com/33403964/113709259-31f35680-96da-11eb-8c75-24ca9f1aacd1.png">

Frontend before
<img width="366" alt="image" src="https://user-images.githubusercontent.com/33403964/113709297-3ae42800-96da-11eb-8a71-e9ecf41db061.png">


Editor after
<img width="399" alt="CleanShot 2021-04-06 at 13 11 57@2x" src="https://user-images.githubusercontent.com/33403964/113708934-c90bde80-96d9-11eb-8292-c2c98da11812.png">

Frontend after
<img width="331" alt="CleanShot 2021-04-06 at 13 12 21@2x" src="https://user-images.githubusercontent.com/33403964/113708948-cdd09280-96d9-11eb-8d6d-aa9a022e6556.png">


## Types of changes
This is mostly a CSS change.
I've removed the `screen-reader-text` class from the archives block label markup (https://github.com/WordPress/gutenberg/blob/3882276868b98d0e3ae4fd5a8d81b404ba2fc616/packages/block-library/src/archives/index.php#L63)  as it will be shown visually.

I also added a new CSS file to style the label on the frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [NA] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [NA] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [NA] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
