### PR TITLE
Try: Remove padding from menu items when no background

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -8,17 +8,10 @@
 		display: flex;
 		align-items: center;
 		position: relative;
-		margin: 0 2em 0 0;
 
 		.wp-block-navigation-link__container:empty {
 			display: none;
 		}
-	}
-
-	// Margin of right-most margin should be zero, for right aligned or justified items.
-	.wp-block-navigation__container > .wp-block-pages-list__item:last-child,
-	.wp-block-navigation__container > .wp-block-navigation-link:last-child {
-		margin-right: 0;
 	}
 
 	// Menu item link.
@@ -27,21 +20,6 @@
 		// Inherit colors set by the block color definition.
 		color: inherit;
 		display: block;
-	}
-
-	// Treat margins and paddings differently when the block has a background.
-	&.has-background {
-		// Menu item container.
-		.wp-block-pages-list__item,
-		.wp-block-navigation-link {
-			margin: 0 0.5em 0 0;
-		}
-
-		// Menu item link.
-		.wp-block-pages-list__item__link,
-		.wp-block-navigation-link__content {
-			padding: 0.5em 1em;
-		}
 	}
 
 	// Force links to inherit text decoration applied to navigation block.
@@ -86,7 +64,6 @@
 	.wp-block-page-list__submenu-icon,
 	.wp-block-navigation-link__submenu-icon {
 		height: inherit;
-		padding: 0.375em 1em 0.375em 0;
 
 		svg {
 			stroke: currentColor;
@@ -105,8 +82,6 @@
 			background-color: inherit;
 			color: inherit;
 			position: absolute;
-			left: 0;
-			top: 100%;
 			z-index: 2;
 			display: flex;
 			flex-direction: column;
@@ -120,8 +95,6 @@
 
 			> .wp-block-pages-list__item,
 			> .wp-block-navigation-link {
-				margin: 0;
-
 				> .wp-block-pages-list__item__link,
 				> .wp-block-navigation-link__content {
 					flex-grow: 1;
@@ -133,13 +106,11 @@
 				}
 			}
 
+			// Nested submenus sit to the left on large breakpoints.
+			// On smaller breakpoints, they open vertically, accordion-style.
 			@include break-medium {
-				// Nested submenus sit to the left on large breakpoints.
 				.submenu-container,
 				.wp-block-navigation-link__container {
-					left: 100%;
-					top: 0;
-
 					// Prevent the menu from disappearing when the mouse is over the gap
 					&::before {
 						content: "";
@@ -218,6 +189,80 @@
 	}
 }
 
+// Margins, paddings, and submenu positions.
+// These need extra specificity to override potentially inherited properties.
+.wp-block.wp-block-navigation {
+
+	// Menu items with no background.
+	.wp-block-page-list,
+	.wp-block-page-list > .wp-block-pages-list__item,
+	.wp-block-navigation__container > .wp-block-navigation-link {
+		margin: 0 2em 0 0;
+
+		// Margin of right-most margin should be zero, for right aligned or justified items.
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+
+	// When the menu has a background, items have paddings, reduce margins to compensate.
+	// Treat margins and paddings differently when the block has a background.
+	&.has-background {
+		.wp-block-page-list,
+		.wp-block-page-list > .wp-block-pages-list__item,
+		.wp-block-navigation__container > .wp-block-navigation-link {
+			margin: 0 0.5em 0 0;
+		}
+
+		.wp-block-page-list > .wp-block-pages-list__item,
+		.wp-block-navigation__container > .wp-block-navigation-link {
+			padding: 0.5em 1em;
+		}
+	}
+
+	// Margins in submenus.
+	.has-child .submenu-container,
+	.has-child .wp-block-navigation-link__container {
+		.wp-block-pages-list__item,
+		.wp-block-navigation-link {
+			margin: 0 0 1em 0;
+		}
+
+		// Submenu indentation.
+		left: -1em;
+		top: calc(100% + 1em);
+
+		@include break-medium {
+			.submenu-container,
+			.wp-block-navigation-link__container {
+				left: calc(100% + 1em);
+				top: calc(-1px - 1em);
+			}
+		}
+	}
+
+	&.has-background .has-child .submenu-container,
+	&.has-background .has-child .wp-block-navigation-link__container {
+		.wp-block-pages-list__item,
+		.wp-block-navigation-link {
+			margin: 0;
+			padding: 0.5em 1em;
+		}
+
+		// Submenu indentation.
+		left: 0;
+		top: 100%;
+
+		@include break-medium {
+			.submenu-container,
+			.wp-block-navigation-link__container {
+				left: 100%;
+				top: 0;
+			}
+		}
+	}
+}
+
 // Default background and font color.
 .wp-block-navigation:not(.has-background) {
 	.submenu-container, // This target items created by the Page List block.
@@ -232,10 +277,5 @@
 
 		// Add some padding to menus even if the parent menu item doesn't have.
 		padding: 1em;
-
-		.submenu-container,
-		.wp-block-navigation-link__container {
-			top: -1px;
-		}
 	}
 }

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -8,7 +8,7 @@
 		display: flex;
 		align-items: center;
 		position: relative;
-		margin: 0 0.5em 0 0;
+		margin: 0 2em 0 0;
 
 		.wp-block-navigation-link__container:empty {
 			display: none;
@@ -27,7 +27,21 @@
 		// Inherit colors set by the block color definition.
 		color: inherit;
 		display: block;
-		padding: 0.5em 1em;
+	}
+
+	// Treat margins and paddings differently when the block has a background.
+	&.has-background {
+		// Menu item container.
+		.wp-block-pages-list__item,
+		.wp-block-navigation-link {
+			margin: 0 0.5em 0 0;
+		}
+
+		// Menu item link.
+		.wp-block-pages-list__item__link,
+		.wp-block-navigation-link__content {
+			padding: 0.5em 1em;
+		}
 	}
 
 	// Force links to inherit text decoration applied to navigation block.
@@ -215,6 +229,9 @@
 		background-color: #fff;
 		color: #000;
 		border: 1px solid rgba(0, 0, 0, 0.15);
+
+		// Add some padding to menus even if the parent menu item doesn't have.
+		padding: 1em;
 
 		.submenu-container,
 		.wp-block-navigation-link__container {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -11,37 +11,6 @@
 		margin-left: 0;
 		padding-left: 0;
 	}
-
-	// Unset horizontal and vertical margin rules from editor normalization stylesheet.
-	// Both margin-left: auto; and margin-right: auto; from .wp-block, and also
-	// margin: revert; from .editor-styles-wrapper ul li.
-	// These rules are not necessary for block themes.
-	.block-editor-block-list__block {
-		margin: 0;
-
-		// This CSS provides a little spacing between blocks.
-		// It matches a rule in style.scss exactly, but needs higher specificity due to the unsetting of inherited styles above.
-		&.wp-block-navigation-link {
-			margin: 0 2em 0 0;
-		}
-
-		&.has-child .block-editor-block-list__block.wp-block-navigation-link {
-			margin: 0;
-		}
-
-		// Margin of right-most margin should be zero, for right aligned or justified items.
-		&.wp-block-pages-list__item:last-child,
-		&.wp-block-navigation-link:last-child {
-			margin-right: 0;
-		}
-	}
-
-	&.block-editor-block-list__block.has-background {
-		.wp-block-pages-list__item.wp-block-pages-list__item,
-		.wp-block-navigation-link.wp-block-navigation-link {
-			margin: 0 0.5em 0 0;
-		}
-	}
 }
 
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -15,13 +15,14 @@
 	// Unset horizontal and vertical margin rules from editor normalization stylesheet.
 	// Both margin-left: auto; and margin-right: auto; from .wp-block, and also
 	// margin: revert; from .editor-styles-wrapper ul li.
+	// These rules are not necessary for block themes.
 	.block-editor-block-list__block {
 		margin: 0;
 
 		// This CSS provides a little spacing between blocks.
 		// It matches a rule in style.scss exactly, but needs higher specificity due to the unsetting of inherited styles above.
 		&.wp-block-navigation-link {
-			margin: 0 0.5em 0 0;
+			margin: 0 2em 0 0;
 		}
 
 		&.has-child .block-editor-block-list__block.wp-block-navigation-link {
@@ -32,6 +33,13 @@
 		&.wp-block-pages-list__item:last-child,
 		&.wp-block-navigation-link:last-child {
 			margin-right: 0;
+		}
+	}
+
+	&.block-editor-block-list__block.has-background {
+		.wp-block-pages-list__item.wp-block-pages-list__item,
+		.wp-block-navigation-link.wp-block-navigation-link {
+			margin: 0 0.5em 0 0;
 		}
 	}
 }


### PR DESCRIPTION
## Description

I'd like to try and make this pattern for the navigation block:

<img width="1440" alt="Pattern 2" src="https://user-images.githubusercontent.com/1204802/114563500-be1ff380-9c6f-11eb-8c9b-5047ccdb7e4d.png">

But I can't, because individual menu items have a built-in padding:

<img width="553" alt="Screenshot 2021-04-13 at 15 51 10" src="https://user-images.githubusercontent.com/1204802/114563861-1820b900-9c70-11eb-8bad-3477084f006a.png">

While it would be nice to implement consistent dimension controls so paddings can be customized (and that will still be nice and possible once #28356 lands), this PR implements a new default, which fixes this:

<img width="489" alt="after" src="https://user-images.githubusercontent.com/1204802/114563853-16ef8c00-9c70-11eb-89c9-a72231d08bc1.png">

The idea is pretty simple:

- If your navigation block has no background, menu items have larger margin between them, but no padding. Submenus have padding, here.
- If your navigation block has a background, menu items have padding, and smaller margin in between to compensate. Submenus have no padding, so menu items align.

Here are two examples. No background — notice how the navigation item aligns with the post title:

<img width="561" alt="Screenshot 2021-04-13 at 15 47 36" src="https://user-images.githubusercontent.com/1204802/114564100-4ef6cf00-9c70-11eb-9092-d341934f15b7.png">

Yes background:

<img width="755" alt="Screenshot 2021-04-13 at 15 47 46" src="https://user-images.githubusercontent.com/1204802/114564109-51f1bf80-9c70-11eb-91be-520aba50c45e.png">

## How has this been tested?

The testing instructions are:

- Test vertical and horizontal navigation blocks with both Page List and custom menu items inside. 
- Be sure to have submenu items.
- Test those with and without background colors.

When no background is there, the padding from menu items should be gone, but items should still be spaced harmoniously, inside and outside of submenus.

When there is a background, it should look the same as today.

Here's some testing content:

```
<!-- wp:paragraph -->
<p><strong>Menu with no background:</strong></p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"horizontal"} -->
<!-- wp:navigation-link {"label":"Gnome dioramas","type":"page","id":664,"url":"http://localhost:8888/?page_id=664","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"Cardboard Coffee","type":"post","id":816,"url":"http://localhost:8888/?p=816","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Services","type":"page","id":656,"url":"http://localhost:8888/?page_id=656","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"The Tape Measure","id":28,"url":"http://localhost:8888/?p=28"} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":15,"url":"http://localhost:8888/?page_id=15","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"(no title)","type":"page","id":731,"url":"http://localhost:8888/?page_id=731","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Custom Template","type":"page","id":725,"url":"http://localhost:8888/?page_id=725","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"Cardboard Coffee","type":"post","id":816,"url":"http://localhost:8888/?p=816","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Gnome dioramas","type":"page","id":664,"url":"http://localhost:8888/?page_id=664","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"(no title)","type":"page","id":731,"url":"http://localhost:8888/?page_id=731","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":11,"url":"http://localhost:8888/","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:page-list /-->
<!-- /wp:navigation -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p><strong>Menu with a background:</strong></p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"horizontal","backgroundColor":"light-gray"} -->
<!-- wp:navigation-link {"label":"Gnome dioramas","type":"page","id":664,"url":"http://localhost:8888/?page_id=664","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"Cardboard Coffee","type":"post","id":816,"url":"http://localhost:8888/?p=816","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Services","type":"page","id":656,"url":"http://localhost:8888/?page_id=656","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"The Tape Measure","id":28,"url":"http://localhost:8888/?p=28"} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":15,"url":"http://localhost:8888/?page_id=15","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"(no title)","type":"page","id":731,"url":"http://localhost:8888/?page_id=731","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Custom Template","type":"page","id":725,"url":"http://localhost:8888/?page_id=725","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"Cardboard Coffee","type":"post","id":816,"url":"http://localhost:8888/?p=816","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Gnome dioramas","type":"page","id":664,"url":"http://localhost:8888/?page_id=664","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"(no title)","type":"page","id":731,"url":"http://localhost:8888/?page_id=731","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":11,"url":"http://localhost:8888/","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:page-list /-->
<!-- /wp:navigation -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p><strong>Vertical with no background:</strong></p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"vertical"} -->
<!-- wp:navigation-link {"label":"Gnome dioramas","type":"page","id":664,"url":"http://localhost:8888/?page_id=664","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"Cardboard Coffee","type":"post","id":816,"url":"http://localhost:8888/?p=816","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Services","type":"page","id":656,"url":"http://localhost:8888/?page_id=656","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"The Tape Measure","id":28,"url":"http://localhost:8888/?p=28"} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":15,"url":"http://localhost:8888/?page_id=15","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"(no title)","type":"page","id":731,"url":"http://localhost:8888/?page_id=731","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Custom Template","type":"page","id":725,"url":"http://localhost:8888/?page_id=725","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Gnome dioramas","type":"page","id":664,"url":"http://localhost:8888/?page_id=664","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"(no title)","type":"page","id":731,"url":"http://localhost:8888/?page_id=731","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":11,"url":"http://localhost:8888/","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:page-list /-->
<!-- /wp:navigation -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p><strong>Veritcal with a background:</strong></p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"vertical","backgroundColor":"light-gray"} -->
<!-- wp:navigation-link {"label":"Gnome dioramas","type":"page","id":664,"url":"http://localhost:8888/?page_id=664","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"Cardboard Coffee","type":"post","id":816,"url":"http://localhost:8888/?p=816","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Services","type":"page","id":656,"url":"http://localhost:8888/?page_id=656","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"The Tape Measure","id":28,"url":"http://localhost:8888/?p=28"} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":15,"url":"http://localhost:8888/?page_id=15","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"(no title)","type":"page","id":731,"url":"http://localhost:8888/?page_id=731","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Custom Template","type":"page","id":725,"url":"http://localhost:8888/?page_id=725","kind":"post-type"} -->
<!-- wp:navigation-link {"label":"Cardboard Coffee","type":"post","id":816,"url":"http://localhost:8888/?p=816","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Gnome dioramas","type":"page","id":664,"url":"http://localhost:8888/?page_id=664","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"(no title)","type":"page","id":731,"url":"http://localhost:8888/?page_id=731","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":11,"url":"http://localhost:8888/","kind":"post-type"} /-->
<!-- /wp:navigation-link -->

<!-- wp:page-list /-->
<!-- /wp:navigation -->
```

☝️ That's tested with TwentyTwelve, you might need to add background colors again if you test in another theme. I will look at that use of has-background separately.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
