### PR TITLE
RichText: add onBlur prop to so onBlur callback from block-editor can be plumbed through

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -146,6 +146,7 @@ function RichText(
 		preserveWhiteSpace,
 		onPaste,
 		format = 'string',
+		onBlur,
 		onDelete,
 		onEnter,
 		onSelectionChange,
@@ -987,6 +988,10 @@ function RichText(
 			'selectionchange',
 			handleSelectionChange
 		);
+
+		if ( onBlur ) {
+			onBlur();
+		}
 	}
 
 	function applyFromProps() {


### PR DESCRIPTION
## Description
The block-editor RichText wrapper has an onBlur prop available, but this is ignored by the underlying RichText package, so there is no way to pass through an onBlur callback from blocks that make use of RichText.

This prevents easy handling of the isSelected state to do the likes of removing the formatting toolbar when the control is blurred, eg. https://github.com/WordPress/gutenberg/issues/30334 

## How has this been tested?
Has been tested manually against https://github.com/WordPress/gutenberg/pull/30407

## Types of changes
Plumbs through an optional onBlur prop which is called on component blur event

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->