### PR TITLE
Try: Toolbar gap.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -702,7 +702,9 @@
 		// Allow clicking through the toolbar holder.
 		pointer-events: none;
 
-		> * > * > * {
+		.block-editor-block-list__block-selection-button,
+		.block-editor-block-contextual-toolbar,
+		.block-editor-block-list__empty-block-inserter {
 			pointer-events: all;
 		}
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -501,6 +501,11 @@
  * Block Toolbar when contextual.
  */
 
+// Show a small gap above the block toolbar when it stickies to the top of the screen.
+.block-editor-block-contextual-toolbar-wrapper {
+	padding-top: $grid-unit-15;
+}
+
 .block-editor-block-contextual-toolbar {
 	// Block UI appearance.
 	border: $border-width solid $gray-900;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -702,10 +702,13 @@
 		// Allow clicking through the toolbar holder.
 		pointer-events: none;
 
-		// Position the block toolbar and enable pointer events.
+		> * > * > * {
+			pointer-events: all;
+		}
+
+		// Position the block toolbar.
 		.block-editor-block-list__block-selection-button,
 		.block-editor-block-contextual-toolbar {
-			pointer-events: auto;
 			margin-top: $grid-unit-15;
 			margin-bottom: $grid-unit-15;
 		}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -501,11 +501,6 @@
  * Block Toolbar when contextual.
  */
 
-// Show a small gap above the block toolbar when it stickies to the top of the screen.
-.block-editor-block-contextual-toolbar-wrapper {
-	padding-top: $grid-unit-15;
-}
-
 .block-editor-block-contextual-toolbar {
 	// Block UI appearance.
 	border: $border-width solid $gray-900;
@@ -707,13 +702,11 @@
 		// Allow clicking through the toolbar holder.
 		pointer-events: none;
 
-		> * {
-			pointer-events: all;
-		}
-
-		// Position the block toolbar.
+		// Position the block toolbar and enable pointer events.
 		.block-editor-block-list__block-selection-button,
 		.block-editor-block-contextual-toolbar {
+			pointer-events: auto;
+			margin-top: $grid-unit-15;
 			margin-bottom: $grid-unit-15;
 		}
 	}


### PR DESCRIPTION
## Description

The contextual toolbar bumps against the top of the screen when you scroll on tall blocks:

<img width="565" alt="before" src="https://user-images.githubusercontent.com/1204802/115357817-4f85ed00-a1bd-11eb-90ff-a08f4f39d991.png">

This PR adds a small gap:

<img width="703" alt="Screenshot 2021-04-20 at 09 42 53" src="https://user-images.githubusercontent.com/1204802/115357839-54e33780-a1bd-11eb-98b6-3a53642a1000.png">

GIF:


![gap](https://user-images.githubusercontent.com/1204802/115357946-73493300-a1bd-11eb-9780-6064aba1e99a.gif)



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
