### PR TITLE
Global Styles: clean cached data when switching themes

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -500,6 +500,10 @@ class WP_Theme_JSON_Resolver {
 		return $located;
 	}
 
+	/**
+	 * Cleans the cached data so it can be recalculated.
+	 *
+	 */
 	public static function clean_cached_data() {
 		self::$core                     = null;
 		self::$theme                    = null;

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -49,6 +49,13 @@ class WP_Theme_JSON_Resolver {
 	private static $user_custom_post_type_id = null;
 
 	/**
+	 * Structure to hold i18n metadata.
+	 *
+	 * @var Array
+	 */
+	private static $theme_json_i18n = null;
+
+	/**
 	 * Processes a file that adheres to the theme.json
 	 * schema and returns an array with its contents,
 	 * or a void array if none found.
@@ -143,12 +150,11 @@ class WP_Theme_JSON_Resolver {
 	 * @return array An array of theme.json fields that are translatable and the keys that are translatable
 	 */
 	public static function get_fields_to_translate() {
-		static $theme_json_i18n = null;
-		if ( null === $theme_json_i18n ) {
+		if ( null === self::$theme_json_i18n ) {
 			$file_structure  = self::read_json_file( __DIR__ . '/experimental-i18n-theme.json' );
-			$theme_json_i18n = self::extract_paths_to_translate( $file_structure );
+			self::$theme_json_i18n = self::extract_paths_to_translate( $file_structure );
 		}
-		return $theme_json_i18n;
+		return self::$theme_json_i18n;
 	}
 
 	/**
@@ -494,4 +500,15 @@ class WP_Theme_JSON_Resolver {
 		return $located;
 	}
 
+	public static function clean_cached_data() {
+		self::$core                     = null;
+		self::$theme                    = null;
+		self::$user                     = null;
+		self::$user_custom_post_type_id = null;
+		self::$theme_has_support        = null;
+		self::$theme_json_i18n          = null;
+	}
+
 }
+
+add_action( 'switch_theme', [ 'WP_Theme_JSON_Resolver', 'clean_cached_data' ] );

--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -151,7 +151,7 @@ class WP_Theme_JSON_Resolver {
 	 */
 	public static function get_fields_to_translate() {
 		if ( null === self::$theme_json_i18n ) {
-			$file_structure  = self::read_json_file( __DIR__ . '/experimental-i18n-theme.json' );
+			$file_structure        = self::read_json_file( __DIR__ . '/experimental-i18n-theme.json' );
 			self::$theme_json_i18n = self::extract_paths_to_translate( $file_structure );
 		}
 		return self::$theme_json_i18n;
@@ -502,7 +502,6 @@ class WP_Theme_JSON_Resolver {
 
 	/**
 	 * Cleans the cached data so it can be recalculated.
-	 *
 	 */
 	public static function clean_cached_data() {
 		self::$core                     = null;
@@ -515,4 +514,4 @@ class WP_Theme_JSON_Resolver {
 
 }
 
-add_action( 'switch_theme', [ 'WP_Theme_JSON_Resolver', 'clean_cached_data' ] );
+add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -134,4 +134,18 @@ class WP_Theme_JSON_Resolver_Test extends WP_UnitTestCase {
 			)
 		);
 	}
+
+	function test_switching_themes_recalculates_data() {
+		// By default, the theme for unit tests is "default",
+		// which doesn't have theme.json support.
+		$default = WP_Theme_JSON_Resolver::theme_has_support();
+
+		// Switch to a theme that does have support.
+		switch_theme( 'fse' );
+		$fse = WP_Theme_JSON_Resolver::theme_has_support();
+
+		$this->assertSame( false, $default );
+		$this->assertSame( true, $fse );
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/30478
Alternative to https://github.com/WordPress/gutenberg/pull/30479

This PR hooks into the `switch_theme` action to clean the cached data, so it can be recalculated for the new theme. This is especially important for unit tests.
