### PR TITLE
Include block title into block switcher label

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -109,7 +109,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					blockTitle
 			  )
 			: sprintf(
-					/* translators: %s: number of blocks. */
+					/* translators: %d: number of blocks. */
 					_n(
 						'Change type of %d block',
 						'Change type of %d blocks',

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -103,7 +103,11 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 
 	const blockSwitcherDescription =
 		1 === blocks.length
-			? __( 'Change block type or style' )
+			? sprintf(
+					/* translators: %s: block title. */
+					__( '%s: Change block type or style' ),
+					blockTitle
+			  )
 			: sprintf(
 					/* translators: %s: number of blocks. */
 					_n(


### PR DESCRIPTION
## Description
Adds block title to block switcher label.

Fixes #30160.

## How has this been tested?
1. Hover or focus on the block/block switcher icon.
2. Updated label should include block title.

## Screenshots <!-- if applicable -->
<img width="968" alt="block-switcher-label" src="https://user-images.githubusercontent.com/240569/114573151-2cbd7b00-9c89-11eb-84ec-cda732e0dd48.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
