### PR TITLE
Focus save button when entities save states panel is opened

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -9,7 +9,7 @@ import {
 	Popover,
 	Button,
 } from '@wordpress/components';
-import { EntityProvider } from '@wordpress/core-data';
+import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { BlockContextProvider, BlockBreadcrumb } from '@wordpress/block-editor';
 import {
 	FullscreenMode,
@@ -79,7 +79,7 @@ function Editor( { initialSettings } ) {
 			templateType: postType,
 			page: getPage(),
 			template: postId
-				? select( 'core' ).getEntityRecord(
+				? select( coreStore ).getEntityRecord(
 						'postType',
 						postType,
 						postId
@@ -210,6 +210,9 @@ function Editor( { initialSettings } ) {
 												<Header
 													openEntitiesSavedStates={
 														openEntitiesSavedStates
+													}
+													isEntitiesSavedStatesOpen={
+														isEntitiesSavedStatesOpen
 													}
 												/>
 											}

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -28,7 +28,10 @@ import DocumentActions from './document-actions';
 import TemplateDetails from '../template-details';
 import { store as editSiteStore } from '../../store';
 
-export default function Header( { openEntitiesSavedStates } ) {
+export default function Header( {
+	openEntitiesSavedStates,
+	isEntitiesSavedStatesOpen,
+} ) {
 	const inserterButton = useRef();
 	const {
 		deviceType,
@@ -168,6 +171,7 @@ export default function Header( { openEntitiesSavedStates } ) {
 					/>
 					<SaveButton
 						openEntitiesSavedStates={ openEntitiesSavedStates }
+						isEntitiesSavedStatesOpen={ isEntitiesSavedStatesOpen }
 					/>
 					<PinnedItems.Slot scope="core/edit-site" />
 					<MoreMenu />

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -9,13 +9,17 @@ import { some } from 'lodash';
 import { useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
-export default function SaveButton( { openEntitiesSavedStates } ) {
+export default function SaveButton( {
+	openEntitiesSavedStates,
+	isEntitiesSavedStatesOpen,
+} ) {
 	const { isDirty, isSaving } = useSelect( ( select ) => {
 		const {
 			__experimentalGetDirtyEntityRecords,
 			isSavingEntityRecord,
-		} = select( 'core' );
+		} = select( coreStore );
 		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 		return {
 			isDirty: dirtyEntityRecords.length > 0,
@@ -33,6 +37,7 @@ export default function SaveButton( { openEntitiesSavedStates } ) {
 				isPrimary
 				className="edit-site-save-button__button"
 				aria-disabled={ disabled }
+				aria-expanded={ isEntitiesSavedStatesOpen }
 				disabled={ disabled }
 				isBusy={ isSaving }
 				onClick={ disabled ? undefined : openEntitiesSavedStates }

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -9,8 +9,9 @@ import { some, groupBy } from 'lodash';
 import { Button, withFocusReturn } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useRef, useEffect } from '@wordpress/element';
 import { close as closeIcon } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -18,14 +19,21 @@ import { close as closeIcon } from '@wordpress/icons';
 import EntityTypeList from './entity-type-list';
 
 function EntitiesSavedStates( { isOpen, close } ) {
+	const saveButtonRef = useRef();
+	useEffect( () => {
+		if ( isOpen ) {
+			// Focus the save button when the saved states panel is opened
+			saveButtonRef.current?.focus();
+		}
+	}, [ isOpen ] );
 	const { dirtyEntityRecords } = useSelect( ( select ) => {
 		return {
 			dirtyEntityRecords: select(
-				'core'
+				coreStore
 			).__experimentalGetDirtyEntityRecords(),
 		};
 	}, [] );
-	const { saveEditedEntityRecord } = useDispatch( 'core' );
+	const { saveEditedEntityRecord } = useDispatch( coreStore );
 
 	// To group entities by type.
 	const partitionedSavables = Object.values(
@@ -81,6 +89,7 @@ function EntitiesSavedStates( { isOpen, close } ) {
 		<div className="entities-saved-states__panel">
 			<div className="entities-saved-states__panel-header">
 				<Button
+					ref={ saveButtonRef }
 					isPrimary
 					disabled={
 						dirtyEntityRecords.length -


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
Fixes #29803 

## Description
Moves focus into the entities save states panel when it is opened via "Save" / "Publish" button. This change applies to both `post-edit` and `site-edit`. Although this panel is only shown in the Post Editor when you make changes to other entities. (For example you edit a template part)

## How has this been tested?
**Site Editor**
1. Open Site Editor
2. Make changes
3. Click on the "Save" button and make sure the focus is on the "Save" button inside the entities panel

**Post Editor**
1. Open Post Editor
2. Add a Template part block and make some changes to it
3. Click on the "Save" / "Publish" button and make sure the focus is on the "Save" button inside the entities panel

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/2256104/114919602-beafba00-9e28-11eb-90e0-f47dc4ba865d.mov


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
