### PR TITLE
Implement Legacy Widget design iterations

### DIFF
--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -459,14 +459,14 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		$serialized_instance = serialize( $instance );
 
 		$response = array(
-			'preview'  => trim(
-				$this->get_widget_preview(
+			'form'     => trim(
+				$this->get_widget_form(
 					$widget_object,
 					$instance
 				)
 			),
-			'form'     => trim(
-				$this->get_widget_form(
+			'preview'  => trim(
+				$this->get_widget_preview(
 					$widget_object,
 					$instance
 				)

--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -456,6 +456,58 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			);
 		}
 
+		$serialized_instance = serialize( $instance );
+
+		$response = array(
+			'preview'  => trim(
+				$this->get_widget_preview(
+					$widget_object,
+					$instance
+				)
+			),
+			'form'     => trim(
+				$this->get_widget_form(
+					$widget_object,
+					$instance
+				)
+			),
+			'instance' => array(
+				'encoded' => base64_encode( $serialized_instance ),
+				'hash'    => wp_hash( $serialized_instance ),
+			),
+		);
+
+		if ( ! empty( $widget_object->show_instance_in_rest ) ) {
+			// Use new stdClass so that JSON result is {} and not [].
+			$response['instance']['raw'] = empty( $instance ) ? new stdClass : $instance;
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Returns the output of WP_Widget::widget() when called with the provided
+	 * instance. Used by encode_form_data() to preview a widget.
+
+	 * @param WP_Widget $widget_object Widget object to call widget() on.
+	 * @param array     $instance Widget instance settings.
+	 * @return string
+	 */
+	private function get_widget_preview( $widget_object, $instance ) {
+		ob_start();
+		the_widget( get_class( $widget_object ), $instance );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Returns the output of WP_Widget::form() when called with the provided
+	 * instance. Used by encode_form_data() to preview a widget's form.
+	 *
+	 * @param WP_Widget $widget_object Widget object to call widget() on.
+	 * @param array     $instance Widget instance settings.
+	 * @return string
+	 */
+	private function get_widget_form( $widget_object, $instance ) {
 		ob_start();
 
 		/** This filter is documented in wp-includes/class-wp-widget.php */
@@ -475,24 +527,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$form = ob_get_clean();
-
-		$serialized_instance = serialize( $instance );
-
-		$response = array(
-			'form'     => trim( $form ),
-			'instance' => array(
-				'encoded' => base64_encode( $serialized_instance ),
-				'hash'    => wp_hash( $serialized_instance ),
-			),
-		);
-
-		if ( ! empty( $widget_object->show_instance_in_rest ) ) {
-			// Use new stdClass so that JSON result is {} and not [].
-			$response['instance']['raw'] = empty( $instance ) ? new stdClass : $instance;
-		}
-
-		return rest_ensure_response( $response );
+		return ob_get_clean();
 	}
 
 	/**

--- a/packages/block-library/src/legacy-widget/edit/form.js
+++ b/packages/block-library/src/legacy-widget/edit/form.js
@@ -25,7 +25,7 @@ export default function Form( { id, idBase, content, setFormData } ) {
 			onSave={ setFormData }
 			// Force a remount when the widget's form HTML changes. This clears
 			// out any mutations to the DOM that widget scripts have made.
-			key={ content.key }
+			key={ content }
 		/>
 	);
 }
@@ -45,7 +45,7 @@ function Control( { id, idBase, content, onChange, onSave } ) {
 
 		const { jQuery: $ } = window;
 
-		if ( content.html ) {
+		if ( content ) {
 			$( document ).trigger( 'widget-added', [
 				$( controlRef.current ),
 			] );
@@ -124,9 +124,7 @@ function Control( { id, idBase, content, onChange, onSave } ) {
 						className="add_new"
 						value=""
 					/>
-					<RawHTML className="widget-content">
-						{ content.html }
-					</RawHTML>
+					<RawHTML className="widget-content">{ content }</RawHTML>
 					{ id && (
 						<Button type="submit" isPrimary>
 							{ __( 'Save' ) }

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -8,12 +8,7 @@ import {
 	BlockIcon,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	ToolbarGroup,
-	ToolbarButton,
-	Spinner,
-	Placeholder,
-} from '@wordpress/components';
+import { ToolbarButton, Spinner, Placeholder } from '@wordpress/components';
 import { brush as brushIcon, update as updateIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
@@ -143,33 +138,31 @@ function NotEmpty( {
 
 	return (
 		<>
-			<BlockControls>
-				{ ! isWidgetTypeHidden && (
-					<ToolbarGroup>
-						<ToolbarButton
-							label={ __( 'Change widget' ) }
-							icon={ updateIcon }
-							onClick={ () =>
-								setAttributes( {
-									id: null,
-									idBase: null,
-									instance: null,
-								} )
-							}
-						/>
-					</ToolbarGroup>
-				) }
-				{ idBase && (
-					<ToolbarGroup>
-						<ToolbarButton onClick={ applyChanges }>
-							{ __( 'Apply' ) }
-						</ToolbarButton>
-						<ToolbarButton onClick={ clearSelectedBlock }>
-							{ __( 'Cancel' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				) }
-			</BlockControls>
+			{ ! isWidgetTypeHidden && (
+				<BlockControls group="block">
+					<ToolbarButton
+						label={ __( 'Change widget' ) }
+						icon={ updateIcon }
+						onClick={ () =>
+							setAttributes( {
+								id: null,
+								idBase: null,
+								instance: null,
+							} )
+						}
+					/>
+				</BlockControls>
+			) }
+			{ idBase && (
+				<BlockControls group="other">
+					<ToolbarButton onClick={ applyChanges }>
+						{ __( 'Apply' ) }
+					</ToolbarButton>
+					<ToolbarButton onClick={ clearSelectedBlock }>
+						{ __( 'Cancel' ) }
+					</ToolbarButton>
+				</BlockControls>
+			) }
 
 			<InspectorControls>
 				<InspectorCard

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -177,9 +177,12 @@ function NotEmpty( {
 			</FormWrapper>
 
 			{ idBase &&
-				! isSelected &&
 				( hasPreview ? (
-					<Preview idBase={ idBase } instance={ instance } />
+					<Preview
+						idBase={ idBase }
+						instance={ instance }
+						isVisible={ ! isSelected }
+					/>
 				) : (
 					<NoPreview name={ widgetType.name } />
 				) ) }

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -107,7 +107,7 @@ function NotEmpty( {
 	const { content, setFormData, hasPreview } = useForm( {
 		id,
 		idBase,
-		instance,
+		instance: pendingInstance,
 		setInstance: setPendingInstance,
 	} );
 

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -28,6 +28,7 @@ import InspectorCard from './inspector-card';
 import FormWrapper from './form-wrapper';
 import Form from './form';
 import Preview from './preview';
+import NoPreview from './no-preview';
 
 export default function Edit( props ) {
 	const { id, idBase } = props.attributes;
@@ -176,10 +177,7 @@ function NotEmpty( {
 					<Preview idBase={ idBase } instance={ instance } />
 				) : (
 					// TODO: This flashes for a second when enode request is pending.
-					<Placeholder>
-						{ widgetType.name && <h3>{ widgetType.name }</h3> }
-						<p>{ __( 'No preview available.' ) }</p>
-					</Placeholder>
+					<NoPreview name={ widgetType.name } />
 				) ) }
 		</>
 	);

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -123,11 +123,22 @@ function NotEmpty( {
 	};
 
 	if ( ! widgetType && hasResolvedWidgetType ) {
-		return <Placeholder>{ __( 'Widget is missing.' ) }</Placeholder>;
+		return (
+			<Placeholder
+				icon={ <BlockIcon icon={ brushIcon } /> }
+				label={ __( 'Legacy Widget' ) }
+			>
+				{ __( 'Widget is missing.' ) }
+			</Placeholder>
+		);
 	}
 
 	if ( ! hasResolvedWidgetType || hasPreview === null ) {
-		return <Spinner />;
+		return (
+			<Placeholder>
+				<Spinner />
+			</Placeholder>
+		);
 	}
 
 	return (

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -81,6 +81,9 @@ function NotEmpty( {
 	setAttributes,
 	isSelected,
 } ) {
+	const [ pendingInstance, setPendingInstance ] = useState( instance );
+	const [ hasPreview, setHasPreview ] = useState( false );
+
 	const { widgetType, hasResolved, isWidgetTypeHidden } = useSelect(
 		( select ) => {
 			const widgetTypeId = id ?? idBase;
@@ -100,18 +103,16 @@ function NotEmpty( {
 
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
-	const [ pendingInstance, setPendingInstance ] = useState( instance );
-
-	const applyChanges = () => {
-		setAttributes( { instance: pendingInstance } );
-		clearSelectedBlock();
-	};
-
 	useEffect( () => {
 		if ( ! isSelected ) {
 			setPendingInstance( instance );
 		}
 	}, [ isSelected ] );
+
+	const applyChanges = () => {
+		setAttributes( { instance: pendingInstance } );
+		clearSelectedBlock();
+	};
 
 	if ( ! widgetType && ! hasResolved ) {
 		return <Spinner />;
@@ -164,16 +165,22 @@ function NotEmpty( {
 					idBase={ idBase }
 					instance={ pendingInstance }
 					setInstance={ setPendingInstance }
+					// TODO: Hm, this is awkward. Probably useForm() should move up a level.
+					setHasPreview={ setHasPreview }
 				/>
 			</FormWrapper>
 
-			{ idBase && (
-				<Preview
-					idBase={ idBase }
-					instance={ instance }
-					isVisible={ ! isSelected }
-				/>
-			) }
+			{ idBase &&
+				! isSelected &&
+				( hasPreview ? (
+					<Preview idBase={ idBase } instance={ instance } />
+				) : (
+					// TODO: This flashes for a second when enode request is pending.
+					<Placeholder>
+						{ widgetType.name && <h3>{ widgetType.name }</h3> }
+						<p>{ __( 'No preview available.' ) }</p>
+					</Placeholder>
+				) ) }
 		</>
 	);
 }

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -184,7 +184,7 @@ function NotEmpty( {
 						isVisible={ ! isSelected }
 					/>
 				) : (
-					<NoPreview name={ widgetType.name } />
+					! isSelected && <NoPreview name={ widgetType.name } />
 				) ) }
 		</>
 	);

--- a/packages/block-library/src/legacy-widget/edit/inspector-card.js
+++ b/packages/block-library/src/legacy-widget/edit/inspector-card.js
@@ -1,16 +1,8 @@
-/**
- * WordPress dependencies
- */
-import { __, sprintf } from '@wordpress/i18n';
-
 export default function InspectorCard( { name, description } ) {
 	return (
 		<div className="wp-block-legacy-widget-inspector-card">
 			<h3 className="wp-block-legacy-widget-inspector-card__name">
-				{
-					/* translators: %s: the name of the widget being viewed. */
-					sprintf( __( 'Widget: %s' ), name )
-				}
+				{ name }
 			</h3>
 			<span>{ description }</span>
 		</div>

--- a/packages/block-library/src/legacy-widget/edit/no-preview.js
+++ b/packages/block-library/src/legacy-widget/edit/no-preview.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default function NoPreview( { name } ) {
+	return (
+		<div className="wp-block-legacy-widget__edit-no-preview">
+			{ name && <h3>{ name }</h3> }
+			<p>{ __( 'No preview available.' ) }</p>
+		</div>
+	);
+}

--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -7,86 +7,61 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { useRef, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function Preview( { idBase, instance, isVisible } ) {
-	return (
-		<div
-			className="wp-block-legacy-widget__edit-preview"
-			hidden={ ! isVisible }
-		>
-			<Disabled>
-				<PreviewIframe
-					className="wp-block-legacy-widget__edit-preview-iframe"
-					title={ __( 'Legacy Widget Preview' ) }
-					// TODO: This chokes when the query param is too big.
-					// Ideally, we'd render a <ServerSideRender>. Maybe by
-					// rendering one in an iframe via a portal.
-					src={ addQueryArgs( 'themes.php', {
-						page: 'gutenberg-widgets',
-						'legacy-widget-preview': {
-							idBase,
-							instance,
-						},
-					} ) }
-					placeholder={
-						<Placeholder>
-							<Spinner />
-						</Placeholder>
-					}
-				/>
-			</Disabled>
-		</div>
-	);
-}
-
-/**
- * Iframe used for rendering a preview of the widget.
- *
- * We use an iframe so that the widget has an opportunity to load scripts and
- * styles that it needs to run.
- *
- * The height of the iframe is set dynamically by looking at the scrollHeight of
- * the iframe contents once it is finished loading.
- *
- * While the iframe contents are loading, we move the iframe off-screen and
- * display a placeholder instead. This ensures that the user doesn't see the
- * iframe resize (which looks really janky). We have to move the iframe
- * off-screen instead of hiding it because web browsers will not trigger onLoad
- * if the iframe is hidden.
- *
- * @param {Object} props
- * @param {string} props.className
- * @param {string} props.title
- * @param {number} props.height
- * @param {WPElement} props.placeholder
- */
-function PreviewIframe( {
-	className,
-	title,
-	height: defaultHeight = 10,
-	placeholder,
-	...props
-} ) {
-	const ref = useRef();
-	const [ height, setHeight ] = useState( null );
+	const [ iframeHeight, setIframeHeight ] = useState( null );
 	return (
 		<>
-			{ height === null && placeholder }
-			<iframe
-				{ ...props }
-				ref={ ref }
-				className={ classnames( className, {
-					'is-offscreen': height === null,
-				} ) }
-				title={ title }
-				height={ height ?? defaultHeight }
-				onLoad={ () => {
-					setHeight( ref.current.contentDocument.body.scrollHeight );
-				} }
-			/>
+			{ /*
+			While the iframe contents are loading, we move the iframe off-screen
+			and display a placeholder instead. This ensures that the user
+			doesn't see the iframe resize (which looks really janky). We have to
+			move the iframe off-screen instead of hiding it because web browsers
+			will not trigger onLoad if the iframe is hidden.
+			*/ }
+			{ isVisible && iframeHeight === null && (
+				<Placeholder>
+					<Spinner />
+				</Placeholder>
+			) }
+			<div
+				className={ classnames(
+					'wp-block-legacy-widget__edit-preview',
+					{
+						'is-offscreen': ! isVisible || iframeHeight === null,
+					}
+				) }
+			>
+				<Disabled>
+					{ /*
+					We use an iframe so that the widget has an opportunity to
+					load scripts and styles that it needs to run.
+					*/ }
+					<iframe
+						className="wp-block-legacy-widget__edit-preview-iframe"
+						title={ __( 'Legacy Widget Preview' ) }
+						// TODO: This chokes when the query param is too big.
+						// Ideally, we'd render a <ServerSideRender>. Maybe by
+						// rendering one in an iframe via a portal.
+						src={ addQueryArgs( 'themes.php', {
+							page: 'gutenberg-widgets',
+							'legacy-widget-preview': {
+								idBase,
+								instance,
+							},
+						} ) }
+						height={ iframeHeight ?? 100 }
+						onLoad={ ( event ) => {
+							setIframeHeight(
+								event.target.contentDocument.body.scrollHeight
+							);
+						} }
+					/>
+				</Disabled>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 
 const DEFAULT_HEIGHT = 300;
 
-export default function PreviewIframe( { idBase, instance, isVisible } ) {
+export default function PreviewIframe( { idBase, instance } ) {
 	const ref = useRef();
 
 	const [ height, setHeight ] = useState( DEFAULT_HEIGHT );
@@ -18,13 +18,11 @@ export default function PreviewIframe( { idBase, instance, isVisible } ) {
 	}, [] );
 
 	useEffect( () => {
-		if ( isVisible ) {
-			adjustHeight();
-		}
-	}, [ isVisible, adjustHeight ] );
+		adjustHeight();
+	}, [ adjustHeight ] );
 
 	return (
-		<Disabled hidden={ ! isVisible }>
+		<Disabled>
 			{ /*
 			Rendering the preview in an iframe ensures compatibility with any
 			scripts that the widget uses. TODO: This chokes when the

--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -1,41 +1,29 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { useRef, useState, useCallback, useEffect } from '@wordpress/element';
-import { Disabled } from '@wordpress/components';
+import { useRef, useState } from '@wordpress/element';
+import { Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const DEFAULT_HEIGHT = 300;
-
 export default function Preview( { idBase, instance, isVisible } ) {
-	const ref = useRef();
-
-	const [ height, setHeight ] = useState( DEFAULT_HEIGHT );
-
-	const adjustHeight = useCallback( () => {
-		setHeight( ref.current.contentDocument.body.scrollHeight );
-	}, [] );
-
-	useEffect( () => {
-		adjustHeight();
-	}, [ adjustHeight ] );
-
 	return (
 		<div
 			className="wp-block-legacy-widget__edit-preview"
 			hidden={ ! isVisible }
 		>
 			<Disabled>
-				{ /*
-				Rendering the preview in an iframe ensures compatibility with
-				any scripts that the widget uses. TODO: This chokes when the
-				legacy-widget-preview query param is too big.  Ideally, we'd
-				render a <ServerSideRender> into an iframe using a portal.
-				*/ }
-				<iframe
-					ref={ ref }
+				<PreviewIframe
 					className="wp-block-legacy-widget__edit-preview-iframe"
+					title={ __( 'Legacy Widget Preview' ) }
+					// TODO: This chokes when the query param is too big.
+					// Ideally, we'd render a <ServerSideRender>. Maybe by
+					// rendering one in an iframe via a portal.
 					src={ addQueryArgs( 'themes.php', {
 						page: 'gutenberg-widgets',
 						'legacy-widget-preview': {
@@ -43,11 +31,62 @@ export default function Preview( { idBase, instance, isVisible } ) {
 							instance,
 						},
 					} ) }
-					title={ __( 'Legacy Widget Preview' ) }
-					height={ height }
-					onLoad={ adjustHeight }
+					placeholder={
+						<Placeholder>
+							<Spinner />
+						</Placeholder>
+					}
 				/>
 			</Disabled>
 		</div>
+	);
+}
+
+/**
+ * Iframe used for rendering a preview of the widget.
+ *
+ * We use an iframe so that the widget has an opportunity to load scripts and
+ * styles that it needs to run.
+ *
+ * The height of the iframe is set dynamically by looking at the scrollHeight of
+ * the iframe contents once it is finished loading.
+ *
+ * While the iframe contents are loading, we move the iframe off-screen and
+ * display a placeholder instead. This ensures that the user doesn't see the
+ * iframe resize (which looks really janky). We have to move the iframe
+ * off-screen instead of hiding it because web browsers will not trigger onLoad
+ * if the iframe is hidden.
+ *
+ * @param {Object} props
+ * @param {string} props.className
+ * @param {string} props.title
+ * @param {number} props.height
+ * @param {WPElement} props.placeholder
+ */
+function PreviewIframe( {
+	className,
+	title,
+	height: defaultHeight = 10,
+	placeholder,
+	...props
+} ) {
+	const ref = useRef();
+	const [ height, setHeight ] = useState( null );
+	return (
+		<>
+			{ height === null && placeholder }
+			<iframe
+				{ ...props }
+				ref={ ref }
+				className={ classnames( className, {
+					'is-offscreen': height === null,
+				} ) }
+				title={ title }
+				height={ height ?? defaultHeight }
+				onLoad={ () => {
+					setHeight( ref.current.contentDocument.body.scrollHeight );
+				} }
+			/>
+		</>
 	);
 }

--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 
 const DEFAULT_HEIGHT = 300;
 
-export default function PreviewIframe( { idBase, instance } ) {
+export default function Preview( { idBase, instance, isVisible } ) {
 	const ref = useRef();
 
 	const [ height, setHeight ] = useState( DEFAULT_HEIGHT );
@@ -22,7 +22,7 @@ export default function PreviewIframe( { idBase, instance } ) {
 	}, [ adjustHeight ] );
 
 	return (
-		<Disabled>
+		<Disabled hidden={ ! isVisible }>
 			{ /*
 			Rendering the preview in an iframe ensures compatibility with any
 			scripts that the widget uses. TODO: This chokes when the

--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -22,27 +22,32 @@ export default function Preview( { idBase, instance, isVisible } ) {
 	}, [ adjustHeight ] );
 
 	return (
-		<Disabled hidden={ ! isVisible }>
-			{ /*
-			Rendering the preview in an iframe ensures compatibility with any
-			scripts that the widget uses. TODO: This chokes when the
-			legacy-widget-preview query param is too big. Ideally, we'd render a
-			<ServerSideRender> into an iframe using a portal.
-			*/ }
-			<iframe
-				ref={ ref }
-				className="wp-block-legacy-widget__edit-preview"
-				src={ addQueryArgs( 'themes.php', {
-					page: 'gutenberg-widgets',
-					'legacy-widget-preview': {
-						idBase,
-						instance,
-					},
-				} ) }
-				title={ __( 'Legacy Widget Preview' ) }
-				height={ height }
-				onLoad={ adjustHeight }
-			/>
-		</Disabled>
+		<div
+			className="wp-block-legacy-widget__edit-preview"
+			hidden={ ! isVisible }
+		>
+			<Disabled>
+				{ /*
+				Rendering the preview in an iframe ensures compatibility with
+				any scripts that the widget uses. TODO: This chokes when the
+				legacy-widget-preview query param is too big.  Ideally, we'd
+				render a <ServerSideRender> into an iframe using a portal.
+				*/ }
+				<iframe
+					ref={ ref }
+					className="wp-block-legacy-widget__edit-preview-iframe"
+					src={ addQueryArgs( 'themes.php', {
+						page: 'gutenberg-widgets',
+						'legacy-widget-preview': {
+							idBase,
+							instance,
+						},
+					} ) }
+					title={ __( 'Legacy Widget Preview' ) }
+					height={ height }
+					onLoad={ adjustHeight }
+				/>
+			</Disabled>
+		</div>
 	);
 }

--- a/packages/block-library/src/legacy-widget/edit/use-form.js
+++ b/packages/block-library/src/legacy-widget/edit/use-form.js
@@ -40,7 +40,7 @@ export default function useForm( { id, idBase, instance, setInstance } ) {
 					);
 					if ( isStillMounted.current ) {
 						setContent( form );
-						setHasPreview( !! preview );
+						setHasPreview( ! isEmptyHTML( preview ) );
 					}
 				}
 			} catch ( error ) {
@@ -69,7 +69,7 @@ export default function useForm( { id, idBase, instance, setInstance } ) {
 					if ( isStillMounted.current ) {
 						outgoingInstances.current.add( nextInstance );
 						setInstance( nextInstance );
-						setHasPreview( !! preview );
+						setHasPreview( ! isEmptyHTML( preview ) );
 					}
 				}
 			} catch ( error ) {
@@ -119,4 +119,10 @@ async function encodeWidget( idBase, instance, formData = null ) {
 		form: response.form,
 		preview: response.preview,
 	};
+}
+
+function isEmptyHTML( html ) {
+	const element = document.createElement( 'div' );
+	element.innerHTML = html;
+	return element.innerText.trim() === '';
 }

--- a/packages/block-library/src/legacy-widget/edit/use-form.js
+++ b/packages/block-library/src/legacy-widget/edit/use-form.js
@@ -1,0 +1,131 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+export default function useForm( { id, idBase, instance, setInstance } ) {
+	const isStillMounted = useRef( false );
+	const outgoingInstances = useRef( new Set() );
+	const [ content, setContent ] = useState( { html: null, key: 0 } );
+	const [ hasPreview, setHasPreview ] = useState( null );
+
+	const { createNotice } = useDispatch( noticesStore );
+
+	useEffect( () => {
+		isStillMounted.current = true;
+		return () => ( isStillMounted.current = false );
+	}, [] );
+
+	useEffect( () => {
+		if ( outgoingInstances.current.has( instance ) ) {
+			outgoingInstances.current.delete( instance );
+			return;
+		}
+
+		( async () => {
+			try {
+				if ( id ) {
+					const { form } = await saveWidget( id );
+					if ( isStillMounted.current ) {
+						setContent( ( { key } ) => ( {
+							html: form,
+							key: key + 1,
+						} ) );
+					}
+				} else if ( idBase ) {
+					const { form, preview } = await encodeWidget(
+						idBase,
+						instance
+					);
+					if ( isStillMounted.current ) {
+						setContent( ( { key } ) => ( {
+							html: form,
+							key: key + 1,
+						} ) );
+						setHasPreview( !! preview );
+					}
+				}
+			} catch ( error ) {
+				createNotice(
+					'error',
+					error?.message ??
+						__( 'An error occured while fetching the widget.' )
+				);
+			}
+		} )();
+	}, [ id, idBase, instance ] );
+
+	const setFormData = useCallback(
+		async ( formData ) => {
+			try {
+				if ( id ) {
+					const { form } = await saveWidget( id, formData );
+					if ( isStillMounted.current ) {
+						setContent( ( { key } ) => ( {
+							html: form,
+							key: key + 1,
+						} ) );
+					}
+				} else if ( idBase ) {
+					const {
+						instance: nextInstance,
+						preview,
+					} = await encodeWidget( idBase, instance, formData );
+					if ( isStillMounted.current ) {
+						outgoingInstances.current.add( nextInstance );
+						setInstance( nextInstance );
+						setHasPreview( !! preview );
+					}
+				}
+			} catch ( error ) {
+				createNotice(
+					'error',
+					error?.message ??
+						__( 'An error occured while updating the widget.' )
+				);
+			}
+		},
+		[ id, idBase ]
+	);
+
+	return { content, setFormData, hasPreview };
+}
+
+async function saveWidget( id, formData = null ) {
+	let widget;
+	if ( formData ) {
+		widget = await apiFetch( {
+			path: `/wp/v2/widgets/${ id }?context=edit`,
+			method: 'PUT',
+			data: {
+				form_data: formData,
+			},
+		} );
+	} else {
+		widget = await apiFetch( {
+			path: `/wp/v2/widgets/${ id }?context=edit`,
+			method: 'GET',
+		} );
+	}
+	return { form: widget.rendered_form };
+}
+
+async function encodeWidget( idBase, instance, formData = null ) {
+	const response = await apiFetch( {
+		path: `/wp/v2/widget-types/${ idBase }/encode`,
+		method: 'POST',
+		data: {
+			instance,
+			form_data: formData,
+		},
+	} );
+	return {
+		instance: response.instance,
+		form: response.form,
+		preview: response.preview,
+	};
+}

--- a/packages/block-library/src/legacy-widget/edit/use-form.js
+++ b/packages/block-library/src/legacy-widget/edit/use-form.js
@@ -10,7 +10,7 @@ import apiFetch from '@wordpress/api-fetch';
 export default function useForm( { id, idBase, instance, setInstance } ) {
 	const isStillMounted = useRef( false );
 	const outgoingInstances = useRef( new Set() );
-	const [ content, setContent ] = useState( { html: null, key: 0 } );
+	const [ content, setContent ] = useState( null );
 	const [ hasPreview, setHasPreview ] = useState( null );
 
 	const { createNotice } = useDispatch( noticesStore );
@@ -31,10 +31,7 @@ export default function useForm( { id, idBase, instance, setInstance } ) {
 				if ( id ) {
 					const { form } = await saveWidget( id );
 					if ( isStillMounted.current ) {
-						setContent( ( { key } ) => ( {
-							html: form,
-							key: key + 1,
-						} ) );
+						setContent( form );
 					}
 				} else if ( idBase ) {
 					const { form, preview } = await encodeWidget(
@@ -42,10 +39,7 @@ export default function useForm( { id, idBase, instance, setInstance } ) {
 						instance
 					);
 					if ( isStillMounted.current ) {
-						setContent( ( { key } ) => ( {
-							html: form,
-							key: key + 1,
-						} ) );
+						setContent( form );
 						setHasPreview( !! preview );
 					}
 				}
@@ -65,10 +59,7 @@ export default function useForm( { id, idBase, instance, setInstance } ) {
 				if ( id ) {
 					const { form } = await saveWidget( id, formData );
 					if ( isStillMounted.current ) {
-						setContent( ( { key } ) => ( {
-							html: form,
-							key: key + 1,
-						} ) );
+						setContent( form );
 					}
 				} else if ( idBase ) {
 					const {

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -21,6 +21,10 @@
 		label {
 			font-size: $default-font-size;
 		}
+
+		label + .widefat {
+			margin-top: $grid-unit-15;
+		}
 	}
 
 	// Reset z-index set on https://github.com/WordPress/wordpress-develop/commit/f26d4d37351a55fd1fc5dad0f5fef8f0f964908c.

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -49,17 +49,16 @@
 	}
 }
 
-.wp-block-legacy-widget__edit-preview-iframe {
-	overflow: auto;
+.wp-block-legacy-widget__edit-preview.is-offscreen {
+	left: -9999px;
+	position: absolute;
+	top: 0;
 	width: 100%;
+}
 
-	&.is-offscreen {
-		left: 0;
-		opacity: 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-	}
+.wp-block-legacy-widget__edit-preview-iframe {
+	overflow: hidden;
+	width: 100%;
 }
 
 .wp-block-legacy-widget__edit-no-preview {

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -80,7 +80,7 @@
 
 .wp-block-legacy-widget-inspector-card {
 	// Padding left = an icon, some margin and some padding
-	padding: 0 $grid-unit-20 $grid-unit-20 ( $icon-size + $grid-unit-40 + $grid-unit-05 );
+	padding: 0 $grid-unit-20 $grid-unit-20 ( $grid-unit-20 + $icon-size + $grid-unit-15 );
 }
 
 .interface-complementary-area .wp-block-legacy-widget-inspector-card__name {

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -1,7 +1,7 @@
 .wp-block-legacy-widget__edit-form {
 	background: $white;
 	border-radius: $radius-block-ui;
-	border: 1px solid $gray-300;
+	border: 1px solid $gray-900;
 	padding: $grid-unit-15 - 1px; //Subtract the border width.
 
 	.wp-block-legacy-widget__edit-form-title {

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -1,5 +1,15 @@
+.wp-block-legacy-widget:not(.is-selected) {
+	cursor: pointer;
+
+	&:hover::after {
+		border: 1px solid $gray-600;
+	}
+}
+
 .wp-block-legacy-widget__edit-form {
 	background: $white;
+	border-radius: $radius-block-ui;
+	border: 1px solid $gray-300;
 	padding: $grid-unit-15;
 
 	.wp-block-legacy-widget__edit-form-title {
@@ -29,6 +39,7 @@
 
 .wp-block-legacy-widget__edit-preview {
 	overflow: auto;
+	width: 100%;
 }
 
 .wp-block-legacy-widget__edit-no-preview {

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -1,11 +1,3 @@
-.wp-block-legacy-widget:not(.is-selected) {
-	cursor: pointer;
-
-	&:hover::after {
-		border: 1px solid $gray-600;
-	}
-}
-
 .wp-block-legacy-widget__edit-form {
 	background: $white;
 	border-radius: $radius-block-ui;
@@ -37,7 +29,23 @@
 	}
 }
 
-.wp-block-legacy-widget__edit-preview {
+.wp-block-legacy-widget__edit-preview,
+.wp-block-legacy-widget__edit-no-preview {
+	cursor: pointer;
+
+	&:hover::after {
+		border-radius: $radius-block-ui;
+		border: 1px solid $gray-600;
+		bottom: 0;
+		content: "";
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+}
+
+.wp-block-legacy-widget__edit-preview-iframe {
 	overflow: auto;
 	width: 100%;
 }

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -48,6 +48,14 @@
 .wp-block-legacy-widget__edit-preview-iframe {
 	overflow: auto;
 	width: 100%;
+
+	&.is-offscreen {
+		left: 0;
+		opacity: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
 }
 
 .wp-block-legacy-widget__edit-no-preview {

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -1,17 +1,13 @@
 .wp-block-legacy-widget__edit-form {
 	background: $white;
-	border-radius: $radius-block-ui;
-	border: $border-width solid $gray-900;
-	padding: $grid-unit-10 $block-padding;
+	padding: $grid-unit-15;
 
 	.wp-block-legacy-widget__edit-form-title {
-		border-bottom: $border-width solid $gray-900;
 		color: $black;
 		font-family: $default-font;
-		font-size: $default-font-size;
+		font-size: 14px;
 		font-weight: 600;
-		margin: (-$grid-unit-10) (-$block-padding) 0;
-		padding: $block-padding 18px;
+		margin: 0 0 $grid-unit-15 0;
 	}
 
 	.widget-inside {
@@ -19,6 +15,10 @@
 		box-shadow: none;
 		display: block;
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
+		label {
+			font-size: $default-font-size;
+		}
 	}
 
 	// Reset z-index set on https://github.com/WordPress/wordpress-develop/commit/f26d4d37351a55fd1fc5dad0f5fef8f0f964908c.
@@ -29,6 +29,22 @@
 
 .wp-block-legacy-widget__edit-preview {
 	overflow: auto;
+}
+
+.wp-block-legacy-widget__edit-no-preview {
+	background: $gray-100;
+	padding: $grid-unit-10 $grid-unit-15;
+	font-size: $default-font-size;
+
+	h3 {
+		font-size: 14px;
+		font-weight: 600;
+		margin: $grid-unit-05 0;
+	}
+
+	p {
+		margin: $grid-unit-05 0;
+	}
 }
 
 .wp-block-legacy-widget-inspector-card {

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -2,7 +2,7 @@
 	background: $white;
 	border-radius: $radius-block-ui;
 	border: 1px solid $gray-300;
-	padding: $grid-unit-15;
+	padding: $grid-unit-15 - 1px; //Subtract the border width.
 
 	.wp-block-legacy-widget__edit-form-title {
 		color: $black;

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -122,7 +122,7 @@ export default function Sidebar() {
 			isGeneralSidebarOpen
 		) {
 			enableComplementaryArea(
-				editWidgetsStore,
+				'core/edit-widgets',
 				BLOCK_INSPECTOR_IDENTIFIER
 			);
 		}
@@ -132,7 +132,7 @@ export default function Sidebar() {
 			isGeneralSidebarOpen
 		) {
 			enableComplementaryArea(
-				editWidgetsStore,
+				'core/edit-widgets',
 				WIDGET_AREAS_IDENTIFIER
 			);
 		}

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -1,5 +1,6 @@
 .edit-widgets-block-editor {
 	position: relative;
+	background: $gray-100;
 
 	// This is the default font that is going to be used in the content of the areas (blocks).
 	font-family: $default-font;

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -43,7 +43,7 @@ body.widgets-php {
 	}
 
 	.interface-interface-skeleton__content {
-		background-color: #f1f1f1;
+		background-color: $gray-100;
 	}
 }
 

--- a/phpunit/class-rest-widget-types-controller-test.php
+++ b/phpunit/class-rest-widget-types-controller-test.php
@@ -265,8 +265,8 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 			"\t\t</p>",
 			$data['form']
 		);
-		$this->assertEquals(
-			"<div class=\"widget widget_search\"><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"http://example.org/\">\n" .
+		$this->assertStringMatchesFormat(
+			"<div class=\"widget widget_search\"><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"%s\">\n" .
 			"\t\t\t\t<div>\n" .
 			"\t\t\t\t\t<label class=\"screen-reader-text\" for=\"s\">Search for:</label>\n" .
 			"\t\t\t\t\t<input type=\"text\" value=\"\" name=\"s\" id=\"s\" />\n" .
@@ -304,8 +304,8 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 			"\t\t</p>",
 			$data['form']
 		);
-		$this->assertEquals(
-			"<div class=\"widget widget_search\"><h2 class=\"widgettitle\">Test title</h2><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"http://example.org/\">\n" .
+		$this->assertStringMatchesFormat(
+			"<div class=\"widget widget_search\"><h2 class=\"widgettitle\">Test title</h2><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"%s\">\n" .
 			"\t\t\t\t<div>\n" .
 			"\t\t\t\t\t<label class=\"screen-reader-text\" for=\"s\">Search for:</label>\n" .
 			"\t\t\t\t\t<input type=\"text\" value=\"\" name=\"s\" id=\"s\" />\n" .
@@ -337,8 +337,8 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 			"\t\t</p>",
 			$data['form']
 		);
-		$this->assertEquals(
-			"<div class=\"widget widget_search\"><h2 class=\"widgettitle\">Updated title</h2><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"http://example.org/\">\n" .
+		$this->assertStringMatchesFormat(
+			"<div class=\"widget widget_search\"><h2 class=\"widgettitle\">Updated title</h2><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"%s\">\n" .
 			"\t\t\t\t<div>\n" .
 			"\t\t\t\t\t<label class=\"screen-reader-text\" for=\"s\">Search for:</label>\n" .
 			"\t\t\t\t\t<input type=\"text\" value=\"\" name=\"s\" id=\"s\" />\n" .
@@ -377,6 +377,16 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 			"\t\t\t<input class=\"widefat\" id=\"widget-search-1-title\" name=\"widget-search[1][title]\" type=\"text\" value=\"Test title\" />\n" .
 			"\t\t</p>",
 			$data['form']
+		);
+		$this->assertStringMatchesFormat(
+			"<div class=\"widget widget_search\"><h2 class=\"widgettitle\">Test title</h2><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"%s\">\n" .
+			"\t\t\t\t<div>\n" .
+			"\t\t\t\t\t<label class=\"screen-reader-text\" for=\"s\">Search for:</label>\n" .
+			"\t\t\t\t\t<input type=\"text\" value=\"\" name=\"s\" id=\"s\" />\n" .
+			"\t\t\t\t\t<input type=\"submit\" id=\"searchsubmit\" value=\"Search\" />\n" .
+			"\t\t\t\t</div>\n" .
+			"\t\t\t</form></div>",
+			$data['preview']
 		);
 		$this->assertEqualSets(
 			array(

--- a/phpunit/class-rest-widget-types-controller-test.php
+++ b/phpunit/class-rest-widget-types-controller-test.php
@@ -265,6 +265,16 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 			"\t\t</p>",
 			$data['form']
 		);
+		$this->assertEquals(
+			"<div class=\"widget widget_search\"><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"http://example.org/\">\n" .
+			"\t\t\t\t<div>\n" .
+			"\t\t\t\t\t<label class=\"screen-reader-text\" for=\"s\">Search for:</label>\n" .
+			"\t\t\t\t\t<input type=\"text\" value=\"\" name=\"s\" id=\"s\" />\n" .
+			"\t\t\t\t\t<input type=\"submit\" id=\"searchsubmit\" value=\"Search\" />\n" .
+			"\t\t\t\t</div>\n" .
+			"\t\t\t</form></div>",
+			$data['preview']
+		);
 		$this->assertEqualSets(
 			array(
 				'encoded' => base64_encode( serialize( array() ) ),
@@ -294,6 +304,16 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 			"\t\t</p>",
 			$data['form']
 		);
+		$this->assertEquals(
+			"<div class=\"widget widget_search\"><h2 class=\"widgettitle\">Test title</h2><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"http://example.org/\">\n" .
+			"\t\t\t\t<div>\n" .
+			"\t\t\t\t\t<label class=\"screen-reader-text\" for=\"s\">Search for:</label>\n" .
+			"\t\t\t\t\t<input type=\"text\" value=\"\" name=\"s\" id=\"s\" />\n" .
+			"\t\t\t\t\t<input type=\"submit\" id=\"searchsubmit\" value=\"Search\" />\n" .
+			"\t\t\t\t</div>\n" .
+			"\t\t\t</form></div>",
+			$data['preview']
+		);
 		$this->assertEqualSets(
 			array(
 				'encoded' => base64_encode( serialize( array( 'title' => 'Test title' ) ) ),
@@ -316,6 +336,16 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 			"\t\t\t<input class=\"widefat\" id=\"widget-search-1-title\" name=\"widget-search[1][title]\" type=\"text\" value=\"Updated title\" />\n" .
 			"\t\t</p>",
 			$data['form']
+		);
+		$this->assertEquals(
+			"<div class=\"widget widget_search\"><h2 class=\"widgettitle\">Updated title</h2><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"http://example.org/\">\n" .
+			"\t\t\t\t<div>\n" .
+			"\t\t\t\t\t<label class=\"screen-reader-text\" for=\"s\">Search for:</label>\n" .
+			"\t\t\t\t\t<input type=\"text\" value=\"\" name=\"s\" id=\"s\" />\n" .
+			"\t\t\t\t\t<input type=\"submit\" id=\"searchsubmit\" value=\"Search\" />\n" .
+			"\t\t\t\t</div>\n" .
+			"\t\t\t</form></div>",
+			$data['preview']
 		);
 		$this->assertEqualSets(
 			array(


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/26179.
Closes https://github.com/WordPress/gutenberg/issues/28671.
Closes https://github.com/WordPress/gutenberg/issues/25960.
Closes https://github.com/WordPress/gutenberg/issues/28995.

Implements the new Legacy Widget flow in https://github.com/WordPress/gutenberg/issues/26179.

- The widget preview now displays by default.
- The widget form now displays when the block is selected or when user presses <kbd>ESC</kbd>.
- There is now a "No preview available" message when the widget has no preview.

https://user-images.githubusercontent.com/612155/115821121-8b32e800-a445-11eb-9035-b8f1687b55c1.mp4