### PR TITLE
wp-env: Fix issue with unquoted paths in docker-compose call

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `wp-env destroy` will now work in environments which don't include the `grep` or `awk` commands, such as Windows PowerShell.
 -   Fix several permissions issues related to wp-config.php and wp-content files.
+-   Fix crash which happened when the path to wp-env's home directory contained a space.
 
 ## 4.0.0 (2021-03-17)
 

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -175,7 +175,7 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 	const siteUrl = config.env.development.config.WP_SITEURL;
 	const e2eSiteUrl = config.env.tests.config.WP_TESTS_DOMAIN;
 	const mySQLAddress = await exec(
-		`docker-compose -f ${ dockerComposeConfigPath } port mysql 3306`
+		`docker-compose -f "${ dockerComposeConfigPath }" port mysql 3306`
 	);
 	const mySQLPort = mySQLAddress.stdout.split( ':' ).pop();
 

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -174,10 +174,12 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 
 	const siteUrl = config.env.development.config.WP_SITEURL;
 	const e2eSiteUrl = config.env.tests.config.WP_TESTS_DOMAIN;
-	const mySQLAddress = await exec(
-		`docker-compose -f "${ dockerComposeConfigPath }" port mysql 3306`
+	const { out: mySQLAddress } = await dockerCompose.port(
+		'mysql',
+		3306,
+		dockerComposeConfig
 	);
-	const mySQLPort = mySQLAddress.stdout.split( ':' ).pop();
+	const mySQLPort = mySQLAddress.split( ':' ).pop();
 
 	spinner.prefixText = 'WordPress development site started'
 		.concat( siteUrl ? ` at ${ siteUrl }` : '.' )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves #28680. We were calling docker-compose without quoting the path to the config, which meant that paths with spaces crashed the program.

## How has this been tested?
Locally on windows. (Theoretically this would also be a problem on other OSes as well)

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
