### PR TITLE
Add transform for group block to cover block.

### DIFF
--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	createBlock,
-	createBlocksFromInnerBlocksTemplate,
-} from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -87,7 +84,7 @@ const transforms = {
 						gradient,
 						customGradient: style?.color?.gradient,
 					},
-					createBlocksFromInnerBlocksTemplate( innerBlocks )
+					innerBlocks
 				);
 			},
 		},

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -52,6 +52,62 @@ const transforms = {
 					]
 				),
 		},
+		{
+			type: 'block',
+			blocks: [ 'core/group' ],
+			transform: (
+				{ align, anchor, backgroundColor, gradient, style },
+				innerBlocks
+			) => {
+				/*
+				 * If a cover block has no background, it displays the "placeholder" state,
+				 * which makes it look like it has no contents.
+				 *
+				 * As this could be confusing to users during a transform, if there aren't any
+				 * existing background colors or gradients in the group, default to 'white' so
+				 * that the transformed group's block contents are not hidden.
+				 */
+				let coverOverlayColor = backgroundColor;
+				if (
+					! (
+						coverOverlayColor ||
+						style?.color?.background ||
+						style?.color?.gradient ||
+						gradient
+					)
+				) {
+					coverOverlayColor = 'white';
+				}
+
+				/*
+				 * Clone the blocks to be transformed.
+				 * Failing to create new block references causes the original blocks
+				 * to be replaced in the switchToBlockType call thereby meaning they
+				 * are removed both from their original location and within the
+				 * new cover block.
+				 */
+				const coverInnerBlocks = innerBlocks.map( ( block ) => {
+					return createBlock(
+						block.name,
+						block.attributes,
+						block.innerBlocks
+					);
+				} );
+
+				return createBlock(
+					'core/cover',
+					{
+						align,
+						anchor,
+						overlayColor: coverOverlayColor,
+						customOverlayColor: style?.color?.background,
+						gradient,
+						customGradient: style?.color?.gradient,
+					},
+					coverInnerBlocks
+				);
+			},
+		},
 	],
 	to: [
 		{

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	createBlocksFromInnerBlocksTemplate,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -57,9 +60,11 @@ const transforms = {
 			blocks: [ 'core/group' ],
 			isMatch: ( { backgroundColor, gradient, style } ) => {
 				/*
-				 * Make sure the group has a background, since if the cover block is
-				 * created without one, it displays the "placeholder" state,
-				 * which makes it look like it has no contents.
+				 * Make this transformation available only if the Group has background
+				 * or gradient set, because otherwise `Cover` block displays a Placeholder.
+				 *
+				 * This helps avoid arbitrary decisions about the Cover block's background
+				 * and user confusion about the existence of previous content.
 				 */
 				return (
 					backgroundColor ||
@@ -72,21 +77,6 @@ const transforms = {
 				{ align, anchor, backgroundColor, gradient, style },
 				innerBlocks
 			) => {
-				/*
-				 * Clone the blocks to be transformed.
-				 * Failing to create new block references causes the original blocks
-				 * to be replaced in the switchToBlockType call thereby meaning they
-				 * are removed both from their original location and within the
-				 * new cover block.
-				 */
-				const coverInnerBlocks = innerBlocks.map( ( block ) => {
-					return createBlock(
-						block.name,
-						block.attributes,
-						block.innerBlocks
-					);
-				} );
-
 				return createBlock(
 					'core/cover',
 					{
@@ -97,7 +87,7 @@ const transforms = {
 						gradient,
 						customGradient: style?.color?.gradient,
 					},
-					coverInnerBlocks
+					createBlocksFromInnerBlocksTemplate( innerBlocks )
 				);
 			},
 		},

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -55,30 +55,23 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/group' ],
+			isMatch: ( { backgroundColor, gradient, style } ) => {
+				/*
+				 * Make sure the group has a background, since if the cover block is
+				 * created without one, it displays the "placeholder" state,
+				 * which makes it look like it has no contents.
+				 */
+				return (
+					backgroundColor ||
+					style?.color?.background ||
+					style?.color?.gradient ||
+					gradient
+				);
+			},
 			transform: (
 				{ align, anchor, backgroundColor, gradient, style },
 				innerBlocks
 			) => {
-				/*
-				 * If a cover block has no background, it displays the "placeholder" state,
-				 * which makes it look like it has no contents.
-				 *
-				 * As this could be confusing to users during a transform, if there aren't any
-				 * existing background colors or gradients in the group, default to 'white' so
-				 * that the transformed group's block contents are not hidden.
-				 */
-				let coverOverlayColor = backgroundColor;
-				if (
-					! (
-						coverOverlayColor ||
-						style?.color?.background ||
-						style?.color?.gradient ||
-						gradient
-					)
-				) {
-					coverOverlayColor = 'white';
-				}
-
 				/*
 				 * Clone the blocks to be transformed.
 				 * Failing to create new block references causes the original blocks
@@ -99,7 +92,7 @@ const transforms = {
 					{
 						align,
 						anchor,
-						overlayColor: coverOverlayColor,
+						overlayColor: backgroundColor,
 						customOverlayColor: style?.color?.background,
 						gradient,
 						customGradient: style?.color?.gradient,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
- Copies inner blocks.
- Uses existing background color or gradient if it's available. ~Otherwise, defaults to a white background to avoid prompt for image/color~.

Initial review props @Mamaduka
Closes: #30445

(edit: removed background default color due to feedback)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested manually in `wp-env`, and with existing automated tests with `npm run test`.

## Screenshots <!-- if applicable -->
<img width="674" alt="Screen Shot 2021-04-16 at 15 53 22" src="https://user-images.githubusercontent.com/1034160/114983753-f1f75500-9ecb-11eb-947d-56591da4255a.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement.
Adds ability to transform a group block into a cover block, maintaining existing background color or gradient.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
