### PR TITLE
fix: bug with color picker input state for falsy values

### DIFF
--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -47,23 +47,42 @@ import { colorToState, simpleCheckForValidColor, isValidHex } from './utils';
 
 const toLowerCase = ( value ) => String( value ).toLowerCase();
 const isValueEmpty = ( data ) => {
-	if ( data.source === 'hex' && ! data.hex ) {
+	if ( data.source === 'hex' && data.hex === undefined ) {
 		return true;
-	} else if (
+	}
+
+	if (
 		data.source === 'hsl' &&
-		( ! data.h || ! data.s || ! data.l )
-	) {
-		return true;
-	} else if (
-		data.source === 'rgb' &&
-		( ! data.r || ! data.g || ! data.b ) &&
-		( ! data.h || ! data.s || ! data.v || ! data.a ) &&
-		( ! data.h || ! data.s || ! data.l || ! data.a )
+		( data.h === undefined || data.s === undefined || data.l === undefined )
 	) {
 		return true;
 	}
-	return false;
+
+	/**
+	 * Check that if source is `rgb`:
+	 * `r`, `g` or `b` properties are not undefined
+	 * OR (||) `h`, `s`, `v` or `a` properties are not undefined
+	 * OR (||) `h`, `s`, `l` or `a` properties are not undefined
+	 *
+	 * before it was checking with NOT(!) statement witch for `0` (bool|int) values returns `true`
+	 * this is a typecasting issue only visible for hex values that derive from #000000
+	 */
+	return (
+		data.source === 'rgb' &&
+		( data.r === undefined ||
+			data.g === undefined ||
+			data.b === undefined ) &&
+		( data.h === undefined ||
+			data.s === undefined ||
+			data.v === undefined ||
+			data.a === undefined ) &&
+		( data.h === undefined ||
+			data.s === undefined ||
+			data.l === undefined ||
+			data.a === undefined )
+	);
 };
+
 const isValidColor = ( colors ) =>
 	colors.hex ? isValidHex( colors.hex ) : simpleCheckForValidColor( colors );
 


### PR DESCRIPTION
## Description
References: https://github.com/WordPress/gutenberg/issues/30798

## Types of changes
Bug fix for referenced issue
Fixes #30798

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
