### PR TITLE
Add a fixed width to the editor sidebar calendar help popover

### DIFF
--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -216,6 +216,7 @@ $arrow-size: 8px;
 
 	.components-popover:not([data-y-axis="middle"])[data-x-axis="left"] & {
 		margin-right: -($grid-unit-30 + $border-width);
+		width: 286px;
 	}
 }
 

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -216,7 +216,7 @@ $arrow-size: 8px;
 
 	.components-popover:not([data-y-axis="middle"])[data-x-axis="left"] & {
 		margin-right: -($grid-unit-30 + $border-width);
-		width: 286px;
+		min-width: 286px;
 	}
 }
 


### PR DESCRIPTION
## Description
Fixed #30532.

## Screenshots <!-- if applicable -->
Before
<img width="404" alt="image" src="https://user-images.githubusercontent.com/33403964/113731885-09c32200-96f1-11eb-8ba3-5a84d40d92d6.png">


After
<img width="396" alt="image" src="https://user-images.githubusercontent.com/33403964/113731799-f748e880-96f0-11eb-9c0d-b961d92d78f4.png">


## Types of changes
CSS fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [NA] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [NA] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [NA] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [NA] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [NA] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
