### PR TITLE
Docs: Add fix to suggested prefixes of branch

### DIFF
--- a/docs/contributors/code/git-workflow.md
+++ b/docs/contributors/code/git-workflow.md
@@ -83,6 +83,7 @@ Suggested prefixes:
 -   `try/` = experimental feature, "tentatively add"
 -   `update/` = update an existing feature
 -   `remove/` = remove an existing feature
+-   `fix/` = fix an existing issue
 
 For example, `add/gallery-block` means you're working on adding a new gallery block.
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

I'm reading git-workflow of Contributing Guidelines and I find that there aren't suggested prefixes of branch name related to fix an issue. Therefore, I add `fix/` prefixes to the docs

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Documentation