### PR TITLE
Fix block-based widget customizer initializing too soon

### DIFF
--- a/packages/customize-widgets/src/controls/inserter-outer-section.js
+++ b/packages/customize-widgets/src/controls/inserter-outer-section.js
@@ -4,117 +4,118 @@
 import { ESCAPE } from '@wordpress/keycodes';
 import { focus } from '@wordpress/dom';
 
-const {
-	wp: { customize },
-} = window;
+export default function getInserterOuterSection() {
+	const {
+		wp: { customize },
+	} = window;
 
-const OuterSection = customize.OuterSection;
-// Override the OuterSection class to handle multiple outer sections.
-// It closes all the other outer sections whenever one is opened.
-// The result is that at most one outer section can be opened at the same time.
-customize.OuterSection = class extends OuterSection {
-	onChangeExpanded( expanded, args ) {
-		if ( expanded ) {
-			customize.section.each( ( section ) => {
-				if (
-					section.params.type === 'outer' &&
-					section.id !== this.id
-				) {
-					if ( section.expanded() ) {
-						section.collapse();
-					}
-				}
-			} );
-		}
-
-		return super.onChangeExpanded( expanded, args );
-	}
-};
-// Handle constructor so that "params.type" can be correctly pointed to "outer".
-customize.sectionConstructor.outer = customize.OuterSection;
-
-class InserterOuterSection extends customize.OuterSection {
-	constructor( ...args ) {
-		super( ...args );
-
-		// This is necessary since we're creating a new class which is not identical to the original OuterSection.
-		// @See https://github.com/WordPress/wordpress-develop/blob/42b05c397c50d9dc244083eff52991413909d4bd/src/js/_enqueues/wp/customize/controls.js#L1427-L1436
-		this.params.type = 'outer';
-
-		this.activeElementBeforeExpanded = null;
-
-		const ownerWindow = this.contentContainer[ 0 ].ownerDocument
-			.defaultView;
-
-		// Handle closing the inserter when pressing the Escape key.
-		ownerWindow.addEventListener(
-			'keydown',
-			( event ) => {
-				if (
-					this.isOpen &&
-					( event.keyCode === ESCAPE || event.code === 'Escape' )
-				) {
-					event.stopPropagation();
-
-					this.close();
-				}
-			},
-			// Use capture mode to make this run before other event listeners.
-			true
-		);
-
-		this.contentContainer.addClass( 'widgets-inserter' );
-	}
-	get isOpen() {
-		return this.expanded();
-	}
-	subscribe( handler ) {
-		this.expanded.bind( handler );
-		return () => this.expanded.unbind( handler );
-	}
-	open() {
-		if ( ! this.isOpen ) {
-			const contentContainer = this.contentContainer[ 0 ];
-			this.activeElementBeforeExpanded =
-				contentContainer.ownerDocument.activeElement;
-
-			this.expand( {
-				completeCallback() {
-					// We have to do this in a "completeCallback" or else the elements will not yet be visible/tabbable.
-					// The first one should be the close button,
-					// we want to skip it and choose the second one instead, which is the search box.
-					const searchBox = focus.tabbable.find(
-						contentContainer
-					)[ 1 ];
-					if ( searchBox ) {
-						searchBox.focus();
-					}
-				},
-			} );
-		}
-	}
-	close() {
-		if ( this.isOpen ) {
-			const contentContainer = this.contentContainer[ 0 ];
-			const activeElement = contentContainer.ownerDocument.activeElement;
-
-			this.collapse( {
-				completeCallback() {
-					// Return back the focus when closing the inserter.
-					// Only do this if the active element which triggers the action is inside the inserter,
-					// (the close button for instance). In that case the focus will be lost.
-					// Otherwise, we don't hijack the focus when the user is focusing on other elements
-					// (like the quick inserter).
-					if ( contentContainer.contains( activeElement ) ) {
-						// Return back the focus when closing the inserter.
-						if ( this.activeElementBeforeExpanded ) {
-							this.activeElementBeforeExpanded.focus();
+	const OuterSection = customize.OuterSection;
+	// Override the OuterSection class to handle multiple outer sections.
+	// It closes all the other outer sections whenever one is opened.
+	// The result is that at most one outer section can be opened at the same time.
+	customize.OuterSection = class extends OuterSection {
+		onChangeExpanded( expanded, args ) {
+			if ( expanded ) {
+				customize.section.each( ( section ) => {
+					if (
+						section.params.type === 'outer' &&
+						section.id !== this.id
+					) {
+						if ( section.expanded() ) {
+							section.collapse();
 						}
 					}
-				},
-			} );
-		}
-	}
-}
+				} );
+			}
 
-export default InserterOuterSection;
+			return super.onChangeExpanded( expanded, args );
+		}
+	};
+	// Handle constructor so that "params.type" can be correctly pointed to "outer".
+	customize.sectionConstructor.outer = customize.OuterSection;
+
+	return class InserterOuterSection extends customize.OuterSection {
+		constructor( ...args ) {
+			super( ...args );
+
+			// This is necessary since we're creating a new class which is not identical to the original OuterSection.
+			// @See https://github.com/WordPress/wordpress-develop/blob/42b05c397c50d9dc244083eff52991413909d4bd/src/js/_enqueues/wp/customize/controls.js#L1427-L1436
+			this.params.type = 'outer';
+
+			this.activeElementBeforeExpanded = null;
+
+			const ownerWindow = this.contentContainer[ 0 ].ownerDocument
+				.defaultView;
+
+			// Handle closing the inserter when pressing the Escape key.
+			ownerWindow.addEventListener(
+				'keydown',
+				( event ) => {
+					if (
+						this.isOpen &&
+						( event.keyCode === ESCAPE || event.code === 'Escape' )
+					) {
+						event.stopPropagation();
+
+						this.close();
+					}
+				},
+				// Use capture mode to make this run before other event listeners.
+				true
+			);
+
+			this.contentContainer.addClass( 'widgets-inserter' );
+		}
+		get isOpen() {
+			return this.expanded();
+		}
+		subscribe( handler ) {
+			this.expanded.bind( handler );
+			return () => this.expanded.unbind( handler );
+		}
+		open() {
+			if ( ! this.isOpen ) {
+				const contentContainer = this.contentContainer[ 0 ];
+				this.activeElementBeforeExpanded =
+					contentContainer.ownerDocument.activeElement;
+
+				this.expand( {
+					completeCallback() {
+						// We have to do this in a "completeCallback" or else the elements will not yet be visible/tabbable.
+						// The first one should be the close button,
+						// we want to skip it and choose the second one instead, which is the search box.
+						const searchBox = focus.tabbable.find(
+							contentContainer
+						)[ 1 ];
+						if ( searchBox ) {
+							searchBox.focus();
+						}
+					},
+				} );
+			}
+		}
+		close() {
+			if ( this.isOpen ) {
+				const contentContainer = this.contentContainer[ 0 ];
+				const activeElement =
+					contentContainer.ownerDocument.activeElement;
+
+				this.collapse( {
+					completeCallback() {
+						// Return back the focus when closing the inserter.
+						// Only do this if the active element which triggers the action is inside the inserter,
+						// (the close button for instance). In that case the focus will be lost.
+						// Otherwise, we don't hijack the focus when the user is focusing on other elements
+						// (like the quick inserter).
+						if ( contentContainer.contains( activeElement ) ) {
+							// Return back the focus when closing the inserter.
+							if ( this.activeElementBeforeExpanded ) {
+								this.activeElementBeforeExpanded.focus();
+							}
+						}
+					},
+				} );
+			}
+		}
+	};
+}

--- a/packages/customize-widgets/src/controls/inspector-section.js
+++ b/packages/customize-widgets/src/controls/inspector-section.js
@@ -1,58 +1,58 @@
-const {
-	wp: { customize },
-} = window;
+export default function getInspectorSection() {
+	const {
+		wp: { customize },
+	} = window;
 
-class InspectorSection extends customize.Section {
-	constructor( id, options ) {
-		super( id, options );
+	return class InspectorSection extends customize.Section {
+		constructor( id, options ) {
+			super( id, options );
 
-		this.parentSection = options.parentSection;
+			this.parentSection = options.parentSection;
 
-		this.returnFocusWhenClose = null;
-	}
-	ready() {
-		this.contentContainer[ 0 ].classList.add(
-			'customize-widgets-layout__inspector'
-		);
-	}
-	onChangeExpanded( expanded, args ) {
-		super.onChangeExpanded( expanded, args );
+			this.returnFocusWhenClose = null;
+		}
+		ready() {
+			this.contentContainer[ 0 ].classList.add(
+				'customize-widgets-layout__inspector'
+			);
+		}
+		onChangeExpanded( expanded, args ) {
+			super.onChangeExpanded( expanded, args );
 
-		if ( this.parentSection && ! args.unchanged ) {
-			if ( expanded ) {
-				this.parentSection.collapse( {
-					manualTransition: true,
-				} );
-			} else {
-				this.parentSection.expand( {
-					manualTransition: true,
-					completeCallback: () => {
-						// Return focus after finishing the transition.
-						if (
-							this.returnFocusWhenClose &&
-							! this.contentContainer[ 0 ].contains(
-								this.returnFocusWhenClose
-							)
-						) {
-							this.returnFocusWhenClose.focus();
-						}
-					},
-				} );
+			if ( this.parentSection && ! args.unchanged ) {
+				if ( expanded ) {
+					this.parentSection.collapse( {
+						manualTransition: true,
+					} );
+				} else {
+					this.parentSection.expand( {
+						manualTransition: true,
+						completeCallback: () => {
+							// Return focus after finishing the transition.
+							if (
+								this.returnFocusWhenClose &&
+								! this.contentContainer[ 0 ].contains(
+									this.returnFocusWhenClose
+								)
+							) {
+								this.returnFocusWhenClose.focus();
+							}
+						},
+					} );
+				}
 			}
 		}
-	}
-	open( { returnFocusWhenClose } = {} ) {
-		this.returnFocusWhenClose = returnFocusWhenClose;
+		open( { returnFocusWhenClose } = {} ) {
+			this.returnFocusWhenClose = returnFocusWhenClose;
 
-		this.expand( {
-			allowMultiple: true,
-		} );
-	}
-	close() {
-		this.collapse( {
-			allowMultiple: true,
-		} );
-	}
+			this.expand( {
+				allowMultiple: true,
+			} );
+		}
+		close() {
+			this.collapse( {
+				allowMultiple: true,
+			} );
+		}
+	};
 }
-
-export default InspectorSection;

--- a/packages/customize-widgets/src/controls/sidebar-control.js
+++ b/packages/customize-widgets/src/controls/sidebar-control.js
@@ -8,53 +8,56 @@ import { render, unmountComponentAtNode } from '@wordpress/element';
  */
 import SidebarBlockEditor from '../components/sidebar-block-editor';
 import SidebarAdapter from '../components/sidebar-block-editor/sidebar-adapter';
-import InserterOuterSection from './inserter-outer-section';
-
-const {
-	wp: { customize },
-} = window;
+import getInserterOuterSection from './inserter-outer-section';
 
 const getInserterId = ( controlId ) => `widgets-inserter-${ controlId }`;
 
-class SidebarControl extends customize.Control {
-	ready() {
-		this.inserter = new InserterOuterSection(
-			getInserterId( this.id ),
-			{}
-		);
-		customize.section.add( this.inserter );
+export default function getSidebarControl() {
+	const {
+		wp: { customize },
+	} = window;
 
-		this.sectionInstance = customize.section( this.section() );
+	return class SidebarControl extends customize.Control {
+		ready() {
+			const InserterOuterSection = getInserterOuterSection();
+			this.inserter = new InserterOuterSection(
+				getInserterId( this.id ),
+				{}
+			);
+			customize.section.add( this.inserter );
 
-		this.inspector = this.sectionInstance.inspector;
+			this.sectionInstance = customize.section( this.section() );
 
-		this.render();
-	}
-	onChangeSectionExpanded( expanded, args ) {
-		if ( ! args.unchanged ) {
-			// Close the inserter when the section collapses.
-			if ( ! expanded ) {
-				this.inserter.close();
-			}
+			this.inspector = this.sectionInstance.inspector;
 
 			this.render();
 		}
-	}
-	render() {
-		if ( this.sectionInstance.expanded() ) {
-			render(
-				<SidebarBlockEditor
-					sidebar={ new SidebarAdapter( this.setting, customize ) }
-					inserter={ this.inserter }
-					inspector={ this.inspector }
-				/>,
-				this.container[ 0 ]
-			);
-		} else if ( ! this.sectionInstance.hasSubSectionOpened() ) {
-			// Don't unmount the node when the sub section (inspector) is opened.
-			unmountComponentAtNode( this.container[ 0 ] );
-		}
-	}
-}
+		onChangeSectionExpanded( expanded, args ) {
+			if ( ! args.unchanged ) {
+				// Close the inserter when the section collapses.
+				if ( ! expanded ) {
+					this.inserter.close();
+				}
 
-export default SidebarControl;
+				this.render();
+			}
+		}
+		render() {
+			if ( this.sectionInstance.expanded() ) {
+				render(
+					<SidebarBlockEditor
+						sidebar={
+							new SidebarAdapter( this.setting, customize )
+						}
+						inserter={ this.inserter }
+						inspector={ this.inspector }
+					/>,
+					this.container[ 0 ]
+				);
+			} else if ( ! this.sectionInstance.hasSubSectionOpened() ) {
+				// Don't unmount the node when the sub section (inspector) is opened.
+				unmountComponentAtNode( this.container[ 0 ] );
+			}
+		}
+	};
+}

--- a/packages/customize-widgets/src/controls/sidebar-section.js
+++ b/packages/customize-widgets/src/controls/sidebar-section.js
@@ -6,74 +6,75 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import InspectorSection from './inspector-section';
-
-const {
-	wp: { customize },
-} = window;
+import getInspectorSection from './inspector-section';
 
 const getInspectorSectionId = ( sidebarId ) =>
 	`widgets-inspector-${ sidebarId }`;
 
-class SidebarSection extends customize.Section {
-	ready() {
-		this.inspector = new InspectorSection(
-			getInspectorSectionId( this.id ),
-			{
-				title: __( 'Block Settings' ),
-				parentSection: this,
-				customizeAction: [
-					__( 'Customizing' ),
-					__( 'Widgets' ),
-					this.params.title,
-				].join( ' ▸ ' ),
-			}
-		);
-		customize.section.add( this.inspector );
-	}
-	hasSubSectionOpened() {
-		return this.inspector.expanded();
-	}
-	onChangeExpanded( expanded, _args ) {
-		const controls = this.controls();
-		const args = {
-			..._args,
-			completeCallback() {
-				controls.forEach( ( control ) => {
-					control.onChangeSectionExpanded( expanded, args );
-				} );
-			},
-		};
+export default function getSidebarSection() {
+	const {
+		wp: { customize },
+	} = window;
 
-		if ( args.manualTransition ) {
-			if ( expanded ) {
-				this.contentContainer.addClass( [ 'busy', 'open' ] );
-				this.contentContainer.removeClass( 'is-sub-section-open' );
-				this.contentContainer
-					.closest( '.wp-full-overlay' )
-					.addClass( 'section-open' );
-				this.contentContainer.one( 'transitionend', () => {
-					this.contentContainer.removeClass( 'busy' );
-					args.completeCallback();
-				} );
-			} else {
-				this.contentContainer.addClass( [
-					'busy',
-					'is-sub-section-open',
-				] );
-				this.contentContainer
-					.closest( '.wp-full-overlay' )
-					.addClass( 'section-open' );
-				this.contentContainer.removeClass( 'open' );
-				this.contentContainer.one( 'transitionend', () => {
-					this.contentContainer.removeClass( 'busy' );
-					args.completeCallback();
-				} );
-			}
-		} else {
-			super.onChangeExpanded( expanded, args );
+	return class SidebarSection extends customize.Section {
+		ready() {
+			const InspectorSection = getInspectorSection();
+			this.inspector = new InspectorSection(
+				getInspectorSectionId( this.id ),
+				{
+					title: __( 'Block Settings' ),
+					parentSection: this,
+					customizeAction: [
+						__( 'Customizing' ),
+						__( 'Widgets' ),
+						this.params.title,
+					].join( ' ▸ ' ),
+				}
+			);
+			customize.section.add( this.inspector );
 		}
-	}
-}
+		hasSubSectionOpened() {
+			return this.inspector.expanded();
+		}
+		onChangeExpanded( expanded, _args ) {
+			const controls = this.controls();
+			const args = {
+				..._args,
+				completeCallback() {
+					controls.forEach( ( control ) => {
+						control.onChangeSectionExpanded( expanded, args );
+					} );
+				},
+			};
 
-export default SidebarSection;
+			if ( args.manualTransition ) {
+				if ( expanded ) {
+					this.contentContainer.addClass( [ 'busy', 'open' ] );
+					this.contentContainer.removeClass( 'is-sub-section-open' );
+					this.contentContainer
+						.closest( '.wp-full-overlay' )
+						.addClass( 'section-open' );
+					this.contentContainer.one( 'transitionend', () => {
+						this.contentContainer.removeClass( 'busy' );
+						args.completeCallback();
+					} );
+				} else {
+					this.contentContainer.addClass( [
+						'busy',
+						'is-sub-section-open',
+					] );
+					this.contentContainer
+						.closest( '.wp-full-overlay' )
+						.addClass( 'section-open' );
+					this.contentContainer.removeClass( 'open' );
+					this.contentContainer.one( 'transitionend', () => {
+						this.contentContainer.removeClass( 'busy' );
+						args.completeCallback();
+					} );
+				}
+			} else {
+				super.onChangeExpanded( expanded, args );
+			}
+		}
+	};
+}

--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -10,8 +10,8 @@ import {
 /**
  * Internal dependencies
  */
-import SidebarSection from './controls/sidebar-section';
-import SidebarControl from './controls/sidebar-control';
+import getSidebarSection from './controls/sidebar-section';
+import getSidebarControl from './controls/sidebar-control';
 
 const { wp } = window;
 
@@ -30,8 +30,8 @@ export function initialize() {
 		} );
 	}
 
-	wp.customize.sectionConstructor.sidebar = SidebarSection;
-	wp.customize.controlConstructor.sidebar_block_editor = SidebarControl;
+	wp.customize.sectionConstructor.sidebar = getSidebarSection();
+	wp.customize.controlConstructor.sidebar_block_editor = getSidebarControl();
 }
 
 wp.domReady( initialize );


### PR DESCRIPTION
## Description
Fixes #30726

This fixes the issue, but there may be other, better options for fixing this. This was just a quick hack around at the end of a day, but will help demonstrate the issue.

### The bug
The customize-widgets 'app' uses `wp.domReady` to defer intialization:
https://github.com/WordPress/gutenberg/blob/82ddc9e405d91066eba6d08fb716ef8feea922ab/packages/customize-widgets/src/index.js#L37

However, there are still some imported files before that point that are executed immediately:
https://github.com/WordPress/gutenberg/blob/82ddc9e405d91066eba6d08fb716ef8feea922ab/packages/customize-widgets/src/index.js#L13-L14

Those files use `wp.customize`, which doesn't seem to be available at this point.

The fix I've made here is to move everything in those files to 'getter' functions so that they're also deferred.

## How has this been tested?
1. Enable the block widget customizer experiment
2. Set Twenty Seventeen as your theme
3. Open the customize > widgets screen

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
