### PR TITLE
Add autoAnchor prop

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -92,9 +92,15 @@ export const withInspectorControl = createHigherOrderComponent(
 						placeholder={ ! isWeb ? __( 'Add an anchor' ) : null }
 						onChange={ ( nextValue ) => {
 							nextValue = nextValue.replace( ANCHOR_REGEX, '-' );
-							props.setAttributes( {
-								anchor: nextValue,
-							} );
+
+							if (
+								props.attributes.autoAnchor &&
+								0 === nextValue.indexOf( 'wp-' )
+							) {
+								nextValue = nextValue.replace( 'wp-', '' );
+							}
+							delete props.attributes.autoAnchor;
+							props.setAttributes( { anchor: nextValue } );
 						} }
 						autoCapitalize="none"
 						autoComplete="off"

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -6,6 +6,9 @@
 		"textAlign": {
 			"type": "string"
 		},
+		"autoAnchor": {
+			"type": "boolean"
+		},
 		"content": {
 			"type": "string",
 			"source": "html",

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -45,7 +45,10 @@ function HeadingEdit( {
 	);
 	useEffect( () => {
 		if ( generatedAnchor !== attributes.anchor ) {
-			setAttributes( { anchor: generatedAnchor } );
+			setAttributes( {
+				anchor: generatedAnchor,
+				autoAnchor: true,
+			} );
 		}
 	}, [ attributes.anchor, content ] );
 


### PR DESCRIPTION
## Description

Add an `autoAnchor` prop to headings.
This prop is set to true when an anchor is auto-generated, and deleted when the user manually edits an anchor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
