### PR TITLE
Editor: Wire PHP tests for block editor settings

### DIFF
--- a/lib/block-editor.php
+++ b/lib/block-editor.php
@@ -77,7 +77,7 @@ function gutenberg_get_default_block_categories() {
 function gutenberg_get_block_categories( $editor_name_or_post ) {
 	// Assume the post editor when the WP_Post object passed.
 	$editor_name        = is_object( $editor_name_or_post ) ? 'post-editor' : $editor_name_or_post;
-	$default_categories = get_default_block_categories();
+	$default_categories = gutenberg_get_default_block_categories();
 
 	/**
 	 * Filters the default array of categories for block types.

--- a/phpunit/block-editor-test.php
+++ b/phpunit/block-editor-test.php
@@ -141,7 +141,8 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	function test_get_default_block_editor_settings() {
 		$settings = gutenberg_get_default_block_editor_settings();
 
-		$this->assertCount( 16, $settings );
+		$this->assertCount( 17, $settings );
+		$this->assertTrue( $settings['__unstableEnableFullSiteEditingBlocks'] );
 		$this->assertFalse( $settings['alignWide'] );
 		$this->assertInternalType( 'array', $settings['allowedMimeTypes'] );
 		$this->assertTrue( $settings['allowedBlockTypes'] );
@@ -243,7 +244,7 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	 */
 	function test_get_block_editor_settings_returns_default_settings() {
 		$this->assertSameSets(
-			gutenberg_get_block_editor_settings( 'post-editor' ),
+			gutenberg_get_block_editor_settings( 'my-editor' ),
 			gutenberg_get_default_block_editor_settings()
 		);
 	}
@@ -274,7 +275,7 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 		add_filter( 'block_categories_my-editor', 'filter_block_categories_my_editor', 10, 1 );
 		add_filter( 'block_editor_settings_my-editor', 'filter_block_editor_settings_my_editor', 10, 1 );
 
-		$settings = get_block_editor_settings( 'my-editor' );
+		$settings = gutenberg_get_block_editor_settings( 'my-editor' );
 
 		remove_filter( 'allowed_block_types_my-editor', 'filter_allowed_block_types_my_editor' );
 		remove_filter( 'block_categories_my-editor', 'filter_block_categories_my_editor' );
@@ -296,12 +297,14 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 52920
+	 * @expectedDeprecated block_categories
 	 * @expectedDeprecated block_editor_settings
 	 */
 	function test_get_block_editor_settings_deprecated_filter_post_editor() {
-		add_filter( 'block_editor_settings', array( $this, 'filter_set_block_editor_settings_post' ), 10, 2 );
+		// This filter needs to run last to account for other filters registered in the plugin.
+		add_filter( 'block_editor_settings', array( $this, 'filter_set_block_editor_settings_post' ), PHP_INT_MAX, 2 );
 
-		$settings = get_block_editor_settings( 'post-editor' );
+		$settings = gutenberg_get_block_editor_settings( 'post-editor' );
 
 		remove_filter( 'block_editor_settings', array( $this, 'filter_set_block_editor_settings_post' ) );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Follow-up for #30245.

I missed one tiny but extremely important detail, PHPUnit test files need to end with `-test.php`. The fact that I extracted code from https://github.com/WordPress/wordpress-develop/pull/1118 didn't help as well 😅 

I had to update some tests in comparison to the version in WordPress core to account for the hooks that are present in the Gutenberg plugin.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run test-php` - ensure that tests run and pass.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
