### PR TITLE
Fix query pattern heights.

### DIFF
--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -52,6 +52,7 @@
 
 		.block-setup-block-layout-list__item {
 			height: 100%;
+			max-height: 140px;
 			display: flex;
 			flex-direction: column;
 			padding: 2px;
@@ -94,6 +95,7 @@
 	// Size consecutive block variation icons the same.
 	.block-setup-block-layout-list__list-item.is-block-variation .block-setup-block-layout-list__item {
 		height: 90px;
+		min-height: 90px;
 	}
 
 	// Size the block variation icon same as the thumbnail on step 1.


### PR DESCRIPTION
## Description

Patterns were too tall in the query block, and when the "Start blank" popped on to its own row, it was too small:

<img width="863" alt="Screenshot 2021-04-13 at 08 58 06" src="https://user-images.githubusercontent.com/1204802/114510046-7d57b880-9c36-11eb-83ee-608b091e9a0c.png">

This PR fixes that:

<img width="857" alt="Screenshot 2021-04-13 at 08 57 50" src="https://user-images.githubusercontent.com/1204802/114510058-80eb3f80-9c36-11eb-8c77-099ac65591af.png">

It also duplicates work from #30757, so props @kjellr 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
