### PR TITLE
RN: Add segment controls to mobile editor

### DIFF
--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -75,6 +75,7 @@ export { default as ReadableContentView } from './mobile/readable-content-view';
 export { default as CycleSelectControl } from './mobile/cycle-select-control';
 export { default as Gradient } from './mobile/gradient';
 export { default as ColorSettings } from './mobile/color-settings';
+export { default as SegmentedControls } from './mobile/segmented-control';
 export { default as FocalPointSettingsPanel } from './mobile/focal-point-settings-panel';
 export { LinkPicker } from './mobile/link-picker';
 export { default as LinkPickerScreen } from './mobile/link-picker/link-picker-screen';


### PR DESCRIPTION
This PR makes the SegmentedControls available to the rest of the code base.

## Description
This PR makes the `SegmentedControls` available to be included in other components and other codebases.

```
import { SegmentedControls } from '@wordpress/components';
```

This was done so that the `SegmentedControls` can be used by mobile controls in 
See https://github.com/Automattic/block-experiments/pull/181/files#diff-2377772b72ef61a95ea2ced860de944c4a160f5c7847e72bd3199140bce6008eR13

## How has this been tested?
Since this just exports the `SegmentedControls` it shouldn't have an effect on how the app is built. 

Build the mobile editor does it still work as expected?

## Types of changes
exports of the `SegmentedControls`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
