### PR TITLE
Widgets REST API: Remove deprecated properties

### DIFF
--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -99,34 +99,6 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 				),
 			)
 		);
-
-		// Backwards compatibility. TODO: Remove.
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)/form-renderer',
-			array(
-				'args' => array(
-					'id'       => array(
-						'description' => __( 'The widget type id.', 'gutenberg' ),
-						'type'        => 'string',
-						'required'    => true,
-					),
-					'instance' => array(
-						'description' => __( 'Current widget instance', 'gutenberg' ),
-						'type'        => 'object',
-						'default'     => array(),
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'permission_callback' => array( $this, 'get_item_permissions_check' ),
-					'callback'            => array( $this, 'get_widget_form' ),
-					'args'                => array(
-						'context' => $this->get_context_param( array( 'default' => 'edit' ) ),
-					),
-				),
-			)
-		);
 	}
 
 	/**
@@ -253,12 +225,6 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			}
 			$widget['classname'] = ltrim( $classname, '_' );
 
-			// Backwards compatibility. TODO: Remove.
-			if ( $widget_object ) {
-				$widget['option_name']  = $widget_object->option_name;
-				$widget['widget_class'] = get_class( $widget_object );
-			}
-
 			$widgets[] = $widget;
 		}
 
@@ -382,56 +348,35 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			'title'      => 'widget-type',
 			'type'       => 'object',
 			'properties' => array(
-				'id'                          => array(
+				'id'          => array(
 					'description' => __( 'Unique slug identifying the widget type.', 'gutenberg' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'name'                        => array(
+				'name'        => array(
 					'description' => __( 'Human-readable name identifying the widget type.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'description'                 => array(
+				'description' => array(
 					'description' => __( 'Description of the widget.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'is_multi'                    => array(
+				'is_multi'    => array(
 					'description' => __( 'Whether the widget supports multiple instances', 'gutenberg' ),
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
-				'classname'                   => array(
+				'classname'   => array(
 					'description' => __( 'Class name', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'option_name'                 => array(
-					'description' => __( 'DEPRECATED. Option name.', 'gutenberg' ),
-					'type'        => 'string',
-					'default'     => '',
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'widget_class'                => array(
-					'description' => __( 'DEPRECATED. Widget class name.', 'gutenberg' ),
-					'type'        => 'string',
-					'default'     => '',
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'customize_selective_refresh' => array(
-					'description' => __( 'DEPRECATED. Customize selective refresh.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'default'     => false,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
@@ -441,45 +386,6 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
-	}
-
-	/**
-	 * Returns the new widget instance and the form that represents it.
-	 *
-	 * @since 5.6.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function get_widget_form( $request ) {
-		_deprecated_function( __METHOD__, '10.2.0' );
-
-		$instance = $request->get_param( 'instance' );
-
-		$widget_name = $request['id'];
-		$widget      = $this->get_widget( $widget_name );
-		$widget_obj  = new $widget['widget_class'];
-		$widget_obj->_set( -1 );
-		ob_start();
-
-		/** This filter is documented in wp-includes/class-wp-widget.php */
-		$instance = apply_filters( 'widget_form_callback', $instance, $widget_obj );
-
-		$return = null;
-		if ( false !== $instance ) {
-			$return = $widget_obj->form( $instance );
-
-			/** This filter is documented in wp-includes/class-wp-widget.php */
-			do_action_ref_array( 'in_widget_form', array( &$widget_obj, &$return, $instance ) );
-		}
-		$form = ob_get_clean();
-
-		return rest_ensure_response(
-			array(
-				'instance' => $instance,
-				'form'     => $form,
-			)
-		);
 	}
 
 	/**

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -243,7 +243,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		}
 
 		if (
-			$request->has_param( 'settings' ) || // Backwards compatibility. TODO: Remove.
 			$request->has_param( 'instance' ) ||
 			$request->has_param( 'form_data' )
 		) {
@@ -386,18 +385,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( ! empty( $request['settings'] ) ) { // Backwards compatibility. TODO: Remove.
-			_deprecated_argument( 'settings', '10.2.0' );
-			if ( $widget_object ) {
-				$form_data = array(
-					"widget-$id_base" => array(
-						$number => $request['settings'],
-					),
-				);
-			} else {
-				$form_data = $request['settings'];
-			}
-		} elseif ( isset( $request['instance'] ) ) {
+		if ( isset( $request['instance'] ) ) {
 			if ( ! $widget_object ) {
 				return new WP_Error(
 					'rest_invalid_widget',
@@ -549,18 +537,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			}
 		}
 
-		// Backwards compatibility. TODO: Remove.
-		$widget_object            = gutenberg_get_widget_object( $parsed_id['id_base'] );
-		$prepared['widget_class'] = $widget_object ? get_class( $widget_object ) : '';
-		$prepared['name']         = $widget['name'];
-		$prepared['description']  = ! empty( $widget['description'] ) ? $widget['description'] : '';
-		$prepared['number']       = $widget_object ? (int) $parsed_id['number'] : 0;
-		if ( rest_is_field_included( 'settings', $fields ) ) {
-			$instance = gutenberg_get_widget_instance( $widget_id );
-			// Use new stdClass so that JSON result is {} and not [].
-			$prepared['settings'] = empty( $instance ) ? new stdClass : $instance;
-		}
-
 		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$prepared = $this->add_additional_fields_to_object( $prepared, $request );
 		$prepared = $this->filter_response_by_context( $prepared, $context );
@@ -707,34 +683,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 						},
 					),
 				),
-				// BEGIN backwards compatibility. TODO: Remove.
-				'widget_class'  => array(
-					'description' => __( 'DEPRECATED. Class name of the widget implementation.', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'name'          => array(
-					'description' => __( 'DEPRECATED. Name of the widget.', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'description'   => array(
-					'description' => __( 'DEPRECATED. Description of the widget.', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'number'        => array(
-					'description' => __( 'DEPRECATED. Number of the widget.', 'gutenberg' ),
-					'type'        => 'integer',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'settings'      => array(
-					'description' => __( 'DEPRECATED. Settings of the widget.', 'gutenberg' ),
-					'type'        => 'object',
-					'context'     => array( 'view', 'edit', 'embed' ),
-					'default'     => array(),
-				),
-				// END backwards compatibility.
 			),
 		);
 

--- a/phpunit/class-rest-widget-types-controller-test.php
+++ b/phpunit/class-rest-widget-types-controller-test.php
@@ -70,8 +70,8 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		$this->assertCount( 1, $routes['/wp/v2/widget-types'] );
 		$this->assertArrayHasKey( '/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)', $routes );
 		$this->assertCount( 1, $routes['/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)'] );
-		$this->assertArrayHasKey( '/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)/form-renderer', $routes );
-		$this->assertCount( 1, $routes['/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)/form-renderer'] );
+		$this->assertArrayHasKey( '/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)/encode', $routes );
+		$this->assertCount( 1, $routes['/wp/v2/widget-types/(?P<id>[a-zA-Z0-9_-]+)/encode'] );
 	}
 
 	/**
@@ -161,16 +161,13 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 8, $properties );
+		$this->assertCount( 5, $properties );
 
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'id', $properties );
-		$this->assertArrayHasKey( 'option_name', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'is_multi', $properties );
 		$this->assertArrayHasKey( 'classname', $properties );
-		$this->assertArrayHasKey( 'customize_selective_refresh', $properties );
-		$this->assertArrayHasKey( 'widget_class', $properties );
 	}
 
 	/**
@@ -254,17 +251,6 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 
 		// Test links.
 		$this->assertSame( rest_url( 'wp/v2/widget-types' ), $links['collection'][0]['href'] );
-	}
-
-	public function test_get_widget_form() {
-		$this->setExpectedDeprecated( 'WP_REST_Widget_Types_Controller::get_widget_form' );
-		$widget_name = 'calendar';
-		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'POST', '/wp/v2/widget-types/' . $widget_name . '/form-renderer' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-		$this->assertArrayHasKey( 'instance', $data );
-		$this->assertArrayHasKey( 'form', $data );
 	}
 
 	public function test_encode_form_data_with_no_input() {

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -266,12 +266,9 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertEqualSets(
 			array(
 				array(
-					'id'           => 'block-1',
-					'sidebar'      => 'sidebar-1',
-					'settings'     => array(
-						'content' => $block_content,
-					),
-					'instance'     => array(
+					'id'       => 'block-1',
+					'sidebar'  => 'sidebar-1',
+					'instance' => array(
 						'encoded' => base64_encode(
 							serialize(
 								array(
@@ -290,20 +287,13 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 							'content' => $block_content,
 						),
 					),
-					'id_base'      => 'block',
-					'widget_class' => 'WP_Widget_Block',
-					'name'         => 'Block',
-					'description'  => 'Gutenberg block.',
-					'number'       => 1,
-					'rendered'     => '<p>Block test</p>',
+					'id_base'  => 'block',
+					'rendered' => '<p>Block test</p>',
 				),
 				array(
-					'id'           => 'rss-1',
-					'sidebar'      => 'sidebar-1',
-					'settings'     => array(
-						'title' => 'RSS test',
-					),
-					'instance'     => array(
+					'id'       => 'rss-1',
+					'sidebar'  => 'sidebar-1',
+					'instance' => array(
 						'encoded' => base64_encode(
 							serialize(
 								array(
@@ -319,27 +309,18 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 							)
 						),
 					),
-					'id_base'      => 'rss',
-					'widget_class' => 'WP_Widget_RSS',
-					'name'         => 'RSS',
-					'description'  => 'Entries from any RSS or Atom feed.',
-					'number'       => 1,
-					'rendered'     => '',
+					'id_base'  => 'rss',
+					'rendered' => '',
 				),
 				array(
-					'id'           => 'testwidget',
-					'sidebar'      => 'sidebar-1',
-					'settings'     => new stdClass,
-					'instance'     => null,
-					'id_base'      => 'testwidget',
-					'widget_class' => '',
-					'name'         => 'WP test widget',
-					'description'  => 'A non-multi widget for testing.',
-					'number'       => 0,
-					'rendered'     => '<h1>Default id</h1><span>Default text</span>',
+					'id'       => 'testwidget',
+					'sidebar'  => 'sidebar-1',
+					'instance' => null,
+					'id_base'  => 'testwidget',
+					'rendered' => '<h1>Default id</h1><span>Default text</span>',
 				),
 			),
-			(array) $data
+			$data
 		);
 
 		$wp_widget_factory->widgets['WP_Widget_RSS']->show_instance_in_rest = true;
@@ -374,9 +355,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				array(
 					'id'            => 'text-1',
 					'sidebar'       => 'sidebar-1',
-					'settings'      => array(
-						'text' => 'Custom text test',
-					),
 					'instance'      => array(
 						'encoded' => base64_encode(
 							serialize(
@@ -397,10 +375,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						),
 					),
 					'id_base'       => 'text',
-					'widget_class'  => 'WP_Widget_Text',
-					'name'          => 'Text',
-					'description'   => 'Arbitrary text.',
-					'number'        => 1,
 					'rendered'      => '<div class="textwidget">Custom text test</div>',
 					'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
 									'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
@@ -410,13 +384,8 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				array(
 					'id'            => 'testwidget',
 					'sidebar'       => 'sidebar-1',
-					'settings'      => new stdClass,
 					'instance'      => null,
 					'id_base'       => 'testwidget',
-					'widget_class'  => '',
-					'name'          => 'WP test widget',
-					'description'   => 'A non-multi widget for testing.',
-					'number'        => 0,
 					'rendered'      => '<h1>Default id</h1><span>Default text</span>',
 					'rendered_form' => 'WP test widget form',
 				),
@@ -449,12 +418,9 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 		$this->assertEqualSets(
 			array(
-				'id'           => 'text-1',
-				'sidebar'      => 'sidebar-1',
-				'settings'     => array(
-					'text' => 'Custom text test',
-				),
-				'instance'     => array(
+				'id'       => 'text-1',
+				'sidebar'  => 'sidebar-1',
+				'instance' => array(
 					'encoded' => base64_encode(
 						serialize(
 							array(
@@ -473,12 +439,8 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						'text' => 'Custom text test',
 					),
 				),
-				'id_base'      => 'text',
-				'widget_class' => 'WP_Widget_Text',
-				'name'         => 'Text',
-				'description'  => 'Arbitrary text.',
-				'number'       => 1,
-				'rendered'     => '<div class="textwidget">Custom text test</div>',
+				'id_base'  => 'text',
+				'rendered' => '<div class="textwidget">Custom text test</div>',
 			),
 			$data
 		);
@@ -728,23 +690,20 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 		$this->assertEquals( 'text-2', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
-		$this->assertEquals( 2, $data['number'] );
 		$this->assertEqualSets(
 			array(
 				'text'   => 'Updated text test',
 				'title'  => '',
 				'filter' => false,
 			),
-			$data['settings']
+			$data['instance']['raw']
 		);
 	}
 
 	/**
 	 * @ticket 51460
 	 */
-	public function test_create_item_using_settings() {
-		$this->setExpectedDeprecated( 'settings' );
-
+	public function test_create_item_multiple_in_a_row() {
 		$this->setup_sidebar(
 			'sidebar-1',
 			array(
@@ -756,8 +715,8 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params(
 			array(
 				'sidebar'  => 'sidebar-1',
-				'settings' => array(
-					'text' => 'Updated text test',
+				'instance' => array(
+					'raw' => array( 'text' => 'Text 1' ),
 				),
 				'id_base'  => 'text',
 			)
@@ -766,57 +725,22 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 		$this->assertEquals( 'text-2', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
-		$this->assertEquals( 2, $data['number'] );
-		$this->assertEqualSets(
-			array(
-				'text'   => 'Updated text test',
-				'title'  => '',
-				'filter' => false,
-			),
-			$data['settings']
-		);
-	}
-
-	/**
-	 * @ticket 51460
-	 */
-	public function test_create_item_multiple_in_a_row() {
-		$this->setExpectedDeprecated( 'settings' );
-
-		$this->setup_sidebar(
-			'sidebar-1',
-			array(
-				'name' => 'Test sidebar',
-			)
-		);
-
-		$request = new WP_REST_Request( 'POST', '/wp/v2/widgets' );
-		$request->set_body_params(
-			array(
-				'sidebar'  => 'sidebar-1',
-				'settings' => array( 'text' => 'Text 1' ),
-				'id_base'  => 'text',
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-		$this->assertEquals( 'text-2', $data['id'] );
-		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
-		$this->assertEquals( 2, $data['number'] );
 		$this->assertEqualSets(
 			array(
 				'text'   => 'Text 1',
 				'title'  => '',
 				'filter' => false,
 			),
-			$data['settings']
+			$data['instance']['raw']
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/widgets' );
 		$request->set_body_params(
 			array(
 				'sidebar'  => 'sidebar-1',
-				'settings' => array( 'text' => 'Text 2' ),
+				'instance' => array(
+					'raw' => array( 'text' => 'Text 2' ),
+				),
 				'id_base'  => 'text',
 			)
 		);
@@ -824,14 +748,13 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 		$this->assertEquals( 'text-3', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
-		$this->assertEquals( 3, $data['number'] );
 		$this->assertEqualSets(
 			array(
 				'text'   => 'Text 2',
 				'title'  => '',
 				'filter' => false,
 			),
-			$data['settings']
+			$data['instance']['raw']
 		);
 
 		$sidebar = rest_do_request( '/wp/v2/sidebars/sidebar-1' );
@@ -843,8 +766,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 51460
 	 */
 	public function test_create_item_second_instance() {
-		$this->setExpectedDeprecated( 'settings' );
-
 		$this->setup_widget(
 			'text',
 			1,
@@ -863,8 +784,10 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params(
 			array(
 				'sidebar'  => 'sidebar-1',
-				'settings' => array(
-					'text' => 'Updated text test',
+				'instance' => array(
+					'raw' => array(
+						'text' => 'Updated text test',
+					),
 				),
 				'id_base'  => 'text',
 			)
@@ -873,14 +796,13 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 		$this->assertEquals( 'text-2', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
-		$this->assertEquals( 2, $data['number'] );
 		$this->assertEqualSets(
 			array(
 				'text'   => 'Updated text test',
 				'title'  => '',
 				'filter' => false,
 			),
-			$data['settings']
+			$data['instance']['raw']
 		);
 	}
 
@@ -888,8 +810,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 51460
 	 */
 	public function test_update_item() {
-		$this->setExpectedDeprecated( 'settings' );
-
 		$this->setup_widget(
 			'text',
 			1,
@@ -908,16 +828,14 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/text-1' );
 		$request->set_body_params(
 			array(
-				'id'           => 'text-1',
-				'sidebar'      => 'sidebar-1',
-				'settings'     => array(
-					'text' => 'Updated text test',
+				'id'       => 'text-1',
+				'sidebar'  => 'sidebar-1',
+				'instance' => array(
+					'raw' => array(
+						'text' => 'Updated text test',
+					),
 				),
-				'id_base'      => 'text',
-				'widget_class' => 'WP_Widget_Text',
-				'name'         => 'Text',
-				'description'  => 'Arbitrary text.',
-				'number'       => 1,
+				'id_base'  => 'text',
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -925,14 +843,13 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertEquals( 'text-1', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
-		$this->assertEquals( 1, $data['number'] );
 		$this->assertEqualSets(
 			array(
 				'text'   => 'Updated text test',
 				'title'  => '',
 				'filter' => false,
 			),
-			$data['settings']
+			$data['instance']['raw']
 		);
 	}
 
@@ -984,8 +901,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 51460
 	 */
 	public function test_update_item_shouldnt_require_id_base() {
-		$this->setExpectedDeprecated( 'settings' );
-
 		$this->setup_widget(
 			'text',
 			1,
@@ -1005,8 +920,10 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params(
 			array(
 				'id'       => 'text-1',
-				'settings' => array(
-					'text' => 'Updated text test',
+				'instance' => array(
+					'raw' => array(
+						'text' => 'Updated text test',
+					),
 				),
 			)
 		);
@@ -1015,14 +932,13 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertEquals( 'text-1', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
-		$this->assertEquals( 1, $data['number'] );
 		$this->assertEqualSets(
 			array(
 				'text'   => 'Updated text test',
 				'title'  => '',
 				'filter' => false,
 			),
-			$data['settings']
+			$data['instance']['raw']
 		);
 	}
 
@@ -1030,7 +946,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @group multisite
 	 */
 	public function test_store_html_as_admin() {
-		$this->setExpectedDeprecated( 'settings' );
 		if ( is_multisite() ) {
 			$this->assertEquals(
 				'<div class="textwidget">alert(1)</div>',
@@ -1048,7 +963,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @group multisite
 	 */
 	public function test_store_html_as_superadmin() {
-		$this->setExpectedDeprecated( 'settings' );
 		wp_set_current_user( self::$superadmin_id );
 		if ( is_multisite() ) {
 			$this->assertEquals(
@@ -1082,15 +996,13 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/text-1' );
 		$request->set_body_params(
 			array(
-				'id'           => 'text-1',
-				'settings'     => array(
-					'text' => $html,
+				'id'       => 'text-1',
+				'instance' => array(
+					'raw' => array(
+						'text' => $html,
+					),
 				),
-				'id_base'      => 'text',
-				'widget_class' => 'WP_Widget_Text',
-				'name'         => 'Text',
-				'description'  => 'Arbitrary text.',
-				'number'       => 1,
+				'id_base'  => 'text',
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -1103,8 +1015,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 51460
 	 */
 	public function test_update_item_legacy_widget() {
-		$this->setExpectedDeprecated( 'settings' );
-
 		$this->setup_sidebar(
 			'sidebar-1',
 			array(
@@ -1116,13 +1026,9 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/testwidget' );
 		$request->set_body_params(
 			array(
-				'id'       => 'testwidget',
-				'name'     => 'WP test widget',
-				'settings' => array(
-					'test_id'           => 'My test id',
-					'test_title'        => 'My test title',
-					'update_testwidget' => true,
-				),
+				'id'        => 'testwidget',
+				'name'      => 'WP test widget',
+				'form_data' => 'test_id=My+test+id&test_title=My+test+title&update_testwidget=true',
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -1132,15 +1038,10 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array(
 				'id'            => 'testwidget',
 				'sidebar'       => 'sidebar-1',
-				'settings'      => new stdClass,
 				'instance'      => null,
 				'rendered'      => '<h1>My test id</h1><span>My test title</span>',
-				'name'          => 'WP test widget',
-				'number'        => 0,
 				'rendered_form' => 'WP test widget form',
-				'widget_class'  => '',
 				'id_base'       => 'testwidget',
-				'description'   => 'A non-multi widget for testing.',
 			),
 			$data
 		);
@@ -1150,8 +1051,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 51460
 	 */
 	public function test_create_item_legacy_widget() {
-		$this->setExpectedDeprecated( 'settings' );
-
 		$this->setup_sidebar(
 			'sidebar-1',
 			array(
@@ -1163,14 +1062,10 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/testwidget' );
 		$request->set_body_params(
 			array(
-				'id'       => 'testwidget',
-				'sidebar'  => 'sidebar-1',
-				'name'     => 'WP test widget',
-				'settings' => array(
-					'test_id'           => 'My test id',
-					'test_title'        => 'My test title',
-					'update_testwidget' => true,
-				),
+				'id'        => 'testwidget',
+				'sidebar'   => 'sidebar-1',
+				'name'      => 'WP test widget',
+				'form_data' => 'test_id=My+test+id&test_title=My+test+title&update_testwidget=true',
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -1180,15 +1075,10 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array(
 				'id'            => 'testwidget',
 				'sidebar'       => 'sidebar-1',
-				'settings'      => new stdClass,
 				'instance'      => null,
 				'rendered'      => '<h1>My test id</h1><span>My test title</span>',
-				'name'          => 'WP test widget',
-				'number'        => 0,
 				'rendered_form' => 'WP test widget form',
-				'widget_class'  => '',
 				'id_base'       => 'testwidget',
-				'description'   => 'A non-multi widget for testing.',
 			),
 			$data
 		);
@@ -1230,24 +1120,20 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * Tests if the endpoint correctly handles "slashable" characters such as " or '.
 	 */
 	public function test_update_item_slashing() {
-		$this->setExpectedDeprecated( 'settings' );
-
 		$this->setup_widget( 'text', 1, array( 'text' => 'Custom text test' ) );
 		$this->setup_sidebar( 'sidebar-1', array( 'name' => 'Test sidebar' ), array( 'text-1', 'rss-1' ) );
 
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/text-1' );
 		$request->set_body_params(
 			array(
-				'id'           => 'text-1',
-				'sidebar'      => 'sidebar-1',
-				'settings'     => array(
-					'text' => 'Updated \\" \\\' text test',
+				'id'       => 'text-1',
+				'sidebar'  => 'sidebar-1',
+				'instance' => array(
+					'raw' => array(
+						'text' => 'Updated \\" \\\' text test',
+					),
 				),
-				'id_base'      => 'text',
-				'widget_class' => 'WP_Widget_Text',
-				'name'         => 'Text',
-				'description'  => 'Arbitrary text.',
-				'number'       => 1,
+				'id_base'  => 'text',
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -1259,7 +1145,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'title'  => '',
 				'filter' => false,
 			),
-			$data['settings']
+			$data['instance']['raw']
 		);
 
 		$this->assertEquals(
@@ -1294,9 +1180,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array(
 				'id'            => 'text-1',
 				'sidebar'       => 'wp_inactive_widgets',
-				'settings'      => array(
-					'text' => 'Custom text test',
-				),
 				'instance'      => array(
 					'encoded' => base64_encode(
 						serialize(
@@ -1317,10 +1200,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					),
 				),
 				'id_base'       => 'text',
-				'widget_class'  => 'WP_Widget_Text',
-				'name'          => 'Text',
-				'description'   => 'Arbitrary text.',
-				'number'        => 1,
 				'rendered'      => '',
 				'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
 								'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
@@ -1361,9 +1240,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 					'id'            => 'text-1',
 					'sidebar'       => 'sidebar-1',
-					'settings'      => array(
-						'text' => 'Custom text test',
-					),
 					'instance'      => array(
 						'encoded' => base64_encode(
 							serialize(
@@ -1384,10 +1260,6 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						),
 					),
 					'id_base'       => 'text',
-					'widget_class'  => 'WP_Widget_Text',
-					'name'          => 'Text',
-					'description'   => 'Arbitrary text.',
-					'number'        => 1,
 					'rendered'      => '<div class="textwidget">Custom text test</div>',
 					'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
 									'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
@@ -1473,17 +1345,12 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 12, count( $properties ) );
+		$this->assertEquals( 7, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'id_base', $properties );
 		$this->assertArrayHasKey( 'sidebar', $properties );
-		$this->assertArrayHasKey( 'widget_class', $properties );
-		$this->assertArrayHasKey( 'name', $properties );
-		$this->assertArrayHasKey( 'description', $properties );
-		$this->assertArrayHasKey( 'number', $properties );
 		$this->assertArrayHasKey( 'rendered', $properties );
 		$this->assertArrayHasKey( 'rendered_form', $properties );
-		$this->assertArrayHasKey( 'settings', $properties );
 		$this->assertArrayHasKey( 'instance', $properties );
 		$this->assertArrayHasKey( 'form_data', $properties );
 	}


### PR DESCRIPTION
## Description

Closes https://github.com/WordPress/gutenberg/issues/30267.

Removes everything in the ` /wp/v2/widgets` and `/wp/v2/widget-types` endpoints that were marked as deprecated in #29649. They were marked deprecated in Gutenberg 10.3 which means they can be removed in Gutenberg 10.5—the next release.

## How has this been tested?

If the `adding-widgets` E2E test passes, then we should be good.