### PR TITLE
Gallery block refactor: check for new images by clientId instead of id to stop link settings being lost when images edited

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -440,7 +440,6 @@ function GalleryEdit( props ) {
 		return <View { ...blockProps }>{ mediaPlaceholder }</View>;
 	}
 
-	const shouldShowSizeOptions = imageSizeOptions?.length > 0;
 	const hasLinkTo = linkTo && linkTo !== 'none';
 
 	return (
@@ -478,7 +477,7 @@ function GalleryEdit( props ) {
 							onChange={ toggleOpenInNewTab }
 						/>
 					) }
-					{ shouldShowSizeOptions && (
+					{ imageSizeOptions?.length > 0 && (
 						<SelectControl
 							label={ __( 'Image size' ) }
 							value={ sizeSlug }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty, concat, find } from 'lodash';
+import { concat, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -440,7 +440,7 @@ function GalleryEdit( props ) {
 		return <View { ...blockProps }>{ mediaPlaceholder }</View>;
 	}
 
-	const shouldShowSizeOptions = ! isEmpty( imageSizeOptions );
+	const shouldShowSizeOptions = imageSizeOptions?.length > 0;
 	const hasLinkTo = linkTo && linkTo !== 'none';
 
 	return (
@@ -478,7 +478,7 @@ function GalleryEdit( props ) {
 							onChange={ toggleOpenInNewTab }
 						/>
 					) }
-					{ shouldShowSizeOptions ? (
+					{ shouldShowSizeOptions && (
 						<SelectControl
 							label={ __( 'Image size' ) }
 							value={ sizeSlug }
@@ -486,7 +486,8 @@ function GalleryEdit( props ) {
 							onChange={ updateImagesSize }
 							hideCancelButton={ true }
 						/>
-					) : (
+					) }
+					{ ! imageSizeOptions && (
 						<BaseControl className={ 'gallery-image-sizes' }>
 							<BaseControl.VisualLabel>
 								{ __( 'Image size' ) }

--- a/packages/block-library/src/gallery/use-get-new-images.js
+++ b/packages/block-library/src/gallery/use-get-new-images.js
@@ -41,7 +41,9 @@ export default function useGetNewImages( images, imageData ) {
 		const newImages = images.filter(
 			( image ) =>
 				! newCurrentImages.find(
-					( currentImage ) => image.id && currentImage.id === image.id
+					( currentImage ) =>
+						image.clientId &&
+						currentImage.clientId === image.clientId
 				) &&
 				imageData?.find( ( img ) => img.id === image.id ) &&
 				! image.fromSavedConent

--- a/packages/block-library/src/gallery/use-image-sizes.js
+++ b/packages/block-library/src/gallery/use-image-sizes.js
@@ -13,7 +13,7 @@ export default function useImageSizes( images, isSelected, getSettings ) {
 
 	function getImageSizing() {
 		if ( ! images || images.length === 0 ) {
-			return [];
+			return;
 		}
 		const { imageSizes } = getSettings();
 		let resizedImages = {};


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/29996

## Description
Currently if an image in gallery has a link set that is different to gallary default, and the image is edited, eg. cropped, then the link is lost and replaced with gallery default. Also fixes an issue with image size select showing loading indefinitely if cropped image has no size data.

## Testing

- Check out this PR and enable gallery refactor experiment
- Add a single image into a gallery and set a custom link
- Crop the image and apply
- Make sure custom link is still set
- Crop the image again to max crop and make sure that no gallery image size selects, and that `loading image sizes` is not showing indefinitely

