### PR TITLE
Query Block Patterns: Add the small image and title pattern back in, fix excerpt length. 

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -29,6 +29,27 @@ register_block_pattern(
 );
 
 register_block_pattern(
+ 	'query/small-posts',
+ 	array(
+ 		'title'      => __( 'Small Image and Title', 'gutenberg' ),
+ 		'blockTypes' => array( 'core/query' ),
+ 		'categories' => array( 'Query' ),
+ 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+ 						<!-- wp:query-loop -->
+ 						<!-- wp:columns {"verticalAlignment":"center"} -->
+ 						<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+ 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:post-featured-image {"isLink":true} /--></div>
+ 						<!-- /wp:column -->
+ 						<!-- wp:column {"verticalAlignment":"center","width":"75%"} -->
+ 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:75%"><!-- wp:post-title {"isLink":true} /--></div>
+ 						<!-- /wp:column --></div>
+ 						<!-- /wp:columns -->
+ 						<!-- /wp:query-loop -->
+ 						<!-- /wp:query -->',
+ 	)
+ );
+
+register_block_pattern(
 	'query/medium-posts',
 	array(
 		'title'      => __( 'Image at Left', 'gutenberg' ),

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -81,7 +81,7 @@ register_block_pattern(
 						<!-- wp:query-loop -->
 						<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
 						<main class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:post-title {"isLink":true} /-->
-						<!-- wp:post-excerpt /-->
+						<!-- wp:post-excerpt {"wordCount":20} /-->
 						<!-- wp:post-date /--></div>
 						<!-- /wp:group -->
 						<!-- /wp:query-loop -->

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -29,27 +29,6 @@ register_block_pattern(
 );
 
 register_block_pattern(
- 	'query/small-posts',
- 	array(
- 		'title'      => __( 'Small Image and Title', 'gutenberg' ),
- 		'blockTypes' => array( 'core/query' ),
- 		'categories' => array( 'Query' ),
- 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
- 						<!-- wp:query-loop -->
- 						<!-- wp:columns {"verticalAlignment":"center"} -->
- 						<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
- 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:post-featured-image {"isLink":true} /--></div>
- 						<!-- /wp:column -->
- 						<!-- wp:column {"verticalAlignment":"center","width":"75%"} -->
- 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:75%"><!-- wp:post-title {"isLink":true} /--></div>
- 						<!-- /wp:column --></div>
- 						<!-- /wp:columns -->
- 						<!-- /wp:query-loop -->
- 						<!-- /wp:query -->',
- 	)
- );
-
-register_block_pattern(
 	'query/medium-posts',
 	array(
 		'title'      => __( 'Image at Left', 'gutenberg' ),
@@ -70,6 +49,27 @@ register_block_pattern(
 						<!-- /wp:query -->',
 	)
 );
+
+register_block_pattern(
+ 	'query/small-posts',
+ 	array(
+ 		'title'      => __( 'Small Image and Title', 'gutenberg' ),
+ 		'blockTypes' => array( 'core/query' ),
+ 		'categories' => array( 'Query' ),
+ 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+ 						<!-- wp:query-loop -->
+ 						<!-- wp:columns {"verticalAlignment":"center"} -->
+ 						<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+ 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:post-featured-image {"isLink":true} /--></div>
+ 						<!-- /wp:column -->
+ 						<!-- wp:column {"verticalAlignment":"center","width":"75%"} -->
+ 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:75%"><!-- wp:post-title {"isLink":true} /--></div>
+ 						<!-- /wp:column --></div>
+ 						<!-- /wp:columns -->
+ 						<!-- /wp:query-loop -->
+ 						<!-- /wp:query -->',
+ 	)
+ );
 
 register_block_pattern(
 	'query/grid-posts',

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -51,25 +51,25 @@ register_block_pattern(
 );
 
 register_block_pattern(
- 	'query/small-posts',
- 	array(
- 		'title'      => __( 'Small Image and Title', 'gutenberg' ),
- 		'blockTypes' => array( 'core/query' ),
- 		'categories' => array( 'Query' ),
- 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
- 						<!-- wp:query-loop -->
- 						<!-- wp:columns {"verticalAlignment":"center"} -->
- 						<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
- 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:post-featured-image {"isLink":true} /--></div>
- 						<!-- /wp:column -->
- 						<!-- wp:column {"verticalAlignment":"center","width":"75%"} -->
- 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:75%"><!-- wp:post-title {"isLink":true} /--></div>
- 						<!-- /wp:column --></div>
- 						<!-- /wp:columns -->
- 						<!-- /wp:query-loop -->
- 						<!-- /wp:query -->',
- 	)
- );
+	'query/small-posts',
+	array(
+		'title'      => __( 'Small Image and Title', 'gutenberg' ),
+		'blockTypes' => array( 'core/query' ),
+		'categories' => array( 'Query' ),
+		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+						<!-- wp:query-loop -->
+						<!-- wp:columns {"verticalAlignment":"center"} -->
+						<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:post-featured-image {"isLink":true} /--></div>
+						<!-- /wp:column -->
+						<!-- wp:column {"verticalAlignment":"center","width":"75%"} -->
+						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:75%"><!-- wp:post-title {"isLink":true} /--></div>
+						<!-- /wp:column --></div>
+						<!-- /wp:columns -->
+						<!-- /wp:query-loop -->
+						<!-- /wp:query -->',
+	)
+);
 
 register_block_pattern(
 	'query/grid-posts',
@@ -162,7 +162,7 @@ register_block_pattern(
 		'blockTypes'    => array( 'core/paragraph' ),
 		'viewportWidth' => 500,
 		'content'       => '<!-- wp:paragraph {"style":{"color":{"link":"#FFFFFF","text":"#FFFFFF","background":"#000000"},"typography":{"lineHeight":"1.3","fontSize":"26px"}}} -->
-						 	<p class="has-text-color has-background has-link-color" style="--wp--style--color--link:#FFFFFF;background-color:#000000;color:#FFFFFF;font-size:26px;line-height:1.3">The whole series of my life appeared to me as a dream; I sometimes doubted if indeed it were all true, for it never presented itself to my mind with the force of reality.</p>
+							<p class="has-text-color has-background has-link-color" style="--wp--style--color--link:#FFFFFF;background-color:#000000;color:#FFFFFF;font-size:26px;line-height:1.3">The whole series of my life appeared to me as a dream; I sometimes doubted if indeed it were all true, for it never presented itself to my mind with the force of reality.</p>
 							<!-- /wp:paragraph -->',
 	)
 );


### PR DESCRIPTION
Quick followup from #30763.

- We removed the small pattern last minute down here, but on second thought, let's keep it back in. The tiny image and title shows some good variety. 
- Adds a max word count to the Excerpt in the Grid pattern, to prevent excerpts from getting huge. 

## Screenshots

New "Small Image and Title" pattern: 

![Screen Shot 2021-04-13 at 3 43 06 PM](https://user-images.githubusercontent.com/1202812/114611367-f5da6b80-9c6e-11eb-822b-240d3fac098a.png)

Excerpts: 

Before|After
---|---
![Screen Shot 2021-04-13 at 3 40 58 PM](https://user-images.githubusercontent.com/1202812/114611513-215d5600-9c6f-11eb-9184-6cdc5af835dc.png)|![Screen Shot 2021-04-13 at 3 39 40 PM](https://user-images.githubusercontent.com/1202812/114611516-21f5ec80-9c6f-11eb-984b-8b8f2714e74c.png)
