### PR TITLE
Copy caption across from image selected from media library

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -276,6 +276,7 @@ function GalleryEdit( props ) {
 			return createBlock( 'core/image', {
 				id: image.id,
 				url: image.url,
+				caption: image.caption,
 			} );
 		} );
 


### PR DESCRIPTION
Fixes #30196

## Description
The caption from images selected in Media library were not being copied to the newly created gallery images.

## Testing

Check out this PR and enable gallery refactor experiment
Add some images to media library and set captions
Add a gallery and select images from media library
Check that the captions display as expected in editor and frontend

![captions](https://user-images.githubusercontent.com/3629020/114484447-5d3bef80-9c5e-11eb-8f43-df7e8fad25ef.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style
