### PR TITLE
Stop matching upon mismatch, reset when trigger char or backspace is pressed, take 2

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -20,7 +20,6 @@ import {
 	DOWN,
 	LEFT,
 	RIGHT,
-	BACKSPACE,
 } from '@wordpress/keycodes';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
@@ -301,7 +300,6 @@ function Autocomplete( {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ autocompleter, setAutocompleter ] = useState( null );
 	const [ AutocompleterUI, setAutocompleterUI ] = useState( null );
-	const [ mismatch, setMismatch ] = useState( false );
 
 	function insertCompletion( replacement ) {
 		const end = record.start;
@@ -384,11 +382,10 @@ function Autocomplete( {
 	}
 
 	function handleKeyDown( event ) {
-		if ( ! autocompleter && event.keyCode !== BACKSPACE ) {
+		if ( ! autocompleter ) {
 			return;
 		}
-		if ( filteredOptions.length === 0 && event.keyCode !== BACKSPACE ) {
-			setMismatch( true );
+		if ( filteredOptions.length === 0 ) {
 			return;
 		}
 
@@ -415,9 +412,6 @@ function Autocomplete( {
 			case ENTER:
 				select( filteredOptions[ selectedIndex ] );
 				break;
-			case BACKSPACE:
-				setMismatch( false );
-				return;
 			case LEFT:
 			case RIGHT:
 				reset();
@@ -452,6 +446,7 @@ function Autocomplete( {
 			( { triggerPrefix, allowContext } ) => {
 				// If we don't have any matching filteredOptions from the last render iteration +
 				// we didn't have a new trigger typed, then we should not continue with this effect.
+				const mismatch = filteredOptions.length === 0;
 				if ( mismatch && text.slice( -1 ) !== triggerPrefix ) {
 					return false;
 				}
@@ -495,7 +490,7 @@ function Autocomplete( {
 			.match( new RegExp( `${ safeTrigger }([\u0000-\uFFFF]*)$` ) );
 		const query = match && match[ 1 ];
 
-		// console.log( match ); // uncomment this to make this easier to test
+		//console.log( match ); // uncomment this to make this easier to test
 
 		setAutocompleter( completer );
 		setAutocompleterUI( () =>


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/30649, tries to retrigger autocompletion upon pressing <backspace>. 