### PR TITLE
Block Editor: update react-spring to 9.2.4

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,12 +122,6 @@ module.exports = {
 			},
 			{
 				selector:
-					'ImportDeclaration[source.value=/^react-spring(?!\\u002Fweb.cjs)/]',
-				message:
-					'The react-spring dependency must specify CommonJS bundle: react-spring/web.cjs',
-			},
-			{
-				selector:
 					'CallExpression[callee.name="deprecated"] Property[key.name="version"][value.value=/' +
 					majorMinorRegExp +
 					'/]',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7856,6 +7856,55 @@
 				"react-native-iphone-x-helper": "^1.2.1"
 			}
 		},
+		"@react-spring/animated": {
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.2.4.tgz",
+			"integrity": "sha512-AfV6ZM8pCCAT29GY5C8/1bOPjZrv/7kD0vedjiE/tEYvNDwg9GlscrvsTViWR2XykJoYrDfdkYArrldWpsCJ5g==",
+			"requires": {
+				"@react-spring/shared": "~9.2.0",
+				"@react-spring/types": "~9.2.0"
+			}
+		},
+		"@react-spring/core": {
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.2.4.tgz",
+			"integrity": "sha512-R+PwyfsjiuYCWqaTTfCpYpRmsP0h87RNm7uxC1Uxy7QAHUfHEm2sAHn+AdHPwq/MbVwDssVT8C5yf2WGcqiXGg==",
+			"requires": {
+				"@react-spring/animated": "~9.2.0",
+				"@react-spring/shared": "~9.2.0",
+				"@react-spring/types": "~9.2.0"
+			}
+		},
+		"@react-spring/rafz": {
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.2.4.tgz",
+			"integrity": "sha512-SOKf9eue+vAX+DGo7kWYNl9i9J3gPUlQjifIcV9Bzw9h3i30wPOOP0TjS7iMG/kLp2cdHQYDNFte6nt23VAZkQ=="
+		},
+		"@react-spring/shared": {
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.2.4.tgz",
+			"integrity": "sha512-ZEr4l2BxmyFRUvRA2VCkPfCJii4E7cGkwbjmTBx1EmcGrOnde/V2eF5dxqCTY3k35QuCegkrWe0coRJVkh8q2Q==",
+			"requires": {
+				"@react-spring/rafz": "~9.2.0",
+				"@react-spring/types": "~9.2.0"
+			}
+		},
+		"@react-spring/types": {
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.2.4.tgz",
+			"integrity": "sha512-zHUXrWO8nweUN/ISjrjqU7GgXXvoEbFca1CgiE0TY0H/dqJb3l+Rhx8ecPVNYimzFg3ZZ1/T0egpLop8SOv4aA=="
+		},
+		"@react-spring/web": {
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.2.4.tgz",
+			"integrity": "sha512-vtPvOalLFvuju/MDBtoSnCyt0xXSL6Amyv82fljOuWPl1yGd4M1WteijnYL9Zlriljl0a3oXcPunAVYTD9dbDQ==",
+			"requires": {
+				"@react-spring/animated": "~9.2.0",
+				"@react-spring/core": "~9.2.0",
+				"@react-spring/shared": "~9.2.0",
+				"@react-spring/types": "~9.2.0"
+			}
+		},
 		"@samverschueren/stream-to-observable": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -17961,6 +18010,7 @@
 			"version": "file:packages/block-editor",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
+				"@react-spring/web": "^9.2.4",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-default-parser": "file:packages/block-serialization-default-parser",
@@ -17994,11 +18044,21 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.2",
 				"traverse": "^0.6.6"
+			},
+			"dependencies": {
+				"react-spring": {
+					"version": "9.2.4",
+					"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-9.2.4.tgz",
+					"integrity": "sha512-bMjbyTW0ZGd+/h9cjtohLqCwOGqX2OuaTvalOVfLCGmhzEg/u3GgopI3LAm4UD2Br3MNdVdGgNVoESg4MGqKFQ==",
+					"requires": {
+						"@react-spring/core": "~9.2.0",
+						"@react-spring/web": "~9.2.0"
+					}
+				}
 			}
 		},
 		"@wordpress/block-library": {
@@ -53929,15 +53989,6 @@
 				"invariant": "^2.2.4",
 				"shallowequal": "^1.1.0",
 				"throttle-debounce": "^3.0.1"
-			}
-		},
-		"react-spring": {
-			"version": "8.0.20",
-			"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.20.tgz",
-			"integrity": "sha512-40ZUQ5uI5YHsoQWLPchWNcEUh6zQ6qvcVDeTI2vW10ldoCN3PvDsII9wBH2xEbMl+BQvYmHzGdfLTQxPxJWGnQ==",
-			"requires": {
-				"@babel/runtime": "^7.3.1",
-				"prop-types": "^15.5.8"
 			}
 		},
 		"react-syntax-highlighter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18048,17 +18048,6 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.2",
 				"traverse": "^0.6.6"
-			},
-			"dependencies": {
-				"react-spring": {
-					"version": "9.2.4",
-					"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-9.2.4.tgz",
-					"integrity": "sha512-bMjbyTW0ZGd+/h9cjtohLqCwOGqX2OuaTvalOVfLCGmhzEg/u3GgopI3LAm4UD2Br3MNdVdGgNVoESg4MGqKFQ==",
-					"requires": {
-						"@react-spring/core": "~9.2.0",
-						"@react-spring/web": "~9.2.0"
-					}
-				}
 			}
 		},
 		"@wordpress/block-library": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -32,6 +32,7 @@
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.13.10",
+		"@react-spring/web": "^9.2.4",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",
@@ -65,7 +66,6 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
-		"react-spring": "^8.0.19",
 		"redux-multi": "^0.1.12",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.2",

--- a/packages/block-editor/src/components/list-view/leaf.js
+++ b/packages/block-editor/src/components/list-view/leaf.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { animated } from 'react-spring/web.cjs';
+import { animated } from '@react-spring/web';
 import classnames from 'classnames';
 
 /**

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useSpring } from 'react-spring/web.cjs';
+import { useSpring } from '@react-spring/web';
 
 /**
  * WordPress dependencies
@@ -136,19 +136,20 @@ function useMovingAnimation( {
 	}
 
 	// Called for every frame computed by useSpring.
-	function onFrame( { x, y } ) {
+	function onChange( { value } ) {
+		let { x, y } = value;
 		x = Math.round( x );
 		y = Math.round( y );
 
-		if ( x !== onFrame.x || y !== onFrame.y ) {
+		if ( x !== onChange.x || y !== onChange.y ) {
 			onFrameChange( { x, y } );
-			onFrame.x = x;
-			onFrame.y = y;
+			onChange.x = x;
+			onChange.y = y;
 		}
 	}
 
-	onFrame.x = 0;
-	onFrame.y = 0;
+	onChange.x = 0;
+	onChange.y = 0;
 
 	useSpring( {
 		from: {
@@ -162,7 +163,7 @@ function useMovingAnimation( {
 		reset: triggeredAnimation !== finishedAnimation,
 		config: { mass: 5, tension: 2000, friction: 200 },
 		immediate: prefersReducedMotion,
-		onFrame,
+		onChange,
 	} );
 
 	return ref;


### PR DESCRIPTION
closes #32398 

This PR updates react-spring to 9.2.4. This should fix overlapping blocks in FF https://github.com/WordPress/gutenberg/issues/19476 when `privacy.resistFingerprinting` is set to true in `about:config`. Note that when  `privacy.resistFingerprinting` is enabled, animations will not be as smooth due to the reduced time precision 100ms or more (https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#reduced_time_precision).

There are a few breaking changes from React Spring 8 -> 9, most notably in the refactor of useTransition and rename of onFrame -> onChange. We'll want to verify that block moving animations still work in the list view and editor block list.

https://aleclarson.github.io/react-spring/v9/
https://aleclarson.github.io/react-spring/v9/breaking-changes/

### Testing Instructions

- Verify that animations work when moving blocks in the block list
- Add a navigation block, then try moving an item up or down.
- We should still respect prefer reduced motion. (Blocks should move immediately)
- Animations work in Chrome, Safari, FF

https://user-images.githubusercontent.com/1270189/132767245-da5b1903-d99e-4db5-b795-2dce6d7def60.mp4

