### PR TITLE
Fix editing performance in Widgets Customizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13964,6 +13964,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
+				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"classnames": "^2.2.6",
 				"lodash": "^4.17.19"

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -33,6 +33,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
 		"classnames": "^2.2.6",
 		"lodash": "^4.17.19"

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createPortal, memo } from '@wordpress/element';
+import { createPortal } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Button, ToolbarItem } from '@wordpress/components';
 import { NavigableToolbar } from '@wordpress/block-editor';
@@ -45,4 +45,4 @@ function Header( { inserter, isInserterOpened, setIsInserterOpened } ) {
 	);
 }
 
-export default memo( Header );
+export default Header;

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createPortal } from '@wordpress/element';
+import { createPortal, memo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Button, ToolbarItem } from '@wordpress/components';
 import { NavigableToolbar } from '@wordpress/block-editor';
@@ -45,4 +45,4 @@ function Header( { inserter, isInserterOpened, setIsInserterOpened } ) {
 	);
 }
 
-export default Header;
+export default memo( Header );

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { createPortal, useMemo } from '@wordpress/element';
+import { createPortal } from '@wordpress/element';
 import {
-	BlockEditorProvider,
 	BlockList,
 	BlockSelectionClearer,
 	BlockInspector,
@@ -22,21 +21,11 @@ import {
  * Internal dependencies
  */
 import BlockInspectorButton from '../block-inspector-button';
-import Header from '../header';
-import useSidebarBlockEditor from './use-sidebar-block-editor';
-import useInserter from '../inserter/use-inserter';
+import SidebarEditorProvider from './sidebar-editor-provider';
 
 export default function SidebarBlockEditor( { sidebar, inserter, inspector } ) {
-	const [ blocks, onInput, onChange ] = useSidebarBlockEditor( sidebar );
 	const parentContainer = document.getElementById(
 		'customize-theme-controls'
-	);
-	const [ isInserterOpened, setIsInserterOpened ] = useInserter( inserter );
-	const settings = useMemo(
-		() => ( {
-			__experimentalSetIsInserterOpened: setIsInserterOpened,
-		} ),
-		[]
 	);
 
 	return (
@@ -44,21 +33,10 @@ export default function SidebarBlockEditor( { sidebar, inserter, inspector } ) {
 			<BlockEditorKeyboardShortcuts.Register />
 			<SlotFillProvider>
 				<DropZoneProvider>
-					<BlockEditorProvider
-						value={ blocks }
-						onInput={ onInput }
-						onChange={ onChange }
-						settings={ settings }
-						useSubRegistry={ false }
+					<SidebarEditorProvider
+						sidebar={ sidebar }
+						inserter={ inserter }
 					>
-						<BlockEditorKeyboardShortcuts />
-
-						<Header
-							inserter={ inserter }
-							isInserterOpened={ isInserterOpened }
-							setIsInserterOpened={ setIsInserterOpened }
-						/>
-
 						<BlockSelectionClearer>
 							<WritingFlow>
 								<ObserveTyping>
@@ -66,7 +44,7 @@ export default function SidebarBlockEditor( { sidebar, inserter, inspector } ) {
 								</ObserveTyping>
 							</WritingFlow>
 						</BlockSelectionClearer>
-					</BlockEditorProvider>
+					</SidebarEditorProvider>
 
 					<Popover.Slot name="block-toolbar" />
 

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createPortal } from '@wordpress/element';
+import { useMemo, createPortal } from '@wordpress/element';
 import {
 	BlockList,
 	BlockSelectionClearer,
@@ -21,9 +21,18 @@ import {
  * Internal dependencies
  */
 import BlockInspectorButton from '../block-inspector-button';
+import Header from '../header';
+import useInserter from '../inserter/use-inserter';
 import SidebarEditorProvider from './sidebar-editor-provider';
 
 export default function SidebarBlockEditor( { sidebar, inserter, inspector } ) {
+	const [ isInserterOpened, setIsInserterOpened ] = useInserter( inserter );
+	const settings = useMemo(
+		() => ( {
+			__experimentalSetIsInserterOpened: setIsInserterOpened,
+		} ),
+		[]
+	);
 	const parentContainer = document.getElementById(
 		'customize-theme-controls'
 	);
@@ -35,8 +44,16 @@ export default function SidebarBlockEditor( { sidebar, inserter, inspector } ) {
 				<DropZoneProvider>
 					<SidebarEditorProvider
 						sidebar={ sidebar }
-						inserter={ inserter }
+						settings={ settings }
 					>
+						<BlockEditorKeyboardShortcuts />
+
+						<Header
+							inserter={ inserter }
+							isInserterOpened={ isInserterOpened }
+							setIsInserterOpened={ setIsInserterOpened }
+						/>
+
 						<BlockSelectionClearer>
 							<WritingFlow>
 								<ObserveTyping>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-adapter.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-adapter.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { difference, isEqual, without } from 'lodash';
-
 const { wp } = window;
 
 function parseWidgetId( widgetId ) {
@@ -53,12 +48,25 @@ export default class SidebarAdapter {
 		this.setting = setting;
 		this.allSettings = allSettings;
 
+		this.locked = false;
+		this.widgetsMap = new WeakMap();
 		this.subscribers = new Set();
+
+		this.history = [
+			this._getWidgetIds().map( ( widgetId ) =>
+				this.getWidget( widgetId )
+			),
+		];
+		this.historyIndex = 0;
 
 		this._handleSettingChange = this._handleSettingChange.bind( this );
 		this._handleAllSettingsChange = this._handleAllSettingsChange.bind(
 			this
 		);
+		this.canUndo = this.canUndo.bind( this );
+		this.canRedo = this.canRedo.bind( this );
+		this.undo = this.undo.bind( this );
+		this.redo = this.redo.bind( this );
 	}
 
 	subscribe( callback ) {
@@ -79,30 +87,47 @@ export default class SidebarAdapter {
 		}
 	}
 
-	trigger( event ) {
+	getWidgets() {
+		return this.history[ this.historyIndex ];
+	}
+
+	_emit( ...args ) {
 		for ( const callback of this.subscribers ) {
-			callback( event );
+			callback( ...args );
 		}
 	}
 
-	_handleSettingChange( newWidgetIds, oldWidgetIds ) {
-		const addedWidgetIds = difference( newWidgetIds, oldWidgetIds );
-		const removedWidgetIds = difference( oldWidgetIds, newWidgetIds );
+	_getWidgetIds() {
+		return this.setting.get();
+	}
 
-		for ( const widgetId of addedWidgetIds ) {
-			this.trigger( { type: 'widgetAdded', widgetId } );
+	_pushHistory() {
+		this.history = [
+			...this.history.slice( 0, this.historyIndex + 1 ),
+			this._getWidgetIds().map( ( widgetId ) =>
+				this.getWidget( widgetId )
+			),
+		];
+		this.historyIndex += 1;
+	}
+
+	_handleSettingChange() {
+		if ( this.locked ) {
+			return;
 		}
 
-		for ( const widgetId of addedWidgetIds ) {
-			this.trigger( { type: 'widgetRemoved', widgetId } );
-		}
+		const prevWidgets = this.getWidgets();
 
-		if ( ! isEqual( addedWidgetIds, removedWidgetIds ) ) {
-			this.trigger( { type: 'widgetsReordered', newWidgetIds } );
-		}
+		this._pushHistory();
+
+		this._emit( prevWidgets, this.getWidgets() );
 	}
 
 	_handleAllSettingsChange( setting ) {
+		if ( this.locked ) {
+			return;
+		}
+
 		if ( ! setting.id.startsWith( 'widget_' ) ) {
 			return;
 		}
@@ -112,30 +137,14 @@ export default class SidebarAdapter {
 			return;
 		}
 
-		this.trigger( { type: 'widgetChanged', widgetId } );
+		const prevWidgets = this.getWidgets();
+
+		this._pushHistory();
+
+		this._emit( prevWidgets, this.getWidgets() );
 	}
 
-	getWidgetIds() {
-		return this.setting.get();
-	}
-
-	setWidgetIds( widgetIds ) {
-		this.setting.set( widgetIds );
-	}
-
-	getWidget( widgetId ) {
-		const { idBase, number } = parseWidgetId( widgetId );
-		const settingId = widgetIdToSettingId( widgetId );
-		const instance = this.allSettings( settingId ).get();
-		return {
-			id: widgetId,
-			idBase,
-			number,
-			instance,
-		};
-	}
-
-	addWidget( widget, index ) {
+	_createWidget( widget ) {
 		const widgetModel = wp.customize.Widgets.availableWidgets.findWhere( {
 			id_base: widget.idBase,
 		} );
@@ -167,24 +176,124 @@ export default class SidebarAdapter {
 			'',
 			settingArgs
 		);
-		setting.set( {} );
+		setting.set( widget.instance );
 
-		const widgetIds = [ ...this.setting.get() ];
 		const widgetId = settingIdToWidgetId( settingId );
-		widgetIds.splice( index, 0, widgetId );
-		this.setting.set( widgetIds );
 
 		return widgetId;
 	}
 
-	updateWidget( widget ) {
+	_updateWidget( widget ) {
+		const prevWidget = this.getWidget( widget.id );
+
+		// Bail out update.
+		if ( prevWidget === widget ) {
+			return widget.id;
+		}
+
 		const settingId = widgetIdToSettingId( widget.id );
 		this.allSettings( settingId ).set( widget.instance );
 		// TODO: what about the other stuff?
+
+		return widget.id;
 	}
 
-	removeWidget( widgetId ) {
-		const widgetIds = this.setting.get();
-		this.setting.set( without( widgetIds, widgetId ) );
+	getWidget( widgetId ) {
+		if ( ! widgetId ) {
+			return null;
+		}
+
+		const { idBase, number } = parseWidgetId( widgetId );
+		const settingId = widgetIdToSettingId( widgetId );
+		const setting = this.allSettings( settingId );
+
+		if ( ! setting ) {
+			return null;
+		}
+
+		const instance = setting.get();
+
+		if ( this.widgetsMap.has( instance ) ) {
+			return this.widgetsMap.get( instance );
+		}
+
+		const widget = {
+			id: widgetId,
+			idBase,
+			number,
+			instance,
+		};
+
+		this.widgetsMap.set( instance, widget );
+
+		return widget;
+	}
+
+	_internalUpdateWidgets( nextWidgets ) {
+		this.locked = true;
+
+		const addedWidgetIds = [];
+
+		const nextWidgetIds = nextWidgets.map( ( nextWidget ) => {
+			if ( nextWidget.id && this.getWidget( nextWidget.id ) ) {
+				addedWidgetIds.push( null );
+
+				return this._updateWidget( nextWidget );
+			}
+
+			const widgetId = this._createWidget( nextWidget );
+
+			addedWidgetIds.push( widgetId );
+
+			return widgetId;
+		} );
+
+		// TODO: We should in theory also handle delete widgets here too.
+
+		this.setting.set( nextWidgetIds );
+
+		this.locked = false;
+
+		return addedWidgetIds;
+	}
+
+	setWidgets( nextWidgets ) {
+		const addedWidgetIds = this._internalUpdateWidgets( nextWidgets );
+
+		this._pushHistory();
+
+		return addedWidgetIds;
+	}
+
+	canUndo() {
+		return this.historyIndex > 0;
+	}
+	canRedo() {
+		return this.historyIndex < this.history.length - 1;
+	}
+	_seek( historyIndex ) {
+		const currentWidgets = this.getWidgets();
+
+		this.historyIndex = historyIndex;
+
+		const widgets = this.history[ this.historyIndex ];
+
+		this._internalUpdateWidgets( widgets );
+
+		this._emit( currentWidgets, this.getWidgets() );
+	}
+	undo() {
+		if ( ! this.canUndo() ) {
+			return;
+		}
+
+		this._seek( this.historyIndex - 1 );
+	}
+	redo() {
+		if ( ! this.canRedo() ) {
+			return;
+		}
+
+		this._seek( this.historyIndex + 1 );
 	}
 }

--- a/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-editor-provider.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-editor-provider.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import {
+	BlockEditorProvider,
+	BlockEditorKeyboardShortcuts,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import useSidebarBlockEditor from './use-sidebar-block-editor';
+import Header from '../header';
+import useInserter from '../inserter/use-inserter';
+
+export default function SidebarEditorProvider( {
+	sidebar,
+	inserter,
+	children,
+} ) {
+	const [ blocks, onInput, onChange ] = useSidebarBlockEditor( sidebar );
+	const [ isInserterOpened, setIsInserterOpened ] = useInserter( inserter );
+	const settings = useMemo(
+		() => ( {
+			__experimentalSetIsInserterOpened: setIsInserterOpened,
+		} ),
+		[]
+	);
+
+	return (
+		<BlockEditorProvider
+			value={ blocks }
+			onInput={ onInput }
+			onChange={ onChange }
+			settings={ settings }
+			useSubRegistry={ false }
+		>
+			<BlockEditorKeyboardShortcuts />
+
+			<Header
+				inserter={ inserter }
+				isInserterOpened={ isInserterOpened }
+				setIsInserterOpened={ setIsInserterOpened }
+			/>
+
+			{ children }
+		</BlockEditorProvider>
+	);
+}

--- a/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-editor-provider.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-editor-provider.js
@@ -1,32 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
-import {
-	BlockEditorProvider,
-	BlockEditorKeyboardShortcuts,
-} from '@wordpress/block-editor';
+import { BlockEditorProvider } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import useSidebarBlockEditor from './use-sidebar-block-editor';
-import Header from '../header';
-import useInserter from '../inserter/use-inserter';
 
 export default function SidebarEditorProvider( {
 	sidebar,
-	inserter,
+	settings,
 	children,
 } ) {
 	const [ blocks, onInput, onChange ] = useSidebarBlockEditor( sidebar );
-	const [ isInserterOpened, setIsInserterOpened ] = useInserter( inserter );
-	const settings = useMemo(
-		() => ( {
-			__experimentalSetIsInserterOpened: setIsInserterOpened,
-		} ),
-		[]
-	);
 
 	return (
 		<BlockEditorProvider
@@ -36,14 +23,6 @@ export default function SidebarEditorProvider( {
 			settings={ settings }
 			useSubRegistry={ false }
 		>
-			<BlockEditorKeyboardShortcuts />
-
-			<Header
-				inserter={ inserter }
-				isInserterOpened={ isInserterOpened }
-				setIsInserterOpened={ setIsInserterOpened }
-			/>
-
 			{ children }
 		</BlockEditorProvider>
 	);

--- a/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
@@ -181,25 +181,27 @@ export default function useSidebarBlockEditor( sidebar ) {
 
 				const addedWidgetIds = sidebar.setWidgets( nextWidgets );
 
-				if (
-					addedWidgetIds.filter( ( widgetId ) => widgetId !== null )
-						.length
-				) {
-					return nextBlocks.map( ( nextBlock, index ) => {
+				return nextBlocks.reduce(
+					( updatedNextBlocks, nextBlock, index ) => {
 						const addedWidgetId = addedWidgetIds[ index ];
 
 						if ( addedWidgetId !== null ) {
-							return addWidgetIdToBlock(
+							// Only create a new instance if necessary to prevent
+							// the whole editor from re-rendering on every edit.
+							if ( updatedNextBlocks === nextBlocks ) {
+								updatedNextBlocks = nextBlocks.slice();
+							}
+
+							updatedNextBlocks[ index ] = addWidgetIdToBlock(
 								nextBlock,
 								addedWidgetId
 							);
 						}
 
-						return nextBlock;
-					} );
-				}
-
-				return nextBlocks;
+						return updatedNextBlocks;
+					},
+					nextBlocks
+				);
 			} );
 		},
 		[ sidebar ]


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This fixes an important performance issue in the Widgets Customizer where editing any block will re-render the whole block editor. This branch is based on #30221 for easier review but should be re-target to trunk before merge.

The problem with the original approach is that every time we update any block we create a new instance of the `nextBlocks` array and set it back to the component's state via `setState`. This feels intuitive but apparently it breaks the optimization `useBlockSync` has. Turns out we need to make sure the `nextBlocks` instance we pass to the `<BlockEditorProvider>`'s `value` should be referential equal to the `nextBlocks` we received from the `onChange` callback. Or else all changes are marked as persistent and will re-render the whole block editor.

The solution is simply to call `setState` with the `nextBlocks` we receive from the callback whenever possible.

I also essentially refactored the code in `SidebarAdaptor` and `useSidebarBlockEditor` to use the customize API as the source of truth of all states, and simplify the logic a little bit. I added a few methods regarding undo/redo in #30400. They're currently unused yet though, but they should work. We can add the UI in another PR.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Enable "Highlight updates" in React devtools.
2. Enable Widgets Customizer in the gutenberg experiments page.
3. Go to Appearance -> Customize -> Widgets.
4. Edit any block in any widget area.
5. Notice that only the block being edited is highlighted by React devtools most of the time.
6. And of course, it's way smoother than before.
7. Also try adding a new block, creating block on enter, or deleting a block. And notice the corresponding changes should reflect on the preview as expected.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/114140441-d677d180-9942-11eb-8285-dcec6520bbdc.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
