### PR TITLE
Revert: Site logo width.

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -181,6 +181,10 @@ const SiteLogo = ( {
 						}
 						min={ minWidth }
 						max={ maxWidthBuffer }
+						initialPosition={ Math.min(
+							naturalWidth,
+							maxWidthBuffer
+						) }
 						value={ width || '' }
 						disabled={ ! isResizable }
 					/>

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -14,16 +14,6 @@
 		display: table;
 	}
 
-	// Provide a sane starting point for the size.
-	&:not(.is-resized) {
-		width: 120px;
-
-		img {
-			width: 100%;
-		}
-	}
-
-
 	.custom-logo-link {
 		cursor: inherit;
 

--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -5,11 +5,6 @@
 		display: inline-block;
 	}
 
-	// Provide a sane starting point for the size.
-	&:not(.is-resized) img {
-		width: 120px;
-	}
-
 	.aligncenter {
 		display: table;
 	}


### PR DESCRIPTION
## Description

This PR reverts parts of #30526 as that failed to take in account published site logos that were not resized.

Creating this revert as an interim solution as I look for a better way to do the default width.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
