### PR TITLE
Add media uploader capabilities to block-based widget customize screen

### DIFF
--- a/lib/class-wp-sidebar-block-editor-control.php
+++ b/lib/class-wp-sidebar-block-editor-control.php
@@ -22,6 +22,24 @@ class WP_Sidebar_Block_Editor_Control extends WP_Customize_Control {
 	 * Enqueue the scripts and styles.
 	 */
 	public function enqueue() {
+		$settings = array_merge(
+			gutenberg_get_common_block_editor_settings(),
+			gutenberg_get_legacy_widget_settings()
+		);
+
+		// This purposefully does not rely on apply_filters( 'block_editor_settings', $settings, null );
+		// Applying that filter would bring over multitude of features from the post editor, some of which
+		// may be undesirable. Instead of using that filter, we simply pick just the settings that are needed.
+		$settings = gutenberg_experimental_global_styles_settings( $settings );
+		$settings = gutenberg_extend_block_editor_styles( $settings );
+
+		gutenberg_initialize_editor(
+			'widgets_customizer',
+			'customize-widgets',
+			array(
+				'editor_settings' => $settings,
+			)
+		);
 		wp_enqueue_script( 'wp-customize-widgets' );
 		wp_enqueue_style( 'wp-customize-widgets' );
 		wp_enqueue_script( 'wp-format-library' );

--- a/lib/class-wp-sidebar-block-editor-control.php
+++ b/lib/class-wp-sidebar-block-editor-control.php
@@ -19,34 +19,6 @@ class WP_Sidebar_Block_Editor_Control extends WP_Customize_Control {
 	public $type = 'sidebar_block_editor';
 
 	/**
-	 * Enqueue the scripts and styles.
-	 */
-	public function enqueue() {
-		$settings = array_merge(
-			gutenberg_get_common_block_editor_settings(),
-			gutenberg_get_legacy_widget_settings()
-		);
-
-		// This purposefully does not rely on apply_filters( 'block_editor_settings', $settings, null );
-		// Applying that filter would bring over multitude of features from the post editor, some of which
-		// may be undesirable. Instead of using that filter, we simply pick just the settings that are needed.
-		$settings = gutenberg_experimental_global_styles_settings( $settings );
-		$settings = gutenberg_extend_block_editor_styles( $settings );
-
-		gutenberg_initialize_editor(
-			'widgets_customizer',
-			'customize-widgets',
-			array(
-				'editor_settings' => $settings,
-			)
-		);
-		wp_enqueue_script( 'wp-customize-widgets' );
-		wp_enqueue_style( 'wp-customize-widgets' );
-		wp_enqueue_script( 'wp-format-library' );
-		wp_enqueue_style( 'wp-format-library' );
-	}
-
-	/**
 	 * Render the widgets block editor container.
 	 */
 	public function render_content() {

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -111,7 +111,7 @@ function gutenberg_widgets_customize_add_unstable_instance( $args, $id ) {
  */
 function gutenberg_customize_widgets_init() {
 	$settings = array_merge(
-		gutenberg_get_common_block_editor_settings(),
+		gutenberg_get_default_block_editor_settings(),
 		gutenberg_get_legacy_widget_settings()
 	);
 

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -106,7 +106,36 @@ function gutenberg_widgets_customize_add_unstable_instance( $args, $id ) {
 	return $args;
 }
 
+/**
+ * Initialize the Gutenberg customize widgets page.
+ */
+function gutenberg_customize_widgets_init() {
+	$settings = array_merge(
+		gutenberg_get_common_block_editor_settings(),
+		gutenberg_get_legacy_widget_settings()
+	);
+
+	// This purposefully does not rely on apply_filters( 'block_editor_settings', $settings, null );
+	// Applying that filter would bring over multitude of features from the post editor, some of which
+	// may be undesirable. Instead of using that filter, we simply pick just the settings that are needed.
+	$settings = gutenberg_experimental_global_styles_settings( $settings );
+	$settings = gutenberg_extend_block_editor_styles( $settings );
+
+	gutenberg_initialize_editor(
+		'widgets_customizer',
+		'customize-widgets',
+		array(
+			'editor_settings' => $settings,
+		)
+	);
+	wp_enqueue_script( 'wp-customize-widgets' );
+	wp_enqueue_style( 'wp-customize-widgets' );
+	wp_enqueue_script( 'wp-format-library' );
+	wp_enqueue_style( 'wp-format-library' );
+}
+
 if ( gutenberg_is_experiment_enabled( 'gutenberg-widgets-in-customizer' ) ) {
 	add_action( 'customize_register', 'gutenberg_widgets_customize_register' );
 	add_filter( 'widget_customizer_setting_args', 'gutenberg_widgets_customize_add_unstable_instance', 10, 2 );
+	add_action( 'customize_controls_enqueue_scripts', 'gutenberg_customize_widgets_init' );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13485,6 +13485,7 @@
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
@@ -13493,6 +13494,7 @@
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
+				"@wordpress/media-utils": "file:packages/media-utils",
 				"classnames": "^2.2.6",
 				"lodash": "^4.17.19"
 			},

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -28,6 +28,7 @@
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
@@ -36,6 +37,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/media-utils": "file:../media-utils",
 		"classnames": "^2.2.6",
 		"lodash": "^4.17.19"
 	},

--- a/packages/customize-widgets/src/controls/sidebar-control.js
+++ b/packages/customize-widgets/src/controls/sidebar-control.js
@@ -12,7 +12,7 @@ import getInserterOuterSection from './inserter-outer-section';
 
 const getInserterId = ( controlId ) => `widgets-inserter-${ controlId }`;
 
-export default function getSidebarControl() {
+export default function getSidebarControl( blockEditorSettings ) {
 	const {
 		wp: { customize },
 	} = window;
@@ -46,6 +46,7 @@ export default function getSidebarControl() {
 			if ( this.sectionInstance.expanded() ) {
 				render(
 					<SidebarBlockEditor
+						blockEditorSettings={ blockEditorSettings }
 						sidebar={
 							new SidebarAdapter( this.setting, customize )
 						}

--- a/packages/customize-widgets/src/filters/index.js
+++ b/packages/customize-widgets/src/filters/index.js
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 import './move-to-sidebar';
+import './replace-media-upload';

--- a/packages/customize-widgets/src/filters/replace-media-upload.js
+++ b/packages/customize-widgets/src/filters/replace-media-upload.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { MediaUpload } from '@wordpress/media-utils';
+
+const replaceMediaUpload = () => MediaUpload;
+
+addFilter(
+	'editor.MediaUpload',
+	'core/edit-widgets/replace-media-upload',
+	replaceMediaUpload
+);

--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -18,8 +18,11 @@ const { wp } = window;
 
 /**
  * Initializes the widgets block editor in the customizer.
+ *
+ * @param {string} editorName          The editor name.
+ * @param {Object} blockEditorSettings Block editor settings.
  */
-export function initialize() {
+export function initialize( editorName, blockEditorSettings ) {
 	const coreBlocks = __experimentalGetCoreBlocks().filter(
 		( block ) => ! [ 'core/more' ].includes( block.name )
 	);
@@ -32,7 +35,7 @@ export function initialize() {
 	}
 
 	wp.customize.sectionConstructor.sidebar = getSidebarSection();
-	wp.customize.controlConstructor.sidebar_block_editor = getSidebarControl();
+	wp.customize.controlConstructor.sidebar_block_editor = getSidebarControl(
+		blockEditorSettings
+	);
 }
-
-wp.domReady( initialize );


### PR DESCRIPTION
## Description
Previously in the block-based widget customizer, users could only link to external media in media based blocks (image, video).

This adds the media uploader functionality in. It's mostly copy/pasta, but required a few changes across the editor.

Changes:
- Move script enqueuing/initializing of the editor out of the `WP_Sidebar_Block_Editor_Control` class. This class is instantiated once per sidebar, but we only want to enqueue and initialize block editor client-side code once.
- Use the standard `gutenberg_initialize_editor` function for the widget customizer.
- Pass block editor settings from the server to the client, through to the BlockEditorProvider. This is required for the `allowedMimeTypes` used by the media uploader.
- Use the replace-media-upload filter to implement the media uploader.

## How has this been tested?
1. Enable the block-based widget customizer experiment
2. Add an image block to a widget area in the customizer
3. Use the media library.

## Screenshots <!-- if applicable -->
![media-upload](https://user-images.githubusercontent.com/677833/115205731-70eac880-a12c-11eb-9727-6c8f8836f773.gif)

## Types of changes
New feature
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
