### PR TITLE
Entity Saving - try contextual label for 'Site' entity.

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -57,34 +57,31 @@ export default function EntityRecordItem( {
 				).title;
 			}
 
-			const entity = select( coreStore ).getEntityRecord(
-				kind,
-				name,
-				key
-			);
-
 			// Determine which sections of the site object have been changed.
 			if ( 'root' === kind && 'site' === name ) {
-				const editedSiteProperties = [];
-				for ( const field in editedEntity ) {
-					if ( editedEntity[ field ] !== entity[ field ] ) {
-						editedSiteProperties.push(
-							TRANSLATED_SITE_PROTPERTIES[ field ] || field
-						);
-					}
-				}
-
-				if ( editedSiteProperties.length === 1 ) {
-					return editedSiteProperties[ 0 ];
-				} else if ( editedSiteProperties.length === 2 ) {
+				const edits = select( coreStore ).getEntityRecordEdits(
+					kind,
+					name,
+					key
+				);
+				const editedSiteProperties = Object.keys( edits );
+				const translatedSiteProperties = editedSiteProperties.map(
+					( field ) => TRANSLATED_SITE_PROTPERTIES[ field ] || field
+				);
+				// Construct a title of edited properties.
+				if ( translatedSiteProperties.length === 1 ) {
+					return translatedSiteProperties[ 0 ];
+				} else if ( translatedSiteProperties.length === 2 ) {
 					return (
-						editedSiteProperties[ 0 ] +
+						translatedSiteProperties[ 0 ] +
 						' & ' +
-						editedSiteProperties[ 1 ]
+						translatedSiteProperties[ 1 ]
 					);
-				} else if ( editedSiteProperties.length > 2 ) {
-					const last = editedSiteProperties.pop();
-					return editedSiteProperties.join( ', ' ) + ', & ' + last;
+				} else if ( translatedSiteProperties.length > 2 ) {
+					const last = translatedSiteProperties.pop();
+					return (
+						translatedSiteProperties.join( ', ' ) + ', & ' + last
+					);
 				}
 
 				return '';

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -74,7 +74,20 @@ export default function EntityRecordItem( {
 					}
 				}
 
-				return editedSiteProperties.join( ', ' );
+				if ( editedSiteProperties.length === 1 ) {
+					return editedSiteProperties[ 0 ];
+				} else if ( editedSiteProperties.length === 2 ) {
+					return (
+						editedSiteProperties[ 0 ] +
+						' & ' +
+						editedSiteProperties[ 1 ]
+					);
+				} else if ( editedSiteProperties.length > 2 ) {
+					const last = editedSiteProperties.pop();
+					return editedSiteProperties.join( ', ' ) + ', & ' + last;
+				}
+
+				return '';
 			}
 
 			return title;

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { close as closeIcon } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -21,11 +22,11 @@ function EntitiesSavedStates( { isOpen, close } ) {
 	const { dirtyEntityRecords } = useSelect( ( select ) => {
 		return {
 			dirtyEntityRecords: select(
-				'core'
+				coreStore
 			).__experimentalGetDirtyEntityRecords(),
 		};
 	}, [] );
-	const { saveEditedEntityRecord } = useDispatch( 'core' );
+	const { saveEditedEntityRecord } = useDispatch( coreStore );
 
 	// To group entities by type.
 	const partitionedSavables = Object.values(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Updates the label for the 'Site' item in the entity save panel to correspond to the items that were saved, as opposed to only showing the current site title itself.

Currently, when we update any Site entity block (Site Title, Site Tagline, Site Logo), the save panel only shows the current site title as the label for the edited entity:
![Screen Shot 2021-04-12 at 4 44 37 PM](https://user-images.githubusercontent.com/28742426/114459462-9157d780-9bae-11eb-9ee1-a49919a9e028.png)
Thus if a user had only updated a Site Logo for example, seeing the item labeled "My Site" really doesn't make any sense in that context.

Here, we have updated the label to be the list of site properties that have been edited:
![Screen Shot 2021-04-12 at 4 40 45 PM](https://user-images.githubusercontent.com/28742426/114459704-df6cdb00-9bae-11eb-9e88-4d3c57a23f26.png)

or in the case of editing all 3 site entity blocks:
![Screen Shot 2021-04-12 at 5 39 19 PM](https://user-images.githubusercontent.com/28742426/114466336-59ed2900-9bb6-11eb-9d23-1eaf6fd0ead6.png)


In the end, I would like to see each site property as its own separate checkbox.  However this will take a bit more exploration due to how the entity and saving mechanisms are structured.  Until then, this seems like it is a step forward that will help provide some clarity.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
