### PR TITLE
Remove unnecessary semicolons in PHP

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -1177,7 +1177,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 				// Invalid terms will be rejected later.
 				if ( ! get_term( $term_id, $taxonomy->name ) ) {
 					continue;
-				};
+				}
 
 				if ( ! current_user_can( 'assign_term', (int) $term_id ) ) {
 					return false;

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -36,7 +36,7 @@ function gutenberg_get_common_block_editor_settings() {
 			'slug' => $image_size_slug,
 			'name' => $image_size_name,
 		);
-	};
+	}
 
 	$settings = array(
 		'__unstableEnableFullSiteEditingBlocks' => gutenberg_supports_block_templates(),

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -222,7 +222,7 @@ function gutenberg_convert_menu_items_to_blocks(
 	}
 
 	return $blocks;
-};
+}
 
 /**
  * Shim that causes `wp_nav_menu()` to output a Navigation block instead of a

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -137,7 +137,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	if ( false !== $class_name ) {
 		$css_classes .= ' ' . $class_name;
-	};
+	}
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(


### PR DESCRIPTION
## Description
A semicolon is not necessary after loops, functions and conditional statements. This makes the code more consistent.