### PR TITLE
Fix crash from non-adjustable unit RangeCell a11y activation

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -188,7 +188,9 @@ class BottomSheetRangeCell extends Component {
 							this.a11yDecrementValue();
 							break;
 						case 'activate':
-							openUnitPicker();
+							if ( openUnitPicker ) {
+								openUnitPicker();
+							}
 							break;
 					}
 				} }

--- a/packages/components/src/mobile/bottom-sheet/test/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/test/range-cell.native.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { AccessibilityInfo } from 'react-native';
+import { create, act } from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import RangeCell from '../range-cell';
+
+// Avoid errors due to mocked stylesheet files missing required selectors
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	withPreferredColorScheme: jest.fn( ( Component ) => ( props ) => (
+		<Component
+			{ ...props }
+			preferredColorScheme={ {} }
+			getStylesFromColorScheme={ jest.fn( () => ( {} ) ) }
+		/>
+	) ),
+} ) );
+
+const isScreenReaderEnabled = Promise.resolve( true );
+beforeAll( () => {
+	// Mock async native module to avoid act warning
+	AccessibilityInfo.isScreenReaderEnabled = jest.fn(
+		() => isScreenReaderEnabled
+	);
+} );
+
+it( 'allows modifying units via a11y actions', async () => {
+	const mockOpenUnitPicker = jest.fn();
+	const renderer = create(
+		<RangeCell
+			label="Opacity"
+			minimumValue={ 0 }
+			maximumValue={ 100 }
+			value={ 50 }
+			onChange={ jest.fn() }
+			openUnitPicker={ mockOpenUnitPicker }
+		/>
+	);
+	// Await async update to component state to avoid act warning
+	await act( () => isScreenReaderEnabled );
+	const { onAccessibilityAction } = renderer.toJSON().props;
+
+	onAccessibilityAction( { nativeEvent: { actionName: 'activate' } } );
+	expect( mockOpenUnitPicker ).toHaveBeenCalled();
+} );
+
+describe( 'when range lacks an adjustable unit', () => {
+	it( 'disallows modifying units via a11y actions', async () => {
+		const renderer = create(
+			<RangeCell
+				label="Opacity"
+				minimumValue={ 0 }
+				maximumValue={ 100 }
+				value={ 50 }
+				onChange={ jest.fn() }
+			/>
+		);
+		// Await async update to component state to avoid act warning
+		await act( () => isScreenReaderEnabled );
+		const { onAccessibilityAction } = renderer.toJSON().props;
+
+		expect( () =>
+			onAccessibilityAction( { nativeEvent: { actionName: 'activate' } } )
+		).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
## Description
Fixes #30625. Previously, the unit picker callback was always invoked when a11y tools activated the element. This caused the app to crash whenever the element did not have adjustable units.

* **Gutenberg Mobile:** wordpress-mobile/gutenberg-mobile#3350

## How has this been tested?
Following the reproduction steps outlined within #30625. 

Additionally...

1. Launch editor.
2. Add Columns block. 
4. Open block settings. 
5. Enable VoiceOver/TalkBack. 
6. Tap to select Column <n> cell. 
7. Double tap.

_Expected:_ The app does not crash. The editor opens the unit picker. 

## Screenshots 
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
