### PR TITLE
Docs: Organize Block API Reference

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -438,15 +438,15 @@
 		"parent": "reference-guides"
 	},
 	{
-		"title": "Block Registration",
-		"slug": "block-registration",
-		"markdown_source": "../docs/reference-guides/block-api/block-registration.md",
+		"title": "Annotations",
+		"slug": "block-annotations",
+		"markdown_source": "../docs/reference-guides/block-api/block-annotations.md",
 		"parent": "block-api"
 	},
 	{
-		"title": "Edit and Save",
-		"slug": "block-edit-save",
-		"markdown_source": "../docs/reference-guides/block-api/block-edit-save.md",
+		"title": "API Versions",
+		"slug": "block-api-versions",
+		"markdown_source": "../docs/reference-guides/block-api/block-api-versions.md",
 		"parent": "block-api"
 	},
 	{
@@ -456,27 +456,45 @@
 		"parent": "block-api"
 	},
 	{
-		"title": "Block Context",
+		"title": "Context",
 		"slug": "block-context",
 		"markdown_source": "../docs/reference-guides/block-api/block-context.md",
 		"parent": "block-api"
 	},
 	{
-		"title": "Deprecated Blocks",
+		"title": "Deprecation",
 		"slug": "block-deprecation",
 		"markdown_source": "../docs/reference-guides/block-api/block-deprecation.md",
 		"parent": "block-api"
 	},
 	{
-		"title": "Block Supports",
-		"slug": "block-supports",
-		"markdown_source": "../docs/reference-guides/block-api/block-supports.md",
+		"title": "Edit and Save",
+		"slug": "block-edit-save",
+		"markdown_source": "../docs/reference-guides/block-api/block-edit-save.md",
 		"parent": "block-api"
 	},
 	{
-		"title": "Block Transforms",
-		"slug": "block-transforms",
-		"markdown_source": "../docs/reference-guides/block-api/block-transforms.md",
+		"title": "Metadata",
+		"slug": "block-metadata",
+		"markdown_source": "../docs/reference-guides/block-api/block-metadata.md",
+		"parent": "block-api"
+	},
+	{
+		"title": "Patterns",
+		"slug": "block-patterns",
+		"markdown_source": "../docs/reference-guides/block-api/block-patterns.md",
+		"parent": "block-api"
+	},
+	{
+		"title": "Registration",
+		"slug": "block-registration",
+		"markdown_source": "../docs/reference-guides/block-api/block-registration.md",
+		"parent": "block-api"
+	},
+	{
+		"title": "Supports",
+		"slug": "block-supports",
+		"markdown_source": "../docs/reference-guides/block-api/block-supports.md",
 		"parent": "block-api"
 	},
 	{
@@ -486,33 +504,15 @@
 		"parent": "block-api"
 	},
 	{
-		"title": "Block Type Metadata",
-		"slug": "block-metadata",
-		"markdown_source": "../docs/reference-guides/block-api/block-metadata.md",
+		"title": "Transforms",
+		"slug": "block-transforms",
+		"markdown_source": "../docs/reference-guides/block-api/block-transforms.md",
 		"parent": "block-api"
 	},
 	{
-		"title": "Block Variations",
+		"title": "Variations",
 		"slug": "block-variations",
 		"markdown_source": "../docs/reference-guides/block-api/block-variations.md",
-		"parent": "block-api"
-	},
-	{
-		"title": "Block Patterns",
-		"slug": "block-patterns",
-		"markdown_source": "../docs/reference-guides/block-api/block-patterns.md",
-		"parent": "block-api"
-	},
-	{
-		"title": "Annotations",
-		"slug": "block-annotations",
-		"markdown_source": "../docs/reference-guides/block-api/block-annotations.md",
-		"parent": "block-api"
-	},
-	{
-		"title": "Block API Versions",
-		"slug": "versions",
-		"markdown_source": "../docs/reference-guides/block-api/versions.md",
 		"parent": "block-api"
 	},
 	{

--- a/docs/reference-guides/README.md
+++ b/docs/reference-guides/README.md
@@ -2,19 +2,19 @@
 
 ## [Block API Reference](/docs/reference-guides/block-api/README.md)
 
--   [Block registration](/docs/reference-guides/block-api/block-registration.md)
--   [Edit and Save](/docs/reference-guides/block-api/block-edit-save.md)
+-   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
+-   [API Versions](/docs/reference-guides/block-api/block-api-versions.md)
 -   [Attributes](/docs/reference-guides/block-api/block-attributes.md)
 -   [Context](/docs/reference-guides/block-api/block-context.md)
 -   [Deprecation](/docs/reference-guides/block-api/block-deprecation.md)
+-   [Edit and Save](/docs/reference-guides/block-api/block-edit-save.md)
+-   [Patterns](/docs/reference-guides/block-api/block-patterns.md)
+-   [Registration](/docs/reference-guides/block-api/block-registration.md)
 -   [Supports](/docs/reference-guides/block-api/block-supports.md)
--   [Transformations](/docs/reference-guides/block-api/block-transforms.md)
 -   [Templates](/docs/reference-guides/block-api/block-templates.md)
+-   [Transformations](/docs/reference-guides/block-api/block-transforms.md)
 -   [Metadata](/docs/reference-guides/block-api/block-metadata.md)
--   [Block Variations](/docs/reference-guides/block-api/block-variations.md)
--   [Block Patterns](/docs/reference-guides/block-api/block-patterns.md)
--   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
--   [Versions](/docs/reference-guides/block-api/versions.md)
+-   [Variations](/docs/reference-guides/block-api/block-variations.md)
 
 ## [Filter Reference](/docs/reference-guides/filters/README.md)
 

--- a/docs/reference-guides/block-api/README.md
+++ b/docs/reference-guides/block-api/README.md
@@ -4,16 +4,16 @@ Blocks are the fundamental element of the editor. They are the primary way in wh
 
 The following sections will walk you through the existing block APIs:
 
--   [Block registration](/docs/reference-guides/block-api/block-registration.md)
--   [Edit and Save](/docs/reference-guides/block-api/block-edit-save.md)
+-   [API Versions](/docs/reference-guides/block-api/block-api-versions.md)
+-   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
 -   [Attributes](/docs/reference-guides/block-api/block-attributes.md)
 -   [Context](/docs/reference-guides/block-api/block-context.md)
 -   [Deprecation](/docs/reference-guides/block-api/block-deprecation.md)
+-   [Edit and Save](/docs/reference-guides/block-api/block-edit-save.md)
+-   [Patterns](/docs/reference-guides/block-api/block-patterns.md)
+-   [Registration](/docs/reference-guides/block-api/block-registration.md)
 -   [Supports](/docs/reference-guides/block-api/block-supports.md)
 -   [Transformations](/docs/reference-guides/block-api/block-transforms.md)
 -   [Templates](/docs/reference-guides/block-api/block-templates.md)
 -   [Metadata](/docs/reference-guides/block-api/block-metadata.md)
--   [Block Variations](/docs/reference-guides/block-api/block-variations.md)
--   [Block Patterns](/docs/reference-guides/block-api/block-patterns.md)
--   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
--   [Versions](/docs/reference-guides/block-api/versions.md)
+-   [Variations](/docs/reference-guides/block-api/block-variations.md)

--- a/docs/reference-guides/block-api/block-api-versions.md
+++ b/docs/reference-guides/block-api/block-api-versions.md
@@ -1,4 +1,4 @@
-# Block API Versions
+# API Versions
 
 This document lists the changes made between the different API versions.
 

--- a/docs/reference-guides/block-api/block-context.md
+++ b/docs/reference-guides/block-api/block-context.md
@@ -1,4 +1,4 @@
-# Block Context
+# Context
 
 Block context is a feature which enables ancestor blocks to provide values which can be consumed by descendent blocks within its own hierarchy. Those descendent blocks can inherit these values without resorting to hard-coded values and without an explicit awareness of the block which provides those values.
 

--- a/docs/reference-guides/block-api/block-deprecation.md
+++ b/docs/reference-guides/block-api/block-deprecation.md
@@ -1,4 +1,4 @@
-# Deprecated Blocks
+# Deprecation
 
 When updating static blocks markup and attributes, block authors need to consider existing posts using the old versions of their block. To provide a good upgrade path, you can choose one of the following strategies:
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -1,4 +1,4 @@
-# Block Type Metadata
+# Metadata
 
 To register a new block type using metadata that can be shared between codebase that uses JavaScript and PHP, start by creating a `block.json` file. This file:
 

--- a/docs/reference-guides/block-api/block-patterns.md
+++ b/docs/reference-guides/block-api/block-patterns.md
@@ -1,4 +1,4 @@
-# Block Patterns
+# Patterns
 
 Block Patterns are predefined block layouts, ready to insert and tweak.
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -1,4 +1,8 @@
-# Block Registration
+# Registration
+
+Block registration API reference.
+
+**Note:** You can use the functions documented on this page, but a flexible method to register new block types is to use the block.json metadata file. See [metadata documentation for complete information](/docs/reference-guides/block-api/block-metadata.md).
 
 ## `registerBlockType`
 

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -1,4 +1,4 @@
-# Block Supports
+# Supports
 
 Block Supports is the API that allows a block to declare features used in the editor.
 

--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -1,4 +1,4 @@
-# Block Transforms
+# Transforms
 
 Block Transforms is the API that allows a block to be transformed _from_ and _to_ other blocks, as well as _from_ other entities. Existing entities that work with this API include shortcodes, files, regular expressions, and raw DOM nodes.
 

--- a/docs/reference-guides/block-api/block-variations.md
+++ b/docs/reference-guides/block-api/block-variations.md
@@ -1,4 +1,4 @@
-# Block Variations
+# Variations
 
 Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality. Each block variation is differentiated from the others by setting some initial attributes or inner blocks. Then at the time when a block is inserted these attributes and/or inner blocks are applied.
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -189,10 +189,10 @@
 			{
 				"docs/reference-guides/block-api/README.md": [
 					{
-						"docs/reference-guides/block-api/block-registration.md": []
+						"docs/reference-guides/block-api/block-annotations.md": []
 					},
 					{
-						"docs/reference-guides/block-api/block-edit-save.md": []
+						"docs/reference-guides/block-api/block-api-versions.md": []
 					},
 					{
 						"docs/reference-guides/block-api/block-attributes.md": []
@@ -201,22 +201,24 @@
 					{
 						"docs/reference-guides/block-api/block-deprecation.md": []
 					},
+					{
+						"docs/reference-guides/block-api/block-edit-save.md": []
+					},
+					{ "docs/reference-guides/block-api/block-metadata.md": [] },
+					{ "docs/reference-guides/block-api/block-patterns.md": [] },
+					{
+						"docs/reference-guides/block-api/block-registration.md": []
+					},
 					{ "docs/reference-guides/block-api/block-supports.md": [] },
+					{
+						"docs/reference-guides/block-api/block-templates.md": []
+					},
 					{
 						"docs/reference-guides/block-api/block-transforms.md": []
 					},
 					{
-						"docs/reference-guides/block-api/block-templates.md": []
-					},
-					{ "docs/reference-guides/block-api/block-metadata.md": [] },
-					{
 						"docs/reference-guides/block-api/block-variations.md": []
-					},
-					{ "docs/reference-guides/block-api/block-patterns.md": [] },
-					{
-						"docs/reference-guides/block-api/block-annotations.md": []
-					},
-					{ "docs/reference-guides/block-api/versions.md": [] }
+					}
 				]
 			},
 			{


### PR DESCRIPTION
## Description

Organize the Block API Reference

- Organize the list alphabetically so easier to scan

- Make all the pages consistent there was a mix of titles using "Block SECTION" and just "SECTION", since it is all under the block api reference, I don't think we need to repeat block on each document. This makes it easier to scan the menu.

## How has this been tested?

Documentation. Confirm links and names work as expected

## Screenshots

**Before:**

<img width="806" alt="block-api-reference-before" src="https://user-images.githubusercontent.com/45363/115333205-1a8e8180-a14e-11eb-9368-1128570b9874.png">

**After:**

<img width="802" alt="block-api-reference-after" src="https://user-images.githubusercontent.com/45363/115333244-2da15180-a14e-11eb-9510-9c4384eef927.png">


## Types of changes

Docs.

