### PR TITLE
Components: Query autocomplete by the term from last trigger prefix character

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -472,9 +472,9 @@ function Autocomplete( {
 		}
 
 		const safeTrigger = escapeRegExp( completer.triggerPrefix );
-		const match = text.match(
-			new RegExp( `${ safeTrigger }([\u0000-\uFFFF]*)$` )
-		);
+		const match = text
+			.slice( text.lastIndexOf( completer.triggerPrefix ) )
+			.match( new RegExp( `${ safeTrigger }([\u0000-\uFFFF]*)$` ) );
 		const query = match && match[ 1 ];
 
 		setAutocompleter( completer );


### PR DESCRIPTION
## Description
Fixes an issue introduced in https://github.com/WordPress/gutenberg/pull/29939, where the search won't retrigger when more than one inline trigger prefix is present.

## How has this been tested?
The autocomplete search results should appear every time the search trigger is typed, i.e. the [user search](https://github.com/WordPress/gutenberg/blob/f63053cace3c02e284f00918e1854284c85b9132/packages/editor/src/components/autocompleters/user.js#L10) via `@`.
(⚠️ The above does not apply to the block search because of its custom [allowContext](https://github.com/WordPress/gutenberg/blob/1fecda195184b491d52e64965035009be6b86bad/packages/block-editor/src/autocompleters/block.js#L108) condition.)

Confirm that searching blocks via multiple words is still working as described in https://github.com/WordPress/gutenberg/pull/29939.

## Types of changes
Bugfix