### PR TITLE
Links Updated on Block Based Theme 

### DIFF
--- a/docs/how-to-guides/block-based-theme/README.md
+++ b/docs/how-to-guides/block-based-theme/README.md
@@ -12,10 +12,10 @@ This tutorial is up to date as of Gutenberg version 9.1.
 
 ## Table of Contents
 
- 1. [What is needed to create a block-based theme?](/docs/how-to-guides/block-based-themes/README.md#what-is-needed-to-create-a-block-based-theme)
- 2. [Creating the theme](/docs/how-to-guides/block-based-themes/README.md#creating-the-theme)
- 3. [Creating the templates and template parts](/docs/how-to-guides/block-based-themes/README.md#creating-the-templates-and-template-parts)
- 4. [experimental-theme.json - Global styles](/docs/how-to-guides/block-based-themes/README.md#experimental-theme-json-global-styles)
+ 1. [What is needed to create a block-based theme?](#what-is-needed-to-create-a-block-based-theme)
+ 2. [Creating the theme](#creating-the-theme)
+ 3. [Creating the templates and template parts](#creating-the-templates-and-template-parts)
+ 4. [experimental-theme.json - Global styles](#experimental-theme-json-global-styles)
  5. [Adding blocks](/docs/how-to-guides/block-based-themes/block-based-themes-2-adding-blocks.md)
 
 ## What is needed to create a block-based theme?


### PR DESCRIPTION
## Description

The url of the list items under [Table of Contents](https://developer.wordpress.org/block-editor/how-to-guides/block-based-theme/) where not attached properly. All the url's were redirecting to this [page](https://developer.wordpress.org/block-editor/how-to-guides/block-based-theme/block-based-themes-2-adding-blocks) 

I Updated those url's of the list items to the ID of h2 elements that rely on the same page. 
Now, when a user clicks on any of the topic's mentioned in the list item. Window is Scrolled to that respective topic's section.

