### PR TITLE
Gutenberg Plugin: Updated `.editorconfig` files to work with automatic file formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,13 +13,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[*.yml]
-indent_style = space
-indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false
-
 [*.{gradle,java,kt}]
 indent_style = space
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Updated `.editorconfig` template files to work with automatic file formatting.
+
 ## 2.2.0 (2021-04-06)
 
 ### Enhancement

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancement
 
--   Updated `.editorconfig` template files to work with automatic file formatting.
+-   Updated `.editorconfig` template files to work with automatic file formatting ([#30794](https://github.com/WordPress/gutenberg/pull/30794)).
 
 ## 2.2.0 (2021-04-06)
 

--- a/packages/create-block/lib/templates/es5/.editorconfig.mustache
+++ b/packages/create-block/lib/templates/es5/.editorconfig.mustache
@@ -12,10 +12,3 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
-
-[*.yml]
-indent_style = space
-indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false

--- a/packages/create-block/lib/templates/esnext/.editorconfig.mustache
+++ b/packages/create-block/lib/templates/esnext/.editorconfig.mustache
@@ -12,10 +12,3 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
-
-[*.yml]
-indent_style = space
-indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Prerequisite to https://github.com/WordPress/gutenberg/pull/30240.
Related to https://github.com/WordPress/gutenberg/pull/30409.

<!-- Please describe what you have changed or added -->
Now that we plan to use Prettier formatting with YML, JSON and markdown files, it makes sense to align `.editorconfig` files with what Prettier uses.