### PR TITLE
Script for commenting logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
 		"worker-farm": "1.7.0"
 	},
 	"scripts": {
+		"comment-on-logs": "node remove-logs.js",
 		"analyze-bundles": "npm run build -- --webpack-bundle-analyzer",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"clean:package-types": "tsc --build --clean",

--- a/remove-logs.js
+++ b/remove-logs.js
@@ -30,6 +30,13 @@ const logConfig = [
 				nonCommented: /\t\t", version " \+ jQuery.migrateVersion \);\n/g,
 				commented: '\t\t", version " + jQuery.migrateVersion );*/\n',
 			},
+				nonCommented: /\t\t\tconsole.warn\( "JQMIGRATE: " \+ msg \);\n/g,
+				commented: '\t\t\t/*console.warn( "JQMIGRATE: " + msg );\n',
+			},
+			{
+				nonCommented: /\t\t\t\tconsole.trace\(\);\n\t\t\t}/g,
+				commented: '\t\t\t\tconsole.trace();\t\t\t}*/\n',
+			},
 		],
 	},
 ];

--- a/remove-logs.js
+++ b/remove-logs.js
@@ -30,6 +30,7 @@ const logConfig = [
 				nonCommented: /\t\t", version " \+ jQuery.migrateVersion \);\n/g,
 				commented: '\t\t", version " + jQuery.migrateVersion );*/\n',
 			},
+			{
 				nonCommented: /\t\t\tconsole.warn\( "JQMIGRATE: " \+ msg \);\n/g,
 				commented: '\t\t\t/*console.warn( "JQMIGRATE: " + msg );\n',
 			},

--- a/remove-logs.js
+++ b/remove-logs.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+
+const fs = require( 'fs' );
+
+const logConfig = [
+	{
+		path: 'packages/blocks/src/api/parser.js',
+		commentLogs: [
+			{
+				nonCommented: /\t\tconsole.info\(/g,
+				commented: '\t\t/*console.info(',
+			},
+			{
+				nonCommented: /block.originalContent\n\t\t\t\);\n/g,
+				commented: 'block.originalContent\n\t\t\t);*/\n',
+			},
+		],
+	},
+	{
+		path: '../../../wp-includes/js/jquery/jquery-migrate.js',
+		commentLogs: [
+			{
+				nonCommented: /\twindow.console.log\( "JQMIGRATE: Migrate is installed"/g,
+				commented:
+					'\t/*window.console.log( "JQMIGRATE: Migrate is installed"',
+			},
+			{
+				nonCommented: /\t\t", version " \+ jQuery.migrateVersion \);\n/g,
+				commented: '\t\t", version " + jQuery.migrateVersion );*/\n',
+			},
+		],
+	},
+];
+
+const commentFunc = ( logConfigs ) => {
+	logConfigs.forEach( ( { path, commentLogs } ) => {
+		fs.readFile( path, 'utf8', ( err, data ) => {
+			if ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( err );
+				return;
+			}
+			commentLogs.forEach( ( { nonCommented, commented } ) => {
+				data = data.replace( nonCommented, commented );
+			} );
+
+			fs.writeFile( path, data, 'utf8', function ( error ) {
+				// eslint-disable-next-line no-console
+				if ( error ) return console.log( err );
+			} );
+		} );
+	} );
+};
+
+commentFunc( logConfig );


### PR DESCRIPTION
Hi ) This is a script for commenting logs on  "Any way to disable the console log comments #30697" issue. Script runs from terminal just like npm run dev , but in this case it will be npm run comment-on-logs .This command run function that is located in remove-logs.js file and comment on  logs from parser.js and jQuery files . 