### PR TITLE
Default appender: try editable paragraph instead of text area

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -41,8 +41,14 @@ export function DefaultBlockAppender( {
 		>
 			<p
 				tabIndex="0"
+				// Only necessary for `useCanvasClickRedirect` to consider it
+				// as a target. Ideally it should consider any tabbable target,
+				// but the inserter is rendered in place while it should be
+				// rendered in a popover, just like it does for an empty
+				// paragraph block.
+				contentEditable
+				suppressContentEditableWarning
 				// We want this element to be styled as a paragraph by themes.
-				// In
 				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 				role="button"
 				aria-label={ __( 'Add block' ) }

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import TextareaAutosize from 'react-autosize-textarea';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -53,14 +48,17 @@ export function DefaultBlockAppender( {
 			data-root-client-id={ rootClientId || '' }
 			className="wp-block block-editor-default-block-appender"
 		>
-			<TextareaAutosize
+			<p
+				contentEditable
+				suppressContentEditableWarning
+				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 				role="button"
 				aria-label={ __( 'Add block' ) }
 				className="block-editor-default-block-appender__content"
-				readOnly
 				onFocus={ onAppend }
-				value={ showPrompt ? value : '' }
-			/>
+			>
+				{ showPrompt ? value : '' }
+			</p>
 			<Inserter
 				rootClientId={ rootClientId }
 				position="bottom right"

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -17,7 +17,7 @@ import { store as blockEditorStore } from '../../store';
  * Zero width non-breaking space, used as padding for the paragraph when it is
  * empty.
  */
-const ZWNBSP = '\ufeff';
+export const ZWNBSP = '\ufeff';
 
 export function DefaultBlockAppender( {
 	isLocked,

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -46,7 +46,7 @@ export function DefaultBlockAppender( {
 	return (
 		<div
 			data-root-client-id={ rootClientId || '' }
-			className="wp-block block-editor-default-block-appender"
+			className="block-editor-default-block-appender"
 		>
 			<p
 				contentEditable
@@ -54,7 +54,7 @@ export function DefaultBlockAppender( {
 				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 				role="button"
 				aria-label={ __( 'Add block' ) }
-				className="block-editor-default-block-appender__content"
+				className="wp-block block-editor-default-block-appender__content"
 				onFocus={ onAppend }
 			>
 				{ showPrompt ? value : '' }

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -13,6 +13,12 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import Inserter from '../inserter';
 import { store as blockEditorStore } from '../../store';
 
+/**
+ * Zero width non-breaking space, used as padding for the paragraph when it is
+ * empty.
+ */
+const ZWNBSP = '\ufeff';
+
 export function DefaultBlockAppender( {
 	isLocked,
 	isVisible,
@@ -28,36 +34,23 @@ export function DefaultBlockAppender( {
 	const value =
 		decodeEntities( placeholder ) || __( 'Type / to choose a block' );
 
-	// The appender "button" is in-fact a text field so as to support
-	// transitions by WritingFlow occurring by arrow key press. WritingFlow
-	// only supports tab transitions into text fields and to the block focus
-	// boundary.
-	//
-	// See: https://github.com/WordPress/gutenberg/issues/4829#issuecomment-374213658
-	//
-	// If it were ever to be made to be a proper `button` element, it is
-	// important to note that `onFocus` alone would not be sufficient to
-	// capture click events, notably in Firefox.
-	//
-	// See: https://gist.github.com/cvrebert/68659d0333a578d75372
-
-	// The wp-block className is important for editor styles.
-
 	return (
 		<div
 			data-root-client-id={ rootClientId || '' }
 			className="block-editor-default-block-appender"
 		>
 			<p
-				contentEditable
-				suppressContentEditableWarning
+				tabIndex="0"
+				// We want this element to be styled as a paragraph by themes.
+				// In
 				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 				role="button"
 				aria-label={ __( 'Add block' ) }
+				// The wp-block className is important for editor styles.
 				className="wp-block block-editor-default-block-appender__content"
 				onFocus={ onAppend }
 			>
-				{ showPrompt ? value : '' }
+				{ showPrompt ? value : ZWNBSP }
 			</p>
 			<Inserter
 				rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -12,45 +12,15 @@
 		outline: 1px solid transparent;
 	}
 
-	textarea.block-editor-default-block-appender__content { // Needs specificity in order to override input field styles from WP-admin styles.
-		font-family: inherit;
-		font-size: inherit;
-		border: none;
-		background: none;
-		box-shadow: none;
-		display: block;
-		cursor: text;
-		width: 100%;
-		outline: $border-width solid transparent;
-		transition: 0.2s outline;
-		@include reduce-motion("transition");
-		margin-top: $default-block-margin;
-		margin-bottom: $default-block-margin;
-
-		// This needs high specificity as it's output as an inline style by the library.
-		resize: none !important;
-
-		// Emulate the dimensions of a paragraph block.
-		// On mobile and in nested contexts, the plus to add blocks shows up on the right.
-		// The rightmost padding makes sure it doesn't overlap text.
-		padding: 0 #{ $block-padding + $button-size } 0 0;
-
-		// Use opacity to work in various editor styles.
-		color: $dark-gray-placeholder;
-		.is-dark-theme & {
-			color: $light-gray-placeholder;
-		}
+	.block-editor-default-block-appender__content {
+		// Set the opacity of the initial block appender to the same as placeholder text in an empty Paragraph block.
+		opacity: 0.62;
 	}
 
 	// Dropzone.
 	.components-drop-zone__content-icon {
 		display: none;
 	}
-}
-
-// Ensure that the height of the first appender, and the one between blocks, is the same as text.
-.block-editor-default-block-appender__content {
-	line-height: $editor-line-height;
 }
 
 // Empty / default block side inserter.
@@ -77,11 +47,5 @@
 
 	&:disabled {
 		display: none;
-	}
-}
-
-.block-editor-default-block-appender .block-editor-inserter {
-	@include break-small {
-		align-items: center;
 	}
 }

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -35,17 +35,19 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
 
 exports[`DefaultBlockAppender should match snapshot 1`] = `
 <div
-  className="wp-block block-editor-default-block-appender"
+  className="block-editor-default-block-appender"
   data-root-client-id=""
 >
-  <ForwardRef
+  <p
     aria-label="Add block"
-    className="block-editor-default-block-appender__content"
+    className="wp-block block-editor-default-block-appender__content"
+    contentEditable={true}
     onFocus={[MockFunction]}
-    readOnly={true}
     role="button"
-    value="Type / to choose a block"
-  />
+    suppressContentEditableWarning={true}
+  >
+    Type / to choose a block
+  </p>
   <WithSelect(WithDispatch(IfCondition(Inserter)))
     __experimentalIsQuick={true}
     isAppender={true}

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -41,10 +41,9 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   <p
     aria-label="Add block"
     className="wp-block block-editor-default-block-appender__content"
-    contentEditable={true}
     onFocus={[MockFunction]}
     role="button"
-    suppressContentEditableWarning={true}
+    tabIndex="0"
   >
     Type / to choose a block
   </p>

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -2,12 +2,12 @@
 
 exports[`DefaultBlockAppender should append a default block when input focused 1`] = `
 <div
-  className="wp-block block-editor-default-block-appender"
+  className="block-editor-default-block-appender"
   data-root-client-id=""
 >
-  <ForwardRef
+  <p
     aria-label="Add block"
-    className="block-editor-default-block-appender__content"
+    className="wp-block block-editor-default-block-appender__content"
     onFocus={
       [MockFunction] {
         "calls": Array [
@@ -21,10 +21,11 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
         ],
       }
     }
-    readOnly={true}
     role="button"
-    value="Type / to choose a block"
-  />
+    tabIndex="0"
+  >
+    Type / to choose a block
+  </p>
   <WithSelect(WithDispatch(IfCondition(Inserter)))
     __experimentalIsQuick={true}
     isAppender={true}
@@ -57,17 +58,18 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
 
 exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
 <div
-  className="wp-block block-editor-default-block-appender"
+  className="block-editor-default-block-appender"
   data-root-client-id=""
 >
-  <ForwardRef
+  <p
     aria-label="Add block"
-    className="block-editor-default-block-appender__content"
+    className="wp-block block-editor-default-block-appender__content"
     onFocus={[MockFunction]}
-    readOnly={true}
     role="button"
-    value=""
-  />
+    tabIndex="0"
+  >
+    ﻿
+  </p>
   <WithSelect(WithDispatch(IfCondition(Inserter)))
     __experimentalIsQuick={true}
     isAppender={true}

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -8,6 +8,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   <p
     aria-label="Add block"
     className="wp-block block-editor-default-block-appender__content"
+    contentEditable={true}
     onFocus={
       [MockFunction] {
         "calls": Array [
@@ -22,6 +23,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
       }
     }
     role="button"
+    suppressContentEditableWarning={true}
     tabIndex="0"
   >
     Type / to choose a block
@@ -42,8 +44,10 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   <p
     aria-label="Add block"
     className="wp-block block-editor-default-block-appender__content"
+    contentEditable={true}
     onFocus={[MockFunction]}
     role="button"
+    suppressContentEditableWarning={true}
     tabIndex="0"
   >
     Type / to choose a block
@@ -64,8 +68,10 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   <p
     aria-label="Add block"
     className="wp-block block-editor-default-block-appender__content"
+    contentEditable={true}
     onFocus={[MockFunction]}
     role="button"
+    suppressContentEditableWarning={true}
     tabIndex="0"
   >
     ﻿

--- a/packages/block-editor/src/components/default-block-appender/test/index.js
+++ b/packages/block-editor/src/components/default-block-appender/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { DefaultBlockAppender } from '../';
+import { DefaultBlockAppender, ZWNBSP } from '../';
 
 describe( 'DefaultBlockAppender', () => {
 	const expectOnAppendCalled = ( onAppend ) => {
@@ -35,7 +35,7 @@ describe( 'DefaultBlockAppender', () => {
 			<DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt />
 		);
 
-		wrapper.find( 'ForwardRef' ).simulate( 'focus' );
+		wrapper.find( 'p' ).simulate( 'focus' );
 
 		expect( wrapper ).toMatchSnapshot();
 
@@ -51,9 +51,9 @@ describe( 'DefaultBlockAppender', () => {
 				showPrompt={ false }
 			/>
 		);
-		const input = wrapper.find( 'ForwardRef' );
+		const input = wrapper.find( 'p' );
 
-		expect( input.prop( 'value' ) ).toEqual( '' );
+		expect( input.prop( 'children' ) ).toEqual( ZWNBSP );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -55,10 +55,9 @@
 		margin-left: auto;
 		margin-right: auto;
 
-		// Apply default block margin below the post title.
-		// This ensures the first block on the page is in a good position.
-		// This rule can be retired once the title becomes an actual block.
-		margin-bottom: $default-block-margin;
+		// Margins between the title and the first block, or appender, do not collapse.
+		// By explicitly setting this to zero, we avoid "double margin".
+		margin-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Swaps out the text area in the default appender (which isn't styled by themes) for a paragraph with a button role.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Create a new post and click the default appender.
Specifically in Firefox, check that you can use the arrow down key to navigate to the appender.
Also create a post that ends with a block other than a paragraph. There will be a default appender without label.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
