### PR TITLE
Try: Provide a baseline submenu background color.

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -205,6 +205,10 @@
 }
 
 // Default background and font color.
+// This includes blocks that have a background color,
+// as you might switch themes and the color specified is no longer registered.
+// But when one is explicitly chosen after the fact, it will override these rules.
+.wp-block-navigation.has-background,
 .wp-block-navigation:not(.has-background) {
 	.submenu-container, // This target items created by the Page List block.
 	.wp-block-navigation__container .wp-block-navigation-link__container {
@@ -214,6 +218,13 @@
 		// several times, so care needs to be taken.
 		background-color: #fff;
 		color: #000;
+	}
+}
+
+// Paint a border only when we know for sure that the block doesn't have a working background color.
+.wp-block-navigation:not(.has-background) {
+	.submenu-container,
+	.wp-block-navigation__container .wp-block-navigation-link__container {
 		border: 1px solid rgba(0, 0, 0, 0.15);
 
 		.submenu-container,


### PR DESCRIPTION
## Description

This one is a bit unique, and is a followup inspired by work in #30805. It is a draft because it is in part more of a question about best practices, and the fix attached I only have medium confidence level in. 

Situation: the navigation block allows submenus. When a submenu has a color set by the user, we can then colorize submenus according to that color (see also #29963).

When the navigation block _does not_ have an explicitly set background color, we have to choose a background color for submenus, they can't just be transparent. But as soon as we choose a background color, we have to also choose a text color. Right now we do this by assigning a white background and black text with a `:not(.has-background) { background-color: inherit; color: inherit; }` rule. It works well enough.

However a theme can assign a palette. For example I have a `bright-red`. So when I assign that to my navigation block, it gets classes `has-background has-bright-red-background-color`. The tricky bit is, those classes continue to exist when I switch from one theme to another, and that other theme likely doesn't have a `bright-red` color defined. In that case, my navigation block will now have transparent submenus, because the CSS assumes there _is_ a background color, even when one isn't actually defined:

<img width="732" alt="Screenshot 2021-04-14 at 11 50 41" src="https://user-images.githubusercontent.com/1204802/114694119-84f08d80-9d1a-11eb-9a96-d3653d43f5f6.png">

This PR fixes that by assigning the white background even when the block has a background, but then relies on the color definition when present to override it. Here's what that looks like when the color is not defined:

<img width="875" alt="Screenshot 2021-04-14 at 11 53 18" src="https://user-images.githubusercontent.com/1204802/114694219-9b96e480-9d1a-11eb-994d-e56dd961ad69.png">

But what's the best practice here? Presumably the problem is the same if I set a background color on my paragraph, then switch themes?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
