### PR TITLE
Fix nav editor links to correctly persist new tab target attribute

### DIFF
--- a/packages/edit-navigation/src/constants/index.js
+++ b/packages/edit-navigation/src/constants/index.js
@@ -39,3 +39,11 @@ export const COMPLEMENTARY_AREA_SCOPE = 'core/edit-navigation';
  * @type {string}
  */
 export const COMPLEMENTARY_AREA_ID = 'edit-navigation/block-inspector';
+
+/**
+ * The string identifier for the menu item's "target" attribute indicating
+ * the menu item link should open in a new tab.
+ *
+ * @type {string}
+ */
+export const NEW_TAB_TARGET_ATTRIBUTE = '_blank';

--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -147,6 +147,7 @@ function convertMenuItemToBlock( menuItem, innerBlocks = [] ) {
 		className: menuItem.classes.join( ' ' ),
 		description: menuItem.description,
 		rel: menuItem.xfn.join( ' ' ),
+		opensInNewTab: menuItem.target === '_blank',
 	};
 
 	return createBlock( 'core/navigation-link', attributes, innerBlocks );

--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -152,7 +152,9 @@ function convertMenuItemToBlock( menuItem, innerBlocks = [] ) {
 		className: menuItem.classes.join( ' ' ),
 		description: menuItem.description,
 		rel: menuItem.xfn.join( ' ' ),
-		opensInNewTab: menuItem.target === NEW_TAB_TARGET_ATTRIBUTE,
+		...( menuItem.target === NEW_TAB_TARGET_ATTRIBUTE && {
+			opensInNewTab: true,
+		} ),
 	};
 
 	return createBlock( 'core/navigation-link', attributes, innerBlocks );

--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -11,7 +11,12 @@ import { parse, createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { NAVIGATION_POST_KIND, NAVIGATION_POST_POST_TYPE } from '../constants';
+import {
+	NAVIGATION_POST_KIND,
+	NAVIGATION_POST_POST_TYPE,
+	NEW_TAB_TARGET_ATTRIBUTE,
+} from '../constants';
+
 import { resolveMenuItems, dispatch } from './controls';
 import { buildNavigationPostId } from './utils';
 
@@ -147,7 +152,7 @@ function convertMenuItemToBlock( menuItem, innerBlocks = [] ) {
 		className: menuItem.classes.join( ' ' ),
 		description: menuItem.description,
 		rel: menuItem.xfn.join( ' ' ),
-		opensInNewTab: menuItem.target === '_blank',
+		opensInNewTab: menuItem.target === NEW_TAB_TARGET_ATTRIBUTE,
 	};
 
 	return createBlock( 'core/navigation-link', attributes, innerBlocks );

--- a/packages/edit-navigation/src/store/test/resolvers.js
+++ b/packages/edit-navigation/src/store/test/resolvers.js
@@ -106,6 +106,7 @@ describe( 'getNavigationPostForMenu', () => {
 				xfn: [],
 				description: '',
 				attr_title: '',
+				target: '_blank',
 			},
 		];
 
@@ -151,6 +152,7 @@ describe( 'getNavigationPostForMenu', () => {
 								rel: '',
 								description: '',
 								title: '',
+								opensInNewTab: true,
 							},
 							clientId: 'client-id-1',
 							innerBlocks: [],

--- a/packages/edit-navigation/src/store/test/utils.js
+++ b/packages/edit-navigation/src/store/test/utils.js
@@ -227,7 +227,7 @@ describe( 'computeCustomizedAttribute', () => {
 			{
 				attributes: {
 					label: 'wp.com',
-					opensInNewTab: false,
+					opensInNewTab: true,
 					url: 'http://wp.com',
 					className: '',
 					rel: '',
@@ -287,6 +287,7 @@ describe( 'computeCustomizedAttribute', () => {
 				type: 'custom',
 				url: 'http://wp.org',
 				xfn: [ 'external' ],
+				target: '',
 			},
 			'nav_menu_item[101]': {
 				_invalid: false,
@@ -302,6 +303,7 @@ describe( 'computeCustomizedAttribute', () => {
 				type: 'custom',
 				url: 'http://wp.com',
 				xfn: [ '' ],
+				target: '_blank',
 			},
 		} );
 	} );

--- a/packages/edit-navigation/src/store/utils.js
+++ b/packages/edit-navigation/src/store/utils.js
@@ -17,6 +17,8 @@ import {
 	isProcessingPost,
 } from './controls';
 
+import { NEW_TAB_TARGET_ATTRIBUTE } from '../constants';
+
 /**
  * Builds an ID for a new navigation post.
  *
@@ -144,7 +146,9 @@ export function computeCustomizedAttribute(
 				xfn: block.attributes.rel?.split( ' ' ),
 				classes: block.attributes.className?.split( ' ' ),
 				attr_title: block.attributes.title,
-				target: block.attributes.opensInNewTab ? '_blank' : '',
+				target: block.attributes.opensInNewTab
+					? NEW_TAB_TARGET_ATTRIBUTE
+					: '',
 			};
 		} else {
 			attributes = {

--- a/packages/edit-navigation/src/store/utils.js
+++ b/packages/edit-navigation/src/store/utils.js
@@ -144,6 +144,7 @@ export function computeCustomizedAttribute(
 				xfn: block.attributes.rel?.split( ' ' ),
 				classes: block.attributes.className?.split( ' ' ),
 				attr_title: block.attributes.title,
+				target: block.attributes.opensInNewTab ? '_blank' : '',
 			};
 		} else {
 			attributes = {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes https://github.com/WordPress/gutenberg/issues/30323.

Currently within the Navigation Editor the feature to cause a nav link to _"Open in new tab"_ does not work. 

Whilst it is possible to toggle the control and have the state persist within the _editor_, if you reload the editor the setting state is not persisted (ie: it is always "off").

The reason for this is that that the `settings` property on the underlying `<LinkControl>` component is called `opensInNewTab` whereas the menuItem data (when stored in the database) expects a `target` property with a string value of `_blank`. This mismatch has not been accounted for when translating `core/navigation-link` blocks into the equivalent menu item to be persisted into the database. 

This PR updates things so that 

* when the block is translated into the database format it sets the `target` attribute to `_blank` if the block has `opensInNewTab` set to `true`.
* when the menu item from the database is converted into a block the `opensInNewTab` property is set based on the presence of the string `_blank` as the value of the menu item's `target` property.

🙏 Note: I'd appreciate a confidence check that the value `_blank` is the correct string value as used on the old WordPress menu page.


## How has this been tested?

1. Manually.
2. Automated tests.

### Manual Testing

In the Navigation Editor (experimental):

* Create a new menu and add a single nav item with a link.
* Toggle the `Opens in new tab` to "on".
* Save the menu.
* Reload the editor.
* Click on the menu item you added and check the `Opens in new tab` setting is still set to "on".
* Now, toggle the `Opens in new tab` setting to "off".
* Save the menu.
* Reload the editor.
* Click on the menu item you added and check the `Opens in new tab` setting is still set to "off".

Note is is important to check that you can toggle this setting on and off. Also repeat for multiple nav items within a menu and using different link types.

### Automated Tests

Run `npm run test-unit packages/edit-navigation/src/store/test/`. See all ✅ .

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/115224742-26098a80-a105-11eb-8c25-53989dfc2dcd.mov



## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
