### PR TITLE
Remove obsolete hardcoded focus style from Social Links

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -133,14 +133,3 @@
 .wp-social-link.wp-social-link__is-incomplete:focus {
 	opacity: 1;
 }
-
-
-// Focus styles for the button inside the child block.
-// The child block itself has a more generic focus style, see line 55.
-[data-type="core/social-links"] .wp-social-link:focus { // This needs specificity.
-	opacity: 1;
-	box-shadow: 0 0 0 2px $white, 0 0 0 4px var(--wp-admin-theme-color);
-
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
-}


### PR DESCRIPTION
## Description

Fixes #30682.

Before the WordPress 5.5 block editor visual refresh, social links required an extra focus style. This is now obsolete, so this PR simply removes it.

Before:

<img width="366" alt="Screenshot 2021-04-12 at 10 13 23" src="https://user-images.githubusercontent.com/1204802/114363825-158f6800-9b79-11eb-8671-979a363370ac.png">

After:

<img width="427" alt="Screenshot 2021-04-12 at 10 20 32" src="https://user-images.githubusercontent.com/1204802/114363840-188a5880-9b79-11eb-9455-ad64972ada86.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
