### PR TITLE
Packages: Remind about required cherry-picks after npm publishing

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -398,8 +398,11 @@ async function publishNpmLatestDistTag() {
 	await prepareForPackageRelease();
 
 	log(
-		'\n>> 🎉 WordPress packages are now published!\n',
-		'Let also people know on WordPress Slack.\n'
+		'\n>> 🎉 WordPress packages are now published!\n\n',
+		'Please remember to run `git cherry-pick` in the `trunk` branch for the newly created commits during the release with labels:\n',
+		' - Update changelog files (if exists)\n',
+		' - chore(release): publish\n\n',
+		'Finally, let also people know on WordPress Slack and celebrate together.'
 	);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
A little detail popped up when @ntsekouras was doing npm publishing today that I figured out was worth highlighting. The message after successful publishing looks this way after refinement:

<img width="1390" alt="Screen Shot 2021-04-15 at 12 39 08" src="https://user-images.githubusercontent.com/699132/114857395-7e304c00-9de8-11eb-882d-277238d38bf1.png">
