### PR TITLE
Fix parameter name typo in useRefEffect

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -358,7 +358,7 @@ callback will be called multiple times for the same node.
 
 _Parameters_
 
--   _calllback_ `Function`: Callback with ref as argument.
+-   _callback_ `Function`: Callback with ref as argument.
 -   _dependencies_ `Array`: Dependencies of the callback.
 
 _Returns_

--- a/packages/compose/src/hooks/use-ref-effect/index.js
+++ b/packages/compose/src/hooks/use-ref-effect/index.js
@@ -17,16 +17,16 @@ import { useCallback, useRef } from '@wordpress/element';
  * to be removed. It *is* necessary if you add dependencies because the ref
  * callback will be called multiple times for the same node.
  *
- * @param {Function} calllback    Callback with ref as argument.
+ * @param {Function} callback    Callback with ref as argument.
  * @param {Array}    dependencies Dependencies of the callback.
  *
  * @return {Function} Ref callback.
  */
-export default function useRefEffect( calllback, dependencies ) {
+export default function useRefEffect( callback, dependencies ) {
 	const cleanup = useRef();
 	return useCallback( ( node ) => {
 		if ( node ) {
-			cleanup.current = calllback( node );
+			cleanup.current = callback( node );
 		} else if ( cleanup.current ) {
 			cleanup.current();
 		}

--- a/packages/compose/src/hooks/use-ref-effect/index.js
+++ b/packages/compose/src/hooks/use-ref-effect/index.js
@@ -17,7 +17,7 @@ import { useCallback, useRef } from '@wordpress/element';
  * to be removed. It *is* necessary if you add dependencies because the ref
  * callback will be called multiple times for the same node.
  *
- * @param {Function} callback    Callback with ref as argument.
+ * @param {Function} callback     Callback with ref as argument.
  * @param {Array}    dependencies Dependencies of the callback.
  *
  * @return {Function} Ref callback.


### PR DESCRIPTION
Renaming calllback to callback.

By the way, every time I change comments I have to manually align everything. Is there a way to automatically format comments?