### PR TITLE
Update param type

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -8,9 +8,9 @@
 /**
  * Renders the `core/social-link` block on server.
  *
- * @param Array   $attributes The block attributes.
- * @param String  $content InnerBlocks content of the Block.
- * @param WPBlock $block Block object.
+ * @param Array  $attributes The block attributes.
+ * @param String $content InnerBlocks content of the Block.
+ * @param Object $block Block object.
  *
  * @return string Rendered HTML of the referenced block.
  */

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -10,7 +10,7 @@
  *
  * @param Array  $attributes The block attributes.
  * @param String $content InnerBlocks content of the Block.
- * @param Object $block Block object.
+ * @param WP_Block $block Block object.
  *
  * @return string Rendered HTML of the referenced block.
  */

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -8,9 +8,9 @@
 /**
  * Renders the `core/social-link` block on server.
  *
- * @param Array  $attributes The block attributes.
- * @param String $content InnerBlocks content of the Block.
- * @param WP_Block $block Block object.
+ * @param Array    $attributes The block attributes.
+ * @param String   $content    InnerBlocks content of the Block.
+ * @param WP_Block $block      Block object.
  *
  * @return string Rendered HTML of the referenced block.
  */


### PR DESCRIPTION
Update param type to Object instead of WPBlock.

Core ticket: https://core.trac.wordpress.org/ticket/53003

Props to ravipatel