### PR TITLE
Fix site logo unresized size.

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -32,6 +32,10 @@ function render_block_core_site_logo( $attributes ) {
 		$classnames[] = "align{$attributes['align']}";
 	}
 
+	if ( ! empty( $attributes['width'] ) ) {
+		$classnames[] = 'is-resized';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
 	$html               = sprintf( '<div %s>%s</div>', $wrapper_attributes, $custom_logo );
 	remove_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );


### PR DESCRIPTION
## Description

Alternative to #30843. This fixes so the `is-resized` class, on which the site logo relies on, is present in the rendered markup as well.

<img width="696" alt="Screenshot 2021-04-14 at 18 32 45" src="https://user-images.githubusercontent.com/1204802/114746347-ee3ec380-9d4f-11eb-95be-509f6c58f955.png">

<img width="833" alt="Screenshot 2021-04-14 at 18 32 55" src="https://user-images.githubusercontent.com/1204802/114746349-ef6ff080-9d4f-11eb-9ec8-6ed7c0a8419a.png">


## How has this been tested?

Insert a site logo block. Add a big image. Duplicate the block

One of the blocks you resize, the other you leave alone. Editor and frontend should look the same.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
