### PR TITLE
Global Styles: Make the config resilient to changes to `safecss_filter_attr()`

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1145,17 +1145,15 @@ class WP_Theme_JSON {
 					if ( isset( $preset_metadata['classes'] ) && count( $preset_metadata['classes'] ) > 0 ) {
 						$single_preset_is_valid = true;
 						foreach ( $preset_metadata['classes'] as $class_meta_data ) {
-							$property          = $class_meta_data['property_name'];
-							$style_to_validate = $property . ': ' . $value;
-							if ( esc_html( safecss_filter_attr( $style_to_validate ) ) !== $style_to_validate ) {
+							$property = $class_meta_data['property_name'];
+							if ( ! self::is_safe_css_declaration( $property, $value ) ) {
 								$single_preset_is_valid = false;
 								break;
 							}
 						}
 					} else {
 						$property               = $preset_metadata['css_var_infix'];
-						$style_to_validate      = $property . ': ' . $value;
-						$single_preset_is_valid = esc_html( safecss_filter_attr( $style_to_validate ) ) === $style_to_validate;
+						$single_preset_is_valid = self::is_safe_css_declaration( $property, $value );
 					}
 					if ( $single_preset_is_valid ) {
 						$escaped_preset[] = $single_preset;
@@ -1183,8 +1181,7 @@ class WP_Theme_JSON {
 		$output       = array();
 		$declarations = self::compute_style_properties( array(), $input );
 		foreach ( $declarations as $declaration ) {
-			$style_to_validate = $declaration['name'] . ': ' . $declaration['value'];
-			if ( esc_html( safecss_filter_attr( $style_to_validate ) ) === $style_to_validate ) {
+			if ( self::is_safe_css_declaration( $declaration['name'], $declaration['value'] ) ) {
 				$property = self::to_property( $declaration['name'] );
 				$path     = self::PROPERTIES_METADATA[ $property ]['value'];
 				if ( self::has_properties( self::PROPERTIES_METADATA[ $property ] ) ) {
@@ -1195,6 +1192,19 @@ class WP_Theme_JSON {
 			}
 		}
 		return $output;
+	}
+
+	/**
+	 * Checks that a declaration provided by the user is safe.
+	 *
+	 * @param string $property_name Property name in a CSS declaration, i.e. the `color` in `color: red`.
+	 * @param string $property_value Value in a CSS declaration, i.e. the `red` in `color: red`.
+	 * @return boolean
+	 */
+	private static function is_safe_css_declaration( $property_name, $property_value ) {
+		$style_to_validate = $property_name . ': ' . $property_value;
+		$filtered          = esc_html( safecss_filter_attr( $style_to_validate ) );
+		return ! empty( trim( $filtered ) );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -774,6 +774,33 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $result );
 	}
 
+	function test_remove_insecure_properties_applies_safe_styles() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'styles' => array(
+					'root' => array(
+						'color' => array(
+							'text' => '#abcabc ', // Trailing space.
+						),
+					),
+				),
+			),
+			true
+		);
+		$theme_json->remove_insecure_properties();
+		$result   = $theme_json->get_raw_data();
+		$expected = array(
+			'styles' => array(
+				'root' => array(
+					'color' => array(
+						'text' => '#abcabc ',
+					),
+				),
+			),
+		);
+		$this->assertEqualSetsWithIndex( $expected, $result );
+	}
+
 	function test_get_custom_templates() {
 		$theme_json = new WP_Theme_JSON(
 			array(


### PR DESCRIPTION
## Description

Unsafe user styles are removed from Global Styles by `WP_Theme_JSON::remove_insecure_properties()`, however the test for whether a style is unsafe is too strict, and makes us more likely to break if WordPress core changes.

`remove_insecure_properties()` relies on a particular implementation of the core `safecss_filter_attr()` function: that it leaves the CSS unchanged if it's safe. But this is an assumption that could change in the future: maybe it removes whitespace around the `:`; or it converts lowercase colours (`#abcabc`) to uppercase (`#ABCABC`). The output of the filter would still be valid but it would break the saving of Global Styles in Gutenberg. In fact `safecss_filter_attr()` already does break this assumption, we just happen to be getting away with it at the moment because of the way we're calling it.
In general it doesn't feel like we should assume filtering functions will return the input unchanged.

Switching the semantics of the safety check from "style was unchanged" to "style was not stripped" fits better with the description of the `safecss_filter_attr()` function.

This PR:
* Refactors the safety check into a new private method
* Changes the semantics of the safety check
* Includes a unit test to check a CSS value that is safe but currently rejected in the current implementation (we might not want to merge this, but included for demonstration purposes, let me know what you think)

## How has this been tested?

Added a unit test that stretches the `remove_insecure_properties()` method a little to show how it could fail for unexpected reasons. It adds trailing whitespace to a CSS colour declaration, which failed before I made the change. However it _didn't_ fail when adding leading whitespace, just due to the idiosyncrasies of how `safecss_filter_attr()` is implemented. Which is sort of my point.

In terms of manual test, this code is exercised when updating and saving Global Styles in the site editor as user without the `unfiltered_html` permission. I've smoke tested this and it works as expected.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (or code quality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

CC @nosolosw @vindl 