### PR TITLE
wp-env: Remove platform-specific destroy commands

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `wp-env destroy` will now work in environments which don't include the `grep` or `awk` commands, such as Windows PowerShell.
+
 ## 4.0.0 (2021-03-17)
 
 ### Breaking Change


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes #27957

When we originally implemented `wp-env destroy`, we used `grep` and `awk` on the command line. These are not compatible with windows, so wp-env would not work on that platform.

This re-implements the parts of the destroy command which were not cross-platform. This new approach works because the API for the Docker command is the same on Windows (I've tested it.)

I will note that Docker recommends that folks should run docker commands from inside a WSL2 instance for better performance. (Assuming folks are using the default WSL setup suggested by Docker.) If that's the case, unix commands like grep should be available. But since it's possible to use non-WSL approaches, we definitely still need to support cross-platform syntax.

## How has this been tested?
- Running wp-env destroy locally and verifying that it correctly removes the volumes and networks.

## Screenshots <!-- if applicable -->

<img width="614" alt="Capture" src="https://user-images.githubusercontent.com/6265975/114101999-69e5cf80-987b-11eb-98e1-c12a7bfdeddd.PNG">

## Types of changes
bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
