### PR TITLE
BoxControl: Allow configurable sides

### DIFF
--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -14,6 +14,7 @@ export default function AllInputControl( {
 	onHoverOn = noop,
 	onHoverOff = noop,
 	values,
+	sides,
 	...props
 } ) {
 	const allValue = getAllValue( values );
@@ -26,13 +27,15 @@ export default function AllInputControl( {
 		onFocus( event, { side: 'all' } );
 	};
 
+	const isSideDisabled = ( side ) => sides && sides[ side ] === false;
+
 	const handleOnChange = ( next ) => {
 		const nextValues = { ...values };
 
-		nextValues.top = next;
-		nextValues.bottom = next;
-		nextValues.left = next;
-		nextValues.right = next;
+		nextValues.top = isSideDisabled( 'top' ) ? values.top : next;
+		nextValues.right = isSideDisabled( 'right' ) ? values.right : next;
+		nextValues.bottom = isSideDisabled( 'bottom' ) ? values.bottom : next;
+		nextValues.left = isSideDisabled( 'left' ) ? values.left : next;
 
 		onChange( nextValues );
 	};

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -27,15 +27,11 @@ export default function AllInputControl( {
 		onFocus( event, { side: 'all' } );
 	};
 
-	const isSideDisabled = ( side ) => sides && sides[ side ] === false;
-
 	const handleOnChange = ( next ) => {
 		const nextValues = { ...values };
+		const selectedSides = sides || [ 'top', 'right', 'bottom', 'left' ];
 
-		nextValues.top = isSideDisabled( 'top' ) ? values.top : next;
-		nextValues.right = isSideDisabled( 'right' ) ? values.right : next;
-		nextValues.bottom = isSideDisabled( 'bottom' ) ? values.bottom : next;
-		nextValues.left = isSideDisabled( 'left' ) ? values.left : next;
+		selectedSides.forEach( ( side ) => ( nextValues[ side ] = next ) );
 
 		onChange( nextValues );
 	};

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -29,7 +29,9 @@ export default function AllInputControl( {
 
 	const handleOnChange = ( next ) => {
 		const nextValues = { ...values };
-		const selectedSides = sides || [ 'top', 'right', 'bottom', 'left' ];
+		const selectedSides = sides?.length
+			? sides
+			: [ 'top', 'right', 'bottom', 'left' ];
 
 		selectedSides.forEach( ( side ) => ( nextValues[ side ] = next ) );
 

--- a/packages/components/src/box-control/icon.js
+++ b/packages/components/src/box-control/icon.js
@@ -18,7 +18,8 @@ export default function BoxControlIcon( {
 	sides,
 	...props
 } ) {
-	const isSideDisabled = ( value ) => sides && sides[ value ] === false;
+	const isSideDisabled = ( value ) => sides && ! sides.includes( value );
+
 	const getSide = ( value ) => {
 		if ( isSideDisabled( value ) ) {
 			return false;

--- a/packages/components/src/box-control/icon.js
+++ b/packages/components/src/box-control/icon.js
@@ -15,12 +15,22 @@ const BASE_ICON_SIZE = 24;
 export default function BoxControlIcon( {
 	size = 24,
 	side = 'all',
+	sides,
 	...props
 } ) {
-	const top = getSide( side, 'top' );
-	const right = getSide( side, 'right' );
-	const bottom = getSide( side, 'bottom' );
-	const left = getSide( side, 'left' );
+	const isSideDisabled = ( value ) => sides && sides[ value ] === false;
+	const getSide = ( value ) => {
+		if ( isSideDisabled( value ) ) {
+			return false;
+		}
+
+		return side === 'all' || side === value;
+	};
+
+	const top = getSide( 'top' );
+	const right = getSide( 'right' );
+	const bottom = getSide( 'bottom' );
+	const left = getSide( 'left' );
 
 	// Simulates SVG Icon scaling
 	const scale = size / BASE_ICON_SIZE;
@@ -35,8 +45,4 @@ export default function BoxControlIcon( {
 			</Viewbox>
 		</Root>
 	);
-}
-
-function getSide( side, value ) {
-	return side === 'all' || side === value;
 }

--- a/packages/components/src/box-control/icon.js
+++ b/packages/components/src/box-control/icon.js
@@ -18,7 +18,8 @@ export default function BoxControlIcon( {
 	sides,
 	...props
 } ) {
-	const isSideDisabled = ( value ) => sides && ! sides.includes( value );
+	const isSideDisabled = ( value ) =>
+		sides?.length && ! sides.includes( value );
 
 	const getSide = ( value ) => {
 		if ( isSideDisabled( value ) ) {

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -51,6 +51,7 @@ export default function BoxControl( {
 	label = __( 'Box Control' ),
 	values: valuesProp,
 	units,
+	sides,
 } ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
@@ -107,6 +108,7 @@ export default function BoxControl( {
 		onHoverOff: handleOnHoverOff,
 		isLinked,
 		units,
+		sides,
 		values: inputValues,
 	};
 
@@ -135,7 +137,7 @@ export default function BoxControl( {
 			</Header>
 			<HeaderControlWrapper className="component-box-control__header-control-wrapper">
 				<FlexItem>
-					<BoxControlIcon side={ side } />
+					<BoxControlIcon side={ side } sides={ sides } />
 				</FlexItem>
 				{ isLinked && (
 					<FlexBlock>

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useRef, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -52,20 +52,13 @@ export default function BoxControl( {
 	values: valuesProp,
 	units,
 	sides,
-	resetToInitialValues = false,
+	resetValues = DEFAULT_VALUES,
 } ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
 	} );
 	const inputValues = values || DEFAULT_VALUES;
 	const hasInitialValue = isValuesDefined( valuesProp );
-
-	// Determine which values the reset button should apply.
-	// Global styles generally prefer to reset to the initial value likely
-	// coming from a theme.
-	const resetValues = useRef(
-		resetToInitialValues && valuesProp ? valuesProp : DEFAULT_VALUES
-	);
 
 	const [ isDirty, setIsDirty ] = useState( hasInitialValue );
 	const [ isLinked, setIsLinked ] = useState(
@@ -101,8 +94,8 @@ export default function BoxControl( {
 	};
 
 	const handleOnReset = () => {
-		onChange( resetValues.current );
-		setValues( resetValues.current );
+		onChange( resetValues );
+		setValues( resetValues );
 		setIsDirty( false );
 	};
 

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -52,12 +52,20 @@ export default function BoxControl( {
 	values: valuesProp,
 	units,
 	sides,
+	resetToInitialValues = false,
 } ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
 	} );
 	const inputValues = values || DEFAULT_VALUES;
 	const hasInitialValue = isValuesDefined( valuesProp );
+
+	// Determine which values the reset button should apply.
+	// Global styles generally prefer to reset to the initial value likely
+	// coming from a theme.
+	const resetValues = useRef(
+		resetToInitialValues && valuesProp ? valuesProp : DEFAULT_VALUES
+	);
 
 	const [ isDirty, setIsDirty ] = useState( hasInitialValue );
 	const [ isLinked, setIsLinked ] = useState(
@@ -93,10 +101,8 @@ export default function BoxControl( {
 	};
 
 	const handleOnReset = () => {
-		const initialValues = DEFAULT_VALUES;
-
-		onChange( initialValues );
-		setValues( initialValues );
+		onChange( resetValues.current );
+		setValues( resetValues.current );
 		setIsDirty( false );
 	};
 

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -59,10 +59,11 @@ export default function BoxControl( {
 	} );
 	const inputValues = values || DEFAULT_VALUES;
 	const hasInitialValue = isValuesDefined( valuesProp );
+	const hasOneSide = sides?.length === 1;
 
 	const [ isDirty, setIsDirty ] = useState( hasInitialValue );
 	const [ isLinked, setIsLinked ] = useState(
-		! hasInitialValue || ! isValuesMixed( inputValues )
+		! hasInitialValue || ! isValuesMixed( inputValues ) || hasOneSide
 	);
 
 	const [ side, setSide ] = useState( isLinked ? 'all' : 'top' );
@@ -146,12 +147,14 @@ export default function BoxControl( {
 						/>
 					</FlexBlock>
 				) }
-				<FlexItem>
-					<LinkedButton
-						onClick={ toggleLinked }
-						isLinked={ isLinked }
-					/>
-				</FlexItem>
+				{ ! hasOneSide && (
+					<FlexItem>
+						<LinkedButton
+							onClick={ toggleLinked }
+							isLinked={ isLinked }
+						/>
+					</FlexItem>
+				) }
 			</HeaderControlWrapper>
 			{ ! isLinked && <InputControls { ...inputControlProps } /> }
 		</Root>

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -10,30 +10,7 @@ import UnitControl from './unit-control';
 import { LABELS } from './utils';
 import { LayoutContainer, Layout } from './styles/box-control-styles';
 
-const getFirstLastAndOnlySides = ( sides ) => {
-	// Handle default config allowing all sides to be configured.
-	if ( ! sides ) {
-		return { first: 'top', last: 'left', only: undefined };
-	}
-
-	let first, last;
-
-	// Check which sides have been opted-into to determine which are first,
-	// last & only.
-	[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {
-		if ( sides && sides[ side ] ) {
-			if ( ! first ) {
-				first = side;
-			}
-
-			last = side;
-		}
-	} );
-
-	const only = first === last && first;
-
-	return { first, last, only };
-};
+const allSides = [ 'top', 'right', 'bottom', 'left' ];
 
 export default function BoxInputControls( {
 	onChange = noop,
@@ -59,8 +36,6 @@ export default function BoxInputControls( {
 	const handleOnChange = ( nextValues ) => {
 		onChange( nextValues );
 	};
-
-	const { top, right, bottom, left } = values;
 
 	const createHandleOnChange = ( side ) => ( next, { event } ) => {
 		const { altKey } = event;
@@ -92,8 +67,14 @@ export default function BoxInputControls( {
 		handleOnChange( nextValues );
 	};
 
-	const isSideDisabled = ( side ) => sides && sides[ side ] === false;
-	const { first, last, only } = getFirstLastAndOnlySides( sides );
+	// Filter sides if custom configuration provided, maintaining default order.
+	const filteredSides = ! sides
+		? allSides
+		: allSides.filter( ( side ) => sides && sides.includes( side ) );
+
+	const first = filteredSides[ 0 ];
+	const last = filteredSides[ filteredSides.length - 1 ];
+	const only = first === last && first;
 
 	return (
 		<LayoutContainer className="component-box-control__input-controls-wrapper">
@@ -102,62 +83,21 @@ export default function BoxInputControls( {
 				align="top"
 				className="component-box-control__input-controls"
 			>
-				{ ! isSideDisabled( 'top' ) && (
+				{ filteredSides.map( ( side ) => (
 					<UnitControl
 						{ ...props }
-						isFirst={ first === 'top' }
-						isLast={ last === 'top' }
-						isOnly={ only === 'top' }
-						value={ top }
-						onChange={ createHandleOnChange( 'top' ) }
-						onFocus={ createHandleOnFocus( 'top' ) }
-						onHoverOn={ createHandleOnHoverOn( 'top' ) }
-						onHoverOff={ createHandleOnHoverOff( 'top' ) }
+						isFirst={ first === side }
+						isLast={ last === side }
+						isOnly={ only === side }
+						value={ values[ side ] }
+						onChange={ createHandleOnChange( side ) }
+						onFocus={ createHandleOnFocus( side ) }
+						onHoverOn={ createHandleOnHoverOn( side ) }
+						onHoverOff={ createHandleOnHoverOff( side ) }
 						label={ LABELS.top }
+						key={ `box-control-${ side }` }
 					/>
-				) }
-				{ ! isSideDisabled( 'right' ) && (
-					<UnitControl
-						{ ...props }
-						isFirst={ first === 'right' }
-						isLast={ last === 'right' }
-						isOnly={ only === 'right' }
-						value={ right }
-						onChange={ createHandleOnChange( 'right' ) }
-						onFocus={ createHandleOnFocus( 'right' ) }
-						onHoverOn={ createHandleOnHoverOn( 'right' ) }
-						onHoverOff={ createHandleOnHoverOff( 'right' ) }
-						label={ LABELS.right }
-					/>
-				) }
-				{ ! isSideDisabled( 'bottom' ) && (
-					<UnitControl
-						{ ...props }
-						isFirst={ first === 'bottom' }
-						isLast={ last === 'bottom' }
-						isOnly={ only === 'bottom' }
-						value={ bottom }
-						onChange={ createHandleOnChange( 'bottom' ) }
-						onFocus={ createHandleOnFocus( 'bottom' ) }
-						onHoverOn={ createHandleOnHoverOn( 'bottom' ) }
-						onHoverOff={ createHandleOnHoverOff( 'bottom' ) }
-						label={ LABELS.bottom }
-					/>
-				) }
-				{ ! isSideDisabled( 'left' ) && (
-					<UnitControl
-						{ ...props }
-						isFirst={ first === 'left' }
-						isLast={ last === 'left' }
-						isOnly={ only === 'left' }
-						value={ left }
-						onChange={ createHandleOnChange( 'left' ) }
-						onFocus={ createHandleOnFocus( 'left' ) }
-						onHoverOn={ createHandleOnHoverOn( 'left' ) }
-						onHoverOff={ createHandleOnHoverOff( 'left' ) }
-						label={ LABELS.left }
-					/>
-				) }
+				) ) }
 			</Layout>
 		</LayoutContainer>
 	);

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -10,12 +10,38 @@ import UnitControl from './unit-control';
 import { LABELS } from './utils';
 import { LayoutContainer, Layout } from './styles/box-control-styles';
 
+const getFirstLastAndOnlySides = ( sides ) => {
+	// Handle default config allowing all sides to be configured.
+	if ( ! sides ) {
+		return { first: 'top', last: 'left', only: undefined };
+	}
+
+	let first, last;
+
+	// Check which sides have been opted-into to determine which are first,
+	// last & only.
+	[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {
+		if ( sides && sides[ side ] ) {
+			if ( ! first ) {
+				first = side;
+			}
+
+			last = side;
+		}
+	} );
+
+	const only = first === last && first;
+
+	return { first, last, only };
+};
+
 export default function BoxInputControls( {
 	onChange = noop,
 	onFocus = noop,
 	onHoverOn = noop,
 	onHoverOff = noop,
 	values,
+	sides,
 	...props
 } ) {
 	const createHandleOnFocus = ( side ) => ( event ) => {
@@ -66,6 +92,9 @@ export default function BoxInputControls( {
 		handleOnChange( nextValues );
 	};
 
+	const isSideDisabled = ( side ) => sides && sides[ side ] === false;
+	const { first, last, only } = getFirstLastAndOnlySides( sides );
+
 	return (
 		<LayoutContainer className="component-box-control__input-controls-wrapper">
 			<Layout
@@ -73,44 +102,62 @@ export default function BoxInputControls( {
 				align="top"
 				className="component-box-control__input-controls"
 			>
-				<UnitControl
-					{ ...props }
-					isFirst
-					value={ top }
-					onChange={ createHandleOnChange( 'top' ) }
-					onFocus={ createHandleOnFocus( 'top' ) }
-					onHoverOn={ createHandleOnHoverOn( 'top' ) }
-					onHoverOff={ createHandleOnHoverOff( 'top' ) }
-					label={ LABELS.top }
-				/>
-				<UnitControl
-					{ ...props }
-					value={ right }
-					onChange={ createHandleOnChange( 'right' ) }
-					onFocus={ createHandleOnFocus( 'right' ) }
-					onHoverOn={ createHandleOnHoverOn( 'right' ) }
-					onHoverOff={ createHandleOnHoverOff( 'right' ) }
-					label={ LABELS.right }
-				/>
-				<UnitControl
-					{ ...props }
-					value={ bottom }
-					onChange={ createHandleOnChange( 'bottom' ) }
-					onFocus={ createHandleOnFocus( 'bottom' ) }
-					onHoverOn={ createHandleOnHoverOn( 'bottom' ) }
-					onHoverOff={ createHandleOnHoverOff( 'bottom' ) }
-					label={ LABELS.bottom }
-				/>
-				<UnitControl
-					{ ...props }
-					isLast
-					value={ left }
-					onChange={ createHandleOnChange( 'left' ) }
-					onFocus={ createHandleOnFocus( 'left' ) }
-					onHoverOn={ createHandleOnHoverOn( 'left' ) }
-					onHoverOff={ createHandleOnHoverOff( 'left' ) }
-					label={ LABELS.left }
-				/>
+				{ ! isSideDisabled( 'top' ) && (
+					<UnitControl
+						{ ...props }
+						isFirst={ first === 'top' }
+						isLast={ last === 'top' }
+						isOnly={ only === 'top' }
+						value={ top }
+						onChange={ createHandleOnChange( 'top' ) }
+						onFocus={ createHandleOnFocus( 'top' ) }
+						onHoverOn={ createHandleOnHoverOn( 'top' ) }
+						onHoverOff={ createHandleOnHoverOff( 'top' ) }
+						label={ LABELS.top }
+					/>
+				) }
+				{ ! isSideDisabled( 'right' ) && (
+					<UnitControl
+						{ ...props }
+						isFirst={ first === 'right' }
+						isLast={ last === 'right' }
+						isOnly={ only === 'right' }
+						value={ right }
+						onChange={ createHandleOnChange( 'right' ) }
+						onFocus={ createHandleOnFocus( 'right' ) }
+						onHoverOn={ createHandleOnHoverOn( 'right' ) }
+						onHoverOff={ createHandleOnHoverOff( 'right' ) }
+						label={ LABELS.right }
+					/>
+				) }
+				{ ! isSideDisabled( 'bottom' ) && (
+					<UnitControl
+						{ ...props }
+						isFirst={ first === 'bottom' }
+						isLast={ last === 'bottom' }
+						isOnly={ only === 'bottom' }
+						value={ bottom }
+						onChange={ createHandleOnChange( 'bottom' ) }
+						onFocus={ createHandleOnFocus( 'bottom' ) }
+						onHoverOn={ createHandleOnHoverOn( 'bottom' ) }
+						onHoverOff={ createHandleOnHoverOff( 'bottom' ) }
+						label={ LABELS.bottom }
+					/>
+				) }
+				{ ! isSideDisabled( 'left' ) && (
+					<UnitControl
+						{ ...props }
+						isFirst={ first === 'left' }
+						isLast={ last === 'left' }
+						isOnly={ only === 'left' }
+						value={ left }
+						onChange={ createHandleOnChange( 'left' ) }
+						onFocus={ createHandleOnFocus( 'left' ) }
+						onHoverOn={ createHandleOnHoverOn( 'left' ) }
+						onHoverOff={ createHandleOnHoverOff( 'left' ) }
+						label={ LABELS.left }
+					/>
+				) }
 			</Layout>
 		</LayoutContainer>
 	);

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -68,9 +68,9 @@ export default function BoxInputControls( {
 	};
 
 	// Filter sides if custom configuration provided, maintaining default order.
-	const filteredSides = ! sides
-		? allSides
-		: allSides.filter( ( side ) => sides && sides.includes( side ) );
+	const filteredSides = sides?.length
+		? allSides.filter( ( side ) => sides.includes( side ) )
+		: allSides;
 
 	const first = filteredSides[ 0 ];
 	const last = filteredSides[ filteredSides.length - 1 ];

--- a/packages/components/src/box-control/styles/box-control-styles.js
+++ b/packages/components/src/box-control/styles/box-control-styles.js
@@ -40,6 +40,7 @@ export const Layout = styled( Flex )`
 	position: relative;
 	height: 100%;
 	width: 100%;
+	justify-content: flex-start;
 `;
 
 const unitControlBorderRadiusStyles = ( { isFirst, isLast, isOnly } ) => {

--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -71,7 +71,7 @@ function InputField(
 	const dragCursor = useDragCursor( isDragging, dragDirection );
 
 	/*
-	 * Handles syncronization of external and internal value state.
+	 * Handles synchronization of external and internal value state.
 	 * If not focused and did not hold a dirty value[1] on blur
 	 * updates the value from the props. Otherwise if not holding
 	 * a dirty value[1] propagates the value and event through onChange.
@@ -155,6 +155,9 @@ function InputField(
 	const dragGestureProps = useDrag(
 		( dragProps ) => {
 			const { distance, dragging, event } = dragProps;
+			// The event is persisted to prevent errors in components using this
+			// to check if a modifier key was held while dragging.
+			event.persist();
 
 			if ( ! distance ) return;
 			event.stopPropagation();


### PR DESCRIPTION
## Description

- Update BoxControl to allow configurable sides
- Fix error thrown when BoxControl attempts to check modifier key on drag gestures
- Fix BoxControl reset button when used from Global Styles sidebar

This allows for the `BoxControl` component to accept a new `sides` prop allowing omission of specific sides. For example, with this you could now choose to only allow editing of top and bottom values.

This was originally part of https://github.com/WordPress/gutenberg/pull/29363 where it was used to manage top/bottom margins on the separator block. It has been extracted into this PR for finer granularity.

## How has this been tested?
Manually.

#### Test Instructions

The easiest method to test this updated `BoxControl` will be to test https://github.com/WordPress/gutenberg/pull/30607. 

That PR is based upon this one and through checking it out and testing it, this updated `BoxControl` will also be tested.

## Screenshots

| Linked | Unlinked |
|---|---|
| <img width="279" alt="Screen Shot 2021-04-08 at 6 54 50 pm" src="https://user-images.githubusercontent.com/60436221/113998014-0029ed80-989c-11eb-8477-f2972a7ebc61.png"> | <img width="279" alt="Screen Shot 2021-04-08 at 6 54 38 pm" src="https://user-images.githubusercontent.com/60436221/113998037-05873800-989c-11eb-9259-ad0300961607.png"> |

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
