### PR TITLE
WordPress minor release - second round of bug fixes

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -322,10 +322,11 @@ function GalleryEdit( props ) {
 	}, [ linkTo ] );
 
 	const hasImages = !! images.length;
+	const hasImageIds = hasImages && images.some( ( image ) => !! image.id );
 
 	const mediaPlaceholder = (
 		<MediaPlaceholder
-			addToGallery={ hasImages }
+			addToGallery={ hasImageIds }
 			isAppender={ hasImages }
 			disableMediaButtons={ hasImages && ! isSelected }
 			icon={ ! hasImages && sharedIcon }
@@ -337,7 +338,7 @@ function GalleryEdit( props ) {
 			accept="image/*"
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			multiple
-			value={ images }
+			value={ hasImageIds ? images : {} }
 			onError={ onUploadError }
 			notices={ hasImages ? undefined : noticeUI }
 			onFocus={ onFocus }

--- a/packages/editor/src/components/post-author/index.js
+++ b/packages/editor/src/components/post-author/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -13,10 +14,8 @@ const minimumUsersForCombobox = 25;
 
 function PostAuthor() {
 	const showCombobox = useSelect( ( select ) => {
-		const authors = select( 'core' ).getUsers( {
-			who: 'authors',
-			per_page: minimumUsersForCombobox + 1,
-		} );
+		// Not using `getUsers()` because it requires `list_users` capability.
+		const authors = select( coreStore ).getAuthors();
 		return authors?.length >= minimumUsersForCombobox;
 	}, [] );
 

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,13 +7,12 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
-export const DEBOUNCE_TIME = 300;
 export default function PostTextEditor() {
 	const postContent = useSelect(
 		( select ) => select( 'core/editor' ).getEditedPostContent(),
@@ -29,18 +28,6 @@ export default function PostTextEditor() {
 	if ( ! isDirty && value !== postContent ) {
 		setValue( postContent );
 	}
-
-	const saveText = () => {
-		const blocks = parse( value );
-		resetEditorBlocks( blocks );
-	};
-
-	useEffect( () => {
-		const timeoutId = setTimeout( saveText, DEBOUNCE_TIME );
-		return () => {
-			clearTimeout( timeoutId );
-		};
-	}, [ value ] );
 
 	/**
 	 * Handles a textarea change event to notify the onChange prop callback and
@@ -67,7 +54,8 @@ export default function PostTextEditor() {
 	 */
 	const stopEditing = () => {
 		if ( isDirty ) {
-			saveText();
+			const blocks = parse( value );
+			resetEditorBlocks( blocks );
 			setIsDirty( false );
 		}
 	};

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -7,14 +7,13 @@ import Textarea from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import * as wp from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import PostTextEditor, { DEBOUNCE_TIME } from '../';
+import PostTextEditor from '../';
 
-const useSelect = wp.useSelect;
 // "Downgrade" ReactAutosizeTextarea to a regular textarea. Assumes aligned
 // props interface.
 jest.mock( 'react-autosize-textarea', () => ( props ) => (
@@ -175,24 +174,5 @@ describe( 'PostTextEditor', () => {
 		act( () => textarea.props.onBlur() );
 
 		expect( textarea.props.value ).toBe( 'Goodbye World' );
-	} );
-	it( 'debounce value update after given time', () => {
-		let wrapper;
-		act( () => {
-			wrapper = create( <PostTextEditor /> );
-		} );
-		const mockDispatchFn = jest.fn();
-		jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-			useDispatch: () => ( {
-				editPost: jest.fn(),
-				resetEditorBlocks: mockDispatchFn,
-			} ),
-		} ) );
-
-		const textarea = wrapper.root.findByType( Textarea );
-		act( () => textarea.props.onChange( { target: { value: 'text' } } ) );
-		setTimeout( () => {
-			expect( mockDispatchFn ).toHaveBeenCalled();
-		}, DEBOUNCE_TIME );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up for https://github.com/WordPress/gutenberg/pull/30517.

Cherry-picks these PRs into `wp/5.7` for WordPress 5.7.1 release:
- Core Data: Use `getAuthors` for `showCombobox` check #30218
- Editor: Revert (#27717) save editors value on change #30524
- Gallery: Set `addToGallery` prop to false when images don't have IDs #30122

