### PR TITLE
Update Dropdown’s toggle/popover coordination to be UA-agnostic

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, Tooltip, VisuallyHidden } from '@wordpress/components';
+import { Button, VisuallyHidden } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 import { _x, sprintf } from '@wordpress/i18n';
 import { Icon, plus } from '@wordpress/icons';
@@ -47,7 +47,7 @@ function ButtonBlockAppender(
 				}
 				const isToggleButton = ! hasSingleBlockType;
 
-				let inserterButton = (
+				return (
 					<Button
 						ref={ ref }
 						onFocus={ onFocus }
@@ -61,6 +61,8 @@ function ButtonBlockAppender(
 						aria-expanded={ isToggleButton ? isOpen : undefined }
 						disabled={ disabled }
 						label={ label }
+						showTooltip
+						tooltipPosition="bottom"
 					>
 						{ ! hasSingleBlockType && (
 							<VisuallyHidden as="span">{ label }</VisuallyHidden>
@@ -68,13 +70,6 @@ function ButtonBlockAppender(
 						<Icon icon={ plus } />
 					</Button>
 				);
-
-				if ( isToggleButton || hasSingleBlockType ) {
-					inserterButton = (
-						<Tooltip text={ label }>{ inserterButton }</Tooltip>
-					);
-				}
-				return inserterButton;
 			} }
 			isAppender
 		/>

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -98,6 +98,8 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
               aria-label="Custom color picker"
               className="components-button is-link"
               onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
               type="button"
             >
               Custom color

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -131,16 +131,12 @@ export default function TemplatePartEdit( {
 				<BlockControls>
 					<ToolbarGroup className="wp-block-template-part__block-control-group">
 						<Dropdown
-							className="wp-block-template-part__preview-dropdown-button"
 							contentClassName="wp-block-template-part__preview-dropdown-content"
 							position="bottom right left"
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<ToolbarButton
 									aria-expanded={ isOpen }
 									onClick={ onToggle }
-									// Disable when open to prevent odd FireFox bug causing reopening.
-									// As noted in https://github.com/WordPress/gutenberg/pull/24990#issuecomment-689094119 .
-									disabled={ isOpen }
 								>
 									{ __( 'Replace' ) }
 								</ToolbarButton>

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -55,21 +55,17 @@ export default function TemplatePartPlaceholder( {
 			) }
 		>
 			<Dropdown
+				className="wp-block-template-part__placeholder-preview-dropdown"
 				contentClassName="wp-block-template-part__placeholder-preview-dropdown-content"
 				position="bottom right left"
 				renderToggle={ ( { isOpen, onToggle } ) => (
-					<>
-						<Button
-							isPrimary
-							onClick={ onToggle }
-							aria-expanded={ isOpen }
-						>
-							{ __( 'Choose existing' ) }
-						</Button>
-						<Button isTertiary onClick={ onCreate }>
-							{ __( 'New template part' ) }
-						</Button>
-					</>
+					<Button
+						isPrimary
+						onClick={ onToggle }
+						aria-expanded={ isOpen }
+					>
+						{ __( 'Choose existing' ) }
+					</Button>
 				) }
 				renderContent={ ( { onClose } ) => (
 					<TemplatePartSelection
@@ -78,6 +74,9 @@ export default function TemplatePartPlaceholder( {
 					/>
 				) }
 			/>
+			<Button isTertiary onClick={ onCreate }>
+				{ __( 'New template part' ) }
+			</Button>
 		</Placeholder>
 	);
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -1,3 +1,8 @@
+// Make dropdown margins the same as Placeholder component does for buttons
+.wp-block-template-part__placeholder-preview-dropdown {
+	margin-right: $grid-unit-15;
+	margin-bottom: $grid-unit-15;
+}
 
 .wp-block-template-part__placeholder-preview-dropdown-content,
 .wp-block-template-part__preview-dropdown-content {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   The callback provided to `renderToggle` prop of `Dropdown` must return a single child in order to ensure expected toggling behavior when the toggle is pressed while the dropdown is open.
+
+### Bug Fix
+
+-   Fix for broken toggling behavior exhibited by `Dropdown` and `DropdownMenu` in some browsers.
+
 ## 13.0.0 (2021-03-17)
 
 ### Breaking Change

--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -8,7 +8,7 @@ import { isEmpty, kebabCase } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { edit, close, chevronDown, chevronUp, plus } from '@wordpress/icons';
 
 /**
@@ -20,15 +20,6 @@ import ColorPicker from '../color-picker';
 import Button from '../button';
 import TextControl from '../text-control';
 import BaseControl from '../base-control';
-
-function DropdownOpenOnMount( { shouldOpen, isOpen, onToggle } ) {
-	useEffect( () => {
-		if ( shouldOpen && ! isOpen ) {
-			onToggle();
-		}
-	}, [] );
-	return null;
-}
 
 function ColorOption( {
 	color,
@@ -56,6 +47,14 @@ function ColorOption( {
 		( isHover || isFocused || isEditingName || isShowingAdvancedPanel ) &&
 		! immutableColorSlugs.includes( slug );
 
+	const dropdownHandle = useRef();
+	useEffect( () => {
+		const { isOpen, onToggle } = dropdownHandle.current;
+		if ( isEditingColorOnMount && isOpen === false ) {
+			onToggle();
+		}
+	}, [ isEditingColorOnMount ] );
+
 	return (
 		<div
 			tabIndex={ 0 }
@@ -77,13 +76,11 @@ function ColorOption( {
 		>
 			<div className="components-color-edit__color-option-main-area">
 				<Dropdown
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<>
-							<DropdownOpenOnMount
-								shouldOpen={ isEditingColorOnMount }
-								isOpen={ isOpen }
-								onToggle={ onToggle }
-							/>
+					renderToggle={ ( { isOpen, onToggle } ) => {
+						if ( isOpen !== dropdownHandle.current?.isOpen ) {
+							dropdownHandle.current = { isOpen, onToggle };
+						}
+						return (
 							<CircularOptionPicker.Option
 								style={ { backgroundColor: color, color } }
 								aria-expanded={ isOpen }
@@ -91,8 +88,8 @@ function ColorOption( {
 								onClick={ onToggle }
 								aria-label={ __( 'Edit color value' ) }
 							/>
-						</>
-					) }
+						);
+					} }
 					renderContent={ () => (
 						<ColorPicker
 							color={ color }

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -118,6 +118,8 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
       aria-label="Custom color picker"
       isLink={true}
       onClick={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
     >
       <button
         aria-describedby={null}
@@ -126,6 +128,8 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
         aria-label="Custom color picker"
         className="components-button is-link"
         onClick={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
         type="button"
       >
         Custom color
@@ -552,6 +556,8 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 aria-label="Custom color picker"
                 isLink={true}
                 onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
               >
                 <button
                   aria-describedby={null}
@@ -560,6 +566,8 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                   aria-label="Custom color picker"
                   className="components-button is-link"
                   onClick={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
                   type="button"
                 >
                   Custom color

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -1,8 +1,8 @@
 # Dropdown
 
-Dropdown is a React component to render a button that opens a floating content modal when clicked.
-This components takes care of updating the state of the dropdown menu (opened/closed), handles closing the menu when clicking outside
-and uses render props to render the button and the content.
+Dropdown is a React component to render a button that opens a floating content dialog when clicked.
+The component takes care of updating the state of the dropdown (opened/closed), handles closing
+the popover when clicking outside and uses render props to render the button and the content.
 
 ## Usage
 
@@ -52,7 +52,9 @@ The direction in which the popover should open relative to its parent node. Spec
 
 ### renderToggle
 
-A callback invoked to render the Dropdown Toggle Button.
+A callback invoked to render the Dropdown Toggle Button. NOTE: The return must be a single child as it
+will be cloned and have some event handlers added to ensure that a press of the toggle while the
+dropdown is open will bypass the auto-closing behavior and defer control to the toggle.
 
 -   Type: `Function`
 -   Required: Yes

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -65,20 +65,20 @@ describe( 'Dropdown', () => {
 			<Dropdown
 				className="container"
 				contentClassName="content"
-				renderToggle={ ( { isOpen, onToggle, onClose } ) => [
+				renderToggle={ ( { isOpen, onToggle } ) => (
 					<button
-						key="open"
 						className="open"
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
 					>
 						Toggleee
-					</button>,
-					<button key="close" className="close" onClick={ onClose }>
-						closee
-					</button>,
-				] }
-				renderContent={ () => null }
+					</button>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<button className="close" onClick={ onClose }>
+						test
+					</button>
+				) }
 			/>
 		);
 

--- a/packages/edit-post/src/components/header/more-menu/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/more-menu/test/__snapshots__/index.js.snap
@@ -60,6 +60,8 @@ exports[`MoreMenu should match snapshot 1`] = `
           label="Options"
           onClick={[Function]}
           onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
           showTooltip={true}
           tooltipPosition="bottom"
         >
@@ -80,6 +82,7 @@ exports[`MoreMenu should match snapshot 1`] = `
               onMouseDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              onMouseUp={[Function]}
               type="button"
             >
               <Icon

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -22,16 +22,14 @@ export function PostSchedule() {
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
 					renderToggle={ ( { onToggle, isOpen } ) => (
-						<>
-							<Button
-								className="edit-post-post-schedule__toggle"
-								onClick={ onToggle }
-								aria-expanded={ isOpen }
-								isTertiary
-							>
-								<PostScheduleLabel />
-							</Button>
-						</>
+						<Button
+							className="edit-post-post-schedule__toggle"
+							onClick={ onToggle }
+							aria-expanded={ isOpen }
+							isTertiary
+						>
+							<PostScheduleLabel />
+						</Button>
 					) }
 					renderContent={ () => <PostScheduleForm /> }
 				/>


### PR DESCRIPTION
The Dropdown (and DropdownMenu) components have broken toggle behavior in some browsers (notably Safari and Firefox on macOS).

To fix it I've explored alternate approaches (a couple in #30397) and this PR is my favored solution as it requires no changes to the vast majority of `Dropdown` implementors because they happen to already meet the new requirement of returning a single child from the`renderToggle` callback. Only four (of the more than twenty) in core needed updates, and being rather minor, those updates have been included in this PR. Mostly they constitute slight code quality improvements. 

## How has this been tested?
Manually in Chrome, Safari and Firefox on macOS. In the Post Editor and Site Editor, checking various instances of `Dropdown` and `DropdownMenu` to verify they toggle as expected when pressing the toggle, `Esc` key, and when opening modals from within (more menu). Also, running the tests.

## Screenshots
Before: the broken toggling of various dropdowns in Safari on macOS

https://user-images.githubusercontent.com/9000376/115271103-d53c6680-a0f1-11eb-997f-0fc677149c1b.mp4

## Types of changes
Bug fix: #29746
Breaking change:  Implementors that don't return a single child from the `renderToggle` callback would exhibit broken toggle (closing) behavior in all browsers but judging by the usage in Gutenberg most implementations should already be compatible.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
