### PR TITLE
Fix block selection issues in safari by avoiding conditional event handlers

### DIFF
--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -80,9 +80,8 @@ function BlockNavigationDropdown(
 					isEnabled={ isEnabled }
 				/>
 			) }
-			renderContent={ ( { onClose } ) => (
+			renderContent={ () => (
 				<BlockNavigation
-					onSelect={ onClose }
 					__experimentalFeatures={ __experimentalFeatures }
 				/>
 			) }

--- a/packages/e2e-tests/specs/editor/blocks/list.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/list.test.js
@@ -113,6 +113,9 @@ describe( 'List', () => {
 		await clickBlockAppender();
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '* ' );
+		// Not entirely certain why  this timeout is needed.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 1000 );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'Backspace' );


### PR DESCRIPTION
With Async Mode, useSelect calls for non selected blocks are not run synchronously which means the event handlers added conditionally by this hook are not attached on time after a block get deselected. This could potentially impact all browsers when the content of the post grows, it's just more visible in Safari.

**Testing instructions**

 - Insert an image placeholder
 - Click to select it
 - Click outside to unselect and then quickly select it back by clicking on it
 - notice the toolbar should appear (in trunk it doesn't always appear).