### PR TITLE
Fix useForceUpdate Memory Leak: Only setState if the component is still mounted

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/fill.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/fill.js
@@ -10,7 +10,19 @@ import useSlot from './use-slot';
 
 function useForceUpdate() {
 	const [ , setState ] = useState( {} );
-	return () => setState( {} );
+	const mounted = useRef( true );
+
+	useEffect( () => {
+		return () => {
+			mounted.current = false;
+		};
+	}, [] );
+
+	return () => {
+		if ( mounted.current ) {
+			setState( {} );
+		}
+	};
 }
 
 export default function Fill( { name, children } ) {


### PR DESCRIPTION
## Description
Whilst working with Slot Fills, I found that when removing a component that renders a Slot Fill, a memory leak error is logged to the console:

![Screenshot 2021-04-09 at 14 51 41](https://user-images.githubusercontent.com/90977/114190444-38383b80-9943-11eb-9577-28b0bd2cb903.png)

Tracing it back, it seems to be occurring because [`useForceUpdate` returns a `setState` method which can still be called after the component consuming it is unmounted](https://github.com/WordPress/gutenberg/blob/3da717b8d0ac7d7821fc6d0475695ccf3ae2829f/packages/components/src/slot-fill/bubbles-virtually/fill.js#L11-L14). This can be fixed by checking if `useForceUpdate` is unmounted before calling `setState`.

https://github.com/WordPress/gutenberg/blob/3da717b8d0ac7d7821fc6d0475695ccf3ae2829f/packages/components/src/slot-fill/bubbles-virtually/fill.js#L11-L14

This only occurs if using Slot Fills with `bubblesVirtually` enabled.

This issue might be related to this note from @diegohaz https://github.com/WordPress/gutenberg/issues/17355#issuecomment-629934483, however, in my testing, it only occurred with `bubblesVirtually` on, not off.

## How has this been tested?
I tested this by applying the fix directly to the node_modules in WooCommerce Gutenberg Products Block plugin, where Slot Fills are imported. After applying the patch I could no longer reproduce the memory leak issue.

Note it can only be tested if:
- `bubblesVirtually` is on
- The Slot has fills (empty slots do not break)

It was logged here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4047

## Types of changes
This is a bug fix within the `components` package, for Slot Fills.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
