### PR TITLE
Render out HTML characters in post and category titles

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
@@ -15,8 +15,15 @@ import { NavigationPanelPreviewFill } from '..';
 import TemplatePreview from './template-preview';
 import { store as editSiteStore } from '../../../store';
 
-const getTitle = ( entity ) =>
-	entity.taxonomy ? entity.name : entity?.title?.rendered;
+const getTitle = ( entity ) => {
+	const title = entity.taxonomy ? entity.name : entity?.title?.rendered;
+
+	// Make sure encoded characters are displayed as the characters they represent.
+	const titleElement = document.createElement( 'div' );
+	titleElement.innerHTML = title;
+
+	return titleElement.textContent || titleElement.innerText || '';
+};
 
 export default function ContentNavigationItem( { item } ) {
 	const [ isPreviewVisible, setIsPreviewVisible ] = useState( false );


### PR DESCRIPTION
## Description
In the navigation section of the full site editing, the post and category titles can be displayed with the `&#....;` version of the characters.

This change will make sure the titles are rendered in a virtual DIV and the "flat" innerText is used to be displayed in the menu.

## How has this been tested?

The first part of the items in the list is how the text is entered.
The second part is how it is displayed in the menu with the changes from the PR.

Created categories with the following names:

- `Three &#8230; dots` --> `Three ... dots`
- `Three ... dots` --> `Three ... dots`
- `Some " double quote` --> `Some " double quote`
- `Some &#34; double quote` --> `Some " double quote`
- `Some <b> html` --> `Some html`

Note: After saving the quotes and three-dots will be sanitized out.

Created posts with the following titles:

- `Quote " quote` --> `Quote " quote`
- `Other &#34; quote` --> `Quote " quote`
    - **note** this is not being shown consistently in the system.
        - The post overview shows the `"` version
        - The block editor shows the `&#34;` version
        - The Site Editor shows the `"` version in the menu, but the `&#34;` version in the page
        - The theme shows the `"` version
- `Three &#8230; dots` --> `Three ... dots`
    - **note** this is being shown as '...' everywhere, thus having different behaviour in relation to the `&#34;` example above!

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
