### PR TITLE
Navigation: add a home link that always points to home_url()

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -91,6 +91,7 @@ import { ViewerFill } from './viewer-slot';
  * @property {Object=}                    suggestionsQuery           Query parameters to pass along to wp.blockEditor.__experimentalFetchLinkSuggestions.
  * @property {boolean=}                   noURLSuggestion            Whether to add a fallback suggestion which treats the search query as a URL.
  * @property {string|Function|undefined}  createSuggestionButtonText The text to use in the button that calls createSuggestion.
+ * @property {boolean}                    allowEditing               Whether a URL is editable in link preview. Defaults to true.
  */
 
 /**
@@ -115,6 +116,7 @@ function LinkControl( {
 	suggestionsQuery = {},
 	noURLSuggestion = false,
 	createSuggestionButtonText,
+	allowEditing = true,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -251,6 +253,7 @@ function LinkControl( {
 				<LinkPreview
 					value={ value }
 					onEditClick={ () => setIsEditingLink( true ) }
+					allowEditing={ allowEditing }
 				/>
 			) }
 

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -15,7 +15,11 @@ import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
  */
 import { ViewerSlot } from './viewer-slot';
 
-export default function LinkPreview( { value, onEditClick } ) {
+export default function LinkPreview( {
+	value,
+	onEditClick,
+	allowEditing = true,
+} ) {
 	const displayURL =
 		( value && filterURLForDisplay( safeDecodeURI( value.url ), 16 ) ) ||
 		'';
@@ -42,13 +46,15 @@ export default function LinkPreview( { value, onEditClick } ) {
 				) }
 			</span>
 
-			<Button
-				isSecondary
-				onClick={ () => onEditClick() }
-				className="block-editor-link-control__search-item-action"
-			>
-				{ __( 'Edit' ) }
-			</Button>
+			{ allowEditing && (
+				<Button
+					isSecondary
+					onClick={ () => onEditClick() }
+					className="block-editor-link-control__search-item-action"
+				>
+					{ __( 'Edit' ) }
+				</Button>
+			) }
 			<ViewerSlot fillProps={ value } />
 		</div>
 	);

--- a/packages/block-library/src/navigation-link/fallback-variations.js
+++ b/packages/block-library/src/navigation-link/fallback-variations.js
@@ -7,6 +7,7 @@ import {
 	page as pageIcon,
 	postTitle as postIcon,
 	tag as tagIcon,
+	home as homeIcon,
 } from '@wordpress/icons';
 
 // FALLBACK: this is only used when the server does not understand the variations property in the
@@ -34,6 +35,18 @@ const fallbackVariations = [
 		title: __( 'Page Link' ),
 		description: __( 'A link to a page.' ),
 		attributes: { type: 'page', kind: 'post-type' },
+	},
+	{
+		name: 'home',
+		icon: homeIcon,
+		title: __( 'Home Link' ),
+		description: __( 'A link back to home.' ),
+		attributes: {
+			type: 'home',
+			url: '/', // make sure a url is provided to avoid editing state, this will get overwritten
+			/* translators: default label for home navigation menu link  */
+			label: __( 'Home' ),
+		},
 	},
 	{
 		name: 'category',

--- a/packages/block-library/src/navigation-link/hooks.js
+++ b/packages/block-library/src/navigation-link/hooks.js
@@ -7,6 +7,7 @@ import {
 	postTitle,
 	tag,
 	customPostType,
+	home,
 } from '@wordpress/icons';
 
 /**
@@ -24,6 +25,8 @@ function getIcon( variationName ) {
 			return tag;
 		case 'category':
 			return category;
+		case 'home':
+			return home;
 		default:
 			return customPostType;
 	}

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -150,7 +150,9 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		'<a class="wp-block-navigation-link__content" ';
 
 	// Start appending HTML attributes to anchor tag.
-	if ( isset( $attributes['url'] ) ) {
+	if ( isset( $attributes['type'] ) && 'home' === $attributes['type'] ) {
+		$html .= ' href="' . esc_url( home_url() ) . '"';
+	} elseif ( isset( $attributes['url'] ) ) {
 		$html .= ' href="' . esc_url( $attributes['url'] ) . '"';
 	}
 
@@ -311,6 +313,18 @@ function register_block_core_navigation_link() {
 			}
 		}
 	}
+	// Home variation.
+	$built_ins[] = array(
+		'name'        => 'home',
+		'title'       => __( 'Home Link' ),
+		'description' => __( 'A link back to home.' ),
+		'attributes'  => array(
+			'type'  => 'home',
+			/* translators: default label for home navigation menu link  */
+			'label' => __( 'Home' ),
+			'url'   => home_url(),
+		),
+	);
 	if ( $taxonomies ) {
 		foreach ( $taxonomies as $taxonomy ) {
 			$variation = build_variation_for_navigation_link( $taxonomy, 'taxonomy' );

--- a/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
+++ b/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
@@ -53,6 +53,25 @@ Object {
     },
     Object {
       "attributes": Object {
+        "label": "Home",
+        "type": "home",
+        "url": "/",
+      },
+      "description": "A link back to home.",
+      "icon": <SVG
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <Path
+          d="M12 4L4 7.9V20h16V7.9L12 4zm6.5 14.5H14V13h-4v5.5H5.5V8.8L12 5.7l6.5 3.1v9.7z"
+        />
+      </SVG>,
+      "isActive": [Function],
+      "name": "home",
+      "title": "Home Link",
+    },
+    Object {
+      "attributes": Object {
         "kind": "taxonomy",
         "type": "category",
       },


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/20542 Alternative to https://github.com/WordPress/gutenberg/pull/30926

This PR adds a new navigation link variations that renders a link, backed by `home_url()`. While editing, this is auto-updated for a user. Note that it's entirely possible for this url value to get out of sync with what home_url(). Two simple examples are:

1. We save a page with the navigation block. We update home_url(). The page is never saved again by the user.
2. Someone modifies the url attribute in code view, classic editor, or in a hook.

**Regardless of how someone may alter block attributes, the render_callback will ignore the url attribute in favor of `home_url()`**. Updating this value in the editor is mainly to give the user a good experience for knowing where home_url currently points to.   

Areas that might need a bit of iteration is the new argument on LinkControl to avoid allowing users to edit a url.

https://user-images.githubusercontent.com/1270189/115285803-29037b80-a103-11eb-8098-164df68756da.mp4

### Testing Instructions

Depending on what version of WP we're using, variations provided to the NavigationLink are either defined in a fallback JS variations file, or in the server block registration.

| No custom variations 5.7.1 and below | Master with custom variations | 
|-----|-----|
| <img width="346" alt="Screen Shot 2021-04-19 at 11 40 03 AM" src="https://user-images.githubusercontent.com/1270189/115286545-06be2d80-a104-11eb-9220-ea7e1a4b9c0e.png"> | <img width="347" alt="Screen Shot 2021-04-19 at 11 45 48 AM" src="https://user-images.githubusercontent.com/1270189/115287240-e17def00-a104-11eb-99b1-b5b99769c63e.png"> |


#### WP 5.7.1 and below

- Checkout this branch
- Click on the block inserter, and add a navigation block
- Click start with empty
- Click on the block inserter in navigation
- Click on Browse All. We should see the home link, but no custom post-types/taxonomies.
- Verify that we can add a home link and edit the label value, and if it opens in a new tab
- Verify that navigation menu nesting works as expected

#### WordPress Develop Master

- Setup a local environment of your choice using [wordpress-develop](https://github.com/WordPress/wordpress-develop)
- Setup gutenberg and checkout this branch . One way of doing this on a local install is to link this via `ln -s your-gutenberg-checkout-path your-wordpress-local-path/wp-content/plugins/gutenberg`. Run `npm run build` in your gutenberg checkout
- Install a plugin with some custom post types and taxonomies (optional, but it makes it obvious that we're using the server provided variations)
- Edit a post or page
- Click on the block inserter, and add a navigation block
- Click start with empty
- Click on the block inserter in navigation
- Click on Browse all. We should see the home link, and installed custom post types and taxonomies as link variant options
Verify that there are no errors in console or in the server error log.
- Verify that we can add a home link and edit the label value, and if it opens in a new tab
- Verify that navigation menu nesting works as expected
 