### PR TITLE
Add/autoanchor no prefix

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -93,13 +93,9 @@ export const withInspectorControl = createHigherOrderComponent(
 						onChange={ ( nextValue ) => {
 							nextValue = nextValue.replace( ANCHOR_REGEX, '-' );
 
-							if (
-								props.attributes.autoAnchor &&
-								0 === nextValue.indexOf( 'wp-' )
-							) {
-								nextValue = nextValue.replace( 'wp-', '' );
+							if ( props.attributes.autoAnchor ) {
+								props.setAttributes( { autoAnchor: false } );
 							}
-							delete props.attributes.autoAnchor;
 							props.setAttributes( { anchor: nextValue } );
 						} }
 						autoCapitalize="none"

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -92,9 +92,15 @@ export const withInspectorControl = createHigherOrderComponent(
 						placeholder={ ! isWeb ? __( 'Add an anchor' ) : null }
 						onChange={ ( nextValue ) => {
 							nextValue = nextValue.replace( ANCHOR_REGEX, '-' );
-							props.setAttributes( {
-								anchor: nextValue,
-							} );
+
+							if (
+								props.attributes.autoAnchor &&
+								0 === nextValue.indexOf( 'wp-' )
+							) {
+								nextValue = nextValue.replace( 'wp-', '' );
+							}
+							delete props.attributes.autoAnchor;
+							props.setAttributes( { anchor: nextValue } );
 						} }
 						autoCapitalize="none"
 						autoComplete="off"

--- a/packages/block-library/src/heading/autogenerate-anchors.js
+++ b/packages/block-library/src/heading/autogenerate-anchors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isNil, deburr, trim, startsWith } from 'lodash';
+import { deburr, trim } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -95,14 +95,13 @@ const generateAnchor = ( anchor, content, allHeadingAnchors ) => {
 		return null;
 	}
 
-	const baseAnchor = `wp-${ slug }`;
-	anchor = baseAnchor;
+	anchor = slug;
 	let i = 0;
 
 	// If the anchor already exists in another heading, append -i.
 	while ( allHeadingAnchors.includes( anchor ) ) {
 		i += 1;
-		anchor = baseAnchor + '-' + i;
+		anchor = slug + '-' + i;
 	}
 
 	return anchor;
@@ -125,8 +124,5 @@ export default function useGeneratedAnchor( clientId, anchor, content ) {
 		},
 		[ clientId ]
 	);
-	if ( isNil( anchor ) || startsWith( anchor, 'wp-' ) ) {
-		return generateAnchor( anchor, content, allHeadingAnchors );
-	}
-	return anchor;
+	return generateAnchor( anchor, content, allHeadingAnchors );
 }

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -6,6 +6,9 @@
 		"textAlign": {
 			"type": "string"
 		},
+		"autoAnchor": {
+			"type": "boolean"
+		},
 		"content": {
 			"type": "string",
 			"source": "html",

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -45,7 +45,10 @@ function HeadingEdit( {
 	);
 	useEffect( () => {
 		if ( generatedAnchor !== attributes.anchor ) {
-			setAttributes( { anchor: generatedAnchor } );
+			setAttributes( {
+				anchor: generatedAnchor,
+				autoAnchor: true,
+			} );
 		}
 	}, [ attributes.anchor, content ] );
 

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -44,7 +44,10 @@ function HeadingEdit( {
 		content
 	);
 	useEffect( () => {
-		if ( generatedAnchor !== attributes.anchor ) {
+		if (
+			false !== attributes.autoAnchor &&
+			generatedAnchor !== attributes.anchor
+		) {
 			setAttributes( {
 				anchor: generatedAnchor,
 				autoAnchor: true,

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/heading.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/heading.test.js.snap
@@ -2,25 +2,25 @@
 
 exports[`Heading can be created by prefixing existing content with number signs and a space 1`] = `
 "<!-- wp:heading {\\"level\\":4} -->
-<h4 id=\\"wp-4\\">4</h4>
+<h4 id=\\"4\\">4</h4>
 <!-- /wp:heading -->"
 `;
 
 exports[`Heading can be created by prefixing number sign and a space 1`] = `
 "<!-- wp:heading {\\"level\\":3} -->
-<h3 id=\\"wp-3\\">3</h3>
+<h3 id=\\"3\\">3</h3>
 <!-- /wp:heading -->"
 `;
 
 exports[`Heading should correctly apply custom colors 1`] = `
 "<!-- wp:heading {\\"level\\":3,\\"style\\":{\\"color\\":{\\"text\\":\\"#7700ff\\"}}} -->
-<h3 class=\\"has-text-color\\" id=\\"wp-heading\\" style=\\"color:#7700ff\\">Heading</h3>
+<h3 class=\\"has-text-color\\" id=\\"heading\\" style=\\"color:#7700ff\\">Heading</h3>
 <!-- /wp:heading -->"
 `;
 
 exports[`Heading should correctly apply named colors 1`] = `
 "<!-- wp:heading {\\"textColor\\":\\"luminous-vivid-orange\\"} -->
-<h2 class=\\"has-luminous-vivid-orange-color has-text-color\\" id=\\"wp-heading\\">Heading</h2>
+<h2 class=\\"has-luminous-vivid-orange-color has-text-color\\" id=\\"heading\\">Heading</h2>
 <!-- /wp:heading -->"
 `;
 
@@ -30,13 +30,13 @@ exports[`Heading should create a paragraph block above when pressing enter at th
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2 id=\\"wp-a\\">a</h2>
+<h2 id=\\"a\\">a</h2>
 <!-- /wp:heading -->"
 `;
 
 exports[`Heading should create a paragraph block below when pressing enter at the end 1`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-a\\">a</h2>
+<h2 id=\\"a\\">a</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -46,12 +46,12 @@ exports[`Heading should create a paragraph block below when pressing enter at th
 
 exports[`Heading should not work with the list input rule 1`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-1-h\\">1. H</h2>
+<h2 id=\\"1-h\\">1. H</h2>
 <!-- /wp:heading -->"
 `;
 
 exports[`Heading should work with the format input rules 1`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-code\\"><code>code</code></h2>
+<h2 id=\\"code\\"><code>code</code></h2>
 <!-- /wp:heading -->"
 `;

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/quote.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/quote.test.js.snap
@@ -40,7 +40,7 @@ exports[`Quote can be converted to paragraphs and renders only one paragraph for
 
 exports[`Quote can be created by converting a heading 1`] = `
 "<!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\" id=\\"wp-test\\"><p>test</p></blockquote>
+<blockquote class=\\"wp-block-quote\\" id=\\"test\\"><p>test</p></blockquote>
 <!-- /wp:quote -->"
 `;
 
@@ -144,7 +144,7 @@ exports[`Quote can be split in the middle and merged back 4`] = `
 
 exports[`Quote is transformed to a heading and a quote if the quote contains a citation 1`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-one\\">one</h2>
+<h2 id=\\"one\\">one</h2>
 <!-- /wp:heading -->
 
 <!-- wp:quote -->
@@ -154,7 +154,7 @@ exports[`Quote is transformed to a heading and a quote if the quote contains a c
 
 exports[`Quote is transformed to a heading and a quote if the quote contains multiple paragraphs 1`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-one\\">one</h2>
+<h2 id=\\"one\\">one</h2>
 <!-- /wp:heading -->
 
 <!-- wp:quote -->
@@ -164,7 +164,7 @@ exports[`Quote is transformed to a heading and a quote if the quote contains mul
 
 exports[`Quote is transformed to a heading if the quote just contains one paragraph 1`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-one\\">one</h2>
+<h2 id=\\"one\\">one</h2>
 <!-- /wp:heading -->"
 `;
 
@@ -176,7 +176,7 @@ exports[`Quote is transformed to an empty heading if the quote is empty 1`] = `
 
 exports[`Quote the resuling quote after transforming to a heading can be transformed again 1`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-one\\">one</h2>
+<h2 id=\\"one\\">one</h2>
 <!-- /wp:heading -->
 
 <!-- wp:quote -->
@@ -186,11 +186,11 @@ exports[`Quote the resuling quote after transforming to a heading can be transfo
 
 exports[`Quote the resuling quote after transforming to a heading can be transformed again 2`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-one\\">one</h2>
+<h2 id=\\"one\\">one</h2>
 <!-- /wp:heading -->
 
 <!-- wp:heading -->
-<h2 id=\\"wp-two\\">two</h2>
+<h2 id=\\"two\\">two</h2>
 <!-- /wp:heading -->
 
 <!-- wp:quote -->
@@ -200,14 +200,14 @@ exports[`Quote the resuling quote after transforming to a heading can be transfo
 
 exports[`Quote the resuling quote after transforming to a heading can be transformed again 3`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-one\\">one</h2>
+<h2 id=\\"one\\">one</h2>
 <!-- /wp:heading -->
 
 <!-- wp:heading -->
-<h2 id=\\"wp-two\\">two</h2>
+<h2 id=\\"two\\">two</h2>
 <!-- /wp:heading -->
 
 <!-- wp:heading -->
-<h2 id=\\"wp-cite\\">cite</h2>
+<h2 id=\\"cite\\">cite</h2>
 <!-- /wp:heading -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/block-grouping.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/block-grouping.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Block Grouping Group creation creates a group from multiple blocks of different types via block transforms 1`] = `
 "<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:heading -->
-<h2 id=\\"wp-group-heading\\">Group Heading</h2>
+<h2 id=\\"group-heading\\">Group Heading</h2>
 <!-- /wp:heading -->
 
 <!-- wp:image -->
@@ -51,7 +51,7 @@ exports[`Block Grouping Group creation creates a group from multiple blocks of t
 exports[`Block Grouping Group creation groups and ungroups multiple blocks of different types via options toolbar 1`] = `
 "<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:heading -->
-<h2 id=\\"wp-group-heading\\">Group Heading</h2>
+<h2 id=\\"group-heading\\">Group Heading</h2>
 <!-- /wp:heading -->
 
 <!-- wp:image -->
@@ -66,7 +66,7 @@ exports[`Block Grouping Group creation groups and ungroups multiple blocks of di
 
 exports[`Block Grouping Group creation groups and ungroups multiple blocks of different types via options toolbar 2`] = `
 "<!-- wp:heading -->
-<h2 id=\\"wp-group-heading\\">Group Heading</h2>
+<h2 id=\\"group-heading\\">Group Heading</h2>
 <!-- /wp:heading -->
 
 <!-- wp:image -->
@@ -81,7 +81,7 @@ exports[`Block Grouping Group creation groups and ungroups multiple blocks of di
 exports[`Block Grouping Preserving selected blocks attributes preserves width alignment settings of selected blocks 1`] = `
 "<!-- wp:group {\\"align\\":\\"full\\"} -->
 <div class=\\"wp-block-group alignfull\\"><!-- wp:heading -->
-<h2 id=\\"wp-group-heading\\">Group Heading</h2>
+<h2 id=\\"group-heading\\">Group Heading</h2>
 <!-- /wp:heading -->
 
 <!-- wp:image {\\"align\\":\\"full\\"} -->

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
@@ -71,7 +71,7 @@ exports[`Inserting blocks inserts a block in proper place after having clicked \
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2 id=\\"wp-heading\\">Heading</h2>
+<h2 id=\\"heading\\">Heading</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -93,7 +93,7 @@ exports[`Inserting blocks inserts a block in proper place after having clicked \
 <!-- /wp:cover -->
 
 <!-- wp:heading -->
-<h2 id=\\"wp-heading\\">Heading</h2>
+<h2 id=\\"heading\\">Heading</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->

--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -309,7 +309,7 @@ describe( 'Widgets screen', () => {
 		<p>First Paragraph</p>
 		</div></div>
 		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
-		<h2 id=\\"wp-my-heading\\">My Heading</h2>
+		<h2 id=\\"my-heading\\">My Heading</h2>
 		</div></div>
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
