### PR TITLE
Gallery block refactor: add data-id to image block for theme/plugin compatibility

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -419,6 +419,7 @@ export default function Image( {
 			<img
 				src={ temporaryURL || url }
 				alt={ defaultedAlt }
+				data-id={ id ? id : null }
 				onClick={ onImageClick }
 				onError={ () => onImageError() }
 				onLoad={ ( event ) => {

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -42,6 +42,7 @@ export default function save( { attributes } ) {
 			width={ width }
 			height={ height }
 			title={ title }
+			data-id={ id ? id : null }
 		/>
 	);
 


### PR DESCRIPTION
## Description
The existing gallery block adds a `data-id` to the `img` tag which some plugins, eg. [Full Screen Galleries](https://wordpress.org/plugins/full-screen-galleries/) and themes, eg. [Arbutus](https://wordpress.org/themes/arbutus/) rely on for some js and css. While Full Screen Galleries does have a fallback if `data-id` does not exist the fallback is not as reliable for determining ID

## How has this been tested?
Tested manually against Full Screen Galleries plugin.

## Types of changes
Adds `data-id` to image block `img` tag in editor and saved content.

## Testing

- Check out this PR
- Add an Image block and check that the `img` tag as `data-id` attrib in editor and frontend

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->

