### PR TITLE
Template part block - fix PHP notice for placeholder block.

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -19,12 +19,7 @@ function render_block_core_template_part( $attributes ) {
 	$content          = null;
 	$area             = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 
-	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
-		$template_part_id = $attributes['postId'];
-		// If we have a post ID and the post exists, which means this template part
-		// is user-customized, render the corresponding post content.
-		$content = get_post( $attributes['postId'] )->post_content;
-	} elseif (
+	if (
 		isset( $attributes['slug'] ) &&
 		isset( $attributes['theme'] ) &&
 		wp_get_theme()->get_stylesheet() === $attributes['theme']
@@ -66,6 +61,10 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	if ( is_null( $content ) && is_user_logged_in() ) {
+		if ( ! isset( $attributes['slug'] ) ) {
+			// If there is no slug this is a placeholder and we dont want to return any message.
+			return;
+		}
 		return sprintf(
 			/* translators: %s: Template part slug. */
 			__( 'Template part has been deleted or is unavailable: %s' ),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
When we attempt to load a post containing a template part block placeholder block a php notice is present:

![Screen Shot 2021-04-16 at 6 49 13 PM](https://user-images.githubusercontent.com/28742426/115091581-def17e80-9ee5-11eb-98d7-159ab8fe18d3.png)

Or on the front-end:

![Screen Shot 2021-04-16 at 6 54 02 PM](https://user-images.githubusercontent.com/28742426/115091603-edd83100-9ee5-11eb-8d13-14979ab22bce.png)

This is because when no content for the template part is resolved, a message is printed to notify the user using `sprintf` to attach the `slug` attribute of the template part to the message:

![Screen Shot 2021-04-16 at 6 53 43 PM](https://user-images.githubusercontent.com/28742426/115091669-2546dd80-9ee6-11eb-8130-57e61b81f6aa.png)

Since a template part placeholder block has no `slug` attribute, this also causes `sprintf` to throw the php notice.  However, we should not be showing this message if no `slug` attribute is present since absence of this attribute indicates a placeholder which by definition there should be no corresponding content found.

In this PR we return nothing in the case of the placeholder, since no content is expected and no error message is required.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Add a template part placeholder block to the post editor (this can be done by selecting 'template part' in the block inserter).
* Save the post.
* preview the post on the front-end.
* verify there is no longer a visible php notice or corresponding message where the template part should be.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
