### PR TITLE
Writing Flow: Make the appender identical to an empty Paragraph block

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -94,11 +94,7 @@ function BlockListAppender( {
 			// Prevent the block from being selected when the appender is
 			// clicked.
 			onFocus={ stopPropagation }
-			className={ classnames(
-				'block-list-appender',
-				'wp-block',
-				className
-			) }
+			className={ classnames( 'block-list-appender', className ) }
 		>
 			{ appender }
 		</TagName>

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -33,7 +33,7 @@ function BlockListAppender( {
 	renderAppender: CustomAppender,
 	className,
 	selectedBlockClientId,
-	tagName: TagName = 'div',
+	tagName: TagName = 'p',
 } ) {
 	if ( isLocked || CustomAppender === false ) {
 		return null;

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -33,7 +33,7 @@ function BlockListAppender( {
 	renderAppender: CustomAppender,
 	className,
 	selectedBlockClientId,
-	tagName: TagName = 'p',
+	tagName: TagName = 'div',
 } ) {
 	if ( isLocked || CustomAppender === false ) {
 		return null;

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -53,3 +53,26 @@
 		transform: scale(0);
 	}
 }
+
+// This targets the appender on new posts, when it is technically a button.
+p.block-list-appender.wp-block {
+	display: flex;
+
+	// This overrides some properties as this appender is also assigned a .wp-block class.
+	.block-editor-default-block-appender {
+		width: 100%;
+		margin-left: 0;
+		margin-right: 0;
+
+		.block-editor-default-block-appender__content {
+			line-height: inherit;
+		}
+	}
+
+	// Make the appender as tall as one paragraph, to match the height of the actual paragraph appenders.
+	&::after {
+		content: "\200B";
+		display: inline-block;
+		width: 0;
+	}
+}

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -55,7 +55,7 @@
 }
 
 // This targets the appender on new posts, when it is technically a button.
-p.block-list-appender.wp-block {
+.block-list-appender.wp-block {
 	display: flex;
 
 	// This overrides some properties as this appender is also assigned a .wp-block class.

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -55,23 +55,6 @@
 }
 
 // This targets the appender on new posts, when it is technically a button.
-.block-list-appender {
-
-	// This overrides some properties as this appender is also assigned a .wp-block class.
-	.block-editor-default-block-appender {
-		width: 100%;
-		margin-left: 0;
-		margin-right: 0;
-
-		.block-editor-default-block-appender__content {
-			line-height: inherit;
-		}
-	}
-
-	// Make the appender as tall as one paragraph, to match the height of the actual paragraph appenders.
-	&::after {
-		content: "\200B";
-		display: inline-block;
-		width: 0;
-	}
+.block-list-appender .block-editor-default-block-appender .block-editor-default-block-appender__content {
+	line-height: inherit;
 }

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -55,8 +55,7 @@
 }
 
 // This targets the appender on new posts, when it is technically a button.
-.block-list-appender.wp-block {
-	display: flex;
+.block-list-appender {
 
 	// This overrides some properties as this appender is also assigned a .wp-block class.
 	.block-editor-default-block-appender {

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -49,25 +49,27 @@ export function DefaultBlockAppender( {
 	// The wp-block className is important for editor styles.
 
 	return (
-		<p
+		<div
 			data-root-client-id={ rootClientId || '' }
 			className="wp-block block-editor-default-block-appender"
 		>
-			<TextareaAutosize
-				role="button"
-				aria-label={ __( 'Add block' ) }
-				className="block-editor-default-block-appender__content"
-				readOnly
-				onFocus={ onAppend }
-				value={ showPrompt ? value : '' }
-			/>
+			<p>
+				<TextareaAutosize
+					role="button"
+					aria-label={ __( 'Add block' ) }
+					className="block-editor-default-block-appender__content"
+					readOnly
+					onFocus={ onAppend }
+					value={ showPrompt ? value : '' }
+				/>
+			</p>
 			<Inserter
 				rootClientId={ rootClientId }
 				position="bottom right"
 				isAppender
 				__experimentalIsQuick
 			/>
-		</p>
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -49,7 +49,7 @@ export function DefaultBlockAppender( {
 	// The wp-block className is important for editor styles.
 
 	return (
-		<div
+		<p
 			data-root-client-id={ rootClientId || '' }
 			className="wp-block block-editor-default-block-appender"
 		>
@@ -67,7 +67,7 @@ export function DefaultBlockAppender( {
 				isAppender
 				__experimentalIsQuick
 			/>
-		</div>
+		</p>
 	);
 }
 

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -24,8 +24,8 @@
 		outline: $border-width solid transparent;
 		transition: 0.2s outline;
 		@include reduce-motion("transition");
-		margin-top: $default-block-margin;
-		margin-bottom: $default-block-margin;
+		margin-top: 0;
+		margin-bottom: 0;
 
 		// This needs high specificity as it's output as an inline style by the library.
 		resize: none !important;

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -79,9 +79,3 @@
 		display: none;
 	}
 }
-
-.block-editor-default-block-appender .block-editor-inserter {
-	@include break-small {
-		align-items: center;
-	}
-}

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -5,26 +5,28 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   className="wp-block block-editor-default-block-appender"
   data-root-client-id=""
 >
-  <ForwardRef
-    aria-label="Add block"
-    className="block-editor-default-block-appender__content"
-    onFocus={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
+  <p>
+    <ForwardRef
+      aria-label="Add block"
+      className="block-editor-default-block-appender__content"
+      onFocus={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
       }
-    }
-    readOnly={true}
-    role="button"
-    value="Type / to choose a block"
-  />
+      readOnly={true}
+      role="button"
+      value="Type / to choose a block"
+    />
+  </p>
   <WithSelect(WithDispatch(IfCondition(Inserter)))
     __experimentalIsQuick={true}
     isAppender={true}
@@ -38,14 +40,16 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   className="wp-block block-editor-default-block-appender"
   data-root-client-id=""
 >
-  <ForwardRef
-    aria-label="Add block"
-    className="block-editor-default-block-appender__content"
-    onFocus={[MockFunction]}
-    readOnly={true}
-    role="button"
-    value="Type / to choose a block"
-  />
+  <p>
+    <ForwardRef
+      aria-label="Add block"
+      className="block-editor-default-block-appender__content"
+      onFocus={[MockFunction]}
+      readOnly={true}
+      role="button"
+      value="Type / to choose a block"
+    />
+  </p>
   <WithSelect(WithDispatch(IfCondition(Inserter)))
     __experimentalIsQuick={true}
     isAppender={true}
@@ -59,14 +63,16 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   className="wp-block block-editor-default-block-appender"
   data-root-client-id=""
 >
-  <ForwardRef
-    aria-label="Add block"
-    className="block-editor-default-block-appender__content"
-    onFocus={[MockFunction]}
-    readOnly={true}
-    role="button"
-    value=""
-  />
+  <p>
+    <ForwardRef
+      aria-label="Add block"
+      className="block-editor-default-block-appender__content"
+      onFocus={[MockFunction]}
+      readOnly={true}
+      role="button"
+      value=""
+    />
+  </p>
   <WithSelect(WithDispatch(IfCondition(Inserter)))
     __experimentalIsQuick={true}
     isAppender={true}

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -55,10 +55,9 @@
 		margin-left: auto;
 		margin-right: auto;
 
-		// Apply default block margin below the post title.
-		// This ensures the first block on the page is in a good position.
-		// This rule can be retired once the title becomes an actual block.
-		margin-bottom: $default-block-margin;
+		// Margins between the title and the first block, or appender, do not collapse.
+		// By explicitly setting this to zero, we avoid "double margin".
+		margin-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
## Description

When you create a new post, there's a "Type / to choose a block" prompt. This is called the "Appender", and in this initial state, it is a `button`, not a `p`. As soon as you click it, it becomes a `p`. 

That means depending on your theme styles, the height and margins will differ:

![before](https://user-images.githubusercontent.com/1204802/114153696-e4682b00-991f-11eb-9317-5664d57e1685.gif)

This PR fixes that:

![after](https://user-images.githubusercontent.com/1204802/114153737-edf19300-991f-11eb-84ad-42010926cf2c.gif)

It does so by outputting a non-breaking space after the appender, and by changing the wrapping container from div to p. That allows the appender to be the same height as a p, and have the same margins.

## How has this been tested?

Please test new empty posts, in a variety of themes, and verify it doesn't regress the initial appender.

It shouldn't touch any actual paragraph appenders (i.e. empy paragraph blocks), but please test regardless.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
