### PR TITLE
Site Editor: Remove call to wpautop that unintentionally alters block markup in template parts

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -101,7 +101,6 @@ function render_block_core_template_part( $attributes ) {
 	unset( $seen_ids[ $template_part_id ] );
 	$content = wptexturize( $content );
 	$content = convert_smilies( $content );
-	$content = wpautop( $content );
 	$content = shortcode_unautop( $content );
 	if ( function_exists( 'wp_filter_content_tags' ) ) {
 		$content = wp_filter_content_tags( $content );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This change is very similar to an older draft PR (#20452 kudos @johnstonphilip) and follows on from discussion in https://github.com/WordPress/gutenberg/pull/20343#issuecomment-589457288 where it was proposed to remove the call to `wpautop` when rendering template parts.

It turns out, while working on a plugin that server renders a block (in this case it was the Jetpack Rating Star block), I noticed that when the block was rendered within a template part, the markup was incorrect and broke the styling for the block, however when the block was rendered within normal post content, the markup was correct.

In core, when `do_blocks` is called, it checks to see whether or not it's running within `the_content` filter, and if so, [it disables](https://github.com/wordpress/wordpress/blob/0a3794a0de6dc119d12f2671844b85e473dbdb72/wp-includes/blocks.php#L843-L843) calling `wpautop` for that run of the filter.

However, in `render_block_core_template_part` we call `do_blocks` directly instead of within the context of `the_content`, so the code to disable `wpautop` doesn't fire (and it wouldn't do anything, anyway).

Since the expected behaviour of calling `do_blocks` with block content is for `wpautop` to be disabled, let's remove the call to it as proposed in https://github.com/WordPress/gutenberg/pull/20343#issuecomment-589457288 and #20452

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually in a local development environment running the Gutenberg plugin and the Jetpack plugin, using the Star Rating block (a server-rendered block that expects not to have `<p>` tags injected into it).

While I tested this with the Jetpack plugin, I believe other plugins will run into a similar issue with server rendered blocks in template parts, so thought it better to fix this in Gutenberg rather than add a workaround in the plugin.

## Screenshots <!-- if applicable -->

### Editor view

This is the editor view of inserting the Jetpack Star Rating block into the Footer template part:

![image](https://user-images.githubusercontent.com/14988353/113809033-a09fe500-97aa-11eb-9589-716e12f97dd2.png)

### Front-end view (without this change applied)

![image](https://user-images.githubusercontent.com/14988353/113809264-160bb580-97ab-11eb-960d-aeddcf015a66.png)

### Front-end view (with this change applied)

![image](https://user-images.githubusercontent.com/14988353/113809066-b7463c00-97aa-11eb-95aa-d508c37478fe.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for blocks rendered within template parts.

## Checklist:
- [ ] My code is tested. (manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] ~I've tested my changes with keyboard and screen readers.~ N/A <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] ~My code has proper inline documentation.~ <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] ~I've included developer documentation if appropriate.~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~I've updated all React Native files affected by any refactorings/renamings in this PR~ (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
