### PR TITLE
Pattern Categories Select: Stop event propagation for the select element's onBlur to fix behaviour in iOS

### DIFF
--- a/packages/block-editor/src/components/inserter/pattern-panel.js
+++ b/packages/block-editor/src/components/inserter/pattern-panel.js
@@ -43,6 +43,16 @@ function PatternInserterPanel( {
 		);
 	};
 
+	// In iOS-based mobile devices, the onBlur will fire when selecting an option
+	// from a Select element. To prevent closing the useDialog on iOS devices, we
+	// stop propagating the onBlur event if there is no relatedTarget, which means
+	// that the user most likely did not click on an element within the editor canvas.
+	const onBlur = ( event ) => {
+		if ( ! event?.relatedTarget ) {
+			event.stopPropagation();
+		}
+	};
+
 	return (
 		<>
 			<div className={ getPanelHeaderClassName() }>
@@ -52,6 +62,7 @@ function PatternInserterPanel( {
 					hideLabelFromVision
 					value={ selectedCategory.name }
 					onChange={ onChangeSelect }
+					onBlur={ onBlur }
 					options={ categoryOptions() }
 				/>
 			</div>


### PR DESCRIPTION
Related to: https://github.com/WordPress/gutenberg/issues/29243

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fix the pattern inserter closing on iOS when switching pattern categories.

As raised in #29243 in iOS when you go to change pattern categories within the pattern inserter, selecting an option from the Select drop-down fires an onBlur event that bubbles up to the parent (in this case I believe it's the `useDialog` [attached to the inserter panel](https://github.com/andrewserong/gutenberg/blob/3882276868b98d0e3ae4fd5a8d81b404ba2fc616/packages/edit-post/src/components/layout/index.js#L205-L205)).

This unexpected onBlur event bubbling causes the inserter to close when the user switches pattern categories. To prevent this from happening, in this change, we update the Pattern Inserter Panel to add an `onBlur` function that stops event propagation if the blur event does not have a related target. When a user clicks from the select element into the editor canvas (e.g. in a web browser) then there will typically be an `event.relatedTarget`. We can use the absence of this as a check to prevent the inserter from closing on iOS.

Note: we might be able to pursue a similar fix directly in the useDialog / use, but this didn't seem quite as safe, since we can't know for certain how the `useDialog` or `useFocusOutside` is being used in other contexts, whereas for the pattern category drop-down, if we are accidentally a bit greedy about stopping propagation, the side-effect is likely going to be negligible. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually, in a web browser, and in iOS Simulator via XCode.

In iOS simulator (or running this PR on a real iOS mobile device):

* Open up the post editor, and go to insert a pattern.
* Switch pattern categories and confirm that the inserter isn't closed automatically.
* In web browser, with the pattern category selected, click on the editor canvas — the pattern inserter _should_ close automatically since you've intentionally focused outside of the inserter.

## Screenshots <!-- if applicable -->

| iOS Simulator | Web |
| --- | --- |
| ![change-pattern-categories-ios-small](https://user-images.githubusercontent.com/14988353/114353421-56ef3a00-9bb0-11eb-9ea4-cf9cf6699925.gif) | ![change-pattern-categories-web-small](https://user-images.githubusercontent.com/14988353/114353445-5f477500-9bb0-11eb-9bca-4e9588f163d9.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested. (manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. (tested via keyboard, this change doesn't affect screen readers) <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
