### PR TITLE
Gallery Block: Use better key for gallery list items

### DIFF
--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -64,7 +64,7 @@ export const Gallery = ( props ) => {
 					return (
 						<li
 							className="blocks-gallery-item"
-							key={ img.id || img.url }
+							key={ img.id ? `${ img.id }-${ index }` : img.url }
 						>
 							<GalleryImage
 								url={ img.url }

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -110,7 +110,7 @@ export const Gallery = ( props ) => {
 
 					return (
 						<GalleryImage
-							key={ img.id || img.url }
+							key={ img.id ? `${ img.id }-${ index }` : img.url }
 							url={ img.url }
 							alt={ img.alt }
 							id={ parseInt( img.id, 10 ) } // make id an integer explicitly


### PR DESCRIPTION
## Description
Galleries can have the same image listed more than once. Users can do this by editing individual items and selecting the image that's already in the gallery. In this case, image ids can't be used as unique key props.

Fixes #30473.


## How has this been tested?
1. Add a gallery block
2. Add two images that are the same next to each other.
3. Try and use the arrows on an adjacent image to move it over.
4. Duplicated images shouldn't replace other images.
5. Following error shouldn't appear in the browser console:

```
Warning: Encountered two children with the same key, `[image.id]`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

## Types of changes
Bugfix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
