### PR TITLE
Documentation: Improve semantics in the block-based theme guide

### DIFF
--- a/docs/how-to-guides/block-based-theme/README.md
+++ b/docs/how-to-guides/block-based-theme/README.md
@@ -172,7 +172,7 @@ Inside the block-templates folder, create an `index.html` file.
 
 In `index.html`, include the template parts by adding two HTML comments.
 
-The HTML comments starts with `wp:template-part` which is the name of the template-part block type. Inside the curly brackets are two keys and their values: The slug of the template part, and the theme name.
+The HTML comments starts with `wp:template-part` which is the name of the template-part block type. Inside the curly brackets are two keys and their values: The slug of the template part, and the theme text domain.
 
 ```
 <!-- wp:template-part {"slug":"header","theme":"myfirsttheme"} /-->

--- a/docs/how-to-guides/block-based-theme/README.md
+++ b/docs/how-to-guides/block-based-theme/README.md
@@ -180,7 +180,7 @@ The HTML comments starts with `wp:template-part` which is the name of the templa
 <!-- wp:template-part {"slug":"footer","theme":"myfirsttheme"} /-->
 ```
 
-If you used a different theme name, adjust the value for the theme key.
+If you used a different theme name, adjust the value for the theme text domain.
 
 Eventually, you will be able to create and combine templates and template parts directly in the site editor.
 


### PR DESCRIPTION
## Description
Changed "theme name" to "theme text domain". "Theme name" suggest the actual theme name with spaces and caps as defined in the style.css file example on line 66: `Theme Name: My first theme`.
In the given example, the "theme text domain" is actually used. Therefore to avoid any confusion it should be changed to "theme text domain", as per line 78: `Text Domain: myfirsttheme`.

## How has this been tested?
Purely a semantics update. For better understanding and consistency.

## Types of changes
Semantics update.

## Checklist:
Not applicable.
