### PR TITLE
Block editor: scroll selected block only if it has no focus

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -448,6 +448,8 @@ _Related_
 
 <a name="MultiSelectScrollIntoView" href="#MultiSelectScrollIntoView">#</a> **MultiSelectScrollIntoView**
 
+> **Deprecated** 
+
 Scrolls the multi block selection end into view if not in view already. This
 is important to do after selection by keyboard.
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -19,7 +19,6 @@ import useBlockDropZone from '../use-block-drop-zone';
 import useInsertionPoint from './insertion-point';
 import BlockPopover from './block-popover';
 import { store as blockEditorStore } from '../../store';
-import { useScrollSelectionIntoView } from '../selection-scroll-into-view';
 import { usePreParsePatterns } from '../../utils/pre-parse-patterns';
 import { LayoutProvider, defaultLayout } from './layout';
 
@@ -30,7 +29,6 @@ export default function BlockList( { className, __experimentalLayout } ) {
 	const ref = useRef();
 	const [ blockNodes, setBlockNodes ] = useState( {} );
 	const insertionPoint = useInsertionPoint( ref );
-	useScrollSelectionIntoView( ref );
 	usePreParsePatterns();
 
 	const isLargeViewport = useViewportMatch( 'medium' );

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -29,6 +29,7 @@ import { useBlockMovingModeClassNames } from './use-block-moving-mode-class-name
 import { useEventHandlers } from './use-event-handlers';
 import { useNavModeExit } from './use-nav-mode-exit';
 import { useBlockNodes } from './use-block-nodes';
+import { useScrollIntoView } from './use-scroll-into-view';
 import { store as blockEditorStore } from '../../../store';
 
 /**
@@ -102,6 +103,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const mergedRefs = useMergeRefs( [
 		props.ref,
 		useFocusFirstElement( clientId ),
+		// Must happen after focus because we check for focus in the block.
+		useScrollIntoView( clientId ),
 		useBlockNodes( clientId ),
 		useEventHandlers( clientId ),
 		useNavModeExit( clientId ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import scrollIntoView from 'dom-scroll-into-view';
+
+/**
+ * WordPress dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { getScrollContainer } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+export function useScrollIntoView( clientId ) {
+	const ref = useRef();
+	const isSelectionEnd = useSelect(
+		( select ) => {
+			const { isBlockSelected, getBlockSelectionEnd } = select(
+				blockEditorStore
+			);
+
+			return (
+				isBlockSelected( clientId ) ||
+				getBlockSelectionEnd() === clientId
+			);
+		},
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		if ( ! isSelectionEnd ) {
+			return;
+		}
+
+		const extentNode = ref.current;
+
+		// If the block is focused, the browser will already have scrolled into
+		// view if necessary.
+		if ( extentNode.contains( extentNode.ownerDocument.activeElement ) ) {
+			return;
+		}
+
+		const scrollContainer = getScrollContainer( extentNode );
+
+		// If there's no scroll container, it follows that there's no scrollbar
+		// and thus there's no need to try to scroll into view.
+		if ( ! scrollContainer ) {
+			return;
+		}
+
+		scrollIntoView( extentNode, scrollContainer, {
+			onlyScrollIfNeeded: true,
+		} );
+	}, [ isSelectionEnd ] );
+
+	return ref;
+}

--- a/packages/block-editor/src/components/selection-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/selection-scroll-into-view/index.js
@@ -1,70 +1,17 @@
 /**
- * External dependencies
- */
-import scrollIntoView from 'dom-scroll-into-view';
-
-/**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { getScrollContainer } from '@wordpress/dom';
-
-/**
- * Internal dependencies
- */
-import { getBlockDOMNode } from '../../utils/dom';
-import { store as blockEditorStore } from '../../store';
-
-export function useScrollSelectionIntoView( ref ) {
-	// Although selectionRootClientId isn't used directly in calculating
-	// whether scrolling should occur, it is used as a dependency of the
-	// effect to take into account situations where a block might be moved
-	// to a different parent. In this situation, the selectionEnd clientId
-	// remains the same, so the rootClientId is used to trigger the effect.
-	const { selectionRootClientId, selectionEnd } = useSelect( ( select ) => {
-		const selectors = select( blockEditorStore );
-		const selectionEndClientId = selectors.getBlockSelectionEnd();
-		return {
-			selectionEnd: selectionEndClientId,
-			selectionRootClientId: selectors.getBlockRootClientId(
-				selectionEndClientId
-			),
-		};
-	}, [] );
-
-	useEffect( () => {
-		if ( ! selectionEnd ) {
-			return;
-		}
-
-		const { ownerDocument } = ref.current;
-		const extentNode = getBlockDOMNode( selectionEnd, ownerDocument );
-
-		if ( ! extentNode ) {
-			return;
-		}
-
-		const scrollContainer = getScrollContainer( extentNode );
-
-		// If there's no scroll container, it follows that there's no scrollbar
-		// and thus there's no need to try to scroll into view.
-		if ( ! scrollContainer ) {
-			return;
-		}
-
-		scrollIntoView( extentNode, scrollContainer, {
-			onlyScrollIfNeeded: true,
-		} );
-	}, [ selectionRootClientId, selectionEnd ] );
-}
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Scrolls the multi block selection end into view if not in view already. This
  * is important to do after selection by keyboard.
+ *
+ * @deprecated
  */
 export function MultiSelectScrollIntoView() {
-	const ref = useRef();
-	useScrollSelectionIntoView( ref );
-	return <div ref={ ref } />;
+	deprecated( 'wp.blockEditor.MultiSelectScrollIntoView', {
+		hint: 'This behaviour is now built-in.',
+	} );
+	return null;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Introduced by #28191.
Fixes #20764.

Currently, when you select any block that is even slightly out of view, the page will be automatically scroll the block so that the top of the block is visible.

This can be very disorientating especially when dealing with large blocks.

For example: clicking at the bottom of a large cover block would scroll the top into view and the bottom out of view.

Generally, we should not be scrolling the page at all when a block is selected by the user.

This PR only allows scrolling only if the focus is not within the block (and thus not selected by the user directly).

I moved this behaviour to the block component so that we no longer need `getBlockDOMNode`.

## How has this been tested?

* Click around the demo page with some blocks partly out of view. The page shouldn't scroll.
* Select a block and scroll it out of view. Open the global inserter and insert a block. The inserted block should scroll into view.
* Multi-select by Shift+ArrowKey and the extent of the selection should stay in view.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
