### PR TITLE
Update the site logo description to be more illustrative.

### DIFF
--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -15,7 +15,9 @@ export { metadata, name };
 
 export const settings = {
 	title: _x( 'Site Logo', 'block title' ),
-	description: __( 'Displays and enables editing of the site logo.' ),
+	description: __(
+		'Useful for displaying a graphic mark, design, or symbol to represent the site. Once a site logo is set, it can be reused in different places and templates. It should not be confused with the site icon, which is the small image used in the dashboard, browser tabs, public search results, etc, to help recognize a site.'
+	),
 	icon,
 	styles: [
 		{


### PR DESCRIPTION
We can continue refining this — especially once it is possible to update the site icon / favicon — but this is a step to make the description more meaningful and less of a rephrasing of the block name.