### PR TITLE
wp-env: Better errors when Docker is not started

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,7 +204,7 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'bin/**/*.js' ],
+			files: [ 'bin/**/*.js', 'packages/env/**' ],
 			rules: {
 				'no-console': 'off',
 			},

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -6,6 +6,7 @@ const chalk = require( 'chalk' );
 const ora = require( 'ora' );
 const yargs = require( 'yargs' );
 const terminalLink = require( 'terminal-link' );
+const { execSync } = require( 'child_process' );
 
 /**
  * Internal dependencies
@@ -63,7 +64,6 @@ const withSpinner = ( command ) => ( ...args ) => {
 					typeof error === 'string' ? error : error.message
 				);
 				// Disable reason: Using console.error() means we get a stack trace.
-				// eslint-disable-next-line no-console
 				console.error( error );
 				process.exit( 1 );
 			} else {
@@ -75,6 +75,16 @@ const withSpinner = ( command ) => ( ...args ) => {
 };
 
 module.exports = function cli() {
+	// Do nothing if Docker is unavailable.
+	try {
+		execSync( 'docker ps', { stdio: 'ignore' } );
+	} catch {
+		console.error(
+			chalk.red( 'Could not connect to Docker. Is it running?' )
+		);
+		process.exit( 1 );
+	}
+
 	yargs.usage( wpPrimary( '$0 <command>' ) );
 	yargs.option( 'debug', {
 		type: 'boolean',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -77,7 +77,7 @@ const withSpinner = ( command ) => ( ...args ) => {
 module.exports = function cli() {
 	// Do nothing if Docker is unavailable.
 	try {
-		execSync( 'docker ps', { stdio: 'ignore' } );
+		execSync( 'docker info', { stdio: 'ignore' } );
 	} catch {
 		console.error(
 			chalk.red( 'Could not connect to Docker. Is it running?' )

--- a/packages/env/lib/commands/logs.js
+++ b/packages/env/lib/commands/logs.js
@@ -60,12 +60,10 @@ module.exports = async function logs( { environment, watch, spinner, debug } ) {
 	);
 
 	if ( result.out.length ) {
-		// eslint-disable-next-line no-console
 		console.log(
 			process.stdout.isTTY ? `\n\n${ result.out }\n\n` : result.out
 		);
 	} else if ( result.err.length ) {
-		// eslint-disable-next-line no-console
 		console.error(
 			process.stdout.isTTY ? `\n\n${ result.err }\n\n` : result.err
 		);

--- a/packages/env/test/cli.js
+++ b/packages/env/test/cli.js
@@ -82,7 +82,6 @@ describe( 'env cli', () => {
 	} );
 
 	it( 'handles failed commands with messages.', async () => {
-		/* eslint-disable no-console */
 		env.start.mockRejectedValueOnce( {
 			message: 'failure message',
 		} );
@@ -100,10 +99,8 @@ describe( 'env cli', () => {
 		expect( process.exit ).toHaveBeenCalledWith( 1 );
 		console.error = consoleError;
 		process.exit = processExit;
-		/* eslint-enable no-console */
 	} );
 	it( 'handles failed docker commands with errors.', async () => {
-		/* eslint-disable no-console */
 		env.start.mockRejectedValueOnce( {
 			err: 'failure error',
 			out: 'message',
@@ -128,6 +125,5 @@ describe( 'env cli', () => {
 		console.error = consoleError;
 		process.exit = processExit;
 		process.stderr.write = stderr;
-		/* eslint-enable no-console */
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
I started noticing esoteric error messages from wp-env, only to find out that docker was not yet started. Since it's so easy to detect that scenario, this makes it much more obvious.

I also took the chance to enable console.log from wp-env in eslint

## How has this been tested?
Locally, on macOS with docker not started and with it started. We should also test on:
- [x] linux (if CI works we should be ok)
- [x] windows

## Screenshots <!-- if applicable -->

## Types of changes
enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
