### PR TITLE
Chore: Cover: Use ALLOWED_MEDIA_TYPES shared constant.

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -49,6 +49,7 @@ import { isBlobURL } from '@wordpress/blob';
  * Internal dependencies
  */
 import {
+	ALLOWED_MEDIA_TYPES,
 	attributesFromMedia,
 	IMAGE_BACKGROUND_TYPE,
 	VIDEO_BACKGROUND_TYPE,
@@ -63,7 +64,7 @@ import {
 /**
  * Module Constants
  */
-const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+
 const INNER_BLOCKS_TEMPLATE = [
 	[
 		'core/paragraph',

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -5,9 +5,6 @@ import { getBlobTypeByURL, isBlobURL } from '@wordpress/blob';
 import { __ } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
 
-const MEDIA_TYPE_IMAGE = 'image';
-const MEDIA_TYPE_VIDEO = 'video';
-
 const POSITION_CLASSNAMES = {
 	'top left': 'is-position-top-left',
 	'top center': 'is-position-top-center',
@@ -29,7 +26,7 @@ export const COVER_DEFAULT_HEIGHT = 300;
 export function backgroundImageStyles( url ) {
 	return url ? { backgroundImage: `url(${ url })` } : {};
 }
-export const ALLOWED_MEDIA_TYPES = [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ];
+export const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
 const isWeb = Platform.OS === 'web';
 


### PR DESCRIPTION
We had an ALLOWED_MEDIA_TYPES constant defined on the shared.js file. That file allows sharing artifacts between web and mobile.
The web version was redefining the ALLOWED_MEDIA_TYPES constant instead of using the one defined on shared.js.
This PR fixes the issue and makes the web code use ALLOWED_MEDIA_TYPES from shared.js.



## How has this been tested?
The cover block still works as expected and allows to select images or videos as the background but not other file types.
