### PR TITLE
(Optionally) rendering classic navigation data source in Navigation B…

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -299,9 +299,14 @@ function gutenberg_output_block_nav_menu( $output, $args ) {
 		$menu_items_by_parent_id[ $menu_item->menu_item_parent ][] = $menu_item;
 	}
 
+	$block_attributes = array();
+	if( isset( $args->block_attributes ) ) {
+		$block_attributes = $args->block_attributes;
+	}
+
 	$navigation_block = array(
 		'blockName'   => 'core/navigation',
-		'attrs'       => array(),
+		'attrs'       => $block_attributes,
 		'innerBlocks' => gutenberg_convert_menu_items_to_blocks(
 			isset( $menu_items_by_parent_id[0] )
 				? $menu_items_by_parent_id[0]

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -300,7 +300,7 @@ function gutenberg_output_block_nav_menu( $output, $args ) {
 	}
 
 	$block_attributes = array();
-	if( isset( $args->block_attributes ) ) {
+	if ( isset( $args->block_attributes ) ) {
 		$block_attributes = $args->block_attributes;
 	}
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -3,6 +3,9 @@
 	"name": "core/navigation",
 	"category": "design",
 	"attributes": {
+		"source": {
+			"type": "string"
+		},
 		"orientation": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -3,7 +3,7 @@
 	"name": "core/navigation",
 	"category": "design",
 	"attributes": {
-		"source": {
+		"location": {
 			"type": "string"
 		},
 		"orientation": {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -101,6 +101,7 @@ function Navigation( {
 			<div { ...blockProps }>
 				<NavigationPlaceholder
 					location={ attributes.location }
+					setAttributes={ setAttributes }
 					onCreate={ ( blocks, selectNavigationBlock ) => {
 						setIsPlaceholderShown( false );
 						updateInnerBlocks( blocks );

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -100,6 +100,7 @@ function Navigation( {
 		return (
 			<div { ...blockProps }>
 				<NavigationPlaceholder
+					location={ attributes.location }
 					onCreate={ ( blocks, selectNavigationBlock ) => {
 						setIsPlaceholderShown( false );
 						updateInnerBlocks( blocks );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -85,8 +85,17 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 	return $font_sizes;
 }
 
+/**
+ * Renders a Navigation Block derived from data from the theme_location source assigned
+ * via the block attribute 'source'.
+ *
+ * If the theme doesn't explicity support 'block-nav-menus' or no source was provided
+ * as a block attribute then an empty string is returned.
+ *
+ * @param  array $attributes Navigation block attributes.
+ * @return string HTML markup of a generated Navigation Block.
+ */
 function get_classic_navigation_elements( $attributes ){
-
 
 	if ( ! current_theme_supports( 'block-nav-menus' ) ) {
 		return '';
@@ -96,14 +105,14 @@ function get_classic_navigation_elements( $attributes ){
 		return '';
 	}
 
-	//TODO: There are $attributes here that need to be communicated through to this call in some way (such as orientation, justification, etc)
 	return wp_nav_menu(
 		array(
-			'theme_location' => $attributes['source'],
-			'container'      => '',
-			'items_wrap'     => '%3$s',
-			'fallback_cb'    => false,
-			'echo'           => false,
+			'theme_location' 	=> $attributes['source'],
+			'block_attributes'	=> $attributes,
+			'container'      	=> '',
+			'items_wrap'     	=> '%3$s',
+			'fallback_cb'    	=> false,
+			'echo'           	=> false,
 		)
 	);
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -87,54 +87,25 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 
 function get_classic_navigation_elements( $attributes ){
 
-	$has_data_source = array_key_exists( 'source', $attributes );
 
-	if( !$has_data_source ) {
+	if ( ! current_theme_supports( 'block-nav-menus' ) ) {
 		return '';
 	}
 
-	$data_source_key = $attributes['source'];
+	if( ! array_key_exists( 'source', $attributes ) ) {
+		return '';
+	}
 
-	$classic_menu_html = wp_nav_menu(
+	//TODO: There are $attributes here that need to be communicated through to this call in some way (such as orientation, justification, etc)
+	return wp_nav_menu(
 		array(
-			'theme_location' => $data_source_key,
-			'container'		 => '',
-			'items_wrap'	 => '%3$s',
-			'link_before' => '<span class="wp-block-navigation-link__label">',
-			'link_after' => '</span>',
-			'depth' => 0,
+			'theme_location' => $attributes['source'],
+			'container'      => '',
+			'items_wrap'     => '%3$s',
 			'fallback_cb'    => false,
 			'echo'           => false,
 		)
 	);
-
-	//What follows is a fair bit of hacky stuff to transform the markup from a classic menu
-	//to the markup of a new menu.
-	$DOM = new DOMDocument();
-	$DOM->loadHTML($classic_menu_html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-	$xpath = new DOMXpath($DOM);
-
-	$anchors = $DOM->getElementsByTagName('a');
-	$listItems = $DOM->getElementsByTagName('li');
-	$subMenus = $xpath->query("//ul[contains(@class,'sub-menu')]");
-	$menuItemsWithChildren = $xpath->query("//li[contains(@class,'menu-item-has-children')]");
-
-	foreach($anchors as $anchor) {
-		$anchor->setAttribute( 'class', 'wp-block-navigation-link__content' );
-	}
-	foreach($listItems as $listItem) {
-		$listItemClasses = $listItem->getAttribute( 'class' );
-		$listItem->setAttribute( 'class', $listItemClasses . ' wp-block-navigation-link' );
-	}
-	foreach($menuItemsWithChildren as $listItem) {
-		$listItemClasses = $listItem->getAttribute( 'class' );
-		$listItem->setAttribute( 'class', $listItemClasses . ' has-child' );
-	}
-	foreach($subMenus as $subMenu) {
-		$subMenu->setAttribute( 'class', 'wp-block-navigation-link__container');
-	}
-
-	return $DOM->saveHTML();
 }
 
 /**
@@ -173,10 +144,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	unset( $attributes['rgbTextColor'], $attributes['rgbBackgroundColor'] );
 
-	$classic_navigation_elements = get_classic_navigation_elements ( $attributes );
-
-	if ( empty( $block->inner_blocks ) && $classic_navigation_elements === '' ) {
-		return '';
+	if ( empty( $block->inner_blocks ) ) {
+		return get_classic_navigation_elements ( $attributes );
 	}
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -85,6 +85,58 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 	return $font_sizes;
 }
 
+function get_classic_navigation_elements( $attributes ){
+
+	$has_data_source = array_key_exists( 'source', $attributes );
+
+	if( !$has_data_source ) {
+		return '';
+	}
+
+	$data_source_key = $attributes['source'];
+
+	$classic_menu_html = wp_nav_menu(
+		array(
+			'theme_location' => $data_source_key,
+			'container'		 => '',
+			'items_wrap'	 => '%3$s',
+			'link_before' => '<span class="wp-block-navigation-link__label">',
+			'link_after' => '</span>',
+			'depth' => 0,
+			'fallback_cb'    => false,
+			'echo'           => false,
+		)
+	);
+
+	//What follows is a fair bit of hacky stuff to transform the markup from a classic menu
+	//to the markup of a new menu.
+	$DOM = new DOMDocument();
+	$DOM->loadHTML($classic_menu_html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+	$xpath = new DOMXpath($DOM);
+
+	$anchors = $DOM->getElementsByTagName('a');
+	$listItems = $DOM->getElementsByTagName('li');
+	$subMenus = $xpath->query("//ul[contains(@class,'sub-menu')]");
+	$menuItemsWithChildren = $xpath->query("//li[contains(@class,'menu-item-has-children')]");
+
+	foreach($anchors as $anchor) {
+		$anchor->setAttribute( 'class', 'wp-block-navigation-link__content' );
+	}
+	foreach($listItems as $listItem) {
+		$listItemClasses = $listItem->getAttribute( 'class' );
+		$listItem->setAttribute( 'class', $listItemClasses . ' wp-block-navigation-link' );
+	}
+	foreach($menuItemsWithChildren as $listItem) {
+		$listItemClasses = $listItem->getAttribute( 'class' );
+		$listItem->setAttribute( 'class', $listItemClasses . ' has-child' );
+	}
+	foreach($subMenus as $subMenu) {
+		$subMenu->setAttribute( 'class', 'wp-block-navigation-link__container');
+	}
+
+	return $DOM->saveHTML();
+}
+
 /**
  * Returns the top-level submenu SVG chevron icon.
  *
@@ -121,7 +173,9 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	unset( $attributes['rgbTextColor'], $attributes['rgbBackgroundColor'] );
 
-	if ( empty( $block->inner_blocks ) ) {
+	$classic_navigation_elements = get_classic_navigation_elements ( $attributes );
+
+	if ( empty( $block->inner_blocks ) && $classic_navigation_elements === '' ) {
 		return '';
 	}
 
@@ -134,9 +188,13 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array()
 	);
 
-	$inner_blocks_html = '';
-	foreach ( $block->inner_blocks as $inner_block ) {
-		$inner_blocks_html .= $inner_block->render();
+	if ( empty( $block->inner_blocks ) ) {
+		$inner_blocks_html = $classic_navigation_elements;
+	} else {
+		$inner_blocks_html = '';
+		foreach ( $block->inner_blocks as $inner_block ) {
+			$inner_blocks_html .= $inner_block->render();
+		}
 	}
 
 	$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -86,10 +86,10 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 }
 
 /**
- * Renders a Navigation Block derived from data from the theme_location source assigned
- * via the block attribute 'source'.
+ * Renders a Navigation Block derived from data from the theme_location assigned
+ * via the block attribute 'location'.
  *
- * If the theme doesn't explicity support 'block-nav-menus' or no source was provided
+ * If the theme doesn't explicity support 'block-nav-menus' or no location was provided
  * as a block attribute then an empty string is returned.
  *
  * @param  array $attributes Navigation block attributes.
@@ -101,16 +101,16 @@ function get_classic_navigation_elements( $attributes ) {
 		return '';
 	}
 
-	if ( ! array_key_exists( 'source', $attributes ) ) {
+	if ( ! array_key_exists( 'location', $attributes ) ) {
 		return '';
 	}
 
 	$block_attributes = $attributes;
-	unset( $block_attributes['source'] );
+	unset( $block_attributes['location'] );
 
 	return wp_nav_menu(
 		array(
-			'theme_location'   => $attributes['source'],
+			'theme_location'   => $attributes['location'],
 			'block_attributes' => $block_attributes,
 			'container'        => '',
 			'items_wrap'       => '%3$s',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -95,27 +95,27 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  * @param  array $attributes Navigation block attributes.
  * @return string HTML markup of a generated Navigation Block.
  */
-function get_classic_navigation_elements( $attributes ){
+function get_classic_navigation_elements( $attributes ) {
 
 	if ( ! current_theme_supports( 'block-nav-menus' ) ) {
 		return '';
 	}
 
-	if( ! array_key_exists( 'source', $attributes ) ) {
+	if ( ! array_key_exists( 'source', $attributes ) ) {
 		return '';
 	}
 
 	$block_attributes = $attributes;
-	unset($block_attributes['source']);
+	unset( $block_attributes['source'] );
 
 	return wp_nav_menu(
 		array(
-			'theme_location' 	=> $attributes['source'],
-			'block_attributes'	=> $block_attributes,
-			'container'      	=> '',
-			'items_wrap'     	=> '%3$s',
-			'fallback_cb'    	=> false,
-			'echo'           	=> false,
+			'theme_location'   => $attributes['source'],
+			'block_attributes' => $block_attributes,
+			'container'        => '',
+			'items_wrap'       => '%3$s',
+			'fallback_cb'      => false,
+			'echo'             => false,
 		)
 	);
 }
@@ -157,7 +157,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	unset( $attributes['rgbTextColor'], $attributes['rgbBackgroundColor'] );
 
 	if ( empty( $block->inner_blocks ) ) {
-		return get_classic_navigation_elements ( $attributes );
+		return get_classic_navigation_elements( $attributes );
 	}
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -105,10 +105,13 @@ function get_classic_navigation_elements( $attributes ){
 		return '';
 	}
 
+	$block_attributes = $attributes;
+	unset($block_attributes['source']);
+
 	return wp_nav_menu(
 		array(
 			'theme_location' 	=> $attributes['source'],
-			'block_attributes'	=> $attributes,
+			'block_attributes'	=> $block_attributes,
 			'container'      	=> '',
 			'items_wrap'     	=> '%3$s',
 			'fallback_cb'    	=> false,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -157,13 +157,9 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array()
 	);
 
-	if ( empty( $block->inner_blocks ) ) {
-		$inner_blocks_html = $classic_navigation_elements;
-	} else {
-		$inner_blocks_html = '';
-		foreach ( $block->inner_blocks as $inner_block ) {
-			$inner_blocks_html .= $inner_block->render();
-		}
+	$inner_blocks_html = '';
+	foreach ( $block->inner_blocks as $inner_block ) {
+		$inner_blocks_html .= $inner_block->render();
 	}
 
 	$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -98,7 +98,7 @@ function convertMenuItemsToBlocks( menuItems ) {
 	return mapMenuItemsToBlocks( menuTree );
 }
 
-function NavigationPlaceholder( { onCreate, location }, ref ) {
+function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 	const [ selectedMenu, setSelectedMenu ] = useState();
 
 	const [ isCreatingFromMenu, setIsCreatingFromMenu ] = useState( false );
@@ -220,23 +220,19 @@ function NavigationPlaceholder( { onCreate, location }, ref ) {
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
 
-	const setSelectedLocation = ( menu ) => {
-		console.log( menu, location );
-	};
-
 	const locationPlaceholder = () => {
 		if ( ! location || ! menuLocations ) {
 			return;
 		}
 
 		const getDropDownText = () => {
-			return menuLocations.map( ( { name, description } ) => {
-				if ( name === location ) {
-					return description;
-				}
+			const selectedMenuLocation = menuLocations.filter(
+				( menuLocation ) => menuLocation.name === location
+			);
 
-				return __( 'No location selected' );
-			} );
+			if ( selectedMenuLocation.length >= 0 ) {
+				return selectedMenuLocation[ 0 ].description;
+			}
 		};
 
 		return (
@@ -253,7 +249,7 @@ function NavigationPlaceholder( { onCreate, location }, ref ) {
 								return (
 									<MenuItem
 										onClick={ () => {
-											setSelectedLocation( name );
+											setAttributes( { location: name } );
 										} }
 										isSelected={ name === location }
 										onClose={ onClose }

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -98,7 +98,7 @@ function convertMenuItemsToBlocks( menuItems ) {
 	return mapMenuItemsToBlocks( menuTree );
 }
 
-function NavigationPlaceholder( { onCreate }, ref ) {
+function NavigationPlaceholder( { onCreate, location }, ref ) {
 	const [ selectedMenu, setSelectedMenu ] = useState();
 
 	const [ isCreatingFromMenu, setIsCreatingFromMenu ] = useState( false );
@@ -216,6 +216,109 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 		isPrimary: true,
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
+
+	const setSelectedLocation = ( menu, location ) => {
+		console.log(menu, location);
+	};
+
+	const locationPlaceholder = () => {
+		if ( ! location ) {
+			return;
+		}
+
+		//TODO: Get this from the gettin' place
+		const menuLocations = [ location ];
+
+		return (
+			<>
+				{ ' ' }
+				<DropdownMenu
+					text={ location }
+					icon={ chevronDown }
+					toggleProps={ toggleProps }
+				>
+					{ ( { onClose } ) => (
+						<MenuGroup>
+							{ menuLocations.map( ( menuLocation ) => {
+								return (
+									<MenuItem
+										onClick={ () => {
+											setSelectedLocation( menuLocation );
+										} }
+										isSelected={ menuLocation === location }
+										onClose={ onClose }
+										key={ menuLocation }
+									>
+										{ menuLocation }
+									</MenuItem>
+								);
+							} ) }
+						</MenuGroup>
+					) }
+				</DropdownMenu>
+				<Button isTertiary onClick={ editExistingMenu() }>
+					{ __( 'Edit' ) }
+				</Button>
+				<Button isTertiary onClick={ onConvertToBlocks() }>
+					{ __( 'Convert to Blocks' ) }
+				</Button>
+			</>
+		);
+	};
+
+	const editExistingMenu = () => {};
+
+	const onConvertToBlocks = () => {};
+
+	const defaultPlaceholder = () => {
+		if ( location ) {
+			return;
+		}
+		return (
+			<>
+				{ hasMenus ? (
+					<DropdownMenu
+						text={ __( 'Existing menu' ) }
+						icon={ chevronDown }
+						toggleProps={ toggleProps }
+					>
+						{ ( { onClose } ) => (
+							<MenuGroup>
+								{ menus.map( ( menu ) => {
+									return (
+										<MenuItem
+											onClick={ () => {
+												setSelectedMenu( menu.id );
+												onCreateFromMenu();
+											} }
+											onClose={ onClose }
+											key={ menu.id }
+										>
+											{ menu.name }
+										</MenuItem>
+									);
+								} ) }
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+				) : undefined }
+
+				{ hasPages ? (
+					<Button
+						isPrimary={ hasMenus ? false : true }
+						isTertiary={ hasMenus ? true : false }
+						onClick={ onCreateAllPages }
+					>
+						{ __( 'Add all pages' ) }
+					</Button>
+				) : undefined }
+				<Button isTertiary onClick={ onCreateEmptyMenu }>
+					{ __( 'Start empty' ) }
+				</Button>
+			</>
+		);
+	};
+
 	return (
 		<div className="wp-block-navigation-placeholder">
 			<PlaceholderPreview />
@@ -234,46 +337,9 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 						<div className="wp-block-navigation-placeholder__actions__indicator">
 							<Icon icon={ navigation } /> { __( 'Navigation' ) }
 						</div>
-						{ hasMenus ? (
-							<DropdownMenu
-								text={ __( 'Existing menu' ) }
-								icon={ chevronDown }
-								toggleProps={ toggleProps }
-							>
-								{ ( { onClose } ) => (
-									<MenuGroup>
-										{ menus.map( ( menu ) => {
-											return (
-												<MenuItem
-													onClick={ () => {
-														setSelectedMenu(
-															menu.id
-														);
-														onCreateFromMenu();
-													} }
-													onClose={ onClose }
-													key={ menu.id }
-												>
-													{ menu.name }
-												</MenuItem>
-											);
-										} ) }
-									</MenuGroup>
-								) }
-							</DropdownMenu>
-						) : undefined }
-						{ hasPages ? (
-							<Button
-								isPrimary={ hasMenus ? false : true }
-								isTertiary={ hasMenus ? true : false }
-								onClick={ onCreateAllPages }
-							>
-								{ __( 'Add all pages' ) }
-							</Button>
-						) : undefined }
-						<Button isTertiary onClick={ onCreateEmptyMenu }>
-							{ __( 'Start empty' ) }
-						</Button>
+
+						{ locationPlaceholder() }
+						{ defaultPlaceholder() }
 					</div>
 				) }
 			</div>

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -227,9 +227,9 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 
 		const selectedMenuLocation = menuLocations.filter(
 			( menuLocation ) => menuLocation.name === location
-		)?.[0];
+		)?.[ 0 ];
 
-		if( ! selectedMenuLocation ) {
+		if ( ! selectedMenuLocation ) {
 			return;
 		}
 
@@ -260,7 +260,10 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 						</MenuGroup>
 					) }
 				</DropdownMenu>
-				<Button isTertiary href={`/wp-admin/nav-menus.php?action=edit&menu=${selectedMenuLocation.menu}`}>
+				<Button
+					isTertiary
+					href={ `/wp-admin/nav-menus.php?action=edit&menu=${ selectedMenuLocation.menu }` }
+				>
 					{ __( 'Edit' ) }
 				</Button>
 				<Button isTertiary onClick={ onConvertToBlocks() }>

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -225,9 +225,9 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 			return;
 		}
 
-		const selectedMenuLocation = menuLocations.filter(
+		const selectedMenuLocation = menuLocations.find(
 			( menuLocation ) => menuLocation.name === location
-		)?.[ 0 ];
+		);
 
 		if ( ! selectedMenuLocation ) {
 			return;
@@ -248,6 +248,7 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 									<MenuItem
 										onClick={ () => {
 											setAttributes( { location: name } );
+											onClose();
 										} }
 										isSelected={ name === location }
 										onClose={ onClose }
@@ -266,19 +267,28 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 				>
 					{ __( 'Edit' ) }
 				</Button>
-				<Button isTertiary onClick={ onConvertToBlocks() }>
+				<Button isTertiary onClick={ convertToBlocks }>
 					{ __( 'Convert to Blocks' ) }
 				</Button>
 			</>
 		);
 	};
 
-	const onConvertToBlocks = () => {};
+	const convertToBlocks = () => {
+		setAttributes( { location: null } );
+	};
+
+	const convertToClassic = ( newLocation ) => {
+		setAttributes( { location: newLocation.name } );
+	};
 
 	const defaultPlaceholder = () => {
 		if ( location ) {
 			return;
 		}
+
+		const defaultClassicMenuLocation = menuLocations?.[ 0 ];
+
 		return (
 			<>
 				{ hasMenus ? (
@@ -320,6 +330,16 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 				<Button isTertiary onClick={ onCreateEmptyMenu }>
 					{ __( 'Start empty' ) }
 				</Button>
+				{ !! defaultClassicMenuLocation ? (
+					<Button
+						isTertiary
+						onClick={ () => {
+							convertToClassic( defaultClassicMenuLocation );
+						} }
+					>
+						{ __( 'Use classic' ) }
+					</Button>
+				) : null }
 			</>
 		);
 	};

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -108,6 +108,7 @@ function NavigationPlaceholder( { onCreate, location }, ref ) {
 		isResolvingPages,
 		hasResolvedPages,
 		menus,
+		menuLocations,
 		isResolvingMenus,
 		hasResolvedMenus,
 		menuItems,
@@ -118,6 +119,7 @@ function NavigationPlaceholder( { onCreate, location }, ref ) {
 				getEntityRecords,
 				getMenus,
 				getMenuItems,
+				getMenuLocations,
 				isResolving,
 				hasFinishedResolution,
 			} = select( coreStore );
@@ -167,6 +169,7 @@ function NavigationPlaceholder( { onCreate, location }, ref ) {
 							menuItemsParameters
 					  )
 					: false,
+				menuLocations: getMenuLocations(),
 			};
 		},
 		[ selectedMenu ]
@@ -217,39 +220,46 @@ function NavigationPlaceholder( { onCreate, location }, ref ) {
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
 
-	const setSelectedLocation = ( menu, location ) => {
-		console.log(menu, location);
+	const setSelectedLocation = ( menu ) => {
+		console.log( menu, location );
 	};
 
 	const locationPlaceholder = () => {
-		if ( ! location ) {
+		if ( ! location || ! menuLocations ) {
 			return;
 		}
 
-		//TODO: Get this from the gettin' place
-		const menuLocations = [ location ];
+		const getDropDownText = () => {
+			return menuLocations.map( ( { name, description } ) => {
+				if ( name === location ) {
+					return description;
+				}
+
+				return __( 'No location selected' );
+			} );
+		};
 
 		return (
 			<>
 				{ ' ' }
 				<DropdownMenu
-					text={ location }
+					text={ getDropDownText() }
 					icon={ chevronDown }
 					toggleProps={ toggleProps }
 				>
 					{ ( { onClose } ) => (
 						<MenuGroup>
-							{ menuLocations.map( ( menuLocation ) => {
+							{ menuLocations.map( ( { name, description } ) => {
 								return (
 									<MenuItem
 										onClick={ () => {
-											setSelectedLocation( menuLocation );
+											setSelectedLocation( name );
 										} }
-										isSelected={ menuLocation === location }
+										isSelected={ name === location }
 										onClose={ onClose }
-										key={ menuLocation }
+										key={ name }
 									>
-										{ menuLocation }
+										{ description }
 									</MenuItem>
 								);
 							} ) }

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -225,21 +225,19 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 			return;
 		}
 
-		const getDropDownText = () => {
-			const selectedMenuLocation = menuLocations.filter(
-				( menuLocation ) => menuLocation.name === location
-			);
+		const selectedMenuLocation = menuLocations.filter(
+			( menuLocation ) => menuLocation.name === location
+		)?.[0];
 
-			if ( selectedMenuLocation.length >= 0 ) {
-				return selectedMenuLocation[ 0 ].description;
-			}
-		};
+		if( ! selectedMenuLocation ) {
+			return;
+		}
 
 		return (
 			<>
 				{ ' ' }
 				<DropdownMenu
-					text={ getDropDownText() }
+					text={ selectedMenuLocation.description }
 					icon={ chevronDown }
 					toggleProps={ toggleProps }
 				>
@@ -262,7 +260,7 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 						</MenuGroup>
 					) }
 				</DropdownMenu>
-				<Button isTertiary onClick={ editExistingMenu() }>
+				<Button isTertiary href={`/wp-admin/nav-menus.php?action=edit&menu=${selectedMenuLocation.menu}`}>
 					{ __( 'Edit' ) }
 				</Button>
 				<Button isTertiary onClick={ onConvertToBlocks() }>
@@ -271,8 +269,6 @@ function NavigationPlaceholder( { location, onCreate, setAttributes }, ref ) {
 			</>
 		);
 	};
-
-	const editExistingMenu = () => {};
 
 	const onConvertToBlocks = () => {};
 


### PR DESCRIPTION
## Description 

**Background**
With [FSE coming in 5.8](https://make.wordpress.org/core/2021/04/20/full-site-editing-go-no-go-next-steps/), we'd like to build production themes that leverage aspects of block-based theming that will be available in core — incorporating them with existing customization behaviors. 

This is related to the concept of universal themes came up in this [comment](https://github.com/WordPress/gutenberg/issues/29024#issuecomment-792796711). There are a few uses cases for universal themes outlined in the comment. 

The use case this PR explores is switching between navigation editing modes — classic / customizer-based to FSE.

**Problem**
The new way to create + edit a navigation is different and not synchronized to the old way. Users will continue to edit their menus using the customizer. Themes don't have a way to keep the contents of those "classic" menus in sync with a navigation block.

There may also be circumstances where sites need to remain on a classic saved menu for some time even if the rest of the site is FSE (because they might have some plugins interacting with nav, or because they want to restrict what users can add to the navigation).

**Use Case**
As a user, I expect the ability to edit my menu using the way I'm familiar with (the customizer) indefinitely.

As a theme developer, I'd like to be able to render those menus using the navigation block. Bonus if updating my theme to be fully block-based in the future won't break or cause the nav to disappear for my users.

**Proposal**
Add an attribute to the navigation block that specifies a theme nav location — pulling its menu items from this location and rendering them using the block (leveraging `add_theme_support( 'block-nav-menus' )`). 

~The FSE side of this proposal is not present in this PR, I think it could benefit from some design exploration.~ The PR also adds some functionality to the navigation block — when the nav block sets its location attribute, it locks the block's features to only allow the menu location to be changed. The user would be presented with an option to "Convert to Blocks" which would do what the existing "import from existing menu" functionality does today, and a link to edit the classic nav in the respective UI (customizer or nav editor). Once you "Convert to Blocks", the connection between classic and nav block is broken, and the menu is edited / saved using the new navigation modality. 

_This was edited Apr 21, here is the original PR description_
This PR makes it possible to create a navigation block that pulls its menu items from a navigation area defined by the theme, by setting an attribute — "source" — on the navigation block. 

This would be of great help to transition from classic to block templates — a simple way to render the content of a classic menu using the navigation block.

## How has this been tested?
- Activate a theme that registers a navigation menu menu and create a menu.
- Add the following block markup to a post or page, where "source" is the $location (slug) of your navigation menu.
```
<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","source":"primary"} -->
```
- Verify the menu appears with the items from the corresponding navigation area.

Tested in https://github.com/Automattic/themes/pull/3658


<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
- New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
