### PR TITLE
Page List: sort by menu_order and page title for consistent ordering

### DIFF
--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -85,10 +85,8 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 				{
 					per_page: MAX_PAGE_COUNT,
 					_fields: PAGE_FIELDS,
-					// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby
-					// values is resolved, update 'orderby' to [ 'menu_order', 'post_title' ] to provide a consistent
-					// sort.
-					orderby: 'menu_order',
+					//TODO: orderby menu_order,title when https://core.trac.wordpress.org/ticket/39037 is implemented
+					orderby: 'title',
 					order: 'asc',
 				},
 			];

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -238,14 +238,12 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	static $block_id = 0;
 	$block_id++;
 
-	// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby values is resolved,
-	// update 'sort_column' to 'menu_order, post_title'. Sorting by both menu_order and post_title ensures a stable sort.
-	// Otherwise with pages that have the same menu_order value, we can see different ordering depending on how DB
-	// queries are constructed internally. For example we might see a different order when a limit is set to <499
-	// versus >= 500.
+	// Sorting by both menu_order and post_title ensures a stable sort. Otherwise with pages that have the same
+	// menu_order value, we can see different ordering depending on how DB queries are constructed internally.
+	// For example we might see a different order when a limit is set to <499 versus >= 500.
 	$all_pages = get_pages(
 		array(
-			'sort_column' => 'menu_order',
+			'sort_column' => 'menu_order, post_title',
 			'order'       => 'asc',
 		)
 	);


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/30390 . Fixes https://github.com/WordPress/gutenberg/issues/31382 ~~and pairs with https://github.com/WordPress/wordpress-develop/pull/1186~~

https://user-images.githubusercontent.com/1270189/116753901-b7f27c80-a9bc-11eb-81b2-904142aa0cae.mp4

Many pages have a `menu_order` of 0. We should not expect a stable sort order from `WP_Query` or `get_pages`, when comparing two items of equal sort value. (Though this may change if WP_Query is updated https://core.trac.wordpress.org/ticket/47642#comment:13 )

 Proposed changes in the PR add a secondary sort of 'title' the PageList `render_callback`. Since we can't sort by multiple columns for the REST API (see https://core.trac.wordpress.org/ticket/39037) this also updates the PageList->NavigationLinks transform to use title sorting for now.

### Testing Instructions

- Try adding a few pages with menu order set to something other than zero)
- Insert a PageList inside of a navigation block
- Insert a PageList outside of a navigation block
- Make sure the sort makes sense
- With the example inside of a navigation block, try converting to navigation links by clicking "edit"
- Verify that the sort is not 💯 the same, but instead uses title sorting.

