### PR TITLE
Site title block: Remove custom theme.json selector

### DIFF
--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -22,7 +22,6 @@
 		"fontSize": true,
 		"lineHeight": true,
 		"__experimentalFontFamily": true,
-		"__experimentalSelector": ".wp-block-site-title, .wp-block-site-title > a",
 		"__experimentalTextTransform": true
 	}
 }


### PR DESCRIPTION
closes #30485 
closes #30484

This selector was creating styles that are too specific and that can't be overriden by specific block options.
It was introduced here but I'm not sure I understand the reasoning for it https://github.com/WordPress/gutenberg/pull/29021/files#r608517316

**Testing instructions**

 - Add a site title block, tweak its font size and case, it should be reflected properly in both editor and frontend.