### PR TITLE
Components: Ignore user completers when reaching >= 4 words after trigger char

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -444,32 +444,25 @@ function Autocomplete( {
 					return false;
 				}
 
-				if (
-					allowContext &&
-					! allowContext( text.slice( 0, index ), textAfterSelection )
-				) {
-					return false;
-				}
-
 				const textWithoutTrigger = text.slice(
 					index + triggerPrefix.length
 				);
 
 				if (
-					/^\s/.test( textWithoutTrigger ) ||
-					/\s\s+$/.test( textWithoutTrigger )
+					allowContext &&
+					! allowContext(
+						text.slice( 0, index ),
+						textAfterSelection,
+						textWithoutTrigger
+					)
 				) {
 					return false;
 				}
 
-				// Escape hatch for inline completer triggers. Allows up to 3 words to
-				// be matched and will bail out on the 4th word onwards. An example is
-				// the "user" completer. Its trigger char isn't removed when completing
-				// is done, so it's always present on the page. Without this hatch, the
-				// autocompleter will keep trying to match everything from the trigger
-				// onwards, up to infinity, slowing down the editor. This limit of words
-				// should work well with other completers.
-				if ( textWithoutTrigger.trim().split( /\s/ ).length >= 4 ) {
+				if (
+					/^\s/.test( textWithoutTrigger ) ||
+					/\s\s+$/.test( textWithoutTrigger )
+				) {
 					return false;
 				}
 

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -462,6 +462,17 @@ function Autocomplete( {
 					return false;
 				}
 
+				// Escape hatch for inline completer triggers. Allows up to 3 words to
+				// be matched and will bail out on the 4th word onwards. An example is
+				// the "user" completer. Its trigger char isn't removed when completing
+				// is done, so it's always present on the page. Without this hatch, the
+				// autocompleter will keep trying to match everything from the trigger
+				// onwards, up to infinity, slowing down the editor. This limit of words
+				// should work well with other completers.
+				if ( textWithoutTrigger.trim().split( /\s/ ).length >= 4 ) {
+					return false;
+				}
+
 				return /[\u0000-\uFFFF]*$/.test( textWithoutTrigger );
 			}
 		);

--- a/packages/editor/src/components/autocompleters/user.js
+++ b/packages/editor/src/components/autocompleters/user.js
@@ -48,6 +48,17 @@ export default {
 			</span>,
 		];
 	},
+	allowContext( before, after, textWithoutTrigger ) {
+		// Escape hatch for inline completer triggers. Allows up to 3 words to
+		// be matched and will bail out on the 4th word onwards. An example is
+		// this "user" completer. Its trigger char isn't removed when completing
+		// is done, so it's always present on the page. Without this hatch, the
+		// autocompleter will keep trying to match everything from the trigger
+		// onwards, up to infinity, slowing down the editor.
+		const reachedWordLimit =
+			textWithoutTrigger.trim().split( /\s/ ).length >= 4;
+		return ! reachedWordLimit;
+	},
 	getOptionCompletion( user ) {
 		return `@${ user.slug }`;
 	},


### PR DESCRIPTION
## Description 

Attempt at fixing https://github.com/WordPress/gutenberg/issues/30640.

Fixes an issue introduced in #29939, where the `user` autocompleter enters an infinite matching loop, causing the editor to eventually slow down and become close to unusable.

The changes in #29939 are somewhat incompatible with the UX for the `user` autocomplete as its triggers can happen anywhere and stay on the editor even after the completion is done. Once the autocomplete finds the trigger, it runs through its matching/querying algorithm, but then doesn't know when to stop. What happens in practice is that the text after the trigger starts being considered as part of the text to match and it goes up to infinity.

The fix limits the number of words that could be matched for the `user` completer to 3, and bails out by on the 4th onwards. This would allow a user name with 3 words to be matched and then wouldn't try to match anymore. This is not perfect as sometimes the match will still be triggered when it shouldn't _(i.e when the user already found the user and confirmed the choice)_, and the popup with the matched username might still be shown even after the name is found and output on the page if within the 3 words limit, but should be good enough to prevent the deadlock/slowdown.

## How has this been tested?

The autocomplete search results should appear every time the search trigger is typed, i.e. the user search via @. If you continue typing after the trigger, it should stop showing the popup (if any matches) after you type 3 words. If you continue typing, you should not notice any slowdowns and the editor should be snappy.

## Type of change

Bugfix.
