### PR TITLE
api-fetch: Align exported type names with DefinitelyTyped types

### DIFF
--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Align exported type names with the DefinitelyTyped type names and actually export those types.
+
 ## 3.23.0 (2021-04-06)
 
 ### New Feature

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -43,11 +43,11 @@ const DEFAULT_OPTIONS = {
 	credentials: 'include',
 };
 
-/** @typedef {import('./types').ApiFetchMiddleware} ApiFetchMiddleware */
-/** @typedef {import('./types').ApiFetchRequestProps} ApiFetchRequestProps */
+/** @typedef {import('./types').APIFetchMiddleware} APIFetchMiddleware */
+/** @typedef {import('./types').APIFetchOptions} APIFetchOptions */
 
 /**
- * @type {import('./types').ApiFetchMiddleware[]}
+ * @type {import('./types').APIFetchMiddleware[]}
  */
 const middlewares = [
 	userLocaleMiddleware,
@@ -59,7 +59,7 @@ const middlewares = [
 /**
  * Register a middleware
  *
- * @param {import('./types').ApiFetchMiddleware} middleware
+ * @param {import('./types').APIFetchMiddleware} middleware
  */
 function registerMiddleware( middleware ) {
 	middlewares.unshift( middleware );
@@ -80,7 +80,7 @@ const checkStatus = ( response ) => {
 	throw response;
 };
 
-/** @typedef {(options: import('./types').ApiFetchRequestProps) => Promise<any>} FetchHandler*/
+/** @typedef {(options: import('./types').APIFetchOptions) => Promise<any>} FetchHandler*/
 
 /**
  * @type {FetchHandler}
@@ -149,7 +149,7 @@ function setFetchHandler( newFetchHandler ) {
 
 /**
  * @template T
- * @param {import('./types').ApiFetchRequestProps} options
+ * @param {import('./types').APIFetchOptions} options
  * @return {Promise<T>} A promise representing the request processed via the registered middlewares.
  */
 function apiFetch( options ) {

--- a/packages/api-fetch/src/middlewares/fetch-all-middleware.js
+++ b/packages/api-fetch/src/middlewares/fetch-all-middleware.js
@@ -11,9 +11,9 @@ import apiFetch from '..';
 /**
  * Apply query arguments to both URL and Path, whichever is present.
  *
- * @param {import('../types').ApiFetchRequestProps} props
+ * @param {import('../types').APIFetchOptions} props
  * @param {Record<string, string | number>} queryArgs
- * @return {import('../types').ApiFetchRequestProps} The request with the modified query args
+ * @return {import('../types').APIFetchOptions} The request with the modified query args
  */
 const modifyQuery = ( { path, url, ...options }, queryArgs ) => ( {
 	...options,
@@ -56,7 +56,7 @@ const getNextPageUrl = ( response ) => {
 };
 
 /**
- * @param {import('../types').ApiFetchRequestProps} options
+ * @param {import('../types').APIFetchOptions} options
  * @return {boolean} True if the request contains an unbounded query.
  */
 const requestContainsUnboundedQuery = ( options ) => {
@@ -72,7 +72,7 @@ const requestContainsUnboundedQuery = ( options ) => {
  * collections, apiFetch consumers can pass `per_page=-1`; this middleware will
  * then recursively assemble a full response array from all available pages.
  *
- * @type {import('../types').ApiFetchMiddleware}
+ * @type {import('../types').APIFetchMiddleware}
  */
 const fetchAllMiddleware = async ( options, next ) => {
 	if ( options.parse === false ) {

--- a/packages/api-fetch/src/middlewares/http-v1.js
+++ b/packages/api-fetch/src/middlewares/http-v1.js
@@ -21,7 +21,7 @@ const DEFAULT_METHOD = 'GET';
  * API Fetch middleware which overrides the request method for HTTP v1
  * compatibility leveraging the REST API X-HTTP-Method-Override header.
  *
- * @type {import('../types').ApiFetchMiddleware}
+ * @type {import('../types').APIFetchMiddleware}
  */
 const httpV1Middleware = ( options, next ) => {
 	const { method = DEFAULT_METHOD } = options;

--- a/packages/api-fetch/src/middlewares/media-upload.js
+++ b/packages/api-fetch/src/middlewares/media-upload.js
@@ -14,7 +14,7 @@ import {
 /**
  * Middleware handling media upload failures and retries.
  *
- * @type {import('../types').ApiFetchMiddleware}
+ * @type {import('../types').APIFetchMiddleware}
  */
 const mediaUploadMiddleware = ( options, next ) => {
 	const isMediaUploadRequest =

--- a/packages/api-fetch/src/middlewares/namespace-endpoint.js
+++ b/packages/api-fetch/src/middlewares/namespace-endpoint.js
@@ -1,5 +1,5 @@
 /**
- * @type {import('../types').ApiFetchMiddleware}
+ * @type {import('../types').APIFetchMiddleware}
  */
 const namespaceAndEndpointMiddleware = ( options, next ) => {
 	let path = options.path;

--- a/packages/api-fetch/src/middlewares/nonce.js
+++ b/packages/api-fetch/src/middlewares/nonce.js
@@ -1,10 +1,10 @@
 /**
  * @param {string} nonce
- * @return {import('../types').ApiFetchMiddleware & { nonce: string }} A middleware to enhance a request with a nonce.
+ * @return {import('../types').APIFetchMiddleware & { nonce: string }} A middleware to enhance a request with a nonce.
  */
 function createNonceMiddleware( nonce ) {
 	/**
-	 * @type {import('../types').ApiFetchMiddleware & { nonce: string }}
+	 * @type {import('../types').APIFetchMiddleware & { nonce: string }}
 	 */
 	const middleware = ( options, next ) => {
 		const { headers = {} } = options;

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -35,7 +35,7 @@ export function getStablePath( path ) {
 
 /**
  * @param {Record<string, any>} preloadedData
- * @return {import('../types').ApiFetchMiddleware} Preloading middleware.
+ * @return {import('../types').APIFetchMiddleware} Preloading middleware.
  */
 function createPreloadingMiddleware( preloadedData ) {
 	const cache = Object.keys( preloadedData ).reduce( ( result, path ) => {

--- a/packages/api-fetch/src/middlewares/root-url.js
+++ b/packages/api-fetch/src/middlewares/root-url.js
@@ -5,7 +5,7 @@ import namespaceAndEndpointMiddleware from './namespace-endpoint';
 
 /**
  * @param {string} rootURL
- * @return {import('../types').ApiFetchMiddleware} Root URL middleware.
+ * @return {import('../types').APIFetchMiddleware} Root URL middleware.
  */
 const createRootURLMiddleware = ( rootURL ) => ( options, next ) => {
 	return namespaceAndEndpointMiddleware( options, ( optionsWithPath ) => {

--- a/packages/api-fetch/src/middlewares/user-locale.js
+++ b/packages/api-fetch/src/middlewares/user-locale.js
@@ -4,7 +4,7 @@
 import { addQueryArgs, hasQueryArg } from '@wordpress/url';
 
 /**
- * @type {import('../types').ApiFetchMiddleware}
+ * @type {import('../types').APIFetchMiddleware}
  */
 const userLocaleMiddleware = ( options, next ) => {
 	if (

--- a/packages/api-fetch/src/types.ts
+++ b/packages/api-fetch/src/types.ts
@@ -1,4 +1,4 @@
-export interface ApiFetchRequestProps extends RequestInit {
+export interface APIFetchOptions extends RequestInit {
 	// Override headers, we only accept it as an object due to the `nonce` middleware
 	headers?: Record< string, string >;
 	path?: string;
@@ -12,7 +12,7 @@ export interface ApiFetchRequestProps extends RequestInit {
 	endpoint?: string;
 }
 
-export type ApiFetchMiddleware = (
-	options: ApiFetchRequestProps,
-	next: ( nextOptions: ApiFetchRequestProps ) => Promise< any >
+export type APIFetchMiddleware = (
+	options: APIFetchOptions,
+	next: ( nextOptions: APIFetchOptions ) => Promise< any >
 ) => Promise< any >;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
It seems that by not aligning the type names exported by the api-fetch package with the types exported on DefinitelyTyped, I broke something in a bad way: https://github.com/Automattic/wp-calypso/pull/51723#issuecomment-814536987

This PR aligns the types with the names exported by the DefinitelyTyped package. This is an important thing to note for the future, that we need to make sure that these align or we'll cause regressions 😞 

## How has this been tested?
I'm not sure how to test that this fixes the problem. Any suggestions are welcome.

## Types of changes
Bug fix. We should publish this as soon as possible.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
