### PR TITLE
[RNMobile] Fix visual glitch when loading Aztec view

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -135,7 +135,7 @@ class RCTAztecView: Aztec.TextView {
         textContainerInset = .zero
         contentInset = .zero
         textContainer.lineFragmentPadding = 0
-        frame.size = CGSize(width: 0, height: 0);
+        frame.size = .zero
         addPlaceholder()
         textDragInteraction?.isEnabled = false
         storage.htmlConverter.characterToReplaceLastEmptyLine = Character(.zeroWidthSpace)

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -135,6 +135,7 @@ class RCTAztecView: Aztec.TextView {
         textContainerInset = .zero
         contentInset = .zero
         textContainer.lineFragmentPadding = 0
+        frame.size = CGSize(width: 0, height: 0);
         addPlaceholder()
         textDragInteraction?.isEnabled = false
         storage.htmlConverter.characterToReplaceLastEmptyLine = Character(.zeroWidthSpace)


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2976.

React Native Aztec view is initialized by default with size (width: 10, height: 10), this produces weird sizes when calculating the content size via the [`sizeThatFits` method](https://developer.apple.com/documentation/uikit/uiview/1622625-sizethatfits?language=objc).

As an example, here are the different sizes produced when a block using Aztec is rendered and calls [`sizeThatFits`](https://github.com/WordPress/gutenberg/blob/2864336523a3053d1e76f7894e53ababd5c68ab8/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift#L200-L206):


### Values with current changes

<details><summary>Paragraph block with one line content</summary>

Content: `<p>Hello world!</p>`

**First render:**
`size: (w: 10, h: 10)` [Initial size]
`fittingSize: (w: 10.0, h: 218.0)` [For some reason it calculates a bigger height that it should 🤷‍♂️]
`minimumHeight: 22.0`
`resultSize: (w: 10.0, h: 218.0)`

**Second render:**
`size:(w: 343.0, h: 218.0)`
`fittingSize:(w: 95.5, h: 22.0)` [On the second pass it gets the correct height, in this case it's the minimum because the content is one line]
`minimumHeight: 22.0`
`result: (w: 95.5, h: 22.0)`

</details>

<details><summary>Paragraph block with three lines content</summary>

Content: `<p>Line 1<br>Line 2<br>Line 3</p>`

**First render:**
`size:(w: 10.0, 10.0)`
`fittingSize:(w: 10.0, 327.0)` [Same as in the previous example, the height is bigger than it should]
`minimumHeight: 22.0`
`result: (w: 10.0, 327.0)`

**Second render:**
`size:(w: 343.0, 327.0)`
`fittingSize:(w: 47.5, 65.5)` [Same as in the previous example, the height is properly calculated on the second pass, in this case bigger because the content is three lines]
`minimumHeight: 22.0`
`result: (w: 47.5, 65.5)`

</details>

### Values with changes from this PR

Surprisingly if the initial size is set to zero `(w: 0, h: 0)`, the calculations are correct:

<details><summary>Paragraph block with one line content</summary>

Content: `<p>Hello world!</p>`

**First render:**
`size:(0.0, 0.0)`
`fittingSize:(95.5, 22.0)` [The size is properly calculated in the first pass]
`minimumHeight: 22.0`
`result: (95.5, 22.0)`

**Second render:**
`sizeThatFits: size:(343.0, 22.0)`
`fittingSize:(95.5, 22.0)`
`minimumHeight: 22.0`
`result: (95.5, 22.0)`

</details>

<details><summary>Paragraph block with three lines content</summary>

Content: `<p>Line 1<br>Line 2<br>Line 3</p>`

**First render:**
`size:(0.0, 0.0)`
`fittingSize:(47.5, 65.5)` [Same as in the previous example, the size is properly calculated in the first pass]
`minimumHeight: 22.0`
`result: (47.5, 65.5)`

**Second render:**
`size:(343.0, 65.5)`
`fittingSize:(47.5, 65.5)`
`minimumHeight: 22.0`
`result: (47.5, 65.5)`

</details>

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

The visual glitch can be hard to identify because it only happens on a second’s fraction, the way I tested it involves the following:

### Check size calculation
1. Added the following code to [this line](https://github.com/WordPress/gutenberg/blob/0fa010e5cf4a37076c9ab65daeb6a9aa305f2e0d/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift#L205) in the RN Aztec view:
`print("sizeThatFits: size:\(size), fittingSize:\(fittingSize), minimumHeight: \(minimumHeight), content: \(storage.getHTML()), result: \(CGSize(width: fittingSize.width, height: height))")`
2. Create a paragraph block with some text
3. Copy the block
4. Clean the Xcode console logs
4. Paste it via the inserter menu
5. Check the size calculations logs in the the Xcode console logs

### Visual glitch
1. Add the following code in [this line](https://github.com/WordPress/gutenberg/blob/0fa010e5cf4a37076c9ab65daeb6a9aa305f2e0d/packages/block-library/src/paragraph/edit.native.js#L34), this will help to identify the size of the block:
`...{ backgroundColor: 'red' },`
2. Create a post in the web version
3. Add at least four or five paragraph blocks and create a Reusable block
4. Open the app
5. Start to record a video
6. Open the post previously created in the web version (it's recommended to do it a couple of times just in case it happens too fast)
7. Stop recording and open the video
8. Go frame by frame and observe that the block's size doesn't go too big

## Screenshots <!-- if applicable -->

**NOTE: Play it frame by frame to verify the fix.**

https://user-images.githubusercontent.com/14905380/114896145-5ce35600-9e10-11eb-8620-3ff3fed87776.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
