### PR TITLE
Perf Workflow: Trigger upon release publishing

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -3,7 +3,7 @@ name: Performances Tests
 on:
     pull_request:
     release:
-        types: [created]
+        types: [published]
 
 jobs:
     performance:
@@ -17,7 +17,7 @@ jobs:
             - name: Use Node.js 14.x
               uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                node-version: 14.x
+                  node-version: 14.x
 
             - name: Cache node modules
               uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4


### PR DESCRIPTION
## Description

The performance tests workflow is supposed to be run
- on every PR, to compare the performance of the PR's branch to `trunk`'s, and
- on release events, to compare the performance of the current release's branch (`release/x.y`) with the previous release's (`release/x.(y-1)`), and to the branch of the current WordPress Core version (`wp/u.v`).

The latter functionality was introduced by https://github.com/WordPress/gutenberg/pull/28046; that perf comparison is mainly required for the perf data table that we attach to [each Gutenberg release post on make.wordpress.org/core](https://make.wordpress.org/core/tag/gutenberg-new/). Alas, to this day, it has [never worked](https://github.com/WordPress/gutenberg/actions/workflows/performance.yml?query=event%3Arelease) 😅  -- we always had to run it manually instead.

The reason for this is probably that I chose the `created` type of the `release` event type: https://github.com/WordPress/gutenberg/blob/8aa446b4e6845c91c10e1fb35a23ee44c257200b/.github/workflows/performance.yml#L3-L6

The `release` event supports a number of subtypes, as listed [here](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release); also documented [here](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#release) (with a bit more detail) for GH's webhooks. I chose `created` since it said:

> a draft is saved, or a release or pre-release is published without previously being saved as a draft

Draft creation seemed like a good trigger for this. However, since that is not working, I'm changing the even type to `published`, which is the same as the trigger for the "Update Changelog and upload Gutenberg plugin to WordPress.org plugin repo" workflow (which is known to work): https://github.com/WordPress/gutenberg/blob/8aa446b4e6845c91c10e1fb35a23ee44c257200b/.github/workflows/upload-release-to-plugin-repo.yml#L3-L5

This should trigger the perf tests workflow for both stable and RC versions.