### PR TITLE
wp-env: update changelog and CI

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -42,7 +42,6 @@ jobs:
 
             - name: Install WordPress
               run: |
-                  chmod -R 767 ./ # TODO: Possibly integrate in wp-env
                   npm run wp-env start
 
             - name: Running the tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -78,7 +78,6 @@ jobs:
 
             - name: Install WordPress
               run: |
-                  chmod -R 767 ./ # TODO: Possibly integrate in wp-env
                   npm run wp-env start
 
             - name: Running lint check

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   `wp-env destroy` will now work in environments which don't include the `grep` or `awk` commands, such as Windows PowerShell.
+-   Fix several permissions issues related to wp-config.php and wp-content files.
 
 ## 4.0.0 (2021-03-17)
 


### PR DESCRIPTION
I noticed after testing #30053 that we could probably update the CI to remove where we used to have to `chmod` the plugin directory to get file uploads working As long as CI passes on this PR, this is good to go.

Additionally, I updated the wp-env changelog. 