### PR TITLE
Remove check for `wp_filter_content_tags()` and fallback

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -206,11 +206,7 @@ function gutenberg_get_the_template_html() {
 	$content = $wp_embed->autoembed( $content );
 	$content = do_blocks( $content );
 	$content = wptexturize( $content );
-	if ( function_exists( 'wp_filter_content_tags' ) ) {
-		$content = wp_filter_content_tags( $content );
-	} else {
-		$content = wp_make_content_images_responsive( $content );
-	}
+	$content = wp_filter_content_tags( $content );
 	$content = str_replace( ']]>', ']]&gt;', $content );
 
 	// Wrap block template in .wp-site-blocks to allow for specific descendant styles

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -103,11 +103,7 @@ function render_block_core_template_part( $attributes ) {
 	$content = convert_smilies( $content );
 	$content = wpautop( $content );
 	$content = shortcode_unautop( $content );
-	if ( function_exists( 'wp_filter_content_tags' ) ) {
-		$content = wp_filter_content_tags( $content );
-	} else {
-		$content = wp_make_content_images_responsive( $content );
-	}
+	$content = wp_filter_content_tags( $content );
 	$content = do_shortcode( $content );
 
 	if ( empty( $attributes['tagName'] ) ) {


### PR DESCRIPTION
## Description
The function [wp_filter_content_tags](https://developer.wordpress.org/reference/functions/wp_filter_content_tags/) was introduced in WP 5.5. The minimum is now WP 5.6, so we can remove this check and the fallback.

It was added in #21514.