### PR TITLE
Editor: Display ten most used terms

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -104,14 +104,17 @@ function FlatTermSelectorMostUsed( { onSelect, taxonomy } ) {
 	const _terms = unescapeTerms( terms );
 
 	return (
-		<div className="flat-term-selector-most-used-container">
+		<div className="editor-post-taxonomies__flat-term-most-used">
 			{ hasTerms && (
 				/*
 				 * Disable reason: The `list` ARIA role is redundant but
 				 * Safari+VoiceOver won't announce the list otherwise.
 				 */
 				/* eslint-disable jsx-a11y/no-redundant-roles */
-				<ul role="list" className="flat-term-selector-most-used">
+				<ul
+					role="list"
+					className="editor-post-taxonomies__flat-term-most-used-list"
+				>
 					{ _terms.map( ( term ) => (
 						<li key={ term.id }>
 							<Button isLink onClick={ () => onSelect( term ) }>

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -8,7 +8,6 @@ import {
 	invoke,
 	isEmpty,
 	map,
-	orderBy,
 	throttle,
 	unescape as lodashUnescapeString,
 	uniqBy,
@@ -17,8 +16,8 @@ import {
 /**
  * WordPress dependencies
  */
-import { __, _n, _x, sprintf } from '@wordpress/i18n';
-import { useMemo, Component } from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import {
 	Button,
 	FormTokenField,
@@ -39,9 +38,6 @@ import { store as editorStore } from '../../store';
 /**
  * Module constants
  */
-const MIN_FONT_SIZE = 10;
-const MAX_FONT_SIZE = 22;
-const FONT_SPREAD = MAX_FONT_SIZE - MIN_FONT_SIZE;
 const MAX_TERMS_SUGGESTIONS = 20;
 const DEFAULT_QUERY = {
 	per_page: MAX_TERMS_SUGGESTIONS,
@@ -99,77 +95,36 @@ function FlatTermSelectorMostUsed( { onSelect, taxonomy } ) {
 			taxonomy.slug,
 			DEFAULT_QUERY
 		);
-
 		return {
-			terms: mostUsedTerms ?? [],
+			terms: mostUsedTerms,
 			hasTerms: mostUsedTerms?.length > 0,
 		};
 	}, [] );
 
-	const { filteredTerms, fontStep, min } = useMemo( () => {
-		const termCounts = terms.map( ( term ) => term.count );
-		const minCount = Math.min( ...termCounts );
-		const maxCount = Math.max( ...termCounts );
-		const spread = maxCount !== minCount ? maxCount - minCount : 1;
-
-		return {
-			filteredTerms: orderBy(
-				unescapeTerms( terms ),
-				[ 'name' ],
-				[ 'asc' ]
-			),
-			fontStep: FONT_SPREAD / spread,
-			min: minCount,
-		};
-	}, [ terms ] );
-
-	// The logic is adapted from `wp_generate_tag_cloud` function.
-	const getFontSize = ( count ) => {
-		const size = MIN_FONT_SIZE + ( count - min ) * fontStep;
-
-		return `${ size }px`;
-	};
-
-	if ( ! hasTerms ) {
-		return null;
-	}
+	const _terms = unescapeTerms( terms );
 
 	return (
 		<div className="editor-post-taxonomies__flat-term-most-used">
-			{ /*
-			 * Disable reason: The `list` ARIA role is redundant but
-			 * Safari+VoiceOver won't announce the list otherwise.
-			 */
-			/* eslint-disable jsx-a11y/no-redundant-roles */ }
-			<ul
-				role="list"
-				className="editor-post-taxonomies__flat-term-most-used-list"
-			>
-				{ filteredTerms.map( ( term ) => (
-					<li key={ term.id }>
-						<Button
-							isLink
-							onClick={ () => onSelect( term ) }
-							style={ {
-								fontSize: getFontSize( term.count ),
-							} }
-							aria-label={ sprintf(
-								/* translators: %1$s: term name. %2$d: number items. */
-								_n(
-									'%1$s (%2$d item)',
-									'%1$s (%2$d items)',
-									term.count
-								),
-								term.name,
-								term.count
-							) }
-						>
-							{ term.name }
-						</Button>
-					</li>
-				) ) }
-			</ul>
-			{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+			{ hasTerms && (
+				/*
+				 * Disable reason: The `list` ARIA role is redundant but
+				 * Safari+VoiceOver won't announce the list otherwise.
+				 */
+				/* eslint-disable jsx-a11y/no-redundant-roles */
+				<ul
+					role="list"
+					className="editor-post-taxonomies__flat-term-most-used-list"
+				>
+					{ _terms.map( ( term ) => (
+						<li key={ term.id }>
+							<Button isLink onClick={ () => onSelect( term ) }>
+								{ term.name }
+							</Button>
+						</li>
+					) ) }
+				</ul>
+				/* eslint-enable jsx-a11y/no-redundant-roles */
+			) }
 		</div>
 	);
 }

--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { unescapeTerms } from '../../utils/terms';
+
+const MAX_MOST_USED_TERMS = 10;
+const DEFAULT_QUERY = {
+	per_page: MAX_MOST_USED_TERMS,
+	orderby: 'count',
+	order: 'desc',
+	_fields: 'id,name,count',
+};
+
+export default function MostUsedTerms( { onSelect, taxonomy } ) {
+	const { _terms, hasTerms } = useSelect( ( select ) => {
+		const mostUsedTerms = select( coreStore ).getEntityRecords(
+			'taxonomy',
+			taxonomy.slug,
+			DEFAULT_QUERY
+		);
+		return {
+			_terms: mostUsedTerms,
+			hasTerms: mostUsedTerms?.length > 0,
+		};
+	}, [] );
+
+	if ( ! hasTerms ) {
+		return null;
+	}
+
+	const terms = unescapeTerms( _terms );
+	const label = get( taxonomy, [ 'labels', 'most_used' ] );
+
+	return (
+		<div className="editor-post-taxonomies__flat-term-most-used">
+			<h3 className="editor-post-taxonomies__flat-term-most-used-label">
+				{ label }
+			</h3>
+			{ /*
+			 * Disable reason: The `list` ARIA role is redundant but
+			 * Safari+VoiceOver won't announce the list otherwise.
+			 */
+			/* eslint-disable jsx-a11y/no-redundant-roles */ }
+			<ul
+				role="list"
+				className="editor-post-taxonomies__flat-term-most-used-list"
+			>
+				{ terms.map( ( term ) => (
+					<li key={ term.id }>
+						<Button isLink onClick={ () => onSelect( term ) }>
+							{ term.name }
+						</Button>
+					</li>
+				) ) }
+			</ul>
+			{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+		</div>
+	);
+}

--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -24,7 +24,7 @@ const DEFAULT_QUERY = {
 };
 
 export default function MostUsedTerms( { onSelect, taxonomy } ) {
-	const { _terms, hasTerms } = useSelect( ( select ) => {
+	const { _terms, showTerms } = useSelect( ( select ) => {
 		const mostUsedTerms = select( coreStore ).getEntityRecords(
 			'taxonomy',
 			taxonomy.slug,
@@ -32,11 +32,11 @@ export default function MostUsedTerms( { onSelect, taxonomy } ) {
 		);
 		return {
 			_terms: mostUsedTerms,
-			hasTerms: mostUsedTerms?.length > 0,
+			showTerms: mostUsedTerms?.length >= MAX_MOST_USED_TERMS,
 		};
 	}, [] );
 
-	if ( ! hasTerms ) {
+	if ( ! showTerms ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -37,13 +37,18 @@
 	width: 100%;
 }
 
-.editor-post-taxonomies__flat-term-most-used-list {
-	li {
-		display: inline;
-		padding-right: 6px;
-	}
+.editor-post-taxonomies__flat-term-most-used {
+	margin: $grid-unit-05 0 $grid-unit-10;
+	padding: $grid-unit-10;
+	border: $border-width solid $gray-300;
+}
 
-	.components-button {
-		font-size: 12px;
+.editor-post-taxonomies__flat-term-most-used-list {
+	margin: 0;
+
+	li {
+		display: inline-block;
+		margin-right: 6px;
+		margin-bottom: 6px;
 	}
 }

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -36,3 +36,14 @@
 	margin-bottom: 8px;
 	width: 100%;
 }
+
+.editor-post-taxonomies__flat-term-most-used-list {
+	li {
+		display: inline;
+		padding-right: 6px;
+	}
+
+	.components-button {
+		font-size: 12px;
+	}
+}

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -37,18 +37,13 @@
 	width: 100%;
 }
 
-.editor-post-taxonomies__flat-term-most-used {
-	margin: $grid-unit-05 0 $grid-unit-10;
-	padding: $grid-unit-10;
-	border: $border-width solid $gray-300;
-}
-
 .editor-post-taxonomies__flat-term-most-used-list {
-	margin: 0;
-
 	li {
-		display: inline-block;
-		margin-right: 6px;
-		margin-bottom: 6px;
+		display: inline;
+		padding-right: 6px;
+	}
+
+	.components-button {
+		font-size: 12px;
 	}
 }

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -37,10 +37,19 @@
 	width: 100%;
 }
 
+.editor-post-taxonomies__flat-term-most-used {
+	.editor-post-taxonomies__flat-term-most-used-label {
+		font-weight: 400;
+		margin-bottom: $grid-unit-15;
+	}
+}
+
 .editor-post-taxonomies__flat-term-most-used-list {
+	margin: 0;
+
 	li {
-		display: inline;
-		padding-right: 6px;
+		display: inline-block;
+		margin-right: $grid-unit-10;
 	}
 
 	.components-button {

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy } from 'lodash';
+import { groupBy, map, unescape as lodashUnescapeString } from 'lodash';
 
 /**
  * Returns terms in a tree form.
@@ -38,3 +38,35 @@ export function buildTermsTree( flatTerms ) {
 
 	return fillWithChildren( termsByParent[ '0' ] || [] );
 }
+
+// Lodash unescape function handles &#39; but not &#039; which may be return in some API requests.
+export const unescapeString = ( arg ) => {
+	return lodashUnescapeString( arg.replace( '&#039;', "'" ) );
+};
+
+/**
+ * Returns a term object with name unescaped.
+ * The unescape of the name property is done using lodash unescape function.
+ *
+ * @param {Object} term The term object to unescape.
+ *
+ * @return {Object} Term object with name property unescaped.
+ */
+export const unescapeTerm = ( term ) => {
+	return {
+		...term,
+		name: unescapeString( term.name ),
+	};
+};
+
+/**
+ * Returns an array of term objects with names unescaped.
+ * The unescape of each term is performed using the unescapeTerm function.
+ *
+ * @param {Object[]} terms Array of term objects to unescape.
+ *
+ * @return {Object[]} Array of term objects unescaped.
+ */
+export const unescapeTerms = ( terms ) => {
+	return map( terms, unescapeTerm );
+};


### PR DESCRIPTION
## Description
The new component displays the 10 most used terms under the flat term selector token field. This component is only displayed when a site has ten or more terms with at least one item (post/page/CPT).

I've included accessibility fixes recommended by @afercia, except the usage count of each specific term. I omitted this `aria-label` since terms in the list don't have different sizes or display term count. Ref - https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/category-template.php#L941.

Fixes #8867.
Closes #21859.

Props to @olivervw and @grappler for the initial code.

## Screenshots <!-- if applicable -->
![CleanShot 2021-05-05 at 14 40 27](https://user-images.githubusercontent.com/240569/117129802-392c8380-adb0-11eb-92cc-f7179cf21628.png)


## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
