### PR TITLE
docs: update import statement of ImageSizeControl component

### DIFF
--- a/packages/block-editor/src/components/image-size-control/README.md
+++ b/packages/block-editor/src/components/image-size-control/README.md
@@ -7,7 +7,7 @@ Allow users to control the width & height of an image.
 Render a ImageSizeControl.
 
 ```jsx
-import { ImageSizeControl } from '@wordpress/components';
+import { __experimentalImageSizeControl as ImageSizeControl } from '@wordpress/block-editor';
 import { withState } from '@wordpress/compose';
 
 const MyImageSizeControl = withState( {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

- Change import statement of ImageSizeControl in the example

ImageSizeControl does not live in `@wordpress/components` but in `@wordpress/block-editor`. The `__experimental` prefix is also needed.
See https://github.com/WordPress/gutenberg/pull/17148#issuecomment-569528836

## How has this been tested?
- By checking the components that use it. Like "Latest Posts", see: https://github.com/WordPress/gutenberg/blob/3da717b8d0ac7d7821fc6d0475695ccf3ae2829f/packages/block-library/src/latest-posts/edit.js
- In a custom block. The previous import failed while changing to `@wordpress/block-editor` it works.

## Types of changes
Docs
