### PR TITLE
Try: One appender at a time.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -31,6 +31,13 @@
 		transition: all 0.1s ease;
 		@include reduce-motion("transition");
 	}
+
+	// Show one appender at a time.
+	display: none;
+}
+
+.block-editor-block-list__block.is-selected .block-list-appender {
+	display: block;
 }
 
 // For vertical flex containers, a 100% width ensures correct alignment.

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -27,17 +27,18 @@
 	.block-list-appender__toggle {
 		padding: 0;
 		opacity: 1;
-		transform: scale(1);
 		transition: all 0.1s ease;
 		@include reduce-motion("transition");
 
 		// Show one appender at a time.
-		display: none;
+		visibility: hidden;
+		transform: scale(0);
 	}
 }
 
 .block-editor-block-list__block.is-selected .block-list-appender .block-list-appender__toggle {
-	display: block;
+	visibility: visible;
+	transform: scale(1);
 }
 
 // For vertical flex containers, a 100% width ensures correct alignment.

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -30,13 +30,13 @@
 		transform: scale(1);
 		transition: all 0.1s ease;
 		@include reduce-motion("transition");
-	}
 
-	// Show one appender at a time.
-	display: none;
+		// Show one appender at a time.
+		display: none;
+	}
 }
 
-.block-editor-block-list__block.is-selected .block-list-appender {
+.block-editor-block-list__block.is-selected .block-list-appender .block-list-appender__toggle {
 	display: block;
 }
 

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -29,14 +29,18 @@
 		opacity: 1;
 		transition: all 0.1s ease;
 		@include reduce-motion("transition");
-
-		// Show one appender at a time.
-		visibility: hidden;
-		transform: scale(0);
 	}
 }
 
-.block-editor-block-list__block.is-selected .block-list-appender .block-list-appender__toggle {
+// Show one appender at a time.
+.block-editor-inserter__toggle,
+.block-list-appender__toggle {
+	visibility: hidden;
+	transform: scale(0);
+}
+
+.block-editor-block-list__block.is-selected .block-editor-inserter__toggle,
+.block-editor-block-list__block.is-selected .block-list-appender__toggle {
 	visibility: visible;
 	transform: scale(1);
 }


### PR DESCRIPTION
## Description

Especially in the site editor which has many nesting contexts, you will often encounter situations where you see a great deal of black plusses at the same time. This is because any selected nesting container gets a plus appender, and they stay visible even as you drill down the hierarchy.

Perhaps not the best example, it can get much worse, but observe how when I select the header template part in the following, the black plus for inserting both into the template part, and inside the navigation block, are visible at the same time:

![before](https://user-images.githubusercontent.com/1204802/114705922-98a2f080-9d28-11eb-915a-e7d650d97c92.gif)

This is disruptive because it's not clear where either one inserts. This PR (which is round 2 of #29559) tries a relatively simpler system; only show the appender if the block is selected:

![after](https://user-images.githubusercontent.com/1204802/114706022-bc663680-9d28-11eb-90c1-2a8761446657.gif)

This needs a great deal of edgecase testing, but from what I can tell, this serves as a small improvement that might get us slightly further along with #26404.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
