### PR TITLE
Components: Stop matching autocompleter upon mismatch

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -435,7 +435,6 @@ function Autocomplete( {
 		const textAfterSelection = getTextContent(
 			slice( record, undefined, getTextContent( record ).length )
 		);
-
 		const completer = find(
 			completers,
 			( { triggerPrefix, allowContext } ) => {
@@ -463,7 +462,6 @@ function Autocomplete( {
 				const tooDistantFromTrigger = textFromLastTrigger.length > 50; // 50 chars seem to be a good limit
 
 				console.log( '------------------------' );
-				//				console.log( 'atTrigger: ', atTrigger );
 				console.log( 'mismatch: ', mismatch );
 				console.log( 'tooDistantFromTrigger: ', tooDistantFromTrigger );
 				console.log( 'textAfterSelection: ', textAfterSelection );

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -462,7 +462,7 @@ function Autocomplete( {
 				const tooDistantFromTrigger = textWithoutTrigger.length > 50; // 50 chars seems to be a good limit.
 				// This is a final barrier to prevent the effect from completing with
 				// an extremely long string, which causes the editor to slow-down
-				// significantly. This could happen, for example, if `isMatchingBackwards`
+				// significantly. This could happen, for example, if `matchingWhileBackspacing`
 				// is true and one of the "words" end up being too long. If that's the case,
 				// it will be caught by this guard.
 				if ( tooDistantFromTrigger ) return false;
@@ -486,12 +486,12 @@ function Autocomplete( {
 				//
 				// Ex: "Some text @marcelo sekkkk" <--- "kkkk" caused a mismatch, but
 				// if the user presses backspace here, it will show the completion popup again.
-				const isMatchingBackwards =
+				const matchingWhileBackspacing =
 					backspacing && textWithoutTrigger.split( /\s/ ).length <= 3;
 
 				if (
 					mismatch &&
-					! ( isMatchingBackwards || hasOneTriggerWord )
+					! ( matchingWhileBackspacing || hasOneTriggerWord )
 				) {
 					return false;
 				}

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -459,12 +459,19 @@ function Autocomplete( {
 				const triggerMatchHint =
 					lastTriggerHintParts.length === 1 &&
 					lastTriggerHintParts[ 0 ];
+				const tooDistantFromTrigger = textFromLastTrigger.length > 50; // 50 chars seem to be a good limit
 
 				console.log( '------------------------' );
 				console.log( 'mismatch: ', mismatch );
+				console.log( 'tooDistantFromTrigger: ', tooDistantFromTrigger );
 				console.log( 'textFromLastTrigger: ', textFromLastTrigger );
 				console.log( 'triggerMatchHint: ', triggerMatchHint );
 				console.log( '------------------------' );
+
+				// Safe-hatch, sometimes when typing too fast after a completion
+				// filteredOptions is still not set to empty. Might be removed after
+				// we better understand why that happens and address that.
+				if ( tooDistantFromTrigger ) return false;
 
 				if ( mismatch && ! triggerMatchHint ) {
 					console.log( 'Mismatch, bailing out!' );
@@ -504,13 +511,13 @@ function Autocomplete( {
 		// autocompleter UI, so uncomment this to make this easier to test:
 		console.log( 'Query: ', query );
 
-		setFilterValue( query );
 		setAutocompleter( completer );
 		setAutocompleterUI( () =>
 			completer !== autocompleter
 				? getAutoCompleterUI( completer )
 				: AutocompleterUI
 		);
+		setFilterValue( query );
 	}, [ textContent ] );
 
 	const { key: selectedKey = '' } = filteredOptions[ selectedIndex ] || {};

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -13,15 +13,7 @@ import {
 	useLayoutEffect,
 	useState,
 } from '@wordpress/element';
-import {
-	ENTER,
-	ESCAPE,
-	UP,
-	DOWN,
-	LEFT,
-	RIGHT,
-	BACKSPACE,
-} from '@wordpress/keycodes';
+import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import {
@@ -301,7 +293,6 @@ function Autocomplete( {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ autocompleter, setAutocompleter ] = useState( null );
 	const [ AutocompleterUI, setAutocompleterUI ] = useState( null );
-	const [ backspacing, setBackspacing ] = useState( false );
 
 	function insertCompletion( replacement ) {
 		const end = record.start;
@@ -384,8 +375,6 @@ function Autocomplete( {
 	}
 
 	function handleKeyDown( event ) {
-		setBackspacing( event.keyCode === BACKSPACE );
-
 		if ( ! autocompleter ) {
 			return;
 		}
@@ -472,7 +461,6 @@ function Autocomplete( {
 				//				console.log( 'atTrigger: ', atTrigger );
 				console.log( 'mismatch: ', mismatch );
 				console.log( 'tooDistantFromTrigger: ', tooDistantFromTrigger );
-				console.log( 'backspacing: ', backspacing );
 				console.log( 'textAfterSelection: ', textAfterSelection );
 				console.log( 'textFromLastTrigger: ', textFromLastTrigger );
 				console.log( 'triggerMatch: ', triggerMatch );
@@ -480,7 +468,7 @@ function Autocomplete( {
 
 				if ( tooDistantFromTrigger ) return false;
 
-				if ( mismatch && ! triggerMatch && ! backspacing ) {
+				if ( mismatch && ! triggerMatch ) {
 					console.log( 'Mismatch!' );
 					return false;
 				}

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -381,7 +381,6 @@ function Autocomplete( {
 		if ( filteredOptions.length === 0 ) {
 			return;
 		}
-
 		switch ( event.keyCode ) {
 			case UP:
 				setSelectedIndex(
@@ -405,10 +404,12 @@ function Autocomplete( {
 			case ENTER:
 				select( filteredOptions[ selectedIndex ] );
 				break;
+
 			case LEFT:
 			case RIGHT:
 				reset();
 				return;
+
 			default:
 				return;
 		}

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -459,12 +459,9 @@ function Autocomplete( {
 				const triggerMatchHint =
 					lastTriggerHintParts.length === 1 &&
 					lastTriggerHintParts[ 0 ];
-				const tooDistantFromTrigger = textFromLastTrigger.length > 50; // 50 chars seem to be a good limit
 
 				console.log( '------------------------' );
 				console.log( 'mismatch: ', mismatch );
-				console.log( 'tooDistantFromTrigger: ', tooDistantFromTrigger );
-				console.log( 'textAfterSelection: ', textAfterSelection );
 				console.log( 'textFromLastTrigger: ', textFromLastTrigger );
 				console.log( 'triggerMatchHint: ', triggerMatchHint );
 				console.log( '------------------------' );
@@ -473,8 +470,6 @@ function Autocomplete( {
 					console.log( 'Mismatch, bailing out!' );
 					return false;
 				}
-
-				if ( tooDistantFromTrigger ) return false;
 
 				if (
 					allowContext &&

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -454,7 +454,7 @@ function Autocomplete( {
 				const textFromLastTrigger = text.slice(
 					text.lastIndexOf( triggerPrefix )
 				);
-				const triggerMatch = textFromLastTrigger.split( /\s/ )[ 0 ];
+				const triggerMatchHint = textFromLastTrigger.split( /\s/ )[ 0 ];
 				const tooDistantFromTrigger = textFromLastTrigger.length > 50; // 50 chars seem to be a good limit
 
 				console.log( '------------------------' );
@@ -463,15 +463,15 @@ function Autocomplete( {
 				console.log( 'tooDistantFromTrigger: ', tooDistantFromTrigger );
 				console.log( 'textAfterSelection: ', textAfterSelection );
 				console.log( 'textFromLastTrigger: ', textFromLastTrigger );
-				console.log( 'triggerMatch: ', triggerMatch );
+				console.log( 'triggerMatchHint: ', triggerMatchHint );
 				console.log( '------------------------' );
 
-				if ( tooDistantFromTrigger ) return false;
-
-				if ( mismatch && ! triggerMatch ) {
+				if ( mismatch && ! triggerMatchHint ) {
 					console.log( 'Mismatch!' );
 					return false;
 				}
+
+				if ( tooDistantFromTrigger ) return false;
 
 				if (
 					allowContext &&

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -459,7 +459,7 @@ function Autocomplete( {
 					index + triggerPrefix.length
 				);
 
-				const tooDistantFromTrigger = textWithoutTrigger.length > 50; // 50 chars seem to be a good limit.
+				const tooDistantFromTrigger = textWithoutTrigger.length > 50; // 50 chars seems to be a good limit.
 				// This is a final barrier to prevent the effect from completing with
 				// an extremely long string, which causes the editor to slow-down
 				// significantly. This could happen, for example, if `isMatchingBackwards`

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -454,7 +454,11 @@ function Autocomplete( {
 				const textFromLastTrigger = text.slice(
 					text.lastIndexOf( triggerPrefix )
 				);
-				const triggerMatchHint = textFromLastTrigger.split( /\s/ )[ 0 ];
+
+				const lastTriggerHintParts = textFromLastTrigger.split( /\s/ );
+				const triggerMatchHint =
+					lastTriggerHintParts.length === 1 &&
+					lastTriggerHintParts[ 0 ];
 				const tooDistantFromTrigger = textFromLastTrigger.length > 50; // 50 chars seem to be a good limit
 
 				console.log( '------------------------' );
@@ -467,7 +471,7 @@ function Autocomplete( {
 				console.log( '------------------------' );
 
 				if ( mismatch && ! triggerMatchHint ) {
-					console.log( 'Mismatch!' );
+					console.log( 'Mismatch, bailing out!' );
 					return false;
 				}
 
@@ -504,7 +508,7 @@ function Autocomplete( {
 
 		// We're trying to avoid reaching this part when there's no match in the
 		// autocompleter UI, so uncomment this to make this easier to test:
-		console.log( match[ 1 ] );
+		console.log( 'Query: ', query );
 
 		setFilterValue( query );
 		setAutocompleter( completer );

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -20,7 +20,6 @@ import {
 	DOWN,
 	LEFT,
 	RIGHT,
-	BACKSPACE,
 } from '@wordpress/keycodes';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
@@ -301,7 +300,6 @@ function Autocomplete( {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ autocompleter, setAutocompleter ] = useState( null );
 	const [ AutocompleterUI, setAutocompleterUI ] = useState( null );
-	const [ mismatch, setMismatch ] = useState( false );
 
 	function insertCompletion( replacement ) {
 		const end = record.start;
@@ -384,11 +382,10 @@ function Autocomplete( {
 	}
 
 	function handleKeyDown( event ) {
-		if ( ! autocompleter && event.keyCode !== BACKSPACE ) {
+		if ( ! autocompleter ) {
 			return;
 		}
-		if ( filteredOptions.length === 0 && event.keyCode !== BACKSPACE ) {
-			setMismatch( true );
+		if ( filteredOptions.length === 0 ) {
 			return;
 		}
 
@@ -415,9 +412,6 @@ function Autocomplete( {
 			case ENTER:
 				select( filteredOptions[ selectedIndex ] );
 				break;
-			case BACKSPACE:
-				setMismatch( false );
-				return;
 			case LEFT:
 			case RIGHT:
 				reset();
@@ -450,12 +444,6 @@ function Autocomplete( {
 		const completer = find(
 			completers,
 			( { triggerPrefix, allowContext } ) => {
-				// If we don't have any matching filteredOptions from the last render iteration +
-				// we didn't have a new trigger typed, then we should not continue with this effect.
-				if ( mismatch && text.slice( -1 ) !== triggerPrefix ) {
-					return false;
-				}
-
 				const index = text.lastIndexOf( triggerPrefix );
 
 				if ( index === -1 ) {
@@ -489,13 +477,20 @@ function Autocomplete( {
 			return;
 		}
 
+		// If we don't have any matching filteredOptions from the last render iteration +
+		// we didn't have a new trigger typed, then we should not continue with this effect.
+		const mismatch = filteredOptions.length === 0;
+		if (mismatch && text.slice(-1) !== completer.triggerPrefix) {
+			return;
+		}
+
 		const safeTrigger = escapeRegExp( completer.triggerPrefix );
 		const match = text
 			.slice( text.lastIndexOf( completer.triggerPrefix ) )
 			.match( new RegExp( `${ safeTrigger }([\u0000-\uFFFF]*)$` ) );
 		const query = match && match[ 1 ];
 
-		// console.log( match ); // uncomment this to make this easier to test
+		//console.log( match ); // uncomment this to make this easier to test
 
 		setAutocompleter( completer );
 		setAutocompleterUI( () =>


### PR DESCRIPTION
Attempts to fix https://github.com/WordPress/gutenberg/issues/30640.

## How to test

1. Spin up a `wp-env` instance in this branch, load the editor by creating a new post or page, open the JS console to check its output;
1. Write an user mention on the page (e.g "@ad... for "admin"), it should bring the autocompleter popup
1. Click any of the mention in the page, then start typing after it. Try typing a text that matches, it should work as expected and filter in the popup
1. Try typing a text that doesn't match anything, it should eventually run out of options
1. Keep typing, you shouldn't have any slowdown
1. Completion with spaces should work as well
1. If you backspace from unmatched text up to a portion that matches a name, it should bring the popup
1. Try the block completer (`/` in a new paragraph). It should work as expected and match blocks with spaces, too.