### PR TITLE
Blocks: Add codeHandler to complement pasteHandler

### DIFF
--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -30,7 +30,7 @@ function BlockHTML( { clientId } ) {
 	);
 	const { updateBlock } = useDispatch( blockEditorStore );
 	const onChange = () => {
-		const sanitizedHtml = codeHandler( { HTML: html } );
+		const sanitizedHtml = codeHandler( { HTML: html, mode: 'INLINE' } );
 		const blockType = getBlockType( block.name );
 		const attributes = getBlockAttributes(
 			blockType,

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -14,6 +14,7 @@ import {
 	getBlockType,
 	isValidBlockContent,
 	getSaveContent,
+	__unstableCodeHandler as codeHandler,
 } from '@wordpress/blocks';
 
 /**
@@ -29,19 +30,21 @@ function BlockHTML( { clientId } ) {
 	);
 	const { updateBlock } = useDispatch( blockEditorStore );
 	const onChange = () => {
+		const sanitizedHtml = codeHandler( { HTML: html } );
 		const blockType = getBlockType( block.name );
 		const attributes = getBlockAttributes(
 			blockType,
-			html,
+			sanitizedHtml,
 			block.attributes
 		);
 
 		// If html is empty  we reset the block to the default HTML and mark it as valid to avoid triggering an error
-		const content = html ? html : getSaveContent( blockType, attributes );
-		const isValid = html
+		const content = sanitizedHtml
+			? sanitizedHtml
+			: getSaveContent( blockType, attributes );
+		const isValid = sanitizedHtml
 			? isValidBlockContent( blockType, attributes, content )
 			: true;
-
 		updateBlock( clientId, {
 			attributes,
 			originalContent: content,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -46,6 +46,7 @@ export {
 export {
 	pasteHandler,
 	rawHandler,
+	codeHandler as __unstableCodeHandler,
 	deprecatedGetPhrasingContentSchema as getPhrasingContentSchema,
 } from './raw-handling';
 

--- a/packages/blocks/src/api/raw-handling/code-handler.js
+++ b/packages/blocks/src/api/raw-handling/code-handler.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { mapValues } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import onFilter from './on-filter';
+import scriptRemover from './script-remover';
+import { deepFilterHTML } from './utils';
+import { getBlockType, getFreeformContentHandlerName } from '../registration';
+import { parseWithGrammar } from '../parser';
+
+export function codeHandler( { HTML = '' } ) {
+	const freeform = getFreeformContentHandlerName();
+
+	return parseWithGrammar( HTML ).map( ( block ) => {
+		const { name } = block;
+
+		// Let TinyMCE handle it
+		if ( name === freeform ) {
+			return block;
+		}
+
+		const blockType = getBlockType( name );
+		return {
+			...block,
+			attributes: mapValues( block.attributes, ( value, key ) => {
+				const attributeType = blockType.attributes[ key ];
+
+				if ( attributeType.source === 'html' ) {
+					return deepFilterHTML( value, [ scriptRemover, onFilter ] );
+				}
+
+				return value;
+			} ),
+		};
+	} );
+}

--- a/packages/blocks/src/api/raw-handling/code-handler.js
+++ b/packages/blocks/src/api/raw-handling/code-handler.js
@@ -16,7 +16,11 @@ import {
 } from '../registration';
 import { parseWithGrammar } from '../parser';
 
-export function codeHandler( { HTML = '' } ) {
+export function codeHandler( { HTML = '', mode = 'BLOCKS' } ) {
+	if ( mode === 'INLINE' ) {
+		return deepFilterHTML( HTML, [ scriptRemover, onFilter ] );
+	}
+
 	const freeformName = getFreeformContentHandlerName();
 	const unregisteredName = getUnregisteredTypeHandlerName();
 

--- a/packages/blocks/src/api/raw-handling/code-handler.js
+++ b/packages/blocks/src/api/raw-handling/code-handler.js
@@ -9,17 +9,22 @@ import { mapValues } from 'lodash';
 import onFilter from './on-filter';
 import scriptRemover from './script-remover';
 import { deepFilterHTML } from './utils';
-import { getBlockType, getFreeformContentHandlerName } from '../registration';
+import {
+	getBlockType,
+	getFreeformContentHandlerName,
+	getUnregisteredTypeHandlerName,
+} from '../registration';
 import { parseWithGrammar } from '../parser';
 
 export function codeHandler( { HTML = '' } ) {
-	const freeform = getFreeformContentHandlerName();
+	const freeformName = getFreeformContentHandlerName();
+	const unregisteredName = getUnregisteredTypeHandlerName();
 
 	return parseWithGrammar( HTML ).map( ( block ) => {
 		const { name } = block;
 
 		// Let TinyMCE handle it
-		if ( name === freeform ) {
+		if ( name === freeformName ) {
 			return block;
 		}
 
@@ -29,7 +34,10 @@ export function codeHandler( { HTML = '' } ) {
 			attributes: mapValues( block.attributes, ( value, key ) => {
 				const attributeType = blockType.attributes[ key ];
 
-				if ( attributeType.source === 'html' ) {
+				if (
+					attributeType.source === 'html' ||
+					name === unregisteredName
+				) {
 					return deepFilterHTML( value, [ scriptRemover, onFilter ] );
 				}
 

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -13,7 +13,6 @@ import { getPhrasingContentSchema } from '@wordpress/dom';
  * Internal dependencies
  */
 import { htmlToBlocks } from './html-to-blocks';
-import { parseWithGrammar } from '../parser';
 import normaliseBlocks from './normalise-blocks';
 import specialCommentConverter from './special-comment-converter';
 import listReducer from './list-reducer';
@@ -21,8 +20,10 @@ import blockquoteNormaliser from './blockquote-normaliser';
 import figureContentReducer from './figure-content-reducer';
 import shortcodeConverter from './shortcode-converter';
 import { deepFilterHTML, getBlockContentSchema } from './utils';
+import { codeHandler } from './code-handler';
 
 export { pasteHandler } from './paste-handler';
+export { codeHandler } from './code-handler';
 
 export function deprecatedGetPhrasingContentSchema( context ) {
 	deprecated( 'wp.blocks.getPhrasingContentSchema', {
@@ -43,7 +44,7 @@ export function deprecatedGetPhrasingContentSchema( context ) {
 export function rawHandler( { HTML = '' } ) {
 	// If we detect block delimiters, parse entirely as blocks.
 	if ( HTML.indexOf( '<!-- wp:' ) !== -1 ) {
-		return parseWithGrammar( HTML );
+		return codeHandler( { HTML } );
 	}
 
 	// An array of HTML strings and block objects. The blocks replace matched

--- a/packages/blocks/src/api/raw-handling/on-filter.js
+++ b/packages/blocks/src/api/raw-handling/on-filter.js
@@ -1,0 +1,10 @@
+export default function onFilter( node ) {
+	if ( ! node.getAttributeNames ) {
+		return;
+	}
+	for ( const attributeName of node.getAttributeNames() ) {
+		if ( attributeName.indexOf( 'on' ) === 0 ) {
+			node.removeAttribute( attributeName );
+		}
+	}
+}

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -11,10 +11,10 @@ import { getPhrasingContentSchema, removeInvalidHTML } from '@wordpress/dom';
 /**
  * Internal dependencies
  */
+import { codeHandler } from './code-handler';
 import { htmlToBlocks } from './html-to-blocks';
 import { hasBlockSupport } from '../registration';
 import { getBlockInnerHTML } from '../serializer';
-import { parseWithGrammar } from '../parser';
 import normaliseBlocks from './normalise-blocks';
 import specialCommentConverter from './special-comment-converter';
 import commentRemover from './comment-remover';
@@ -108,7 +108,7 @@ export function pasteHandler( {
 		const content = HTML ? HTML : plainText;
 
 		if ( content.indexOf( '<!-- wp:' ) !== -1 ) {
-			return parseWithGrammar( content );
+			return codeHandler( { HTML: content } );
 		}
 	}
 

--- a/packages/blocks/src/api/raw-handling/script-remover.js
+++ b/packages/blocks/src/api/raw-handling/script-remover.js
@@ -1,0 +1,7 @@
+export default function scriptRemover( node ) {
+	if ( node.nodeName !== 'SCRIPT' ) {
+		return;
+	}
+
+	node.parentNode.removeChild( node );
+}

--- a/packages/e2e-tests/specs/editor/various/invalid-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/invalid-block.test.js
@@ -46,8 +46,9 @@ describe( 'invalid blocks', () => {
 			'.block-editor-block-compare__html',
 			( node ) => node.textContent
 		);
+		// The parser will have closed the P tag for us
 		expect( htmlBlockContent ).toEqual(
-			'<p>hello</p><p>invalid paragraph'
+			'<p>hello</p><p>invalid paragraph</p>'
 		);
 	} );
 } );

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -8,7 +8,7 @@ import Textarea from 'react-autosize-textarea';
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { parse } from '@wordpress/blocks';
+import { __unstableCodeHandler as codeHandler } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
@@ -54,7 +54,7 @@ export default function PostTextEditor() {
 	 */
 	const stopEditing = () => {
 		if ( isDirty ) {
-			const blocks = parse( value );
+			const blocks = codeHandler( { HTML: value } );
 			resetEditorBlocks( blocks );
 			setIsDirty( false );
 		}


### PR DESCRIPTION
Alternative to #29157.

## Description
Pasting text sometimes breaks related CSS, this refactor fixes that.

## Test plan
* Create a new HTML block
* Paste `<p>This is a <em>test</em></p>` in the editor
* Confirm there were no errors and that visually everything looks correctly

## Types of changes
Bug fix (non-breaking change which fixes an issue)