### PR TITLE
wp-env: First exploration of a static docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,112 @@
+version: '3.7'
+services:
+    mysql:
+        image: mariadb
+        ports:
+            - '3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: password
+            MYSQL_DATABASE: wordpress
+        volumes:
+            - 'mysql:/var/lib/mysql'
+    tests-mysql:
+        image: mariadb
+        ports:
+            - '3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: password
+            MYSQL_DATABASE: tests-wordpress
+        volumes:
+            - 'mysql-test:/var/lib/mysql'
+    wordpress:
+        build: .
+        depends_on:
+            - mysql
+        image: wordpress
+        ports:
+            - '${WP_ENV_PORT:-8888}:80'
+        environment:
+            WORDPRESS_DB_USER: root
+            WORDPRESS_DB_PASSWORD: password
+            WORDPRESS_DB_NAME: wordpress
+        volumes: &ref_0
+            - >-
+                /Users/ockham/.wp-env/f225b6dcecc0956ba67033945142a55c/WordPress:/var/www/html
+            - >-
+                /Users/ockham/src/gutenberg:/var/www/html/wp-content/plugins/gutenberg
+            - >-
+                /Users/ockham/.wp-env/f225b6dcecc0956ba67033945142a55c/theme-experiments/tt1-blocks:/var/www/html/wp-content/themes/tt1-blocks
+    tests-wordpress:
+        depends_on:
+            - tests-mysql
+        image: wordpress
+        ports:
+            - '${WP_ENV_TESTS_PORT:-8889}:80'
+        environment:
+            WORDPRESS_DB_USER: root
+            WORDPRESS_DB_PASSWORD: password
+            WORDPRESS_DB_NAME: tests-wordpress
+            WORDPRESS_DB_HOST: tests-mysql
+        volumes: &ref_1
+            - >-
+                /Users/ockham/.wp-env/f225b6dcecc0956ba67033945142a55c/tests-WordPress:/var/www/html
+            - >-
+                /Users/ockham/src/gutenberg/packages/e2e-tests/mu-plugins:/var/www/html/wp-content/mu-plugins
+            - >-
+                /Users/ockham/src/gutenberg/packages/e2e-tests/plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
+            - >-
+                /Users/ockham/src/gutenberg:/var/www/html/wp-content/plugins/gutenberg
+            - >-
+                /Users/ockham/.wp-env/f225b6dcecc0956ba67033945142a55c/theme-experiments/tt1-blocks:/var/www/html/wp-content/themes/tt1-blocks
+    cli:
+        depends_on:
+            - wordpress
+        image: 'wordpress:cli'
+        volumes: *ref_0
+        user: '33:33'
+        environment:
+            WORDPRESS_DB_USER: root
+            WORDPRESS_DB_PASSWORD: password
+            WORDPRESS_DB_NAME: wordpress
+    tests-cli:
+        depends_on:
+            - tests-wordpress
+        image: 'wordpress:cli'
+        volumes: *ref_1
+        user: '33:33'
+        environment:
+            WORDPRESS_DB_USER: root
+            WORDPRESS_DB_PASSWORD: password
+            WORDPRESS_DB_NAME: tests-wordpress
+            WORDPRESS_DB_HOST: tests-mysql
+    composer:
+        image: composer
+        volumes:
+            - '/Users/ockham/src/gutenberg:/app'
+    phpunit:
+        image: 'wordpressdevelop/phpunit:latest'
+        depends_on:
+            - tests-wordpress
+        volumes:
+            - >-
+                /Users/ockham/.wp-env/f225b6dcecc0956ba67033945142a55c/tests-WordPress:/var/www/html
+            - >-
+                /Users/ockham/src/gutenberg/packages/e2e-tests/mu-plugins:/var/www/html/wp-content/mu-plugins
+            - >-
+                /Users/ockham/src/gutenberg/packages/e2e-tests/plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
+            - >-
+                /Users/ockham/src/gutenberg:/var/www/html/wp-content/plugins/gutenberg
+            - >-
+                /Users/ockham/.wp-env/f225b6dcecc0956ba67033945142a55c/theme-experiments/tt1-blocks:/var/www/html/wp-content/themes/tt1-blocks
+            - 'phpunit-uploads:/var/www/html/wp-content/uploads'
+        environment:
+            LOCAL_DIR: html
+            WP_PHPUNIT__TESTS_CONFIG: /var/www/html/phpunit-wp-config.php
+            WORDPRESS_DB_USER: root
+            WORDPRESS_DB_PASSWORD: password
+            WORDPRESS_DB_NAME: tests-wordpress
+            WORDPRESS_DB_HOST: tests-mysql
+volumes:
+    mysql: {}
+    mysql-test: {}
+    phpunit-uploads: {}


### PR DESCRIPTION
## Description
Experiment, do not merge. Continues a [conversation](https://github.com/WordPress/gutenberg/issues/28703#issuecomment-816748577) about a potential simplification of the architecture of `wp-env`.

Copied from my own `~/.wp-env/.../docker-compose.yml`, which was generated by `wp-env` based on Gutenberg's [`.wp-env.json`](https://github.com/WordPress/gutenberg/blob/8d630b6caae7a6ad1c85188aaaf227b6904beb15/.wp-env.json).

This PR is a first step, to review each part of the file and what information it needs, and what concerns it relates to. 
To that end, it's important to re-state the goals of this dev environment:

_Have a zero-config environment for developing a given WordPress plugin (or theme), that allows including other 3rd party themes and/or plugins that are needed for development. Furthermore, the environment shouldn't get in the way of the user, if they desire to make a simple change to an underlying tool's configuration._

An early goal is to identify whether it could be broken into e.g.

- a static baseline `docker-compose.yml` that's shipped as part of `wp-env`
- a Gutenberg-specific `docker-compose.override.yml` (that can be generalized for other plugins and themes)
- concerns that cannot be mapped to a static `docker-compose.yml`, but can be potentially tackled at a different level. E.g. dependency and version management of 3rd party themes and plugins.

/cc @noahtallen 
