### PR TITLE
Updates the template mode canvas padding and adds a back link

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -7,7 +7,6 @@ $black: #000;			// Use only when you truly need pure black. For UI, use $gray-90
 $gray-900: #1e1e1e;
 $gray-700: #757575;		// Meets 4.6:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
-$gray-500: #bbb;
 $gray-400: #ccc;
 $gray-300: #ddd;		// Used for most borders.
 $gray-200: #e0e0e0;		// Used sparingly for light borders.

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -9,7 +9,7 @@ import { useRefEffect } from '@wordpress/compose';
  */
 import { store as blockEditorStore } from '../../store';
 
-export function useBlockSelectionClearer() {
+export function useBlockSelectionClearer( onlySelfClicks = false ) {
 	const hasSelection = useSelect( ( select ) => {
 		const { hasSelectedBlock, hasMultiSelection } = select(
 			blockEditorStore
@@ -27,7 +27,10 @@ export function useBlockSelectionClearer() {
 
 			function onMouseDown( event ) {
 				// Only handle clicks on the canvas, not the content.
-				if ( event.target.closest( '.wp-block' ) ) {
+				if (
+					event.target.closest( '.wp-block' ) ||
+					( onlySelfClicks && event.target !== node )
+				) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -68,6 +68,7 @@ export default function useResizeCanvas(
 					maxHeight: height,
 					overflowY: 'auto',
 					borderRadius: '2px',
+					boxShadow: '0 1px 3px rgba(0, 0, 0, 0.4)',
 				};
 			default:
 				return null;

--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -68,7 +68,7 @@ export default function useResizeCanvas(
 					maxHeight: height,
 					overflowY: 'auto',
 					borderRadius: '2px',
-					boxShadow: '0 1px 3px rgba(0, 0, 0, 0.4)',
+					border: '1px solid #ddd',
 				};
 			default:
 				return null;

--- a/packages/edit-post/src/components/header/template-save-button/index.js
+++ b/packages/edit-post/src/components/header/template-save-button/index.js
@@ -21,9 +21,6 @@ function TemplateSaveButton() {
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	return (
 		<>
-			<Button onClick={ () => setIsEditingTemplate( false ) } isTertiary>
-				{ __( 'Cancel' ) }
-			</Button>
 			<Button
 				isPrimary
 				onClick={ () => setIsEntitiesReviewPanelOpen( true ) }

--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -25,11 +25,18 @@ function TemplateTitle() {
 		return null;
 	}
 
+	let templateTitle = __( 'Default' );
+	if ( template && template?.title?.raw ) {
+		templateTitle = template?.title?.raw;
+	} else if ( template ) {
+		templateTitle = template.slug;
+	}
+
 	return (
 		<span className="edit-post-template-title">
 			{
 				/* translators: 1: Template name. */
-				sprintf( __( 'Editing template: %s' ), template.slug )
+				sprintf( __( 'Editing template: %s' ), templateTitle )
 			}
 		</span>
 	);

--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -26,9 +26,9 @@ function TemplateTitle() {
 	}
 
 	let templateTitle = __( 'Default' );
-	if ( template && template?.title?.raw ) {
-		templateTitle = template?.title?.raw;
-	} else if ( template ) {
+	if ( template?.title?.raw ) {
+		templateTitle = template.title.raw;
+	} else if ( !! template ) {
 		templateTitle = template.slug;
 	}
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -87,7 +87,7 @@
 }
 
 .edit-post-layout .interface-interface-skeleton__content {
-	background-color: $gray-400;
+	background-color: $gray-100;
 }
 
 .edit-post-layout__inserter-panel {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -87,7 +87,7 @@
 }
 
 .edit-post-layout .interface-interface-skeleton__content {
-	background-color: $gray-500;
+	background-color: $gray-400;
 }
 
 .edit-post-layout__inserter-panel {

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -59,18 +59,20 @@ function PostTemplate() {
 		return null;
 	}
 
+	const templateTitle = (
+		<>
+			{ !! template && template?.title?.raw }
+			{ !! template && ! template?.title?.raw && template.slug }
+			{ ! template && __( 'Default' ) }
+		</>
+	);
+
 	return (
 		<PanelRow className="edit-post-post-template">
 			<span>{ __( 'Template' ) }</span>
 			{ ! isEditing && (
 				<div className="edit-post-post-template__value">
-					<div>
-						{ !! template && template?.title?.raw }
-						{ !! template &&
-							! template?.title?.raw &&
-							template.slug }
-						{ ! template && __( 'Default' ) }
-					</div>
+					<div>{ templateTitle }</div>
 					<div className="edit-post-post-template__actions">
 						{ !! template && (
 							<Button
@@ -90,7 +92,7 @@ function PostTemplate() {
 			) }
 			{ isEditing && (
 				<span className="edit-post-post-template__value">
-					{ template?.slug }
+					{ templateTitle }
 				</span>
 			) }
 			{ isModalOpen && (

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -78,15 +78,17 @@ export default function VisualEditor( { styles } ) {
 		useClipboardHandler(),
 		useCanvasClickRedirect(),
 		useTypewriter(),
-		useBlockSelectionClearer(),
 		useTypingObserver(),
 	] );
+
+	const blockSelectionClearerRef = useBlockSelectionClearer();
 
 	return (
 		<div
 			className={ classnames( 'edit-post-visual-editor', {
 				'is-template-mode': isTemplateMode,
 			} ) }
+			ref={ blockSelectionClearerRef }
 		>
 			{ themeSupportsLayout && (
 				<LayoutStyle

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -79,9 +79,10 @@ export default function VisualEditor( { styles } ) {
 		useCanvasClickRedirect(),
 		useTypewriter(),
 		useTypingObserver(),
+		useBlockSelectionClearer(),
 	] );
 
-	const blockSelectionClearerRef = useBlockSelectionClearer();
+	const blockSelectionClearerRef = useBlockSelectionClearer( true );
 
 	return (
 		<div

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -20,10 +25,12 @@ import {
 	__experimentalUseEditorFeature as useEditorFeature,
 	__experimentalLayoutStyle as LayoutStyle,
 } from '@wordpress/block-editor';
-import { Popover } from '@wordpress/components';
+import { Popover, Button } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useMergeRefs } from '@wordpress/compose';
+import { arrowLeft } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -51,6 +58,7 @@ export default function VisualEditor( { styles } ) {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().supportsLayout;
 	}, [] );
+	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {
 		height: '100%',
 		// Add a constant padding for the typewritter effect. When typing at the
@@ -75,7 +83,11 @@ export default function VisualEditor( { styles } ) {
 	] );
 
 	return (
-		<div className="edit-post-visual-editor">
+		<div
+			className={ classnames( 'edit-post-visual-editor', {
+				'is-template-mode': isTemplateMode,
+			} ) }
+		>
 			{ themeSupportsLayout && (
 				<LayoutStyle
 					selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
@@ -85,6 +97,15 @@ export default function VisualEditor( { styles } ) {
 			<EditorStyles styles={ styles } />
 			<VisualEditorGlobalKeyboardShortcuts />
 			<Popover.Slot name="block-toolbar" />
+			{ isTemplateMode && (
+				<Button
+					className="edit-post-visual-editor__exit-template-mode"
+					icon={ arrowLeft }
+					onClick={ () => setIsEditingTemplate( false ) }
+				>
+					{ __( 'Back' ) }
+				</Button>
+			) }
 			<div
 				ref={ mergedRefs }
 				className="editor-styles-wrapper"

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -23,6 +23,14 @@
 	@supports (position: sticky) {
 		flex-basis: 100%;
 	}
+
+	&.is-template-mode {
+		padding: $grid-unit-60;
+
+		.editor-styles-wrapper {
+			border-radius: 2px;
+		}
+	}
 }
 
 .editor-styles-wrapper {
@@ -54,4 +62,10 @@
 		// This rule can be retired once the title becomes an actual block.
 		margin-bottom: $default-block-margin;
 	}
+}
+
+.edit-post-visual-editor__exit-template-mode {
+	position: absolute;
+	top: $grid-unit-10;
+	left: $grid-unit-10;
 }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -29,6 +29,7 @@
 
 		.editor-styles-wrapper {
 			border-radius: 2px;
+			box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 		}
 	}
 }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -29,7 +29,7 @@
 
 		.editor-styles-wrapper {
 			border-radius: 2px;
-			box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+			border: 1px solid $gray-300;
 		}
 	}
 }

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -313,7 +313,7 @@ export function isSavingMetaBoxes( state ) {
  * @return {string} Device type.
  */
 export function __experimentalGetPreviewDeviceType( state ) {
-	return state.deviceType;
+	return state.isEditingTemplate ? 'Desktop' : state.deviceType;
 }
 
 /**


### PR DESCRIPTION
This is a small iteration towards a better block template mode in the post editor like shown here https://github.com/WordPress/gutenberg/issues/27849#issuecomment-800372073

This does a few small things:

 - Adds a padding around the template in template mode to better distinguish between the template and the default mode.
 - Adds a "back" button to move back to the regular mode.
 - Shows the title in the header and sidebar of the template mode.

This probably need some design  polish.

<img width="1435" alt="Capture d’écran 2021-04-09 à 11 37 49 AM" src="https://user-images.githubusercontent.com/272444/114168347-0f567d00-9928-11eb-8b9a-294331fc9e33.png">
