### PR TITLE
Use theme locations description instead of slug for navigation screen location labels

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/manage-locations.js
+++ b/packages/edit-navigation/src/components/inspector-additions/manage-locations.js
@@ -53,35 +53,37 @@ export default function ManageLocations( {
 		menuLocations.length
 	);
 
-	const menusWithSelection = menuLocations.map( ( { name, description, menu } ) => {
-		const menuOnLocation = menus
-			.filter( ( { id } ) => ! [ 0, selectedMenuId ].includes( id ) )
-			.find( ( { id } ) => id === menu );
+	const menusWithSelection = menuLocations.map(
+		( { name, description, menu } ) => {
+			const menuOnLocation = menus
+				.filter( ( { id } ) => ! [ 0, selectedMenuId ].includes( id ) )
+				.find( ( { id } ) => id === menu );
 
-		return (
-			<li
-				key={ name }
-				className="edit-navigation-manage-locations__checklist-item"
-			>
-				<CheckboxControl
-					className="edit-navigation-manage-locations__menu-location-checkbox"
-					checked={ menu === selectedMenuId }
-					onChange={ () =>
-						toggleMenuLocationAssignment( name, selectedMenuId )
-					}
-					label={ description }
-					help={
-						menuOnLocation &&
-						sprintf(
-							// translators: menu name.
-							__( 'Currently using %s' ),
-							menuOnLocation.name
-						)
-					}
-				/>
-			</li>
-		);
-	} );
+			return (
+				<li
+					key={ name }
+					className="edit-navigation-manage-locations__checklist-item"
+				>
+					<CheckboxControl
+						className="edit-navigation-manage-locations__menu-location-checkbox"
+						checked={ menu === selectedMenuId }
+						onChange={ () =>
+							toggleMenuLocationAssignment( name, selectedMenuId )
+						}
+						label={ description }
+						help={
+							menuOnLocation &&
+							sprintf(
+								// translators: menu name.
+								__( 'Currently using %s' ),
+								menuOnLocation.description
+							)
+						}
+					/>
+				</li>
+			);
+		}
+	);
 
 	const menuLocationCard = menuLocations.map( ( menuLocation ) => (
 		<div

--- a/packages/edit-navigation/src/components/inspector-additions/manage-locations.js
+++ b/packages/edit-navigation/src/components/inspector-additions/manage-locations.js
@@ -53,7 +53,7 @@ export default function ManageLocations( {
 		menuLocations.length
 	);
 
-	const menusWithSelection = menuLocations.map( ( { name, menu } ) => {
+	const menusWithSelection = menuLocations.map( ( { name, description, menu } ) => {
 		const menuOnLocation = menus
 			.filter( ( { id } ) => ! [ 0, selectedMenuId ].includes( id ) )
 			.find( ( { id } ) => id === menu );
@@ -69,7 +69,7 @@ export default function ManageLocations( {
 					onChange={ () =>
 						toggleMenuLocationAssignment( name, selectedMenuId )
 					}
-					label={ name }
+					label={ description }
 					help={
 						menuOnLocation &&
 						sprintf(


### PR DESCRIPTION
## Description
Fixes #30179.

##How has this been tested?

1. Enable the navigation screen experiment using the Gutenberg plugin settings
2. Navigate to the navigation editor
3. Add a menu
4. Select the navigation block and check the locations in the sidebar
5. The locations labels should be the same as the menu name, instead of slug


## Screenshots <!-- if applicable -->
Before
<img width="280" alt="CleanShot 2021-04-13 at 08 57 18@2x" src="https://user-images.githubusercontent.com/33403964/114517488-4bdeed00-9c36-11eb-96df-206995b33fa0.png">

After
<img width="282" alt="CleanShot 2021-04-13 at 08 56 45@2x" src="https://user-images.githubusercontent.com/33403964/114517562-5c8f6300-9c36-11eb-849e-caec3c3fe6ae.png">