### PR TITLE
Docs: Fix return type of `construct_wp_query_args()`

### DIFF
--- a/lib/query-utils.php
+++ b/lib/query-utils.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Helper function that constructs a WP_Query args object from
+ * Helper function that constructs a WP_Query args array from
  * a `Query` block properties.
  *
  * It's used in QueryLoop, QueryPaginationNumbers and QueryPaginationNext blocks.

--- a/lib/query-utils.php
+++ b/lib/query-utils.php
@@ -13,9 +13,9 @@
  * It's used in QueryLoop, QueryPaginationNumbers and QueryPaginationNext blocks.
  *
  * @param WP_Block $block Block instance.
- * @param int      $page  Curren query's page.
+ * @param int      $page  Current query's page.
  *
- * @return object Returns the constructed WP_Query object.
+ * @return array Returns the constructed WP_Query arguments.
  */
 function construct_wp_query_args( $block, $page ) {
 	$query = array(


### PR DESCRIPTION
## Description
The function `construct_wp_query_args` returns the arguments for a WP_Query as an array not an object.