### PR TITLE
E2E tests: Return original content if edited content is unavailable ( siteEditor.getEditedPostContent() )

### DIFF
--- a/packages/e2e-tests/experimental-features.js
+++ b/packages/e2e-tests/experimental-features.js
@@ -162,7 +162,7 @@ export const siteEditor = {
 			postType,
 			postId
 		);
-		const editedContent = getEntityContent( editedRecord );
+		const editedContent = await getEntityContent( editedRecord );
 		if ( editedContent ) {
 			return editedContent;
 		}
@@ -173,7 +173,7 @@ export const siteEditor = {
 			postType,
 			postId
 		);
-		const originalContent = getEntityContent( originalRecord );
+		const originalContent = await getEntityContent( originalRecord );
 		if ( originalContent ) {
 			return originalContent;
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
For some reason the object returned by `getEditedEntityRecord` sometimes contain an empty `content` property. To make sure we always have something returned, we fallback to the original content. 

This should improve the consistency of the tests that are using this function.

## How has this been tested?
1.
Make sure tests are passing

2.
Apply https://github.com/WordPress/gutenberg/pull/30804 and make sure tests are passing.

## Types of changes
Improve E2E tests consistency
 
## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
