### PR TITLE
Replace older-style PHP type conversion functions with typecasts

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -55,7 +55,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	$has_border_radius_support = gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ), false );
 	if ( $has_border_radius_support ) {
 		if ( isset( $block_attributes['style']['border']['radius'] ) ) {
-			$border_radius = intval( $block_attributes['style']['border']['radius'] );
+			$border_radius = (int) $block_attributes['style']['border']['radius'];
 			$styles[]      = sprintf( 'border-radius: %dpx;', $border_radius );
 		}
 	}

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -571,7 +571,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		foreach ( array( 'menu-item-object-id', 'menu-item-parent-id' ) as $key ) {
 			// Note we need to allow negative-integer IDs for previewed objects not inserted yet.
-			$prepared_nav_item[ $key ] = intval( $prepared_nav_item[ $key ] );
+			$prepared_nav_item[ $key ] = (int) $prepared_nav_item[ $key ];
 		}
 
 		foreach ( array( 'menu-item-type', 'menu-item-object', 'menu-item-target' ) as $key ) {

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -17,8 +17,8 @@ function render_block_core_site_logo( $attributes ) {
 		if ( empty( $attributes['width'] ) ) {
 			return $image;
 		}
-		$height = floatval( $attributes['width'] ) / ( floatval( $image[1] ) / floatval( $image[2] ) );
-		return array( $image[0], intval( $attributes['width'] ), intval( $height ) );
+		$height = (float) $attributes['width'] / ( (float) $image[1] / (float) $image[2] );
+		return array( $image[0], (int) $attributes['width'], (int) $height );
 	};
 
 	add_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );


### PR DESCRIPTION
This improves performance, readability, and consistency throughout core. See ticket from WP Core: https://core.trac.wordpress.org/ticket/42918