### PR TITLE
Add uploading state to video block

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
@@ -7,6 +12,7 @@ import {
 	Button,
 	Disabled,
 	PanelBody,
+	Spinner,
 	withNotices,
 } from '@wordpress/components';
 import {
@@ -43,6 +49,7 @@ function VideoEdit( {
 	isSelected,
 	noticeUI,
 	attributes,
+	className,
 	setAttributes,
 	insertBlocksAfter,
 	onReplace,
@@ -52,6 +59,7 @@ function VideoEdit( {
 	const videoPlayer = useRef();
 	const posterImageButton = useRef();
 	const { id, caption, controls, poster, src, tracks } = attributes;
+	const isTemporaryVideo = ! id && isBlobURL( src );
 	const mediaUpload = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().mediaUpload
 	);
@@ -113,7 +121,13 @@ function VideoEdit( {
 		noticeOperations.createErrorNotice( message );
 	}
 
-	const blockProps = useBlockProps();
+	const classes = classnames( className, {
+		'is-transient': isTemporaryVideo,
+	} );
+
+	const blockProps = useBlockProps( {
+		className: classes,
+	} );
 
 	if ( ! src ) {
 		return (
@@ -235,6 +249,7 @@ function VideoEdit( {
 						<Tracks tracks={ tracks } />
 					</video>
 				</Disabled>
+				{ isTemporaryVideo && <Spinner /> }
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
 						tagName="figcaption"

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -2,6 +2,23 @@
 	text-align: center;
 }
 
+.wp-block-video {
+	position: relative;
+
+	&.is-transient video {
+		opacity: 0.3;
+	}
+
+	// Shown while video is being uploaded
+	.components-spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
+	}
+}
+
 .editor-video-poster-control {
 	.components-base-control__label {
 		display: block;


### PR DESCRIPTION
## Description
Adds uploading state to the video block, similar to other blocks that let you upload media.

Fixes #30787.

## How has this been tested?
1. Throttle network to 3G via DevTools.
2. Add a new video block
3. Upload video.
4. Uploading state should be visible.

## Screenshots <!-- if applicable -->
<img width="970" alt="video-block-upload-state" src="https://user-images.githubusercontent.com/240569/114719123-cb101600-9d47-11eb-8c5a-04f077eb6dc5.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
