### PR TITLE
RNMobile: Truncate rangecell screenreader decimals

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -160,7 +160,7 @@ class BottomSheetRangeCell extends Component {
 				__( '%1$s. %2$s is %3$s %4$s.' ),
 				cellProps.label,
 				settingLabel,
-				value,
+				toFixed( value, decimalNum ),
 				unitLabel
 			);
 		};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Screenreaders (VoiceOver and TalkBack) were reading values of range-cells with too much precision. For example, a Column block with three columns would read widths as 33.33333333 when it should be read as 33.3.
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3358
Related: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3360

## How has this been tested?

### iOS
1. Run the packager, `npm run native start:reset`
2. Run the Gutenberg demo project from Xcode (running via `npm run native ios` opens an iOS 13 simulator which doesn't work well for me with the built-in Accessibility Inspector macOS app)
3. Add a Columns block with a 50/50 width distribution
4. Open the Accessibility Inspector app and choose the running simulator in the top-left dropdown
5. Tap the small target-like icon in Accessibility Inspector to get VoiceOver readings as you mouse over elements in the simulator
6. Mouse over Column 1 and Column 2 in the simulator, expect to see "Column 1. Width is 50 percent." in Accessibility Inspector
7. Add another column for a 33/33/33 distribution
8. Mouse over again and expect "Column 1. Width is 33.3 percent.", etc

### Android
1. Run the packager, `npm run native start:reset`
2. With an Android device connected, run `npm run native android` to run the demo app on the device
3. Add a Columns block with a 50/50 width distribution
4. Enable TalkBack
5. Open the Columns block settings
6. Tap the Column 1 area of the bottom sheet and expect to hear "Column 1. Width is 50 percent."
7. Add another column for a 33/33/33 distribution (you might run into https://github.com/wordpress-mobile/gutenberg-mobile/issues/3357 when doing this)
8. Tap the column area again and expect to hear "Column 1. Width is 33.3 percent."



## Screenshots <!-- if applicable -->

<img width="768" alt="Screen Shot 2021-04-09 at 11 46 06" src="https://user-images.githubusercontent.com/1898325/114206737-a2dc7d80-9929-11eb-8c2d-6b6fc56db401.png">


## Types of changes
Bug fix.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
