### PR TITLE
Block Library: Fix Post Title warnings for RichText in inline containers

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -82,5 +82,6 @@
 				}
 			}
 		}
-	}
+	},
+	"style": "wp-block-post-title"
 }

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -1,0 +1,3 @@
+.wp-block-post-title > a {
+	display: inline-block;
+}

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -1,3 +1,3 @@
-.wp-block-post-title > a {
+.wp-block-post-title a {
 	display: inline-block;
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -28,6 +28,7 @@
 @import "./post-author/style.scss";
 @import "./post-comments-form/style.scss";
 @import "./post-excerpt/style.scss";
+@import "./post-title/style.scss";
 @import "./preformatted/style.scss";
 @import "./pullquote/style.scss";
 @import "./query-loop/style.scss";


### PR DESCRIPTION
This PR fixes some warnings related to `RichText` cannot be used with an inline container.

Reference: https://developer.wordpress.org/block-editor/reference-guides/richtext/#placeholder-content-separates-from-the-input