### PR TITLE
Handbook: Fix more example for register_block_type - apiVersion to api_version

### DIFF
--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -142,7 +142,7 @@ function gutenberg_examples_02_register_block() {
 	wp_style_add_data( 'gutenberg-examples-02', 'path', dirname( __FILE__ ) . '/style.css' );
 
 	register_block_type( 'gutenberg-examples/example-02-stylesheets', array(
-		'apiVersion' => 2,
+		'api_version' => 2,
 		'style' => 'gutenberg-examples-02',
 		'editor_style' => 'gutenberg-examples-02-editor',
 		'editor_script' => 'gutenberg-examples-02',

--- a/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md
@@ -134,7 +134,7 @@ function gutenberg_examples_dynamic() {
 	);
 
 	register_block_type( 'gutenberg-examples/example-dynamic', array(
-		'apiVersion' => 2,
+		'api_version' => 2,
 		'editor_script' => 'gutenberg-examples-dynamic',
 		'render_callback' => 'gutenberg_examples_dynamic_render_callback'
 	) );

--- a/docs/how-to-guides/internationalization.md
+++ b/docs/how-to-guides/internationalization.md
@@ -28,7 +28,7 @@ function myguten_block_init() {
     );
 
     register_block_type( 'myguten/simple', array(
-		'apiVersion' => 2,
+		'api_version' => 2,
         'editor_script' => 'myguten-script',
     ) );
 }

--- a/docs/how-to-guides/metabox/meta-block-4-use-data.md
+++ b/docs/how-to-guides/metabox/meta-block-4-use-data.md
@@ -36,7 +36,7 @@ function myguten_render_paragraph( $block_attributes, $content ) {
 }
 
 register_block_type( 'core/paragraph', array(
-	'apiVersion' => 2,
+	'api_version' => 2,
 	'render_callback' => 'myguten_render_paragraph',
 ) );
 ```

--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -134,7 +134,7 @@ If you pass `attributes` to `ServerSideRender`, the block must also be registere
 register_block_type(
 	'core/archives',
 	array(
-		'apiVersion' => 2,
+		'api_version' => 2,
 		'attributes'      => array(
 			'showPostCounts'    => array(
 				'type'      => 'boolean',


### PR DESCRIPTION
## Description
In the PR  #30818 @reason-alex fixed the typo `apiVersion` => `api_version` in the PHP examples for register_block_type(). This is also incorrect in other examples.