### PR TITLE
RNMobile: Use the default div tagName on native for the Quote block

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -15,6 +15,9 @@ import {
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
+import { Platform } from '@wordpress/element';
+
+const isWebPlatform = Platform.OS === 'web';
 
 export default function QuoteEdit( {
 	attributes,
@@ -82,7 +85,7 @@ export default function QuoteEdit( {
 				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 					<RichText
 						identifier="citation"
-						tagName="cite"
+						tagName={ isWebPlatform ? 'cite' : undefined }
 						style={ { display: 'block' } }
 						value={ citation }
 						onChange={ ( nextCitation ) =>


### PR DESCRIPTION
## Description

Fixes: https://github.com/WordPress/gutenberg/issues/30548
See https://github.com/wordpress-mobile/gutenberg-mobile/pull/3352

This PR prevents the `tagName` prop from being passed to the Quote block citation on mobile. While it was added in https://github.com/WordPress/gutenberg/pull/30190 for both web and mobile, it resulted in a regression.

Not passing in the `tagName` appears to be the best solution we have at hand, although it isn't ideal since the `tagName` should correspond to the tag that the rich text represents i.e. a `<cite>` tag here.

## How has this been tested?
1. Add a quote block
2. In the citation section, type a few words
3. In the middle of the citation, hit return
4. Verify that the citation is split onto a single new line as you would expect.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
