### PR TITLE
Fix post date component.

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -1,7 +1,14 @@
 @import "./datepicker";
 
 .components-datetime {
-	padding: 0;
+	// This padding is leveraged when the component is used alone,
+	// usually inside popovers.
+	padding: $grid-unit-20;
+
+	// This rule removes the padding when used inside a panel.
+	.components-panel__body & {
+		padding: 0;
+	}
 
 	.components-datetime__calendar-help {
 		padding: $grid-unit-20;

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -12,3 +12,9 @@
 .components-button.edit-post-post-schedule__toggle {
 	text-align: right;
 }
+
+// Zero out a blanket padding that is set on the popover component.
+// The datetime component has its own padding.
+.edit-post-post-schedule__dialog .components-popover__content > div {
+	padding: 0;
+}


### PR DESCRIPTION
## Description

This PR tweaks the padding rules for the post date component. When inside a popover, it should have padding, when inside a panel, it should not. Fixes #30581.

Before:

<img width="599" alt="Screenshot 2021-04-13 at 09 06 31" src="https://user-images.githubusercontent.com/1204802/114512408-623a7800-9c39-11eb-8251-f8c582cbe7e0.png">

After:

<img width="632" alt="Screenshot 2021-04-13 at 09 09 28" src="https://user-images.githubusercontent.com/1204802/114512416-64043b80-9c39-11eb-9620-c8315c6a34e4.png">
<img width="345" alt="Screenshot 2021-04-13 at 09 13 01" src="https://user-images.githubusercontent.com/1204802/114512423-65356880-9c39-11eb-8090-a36438820423.png">
<img width="544" alt="Screenshot 2021-04-13 at 09 16 00" src="https://user-images.githubusercontent.com/1204802/114512429-65cdff00-9c39-11eb-9254-4edec3e2aae1.png">

## How has this been tested?

Please test pressing the Edit button on the Post Date block.

Please test the pre-publish shedule panel.

Please test the document sidebar schedule popover.

All should look the same.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
