### PR TITLE
Stop keypresses being caught by other elements when they happen in a CustomSelectControl

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Bug Fix
 
-- Add missing styles to the `BaseControl.VisualLabel` component. ([#37747](https://github.com/WordPress/gutenberg/pull/37747))
-- Prevent keyDown events from propagating up in `CustomSelectControl` ([#30557](https://github.com/WordPress/gutenberg/pull/30557))
+-   Add missing styles to the `BaseControl.VisualLabel` component. ([#37747](https://github.com/WordPress/gutenberg/pull/37747))
+-   Prevent keyDown events from propagating up in `CustomSelectControl` ([#30557](https://github.com/WordPress/gutenberg/pull/30557))
 
 ## 19.2.0 (2022-01-04)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fix
 
--   Add missing styles to the `BaseControl.VisualLabel` component. ([#37747](https://github.com/WordPress/gutenberg/pull/37747))
+- Add missing styles to the `BaseControl.VisualLabel` component. ([#37747](https://github.com/WordPress/gutenberg/pull/37747))
+- Prevent keyDown events from propagating up in `CustomSelectControl` ([#30557](https://github.com/WordPress/gutenberg/pull/30557))
 
 ## 19.2.0 (2022-01-04)
 

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -141,7 +141,14 @@ export default function CustomSelectControl( {
 					className="components-custom-select-control__button-icon"
 				/>
 			</Button>
-			<ul { ...menuProps }>
+			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
+			<ul
+				{ ...menuProps }
+				onKeyDown={ ( e ) => {
+					e.nativeEvent.stopImmediatePropagation();
+					menuProps.onKeyDown( e );
+				} }
+			>
 				{ isOpen &&
 					items.map( ( item, index ) => (
 						// eslint-disable-next-line react/jsx-key

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -145,7 +145,7 @@ export default function CustomSelectControl( {
 			<ul
 				{ ...menuProps }
 				onKeyDown={ ( e ) => {
-					e.nativeEvent.stopImmediatePropagation();
+					e.stopPropagation();
 					menuProps.onKeyDown( e );
 				} }
 			>

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -9,6 +9,8 @@ import classnames from 'classnames';
  */
 import { Icon, check, chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */
@@ -98,6 +100,15 @@ export default function CustomSelectControl( {
 		className: 'components-custom-select-control__menu',
 		'aria-hidden': ! isOpen,
 	} );
+
+	const onKeyDownHandler = useCallback(
+		( e ) => {
+			e.stopPropagation();
+			menuProps?.onKeyDown?.( e );
+		},
+		[ menuProps ]
+	);
+
 	// We need this here, because the null active descendant is not fully ARIA compliant.
 	if (
 		menuProps[ 'aria-activedescendant' ]?.startsWith( 'downshift-null' )
@@ -142,13 +153,7 @@ export default function CustomSelectControl( {
 				/>
 			</Button>
 			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
-			<ul
-				{ ...menuProps }
-				onKeyDown={ ( e ) => {
-					e.stopPropagation();
-					menuProps.onKeyDown( e );
-				} }
-			>
+			<ul { ...menuProps } onKeyDown={ onKeyDownHandler }>
 				{ isOpen &&
 					items.map( ( item, index ) => (
 						// eslint-disable-next-line react/jsx-key

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -8,9 +8,8 @@ import { render, fireEvent } from '@testing-library/react';
 import { CustomSelectControl } from '@wordpress/components';
 
 describe( 'CustomSelectControl', () => {
-	const onKeyDown = jest.fn();
-
 	it( 'Captures the keypress event and does not let it propagate', () => {
+		const onKeyDown = jest.fn();
 		const wrapper = (
 			<div
 				// This role="none" is required to prevent an eslint warning about accessibility.

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -13,8 +13,8 @@ describe( 'CustomSelectControl', () => {
 	it( 'Captures the keypress event and does not let it propagate', () => {
 		const wrapper = (
 			<div
+				// This role="none" is required to prevent an eslint warning about accessibility.
 				role="none"
-				className="test-class-name"
 				onKeyDown={ onKeyDown }
 			>
 				<CustomSelectControl options={ [ 'a', 'b', 'c' ] } />

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+/**
+ * WordPress dependencies
+ */
+import { CustomSelectControl } from '@wordpress/components';
+
+describe( 'CustomSelectControl', () => {
+	const onKeyDown = jest.fn();
+
+	it( 'Captures the keypress event and does not let it propagate', () => {
+		const wrapper = (
+			<div
+				role="none"
+				className="test-class-name"
+				onKeyDown={ onKeyDown }
+			>
+				<CustomSelectControl options={ [ 'a', 'b', 'c' ] } />
+			</div>
+		);
+		const { container } = render( wrapper );
+		fireEvent.keyDown(
+			container.getElementsByClassName(
+				'components-custom-select-control__menu'
+			)[ 0 ]
+		);
+		expect( onKeyDown.mock.calls.length ).toBe( 0 );
+	} );
+} );

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -10,13 +10,27 @@ import { CustomSelectControl } from '@wordpress/components';
 describe( 'CustomSelectControl', () => {
 	it( 'Captures the keypress event and does not let it propagate', () => {
 		const onKeyDown = jest.fn();
+		const options = [
+			{
+				key: 'one',
+				name: 'Option one',
+			},
+			{
+				key: 'two',
+				name: 'Option two',
+			},
+			{
+				key: 'three',
+				name: 'Option three',
+			},
+		];
 		const wrapper = (
 			<div
 				// This role="none" is required to prevent an eslint warning about accessibility.
 				role="none"
 				onKeyDown={ onKeyDown }
 			>
-				<CustomSelectControl options={ [ 'a', 'b', 'c' ] } />
+				<CustomSelectControl options={ options } />
 			</div>
 		);
 		const { container } = render( wrapper );

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+
 /**
  * WordPress dependencies
  */
@@ -24,7 +25,8 @@ describe( 'CustomSelectControl', () => {
 				name: 'Option three',
 			},
 		];
-		const wrapper = (
+
+		render(
 			<div
 				// This role="none" is required to prevent an eslint warning about accessibility.
 				role="none"
@@ -33,12 +35,12 @@ describe( 'CustomSelectControl', () => {
 				<CustomSelectControl options={ options } />
 			</div>
 		);
-		const { container } = render( wrapper );
-		fireEvent.keyDown(
-			container.getElementsByClassName(
-				'components-custom-select-control__menu'
-			)[ 0 ]
-		);
-		expect( onKeyDown.mock.calls.length ).toBe( 0 );
+		const toggleButton = screen.getByRole( 'button' );
+		fireEvent.click( toggleButton );
+
+		const customSelect = screen.getByRole( 'listbox' );
+		fireEvent.keyDown( customSelect );
+
+		expect( onKeyDown ).toHaveBeenCalledTimes( 0 );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
In the `<ul>` output by `CustomSelectControl` I have added a function to handle `onKeyDown` - this stops the event from propagating, but still calls the `onKeyDown` handler (which is derived ultimately from `downshift`). 

This PR fixes #30204.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
In the linked issue (#30204) the reproducible steps can also be used to test:

1. Open the storybook for this project: `npm run storybook:dev`
2. Go to the `CustomSelectControl > Default` component, click it and start typing `s` to get to the entry `Small`
3. Notice the storybook sidebar no longer closes due to the `s` keypress being cancelled.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ --> **Unsure, I had to add eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions but I don't see any other way of capturing this event**
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->