### PR TITLE
Widgets API: Fix null instance property when instance settings are empty

### DIFF
--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -573,13 +573,8 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		);
 
 		if ( ! empty( $widget_object->show_instance_in_rest ) ) {
-			if ( empty( $instance ) ) {
-				// Use new stdClass() instead of array() so that endpoint
-				// returns {} and not [].
-				$response['instance']['raw'] = new stdClass;
-			} else {
-				$response['instance']['raw'] = $instance;
-			}
+			// Use new stdClass so that JSON result is {} and not [].
+			$response['instance']['raw'] = empty( $instance ) ? new stdClass : $instance;
 		}
 
 		return rest_ensure_response( $response );

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -537,7 +537,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$widget_object = gutenberg_get_widget_object( $parsed_id['id_base'] );
 			$instance      = gutenberg_get_widget_instance( $widget_id );
 
-			if ( $instance ) {
+			if ( ! is_null( $instance ) ) {
 				$serialized_instance             = serialize( $instance );
 				$prepared['instance']['encoded'] = base64_encode( $serialized_instance );
 				$prepared['instance']['hash']    = wp_hash( $serialized_instance );
@@ -675,6 +675,23 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'default'     => null,
+					'properties'  => array(
+						'encoded' => array(
+							'description' => __( 'Base64 encoded representation of the instance settings.', 'gutenberg' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit', 'embed' ),
+						),
+						'hash'    => array(
+							'description' => __( 'Cryptographic hash of the instance settings.', 'gutenberg' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit', 'embed' ),
+						),
+						'raw'     => array(
+							'description' => __( 'Unencoded instance settings, if supported.', 'gutenberg' ),
+							'type'        => 'object',
+							'context'     => array( 'view', 'edit', 'embed' ),
+						),
+					),
 				),
 				'form_data'     => array(
 					'description' => __( 'URL-encoded form data from the widget admin form. Used to update a widget that does not support instance. Write only.', 'gutenberg' ),

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -543,7 +543,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 				$prepared['instance']['hash']    = wp_hash( $serialized_instance );
 
 				if ( ! empty( $widget_object->show_instance_in_rest ) ) {
-					$prepared['instance']['raw'] = $instance;
+					// Use new stdClass so that JSON result is {} and not [].
+					$prepared['instance']['raw'] = empty( $instance ) ? new stdClass : $instance;
 				}
 			}
 		}
@@ -555,8 +556,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		$prepared['description']  = ! empty( $widget['description'] ) ? $widget['description'] : '';
 		$prepared['number']       = $widget_object ? (int) $parsed_id['number'] : 0;
 		if ( rest_is_field_included( 'settings', $fields ) ) {
-			$instance             = gutenberg_get_widget_instance( $widget_id );
-			$prepared['settings'] = $instance ? $instance : array();
+			$instance = gutenberg_get_widget_instance( $widget_id );
+			// Use new stdClass so that JSON result is {} and not [].
+			$prepared['settings'] = empty( $instance ) ? new stdClass : $instance;
 		}
 
 		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -329,7 +329,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				array(
 					'id'           => 'testwidget',
 					'sidebar'      => 'sidebar-1',
-					'settings'     => array(),
+					'settings'     => new stdClass,
 					'instance'     => null,
 					'id_base'      => 'testwidget',
 					'widget_class' => '',
@@ -339,7 +339,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					'rendered'     => '<h1>Default id</h1><span>Default text</span>',
 				),
 			),
-			$data
+			(array) $data
 		);
 
 		$wp_widget_factory->widgets['WP_Widget_RSS']->show_instance_in_rest = true;
@@ -410,7 +410,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				array(
 					'id'            => 'testwidget',
 					'sidebar'       => 'sidebar-1',
-					'settings'      => array(),
+					'settings'      => new stdClass,
 					'instance'      => null,
 					'id_base'       => 'testwidget',
 					'widget_class'  => '',
@@ -1132,7 +1132,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array(
 				'id'            => 'testwidget',
 				'sidebar'       => 'sidebar-1',
-				'settings'      => array(),
+				'settings'      => new stdClass,
 				'instance'      => null,
 				'rendered'      => '<h1>My test id</h1><span>My test title</span>',
 				'name'          => 'WP test widget',
@@ -1180,7 +1180,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array(
 				'id'            => 'testwidget',
 				'sidebar'       => 'sidebar-1',
-				'settings'      => array(),
+				'settings'      => new stdClass,
 				'instance'      => null,
 				'rendered'      => '<h1>My test id</h1><span>My test title</span>',
 				'name'          => 'WP test widget',
@@ -1501,7 +1501,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		}
 		$count = 0;
 		foreach ( $data as $item ) {
-			if ( isset( $item['_links'] ) ) {
+			if ( is_array( $item ) && isset( $item['_links'] ) ) {
 				unset( $data[ $count ]['_links'] );
 			}
 			$count ++;


### PR DESCRIPTION
## Description

When fetching a widget that has empty widget settings from the REST API, the `instance` property should be an object that looks like `{ "encoded": "...", "hash": "...", "raw": {} }`. Instead, `instance` is `null`. This fixes that.

The problem is that we were using `if ( $instance )` which isn't correct as PHP treats empty arrays as falseish. When `$instance` is an empty array, we still want to output it. We therefore should use `if ( ! is_null( $instance ) )` instead.

## How has this been tested?

I'm using https://httpie.io here.

1. Create a new image widget with empty settings:

   ```
   http -a admin:password POST http://wp-git-build.test/wp-json/wp/v2/widgets id_base=media_image instance:='{"raw":{}}'
   ```

2. `GET` that widget:

   ```
   http -a admin:password GET http://wp-git-build.test/wp-json/wp/v2/widgets/media_image-9
   ```

3. The `"instance"` property should be an object that looks like `{ "encoded": "...", "hash": "...", "raw": {} }` and not `null`.