### PR TITLE
docgen: Add support for assignment patterns

### DIFF
--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -401,6 +401,45 @@ function getFunctionNameForError( declarationToken ) {
 	return namedFunctionToken.id.name;
 }
 
+function getArrayTagNamePosition( tag ) {
+	return parseInt( tag.name.split( '.' ).slice( -1 )[ 0 ], 0 );
+}
+
+function getQualifiedArrayPatternTypeAnnotation( tag, paramType ) {
+	if ( babelTypes.isTSArrayType( paramType ) ) {
+		if ( babelTypes.isTSTypeReference( paramType.elementType ) ) {
+			// just get the element type for the array
+			return paramType.elementType.typeName.name;
+		}
+		return getTypeAnnotation( paramType.elementType.typeAnnotation );
+	} else if ( babelTypes.isTSTupleType( paramType ) ) {
+		return getTypeAnnotation(
+			paramType.elementTypes[ getArrayTagNamePosition( tag ) ]
+		);
+	}
+
+	// anything else, `Alias[ position ]`
+	return `( ${ getTypeAnnotation( paramType ) } )[ ${ getArrayTagNamePosition(
+		tag
+	) } ]`;
+}
+
+function getQualifiedObjectPatternTypeAnnotation( tag, paramType ) {
+	const memberName = tag.name.split( '.' ).slice( -1 )[ 0 ];
+	if ( babelTypes.isTSTypeLiteral( paramType ) ) {
+		// if it's a type literal we can try to find the member on the type
+		const member = paramType.members.find(
+			( m ) => m.key.name === memberName
+		);
+		if ( member !== undefined ) {
+			return getTypeAnnotation( member.typeAnnotation.typeAnnotation );
+		}
+	}
+	// If we couldn't find a specific member for the type then we'll just return something like `Type[ memberName ]` to indicate the parameter is a member of that type
+	const typeAnnotation = getTypeAnnotation( paramType );
+	return `${ typeAnnotation }[ '${ memberName }' ]`;
+}
+
 /**
  * @param {CommentTag} tag The documented parameter.
  * @param {ASTNode} declarationToken The function the parameter is documented on.
@@ -411,7 +450,7 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 	const functionToken = getFunctionToken( declarationToken );
 
 	// otherwise find the corresponding parameter token for the documented parameter
-	const paramToken = functionToken.params[ paramIndex ];
+	let paramToken = functionToken.params[ paramIndex ];
 
 	// This shouldn't happen due to our ESLint enforcing correctly documented parameter names but just in case
 	// we'll give a descriptive error so that it's easy to diagnose the issue.
@@ -426,7 +465,12 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 	const isQualifiedName = tag.name.includes( '.' );
 
 	try {
+		if ( babelTypes.isAssignmentPattern( paramToken ) ) {
+			paramToken = paramToken.left;
+		}
+
 		const paramType = paramToken.typeAnnotation.typeAnnotation;
+
 		if (
 			babelTypes.isIdentifier( paramToken ) ||
 			babelTypes.isRestElement( paramToken ) ||
@@ -436,40 +480,9 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 		) {
 			return getTypeAnnotation( paramType );
 		} else if ( babelTypes.isArrayPattern( paramToken ) ) {
-			// qualified name i.e., an element of the array being destructured
-			const position = parseInt(
-				tag.name.split( '.' ).slice( -1 )[ 0 ],
-				0
-			);
-			if ( babelTypes.isTSArrayType( paramType ) ) {
-				if ( babelTypes.isTSTypeReference( paramType.elementType ) ) {
-					// just get the element type for the array
-					return paramType.elementType.typeName.name;
-				}
-				return getTypeAnnotation(
-					paramType.elementType.typeAnnotation
-				);
-			} else if ( babelTypes.isTSTupleType( paramType ) ) {
-				return getTypeAnnotation( paramType.elementTypes[ position ] );
-			}
-			// anything else, `Alias[ position ]`
-			return `( ${ getTypeAnnotation( paramType ) } )[ ${ position } ]`;
+			return getQualifiedArrayPatternTypeAnnotation( tag, paramType );
 		} else if ( babelTypes.isObjectPattern( paramToken ) ) {
-			const memberName = tag.name.split( '.' ).slice( -1 )[ 0 ];
-			if ( babelTypes.isTSTypeLiteral( paramType ) ) {
-				// if it's a type literal we can try to find the member on the type
-				const member = paramType.members.find(
-					( m ) => m.key.name === memberName
-				);
-				if ( member !== undefined ) {
-					return getTypeAnnotation(
-						member.typeAnnotation.typeAnnotation
-					);
-				}
-			}
-			// If we couldn't find a specific member for the type then we'll just return something like `Type[ memberName ]` to indicate the parameter is a member of that type
-			const typeAnnotation = getTypeAnnotation( paramType );
-			return `${ typeAnnotation }[ '${ memberName }' ]`;
+			return getQualifiedObjectPatternTypeAnnotation( tag, paramType );
 		}
 	} catch ( e ) {
 		throw new Error(

--- a/packages/docgen/test/fixtures/type-annotations/assignment-pattern/example.ts
+++ b/packages/docgen/test/fixtures/type-annotations/assignment-pattern/example.ts
@@ -1,0 +1,3 @@
+function fn( [ foo ]: string = '' ): string {
+	return foo;
+}

--- a/packages/docgen/test/fixtures/type-annotations/assignment-pattern/get-node.js
+++ b/packages/docgen/test/fixtures/type-annotations/assignment-pattern/get-node.js
@@ -1,0 +1,233 @@
+module.exports = () => ( {
+	type: 'FunctionDeclaration',
+	start: 55,
+	end: 115,
+	loc: {
+		start: {
+			line: 6,
+			column: 0,
+		},
+		end: {
+			line: 8,
+			column: 1,
+		},
+	},
+	leadingComments: [
+		{
+			type: 'CommentBlock',
+			value: '*\n * @param param0\n * @param param0.0\n * @return\n ',
+			start: 0,
+			end: 54,
+			loc: {
+				start: {
+					line: 1,
+					column: 0,
+				},
+				end: {
+					line: 5,
+					column: 3,
+				},
+			},
+		},
+	],
+	id: {
+		type: 'Identifier',
+		start: 64,
+		end: 66,
+		loc: {
+			start: {
+				line: 6,
+				column: 9,
+			},
+			end: {
+				line: 6,
+				column: 11,
+			},
+			identifierName: 'fn',
+		},
+		name: 'fn',
+	},
+	generator: false,
+	async: false,
+	params: [
+		{
+			type: 'AssignmentPattern',
+			start: 68,
+			end: 88,
+			loc: {
+				start: {
+					line: 6,
+					column: 13,
+				},
+				end: {
+					line: 6,
+					column: 33,
+				},
+			},
+			left: {
+				type: 'ArrayPattern',
+				start: 68,
+				end: 83,
+				loc: {
+					start: {
+						line: 6,
+						column: 13,
+					},
+					end: {
+						line: 6,
+						column: 28,
+					},
+				},
+				elements: [
+					{
+						type: 'Identifier',
+						start: 70,
+						end: 73,
+						loc: {
+							start: {
+								line: 6,
+								column: 15,
+							},
+							end: {
+								line: 6,
+								column: 18,
+							},
+							identifierName: 'foo',
+						},
+						name: 'foo',
+					},
+				],
+				typeAnnotation: {
+					type: 'TSTypeAnnotation',
+					start: 75,
+					end: 83,
+					loc: {
+						start: {
+							line: 6,
+							column: 20,
+						},
+						end: {
+							line: 6,
+							column: 28,
+						},
+					},
+					typeAnnotation: {
+						type: 'TSStringKeyword',
+						start: 77,
+						end: 83,
+						loc: {
+							start: {
+								line: 6,
+								column: 22,
+							},
+							end: {
+								line: 6,
+								column: 28,
+							},
+						},
+					},
+				},
+			},
+			right: {
+				type: 'StringLiteral',
+				start: 86,
+				end: 88,
+				loc: {
+					start: {
+						line: 6,
+						column: 31,
+					},
+					end: {
+						line: 6,
+						column: 33,
+					},
+				},
+				extra: {
+					rawValue: '',
+					raw: "''",
+				},
+				value: '',
+			},
+		},
+	],
+	returnType: {
+		type: 'TSTypeAnnotation',
+		start: 90,
+		end: 98,
+		loc: {
+			start: {
+				line: 6,
+				column: 35,
+			},
+			end: {
+				line: 6,
+				column: 43,
+			},
+		},
+		typeAnnotation: {
+			type: 'TSStringKeyword',
+			start: 92,
+			end: 98,
+			loc: {
+				start: {
+					line: 6,
+					column: 37,
+				},
+				end: {
+					line: 6,
+					column: 43,
+				},
+			},
+		},
+	},
+	body: {
+		type: 'BlockStatement',
+		start: 99,
+		end: 115,
+		loc: {
+			start: {
+				line: 6,
+				column: 44,
+			},
+			end: {
+				line: 8,
+				column: 1,
+			},
+		},
+		body: [
+			{
+				type: 'ReturnStatement',
+				start: 102,
+				end: 113,
+				loc: {
+					start: {
+						line: 7,
+						column: 1,
+					},
+					end: {
+						line: 7,
+						column: 12,
+					},
+				},
+				argument: {
+					type: 'Identifier',
+					start: 109,
+					end: 112,
+					loc: {
+						start: {
+							line: 7,
+							column: 8,
+						},
+						end: {
+							line: 7,
+							column: 11,
+						},
+						identifierName: 'foo',
+					},
+					name: 'foo',
+				},
+			},
+		],
+		directives: [],
+	},
+} );

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -16,6 +16,7 @@ const getArrayDestructuringArrayTypeNode = require( './fixtures/type-annotations
 const getArrayDestructuringTupleTypeNode = require( './fixtures/type-annotations/array-destructuring-tuple-type/get-node' );
 const getArrayDestructuringAnyOtherTypeNode = require( './fixtures/type-annotations/array-destructuring-any-other-type/get-node' );
 const getObjectDestructuringTypeLiteralNode = require( './fixtures/type-annotations/object-destructuring-object-literal-type/get-node' );
+const getAssignmentPatternNode = require( './fixtures/type-annotations/assignment-pattern/get-node' );
 
 describe( 'Type annotations', () => {
 	it( 'are taken from JSDoc if any', () => {
@@ -294,6 +295,20 @@ describe( 'Type annotations', () => {
 					)
 				).toBe( "{ foo: string; }[ 'notFoo' ]" );
 			} );
+		} );
+	} );
+
+	describe( 'assignment pattern', () => {
+		const node = getAssignmentPatternNode();
+
+		it( 'should get the type of the assignment pattern', () => {
+			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBe( 'string' );
+		} );
+
+		it( 'should get the type of the assignment pattern for array destructuring', () => {
+			expect(
+				getTypeAnnotation( { ...paramTag, name: 'props.0' }, node, 0 )
+			).toBe( '( string )[ 0 ]' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds support for assignment patterns to docgen's TS parsing. Fixes the last part of #29944 

## How has this been tested?
unit tests added and existing ones pass. No changes to existing docgen output.

## Types of changes
New feature/bug fix (which is it?)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
