### PR TITLE
docgen: Add support for object-destructuring

### DIFF
--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Add support for array and object destructured arguments in TypeScript documentation generation.
+
 ## 1.16.0 (2021-03-17)
 
 - Replace deprecated `doctrine` parser with simpler `comment-parser` to support a wider variety of types. This also de-normalizes types such that types will be transcribed exactly as they are declared in the doc comments.

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -456,13 +456,9 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 			return `( ${ getTypeAnnotation( paramType ) } )[ ${ position } ]`;
 		} else if ( babelTypes.isObjectPattern( paramToken ) ) {
 			const memberName = tag.name.split( '.' ).slice( -1 )[ 0 ];
-			if (
-				babelTypes.isTSTypeLiteral(
-					paramToken.typeAnnotation.typeAnnotation
-				)
-			) {
+			if ( babelTypes.isTSTypeLiteral( paramType ) ) {
 				// if it's a type literal we can try to find the member on the type
-				const member = paramToken.typeAnnotation.typeAnnotation.members.find(
+				const member = paramType.members.find(
 					( m ) => m.key.name === memberName
 				);
 				if ( member !== undefined ) {
@@ -472,9 +468,7 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 				}
 			}
 			// If we couldn't find a specific member for the type then we'll just return something like `Type[ memberName ]` to indicate the parameter is a member of that type
-			const typeAnnotation = getTypeAnnotation(
-				paramToken.typeAnnotation.typeAnnotation
-			);
+			const typeAnnotation = getTypeAnnotation( paramType );
 			return `${ typeAnnotation }[ '${ memberName }' ]`;
 		}
 	} catch ( e ) {

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -423,13 +423,16 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 		);
 	}
 
+	const isQualifiedName = tag.name.includes( '.' );
+
 	try {
 		const paramType = paramToken.typeAnnotation.typeAnnotation;
 		if (
 			babelTypes.isIdentifier( paramToken ) ||
 			babelTypes.isRestElement( paramToken ) ||
-			( babelTypes.isArrayPattern( paramToken ) &&
-				! tag.name.includes( '.' ) )
+			( ( babelTypes.isArrayPattern( paramToken ) ||
+				babelTypes.isObjectPattern( paramToken ) ) &&
+				! isQualifiedName )
 		) {
 			return getTypeAnnotation( paramType );
 		} else if ( babelTypes.isArrayPattern( paramToken ) ) {
@@ -451,6 +454,28 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 			}
 			// anything else, `Alias[ position ]`
 			return `( ${ getTypeAnnotation( paramType ) } )[ ${ position } ]`;
+		} else if ( babelTypes.isObjectPattern( paramToken ) ) {
+			const memberName = tag.name.split( '.' ).slice( -1 )[ 0 ];
+			if (
+				babelTypes.isTSTypeLiteral(
+					paramToken.typeAnnotation.typeAnnotation
+				)
+			) {
+				// if it's a type literal we can try to find the member on the type
+				const member = paramToken.typeAnnotation.typeAnnotation.members.find(
+					( m ) => m.key.name === memberName
+				);
+				if ( member !== undefined ) {
+					return getTypeAnnotation(
+						member.typeAnnotation.typeAnnotation
+					);
+				}
+			}
+			// If we couldn't find a specific member for the type then we'll just return something like `Type[ memberName ]` to indicate the parameter is a member of that type
+			const typeAnnotation = getTypeAnnotation(
+				paramToken.typeAnnotation.typeAnnotation
+			);
+			return `${ typeAnnotation }[ '${ memberName }' ]`;
 		}
 	} catch ( e ) {
 		throw new Error(

--- a/packages/docgen/test/fixtures/type-annotations/object-destructuring-object-literal-type/example.ts
+++ b/packages/docgen/test/fixtures/type-annotations/object-destructuring-object-literal-type/example.ts
@@ -1,0 +1,3 @@
+function fn( { foo, ...rest }: { foo: string } ): string {
+	return foo;
+}

--- a/packages/docgen/test/fixtures/type-annotations/object-destructuring-object-literal-type/get-node.js
+++ b/packages/docgen/test/fixtures/type-annotations/object-destructuring-object-literal-type/get-node.js
@@ -1,0 +1,315 @@
+module.exports = () => ( {
+	type: 'FunctionDeclaration',
+	start: 0,
+	end: 73,
+	loc: {
+		start: {
+			line: 1,
+			column: 0,
+		},
+		end: {
+			line: 3,
+			column: 1,
+		},
+	},
+	id: {
+		type: 'Identifier',
+		start: 9,
+		end: 11,
+		loc: {
+			start: {
+				line: 1,
+				column: 9,
+			},
+			end: {
+				line: 1,
+				column: 11,
+			},
+			identifierName: 'fn',
+		},
+		name: 'fn',
+	},
+	generator: false,
+	async: false,
+	params: [
+		{
+			type: 'ObjectPattern',
+			start: 13,
+			end: 46,
+			loc: {
+				start: {
+					line: 1,
+					column: 13,
+				},
+				end: {
+					line: 1,
+					column: 46,
+				},
+			},
+			properties: [
+				{
+					type: 'ObjectProperty',
+					start: 15,
+					end: 18,
+					loc: {
+						start: {
+							line: 1,
+							column: 15,
+						},
+						end: {
+							line: 1,
+							column: 18,
+						},
+					},
+					extra: {
+						shorthand: true,
+					},
+					method: false,
+					key: {
+						type: 'Identifier',
+						start: 15,
+						end: 18,
+						loc: {
+							start: {
+								line: 1,
+								column: 15,
+							},
+							end: {
+								line: 1,
+								column: 18,
+							},
+							identifierName: 'foo',
+						},
+						name: 'foo',
+					},
+					computed: false,
+					shorthand: true,
+					value: {
+						type: 'Identifier',
+						start: 15,
+						end: 18,
+						loc: {
+							start: {
+								line: 1,
+								column: 15,
+							},
+							end: {
+								line: 1,
+								column: 18,
+							},
+							identifierName: 'foo',
+						},
+						name: 'foo',
+					},
+				},
+				{
+					type: 'RestElement',
+					start: 20,
+					end: 27,
+					loc: {
+						start: {
+							line: 1,
+							column: 20,
+						},
+						end: {
+							line: 1,
+							column: 27,
+						},
+					},
+					argument: {
+						type: 'Identifier',
+						start: 23,
+						end: 27,
+						loc: {
+							start: {
+								line: 1,
+								column: 23,
+							},
+							end: {
+								line: 1,
+								column: 27,
+							},
+							identifierName: 'rest',
+						},
+						name: 'rest',
+					},
+				},
+			],
+			typeAnnotation: {
+				type: 'TSTypeAnnotation',
+				start: 29,
+				end: 46,
+				loc: {
+					start: {
+						line: 1,
+						column: 29,
+					},
+					end: {
+						line: 1,
+						column: 46,
+					},
+				},
+				typeAnnotation: {
+					type: 'TSTypeLiteral',
+					start: 31,
+					end: 46,
+					loc: {
+						start: {
+							line: 1,
+							column: 31,
+						},
+						end: {
+							line: 1,
+							column: 46,
+						},
+					},
+					members: [
+						{
+							type: 'TSPropertySignature',
+							start: 33,
+							end: 44,
+							loc: {
+								start: {
+									line: 1,
+									column: 33,
+								},
+								end: {
+									line: 1,
+									column: 44,
+								},
+							},
+							key: {
+								type: 'Identifier',
+								start: 33,
+								end: 36,
+								loc: {
+									start: {
+										line: 1,
+										column: 33,
+									},
+									end: {
+										line: 1,
+										column: 36,
+									},
+									identifierName: 'foo',
+								},
+								name: 'foo',
+							},
+							computed: false,
+							typeAnnotation: {
+								type: 'TSTypeAnnotation',
+								start: 36,
+								end: 44,
+								loc: {
+									start: {
+										line: 1,
+										column: 36,
+									},
+									end: {
+										line: 1,
+										column: 44,
+									},
+								},
+								typeAnnotation: {
+									type: 'TSStringKeyword',
+									start: 38,
+									end: 44,
+									loc: {
+										start: {
+											line: 1,
+											column: 38,
+										},
+										end: {
+											line: 1,
+											column: 44,
+										},
+									},
+								},
+							},
+						},
+					],
+				},
+			},
+		},
+	],
+	returnType: {
+		type: 'TSTypeAnnotation',
+		start: 48,
+		end: 56,
+		loc: {
+			start: {
+				line: 1,
+				column: 48,
+			},
+			end: {
+				line: 1,
+				column: 56,
+			},
+		},
+		typeAnnotation: {
+			type: 'TSStringKeyword',
+			start: 50,
+			end: 56,
+			loc: {
+				start: {
+					line: 1,
+					column: 50,
+				},
+				end: {
+					line: 1,
+					column: 56,
+				},
+			},
+		},
+	},
+	body: {
+		type: 'BlockStatement',
+		start: 57,
+		end: 73,
+		loc: {
+			start: {
+				line: 1,
+				column: 57,
+			},
+			end: {
+				line: 3,
+				column: 1,
+			},
+		},
+		body: [
+			{
+				type: 'ReturnStatement',
+				start: 60,
+				end: 71,
+				loc: {
+					start: {
+						line: 2,
+						column: 1,
+					},
+					end: {
+						line: 2,
+						column: 12,
+					},
+				},
+				argument: {
+					type: 'Identifier',
+					start: 67,
+					end: 70,
+					loc: {
+						start: {
+							line: 2,
+							column: 8,
+						},
+						end: {
+							line: 2,
+							column: 11,
+						},
+						identifierName: 'foo',
+					},
+					name: 'foo',
+				},
+			},
+		],
+		directives: [],
+	},
+} );

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -15,6 +15,7 @@ const getArrowFunctionNode = require( './fixtures/type-annotations/arrow-functio
 const getArrayDestructuringArrayTypeNode = require( './fixtures/type-annotations/array-destructuring-array-type/get-node' );
 const getArrayDestructuringTupleTypeNode = require( './fixtures/type-annotations/array-destructuring-tuple-type/get-node' );
 const getArrayDestructuringAnyOtherTypeNode = require( './fixtures/type-annotations/array-destructuring-any-other-type/get-node' );
+const getObjectDestructuringTypeLiteralNode = require( './fixtures/type-annotations/object-destructuring-object-literal-type/get-node' );
 
 describe( 'Type annotations', () => {
 	it( 'are taken from JSDoc if any', () => {
@@ -261,6 +262,38 @@ describe( 'Type annotations', () => {
 			expect(
 				getTypeAnnotation( { ...paramTag, name: 'callback' }, node, 0 )
 			).toBe( '( foo: string, ...rest: any[] ) => GenericType< T >' );
+		} );
+	} );
+
+	describe( 'function argument object destructuring', () => {
+		describe( 'type literal', () => {
+			const node = getObjectDestructuringTypeLiteralNode();
+
+			it( 'should get the full type for the param', () => {
+				expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe(
+					'{ foo: string; }'
+				);
+			} );
+
+			it( 'should get the member type for the param', () => {
+				expect(
+					getTypeAnnotation(
+						{ ...paramTag, name: 'props.foo' },
+						node,
+						0
+					)
+				).toBe( 'string' );
+			} );
+
+			it( 'should get the member type for an unfindable member', () => {
+				expect(
+					getTypeAnnotation(
+						{ ...paramTag, name: 'props.notFoo' },
+						node,
+						0
+					)
+				).toBe( "{ foo: string; }[ 'notFoo' ]" );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds support for object destructured arguments. Fixes part of #29944 

## How has this been tested?
docgen output remains the same, unit tests added and existing tests pass

## Types of changes
Bug fix/new feature (which is it?)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
