### PR TITLE
Block Supports: Allow skipping serialization of typography attributes

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -61,6 +61,11 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
+	$skip_typography_serialization = _wp_array_get( $block_type->supports, array( '__experimentalSkipTypographySerialization' ), false );
+	if ( $skip_typography_serialization ) {
+		return array();
+	}
+
 	$classes = array();
 	$styles  = array();
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -91,65 +91,63 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( ! $skip_typography_serialization ) {
-		// Font Family.
-		if ( $has_font_family_support ) {
-			$has_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
-			// Apply required class and style.
-			if ( $has_font_family ) {
-				$font_family = $block_attributes['style']['typography']['fontFamily'];
-				if ( strpos( $font_family, 'var:preset|font-family' ) !== false ) {
-					// Get the name from the string and add proper styles.
-					$index_to_splice  = strrpos( $font_family, '|' ) + 1;
-					$font_family_name = substr( $font_family, $index_to_splice );
-					$styles[]         = sprintf( 'font-family: var(--wp--preset--font-family--%s);', $font_family_name );
-				} else {
-					$styles[] = sprintf( 'font-family: %s;', $block_attributes['style']['typography']['fontFamily'] );
-				}
+	// Font Family.
+	if ( $has_font_family_support && ! $skip_typography_serialization ) {
+		$has_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
+		// Apply required class and style.
+		if ( $has_font_family ) {
+			$font_family = $block_attributes['style']['typography']['fontFamily'];
+			if ( strpos( $font_family, 'var:preset|font-family' ) !== false ) {
+				// Get the name from the string and add proper styles.
+				$index_to_splice  = strrpos( $font_family, '|' ) + 1;
+				$font_family_name = substr( $font_family, $index_to_splice );
+				$styles[]         = sprintf( 'font-family: var(--wp--preset--font-family--%s);', $font_family_name );
+			} else {
+				$styles[] = sprintf( 'font-family: %s;', $block_attributes['style']['typography']['fontFamily'] );
 			}
 		}
+	}
 
-		// Font style.
-		if ( $has_font_style_support ) {
-			// Apply font style.
-			$font_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'fontStyle', 'font-style' );
-			if ( $font_style ) {
-				$styles[] = $font_style;
-			}
+	// Font style.
+	if ( $has_font_style_support && ! $skip_typography_serialization ) {
+		// Apply font style.
+		$font_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'fontStyle', 'font-style' );
+		if ( $font_style ) {
+			$styles[] = $font_style;
 		}
+	}
 
-		// Font weight.
-		if ( $has_font_weight_support ) {
-			// Apply font weight.
-			$font_weight = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'fontWeight', 'font-weight' );
-			if ( $font_weight ) {
-				$styles[] = $font_weight;
-			}
+	// Font weight.
+	if ( $has_font_weight_support && ! $skip_typography_serialization ) {
+		// Apply font weight.
+		$font_weight = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'fontWeight', 'font-weight' );
+		if ( $font_weight ) {
+			$styles[] = $font_weight;
 		}
+	}
 
-		// Line Height.
-		if ( $has_line_height_support ) {
-			$has_line_height = isset( $block_attributes['style']['typography']['lineHeight'] );
-			// Add the style (no classes for line-height).
-			if ( $has_line_height ) {
-				$styles[] = sprintf( 'line-height: %s;', $block_attributes['style']['typography']['lineHeight'] );
-			}
+	// Line Height.
+	if ( $has_line_height_support && ! $skip_typography_serialization ) {
+		$has_line_height = isset( $block_attributes['style']['typography']['lineHeight'] );
+		// Add the style (no classes for line-height).
+		if ( $has_line_height ) {
+			$styles[] = sprintf( 'line-height: %s;', $block_attributes['style']['typography']['lineHeight'] );
 		}
+	}
 
-		// Text Decoration.
-		if ( $has_text_decoration_support ) {
-			$text_decoration_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'textDecoration', 'text-decoration' );
-			if ( $text_decoration_style ) {
-				$styles[] = $text_decoration_style;
-			}
+	// Text Decoration.
+	if ( $has_text_decoration_support && ! $skip_typography_serialization ) {
+		$text_decoration_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'textDecoration', 'text-decoration' );
+		if ( $text_decoration_style ) {
+			$styles[] = $text_decoration_style;
 		}
+	}
 
-		// Text Transform.
-		if ( $has_text_transform_support ) {
-			$text_transform_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'textTransform', 'text-transform' );
-			if ( $text_transform_style ) {
-				$styles[] = $text_transform_style;
-			}
+	// Text Transform.
+	if ( $has_text_transform_support && ! $skip_typography_serialization ) {
+		$text_transform_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'textTransform', 'text-transform' );
+		if ( $text_transform_style ) {
+			$styles[] = $text_transform_style;
 		}
 	}
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -141,7 +141,7 @@ export function addSaveProps( props, blockType, attributes ) {
 		[ COLOR_SUPPORT_KEY ]: getBlockSupport( blockType, COLOR_SUPPORT_KEY ),
 	} );
 
-	let typographyFeaturesToRemove = [];
+	let typographyFeaturesToOmit = [];
 	if (
 		getBlockSupport(
 			blockType,
@@ -149,7 +149,7 @@ export function addSaveProps( props, blockType, attributes ) {
 		)
 	) {
 		// Font size is handled separately.
-		typographyFeaturesToRemove = without(
+		typographyFeaturesToOmit = without(
 			TYPOGRAPHY_SUPPORT_KEYS,
 			FONT_SIZE_SUPPORT_KEY
 		);
@@ -158,15 +158,15 @@ export function addSaveProps( props, blockType, attributes ) {
 	if (
 		getBlockSupport( blockType, '__experimentalSkipFontSizeSerialization' )
 	) {
-		typographyFeaturesToRemove = [
-			...typographyFeaturesToRemove,
+		typographyFeaturesToOmit = [
+			...typographyFeaturesToOmit,
 			FONT_SIZE_SUPPORT_KEY,
 		];
 	}
 
 	const { typography, ...otherStyle } = filteredStyle;
 	filteredStyle = {
-		typography: omit( typography, typographyFeaturesToRemove ),
+		typography: omit( typography, typographyFeaturesToOmit ),
 		...otherStyle,
 	};
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,7 +1,15 @@
 /**
  * External dependencies
  */
-import { capitalize, get, has, omit, omitBy, startsWith } from 'lodash';
+import {
+	capitalize,
+	get,
+	has,
+	omit,
+	omitBy,
+	startsWith,
+	without,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -133,13 +141,34 @@ export function addSaveProps( props, blockType, attributes ) {
 		[ COLOR_SUPPORT_KEY ]: getBlockSupport( blockType, COLOR_SUPPORT_KEY ),
 	} );
 
+	let typographyFeaturesToRemove = [];
+	if (
+		getBlockSupport(
+			blockType,
+			'__experimentalSkipTypographySerialization'
+		)
+	) {
+		// Font size is handled separately.
+		typographyFeaturesToRemove = without(
+			TYPOGRAPHY_SUPPORT_KEYS,
+			FONT_SIZE_SUPPORT_KEY
+		);
+	}
+
 	if (
 		getBlockSupport( blockType, '__experimentalSkipFontSizeSerialization' )
 	) {
-		filteredStyle = omit( filteredStyle, [
-			[ 'typography', FONT_SIZE_SUPPORT_KEY ],
-		] );
+		typographyFeaturesToRemove = [
+			...typographyFeaturesToRemove,
+			FONT_SIZE_SUPPORT_KEY,
+		];
 	}
+
+	const { typography, ...otherStyle } = filteredStyle;
+	filteredStyle = {
+		typography: omit( typography, typographyFeaturesToRemove ),
+		...otherStyle,
+	};
 
 	props.style = {
 		...getInlineStyles( filteredStyle ),

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -4,6 +4,7 @@
 import {
 	capitalize,
 	find,
+	forEach,
 	get,
 	has,
 	isEqual,
@@ -107,29 +108,22 @@ function addAttribute( settings ) {
 	return settings;
 }
 
-const skipSerializationPaths = [
-	{
-		indicator: `${ BORDER_SUPPORT_KEY }.__experimentalSkipSerialization`,
-		path: [ 'border' ],
-	},
-	{
-		indicator: `${ COLOR_SUPPORT_KEY }.__experimentalSkipSerialization`,
-		path: [ COLOR_SUPPORT_KEY ],
-	},
-	{
-		indicator: `__experimentalSkipFontSizeSerialization`,
-		path: [ 'typography', 'fontSize' ],
-	},
-	{
-		indicator: `__experimentalSkipTypographySerialization`,
-		path: without( TYPOGRAPHY_SUPPORT_KEYS, FONT_SIZE_SUPPORT_KEY ).map(
-			( feature ) =>
-				find( STYLE_PROPERTY, ( property ) =>
-					isEqual( property.support, [ feature ] )
-				)?.value
-		),
-	},
-];
+const skipSerializationPaths = {
+	[ `${ BORDER_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [ 'border' ],
+	[ `${ COLOR_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
+		COLOR_SUPPORT_KEY,
+	],
+	[ `__experimentalSkipFontSizeSerialization` ]: [ 'typography', 'fontSize' ],
+	[ `__experimentalSkipTypographySerialization` ]: without(
+		TYPOGRAPHY_SUPPORT_KEYS,
+		FONT_SIZE_SUPPORT_KEY
+	).map(
+		( feature ) =>
+			find( STYLE_PROPERTY, ( property ) =>
+				isEqual( property.support, [ feature ] )
+			)?.value
+	),
+};
 
 /**
  * Override props assigned to save component to inject the CSS variables definition.
@@ -146,7 +140,7 @@ export function addSaveProps( props, blockType, attributes ) {
 
 	let { style } = attributes;
 
-	skipSerializationPaths.forEach( ( { indicator, path } ) => {
+	forEach( skipSerializationPaths, ( path, indicator ) => {
 		if ( getBlockSupport( blockType, indicator ) ) {
 			style = omit( style, path );
 		}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -109,7 +109,7 @@ function addAttribute( settings ) {
 
 const skipSerializationPaths = [
 	{
-		indicator: `${ BORDER_SUPPORT_KEY }.__experimentalSkipSerialization'`,
+		indicator: `${ BORDER_SUPPORT_KEY }.__experimentalSkipSerialization`,
 		path: [ 'border' ],
 	},
 	{

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getInlineStyles, omitKeysNotToSerialize } from '../style';
+import { getInlineStyles } from '../style';
 
 describe( 'getInlineStyles', () => {
 	it( 'should return an empty object when called with undefined', () => {
@@ -39,34 +39,6 @@ describe( 'getInlineStyles', () => {
 			fontSize: 10,
 			marginBottom: '15px',
 			paddingTop: '10px',
-		} );
-	} );
-} );
-
-describe( 'omitKeysNotToSerialize', () => {
-	it( 'should return the same style if no keys are skipped from serialization', () => {
-		const style = {
-			color: { text: 'red' },
-			lineHeight: 2,
-		};
-		expect( omitKeysNotToSerialize( style, {} ) ).toEqual( {
-			color: { text: 'red' },
-			lineHeight: 2,
-		} );
-	} );
-
-	it( 'should omit the color key if it is skipped for serialization', () => {
-		const style = {
-			color: { text: 'red' },
-			lineHeight: 2,
-		};
-		const blockSupports = {
-			color: {
-				__experimentalSkipSerialization: true,
-			},
-		};
-		expect( omitKeysNotToSerialize( style, blockSupports ) ).toEqual( {
-			lineHeight: 2,
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
Part of #28913. Counterpart to #30879, #30035, or #29142+#29253.

Find affected blocks by grepping any of the following typography related feature flags in `block.json` files:

- `__experimentalFontFamily`
- `__experimentalFontStyle`
- `__experimentalFontWeight`
- `lineHeight`
- `__experimentalTextDecoration`
- `__experimentalTextTransform`

Note that `fontSize` is handled separately (see #30879). (The main difference to this PR is that in addition to `style` attributes, `fontSize` also adds `className`s.)

Since `lineHeight` is no longer experimental, it's fairly widespread; it's e.g. present in the Heading and Paragraph blocks.
Examples of the other features include the Navigation block. (A number of other blocks has the `__experimentalFontFamily` flag set to `true`, but this feature doesn't seem to be visible in the TT1 Blocks theme.)

## How has this been tested?

(Based on #30879.)

- Install and activate the TT1-blocks theme.
- Add `"__experimentalSkipTypographySerialization": true` as a new key-value pair within the `supports` object for any block that also has one of the aforementioned typography flags set. In the following, we'll be using the Heading block.

Here's a patch for your convenience:

```diff
diff --git a/packages/block-library/src/heading/block.json b/packages/block-library/src/heading/block.json
index 8d7e0fdd5c..74c5ba7365 100644
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -74,6 +74,7 @@
                                }
                        }
                },
+               "__experimentalSkipTypographySerialization": true,
                "__unstablePasteTextInline": true
        },
        "editorStyle": "wp-block-heading-editor",
```

The expected result is that:

- In the block sidebar's Typography panel, the UI control for line height is shown:
![image](https://user-images.githubusercontent.com/96308/116130549-a6168e00-a6cb-11eb-96f5-cc8d4230dd0e.png)
- Using the UI control still syncs the block attributes.
	- Use the line height control to change the corresponding typography setting.
	- Open the Code Editor and verify that the block has the proper line height value as a nested `typography:{ lineHeight: ... } }` attribute, e.g. `<!-- wp:heading {"style":{"typography":{"lineHeight":"1.7"}}} -->` -- but _not_ as inlined markup (HTML `style="line-height:1.7"` attribute on the `<h2 />` tag).
	- Make sure to also change the font size control, to verify that it is unaffected (i.e. there's still a `style="font-size:...` attribute on the `<h2 />` tag).
	- Finally, publish (or preview) the post, and verify that the line height isn't set.

## Screencasts

### Before

![typography-before](https://user-images.githubusercontent.com/96308/116137897-715b0480-a6d4-11eb-9e08-05dbd194e163.gif)

### After

![typography-after](https://user-images.githubusercontent.com/96308/116137915-761fb880-a6d4-11eb-815c-a830e53cddc9.gif)

## Note

For a discussion of the nomenclature, syntax, and granularity of the typrography-related `__experimental...` flag(s), see #30879 (both PR desc and comments), and https://github.com/WordPress/gutenberg/issues/28913#issuecomment-824630575 (and below).