### PR TITLE
Add disable FSE theme support flag

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -64,6 +64,9 @@ class WP_Theme_JSON {
 	);
 
 	const VALID_STYLES = array(
+		'experience' => array(
+			'enable_fse' => null,
+		),
 		'border'     => array(
 			'radius' => null,
 			'color'  => null,

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -11,7 +11,7 @@
  * @return boolean Whether the current theme is an FSE theme or not.
  */
 function gutenberg_is_fse_theme() {
-	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' );
+	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) && !current_theme_supports( 'disable-fse' );
 }
 
 /**

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -20,7 +20,13 @@ function gutenberg_is_fse_theme() {
  * @return boolean Whether the current theme is FSE-enabled or not.
  */
 function gutenberg_supports_block_templates() {
-	return gutenberg_is_fse_theme() || current_theme_supports( 'block-templates' );
+	$enable_fse     = true;
+	$theme_settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
+	if ( isset( $theme_settings['defaults']['experience']['enable_fse'] ) ) {
+		$enable_fse = $theme_settings['defaults']['experience']['enable_fse'];
+	}
+
+	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) && $enable_fse;
 }
 
 /**

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -11,7 +11,13 @@
  * @return boolean Whether the current theme is an FSE theme or not.
  */
 function gutenberg_is_fse_theme() {
-	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) && !current_theme_supports( 'disable-fse' );
+	$enable_fse     = true;
+	$theme_settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
+	if ( isset( $theme_settings['defaults']['experience']['enable_fse'] ) ) {
+		$enable_fse = $theme_settings['defaults']['experience']['enable_fse'];
+	}
+
+	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) && $enable_fse;
 }
 
 /**
@@ -20,13 +26,7 @@ function gutenberg_is_fse_theme() {
  * @return boolean Whether the current theme is FSE-enabled or not.
  */
 function gutenberg_supports_block_templates() {
-	$enable_fse     = true;
-	$theme_settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
-	if ( isset( $theme_settings['defaults']['experience']['enable_fse'] ) ) {
-		$enable_fse = $theme_settings['defaults']['experience']['enable_fse'];
-	}
-
-	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) && $enable_fse;
+	return gutenberg_is_fse_theme() || current_theme_supports( 'block-templates' );
 }
 
 /**


### PR DESCRIPTION
## Description
Made FSE optional via a theme support flag so that block-based themes can be used in a classic environment.

## How has this been tested?
Added the `add_theme_support( 'disable-fse' );` flag to a block based theme (such as Empty Theme)

## Screenshots <!-- if applicable -->
<img width="801" alt="Screenshot 2021-04-12 at 18 10 22" src="https://user-images.githubusercontent.com/3593343/114426459-64112680-9bba-11eb-9009-829a0c7239d6.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
