### PR TITLE
Block Supports: Allow skipping serialization of font size

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -72,8 +72,10 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_decoration_support = _wp_array_get( $block_type->supports, array( '__experimentalTextDecoration' ), false );
 	$has_text_transform_support  = _wp_array_get( $block_type->supports, array( '__experimentalTextTransform' ), false );
 
+	$skip_font_size_support_serialization = _wp_array_get( $block_type->supports, array( '__experimentalSkipTypographySerialization' ), false );
+
 	// Font Size.
-	if ( $has_font_size_support ) {
+	if ( $has_font_size_support && ! $skip_font_size_support_serialization ) {
 		$has_named_font_size  = array_key_exists( 'fontSize', $block_attributes );
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -72,7 +72,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_decoration_support = _wp_array_get( $block_type->supports, array( '__experimentalTextDecoration' ), false );
 	$has_text_transform_support  = _wp_array_get( $block_type->supports, array( '__experimentalTextTransform' ), false );
 
-	$skip_font_size_support_serialization = _wp_array_get( $block_type->supports, array( '__experimentalSkipTypographySerialization' ), false );
+	$skip_font_size_support_serialization = _wp_array_get( $block_type->supports, array( '__experimentalSkipFontSizeSerialization' ), false );
 
 	// Font Size.
 	if ( $has_font_size_support && ! $skip_font_size_support_serialization ) {

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -57,6 +57,12 @@ function addSaveProps( props, blockType, attributes ) {
 		return props;
 	}
 
+	if (
+		hasBlockSupport( blockType, '__experimentalSkipFontSizeSerialization' )
+	) {
+		return props;
+	}
+
 	// Use TokenList to dedupe classes.
 	const classes = new TokenList( props.className );
 	classes.add( getFontSizeClass( attributes.fontSize ) );

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -174,11 +174,16 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 			wrapperProps,
 		} = props;
 
-		// Only add inline styles if the block supports font sizes, doesn't
-		// already have an inline font size, and does have a class to extract
-		// the font size from.
+		// Only add inline styles if the block supports font sizes,
+		// doesn't skip serialization of font sizes,
+		// doesn't already have an inline font size,
+		// and does have a class to extract the font size from.
 		if (
 			! hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) ||
+			hasBlockSupport(
+				blockName,
+				'__experimentalSkipFontSizeSerialization'
+			) ||
 			! fontSize ||
 			style?.typography?.fontSize
 		) {

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -174,30 +174,32 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 			wrapperProps,
 		} = props;
 
-		const newProps = { ...props };
-
 		// Only add inline styles if the block supports font sizes, doesn't
 		// already have an inline font size, and does have a class to extract
 		// the font size from.
 		if (
-			hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) &&
-			fontSize &&
-			! style?.typography?.fontSize
+			! hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) ||
+			! fontSize ||
+			style?.typography?.fontSize
 		) {
-			const fontSizeValue = getFontSize(
-				fontSizes,
-				fontSize,
-				style?.typography?.fontSize
-			).size;
-
-			newProps.wrapperProps = {
-				...wrapperProps,
-				style: {
-					fontSize: fontSizeValue,
-					...wrapperProps?.style,
-				},
-			};
+			return <BlockListBlock { ...props } />;
 		}
+
+		const newProps = { ...props };
+
+		const fontSizeValue = getFontSize(
+			fontSizes,
+			fontSize,
+			style?.typography?.fontSize
+		).size;
+
+		newProps.wrapperProps = {
+			...wrapperProps,
+			style: {
+				fontSize: fontSizeValue,
+				...wrapperProps?.style,
+			},
+		};
 
 		return <BlockListBlock { ...newProps } />;
 	},

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -190,19 +190,20 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 			return <BlockListBlock { ...props } />;
 		}
 
-		const newProps = { ...props };
-
 		const fontSizeValue = getFontSize(
 			fontSizes,
 			fontSize,
 			style?.typography?.fontSize
 		).size;
 
-		newProps.wrapperProps = {
-			...wrapperProps,
-			style: {
-				fontSize: fontSizeValue,
-				...wrapperProps?.style,
+		const newProps = {
+			...props,
+			wrapperProps: {
+				...wrapperProps,
+				style: {
+					fontSize: fontSizeValue,
+					...wrapperProps?.style,
+				},
 			},
 		};
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { capitalize, get, has, omitBy, startsWith } from 'lodash';
+import { capitalize, get, has, omit, omitBy, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,7 +20,6 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
-import { FONT_SIZE_SUPPORT_KEY } from './font-size';
 import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
 import SpacingPanelControl from '../components/spacing-panel-control';
 
@@ -128,14 +127,17 @@ export function addSaveProps( props, blockType, attributes ) {
 	}
 
 	const { style } = attributes;
-	const filteredStyle = omitKeysNotToSerialize( style, {
+	let filteredStyle = omitKeysNotToSerialize( style, {
 		border: getBlockSupport( blockType, BORDER_SUPPORT_KEY ),
 		[ COLOR_SUPPORT_KEY ]: getBlockSupport( blockType, COLOR_SUPPORT_KEY ),
-		[ FONT_SIZE_SUPPORT_KEY ]: getBlockSupport(
-			blockType,
-			FONT_SIZE_SUPPORT_KEY
-		),
 	} );
+
+	if (
+		getBlockSupport( blockType, '__experimentalSkipFontSizeSerialization' )
+	) {
+		filteredStyle = omit( filteredStyle, TYPOGRAPHY_SUPPORT_KEYS );
+	}
+
 	props.style = {
 		...getInlineStyles( filteredStyle ),
 		...props.style,

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -19,6 +19,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
+import { FONT_SIZE_SUPPORT_KEY } from './font-size';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
 import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
 import SpacingPanelControl from '../components/spacing-panel-control';
@@ -135,7 +136,9 @@ export function addSaveProps( props, blockType, attributes ) {
 	if (
 		getBlockSupport( blockType, '__experimentalSkipFontSizeSerialization' )
 	) {
-		filteredStyle = omit( filteredStyle, TYPOGRAPHY_SUPPORT_KEYS );
+		filteredStyle = omit( filteredStyle, [
+			[ 'typography', FONT_SIZE_SUPPORT_KEY ],
+		] );
 	}
 
 	props.style = {

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -20,6 +20,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
+import { FONT_SIZE_SUPPORT_KEY } from './font-size';
 import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
 import SpacingPanelControl from '../components/spacing-panel-control';
 
@@ -130,6 +131,10 @@ export function addSaveProps( props, blockType, attributes ) {
 	const filteredStyle = omitKeysNotToSerialize( style, {
 		border: getBlockSupport( blockType, BORDER_SUPPORT_KEY ),
 		[ COLOR_SUPPORT_KEY ]: getBlockSupport( blockType, COLOR_SUPPORT_KEY ),
+		[ FONT_SIZE_SUPPORT_KEY ]: getBlockSupport(
+			blockType,
+			FONT_SIZE_SUPPORT_KEY
+		),
 	} );
 	props.style = {
 		...getInlineStyles( filteredStyle ),


### PR DESCRIPTION
## Description
Part of #28913. Counterpart to #29142+#29253, or #30035.

Find affected blocks by grepping `"fontSize": true` in `block.json` files.

## How has this been tested?

(Based on @nosolosw's https://github.com/WordPress/gutenberg/pull/30035#issuecomment-804218854, and adapted for fontSize block support.)

- Install and activate the TT1-blocks theme.
- Add `"__experimentalSkipFontSizeSerialization": true` as a new key-value pair within the `supports` object for any block that also has `"fontSize": true` set. In the following, we'll be using the Heading block.

Here's a patch for your convenience:

```diff
diff --git a/packages/block-library/src/heading/block.json b/packages/block-library/src/heading/block.json
index 8d7e0fdd5c..a35cf68b6c 100644
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -74,6 +74,7 @@
                                }
                        }
                },
+               "__experimentalSkipFontSizeSerialization": true,
                "__unstablePasteTextInline": true
        },
        "editorStyle": "wp-block-heading-editor",
```

The expected result is that:

- The UI control for font size is shown.
- Using the UI control still syncs the block attributes.
	- Use the font size control.
	- Use the dropdown to select a "named" font size, e.g. "Large".
	- Open the Code Editor and verify that the block has the proper font size value as `fontSize` attribute, e.g. `<!-- wp:heading {"fontSize":"large"} -->` -- but _not_ as inlined markup (HTML `class="has-large-font-size"` attribute on the `<h2 />` tag).
	- Return to the Visual Editor.
	- Use the font size control to set the block's font size to a numeric value (e.g. 25px).
	- Open the Code Editor and verify that the block has the proper font size value as a nested `typography:{ fontSize: ... } }` attribute, e.g. `<!-- wp:heading {"style":{"typography":{"fontSize":"25px"}}} -->
` -- but _not_ as inlined markup (HTML `style="font-size:25px"` attribute on the `<h2 />` tag).
	- Make sure to also change the line height control, to verify that it is unaffected (i.e. there's still a `style="line-height:...` attribute on the `<h2 />` tag).

## Screencasts

### Before

![font-size-before](https://user-images.githubusercontent.com/96308/115074234-b96e7000-9ef9-11eb-81a0-d6a80c88e2e3.gif)

### After

![font-size](https://user-images.githubusercontent.com/96308/115073466-a8712f00-9ef8-11eb-9d85-0bb7e9663b16.gif)

## Question

`fontSize` is a non-experimental, "flat" (non-array) block-supports flag. This is the reason why we're introducing _another_ "flat" flag to skip serialization specifically of font size here: `__experimentalSkipFontSizeSerialization`. 

Compare that to "nested" block-supports flags (such as `color`), where we can include a "generic" `__experimentalSkipSerialization` in that array: https://github.com/WordPress/gutenberg/blob/aa272f8432ca055961005a62c200a856e8017cb7/packages/block-library/src/button/block.json#L56-L59

A dedicated `__experimentalSkipFontSizeSerialization` flag doesn't scale particularly well, and might get awkward once we allow skipping of serialization for other typographic properties (line height, font family, font appearance, text decoration, text transform). Will each of these get their own `__experimentalSkip...Serialization`? Or will we have to group typographic block-supports flags into a shared `typography` object first? (But that might affect themes that use these already, won't it?) 🤔 