### PR TITLE
Editor: Handle case where unavailable siteData is causing WSOD

### DIFF
--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -53,7 +53,7 @@ function PostPublishPanelPrepublish( { children } ) {
 			] ),
 			siteIconUrl: siteData.site_icon_url,
 			siteTitle: siteData.name,
-			siteHome: filterURLForDisplay( siteData.home ),
+			siteHome: siteData.home && filterURLForDisplay( siteData.home ),
 		};
 	}, [] );
 
@@ -102,10 +102,20 @@ function PostPublishPanelPrepublish( { children } ) {
 			<p>{ prePublishBodyText }</p>
 			<div className="components-site-card">
 				{ siteIcon }
-				<div className="components-site-info">
-					<span className="components-site-name">{ siteTitle }</span>
-					<span className="components-site-home">{ siteHome }</span>
-				</div>
+				{ ( siteTitle || siteHome ) && (
+					<div className="components-site-info">
+						{ siteTitle && (
+							<span className="components-site-name">
+								{ siteTitle }
+							</span>
+						) }
+						{ siteHome && (
+							<span className="components-site-home">
+								{ siteHome }
+							</span>
+						) }
+					</div>
+				) }
 			</div>
 			{ hasPublishAction && (
 				<>

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -102,20 +102,12 @@ function PostPublishPanelPrepublish( { children } ) {
 			<p>{ prePublishBodyText }</p>
 			<div className="components-site-card">
 				{ siteIcon }
-				{ ( siteTitle || siteHome ) && (
-					<div className="components-site-info">
-						{ siteTitle && (
-							<span className="components-site-name">
-								{ siteTitle }
-							</span>
-						) }
-						{ siteHome && (
-							<span className="components-site-home">
-								{ siteHome }
-							</span>
-						) }
-					</div>
-				) }
+				<div className="components-site-info">
+					<span className="components-site-name">
+						{ siteTitle || __( '(Untitled)' ) }
+					</span>
+					<span className="components-site-home">{ siteHome }</span>
+				</div>
 			</div>
 			{ hasPublishAction && (
 				<>


### PR DESCRIPTION
## Description
Fix a bug introduced in https://github.com/WordPress/gutenberg/pull/30231, where the WSOD is thrown in the pre-publish phase if the [`siteData`](https://github.com/WordPress/gutenberg/blob/e7f15ba42ea16cb39167dff5191767531525e5ca/packages/editor/src/components/post-publish-panel/prepublish.js#L39-L40) object is empty. 

## How has this been tested?
- Force the [`siteData` object](https://github.com/WordPress/gutenberg/blob/e7f15ba42ea16cb39167dff5191767531525e5ca/packages/editor/src/components/post-publish-panel/prepublish.js#L39-L40) to be empty,
- Click the `Publish` button - WSOD should not be thrown,
- Check the [`siteTitle` and `siteHome` elements](https://github.com/WordPress/gutenberg/blob/e7f15ba42ea16cb39167dff5191767531525e5ca/packages/editor/src/components/post-publish-panel/prepublish.js#L105-L118) in the pre-publish panel and make sure they're not rendered empty.

## Screenshot
Errors thrown when `siteData` object is unavailable:

<img width="1049" alt="Screenshot 2021-04-13 at 18 24 38" src="https://user-images.githubusercontent.com/1451471/114587086-9b003e80-9c85-11eb-8ce6-4ce284e9eb5f.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue)