### PR TITLE
Fixes color picker segmented control rendering and scrolling issues

### DIFF
--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -7,6 +7,7 @@ import {
 	View,
 	Animated,
 	Easing,
+	Dimensions,
 	Platform,
 	Text,
 } from 'react-native';
@@ -25,8 +26,9 @@ import ColorIndicator from '../color-indicator';
 import { colorsUtils } from '../mobile/color-settings/utils';
 
 const ANIMATION_DURATION = 200;
-const SEGMENTED_CONTROL_ANIMATION_DURATION_DELAY = 200;
 
+let contentWidth = 0;
+let scrollPosition = 0;
 let customIndicatorWidth = 0;
 
 function ColorPalette( {
@@ -79,17 +81,12 @@ function ColorPalette( {
 	useEffect( () => {
 		setShouldShowCustomIndicator(
 			shouldShowCustomIndicatorOption &&
-				( ! isGradientSegment ||
-					( isGradientColor &&
-						activeColor &&
-						! ( colors && colors.includes( activeColor ) ) ) )
+				( ! isGradientSegment || isCustomGradientColor )
 		);
 	}, [
 		shouldShowCustomIndicatorOption,
 		isGradientSegment,
-		activeColor,
-		colors,
-		isGradientColor,
+		isCustomGradientColor,
 	] );
 
 	const accessibilityHint = isGradientSegment
@@ -98,15 +95,6 @@ function ColorPalette( {
 	const customText = __( 'Custom' );
 
 	useEffect( () => {
-		const delayedScroll = setTimeout( () => {
-			resetScrollPosition();
-		}, SEGMENTED_CONTROL_ANIMATION_DURATION_DELAY );
-		return () => {
-			clearTimeout( delayedScroll );
-		};
-	}, [ currentSegment ] );
-
-	function resetScrollPosition() {
 		if ( scrollViewRef.current ) {
 			if ( isSelectedCustom() ) {
 				scrollViewRef.current.scrollToEnd();
@@ -114,7 +102,7 @@ function ColorPalette( {
 				scrollViewRef.current.scrollTo( { x: 0, y: 0 } );
 			}
 		}
-	}
+	}, [ currentSegment ] );
 
 	function isSelectedCustom() {
 		const isWithinColors =
@@ -160,9 +148,40 @@ function ColorPalette( {
 		outputRange: [ 1, 0.7, 1 ],
 	} );
 
+	function deselectCustomGradient() {
+		const { width } = Dimensions.get( 'window' );
+		const isVisible =
+			contentWidth - scrollPosition - customIndicatorWidth < width;
+
+		if ( isCustomGradientColor ) {
+			if ( ! isIOS ) {
+				// Scroll position on Android doesn't adjust automatically when removing the last item from the horizontal list.
+				// https://github.com/facebook/react-native/issues/27504
+				// Workaround: Force the scroll when deselecting custom gradient color and when custom indicator is visible on layout.
+				if (
+					isCustomGradientColor &&
+					isVisible &&
+					scrollViewRef.current
+				) {
+					scrollViewRef.current.scrollTo( {
+						x: scrollPosition - customIndicatorWidth,
+					} );
+				}
+			}
+		}
+	}
+
 	function onColorPress( color ) {
+		deselectCustomGradient();
 		performAnimation( color );
 		setColor( color );
+	}
+
+	function onContentSizeChange( width ) {
+		contentWidth = width;
+		if ( isSelectedCustom() && scrollViewRef.current ) {
+			scrollViewRef.current.scrollToEnd( { animated: ! isIOS } );
+		}
 	}
 
 	function onCustomIndicatorLayout( { nativeEvent } ) {
@@ -170,6 +189,10 @@ function ColorPalette( {
 		if ( width !== customIndicatorWidth ) {
 			customIndicatorWidth = width;
 		}
+	}
+
+	function onScroll( { nativeEvent } ) {
+		scrollPosition = nativeEvent.contentOffset.x;
 	}
 
 	const verticalSeparatorStyle = usePreferredColorSchemeStyle(
@@ -196,7 +219,8 @@ function ColorPalette( {
 			keyboardShouldPersistTaps="always"
 			disableScrollViewPanResponder
 			scrollEventThrottle={ 16 }
-			onContentSizeChange={ resetScrollPosition }
+			onScroll={ onScroll }
+			onContentSizeChange={ onContentSizeChange }
 			onScrollBeginDrag={ () => shouldEnableBottomSheetScroll( false ) }
 			onScrollEndDrag={ () => shouldEnableBottomSheetScroll( true ) }
 			ref={ scrollViewRef }

--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -25,6 +25,7 @@ import ColorIndicator from '../color-indicator';
 import { colorsUtils } from '../mobile/color-settings/utils';
 
 const ANIMATION_DURATION = 200;
+const SEGMENTED_CONTROL_ANIMATION_DURATION_DELAY = 200;
 
 let customIndicatorWidth = 0;
 
@@ -97,10 +98,9 @@ function ColorPalette( {
 	const customText = __( 'Custom' );
 
 	useEffect( () => {
-		const delayedScroll = setTimeout(
-			resetScrollPosition,
-			ANIMATION_DURATION
-		);
+		const delayedScroll = setTimeout( () => {
+			resetScrollPosition();
+		}, SEGMENTED_CONTROL_ANIMATION_DURATION_DELAY );
 		return () => {
 			clearTimeout( delayedScroll );
 		};

--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -81,7 +81,7 @@ function ColorPalette( {
 	useEffect( () => {
 		if ( scrollViewRef.current ) {
 			if ( isSelectedCustom() ) {
-				scrollViewRef.current.scrollToEnd();
+				scrollToEndWithDelay();
 			} else {
 				scrollViewRef.current.scrollTo( { x: 0, y: 0 } );
 			}
@@ -164,8 +164,17 @@ function ColorPalette( {
 	function onContentSizeChange( width ) {
 		contentWidth = width;
 		if ( isSelectedCustom() && scrollViewRef.current ) {
-			scrollViewRef.current.scrollToEnd( { animated: ! isIOS } );
+			scrollToEndWithDelay();
 		}
+	}
+
+	function scrollToEndWithDelay() {
+		const delayedScroll = setTimeout( () => {
+			scrollViewRef.current.scrollToEnd();
+		}, ANIMATION_DURATION );
+		return () => {
+			clearTimeout( delayedScroll );
+		};
 	}
 
 	function onCustomIndicatorLayout( { nativeEvent } ) {

--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -25,7 +25,6 @@ import ColorIndicator from '../color-indicator';
 import { colorsUtils } from '../mobile/color-settings/utils';
 
 const ANIMATION_DURATION = 200;
-const SEGMENTED_CONTROL_ANIMATION_DURATION_DELAY = 200;
 
 let customIndicatorWidth = 0;
 
@@ -98,9 +97,10 @@ function ColorPalette( {
 	const customText = __( 'Custom' );
 
 	useEffect( () => {
-		const delayedScroll = setTimeout( () => {
-			resetScrollPosition();
-		}, SEGMENTED_CONTROL_ANIMATION_DURATION_DELAY );
+		const delayedScroll = setTimeout(
+			resetScrollPosition,
+			ANIMATION_DURATION
+		);
 		return () => {
 			clearTimeout( delayedScroll );
 		};

--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -16,7 +16,7 @@ import { map, uniq } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useRef, useEffect, useState } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 /**
  * Internal dependencies
@@ -50,15 +50,6 @@ function ColorPalette( {
 		'linear-gradient(240deg, rgba(0,255,0,.8) 0%, rgba(0,255,0,0) 70.71%)',
 		'linear-gradient(360deg, rgba(0,0,255,.8) 0%, rgba(0,0,255,0) 70.71%)',
 	];
-	const isCustomGradientColor = isGradientColor && isSelectedCustom();
-
-	const [
-		shouldShowCustomIndicator,
-		setShouldShowCustomIndicator,
-	] = useState(
-		shouldShowCustomIndicatorOption &&
-			( ! isGradientSegment || isCustomGradientColor )
-	);
 
 	const scrollViewRef = useRef();
 	const isIOS = Platform.OS === 'ios';
@@ -77,17 +68,10 @@ function ColorPalette( {
 	const customIndicatorColor = isGradientSegment
 		? activeColor
 		: customSwatchGradients;
-
-	useEffect( () => {
-		setShouldShowCustomIndicator(
-			shouldShowCustomIndicatorOption &&
-				( ! isGradientSegment || isCustomGradientColor )
-		);
-	}, [
-		shouldShowCustomIndicatorOption,
-		isGradientSegment,
-		isCustomGradientColor,
-	] );
+	const isCustomGradientColor = isGradientColor && isSelectedCustom();
+	const shouldShowCustomIndicator =
+		shouldShowCustomIndicatorOption &&
+		( ! isGradientSegment || isCustomGradientColor );
 
 	const accessibilityHint = isGradientSegment
 		? __( 'Navigates to customize the gradient' )
@@ -225,6 +209,41 @@ function ColorPalette( {
 			onScrollEndDrag={ () => shouldEnableBottomSheetScroll( true ) }
 			ref={ scrollViewRef }
 		>
+			{ shouldShowCustomIndicator && (
+				<View
+					style={ customIndicatorWrapperStyle }
+					onLayout={ onCustomIndicatorLayout }
+				>
+					{ shouldShowCustomVerticalSeparator && (
+						<View style={ verticalSeparatorStyle } />
+					) }
+					<TouchableWithoutFeedback
+						onPress={ onCustomPress }
+						accessibilityRole={ 'button' }
+						accessibilityState={ { selected: isSelectedCustom() } }
+						accessibilityHint={ accessibilityHint }
+					>
+						<View style={ customIndicatorWrapperStyle }>
+							<ColorIndicator
+								withCustomPicker={ ! isGradientSegment }
+								color={ customIndicatorColor }
+								isSelected={ isSelectedCustom() }
+								style={ [
+									styles.colorIndicator,
+									customColorIndicatorStyles,
+								] }
+							/>
+							{ shouldShowCustomLabel && (
+								<Text style={ customTextStyle }>
+									{ isIOS
+										? customText
+										: customText.toUpperCase() }
+								</Text>
+							) }
+						</View>
+					</TouchableWithoutFeedback>
+				</View>
+			) }
 			{ colors.map( ( color ) => {
 				const scaleValue = isSelected( color ) ? scaleInterpolation : 1;
 				return (
@@ -260,43 +279,6 @@ function ColorPalette( {
 					</View>
 				);
 			} ) }
-			{ shouldShowCustomIndicator && (
-				<View
-					style={ customIndicatorWrapperStyle }
-					onLayout={ onCustomIndicatorLayout }
-				>
-					{ shouldShowCustomVerticalSeparator && (
-						<View style={ verticalSeparatorStyle } />
-					) }
-					<TouchableWithoutFeedback
-						onPress={ onCustomPress }
-						accessibilityRole={ 'button' }
-						accessibilityState={ {
-							selected: isSelectedCustom(),
-						} }
-						accessibilityHint={ accessibilityHint }
-					>
-						<View style={ customIndicatorWrapperStyle }>
-							<ColorIndicator
-								withCustomPicker={ ! isGradientSegment }
-								color={ customIndicatorColor }
-								isSelected={ isSelectedCustom() }
-								style={ [
-									styles.colorIndicator,
-									customColorIndicatorStyles,
-								] }
-							/>
-							{ shouldShowCustomLabel && (
-								<Text style={ customTextStyle }>
-									{ isIOS
-										? customText
-										: customText.toUpperCase() }
-								</Text>
-							) }
-						</View>
-					</TouchableWithoutFeedback>
-				</View>
-			) }
 		</ScrollView>
 	);
 }

--- a/packages/components/src/color-palette/style.native.scss
+++ b/packages/components/src/color-palette/style.native.scss
@@ -1,5 +1,5 @@
 .contentContainer {
-	flex-direction: row;
+	flex-direction: row-reverse;
 	padding: 0 $grid-unit-20;
 }
 

--- a/packages/components/src/color-palette/style.native.scss
+++ b/packages/components/src/color-palette/style.native.scss
@@ -1,4 +1,5 @@
 .contentContainer {
+	flex-grow: 1;
 	flex-direction: row;
 	padding: 0 $grid-unit-20;
 }

--- a/packages/components/src/color-palette/style.native.scss
+++ b/packages/components/src/color-palette/style.native.scss
@@ -1,5 +1,4 @@
 .contentContainer {
-	flex-grow: 1;
 	flex-direction: row;
 	padding: 0 $grid-unit-20;
 }

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Bottom-sheet: Add custom header [#30291]
+-   [*] Fixes color picker rendering bug when scrolling [#30994]
 
 ## 1.52.0
 


### PR DESCRIPTION
**Fixes**: https://github.com/WordPress/gutenberg/issues/30878 and https://github.com/wordpress-mobile/gutenberg-mobile/issues/3104

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3394
`WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/14492
`WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/16366

## Description
This [reverts](https://github.com/WordPress/gutenberg/pull/30994/commits/9094f38a4767da1fc6735c3c25b75cdce587dcdd) https://github.com/WordPress/gutenberg/pull/28740 falling back to the previous [workaround](https://github.com/WordPress/gutenberg/pull/28698) for fixing the crash occurring when segments are changed quickly.
The applied solution is based on rearranging components which might not be optimal but does not cause the following two issues: #30878 and #3104.
The applied solution additionally [adds a delay when scrolling to the end](https://github.com/WordPress/gutenberg/pull/30994/commits/9094f38a4767da1fc6735c3c25b75cdce587dcdd) to counteract the segment selection delay.

## How has this been tested?

*Notes: The tests bellow should be performed with builds from the [Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14492) and [iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/16366)*

### Crash regression check
1. Go to a post/page.
2. Add Buttons block.
3. Tap on the gear button.
4. Tap on Background Color options.
5. Switch several times between Solid and Gradient segments.
6. **Verify** that the app does not crash

### Custom gradient button is visible
1. Go to a post/page
2. Add `Buttons` block
3. Tap on gear button
4. Tap on `Background color` option
5. Tap on `Gradient` option
6. Tap one gradient color
7. Tap on `Customize Gradient`
8. Change `Gradient Type` to `Radial` (it also works changing other options)
9. Tap on back arrow button
10. Tap on `Solid` option
11. Tap on `Gradient` option again
12. **Verify** that the custom gradient button is shown and selected
13. **Verify** that the scroll goes to the end where the custom gradient is shown

### Color picker is not cropped
1. Launch block editor on WPAndroid.
2. Add a Button block.
3. Open the Button block settings.
4. Tap Background Color.
5. Tap Gradient.
6. Scroll to the end of the gradient list.
7. Tap Solid.
8. **Verify** that content is not cropped 

### [Sanity testing test cases](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/color-settings.md)

#### Known issues: 
* [TC005](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/color-settings.md#tc005): When switching from a customized gradient to a built-in gradient, the Custom button does not "slide out" with a smooth animation

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
