### PR TITLE
Fixture regeneration: Infer tabs use from prettier config

### DIFF
--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -19,6 +19,7 @@ import {
 	registerCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
+import prettierConfig from '@wordpress/prettier-config';
 //eslint-disable-next-line no-restricted-syntax
 import {
 	blockNameToFixtureBasename,
@@ -75,6 +76,13 @@ describe( 'full post content fixture', () => {
 		}
 	} );
 
+	let spacer = 4;
+	if ( prettierConfig?.useTabs ) {
+		spacer = '\t';
+	} else if ( prettierConfig?.tabWidth ) {
+		spacer = prettierConfig?.tabWidth;
+	}
+
 	blockBasenames.forEach( ( basename ) => {
 		// eslint-disable-next-line jest/valid-title
 		it( basename, () => {
@@ -98,7 +106,7 @@ describe( 'full post content fixture', () => {
 				parserOutputExpectedString = parsedJSONFixtureContent;
 			} else if ( process.env.GENERATE_MISSING_FIXTURES ) {
 				parserOutputExpectedString =
-					JSON.stringify( parserOutputActual, null, '\t' ) + '\n';
+					JSON.stringify( parserOutputActual, null, spacer ) + '\n';
 				writeBlockFixtureParsedJSON(
 					basename,
 					parserOutputExpectedString
@@ -152,7 +160,8 @@ describe( 'full post content fixture', () => {
 				blocksExpectedString = jsonFixtureContent;
 			} else if ( process.env.GENERATE_MISSING_FIXTURES ) {
 				blocksExpectedString =
-					JSON.stringify( blocksActualNormalized, null, '\t' ) + '\n';
+					JSON.stringify( blocksActualNormalized, null, spacer ) +
+					'\n';
 				writeBlockFixtureJSON( basename, blocksExpectedString );
 			} else {
 				throw new Error(

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -98,7 +98,7 @@ describe( 'full post content fixture', () => {
 				parserOutputExpectedString = parsedJSONFixtureContent;
 			} else if ( process.env.GENERATE_MISSING_FIXTURES ) {
 				parserOutputExpectedString =
-					JSON.stringify( parserOutputActual, null, 4 ) + '\n';
+					JSON.stringify( parserOutputActual, null, '\t' ) + '\n';
 				writeBlockFixtureParsedJSON(
 					basename,
 					parserOutputExpectedString
@@ -152,7 +152,7 @@ describe( 'full post content fixture', () => {
 				blocksExpectedString = jsonFixtureContent;
 			} else if ( process.env.GENERATE_MISSING_FIXTURES ) {
 				blocksExpectedString =
-					JSON.stringify( blocksActualNormalized, null, 4 ) + '\n';
+					JSON.stringify( blocksActualNormalized, null, '\t' ) + '\n';
 				writeBlockFixtureJSON( basename, blocksExpectedString );
 			} else {
 				throw new Error(


### PR DESCRIPTION
## Description
First iteration towards fixing #30795.

This changes the `npm run fixtures:regenerate` script such that it infers tabs or spaces usage from `@wordpress/prettier-config`.

## How has this been tested?
Run

```
npm run fixtures:regenerate test/integration/full-content/full-content.test.js
```

This will _still_ result in a diff over what `prettier` produces, but it's significantly smaller than before. Basically, it now only affects non-empty arrays (specifically found in the `innerContent` field), e.g.:

```diff
diff --git a/packages/e2e-tests/fixtures/blocks/core__4-invalid-starting-letter.parsed.json b/packages/e2e-tests/fixtures/blocks/core__4-invalid-starting-letter.parsed.json
index 2361c26919..365e6db3a3 100644
--- a/packages/e2e-tests/fixtures/blocks/core__4-invalid-starting-letter.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__4-invalid-starting-letter.parsed.json
@@ -4,6 +4,8 @@
                "attrs": {},
                "innerBlocks": [],
                "innerHTML": "<!-- wp:core/4-invalid /-->\n",
-               "innerContent": [ "<!-- wp:core/4-invalid /-->\n" ]
+               "innerContent": [
+                       "<!-- wp:core/4-invalid /-->\n"
+               ]
        }
 ]
diff --git a/packages/e2e-tests/fixtures/blocks/core__audio.parsed.json b/packages/e2e-tests/fixtures/blocks/core__audio.parsed.json
index e634266522..ac51bb9e7f 100644
--- a/packages/e2e-tests/fixtures/blocks/core__audio.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__audio.parsed.json
@@ -15,6 +15,8 @@
                "attrs": {},
                "innerBlocks": [],
                "innerHTML": "\n",
-               "innerContent": [ "\n" ]
+               "innerContent": [
+                       "\n"
+               ]
        }
 ]
```

etc.

I don't think we can "teach" [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) to behave like `prettier` here. Alternatively, we might want to run `prettier` as part of the `fixtures:regenerate` command.