### PR TITLE
[Block Library - Site Title]: Normalize the toolbar

### DIFF
--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -31,7 +31,7 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 	} );
 	return (
 		<>
-			<BlockControls>
+			<BlockControls group="block">
 				<AlignmentToolbar
 					value={ textAlign }
 					onChange={ ( nextAlign ) => {

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -32,18 +32,17 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<BlockControls group="block">
-				<AlignmentToolbar
-					value={ textAlign }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { textAlign: nextAlign } );
-					} }
-				/>
-
 				<LevelToolbar
 					level={ level }
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}
+				/>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
 				/>
 			</BlockControls>
 			<TagName { ...blockProps }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Part of: https://github.com/WordPress/gutenberg/issues/30918

Normalizes the toolbar for `Site Title` block.
<!-- Please describe what you have changed or added -->

### Before
<img width="486" alt="Screenshot 2021-04-20 at 3 57 36 PM" src="https://user-images.githubusercontent.com/16275880/115400927-7ca0c280-a1f2-11eb-9a11-ded18865b7aa.png">


### After
<img width="486" alt="Screenshot 2021-04-20 at 4 43 01 PM" src="https://user-images.githubusercontent.com/16275880/115406106-88db4e80-a1f7-11eb-8c27-8a71428a72a1.png">
