### PR TITLE
Only remove default font family in the editor from themes with theme.json file

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -660,7 +660,7 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 	}
 
 	// Remove the default font editor styles for FSE themes.
-	if ( gutenberg_supports_block_templates() ) {
+	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
 		foreach ( $settings['styles'] as $j => $style ) {
 			if ( 0 === strpos( $style['css'], 'body { font-family:' ) ) {
 				unset( $settings['styles'][ $j ] );


### PR DESCRIPTION
Relying on "bock-template-supports" check means that all themes get the font family removed by default from editor styles which is not great considering that we reverted the change for classic themes explicitly after some reports of breakage.

Since theme.json presence is opt-in, I updated the check to rely on that instead.