### PR TITLE
Block Editor: Bring back imageDefaultSize shim for WP 5.7

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -8,11 +8,20 @@
 /**
  * Extends the block editor with settings that are only in the plugin.
  *
+ * This is a temporary solution until the Gutenberg plugin sets
+ * the required WordPress version to 5.8.
+ *
+ * @see https://core.trac.wordpress.org/ticket/52920
+ *
  * @param array $settings Existing editor settings.
  *
  * @return array Filtered settings.
  */
 function gutenberg_extend_post_editor_settings( $settings ) {
+	$image_default_size = get_option( 'image_default_size', 'large' );
+	$image_sizes        = wp_list_pluck( $settings['imageSizes'], 'slug' );
+
+	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_supports_block_templates();
 
 	return $settings;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Quick follow-u for  #30245.

I have just realized that I shouldn't remove the `imageDefaultSize` setting override in `block_editor_setting` filter. It's still necessary for WordPress 5.6 and 5.7 to use with the post editor that we applied earlier and wasn't backported to earlier versions of WordPress.

