### PR TITLE
Fix is-link style to take colors from wp-admin theme.

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -210,8 +210,7 @@
 		background: none;
 		outline: none;
 		text-align: left;
-		/* Mimics the default link style in common.css */
-		color: #0073aa;
+		color: var(--wp-admin-theme-color);
 		text-decoration: underline;
 		transition-property: border, background, color;
 		transition-duration: 0.05s;
@@ -219,17 +218,8 @@
 		@include reduce-motion("transition");
 		height: auto;
 
-		&:hover:not(:disabled),
-		&:active:not(:disabled) {
-			color: #00a0d2;
-			box-shadow: none;
-		}
-
 		&:focus {
-			color: #124964;
-			box-shadow:
-				0 0 0 $border-width #5b9dd9,
-				0 0 var(--wp-admin-border-width-focus) $border-width rgba(30, 140, 190, 0.8);
+			border-radius: $radius-block-ui;
 		}
 
 		// Link buttons that are red to indicate destructive behavior.


### PR DESCRIPTION
## Description

`is-link` buttons did not get their colors from your wp-admin color theme. This PR fixes that. Before:

<img width="360" alt="Screenshot 2021-04-14 at 08 37 05" src="https://user-images.githubusercontent.com/1204802/114665494-6760fb00-9cfd-11eb-9d7a-c31e8c0a5478.png">

After:

![after](https://user-images.githubusercontent.com/1204802/114665502-69c35500-9cfd-11eb-85ac-eff580c8cd4e.gif)

Previously: https://github.com/WordPress/gutenberg/pull/6562

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
