### PR TITLE
Gallery block: Caption toolbar is not dismissed onBlur

### DIFF
--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -10,6 +10,7 @@ import { RichText } from '@wordpress/block-editor';
 import { VisuallyHidden } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
+import { useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -42,6 +43,22 @@ export const Gallery = ( props ) => {
 		imageCrop,
 		images,
 	} = attributes;
+
+	const captionRef = useRef();
+	const [ captionFocused, setCaptionFocused ] = useState( false );
+	const onFocusCaption = () => {
+		if ( ! captionFocused ) {
+			setCaptionFocused( true );
+			onFocusGalleryCaption();
+		}
+	};
+
+	const onCaptionBlur = () => {
+		//captionRef.current.blur()
+		if ( captionFocused ) {
+			setCaptionFocused( false );
+		}
+	};
 
 	return (
 		<figure
@@ -93,13 +110,16 @@ export const Gallery = ( props ) => {
 			</ul>
 			{ mediaPlaceholder }
 			<RichTextVisibilityHelper
+				isSelected={ captionFocused }
+				ref={ captionRef }
+				onBlur={ onCaptionBlur }
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
 				tagName="figcaption"
 				className="blocks-gallery-caption"
 				aria-label={ __( 'Gallery caption text' ) }
 				placeholder={ __( 'Write gallery caption…' ) }
 				value={ caption }
-				unstableOnFocus={ onFocusGalleryCaption }
+				unstableOnFocus={ onFocusCaption }
 				onChange={ ( value ) => setAttributes( { caption: value } ) }
 				inlineToolbar
 				__unstableOnSplitAtEnd={ () =>

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -10,7 +10,7 @@ import { RichText } from '@wordpress/block-editor';
 import { VisuallyHidden } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
-import { useState, useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -44,7 +44,6 @@ export const Gallery = ( props ) => {
 		images,
 	} = attributes;
 
-	const captionRef = useRef();
 	const [ captionFocused, setCaptionFocused ] = useState( false );
 	const onFocusCaption = () => {
 		if ( ! captionFocused ) {
@@ -54,7 +53,6 @@ export const Gallery = ( props ) => {
 	};
 
 	const onCaptionBlur = () => {
-		//captionRef.current.blur()
 		if ( captionFocused ) {
 			setCaptionFocused( false );
 		}
@@ -111,7 +109,6 @@ export const Gallery = ( props ) => {
 			{ mediaPlaceholder }
 			<RichTextVisibilityHelper
 				isSelected={ captionFocused }
-				ref={ captionRef }
 				onBlur={ onCaptionBlur }
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
 				tagName="figcaption"


### PR DESCRIPTION
This PR is in anticipation of the work @glendaviesnz has done in https://github.com/WordPress/gutenberg/pull/30587, which passes through an optional `onBlur` prop to the RichText component.

It can therefore only be tested on top of https://github.com/WordPress/gutenberg/pull/30587.

## Description
This commit ensures that the RichText toolbar is dismissed when we blur from the caption field.

To do this we add an onBlur event to the RichText block based on the work so far in #30587, which fires an onBlur handler passed as a prop.

We've taken a similar approach used for the Image block captions blur handlers: https://github.com/WordPress/gutenberg/pull/30407

## How has this been tested?

1. Apply https://github.com/WordPress/gutenberg/pull/30587 as a [patch](https://patch-diff.githubusercontent.com/raw/WordPress/gutenberg/pull/30587.patch)
2. Add a Gallery block to a new post
3. Edit the Gallery caption
4. Remove focus by clicking on the gallery or elsewhere.
5. The RichText toolbar should be dismissed as the caption loses focus.
6. Rejoice.

## Screenshots 

**Before**
![before-wombats](https://user-images.githubusercontent.com/6458278/113960129-529ce700-9867-11eb-8033-c1cb35c1f02c.gif)


**After**
![wombats](https://user-images.githubusercontent.com/6458278/113960120-4f096000-9867-11eb-9729-5d8ece72c8c3.gif)

## Types of changes

Adding an `onBlur` handler to the RichText block props for the gallery caption.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: 
