### PR TITLE
Fixes return type for getEntitiesByKind

### DIFF
--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -376,7 +376,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: Whether the entities are loaded
+-   `Array<Object>`: Array of entities with config matching kind.
 
 <a name="getEntity" href="#getEntity">#</a> **getEntity**
 

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -110,7 +110,7 @@ export const getUserQueryResults = createSelector(
  * @param {Object} state   Data state.
  * @param {string} kind  Entity kind.
  *
- * @return {boolean} Whether the entities are loaded
+ * @return {Array<Object>} Array of entities with config matching kind.
  */
 export function getEntitiesByKind( state, kind ) {
 	return filter( state.entities.config, { kind } );


### PR DESCRIPTION
The return type was specified as boolean, but the data is being passed to
the lodash filter function and returning its result which will be an
Array<Object> not a boolean.

Closes #29260
