### PR TITLE
Change Navigation block markup on front end only

### DIFF
--- a/packages/block-library/src/home-link/edit.js
+++ b/packages/block-library/src/home-link/edit.js
@@ -56,7 +56,7 @@ export default function HomeEdit( {
 
 	return (
 		<>
-			<li { ...blockProps }>
+			<div { ...blockProps }>
 				<a
 					className="wp-block-home-link__content"
 					href={ homeUrl }
@@ -80,7 +80,7 @@ export default function HomeEdit( {
 						] }
 					/>
 				</a>
-			</li>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -48,7 +48,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { ItemSubmenuIcon } from './icons';
 import { name } from './block.json';
 
-const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/spacer' ];
+const ALLOWED_BLOCKS = [ 'core/navigation-link' ];
 
 const MAX_NESTING = 5;
 
@@ -418,7 +418,6 @@ export default function NavigationLinkEdit( {
 				hasDescendants
 					? InnerBlocks.DefaultAppender
 					: false,
-			__experimentalAppenderTagName: 'li',
 		}
 	);
 
@@ -507,7 +506,7 @@ export default function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<li { ...blockProps }>
+			<div { ...blockProps }>
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>
 					{ /* eslint-enable */ }
@@ -611,8 +610,8 @@ export default function NavigationLinkEdit( {
 						</span>
 					) }
 				</a>
-				<ul { ...innerBlocksProps } />
-			</li>
+				<div { ...innerBlocksProps } />
+			</div>
 		</Fragment>
 	);
 }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -167,15 +167,13 @@ function Navigation( {
 					</PanelBody>
 				) }
 			</InspectorControls>
-			<nav { ...blockProps }>
+			<nav { ...innerBlocksProps }>
 				<ResponsiveWrapper
 					id={ clientId }
 					onToggle={ setResponsiveMenuVisibility }
 					isOpen={ isResponsiveMenuOpen }
 					isResponsive={ attributes.isResponsive }
-				>
-					<ul { ...innerBlocksProps }></ul>
-				</ResponsiveWrapper>
+				></ResponsiveWrapper>
 			</nav>
 		</>
 	);

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -167,13 +167,15 @@ function Navigation( {
 					</PanelBody>
 				) }
 			</InspectorControls>
-			<nav { ...innerBlocksProps }>
+			<nav { ...blockProps }>
 				<ResponsiveWrapper
 					id={ clientId }
 					onToggle={ setResponsiveMenuVisibility }
 					isOpen={ isResponsiveMenuOpen }
 					isResponsive={ attributes.isResponsive }
-				></ResponsiveWrapper>
+				>
+					<div { ...innerBlocksProps }></div>
+				</ResponsiveWrapper>
 			</nav>
 		</>
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -202,7 +202,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// return early if they don't.
 	if ( ! isset( $attributes['isResponsive'] ) || false === $attributes['isResponsive'] ) {
 		return sprintf(
-			'<nav %1$s><ul class="wp-block-navigation__container">%2$s</ul></nav>',
+			'<nav %1$s>%2$s</nav>',
 			$wrapper_attributes,
 			$inner_blocks_html
 		);
@@ -215,7 +215,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 					<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-%1$s-title" >
 							<button aria-label="%4$s" data-micromodal-close class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
 						<div class="wp-block-navigation__responsive-container-content" id="modal-%1$s-content">
-							<ul class="wp-block-navigation__container">%2$s</ul>
+							%2$s
 						</div>
 					</div>
 				</div>

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -180,7 +180,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			$is_list_open = true;
 			$inner_blocks_html .= '<ul class="wp-block-navigation__container">';
 		}
-		if ($inner_block->name !== "core/navigation-link" && $inner_block->name !== "core/spacer" && $is_list_open === true) {
+		if ($inner_block->name !== "core/navigation-link" && $is_list_open === true) {
 			$is_list_open = false;
 			$inner_blocks_html .= '</ul>';
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -174,14 +174,14 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	);
 
 	$inner_blocks_html = '';
-	$is_list_open = false;
+	$is_list_open      = false;
 	foreach ( $block->inner_blocks as $inner_block ) {
-		if ($inner_block->name === "core/navigation-link" && $is_list_open === false) {
-			$is_list_open = true;
+		if ( 'core/navigation-link' === $inner_block->name && false === $is_list_open ) {
+			$is_list_open       = true;
 			$inner_blocks_html .= '<ul class="wp-block-navigation__container">';
 		}
-		if ($inner_block->name !== "core/navigation-link" && $is_list_open === true) {
-			$is_list_open = false;
+		if ( 'core/navigation-link' !== $inner_block->name && true === $is_list_open ) {
+			$is_list_open       = false;
 			$inner_blocks_html .= '</ul>';
 		}
 		$inner_blocks_html .= $inner_block->render();

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -174,7 +174,16 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	);
 
 	$inner_blocks_html = '';
+	$is_list_open = false;
 	foreach ( $block->inner_blocks as $inner_block ) {
+		if ($inner_block->name === "core/navigation-link" && $is_list_open === false) {
+			$is_list_open = true;
+			$inner_blocks_html .= '<ul class="wp-block-navigation__container">';
+		}
+		if ($inner_block->name !== "core/navigation-link" && $inner_block->name !== "core/spacer" && $is_list_open === true) {
+			$is_list_open = false;
+			$inner_blocks_html .= '</ul>';
+		}
 		$inner_blocks_html .= $inner_block->render();
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -176,11 +176,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$inner_blocks_html = '';
 	$is_list_open      = false;
 	foreach ( $block->inner_blocks as $inner_block ) {
-		if ( 'core/navigation-link' === $inner_block->name && false === $is_list_open ) {
+		if ( ( 'core/navigation-link' === $inner_block->name || 'core/home-link' === $inner_block->name ) && false === $is_list_open ) {
 			$is_list_open       = true;
 			$inner_blocks_html .= '<ul class="wp-block-navigation__container">';
 		}
-		if ( 'core/navigation-link' !== $inner_block->name && true === $is_list_open ) {
+		if ( 'core/navigation-link' !== $inner_block->name && 'core/home-link' !== $inner_block->name && true === $is_list_open ) {
 			$is_list_open       = false;
 			$inner_blocks_html .= '</ul>';
 		}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -6,6 +6,17 @@
 .wp-block-navigation {
 	position: relative;
 
+	// Horizontal layout
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+
+	// Vertical layout
+	&.is-vertical {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
 	// Normalize list styles.
 	ul,
 	ul li {

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -348,7 +348,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the Editor's "Content" region as otherwise it picks up on
 			// block previews.
 			const navBlockItemsLength = await page.$$eval(
-				'[aria-label="Editor content"][role="region"] li[aria-label="Block: Custom Link"]',
+				'[aria-label="Editor content"][role="region"] div[aria-label="Block: Custom Link"]',
 				( els ) => els.length
 			);
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -313,7 +313,7 @@ describe( 'Navigation editor', () => {
 
 		// Select a link block with nested links in a submenu.
 		const parentLinkXPath =
-			'//li[@aria-label="Block: Custom Link" and contains(.,"WordPress.org")]';
+			'//div[@aria-label="Block: Custom Link" and contains(.,"WordPress.org")]';
 		const linkBlock = await page.waitForXPath( parentLinkXPath );
 		await linkBlock.click();
 
@@ -322,7 +322,7 @@ describe( 'Navigation editor', () => {
 		// Submenus are hidden using `visibility: hidden` and shown using
 		// `visibility: visible` so the visible/hidden options must be used
 		// when selecting the elements.
-		const submenuLinkXPath = `${ parentLinkXPath }//li[@aria-label="Block: Custom Link"]`;
+		const submenuLinkXPath = `${ parentLinkXPath }//div[@aria-label="Block: Custom Link"]`;
 		const submenuLinkVisible = await page.waitForXPath( submenuLinkXPath, {
 			visible: true,
 		} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

[Follow-up exploration](https://github.com/WordPress/gutenberg/pull/30430#issuecomment-813233147) into minimising impact of nav semantics for end users. This removes the `<ul>` from the Navigation block markup and adds it conditionally on innerBlock type, only on the server-side render, so it only applies on the front end. 

Disadvantages: markup will be different between editor and front end; ~~editor markup will be unsemantic with `<li>` elements nested directly inside the `<nav>` (we can fiddle with the Navigation link block and change its editor output too if we want to fix this).~~ UPDATE: this has now been fixed, to render all link children of the Nav as `div`s in the editor.

Advantages: users don't have to bother about adding intermediary list blocks.

~~NOTE: Spacer blocks are (unsemantically) added inside the `ul` elements for now, as I was given to understand that Spacers would be required to work inside submenus too. If this is not the case, I can remove them from the lists. Otherwise we'll need to think of another way to address the Spacer issue.~~ 

The Spacer block has been temporarily removed from submenus and will be addressed separately; #33018 and #30590 explain what is needed.

With the changes in this PR, the Navigation block should contain fully semantic markup, no matter what its contents are.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
