### PR TITLE
Template part - register block variations and area selection inputs from original area definitions.

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -84,6 +84,10 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_supports_block_templates();
 
+	if ( gutenberg_is_fse_theme() ) {
+		$settings['defaultTemplatePartAreas'] = gutenberg_get_allowed_template_part_areas();
+	}
+
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -184,14 +184,16 @@ function gutenberg_get_allowed_template_part_areas() {
 				'The Header template defines a page area that typically contains a title, logo, and main navigation.',
 				'gutenberg'
 			),
+			'icon'        => 'header',
 		),
 		array(
 			'area'        => WP_TEMPLATE_PART_AREA_FOOTER,
 			'label'       => __( 'Footer', 'gutenberg' ),
 			'description' => __(
 				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.',
-				'gutenberg'
+				'gutenberg',
 			),
+			'icon'        => 'footer',
 		),
 	);
 

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -192,7 +192,7 @@ function gutenberg_get_allowed_template_part_areas() {
 			'label'                 => __( 'Footer', 'gutenberg' ),
 			'description'           => __(
 				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.',
-				'gutenberg',
+				'gutenberg'
 			),
 			'icon'                  => 'footer',
 			'defaultWrapperElement' => 'footer',

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -176,26 +176,28 @@ function gutenberg_get_allowed_template_part_areas() {
 				'General templates often perform a specific role like displaying post content, and are not tied to any particular area.',
 				'gutenberg'
 			),
+			'icon'        => 'layout',
+			'area_tag'    => 'div',
 		),
 		array(
-			'area'                  => WP_TEMPLATE_PART_AREA_HEADER,
-			'label'                 => __( 'Header', 'gutenberg' ),
-			'description'           => __(
+			'area'        => WP_TEMPLATE_PART_AREA_HEADER,
+			'label'       => __( 'Header', 'gutenberg' ),
+			'description' => __(
 				'The Header template defines a page area that typically contains a title, logo, and main navigation.',
 				'gutenberg'
 			),
-			'icon'                  => 'header',
-			'defaultWrapperElement' => 'header',
+			'icon'        => 'header',
+			'area_tag'    => 'header',
 		),
 		array(
-			'area'                  => WP_TEMPLATE_PART_AREA_FOOTER,
-			'label'                 => __( 'Footer', 'gutenberg' ),
-			'description'           => __(
+			'area'        => WP_TEMPLATE_PART_AREA_FOOTER,
+			'label'       => __( 'Footer', 'gutenberg' ),
+			'description' => __(
 				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.',
 				'gutenberg'
 			),
-			'icon'                  => 'footer',
-			'defaultWrapperElement' => 'footer',
+			'icon'        => 'footer',
+			'area_tag'    => 'footer',
 		),
 	);
 

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -178,22 +178,24 @@ function gutenberg_get_allowed_template_part_areas() {
 			),
 		),
 		array(
-			'area'        => WP_TEMPLATE_PART_AREA_HEADER,
-			'label'       => __( 'Header', 'gutenberg' ),
-			'description' => __(
+			'area'                  => WP_TEMPLATE_PART_AREA_HEADER,
+			'label'                 => __( 'Header', 'gutenberg' ),
+			'description'           => __(
 				'The Header template defines a page area that typically contains a title, logo, and main navigation.',
 				'gutenberg'
 			),
-			'icon'        => 'header',
+			'icon'                  => 'header',
+			'defaultWrapperElement' => 'header',
 		),
 		array(
-			'area'        => WP_TEMPLATE_PART_AREA_FOOTER,
-			'label'       => __( 'Footer', 'gutenberg' ),
-			'description' => __(
+			'area'                  => WP_TEMPLATE_PART_AREA_FOOTER,
+			'label'                 => __( 'Footer', 'gutenberg' ),
+			'description'           => __(
 				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.',
 				'gutenberg',
 			),
-			'icon'        => 'footer',
+			'icon'                  => 'footer',
+			'defaultWrapperElement' => 'footer',
 		),
 	);
 

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -8,16 +8,12 @@ import { InspectorAdvancedControls } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
-/**
- * Internal dependencies
- */
-import { getTagBasedOnArea } from './get-tag-based-on-area';
-
 export function TemplatePartAdvancedControls( {
 	tagName,
 	setAttributes,
 	isEntityAvailable,
 	templatePartId,
+	defaultWrapper,
 } ) {
 	const [ area, setArea ] = useEntityProp(
 		'postType',
@@ -74,7 +70,7 @@ export function TemplatePartAdvancedControls( {
 						label: sprintf(
 							/* translators: %s: HTML tag based on area. */
 							__( 'Default based on area (%s)' ),
-							`<${ getTagBasedOnArea( area ) }>`
+							`<${ defaultWrapper }>`
 						),
 						value: '',
 					},

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -5,20 +5,13 @@ import { useEntityProp } from '@wordpress/core-data';
 import { SelectControl, TextControl } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import { getTagBasedOnArea } from './get-tag-based-on-area';
-
-const AREA_OPTIONS = [
-	{ label: __( 'Header' ), value: 'header' },
-	{ label: __( 'Footer' ), value: 'footer' },
-	{
-		label: __( 'General' ),
-		value: 'uncategorized',
-	},
-];
 
 export function TemplatePartAdvancedControls( {
 	tagName,
@@ -40,6 +33,18 @@ export function TemplatePartAdvancedControls( {
 		templatePartId
 	);
 
+	const { areaOptions } = useSelect( ( select ) => {
+		const definedAreas = select(
+			editorStore
+		).__experimentalGetDefaultTemplatePartAreas();
+		return {
+			areaOptions: definedAreas.map( ( { label, area: _area } ) => ( {
+				label,
+				value: _area,
+			} ) ),
+		};
+	}, [] );
+
 	return (
 		<InspectorAdvancedControls>
 			{ isEntityAvailable && (
@@ -56,7 +61,7 @@ export function TemplatePartAdvancedControls( {
 					<SelectControl
 						label={ __( 'Area' ) }
 						labelPosition="top"
-						options={ AREA_OPTIONS }
+						options={ areaOptions }
 						value={ area }
 						onChange={ setArea }
 					/>

--- a/packages/block-library/src/template-part/edit/get-tag-based-on-area.js
+++ b/packages/block-library/src/template-part/edit/get-tag-based-on-area.js
@@ -1,9 +1,0 @@
-const AREA_TAGS = {
-	footer: 'footer',
-	header: 'header',
-	uncategorized: 'div',
-};
-
-export function getTagBasedOnArea( area ) {
-	return AREA_TAGS[ area ] || AREA_TAGS.uncategorized;
-}

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -66,8 +66,10 @@ export default function TemplatePartEdit( {
 
 			const defaultWrapperElement = select( editorStore )
 				.__experimentalGetDefaultTemplatePartAreas()
-				.find( ( { area } ) => area === entityRecord?.area )
-				?.defaultWrapperElement;
+				.find(
+					( { area } ) =>
+						area === ( entityRecord?.area || attributes.area )
+				)?.area_tag;
 
 			return {
 				innerBlocks: getBlocks( clientId ),

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -25,7 +26,6 @@ import TemplatePartInnerBlocks from './inner-blocks';
 import TemplatePartPlaceholder from './placeholder';
 import TemplatePartSelection from './selection';
 import { TemplatePartAdvancedControls } from './advanced-controls';
-import { getTagBasedOnArea } from './get-tag-based-on-area';
 
 export default function TemplatePartEdit( {
 	attributes,
@@ -42,7 +42,7 @@ export default function TemplatePartEdit( {
 	// Set the postId block attribute if it did not exist,
 	// but wait until the inner blocks have loaded to allow
 	// new edits to trigger this.
-	const { isResolved, innerBlocks, isMissing, area } = useSelect(
+	const { isResolved, innerBlocks, isMissing, defaultWrapper } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, hasFinishedResolution } = select(
 				coreStore
@@ -64,11 +64,16 @@ export default function TemplatePartEdit( {
 				  )
 				: false;
 
+			const defaultWrapperElement = select( editorStore )
+				.__experimentalGetDefaultTemplatePartAreas()
+				.find( ( { area } ) => area === entityRecord?.area )
+				?.defaultWrapperElement;
+
 			return {
 				innerBlocks: getBlocks( clientId ),
 				isResolved: hasResolvedEntity,
 				isMissing: hasResolvedEntity && ! entityRecord,
-				area: entityRecord?.area,
+				defaultWrapper: defaultWrapperElement || 'div',
 			};
 		},
 		[ templatePartId, clientId ]
@@ -77,7 +82,7 @@ export default function TemplatePartEdit( {
 	const blockProps = useBlockProps();
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
-	const TagName = tagName || getTagBasedOnArea( area );
+	const TagName = tagName || defaultWrapper;
 
 	// We don't want to render a missing state if we have any inner blocks.
 	// A new template part is automatically created if we have any inner blocks but no entity.
@@ -117,6 +122,7 @@ export default function TemplatePartEdit( {
 				setAttributes={ setAttributes }
 				isEntityAvailable={ isEntityAvailable }
 				templatePartId={ templatePartId }
+				defaultWrapper={ defaultWrapper }
 			/>
 			{ isPlaceholder && (
 				<TagName { ...blockProps }>

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -16,7 +16,7 @@ import { layout } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
-import variations from './variations';
+import './variations';
 
 const { name } = metadata;
 export { metadata, name };
@@ -47,5 +47,4 @@ export const settings = {
 		return startCase( entity.title?.rendered || entity.slug );
 	},
 	edit,
-	variations,
 };

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -114,8 +114,8 @@ function render_block_core_template_part( $attributes ) {
 		$area_tag      = 'div';
 		if ( null !== $area ) {
 			foreach ( $defined_areas as $defined_area ) {
-				if ( $defined_area['area'] === $area && isset( $defined_area['defaultWrapperElement'] ) ) {
-					$area_tag = $defined_area['defaultWrapperElement'];
+				if ( $defined_area['area'] === $area && isset( $defined_area['area_tag'] ) ) {
+					$area_tag = $defined_area['area_tag'];
 				}
 			}
 		}

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -110,12 +110,16 @@ function render_block_core_template_part( $attributes ) {
 	$content = do_shortcode( $content );
 
 	if ( empty( $attributes['tagName'] ) ) {
-		$area_tags = array(
-			WP_TEMPLATE_PART_AREA_HEADER        => 'header',
-			WP_TEMPLATE_PART_AREA_FOOTER        => 'footer',
-			WP_TEMPLATE_PART_AREA_UNCATEGORIZED => 'div',
-		);
-		$html_tag  = null !== $area && isset( $area_tags[ $area ] ) ? $area_tags[ $area ] : $area_tags[ WP_TEMPLATE_PART_AREA_UNCATEGORIZED ];
+		$defined_areas = gutenberg_get_allowed_template_part_areas();
+		$area_tag      = 'div';
+		if ( null !== $area ) {
+			foreach ( $defined_areas as $defined_area ) {
+				if ( $defined_area['area'] === $area && isset( $defined_area['defaultWrapperElement'] ) ) {
+					$area_tag = $defined_area['defaultWrapperElement'];
+				}
+			}
+		}
+		$html_tag = $area_tag;
 	} else {
 		$html_tag = esc_attr( $attributes['tagName'] );
 	}

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -112,11 +112,9 @@ function render_block_core_template_part( $attributes ) {
 	if ( empty( $attributes['tagName'] ) ) {
 		$defined_areas = gutenberg_get_allowed_template_part_areas();
 		$area_tag      = 'div';
-		if ( null !== $area ) {
-			foreach ( $defined_areas as $defined_area ) {
-				if ( $defined_area['area'] === $area && isset( $defined_area['area_tag'] ) ) {
-					$area_tag = $defined_area['area_tag'];
-				}
+		foreach ( $defined_areas as $defined_area ) {
+			if ( $defined_area['area'] === $area && isset( $defined_area['area_tag'] ) ) {
+				$area_tag = $defined_area['area_tag'];
 			}
 		}
 		$html_tag = $area_tag;

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -1,56 +1,62 @@
 /**
  * WordPress dependencies
  */
-import { footer, header } from '@wordpress/icons';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { select } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
+import { store as blocksStore } from '@wordpress/blocks';
+import { dispatch, select, subscribe } from '@wordpress/data';
 
-const variations = [
-	{
-		name: 'header',
-		title: __( 'Header' ),
-		description: __(
-			"The header template defines a page area that typically contains a title, logo, and main navigation. Since it's a global element it can be present across all pages and posts."
-		),
-		icon: header,
-		attributes: { area: 'header' },
-		scope: [ 'inserter' ],
-	},
-	{
-		name: 'footer',
-		title: __( 'Footer' ),
-		description: __(
-			"The footer template defines a page area that typically contains site credits, social links, or any other combination of blocks. Since it's a global element it can be present across all pages and posts."
-		),
-		icon: footer,
-		attributes: { area: 'footer' },
-		scope: [ 'inserter' ],
-	},
-];
+const unsubscribe = subscribe( () => {
+	const definedVariations =
+		select( editorStore ).__experimentalGetDefaultTemplatePartAreas() || [];
 
-/**
- * Add `isActive` function to all `Template Part` variations, if not defined.
- * `isActive` function is used to find a variation match from a created
- *  Block by providing its attributes.
- */
-variations.forEach( ( variation ) => {
-	if ( variation.isActive ) return;
-	variation.isActive = ( blockAttributes, variationAttributes ) => {
-		const { area, theme, slug } = blockAttributes;
-		// We first check the `area` block attribute which is set during insertion.
-		// This property is removed on the creation of a template part.
-		if ( area ) return area === variationAttributes.area;
-		// Find a matching variation from the created template part
-		// by checking the entity's `area` property.
-		if ( ! slug ) return false;
-		const entity = select( coreDataStore ).getEntityRecord(
-			'postType',
-			'wp_template_part',
-			`${ theme }//${ slug }`
-		);
-		return entity?.area === variationAttributes.area;
-	};
+	if ( definedVariations.length ) {
+		unsubscribe();
+	} else {
+		return;
+	}
+
+	const variations = definedVariations
+		.filter( ( { area } ) => 'uncategorized' !== area )
+		.map( ( { area, label, description, icon } ) => {
+			return {
+				name: area,
+				title: label,
+				description,
+				icon,
+				attributes: { area },
+				scope: [ 'inserter' ],
+			};
+		} );
+
+	/**
+	 * Add `isActive` function to all `Template Part` variations, if not defined.
+	 * `isActive` function is used to find a variation match from a created
+	 *  Block by providing its attributes.
+	 */
+	variations.forEach( ( variation ) => {
+		if ( variation.isActive ) return;
+		variation.isActive = ( blockAttributes, variationAttributes ) => {
+			const { area, theme, slug } = blockAttributes;
+			// We first check the `area` block attribute which is set during insertion.
+			// This property is removed on the creation of a template part.
+			if ( area ) return area === variationAttributes.area;
+			// Find a matching variation from the created template part
+			// by checking the entity's `area` property.
+			if ( ! slug ) return false;
+			const entity = select( coreDataStore ).getEntityRecord(
+				'postType',
+				'wp_template_part',
+				`${ theme }//${ slug }`
+			);
+			return entity?.area === variationAttributes.area;
+		};
+	} );
+
+	dispatch( blocksStore ).addBlockVariations(
+		'core/template-part',
+		variations
+	);
 } );
 
-export default variations;
+export default [];

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -58,5 +58,3 @@ const unsubscribe = subscribe( () => {
 		variations
 	);
 } );
-
-export default [];

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -7,14 +7,14 @@ import { store as blocksStore } from '@wordpress/blocks';
 import { dispatch, select, subscribe } from '@wordpress/data';
 
 const unsubscribe = subscribe( () => {
-	const definedVariations =
-		select( editorStore ).__experimentalGetDefaultTemplatePartAreas() || [];
+	const definedVariations = select(
+		editorStore
+	).__experimentalGetDefaultTemplatePartAreas();
 
-	if ( definedVariations.length ) {
-		unsubscribe();
-	} else {
+	if ( ! definedVariations?.length ) {
 		return;
 	}
+	unsubscribe();
 
 	const variations = definedVariations
 		.filter( ( { area } ) => 'uncategorized' !== area )

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1681,7 +1681,8 @@ export function __experimentalGetDefaultTemplateTypes( state ) {
  */
 export const __experimentalGetDefaultTemplatePartAreas = createSelector(
 	( state ) => {
-		const areas = getEditorSettings( state )?.defaultTemplatePartAreas;
+		const areas =
+			getEditorSettings( state )?.defaultTemplatePartAreas || [];
 		return areas?.map( ( item ) => {
 			return { ...item, icon: getTemplatePartIcon( item.icon ) };
 		} );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -27,6 +27,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { createRegistrySelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { Platform } from '@wordpress/element';
+import { layout } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -40,7 +41,7 @@ import {
 } from './constants';
 import { getPostRawValue } from './reducer';
 import { cleanForSlug } from '../utils/url';
-import { getTemplatePartIconByArea } from './utils/get-template-part-icon';
+import { getTemplatePartIcon } from './utils/get-template-part-icon';
 
 /**
  * Shared reference to an empty object for cases where it is important to avoid
@@ -1682,7 +1683,7 @@ export const __experimentalGetDefaultTemplatePartAreas = createSelector(
 	( state ) => {
 		const areas = getEditorSettings( state )?.defaultTemplatePartAreas;
 		return areas?.map( ( item ) => {
-			return { ...item, icon: getTemplatePartIconByArea( item.area ) };
+			return { ...item, icon: getTemplatePartIcon( item.icon ) };
 		} );
 	},
 	( state ) => [ getEditorSettings( state )?.defaultTemplatePartAreas ]
@@ -1723,7 +1724,10 @@ export function __experimentalGetTemplateInfo( state, template ) {
 
 	const templateTitle = isString( title ) ? title : title?.rendered;
 	const templateDescription = isString( excerpt ) ? excerpt : excerpt?.raw;
-	const templateIcon = getTemplatePartIconByArea( area );
+	const templateIcon =
+		__experimentalGetDefaultTemplatePartAreas( state ).find(
+			( item ) => area === item.area
+		)?.icon || layout;
 
 	return {
 		title:

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -193,11 +193,13 @@ const defaultTemplatePartAreas = [
 		area: 'header',
 		label: 'Header',
 		description: 'Some description of a header',
+		icon: 'header',
 	},
 	{
 		area: 'footer',
 		label: 'Footer',
 		description: 'Some description of a footer',
+		icon: 'footer',
 	},
 ];
 
@@ -2821,11 +2823,11 @@ describe( 'selectors', () => {
 	describe( '__experimentalGetDefaultTemplatePartAreas', () => {
 		const state = { editorSettings: { defaultTemplatePartAreas } };
 
-		it( 'returns undefined if there are no default template part areas', () => {
+		it( 'returns empty array if there are no default template part areas', () => {
 			const emptyState = { editorSettings: {} };
 			expect(
 				__experimentalGetDefaultTemplatePartAreas( emptyState )
-			).toBeUndefined();
+			).toHaveLength( 0 );
 		} );
 
 		it( 'returns a list of default template part areas if present in state', () => {
@@ -2882,7 +2884,9 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '__experimentalGetTemplateInfo', () => {
-		const state = { editorSettings: { defaultTemplateTypes } };
+		const state = {
+			editorSettings: { defaultTemplateTypes, defaultTemplatePartAreas },
+		};
 
 		it( 'should return an empty object if no template is passed', () => {
 			expect( __experimentalGetTemplateInfo( state, null ) ).toEqual(

--- a/packages/editor/src/store/utils/get-template-part-icon.js
+++ b/packages/editor/src/store/utils/get-template-part-icon.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-const icons = require( '@wordpress/icons' );
+import * as icons from '@wordpress/icons';
 /**
  * Helper function to retrieve the corresponding icon by name.
  *

--- a/packages/editor/src/store/utils/get-template-part-icon.js
+++ b/packages/editor/src/store/utils/get-template-part-icon.js
@@ -3,7 +3,7 @@
  */
 const icons = require( '@wordpress/icons' );
 /**
- * Helper function to find the corresponding icon for a template part's 'area'.
+ * Helper function to retrieve the corresponding icon by name.
  *
  * @param {string} iconName The name of the icon.
  *

--- a/packages/editor/src/store/utils/get-template-part-icon.js
+++ b/packages/editor/src/store/utils/get-template-part-icon.js
@@ -1,19 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { layout, header, footer } from '@wordpress/icons';
-
+const icons = require( '@wordpress/icons' );
 /**
  * Helper function to find the corresponding icon for a template part's 'area'.
  *
- * @param {string} area The value of the template part 'area' tax term.
+ * @param {string} iconName The value of the template part 'area' tax term.
  *
  * @return {Object} The corresponding icon.
  */
-export function getTemplatePartIconByArea( area ) {
-	const iconsByArea = {
-		footer,
-		header,
-	};
-	return iconsByArea[ area ] || layout;
+export function getTemplatePartIcon( iconName ) {
+	return icons[ iconName ] || icons.layout;
 }

--- a/packages/editor/src/store/utils/get-template-part-icon.js
+++ b/packages/editor/src/store/utils/get-template-part-icon.js
@@ -5,7 +5,7 @@ const icons = require( '@wordpress/icons' );
 /**
  * Helper function to find the corresponding icon for a template part's 'area'.
  *
- * @param {string} iconName The value of the template part 'area' tax term.
+ * @param {string} iconName The name of the icon.
  *
  * @return {Object} The corresponding icon.
  */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR updates the Template Part block's variations, area selection inputs, and default wrapper elements to be based off the areas defined in template-parts.php and passed into the editor store via settings.  This allows these block variations and corresponding selection interfaces throughout the editors to share a single source of truth for the valid areas, their labels, descriptions, etc.  Once a new area is defined in template-parts.php (or by the related filter), the corresponding block variation and selection options will automatically be present in the editor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Smoke test the Template parts block variations in the post/page editor and the site editor, verify they continue to work as expected and that the expected wrapper element appears in both the editor and front-end.

### Extra Credit Testing:

Add a new area variation and verify it appears and functions as expected throughout the editor.  This can either be added directly to the `$default_area_definitions` in template-parts.php, or via the `default_wp_template_part_areas` filter (for simplicity this can be done in template-parts.php above the corresponding `apply_filters` call). Example:
```
function register_my_new_area( $areas ) {
	array_push(
		$areas,
		array(
			'area'                  => 'example',
			'label'                 => __( 'Some Example', 'gutenberg' ),
			'description'           => __(
				'Its a description of an example!'
			),
			'icon'                  => 'audio',
			'area_tag'           => 'article',
		)
	);
	return $areas;
}
add_filter( 'default_wp_template_part_areas', 'register_my_new_area' );
```

Load the editor and verify the new block variation is registered in the inserter and placeholder flow:

![Screen Shot 2021-04-14 at 2 36 07 PM](https://user-images.githubusercontent.com/28742426/114761634-c2f7ac80-9d2e-11eb-9475-be0d2fe7c8b9.png)

![Screen Shot 2021-04-14 at 2 36 59 PM](https://user-images.githubusercontent.com/28742426/114761757-ec183d00-9d2e-11eb-8f7f-dcbac0f029a4.png)

That the corresponding icons and description appear for a template part using that variation:

![Screen Shot 2021-04-14 at 2 38 15 PM](https://user-images.githubusercontent.com/28742426/114761869-0fdb8300-9d2f-11eb-9353-7c7188f90da7.png)

That it appears as an option in the 'area' selection in the block inspector:

![Screen Shot 2021-04-14 at 2 41 28 PM](https://user-images.githubusercontent.com/28742426/114762265-8ed0bb80-9d2f-11eb-8fa4-297889dfa79a.png)

That the 'convert to template part' flow from the block toolbar's ellipsis menu (site editor only) contains the new variation as an option:

![Screen Shot 2021-04-14 at 2 44 25 PM](https://user-images.githubusercontent.com/28742426/114762620-f2f37f80-9d2f-11eb-9f55-6af00ee7875b.png)

And that the new template part uses its specified `defaultWrapperElement` (both in editor and on front-end) and that it appears as the default in the block inspector selection:

![Screen Shot 2021-04-14 at 3 36 54 PM](https://user-images.githubusercontent.com/28742426/114768712-40bfb600-9d37-11eb-9928-b2581b41445d.png)
![Screen Shot 2021-04-14 at 3 37 11 PM](https://user-images.githubusercontent.com/28742426/114768738-4a491e00-9d37-11eb-9c93-1266fdd9e955.png)
![Screen Shot 2021-04-14 at 4 01 07 PM](https://user-images.githubusercontent.com/28742426/114771499-a2cdea80-9d3a-11eb-950f-61e93388b88c.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Refactor existing functionality for truth consolidation and extensibility.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
