### PR TITLE
PHP Unit Tests: Set theme to TT1 Blocks

### DIFF
--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -75,6 +75,8 @@ $GLOBALS['wp_tests_options'] = array(
 		'gutenberg-widget-experiments' => '1',
 		'gutenberg-full-site-editing'  => 1,
 	),
+	'stylesheet' => 'tt1-blocks',
+	'template'   => 'tt1-blocks'
 );
 
 // Enable the widget block editor.


### PR DESCRIPTION
## Description
Fixes #30478. Alternative (or maybe complementary) to #30479.

As explained in #30478, we're caching the return value of `WP_Theme_JSON_Resolver::theme_has_support()`.
This seems to work fine in a "normal" WordPress environment; however, it seems to pose a problem for unit tests: `WP_Theme_JSON_Resolver::theme_has_support()` is first called while the current theme [is still set to the default theme](https://github.com/wp-phpunit/wp-phpunit/blob/fefaaf8d086c0401d887661e21dc9e9afdfc0411/includes/bootstrap.php#L138-L145) -- which of course _doesn't_ have an `experimental-theme.json` file -- so we're erroneously caching `false` as return value for `WP_Theme_JSON_Resolver::theme_has_support()`.

Even if an individual unit test later sets the current theme to one that has an `experimental-theme.json`, `WP_Theme_JSON_Resolver::theme_has_support()` will continue to return the cached `false` value.

The fix is to set `$GLOBALS['wp_tests_options']` values for `stylesheet` and `template`, which are [evaluated](https://github.com/wp-phpunit/wp-phpunit/blob/fefaaf8d086c0401d887661e21dc9e9afdfc0411/includes/bootstrap.php#L177-L188) by `wp-phunit`'s bootstrap to set a few options before loading WordPress.

## How has this been tested?
See #30478 for instructions on how to repro the issue on `trunk`.

Then, check out this branch, and apply the patch on top of it.

<details>
<summary>Patch</summary>

```diff
diff --git a/lib/class-wp-theme-json-resolver.php b/lib/class-wp-theme-json-resolver.php
index 31ecb553a2..8b2248a0cb 100644
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -460,10 +460,12 @@ class WP_Theme_JSON_Resolver {
         * @return boolean
         */
        public static function theme_has_support() {
+               debug_print_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 2 );
+               echo get_stylesheet_directory() . "\n";
                if ( ! isset( self::$theme_has_support ) ) {
                        self::$theme_has_support = (bool) self::get_file_path_from_theme( 'experimental-theme.json' );
                }
-
+               echo "theme_has_support: " . self::$theme_has_support . "\n";
                return self::$theme_has_support;
        }
 
```
</details>

Then, run 

```
npm run test-unit-php -- /var/www/html/wp-content/plugins/gutenberg/phpunit/class-block-templates-test.php
```

This time, the stylesheet output should correctly be `/var/www/html/wp-content/themes/tt1-blocks` in all cases, and `theme_has_support()` should return `true` every time:

<details>
<summary>Output</summary>

```
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
#0  WP_Theme_JSON_Resolver::theme_has_support() called at [/var/www/html/wp-content/plugins/gutenberg/lib/client-assets.php:364]
#1  gutenberg_register_packages_styles() called at [/var/www/html/wp-includes/class-wp-hook.php:292]
/var/www/html/wp-content/themes/tt1-blocks
theme_has_support: 1
#0  WP_Theme_JSON_Resolver::theme_has_support() called at [/var/www/html/wp-content/plugins/gutenberg/lib/global-styles.php:163]
#1  gutenberg_experimental_global_styles_register_user_cpt() called at [/var/www/html/wp-includes/class-wp-hook.php:292]
/var/www/html/wp-content/themes/tt1-blocks
theme_has_support: 1
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.16
Configuration: /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist

....#0  WP_Theme_JSON_Resolver::theme_has_support() called at [/var/www/html/wp-content/plugins/gutenberg/lib/full-site-editing/block-templates.php:127]
#1  _gutenberg_add_template_part_area_info() called at [/var/www/html/wp-content/plugins/gutenberg/lib/full-site-editing/block-templates.php:60]
/var/www/html/wp-content/themes/tt1-blocks
theme_has_support: 1
..                                                              6 / 6 (100%)#0  WP_Theme_JSON_Resolver::theme_has_support() called at [/var/www/html/wp-content/plugins/gutenberg/lib/full-site-editing/block-templates.php:127]
#1  _gutenberg_add_template_part_area_info() called at [/var/www/html/wp-content/plugins/gutenberg/lib/full-site-editing/block-templates.php:109]
/var/www/html/wp-content/themes/tt1-blocks
theme_has_support: 1
#0  WP_Theme_JSON_Resolver::theme_has_support() called at [/var/www/html/wp-content/plugins/gutenberg/lib/full-site-editing/block-templates.php:127]
#1  _gutenberg_add_template_part_area_info() called at [/var/www/html/wp-content/plugins/gutenberg/lib/full-site-editing/block-templates.php:109]
/var/www/html/wp-content/themes/tt1-blocks
theme_has_support: 1


Time: 1.92 seconds, Memory: 36.50 MB

OK (6 tests, 70 assertions)
```
</details>

---

However, this patch seems to break a few of the other PHP unit tests -- which might need an update to correctly reflect properties of TT1 Blocks?

