### PR TITLE
Plugin Build Workflow: Pull trunk before pushing

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -92,6 +92,7 @@ jobs:
             - name: Cherry-pick to trunk
               run: |
                   git checkout trunk
+                  git pull
                   TRUNK_VERSION=$(jq --raw-output '.version' package.json)
                   if [[ ${{ steps.get_version.outputs.old_version }} == "$TRUNK_VERSION" ]]; then
                     git cherry-pick "${{ steps.get_version.outputs.release_branch }}"
@@ -112,7 +113,7 @@ jobs:
             - name: Use Node.js 14.x
               uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                node-version: 14.x
+                  node-version: 14.x
 
             - name: Cache node modules
               uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4


### PR DESCRIPTION
## Description
The build workflow recently [failed to push the cherry-picked version bump commit to `trunk`](https://github.com/WordPress/gutenberg/runs/2288075442?check_suite_focus=true). Our best guess is that this happened because a [PR was merged](https://github.com/WordPress/gutenberg/pull/30539#event-4562689224) (on Apr 7 at 13:58 UTC) after the workflow [was started](https://github.com/WordPress/gutenberg/actions/runs/726230952) (on Apr 7, also at 13:58 UTC), so the workflow's checked out copy of `trunk` didn't match the remote.

The remedy should be to pull `trunk` right before cherry-picking and pushing.