### PR TITLE
[RNMobile] Search Block: Implement long button text handling

### DIFF
--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -101,7 +101,6 @@ export default function SearchEdit( {
 
 		if ( width ) {
 			setButtonWidth( width );
-			// processButtonWidthChanges( containerWidth, width );
 		}
 	};
 
@@ -110,7 +109,6 @@ export default function SearchEdit( {
 
 		if ( width ) {
 			setContainerWidth( width );
-			// processButtonWidthChanges( width, buttonWidth );
 		}
 	};
 

--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -81,14 +81,28 @@ export default function SearchEdit( {
 		}
 	}, [ isSelected ] );
 
+	useEffect( () => {
+		const maxButtonWidth = Math.floor( containerWidth / 2 - MARGINS );
+		const tempIsLongButton = buttonWidth > maxButtonWidth;
+
+		// Update this value only if it has changed to avoid flickering. This is required
+		// to update the view on orientation change if needed.
+		if ( isLongButton !== tempIsLongButton ) {
+			setIsLongButton( tempIsLongButton );
+		}
+	}, [ containerWidth, buttonWidth ] );
+
 	const hasTextInput = () => {
 		return textInputRef && textInputRef.current;
 	};
 
 	const onLayoutButton = ( { nativeEvent } ) => {
-		const { width } = nativeEvent.layout;
-		setButtonWidth( width );
-		processButtonWidthChanges( containerWidth );
+		const { width } = nativeEvent?.layout;
+
+		if ( width ) {
+			setButtonWidth( width );
+			// processButtonWidthChanges( containerWidth, width );
+		}
 	};
 
 	const onLayoutContainer = ( { nativeEvent } ) => {
@@ -96,17 +110,7 @@ export default function SearchEdit( {
 
 		if ( width ) {
 			setContainerWidth( width );
-			processButtonWidthChanges( width );
-		}
-	};
-
-	const processButtonWidthChanges = ( parentWidth ) => {
-		const maxButtonWidth = parentWidth / 2 - MARGINS;
-		// Update this value only if it has changed to avoid flickering. This is required
-		// to update the view on orientation change if needed.
-		const tempIsLongButton = buttonWidth > maxButtonWidth;
-		if ( isLongButton !== tempIsLongButton ) {
-			setIsLongButton( tempIsLongButton );
+			// processButtonWidthChanges( width, buttonWidth );
 		}
 	};
 
@@ -275,7 +279,13 @@ export default function SearchEdit( {
 					isLongButton && styles.buttonContainerWide,
 				] }
 			>
-				{ buttonUseIcon && <Icon icon={ search } { ...styles.icon } /> }
+				{ buttonUseIcon && (
+					<Icon
+						icon={ search }
+						{ ...styles.icon }
+						onLayout={ onLayoutButton }
+					/>
+				) }
 
 				{ ! buttonUseIcon && (
 					<View

--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View, Dimensions } from 'react-native';
+import { View } from 'react-native';
 import classnames from 'classnames';
 
 /**
@@ -48,6 +48,7 @@ export default function SearchEdit( {
 	attributes,
 	setAttributes,
 	className,
+	blockWidth,
 } ) {
 	const [ isButtonSelected, setIsButtonSelected ] = useState( false );
 	const [ isLabelSelected, setIsLabelSelected ] = useState( false );
@@ -55,9 +56,6 @@ export default function SearchEdit( {
 		true
 	);
 	const [ isLongButton, setIsLongButton ] = useState( false );
-	const [ containerWidth, setContainerWidth ] = useState(
-		Math.floor( Dimensions.get( 'window' ).width )
-	);
 	const [ buttonWidth, setButtonWidth ] = useState( MIN_BUTTON_WIDTH );
 
 	const textInputRef = useRef( null );
@@ -82,7 +80,7 @@ export default function SearchEdit( {
 	}, [ isSelected ] );
 
 	useEffect( () => {
-		const maxButtonWidth = Math.floor( containerWidth / 2 - MARGINS );
+		const maxButtonWidth = Math.floor( blockWidth / 2 - MARGINS );
 		const tempIsLongButton = buttonWidth > maxButtonWidth;
 
 		// Update this value only if it has changed to avoid flickering. This is required
@@ -90,7 +88,7 @@ export default function SearchEdit( {
 		if ( isLongButton !== tempIsLongButton ) {
 			setIsLongButton( tempIsLongButton );
 		}
-	}, [ containerWidth, buttonWidth ] );
+	}, [ blockWidth, buttonWidth ] );
 
 	const hasTextInput = () => {
 		return textInputRef && textInputRef.current;
@@ -101,14 +99,6 @@ export default function SearchEdit( {
 
 		if ( width ) {
 			setButtonWidth( width );
-		}
-	};
-
-	const onLayoutContainer = ( { nativeEvent } ) => {
-		const { width } = nativeEvent?.layout;
-
-		if ( width ) {
-			setContainerWidth( width );
 		}
 	};
 
@@ -309,7 +299,7 @@ export default function SearchEdit( {
 								setAttributes( { buttonText: html } )
 							}
 							minWidth={ MIN_BUTTON_WIDTH }
-							maxWidth={ containerWidth - MARGINS }
+							maxWidth={ blockWidth - MARGINS }
 							textAlign="center"
 							isSelected={ isButtonSelected }
 							__unstableMobileNoFocusOnMount={ ! isSelected }
@@ -375,7 +365,7 @@ export default function SearchEdit( {
 
 			{ ( 'button-inside' === buttonPosition ||
 				'button-outside' === buttonPosition ) && (
-				<View style={ searchBarStyle } onLayout={ onLayoutContainer }>
+				<View style={ searchBarStyle }>
 					{ renderTextField() }
 					{ renderButton() }
 				</View>

--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -83,8 +83,7 @@ export default function SearchEdit( {
 		const maxButtonWidth = Math.floor( blockWidth / 2 - MARGINS );
 		const tempIsLongButton = buttonWidth > maxButtonWidth;
 
-		// Update this value only if it has changed to avoid flickering. This is required
-		// to update the view on orientation change if needed.
+		// Update this value only if it has changed to avoid flickering.
 		if ( isLongButton !== tempIsLongButton ) {
 			setIsLongButton( tempIsLongButton );
 		}

--- a/packages/block-library/src/search/style.native.scss
+++ b/packages/block-library/src/search/style.native.scss
@@ -20,7 +20,6 @@
 	border: $border-width solid $gray-5;
 	border-radius: $grid-unit-05;
 	padding: $grid-unit-05;
-	padding-left: $grid-unit-10;
 }
 
 .borderDark {
@@ -35,7 +34,11 @@
 	border-radius: $grid-unit-05;
 	align-content: center;
 	align-items: center;
-	flex-shrink: 1;
+}
+
+.buttonContainerWide {
+	margin-left: 0;
+	margin-top: $grid-unit-05;
 }
 
 .icon {
@@ -59,7 +62,8 @@
 	font-weight: 400;
 	background-color: transparent;
 	font-family: $default-regular-font;
-	padding: 0;
+	padding-left: $grid-unit-10;
+	padding-right: $grid-unit-10;
 	margin: 0;
 	text-align: center;
 	min-height: 24px;
@@ -72,7 +76,7 @@
 .plainTextInput {
 	min-height: 42px;
 	padding: $grid-unit-05;
-	padding-left: 0;
+	padding-left: $grid-unit-10;
 	font-family: $default-regular-font;
 	color: $gray-90;
 }
@@ -87,4 +91,9 @@
 
 .plainTextPlaceholderDark {
 	color: $gray-50;
+}
+
+.widthMargin {
+	margin: $grid-unit-20;
+	padding: $grid-unit-05;
 }

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -65,7 +65,6 @@ exports[`Search Block renders block with button inside option 1`] = `
     </View>
   </View>
   <View
-    onLayout={[Function]}
     style={
       Array [
         undefined,
@@ -242,7 +241,6 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
     </View>
   </View>
   <View
-    onLayout={[Function]}
     style={
       Array [
         undefined,
@@ -301,7 +299,6 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
   importantForAccessibility="no-hide-descendants"
 >
   <View
-    onLayout={[Function]}
     style={
       Array [
         undefined,
@@ -478,7 +475,6 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
     </View>
   </View>
   <View
-    onLayout={[Function]}
     style={
       Array [
         undefined,

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -65,10 +65,12 @@ exports[`Search Block renders block with button inside option 1`] = `
     </View>
   </View>
   <View
+    onLayout={[Function]}
     style={
       Array [
         undefined,
         undefined,
+        false,
       ]
     }
   >
@@ -94,19 +96,27 @@ exports[`Search Block renders block with button inside option 1`] = `
         scrollEnabled={false}
         style={
           Array [
-            undefined,
             false,
+            undefined,
           ]
         }
         underlineColorAndroid="transparent"
       />
     </View>
-    <View>
+    <View
+      style={
+        Array [
+          undefined,
+          false,
+        ]
+      }
+    >
       <View
         accessibilityHint="Double tap to edit button text"
         accessibilityLabel="Search button. Current button text is Search Button"
         accessibilityRole="none"
         accessible={true}
+        onLayout={[Function]}
       >
         <View>
           <RCTAztecView
@@ -145,7 +155,7 @@ exports[`Search Block renders block with button inside option 1`] = `
             style={
               Object {
                 "backgroundColor": undefined,
-                "maxWidth": undefined,
+                "maxWidth": NaN,
                 "minHeight": 0,
               }
             }
@@ -232,9 +242,11 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
     </View>
   </View>
   <View
+    onLayout={[Function]}
     style={
       Array [
         undefined,
+        false,
         false,
       ]
     }
@@ -268,7 +280,14 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
         underlineColorAndroid="transparent"
       />
     </View>
-    <View>
+    <View
+      style={
+        Array [
+          undefined,
+          false,
+        ]
+      }
+    >
       Svg
     </View>
   </View>
@@ -282,9 +301,11 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
   importantForAccessibility="no-hide-descendants"
 >
   <View
+    onLayout={[Function]}
     style={
       Array [
         undefined,
+        false,
         false,
       ]
     }
@@ -318,12 +339,20 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
         underlineColorAndroid="transparent"
       />
     </View>
-    <View>
+    <View
+      style={
+        Array [
+          undefined,
+          false,
+        ]
+      }
+    >
       <View
         accessibilityHint="Double tap to edit button text"
         accessibilityLabel="Search button. Current button text is Search Button"
         accessibilityRole="none"
         accessible={true}
+        onLayout={[Function]}
       >
         <View>
           <RCTAztecView
@@ -362,7 +391,7 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
             style={
               Object {
                 "backgroundColor": undefined,
-                "maxWidth": undefined,
+                "maxWidth": NaN,
                 "minHeight": 0,
               }
             }
@@ -449,9 +478,11 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
     </View>
   </View>
   <View
+    onLayout={[Function]}
     style={
       Array [
         undefined,
+        false,
         false,
       ]
     }
@@ -485,12 +516,20 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
         underlineColorAndroid="transparent"
       />
     </View>
-    <View>
+    <View
+      style={
+        Array [
+          undefined,
+          false,
+        ]
+      }
+    >
       <View
         accessibilityHint="Double tap to edit button text"
         accessibilityLabel="Search button. Current button text is Search Button"
         accessibilityRole="none"
         accessible={true}
+        onLayout={[Function]}
       >
         <View>
           <RCTAztecView
@@ -529,7 +568,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
             style={
               Object {
                 "backgroundColor": undefined,
-                "maxWidth": undefined,
+                "maxWidth": NaN,
                 "minHeight": 0,
               }
             }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

**Gutenberg Mobile PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/3210

## Description
<!-- Please describe what you have changed or added -->
This PR implements the design for moving the button below the input element if the button text makes the button grow to more than 50% of the available width of the block:

![Screen Shot 2021-04-14 at 9 28 06 PM](https://user-images.githubusercontent.com/5810477/114801052-f2c3a600-9d68-11eb-9dc9-2ac824ff4873.png)

**Changes include the following:** 
- If the button is more the 50% in portrait mode, but not more than 50% in landscape mode, the view will appropriately reflect these changes when changing orientation. 
- If the button is moved below the search input element due to the length of text, and then the user changes to icon only button, the button will be moved back up to be inline with the input element. 
- Updated snapshots for unit tests

**Known issues/not included**
- Android text wraps before the text completely fills the button width. I'm not sure why this happens, but it doesn't appear to be related to my code directly (please let me know if I'm wrong about this). I've verified `maxWidth` is set appropriately but the text will still wrap before it fills the full width. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Test the following scenarios on iOS simulator and Android emulator. 

#### Long button text moves button below search input element
1. Add the Search Block. 
2. Click into the Search button text field and enter enough text to verify that the button is moved below the search input field when the width reaches about 50%. 
3. Delete the extra button text to verify the button will be moved inline with the search input field when expected. 

#### Long text button moves back inline with search input when icon only option enabled
1. Add the Search Block. 
2. Click into the Search button text field and enter enough text to verify that the button is moved below the search input field when the width reaches about 50%. 
3. Open the block settings.
4. Toggle icon only button to "on" and verify button is moved back up to be inline with search input element. 

#### Long button with button position set to "inside"
1. Add the Search Block. 
2. Click into the Search button text field and enter enough text to verify that the button is moved below the search input field when the width reaches about 50%. 
3. Open block settings.
4. Change "button position" option to "Inside". Verify design. 

#### Long button recalculated on orientation change
1. Add the Search Block in portrait mode.
2. Click into the Search button text field and enter _just enough text_ so the button moves below the search input element. 
3. Rotate the device to landscape mode. Verify the button moves back up to be inline with the search input element. 
4. Enter more text in the button to verify that once the button is about 50% of the width it gets moved below the search input element. 


## Screenshots <!-- if applicable -->

#### Interacting with the UI


https://user-images.githubusercontent.com/5810477/114802279-6e265700-9d6b-11eb-815e-e23e49709705.mov



#### Rotating on Android

https://user-images.githubusercontent.com/5810477/114802233-5b138700-9d6b-11eb-97e3-c0d19ebe61c2.mov

#### Rotating on iOS

https://user-images.githubusercontent.com/5810477/114802266-6961a300-9d6b-11eb-928f-2ffa820b8b83.mov





## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
