### PR TITLE
Widgets: Fix the undo/redo buttons in the standalone block-based widgets editor

### DIFF
--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -90,8 +90,8 @@ function Header() {
 								'Generic label for block inserter button'
 							) }
 						/>
-						<ToolbarItem as={ UndoButton } />
-						<ToolbarItem as={ RedoButton } />
+						<UndoButton />
+						<RedoButton />
 						<ToolbarItem as={ BlockNavigationDropdown } />
 					</NavigableToolbar>
 				</div>

--- a/packages/edit-widgets/src/components/header/undo-redo/redo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/redo.js
@@ -1,18 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 
-function RedoButton( props, ref ) {
+export default function RedoButton() {
 	const hasRedo = useSelect( ( select ) => select( 'core' ).hasRedo() );
 	const { redo } = useDispatch( 'core' );
 	return (
-		<Button
+		<ToolbarButton
 			icon={ redoIcon }
 			label={ __( 'Redo' ) }
 			shortcut={ displayShortcut.primaryShift( 'z' ) }
@@ -21,10 +20,6 @@ function RedoButton( props, ref ) {
 			// See: https://github.com/WordPress/gutenberg/issues/3486
 			aria-disabled={ ! hasRedo }
 			onClick={ hasRedo ? redo : undefined }
-			ref={ ref }
-			{ ...props }
 		/>
 	);
 }
-
-export default forwardRef( RedoButton );

--- a/packages/edit-widgets/src/components/header/undo-redo/undo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/undo.js
@@ -1,18 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { undo as undoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 
-function UndoButton( props, ref ) {
+export default function UndoButton() {
 	const hasUndo = useSelect( ( select ) => select( 'core' ).hasUndo() );
 	const { undo } = useDispatch( 'core' );
 	return (
-		<Button
+		<ToolbarButton
 			icon={ undoIcon }
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }
@@ -21,10 +20,6 @@ function UndoButton( props, ref ) {
 			// See: https://github.com/WordPress/gutenberg/issues/3486
 			aria-disabled={ ! hasUndo }
 			onClick={ hasUndo ? undo : undefined }
-			ref={ ref }
-			{ ...props }
 		/>
 	);
 }
-
-export default forwardRef( UndoButton );


### PR DESCRIPTION
## Description
Fixes #30050.

The undo/redo buttons weren't working in the standalone widgets editor.

The issue is the way they were implemented as `ToolbarItem`s. A `ToolbarItem` injects its own `onClick` prop into the component it displays as, and this was overriding the actual undoing and redoing `onClick`.

There's a `ToolbarButton` component, so that seems easier. I don't see a situation where undo/redo will not be toolbar buttons, so it seems fine to implicitly make them use that component.

## How has this been tested?
1. Go to the standalone widget editor (Appearance > Widgets
2. Make some edits
3. Press undo
4. Changes should undo
5. Press redo
6. Changes should redo

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
