### PR TITLE
Remove title attribute from NavigationItem inside the site-editor

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -51,7 +51,6 @@ export default function TemplateNavigationItem( { item } ) {
 		<NavigationItem
 			className="edit-site-navigation-panel__template-item"
 			item={ `${ item.type }-${ item.id }` }
-			title={ title }
 		>
 			<Button
 				onClick={ onActivateItem }


### PR DESCRIPTION
## Description

Came up as a11y feedback during a contributors day:
`<li>` items in the site-editor's main navigation have a `title` attribute, and then the title again in the contents.
`title` should be avoided, and since it doesn't really add anything here this PR removes it.

## Types of changes

Removed `title` from `NavigationItem`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
