### PR TITLE
Skip unstable template part e2e test

### DIFF
--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -53,7 +53,7 @@ describe( 'Document Settings', () => {
 		} );
 
 		describe( 'and a template part is clicked in the template', () => {
-			it( "should display the selected template part's name in the document header", async () => {
+			it.skip( "should display the selected template part's name in the document header", async () => {
 				// Select the header template part via list view.
 				await page.click( 'button[aria-label="List View"]' );
 				const headerTemplatePartListViewButton = await page.waitForXPath(


### PR DESCRIPTION
I noticed that this test has been failing often in trunk lately. I'm skipping it now but we should consider investigating it cc @jeyip @talldan 

Failure examples: https://github.com/WordPress/gutenberg/runs/2323110650 and https://github.com/WordPress/gutenberg/runs/2323376961