### PR TITLE
[Block Library - Site Title]: Add default block after pressing enter at the end of Site Title

### DIFF
--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -14,13 +14,18 @@ import {
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import LevelToolbar from './level-toolbar';
 
-export default function SiteTitleEdit( { attributes, setAttributes } ) {
+export default function SiteTitleEdit( {
+	attributes,
+	setAttributes,
+	insertBlocksAfter,
+} ) {
 	const { level, textAlign } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const TagName = level === 0 ? 'p' : `h${ level }`;
@@ -56,6 +61,11 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 					onChange={ setTitle }
 					allowedFormats={ [] }
 					disableLineBreaks
+					__unstableOnSplitAtEnd={ () =>
+						insertBlocksAfter(
+							createBlock( getDefaultBlockName() )
+						)
+					}
 				/>
 			</TagName>
 		</>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/27831
<!-- Please describe what you have changed or added -->
Previously if you were editing the `Site Title`, pressing enter would do nothing. Noting that if you had just the block selected and not editing the content of the block, pressing enter would create a new block.

## Testing instructions
1. Add a `Site Title` block
2. Focus on title's text at the end and press enter - observe new default block is created
3. Focus on title's text anywhere **but** the end and press enter - observe nothing is happening.
