### PR TITLE
Color Block Support: Add utilities to retrieve color classes and styles

### DIFF
--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -9,3 +9,5 @@ import './style';
 import './color';
 import './font-size';
 import './layout';
+
+export { getColorClassesAndStyles, useColorProps } from './use-color-props';

--- a/packages/block-editor/src/hooks/use-color-props.js
+++ b/packages/block-editor/src/hooks/use-color-props.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { getInlineStyles } from './style';
+import {
+	getColorClassName,
+	getColorObjectByAttributeValues,
+} from '../components/colors';
+import {
+	__experimentalGetGradientClass,
+	getGradientValueBySlug,
+} from '../components/gradients';
+import useEditorFeature from '../components/use-editor-feature';
+
+// The code in this file has largely been lifted from the color block support
+// hook.
+//
+// This utility is intended to assist where the serialization of the colors
+// block support is being skipped for a block but the color related CSS classes
+// & styles still need to be generated so they can be applied to inner elements.
+
+const EMPTY_ARRAY = [];
+
+/**
+ * Provides the CSS class names and inline styles for a block's color support
+ * attributes.
+ *
+ * @param  {Object} attributes Block attributes.
+ * @return {Object}            Color block support derived CSS classes & styles.
+ */
+export function getColorClassesAndStyles( attributes ) {
+	const { backgroundColor, textColor, gradient, style } = attributes;
+
+	// Collect color CSS classes.
+	const backgroundClass = getColorClassName(
+		'background-color',
+		backgroundColor
+	);
+	const textClass = getColorClassName( 'color', textColor );
+
+	const gradientClass = __experimentalGetGradientClass( gradient );
+	const hasGradient = gradientClass || style?.color?.gradient;
+
+	// Determine color CSS class name list.
+	const className = classnames( textClass, gradientClass, {
+		// Don't apply the background class if there's a gradient.
+		[ backgroundClass ]: ! hasGradient && !! backgroundClass,
+		'has-text-color': textColor || style?.color?.text,
+		'has-background':
+			backgroundColor ||
+			style?.color?.background ||
+			gradient ||
+			style?.color?.gradient,
+		'has-link-color': style?.color?.link,
+	} );
+
+	// Collect inline styles for colors.
+	const colorStyles = style?.color || {};
+	const styleProp = getInlineStyles( { color: colorStyles } );
+
+	return {
+		className: className || undefined,
+		style: styleProp,
+	};
+}
+
+/**
+ * Determines the color related props for a block derived from its color block
+ * support attributes.
+ *
+ * Inline styles are forced for named colors to ensure these selections are
+ * reflected when themes do not load their color stylesheets in the editor.
+ *
+ * @param  {Object} attributes Block attributes.
+ * @return {Object}            ClassName & style props from colors block support.
+ */
+export function useColorProps( attributes ) {
+	const { backgroundColor, textColor, gradient } = attributes;
+
+	const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
+	const gradients = useEditorFeature( 'color.gradients' ) || EMPTY_ARRAY;
+
+	const colorProps = getColorClassesAndStyles( attributes );
+
+	// Force inline styles to apply colors when themes do not load their color
+	// stylesheets in the editor.
+	if ( backgroundColor ) {
+		const backgroundColorObject = getColorObjectByAttributeValues(
+			colors,
+			backgroundColor
+		);
+
+		colorProps.style.backgroundColor = backgroundColorObject.color;
+	}
+
+	if ( gradient ) {
+		colorProps.style.background = getGradientValueBySlug(
+			gradients,
+			gradient
+		);
+	}
+
+	if ( textColor ) {
+		const textColorObject = getColorObjectByAttributeValues(
+			colors,
+			textColor
+		);
+
+		colorProps.style.color = textColorObject.color;
+	}
+
+	return colorProps;
+}

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -7,6 +7,10 @@ import '@wordpress/rich-text';
  * Internal dependencies
  */
 import './hooks';
+export {
+	getColorClassesAndStyles as __experimentalGetColorClassesAndStyles,
+	useColorProps as __experimentalUseColorProps,
+} from './hooks';
 export * from './components';
 export * from './utils';
 export { storeConfig, store } from './store';


### PR DESCRIPTION
## Description

This adds two utilities to assist in applying color block support classes and styles to inner block elements when choosing to skip serialization.

The first function collects CSS classes and styles in much the same manner as they are generated and applied to the block's wrapper element when not skipping serialization. This function is all that is needed in a block's save.

The second is a hook to also force inline styles so named color selections are respected even when themes do not load their color stylesheets in the editor. This extends the first function above.

## How has this been tested?

Manually and running `npm run test-unit` to ensure fixtures tests still pass after updating the table and button blocks to use these utilities instead previous ad-hoc approach.

The easiest method to test this PR is via the [PR updating the button block](https://github.com/WordPress/gutenberg/pull/30870) or [table block](https://github.com/WordPress/gutenberg/pull/30791).

To test the link colors, you can update the block's colors support config to toggle `"link": true`. Then inspect via dev tools the correct CSS classes and styles are being applied. 

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
