### PR TITLE
Ensure Hello Dolly plugin text doesn't overlap the widgets screen UI

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -41,6 +41,8 @@ function gutenberg_widgets_init( $hook ) {
 		return;
 	}
 
+	add_filter( 'admin_body_class', 'gutenberg_widgets_editor_add_admin_body_classes' );
+
 	$settings = array_merge(
 		gutenberg_get_common_block_editor_settings(),
 		gutenberg_get_legacy_widget_settings()
@@ -91,14 +93,15 @@ function gutenberg_widgets_editor_load_block_editor_scripts_and_styles( $is_bloc
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_editor_load_block_editor_scripts_and_styles' );
 
 /**
- * Show responsive embeds correctly on the widgets screen by adding the wp-embed-responsive class.
+ * Adds admin classes necessary for the block-based widgets screen.
+ *
+ * - Adds `block-editor-page` editor body class to allow directly styling the admin pages that are based on the block editor.
+ * - Shows responsive embeds correctly on the widgets screen by adding the `wp-embed-responsive` class.
  *
  * @param string $classes existing admin body classes.
  *
- * @return string admin body classes including the wp-embed-responsive class.
+ * @return string admin body classes including the `block-editor-page` and `wp-embed-responsive` classes.
  */
-function gutenberg_widgets_editor_add_responsive_embed_body_class( $classes ) {
-	return "$classes wp-embed-responsive";
+function gutenberg_widgets_editor_add_admin_body_classes( $classes ) {
+	return "$classes block-editor-page wp-embed-responsive";
 }
-
-add_filter( 'admin_body_class', 'gutenberg_widgets_editor_add_responsive_embed_body_class' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Consolidates both classes necessary (`block-editor-page` and `wp-embed-responsive`) into one function to add required admin body classes for the new Widgets editor, `gutenberg_widgets_editor_add_admin_body_classes()`.

Only calls `add_filter()` when widgets editor page is being loaded.

Closes: #26219

<!-- Please describe what you have changed or added -->

## How has this been tested?
Tested manually with Hello Dolly in `wp-env`, along with existing automated tests with `npm run test`.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
One of the issues this fixes is Hello Dolly text being overlapped by the editor:
Before:
<img width="354" alt="Screen Shot 2021-04-12 at 17 55 42" src="https://user-images.githubusercontent.com/1034160/114368556-7be7ab00-9bb8-11eb-883d-ef6e5dc88635.png">

After: 
<img width="382" alt="Screen Shot 2021-04-12 at 17 55 26" src="https://user-images.githubusercontent.com/1034160/114368597-84d87c80-9bb8-11eb-975c-bc287c379f24.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Primarily a bug fix to resolve the Hello Dolly issue above, but includes behavior changes.
`block-editor-page` is added to the new Widgets screen, which would mean styles targeted to that class will now be applied.

Changes the way the `wp-embed-responsive` class is added, as it is now only added when the widget page is loaded, instead of adding it to every admin page. I believe this is what was intended, based on the previous function's wording.

As part of this, an existing function, `gutenberg_widgets_editor_add_responsive_embed_body_class` is removed in favor of `gutenberg_widgets_editor_add_admin_body_classes` to add both classes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
