### PR TITLE
api-fetch: Export all types

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -43,6 +43,9 @@ const DEFAULT_OPTIONS = {
 	credentials: 'include',
 };
 
+/** @typedef {import('./types').ApiFetchMiddleware} ApiFetchMiddleware */
+/** @typedef {import('./types').ApiFetchRequestProps} ApiFetchRequestProps */
+
 /**
  * @type {import('./types').ApiFetchMiddleware[]}
  */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes a problem where only `FetchHandler` was being exported from `api-fetch` but not the `ApiFetchMiddleware` and `ApiFetchRequestProps` which are needed by other packages in DefinitelyTyped: https://github.com/saramarcondes/DefinitelyTyped/blob/a3daf52bcd201345739f7b792decc181dfba61d8/types/wordpress__data-controls/index.d.ts#L7

## How has this been tested?
Build passes. No runtime changes, but type exports.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
