### PR TITLE
Deprecate the heading prop for the CheckboxControl component

### DIFF
--- a/packages/components/src/checkbox-control/README.md
+++ b/packages/components/src/checkbox-control/README.md
@@ -63,7 +63,6 @@ const MyCheckboxControl = () => {
 	const [ isChecked, setChecked ] = useState( true );
 	return (
 		<CheckboxControl
-			heading="User"
 			label="Is author"
 			help="Is the user a author or not?"
 			checked={ isChecked }
@@ -77,13 +76,6 @@ const MyCheckboxControl = () => {
 
 The set of props accepted by the component will be specified below.
 Props not included in this set will be applied to the input element.
-
-#### heading
-
-A heading for the input field, that appears above the checkbox. If the prop is not passed no heading will be rendered.
-
--   Type: `String`
--   Required: No
 
 #### label
 

--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -26,8 +26,7 @@ export default function CheckboxControl( {
 } ) {
 	if ( heading ) {
 		deprecated( '`heading` prop in `CheckboxControl`', {
-			alternative:
-				'A separate element should be used to implement a heading',
+			alternative: 'a separate element to implement a heading',
 			plugin: 'Gutenberg',
 		} );
 	}

--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 import { Icon, check } from '@wordpress/icons';
 
 /**
@@ -18,6 +24,14 @@ export default function CheckboxControl( {
 	onChange,
 	...props
 } ) {
+	if ( heading ) {
+		deprecated( '`heading` prop in `CheckboxControl`', {
+			alternative:
+				'A separate element should be used to implement a heading',
+			plugin: 'Gutenberg',
+		} );
+	}
+
 	const instanceId = useInstanceId( CheckboxControl );
 	const id = `inspector-checkbox-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.checked );
@@ -27,7 +41,7 @@ export default function CheckboxControl( {
 			label={ heading }
 			id={ id }
 			help={ help }
-			className={ className }
+			className={ classnames( 'components-checkbox-control', className ) }
 		>
 			<span className="components-checkbox-control__input-container">
 				<input

--- a/packages/components/src/checkbox-control/stories/index.js
+++ b/packages/components/src/checkbox-control/stories/index.js
@@ -37,16 +37,8 @@ export const _default = () => {
 };
 
 export const all = () => {
-	const heading = text( 'Heading', 'User' );
 	const label = text( 'Label', 'Is author' );
 	const help = text( 'Help', 'Is the user an author or not?' );
 
-	return (
-		<CheckboxControlWithState
-			heading={ heading }
-			label={ label }
-			help={ help }
-			checked
-		/>
-	);
+	return <CheckboxControlWithState label={ label } help={ help } checked />;
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes #30036

As discussed in #30037, the `heading` prop is a bit of an irregularity on the CheckboxControl component. This PR deprecates it.

I've also added the `components-checkbox-control` classname, which this component was missing.

Why deprecate?
- It isn't used anywhere in this codebase
- The styles were broken as described by #30036.
- The README also described the heading as appearing above the checkbox. Which it doesn't.
- When used, it causes VoiceOver not to read the label (https://github.com/WordPress/gutenberg/pull/30037#issuecomment-815425615)
- The implementation is incorrect
- Other similar components don't have this prop (ToggleControl, RadioControl).
- It isn't implemented in the g2 version of the component.

## How has this been tested?
1. Fire up a dev environment
2. Add a heading prop to a CheckboxControl
3. View the CheckboxControl in a browser

Expected: The following should appear in the console (I fixed the text that shows in the screenshot, it now reads "Please use a separate element to implement a heading"):
<img width="624" alt="Screenshot 2021-04-08 at 12 08 33 pm" src="https://user-images.githubusercontent.com/677833/113967703-203dba80-9864-11eb-951d-fb2f86669d41.png">

## Types of changes
Deprecation
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
