### PR TITLE
Fix nav placeholder height issue.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -290,6 +290,7 @@ $color-control-label-height: 20px;
 		align-items: center;
 		justify-content: flex-start;
 		display: none;
+		line-height: 0;
 
 		// line up with the icon in the toolbar.
 		margin-left: $grid-unit-05 + $border-width;


### PR DESCRIPTION
## Description

The revamped navigation placeholder had an indicator that inherited a line height and therefore got taller than it should:

<img width="813" alt="Screenshot 2021-04-14 at 09 32 38" src="https://user-images.githubusercontent.com/1204802/114671662-9cbd1700-9d04-11eb-9ba2-1fa789541355.png">

This PR fixes that by unsetting that line height:

<img width="829" alt="Screenshot 2021-04-14 at 09 33 43" src="https://user-images.githubusercontent.com/1204802/114671683-a34b8e80-9d04-11eb-8dc6-9febc4fd726d.png">

## How has this been tested?

Test a theme that has a body line-height of 2 or more (or inspect it in on the editor-styles-wrapper), then test the navigation placeholder and observe that the focus style is correctly positioned.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
