### PR TITLE
Add an initial value to the Site Logo block.

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -141,6 +141,10 @@ const SiteLogo = ( {
 	// becomes available.
 	const maxWidthBuffer = maxWidth * 2.5;
 
+	// Set the default width to a responsible size.
+	// Note that this width is also set in the attached CSS file.
+	const defaultWidth = 120;
+
 	let showRightHandle = false;
 	let showLeftHandle = false;
 
@@ -181,6 +185,10 @@ const SiteLogo = ( {
 						}
 						min={ minWidth }
 						max={ maxWidthBuffer }
+						initialPosition={ Math.min(
+							defaultWidth,
+							maxWidthBuffer
+						) }
 						value={ width || '' }
 						disabled={ ! isResizable }
 					/>


### PR DESCRIPTION
## Description

The Site Logo block had some changes recently to set a new default width of 120px. As part of that, the initial width was unset. This PR adds back an initial width that matches the CSS properties.

Before:

<img width="964" alt="Screenshot 2021-04-16 at 13 21 16" src="https://user-images.githubusercontent.com/1204802/115017311-a6867c00-9eb6-11eb-8ded-85ac366ef8d5.png">


After:

<img width="952" alt="Screenshot 2021-04-16 at 13 16 02" src="https://user-images.githubusercontent.com/1204802/115017282-97073300-9eb6-11eb-90e2-36f9aae6c62b.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
