### PR TITLE
Block Library - Query Pagination Numbers: Print nothing if content is empty

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -55,6 +55,9 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 		wp_reset_postdata(); // Restore original Post Data.
 		$wp_query = $prev_wp_query;
 	}
+	if ( empty( $content ) ) {
+		return '';
+	}
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
A tiny PR to print nothing if `QueryPaginationNumbers` has no content. This can happen when we have a `Query` block with more `posts per page` than the actual number of published posts.
