### PR TITLE
Add reset button to Layout controls

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -13,6 +13,7 @@ import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
+	Button,
 	ToggleControl,
 	PanelBody,
 	__experimentalUnitControl as UnitControl,
@@ -82,52 +83,72 @@ function LayoutPanel( { setAttributes, attributes } ) {
 					/>
 				) }
 				{ ! inherit && (
-					<div className="block-editor-hooks__layout-controls">
-						<div className="block-editor-hooks__layout-controls-unit">
-							<UnitControl
-								label={ __( 'Content' ) }
-								labelPosition="top"
-								__unstableInputWidth="80px"
-								value={ contentSize || wideSize || '' }
-								onChange={ ( nextWidth ) => {
-									nextWidth =
-										0 > parseFloat( nextWidth )
-											? '0'
-											: nextWidth;
+					<>
+						<div className="block-editor-hooks__layout-controls">
+							<div className="block-editor-hooks__layout-controls-unit">
+								<UnitControl
+									label={ __( 'Content' ) }
+									labelPosition="top"
+									__unstableInputWidth="80px"
+									value={ contentSize || wideSize || '' }
+									onChange={ ( nextWidth ) => {
+										nextWidth =
+											0 > parseFloat( nextWidth )
+												? '0'
+												: nextWidth;
+										setAttributes( {
+											layout: {
+												...layout,
+												contentSize: nextWidth,
+											},
+										} );
+									} }
+									units={ CSS_UNITS }
+								/>
+								<Icon icon={ positionCenter } />
+							</div>
+							<div className="block-editor-hooks__layout-controls-unit">
+								<UnitControl
+									label={ __( 'Wide' ) }
+									labelPosition="top"
+									__unstableInputWidth="80px"
+									value={ wideSize || contentSize || '' }
+									onChange={ ( nextWidth ) => {
+										nextWidth =
+											0 > parseFloat( nextWidth )
+												? '0'
+												: nextWidth;
+										setAttributes( {
+											layout: {
+												...layout,
+												wideSize: nextWidth,
+											},
+										} );
+									} }
+									units={ CSS_UNITS }
+								/>
+								<Icon icon={ stretchWide } />
+							</div>
+						</div>
+						<div className="block-editor-hooks__layout-controls-reset">
+							<Button
+								isSecondary
+								isSmall
+								disabled={ ! contentSize && ! wideSize }
+								onClick={ () =>
 									setAttributes( {
 										layout: {
-											...layout,
-											contentSize: nextWidth,
+											contentSize: undefined,
+											wideSize: undefined,
+											inherit: false,
 										},
-									} );
-								} }
-								units={ CSS_UNITS }
-							/>
-							<Icon icon={ positionCenter } />
+									} )
+								}
+							>
+								{ __( 'Reset' ) }
+							</Button>
 						</div>
-						<div className="block-editor-hooks__layout-controls-unit">
-							<UnitControl
-								label={ __( 'Wide' ) }
-								labelPosition="top"
-								__unstableInputWidth="80px"
-								value={ wideSize || contentSize || '' }
-								onChange={ ( nextWidth ) => {
-									nextWidth =
-										0 > parseFloat( nextWidth )
-											? '0'
-											: nextWidth;
-									setAttributes( {
-										layout: {
-											...layout,
-											wideSize: nextWidth,
-										},
-									} );
-								} }
-								units={ CSS_UNITS }
-							/>
-							<Icon icon={ stretchWide } />
-						</div>
-					</div>
+					</>
 				) }
 				<p className="block-editor-hooks__layout-controls-helptext">
 					{ __(

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -1,6 +1,6 @@
 .block-editor-hooks__layout-controls {
 	display: flex;
-	margin-bottom: $grid-unit-30;
+	margin-bottom: $grid-unit-20;
 
 	.block-editor-hooks__layout-controls-unit {
 		display: flex;
@@ -10,6 +10,12 @@
 			margin: auto 0 $grid-unit-05 $grid-unit-10;
 		}
 	}
+}
+
+.block-editor-hooks__layout-controls-reset {
+	display: flex;
+	justify-content: flex-end;
+	margin-bottom: $grid-unit-30;
 }
 
 .block-editor-hooks__layout-controls-helptext {


### PR DESCRIPTION
Adds reset button to the Layout controls, similar to other custom value controls.

Fixes #30614.

## Screenshots <!-- if applicable -->
<img width="282" alt="layout-reset-button" src="https://user-images.githubusercontent.com/240569/114689172-7d36e600-9d26-11eb-93b1-256c81c96969.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
