### PR TITLE
Clean up bundled pattern titles & categories

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -34,7 +34,7 @@ register_block_pattern(
 register_block_pattern(
 	'query/medium-posts',
 	array(
-		'title'      => __( 'Image at Left', 'gutenberg' ),
+		'title'      => __( 'Image at left', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
 		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
@@ -56,7 +56,7 @@ register_block_pattern(
 register_block_pattern(
 	'query/small-posts',
 	array(
-		'title'      => __( 'Small Image and Title', 'gutenberg' ),
+		'title'      => __( 'Small image and title', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
 		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
@@ -95,7 +95,7 @@ register_block_pattern(
 register_block_pattern(
 	'query/large-title-posts',
 	array(
-		'title'      => __( 'Large Title', 'gutenberg' ),
+		'title'      => __( 'Large title', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
 		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"100px","right":"100px","bottom":"100px","left":"100px"}},"color":{"text":"#ffffff","background":"#000000"}}} -->

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-// Register categories used for block patterns. 
+// Register categories used for block patterns.
 register_block_pattern_category( 'query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
 register_block_pattern_category( 'text', array( 'label' => __( 'Text', 'gutenberg' ) ) );
 register_block_pattern_category( 'buttons', array( 'label' => __( 'Buttons', 'gutenberg' ) ) );

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -161,7 +161,7 @@ register_block_pattern(
 register_block_pattern(
 	'paragraph/large-with-background-color',
 	array(
-		'title'         => __( 'Large Paragraph with background color', 'gutenberg' ),
+		'title'         => __( 'Large paragraph with background color', 'gutenberg' ),
 		'categories'    => array( 'text' ),
 		'blockTypes'    => array( 'core/paragraph' ),
 		'viewportWidth' => 500,

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -5,7 +5,10 @@
  * @package gutenberg
  */
 
-register_block_pattern_category( 'Query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
+// Register categories used for block patterns. 
+register_block_pattern_category( 'query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
+register_block_pattern_category( 'text', array( 'label' => __( 'Text', 'gutenberg' ) ) );
+register_block_pattern_category( 'buttons', array( 'label' => __( 'Buttons', 'gutenberg' ) ) );
 
 // Initial Query block patterns.
 register_block_pattern(
@@ -13,7 +16,7 @@ register_block_pattern(
 	array(
 		'title'      => __( 'Standard', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
-		'categories' => array( 'Query' ),
+		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 						<!-- wp:query-loop -->
 						<!-- wp:post-title {"isLink":true} /-->
@@ -33,7 +36,7 @@ register_block_pattern(
 	array(
 		'title'      => __( 'Image at Left', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
-		'categories' => array( 'Query' ),
+		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 						<!-- wp:query-loop -->
 						<!-- wp:columns {"align":"wide"} -->
@@ -55,7 +58,7 @@ register_block_pattern(
 	array(
 		'title'      => __( 'Small Image and Title', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
-		'categories' => array( 'Query' ),
+		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 						<!-- wp:query-loop -->
 						<!-- wp:columns {"verticalAlignment":"center"} -->
@@ -76,7 +79,7 @@ register_block_pattern(
 	array(
 		'title'      => __( 'Grid', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
-		'categories' => array( 'Query' ),
+		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":true},"layout":{"type":"flex","columns":3}} -->
 						<!-- wp:query-loop -->
 						<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
@@ -94,7 +97,7 @@ register_block_pattern(
 	array(
 		'title'      => __( 'Large Title', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
-		'categories' => array( 'Query' ),
+		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"100px","right":"100px","bottom":"100px","left":"100px"}},"color":{"text":"#ffffff","background":"#000000"}}} -->
 						<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:100px;padding-right:100px;padding-bottom:100px;padding-left:100px"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 						<!-- wp:query-loop -->
@@ -122,7 +125,7 @@ register_block_pattern(
 	array(
 		'title'      => __( 'Offset', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
-		'categories' => array( 'Query' ),
+		'categories' => array( 'query' ),
 		'content'    => '<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
 						<main class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:columns -->
 						<div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
@@ -159,7 +162,7 @@ register_block_pattern(
 	'paragraph/large-with-background-color',
 	array(
 		'title'         => __( 'Large Paragraph with background color', 'gutenberg' ),
-		'categories'    => array( 'Text' ),
+		'categories'    => array( 'text' ),
 		'blockTypes'    => array( 'core/paragraph' ),
 		'viewportWidth' => 500,
 		'content'       => '<!-- wp:paragraph {"style":{"color":{"link":"#FFFFFF","text":"#FFFFFF","background":"#000000"},"typography":{"lineHeight":"1.3","fontSize":"26px"}}} -->
@@ -171,7 +174,7 @@ register_block_pattern(
 	'social-links/shared-background-color',
 	array(
 		'title'         => __( 'Social links with a shared background color', 'gutenberg' ),
-		'categories'    => array( 'Buttons' ),
+		'categories'    => array( 'buttons' ),
 		'blockTypes'    => array( 'core/social-links' ),
 		'viewportWidth' => 500,
 		'content'       => '<!-- wp:social-links {"customIconColor":"#ffffff","iconColorValue":"#ffffff","customIconBackgroundColor":"#3962e3","iconBackgroundColorValue":"#3962e3","className":"has-icon-color"} -->
@@ -227,11 +230,9 @@ add_action(
 			unregister_block_pattern( 'core/' . $core_block_pattern );
 		}
 
-		register_block_pattern_category( 'buttons', array( 'label' => _x( 'Buttons', 'Block pattern category', 'default' ) ) );
 		register_block_pattern_category( 'columns', array( 'label' => _x( 'Columns', 'Block pattern category', 'default' ) ) );
 		register_block_pattern_category( 'header', array( 'label' => _x( 'Headers', 'Block pattern category', 'default' ) ) );
 		register_block_pattern_category( 'gallery', array( 'label' => _x( 'Gallery', 'Block pattern category', 'default' ) ) );
-		register_block_pattern_category( 'text', array( 'label' => _x( 'Text', 'Block pattern category', 'default' ) ) );
 
 		foreach ( $new_core_block_patterns as $core_block_pattern ) {
 			register_block_pattern(

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -7,8 +7,6 @@
 
 // Register categories used for block patterns.
 register_block_pattern_category( 'query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
-register_block_pattern_category( 'text', array( 'label' => __( 'Text', 'gutenberg' ) ) );
-register_block_pattern_category( 'buttons', array( 'label' => __( 'Buttons', 'gutenberg' ) ) );
 
 // Initial Query block patterns.
 register_block_pattern(
@@ -229,10 +227,6 @@ add_action(
 		foreach ( $core_block_patterns as $core_block_pattern ) {
 			unregister_block_pattern( 'core/' . $core_block_pattern );
 		}
-
-		register_block_pattern_category( 'columns', array( 'label' => _x( 'Columns', 'Block pattern category', 'default' ) ) );
-		register_block_pattern_category( 'header', array( 'label' => _x( 'Headers', 'Block pattern category', 'default' ) ) );
-		register_block_pattern_category( 'gallery', array( 'label' => _x( 'Gallery', 'Block pattern category', 'default' ) ) );
 
 		foreach ( $new_core_block_patterns as $core_block_pattern ) {
 			register_block_pattern(


### PR DESCRIPTION
Some minor followup from #30763, #29973, and https://github.com/WordPress/gutenberg/pull/30469. 

This PR: 

- Changes all slugs to be lowercase, and all titles to sentence case for consistency. 
- Moves the "Large paragraph with background color" and "Social links with a shared background color" patterns into their correct categories, so they don't appear "Uncategorized". 
- Defines the "Buttons" and "Text" categories up at the the top of the file, since they're used for patterns that live outside of the action at the bottom of the file. 

Before|After
---|---
<img width="350" alt="Screen Shot 2021-04-20 at 8 42 58 AM" src="https://user-images.githubusercontent.com/1202812/115398911-a091e300-a1b5-11eb-9aa6-044772170a8d.png">|<img width="351" alt="Screen Shot 2021-04-20 at 8 38 52 AM" src="https://user-images.githubusercontent.com/1202812/115398922-a4256a00-a1b5-11eb-9bc6-e304cc9535d8.png"><img width="349" alt="Screen Shot 2021-04-20 at 8 38 39 AM" src="https://user-images.githubusercontent.com/1202812/115398923-a4256a00-a1b5-11eb-82a3-6c143c882997.png">


