### PR TITLE
Global Styles: refactor how we iterate over the tree

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1000,6 +1000,26 @@ class WP_Theme_JSON {
 		return $nodes;
 	}
 
+	public static function get_setting_nodes( $theme_json, $selectors = array() ) {
+		$nodes = array();
+		if ( ! isset( $theme_json['settings'] ) ) {
+			return $nodes;
+		}
+
+		foreach( $theme_json['settings'] as $name => $node ) {
+			$selector = null;
+			if ( isset( $selectors[ $name ]['selector'] ) ) {
+				$selector = $selectors[ $name ]['selector'];
+			}
+
+			$nodes[] = array(
+				'path'     => array( 'settings', $name ),
+				'selector' => $selector,
+			);
+		}
+		return $nodes;
+	}
+	
 	/**
 	 * Returns the stylesheet that results of processing
 	 * the theme.json structure this object represents.

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -872,28 +872,18 @@ class WP_Theme_JSON {
 	 * @return string The new stylesheet.
 	 */
 	private function get_block_styles() {
-		$stylesheet = '';
-		if ( ! isset( $this->theme_json['styles'] ) && ! isset( $this->theme_json['settings'] ) ) {
-			return $stylesheet;
-		}
-
 		$blocks_metadata = self::get_blocks_metadata();
+
 		$block_rules     = '';
-		foreach ( $blocks_metadata as $block_selector => $metadata ) {
-			if ( empty( $metadata['selector'] ) ) {
+		$style_nodes = self::get_style_nodes( $this->theme_json, $blocks_metadata );
+		foreach( $style_nodes as $metadata ) {
+			if ( null === $metadata['selector'] ) {
 				continue;
 			}
 
-			$selector = $metadata['selector'];
-
-			$declarations = array();
-			if ( isset( $this->theme_json['styles'][ $block_selector ] ) ) {
-				$declarations = self::compute_style_properties(
-					$declarations,
-					$this->theme_json['styles'][ $block_selector ]
-				);
-			}
-
+			$selector     = $metadata['selector'];
+			$node         = _wp_array_get( $this->theme_json, $metadata['path'], array() );
+			$declarations = self::compute_style_properties( array(), $node );
 			$block_rules .= self::to_ruleset( $selector, $declarations );
 		}
 

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -877,10 +877,9 @@ class WP_Theme_JSON {
 			return $stylesheet;
 		}
 
-		$metadata     = self::get_blocks_metadata();
-		$block_rules  = '';
-		$preset_rules = '';
-		foreach ( $metadata as $block_selector => $metadata ) {
+		$blocks_metadata = self::get_blocks_metadata();
+		$block_rules     = '';
+		foreach ( $blocks_metadata as $block_selector => $metadata ) {
 			if ( empty( $metadata['selector'] ) ) {
 				continue;
 			}
@@ -896,14 +895,18 @@ class WP_Theme_JSON {
 			}
 
 			$block_rules .= self::to_ruleset( $selector, $declarations );
+		}
 
-			// Attach the rulesets for the classes.
-			if ( isset( $this->theme_json['settings'][ $block_selector ] ) ) {
-				$preset_rules .= self::compute_preset_classes(
-					$this->theme_json['settings'][ $block_selector ],
-					$selector
-				);
+		$preset_rules  = '';
+		$setting_nodes = self::get_setting_nodes( $this->theme_json, $blocks_metadata );
+		foreach( $setting_nodes as $metadata ) {
+			if( null === $metadata['selector'] ) {
+				continue;
 			}
+
+			$selector      = $metadata['selector'];
+			$node          = _wp_array_get( $this->theme_json, $metadata['path'], array() );
+			$preset_rules .= self::compute_preset_classes( $node, $selector );
 		}
 
 		return $block_rules . $preset_rules;

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -980,6 +980,21 @@ class WP_Theme_JSON {
 		return $template_parts;
 	}
 
+	public static function get_style_nodes( $theme_json, $metadata = array() ) {
+		$nodes = array();
+		if ( ! isset( $theme_json['styles'] ) ) {
+			return $nodes;
+		}
+
+		foreach( $theme_json['styles'] as $name => $node ) {
+			$nodes[] = array(
+				'path'     => array( 'styles', $name ),
+				'selector' => null,
+			);
+		}
+		return $nodes;
+	}
+
 	/**
 	 * Returns the stylesheet that results of processing
 	 * the theme.json structure this object represents.

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -980,16 +980,21 @@ class WP_Theme_JSON {
 		return $template_parts;
 	}
 
-	public static function get_style_nodes( $theme_json, $metadata = array() ) {
+	public static function get_style_nodes( $theme_json, $selectors = array() ) {
 		$nodes = array();
 		if ( ! isset( $theme_json['styles'] ) ) {
 			return $nodes;
 		}
 
 		foreach( $theme_json['styles'] as $name => $node ) {
+			$selector = null;
+			if ( isset( $selectors[ $name ]['selector'] ) ) {
+				$selector = $selectors[ $name ]['selector'];
+			}
+
 			$nodes[] = array(
 				'path'     => array( 'styles', $name ),
-				'selector' => null,
+				'selector' => $selector,
 			);
 		}
 		return $nodes;

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -812,10 +812,8 @@ class WP_Theme_JSON {
 	 *
 	 * @return string The new stylesheet.
 	 */
-	private function get_css_variables() {
+	private function get_css_variables( $nodes ) {
 		$stylesheet = '';
-
-		$nodes = self::get_setting_nodes( $this->theme_json, self::get_blocks_metadata() );
 		foreach ( $nodes as $metadata ) {
 			if ( null === $metadata['selector'] ) {
 				continue;
@@ -871,11 +869,8 @@ class WP_Theme_JSON {
 	 *
 	 * @return string The new stylesheet.
 	 */
-	private function get_block_styles() {
-		$blocks_metadata = self::get_blocks_metadata();
-
+	private function get_block_styles( $style_nodes, $setting_nodes ) {
 		$block_rules     = '';
-		$style_nodes = self::get_style_nodes( $this->theme_json, $blocks_metadata );
 		foreach( $style_nodes as $metadata ) {
 			if ( null === $metadata['selector'] ) {
 				continue;
@@ -888,7 +883,6 @@ class WP_Theme_JSON {
 		}
 
 		$preset_rules  = '';
-		$setting_nodes = self::get_setting_nodes( $this->theme_json, $blocks_metadata );
 		foreach( $setting_nodes as $metadata ) {
 			if( null === $metadata['selector'] ) {
 				continue;
@@ -1021,13 +1015,17 @@ class WP_Theme_JSON {
 	 * @return string Stylesheet.
 	 */
 	public function get_stylesheet( $type = 'all' ) {
+		$blocks_metadata = self::get_blocks_metadata();
+		$style_nodes     = self::get_style_nodes( $this->theme_json, $blocks_metadata );
+		$setting_nodes   = self::get_setting_nodes( $this->theme_json, $blocks_metadata );
+
 		switch ( $type ) {
 			case 'block_styles':
-				return $this->get_block_styles();
+				return $this->get_block_styles( $style_nodes, $setting_nodes );
 			case 'css_variables':
-				return $this->get_css_variables();
+				return $this->get_css_variables( $setting_nodes );
 			default:
-				return $this->get_css_variables() . $this->get_block_styles();
+				return $this->get_css_variables( $setting_nodes ) . $this->get_block_styles( $style_nodes, $setting_nodes );
 		}
 	}
 

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -814,23 +814,23 @@ class WP_Theme_JSON {
 	 */
 	private function get_css_variables() {
 		$stylesheet = '';
-		if ( ! isset( $this->theme_json['settings'] ) ) {
-			return $stylesheet;
-		}
 
-		$metadata = self::get_blocks_metadata();
-		foreach ( $this->theme_json['settings'] as $block_selector => $settings ) {
-			if ( empty( $metadata[ $block_selector ]['selector'] ) ) {
+		$nodes = self::get_setting_nodes( $this->theme_json, self::get_blocks_metadata() );
+		foreach ( $nodes as $metadata ) {
+			if ( null === $metadata['selector'] ) {
 				continue;
 			}
-			$selector = $metadata[ $block_selector ]['selector'];
 
-			$declarations = self::compute_preset_vars( array(), $settings );
-			$declarations = self::compute_theme_vars( $declarations, $settings );
+			$selector     = $metadata['selector'];
 
-			// Attach the ruleset for style and custom properties.
-			$stylesheet .= self::to_ruleset( $selector, $declarations );
+			$node         = _wp_array_get( $this->theme_json, $metadata['path'], array() );
+			$declarations = array();
+			$declarations = self::compute_preset_vars( array(), $node );
+			$declarations = self::compute_theme_vars( $declarations, $node );
+
+			$stylesheet  .= self::to_ruleset( $selector, $declarations );
 		}
+
 		return $stylesheet;
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -999,4 +999,36 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual['settings']['defaults']['spacing'] );
 	}
 
+	function test_get_style_nodes() {
+		$theme_json = array(
+			'styles' => array(
+				'defaults' => array(
+					'color' => array( 'background' => 'red' ),
+				),
+				'root' => array(
+					'color' => array( 'background' => 'green' ),
+				),
+				'core/paragraph' => array(
+					'color' => array( 'background' => 'blue' ),
+				),
+			)
+		);
+		$actual  = WP_Theme_JSON::get_style_nodes( $theme_json );
+		$expected = array(
+			array(
+				'path'     => array( 'styles', 'defaults' ),
+				'selector' => null
+			),
+			array(
+				'path'     => array( 'styles', 'root' ),
+				'selector' => null,
+			),
+			array(
+				'path'     => array( 'styles', 'core/paragraph' ),
+				'selector' => null,
+			),
+		);
+
+		$this->assertEqualSets( $expected, $actual );
+	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1008,20 +1008,22 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				'core/heading/h1' => array( 'color' => array( 'background' => 'yellow' ) ),
 				'core/group'      => array( 'color' => array( 'background' => 'pink' ) ),
 				'core/post-title' => array( 'color' => array( 'background' => 'white' ) ),
-			)
+			),
 		);
-		$selectors = array(
+		$selectors  = array(
 			'defaults'        => array( 'selector' => ':root' ),
 			'root'            => array( 'selector' => ':root' ),
 			'core/paragraph'  => array( 'selector' => 'p' ),
 			'core/heading/h1' => array( 'selector' => 'h1' ),
 			'core/group'      => array( 'selector' => '.wp-block-group' ),
 		);
-		$actual  = WP_Theme_JSON::get_style_nodes( $theme_json, $selectors );
+
+		$actual = WP_Theme_JSON::get_style_nodes( $theme_json, $selectors );
+
 		$expected = array(
 			array(
 				'path'     => array( 'styles', 'defaults' ),
-				'selector' => ':root'
+				'selector' => ':root',
 			),
 			array(
 				'path'     => array( 'styles', 'root' ),
@@ -1057,20 +1059,22 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				'core/heading/h1' => array( 'border' => array( 'customRadius' => false ) ),
 				'core/group'      => array( 'border' => array( 'customRadius' => true ) ),
 				'core/post-title' => array( 'border' => array( 'customRadius' => false ) ),
-			)
+			),
 		);
-		$selectors = array(
+		$selectors  = array(
 			'defaults'        => array( 'selector' => ':root' ),
 			'root'            => array( 'selector' => ':root' ),
 			'core/paragraph'  => array( 'selector' => 'p' ),
 			'core/heading/h1' => array( 'selector' => 'h1' ),
 			'core/group'      => array( 'selector' => '.wp-block-group' ),
 		);
-		$actual  = WP_Theme_JSON::get_setting_nodes( $theme_json, $selectors );
+
+		$actual = WP_Theme_JSON::get_setting_nodes( $theme_json, $selectors );
+
 		$expected = array(
 			array(
 				'path'     => array( 'settings', 'defaults' ),
-				'selector' => ':root'
+				'selector' => ':root',
 			),
 			array(
 				'path'     => array( 'settings', 'root' ),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1002,29 +1002,45 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	function test_get_style_nodes() {
 		$theme_json = array(
 			'styles' => array(
-				'defaults' => array(
-					'color' => array( 'background' => 'red' ),
-				),
-				'root' => array(
-					'color' => array( 'background' => 'green' ),
-				),
-				'core/paragraph' => array(
-					'color' => array( 'background' => 'blue' ),
-				),
+				'defaults'        => array( 'color' => array( 'background' => 'red' ) ),
+				'root'            => array( 'color' => array( 'background' => 'green' ) ),
+				'core/paragraph'  => array( 'color' => array( 'background' => 'blue' ) ),
+				'core/heading/h1' => array( 'color' => array( 'background' => 'yellow' ) ),
+				'core/group'      => array( 'color' => array( 'background' => 'pink' ) ),
+				'core/post-title' => array( 'color' => array( 'background' => 'white' ) ),
 			)
 		);
-		$actual  = WP_Theme_JSON::get_style_nodes( $theme_json );
+		$selectors = array(
+			'defaults'        => array( 'selector' => ':root' ),
+			'root'            => array( 'selector' => ':root' ),
+			'core/paragraph'  => array( 'selector' => 'p' ),
+			'core/heading/h1' => array( 'selector' => 'h1' ),
+			'core/group'      => array( 'selector' => '.wp-block-group' ),
+		);
+		$actual  = WP_Theme_JSON::get_style_nodes( $theme_json, $selectors );
 		$expected = array(
 			array(
 				'path'     => array( 'styles', 'defaults' ),
-				'selector' => null
+				'selector' => ':root'
 			),
 			array(
 				'path'     => array( 'styles', 'root' ),
-				'selector' => null,
+				'selector' => ':root',
 			),
 			array(
 				'path'     => array( 'styles', 'core/paragraph' ),
+				'selector' => 'p',
+			),
+			array(
+				'path'     => array( 'styles', 'core/heading/h1' ),
+				'selector' => 'h1',
+			),
+			array(
+				'path'     => array( 'styles', 'core/group' ),
+				'selector' => '.wp-block-group',
+			),
+			array(
+				'path'     => array( 'styles', 'core/post-title' ),
 				'selector' => null,
 			),
 		);

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1047,4 +1047,53 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
 		$this->assertEqualSets( $expected, $actual );
 	}
+
+	function test_get_setting_nodes() {
+		$theme_json = array(
+			'settings' => array(
+				'defaults'        => array( 'border' => array( 'customRadius' => true ) ),
+				'root'            => array( 'border' => array( 'customRadius' => false ) ),
+				'core/paragraph'  => array( 'border' => array( 'customRadius' => true ) ),
+				'core/heading/h1' => array( 'border' => array( 'customRadius' => false ) ),
+				'core/group'      => array( 'border' => array( 'customRadius' => true ) ),
+				'core/post-title' => array( 'border' => array( 'customRadius' => false ) ),
+			)
+		);
+		$selectors = array(
+			'defaults'        => array( 'selector' => ':root' ),
+			'root'            => array( 'selector' => ':root' ),
+			'core/paragraph'  => array( 'selector' => 'p' ),
+			'core/heading/h1' => array( 'selector' => 'h1' ),
+			'core/group'      => array( 'selector' => '.wp-block-group' ),
+		);
+		$actual  = WP_Theme_JSON::get_setting_nodes( $theme_json, $selectors );
+		$expected = array(
+			array(
+				'path'     => array( 'settings', 'defaults' ),
+				'selector' => ':root'
+			),
+			array(
+				'path'     => array( 'settings', 'root' ),
+				'selector' => ':root',
+			),
+			array(
+				'path'     => array( 'settings', 'core/paragraph' ),
+				'selector' => 'p',
+			),
+			array(
+				'path'     => array( 'settings', 'core/heading/h1' ),
+				'selector' => 'h1',
+			),
+			array(
+				'path'     => array( 'settings', 'core/group' ),
+				'selector' => '.wp-block-group',
+			),
+			array(
+				'path'     => array( 'settings', 'core/post-title' ),
+				'selector' => null,
+			),
+		);
+
+		$this->assertEqualSets( $expected, $actual );
+	}
 }


### PR DESCRIPTION
Extracted from #30541 so it can land in pieces and make reviews easier/quicker.

This PR refactors the existing `WP_Theme_JSON` methods so they operate over nodes and so are independent of the theme.json structure. The logic about which paths to iterate over (the structure of theme.json) is centralized in two methods: `get_style_nodes` and `get_setting_nodes`. After this change, #30541 only has to update the `get_style_nodes` and `get_setting_nodes` logic to compute the paths based on the new structure ― the other methods will remain unchanged.

Perhaps the quickest way to review this PR is going commit by commit and compare the before/after changes. It doesn't change any behavior, only the internal logic of the methods ― I tried to keep each commit isolate for ease of review.

## How to test

`npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-test.php`
