### PR TITLE
Themes: Fix template-hierarchy fallbacks

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -71,6 +71,11 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	foreach ( $templates as $template_item ) {
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
+		// Break the loop if we have a block-template that matches.
+		if ( $current_block_template_slug === $template_item_slug ) {
+			break;
+		}
+
 		// Is this a custom template?
 		// This check should be removed when merged in core.
 		// Instead, wp_templates should be considered valid in locate_template.

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -71,7 +71,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	foreach ( $templates as $template_item ) {
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
-		// Break the loop if we have a block-template that matches.
+		// Break the loop if the block-template matches the template slug.
 		if ( $current_block_template_slug === $template_item_slug ) {
 			break;
 		}


### PR DESCRIPTION
## Description

Fixes #30565 and https://github.com/bobbingwide/fizzie/issues/58

The problem was that there was no `break` in the loop, so `.html` templates with a higher specificity than `.php` templates were not properly detected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
