### PR TITLE
[RNMobile] Add improvements to Reusable block

### DIFF
--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -50,6 +50,8 @@ export { default as Caption } from './caption';
 export { default as PanelColorSettings } from './panel-color-settings';
 export { default as __experimentalPanelColorGradientSettings } from './colors-gradients/panel-color-gradient-settings';
 export { default as __experimentalUseEditorFeature } from './use-editor-feature';
+export { default as __experimentalUseNoRecursiveRenders } from './use-no-recursive-renders';
+export { default as Warning } from './warning';
 
 export {
 	BottomSheetSettings,

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -13,14 +13,18 @@ import {
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
+import {
+	useEntityBlockEditor,
+	useEntityProp,
+	store as coreStore,
+} from '@wordpress/core-data';
 import { BottomSheet, Icon, Disabled } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
-	BlockEditorProvider,
-	BlockList,
-	store as blockEditorStore,
+	__experimentalUseNoRecursiveRenders as useNoRecursiveRenders,
+	InnerBlocks,
+	Warning,
 } from '@wordpress/block-editor';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { help } from '@wordpress/icons';
@@ -37,7 +41,9 @@ export default function ReusableBlockEdit( {
 	clientId,
 	isSelected,
 } ) {
-	const recordArgs = [ 'postType', 'wp_block', ref ];
+	const [ hasAlreadyRendered, RecursionProvider ] = useNoRecursiveRenders(
+		ref
+	);
 
 	const [ showHelp, setShowHelp ] = useState( false );
 	const infoTextStyle = usePreferredColorSchemeStyle(
@@ -57,30 +63,26 @@ export default function ReusableBlockEdit( {
 		styles.spinnerDark
 	);
 
-	const { reusableBlock, hasResolved, isEditing, settings } = useSelect(
+	const { hasResolved, isEditing, isMissing } = useSelect(
 		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-
+			const persistedBlock = select( coreStore ).getEntityRecord(
+				'postType',
+				'wp_block',
+				ref
+			);
+			const hasResolvedBlock = select(
+				coreStore
+			).hasFinishedResolution( 'getEntityRecord', [
+				'postType',
+				'wp_block',
+				ref,
+			] );
 			return {
-				reusableBlock: select( coreStore ).getEditedEntityRecord(
-					...recordArgs
-				),
-				hasResolved: select( coreStore ).hasFinishedResolution(
-					'getEditedEntityRecord',
-					recordArgs
-				),
-				isSaving: select( coreStore ).isSavingEntityRecord(
-					...recordArgs
-				),
-				canUserUpdate: select( coreStore ).canUser(
-					'update',
-					'blocks',
-					ref
-				),
+				hasResolved: hasResolvedBlock,
 				isEditing: select(
 					reusableBlocksStore
 				).__experimentalIsEditingReusableBlock( clientId ),
-				settings: getSettings(),
+				isMissing: hasResolvedBlock && ! persistedBlock,
 			};
 		},
 		[ ref, clientId ]
@@ -91,6 +93,8 @@ export default function ReusableBlockEdit( {
 		'wp_block',
 		{ id: ref }
 	);
+
+	const [ title ] = useEntityProp( 'postType', 'wp_block', 'title', ref );
 
 	function openSheet() {
 		setShowHelp( true );
@@ -128,6 +132,22 @@ export default function ReusableBlockEdit( {
 		);
 	}
 
+	if ( hasAlreadyRendered ) {
+		return (
+			<Warning
+				message={ __( 'Block cannot be rendered inside itself.' ) }
+			/>
+		);
+	}
+
+	if ( isMissing ) {
+		return (
+			<Warning
+				message={ __( 'Block has been deleted or is unavailable.' ) }
+			/>
+		);
+	}
+
 	if ( ! hasResolved ) {
 		return (
 			<View style={ spinnerStyle }>
@@ -136,22 +156,12 @@ export default function ReusableBlockEdit( {
 		);
 	}
 
-	if ( ! reusableBlock ) {
-		return (
-			<Text>{ __( 'Block has been deleted or is unavailable.' ) }</Text>
-		);
-	}
-
-	const { title } = reusableBlock;
 	let element = (
-		<BlockEditorProvider
-			settings={ settings }
+		<InnerBlocks
 			value={ blocks }
 			onChange={ onChange }
 			onInput={ onInput }
-		>
-			<BlockList withFooter={ false } marginHorizontal={ 0 } />
-		</BlockEditorProvider>
+		/>
 	);
 
 	if ( ! isEditing ) {
@@ -159,18 +169,20 @@ export default function ReusableBlockEdit( {
 	}
 
 	return (
-		<TouchableWithoutFeedback
-			disabled={ ! isSelected }
-			accessibilityLabel={ __( 'Help button' ) }
-			accessibilityRole={ 'button' }
-			accessibilityHint={ __( 'Tap here to show help' ) }
-			onPress={ openSheet }
-		>
-			<View>
-				{ isSelected && <EditTitle title={ title } /> }
-				{ element }
-				{ renderSheet() }
-			</View>
-		</TouchableWithoutFeedback>
+		<RecursionProvider>
+			<TouchableWithoutFeedback
+				disabled={ ! isSelected }
+				accessibilityLabel={ __( 'Help button' ) }
+				accessibilityRole={ 'button' }
+				accessibilityHint={ __( 'Tap here to show help' ) }
+				onPress={ openSheet }
+			>
+				<View>
+					{ isSelected && <EditTitle title={ title } /> }
+					{ element }
+					{ renderSheet() }
+				</View>
+			</TouchableWithoutFeedback>
+		</RecursionProvider>
 	);
 }

--- a/packages/block-library/src/block/editor.native.scss
+++ b/packages/block-library/src/block/editor.native.scss
@@ -1,7 +1,7 @@
 .titleContainer {
 	flex-direction: row;
 	align-items: center;
-	padding-bottom: 12;
+	padding-bottom: 28;
 }
 
 .title {
@@ -21,7 +21,7 @@
 	position: absolute;
 	left: -$block-selected-to-content + $block-selected-border-width;
 	right: -$block-selected-to-content + $block-selected-border-width;
-	bottom: 0;
+	bottom: 16;
 }
 
 .separatorDark {


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3391

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR introduces the following improvements on the Reusable block:
- Content is now rendered via the `InnerBlock` component
- Handle the case when a deleted reusable block is referenced in the content
- Handle the case when the same reusable block is referenced in the content

**NOTE:** Reusable block is only available in development mode.

### Minor bugs identified during testing
#### Block's title is not displayed in the floating toolbar

For some reason I haven't found out yet, the floating toolbar only fetches the block's title from [the initial blocks request that only gets 10 items](https://github.com/WordPress/gutenberg/blob/fe379134644e6a8b43a220d1d6e956def9b5295e/packages/editor/src/components/provider/use-block-editor-settings.js#L44-L51). If the selected reusable block is not included in that list, the block's title is not displayed but shows Reusable block.

I'd like to investigate this issue further, the content of the reusable block is fetched when it is mounted so in theory the title should be updated too in the state and therefore accessible by the floating toolbar. Since it's a minor issue, I think it shouldn't block this PR.

<details><summary>Screenshot</summary>

<img width="469" alt="Screenshot 2021-04-19 at 16 33 56" src="https://user-images.githubusercontent.com/14905380/115253922-29187100-a12d-11eb-9a50-069315cb6ceb.png">

</details>

#### Reusable block's data is cached for 10 minutes on Android

I realised that on Android the network requests from React native are cached by default for 10 minutes. For now this is only affecting the media items because it's the only data that is requested from React native, I haven't found any major issue regarding this although I haven't explored deeply. However for the reusable blocks this behaviour could be a problem because the content is modified often.

Here are the references to the code:
- [Cache enabled by default](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/341cc38bd50aee47f5c4d46dccef8dcd96261f6a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt#L60)
- [Default cache lifetime](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java#L36)

My idea is to solve this issue in a separate PR but it shouldn't block this PR.

**EDIT:** This issue is addressed in this [PR](https://github.com/WordPress/gutenberg/pull/31186).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**NOTE: Reusable blocks can be managed by navigating to the "Reusable blocks page":**
- WP.com: `https://wordpress.com/types/wp_block/<YOUR_WPCOM_SITE_DOMAIN>`
- Self-hosted: `https://<YOUR_SELF_HOSTED_SITE_DOMAIN>/wp-admin/edit.php?post_type=wp_block`

Here are the steps for creating reusable blocks in the web version:

**Option 1:**
1. Edit a post/page
2. Add some blocks
3. Select multiple blocks
4. Click on options (three dots button)
5. Click on "Add to Reusable blocks" button
6. Input a name for the block
7. Save the post/page

**Option 2:**
1. Navigate to "Reusable blocks page" (referenced above)
2. Click on "Add new reusable block"/"Add new" button
3. Add a title
4. Add some blocks
5. Publish it

### Preview content
1. Create a reusable block and add it to a post/page
2. Edit the post/page in the mobile app
3. Observe that the reusable block is shown
4. Tap on it and observe that the title of the reusable blocks is shown

### Deleted reusable block
1. Create two reusable blocks
2. Add the second reusable block as part of the content of the first one and save it
3. Delete the second reusable block from the "Reusable blocks page" (referenced above)
4. The second reusable block will go to the trashed tab, delete it permanently
5. Add the first reusable block to a post/page
6. Edit the post/page in the mobile app
7. Observe that the reusable block is shown and that no errors are displayed
8. Observe that the second reusable block is not rendered but displays a warning

### Recursive block rendering
1. Create a reusable block
2. Edit the reusable block, add the same reusable block as part of the content and save it
3. Add the reusable block to a post/page
4. Edit the post/page in the mobile app
5. Observe that the reusable block is shown and that no errors are displayed
6. Observe that it displays a warning instead of rendering multiple times the same block

## Screenshots <!-- if applicable -->

<details><summary>Preview content</summary>

https://user-images.githubusercontent.com/14905380/115435166-d791e400-a209-11eb-8f06-ca7814189946.mp4

</details>

<details><summary>Deleted reusable block</summary>

https://user-images.githubusercontent.com/14905380/115435635-5424c280-a20a-11eb-91df-a0ded0cdc4ab.mp4

</details>

<details><summary>Recursive block rendering</summary>

https://user-images.githubusercontent.com/14905380/115435823-8afad880-a20a-11eb-8683-c8b1548b9880.mp4

</details>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
