### PR TITLE
Media & Text: Add media width control

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -22,6 +22,7 @@ import {
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
+	RangeControl,
 	TextareaControl,
 	ToggleControl,
 	ToolbarButton,
@@ -48,6 +49,21 @@ const TEMPLATE = [
 			placeholder: _x( 'Content…', 'content placeholder' ),
 		},
 	],
+];
+
+const WIDTH_SCALE_MARKS = [
+	{
+		value: 25,
+		label: '25%',
+	},
+	{
+		value: 50,
+		label: '50%',
+	},
+	{
+		value: 75,
+		label: '75%',
+	},
 ];
 // this limits the resize to a safe zone to avoid making broken layouts
 const WIDTH_CONSTRAINT_PERCENTAGE = 15;
@@ -274,6 +290,16 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					slug={ mediaSizeSlug }
 					imageSizeOptions={ imageSizeOptions }
 					isResizable={ false }
+				/>
+			) }
+			{ mediaUrl && (
+				<RangeControl
+					label={ __( 'Media width' ) }
+					value={ temporaryMediaWidth || mediaWidth }
+					marks={ WIDTH_SCALE_MARKS }
+					onChange={ commitWidthChange }
+					min={ WIDTH_CONSTRAINT_PERCENTAGE }
+					max={ 100 - WIDTH_CONSTRAINT_PERCENTAGE }
 				/>
 			) }
 		</PanelBody>

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -51,20 +51,6 @@ const TEMPLATE = [
 	],
 ];
 
-const WIDTH_SCALE_MARKS = [
-	{
-		value: 25,
-		label: '25%',
-	},
-	{
-		value: 50,
-		label: '50%',
-	},
-	{
-		value: 75,
-		label: '75%',
-	},
-];
 // this limits the resize to a safe zone to avoid making broken layouts
 const WIDTH_CONSTRAINT_PERCENTAGE = 15;
 const applyWidthConstraints = ( width ) =>
@@ -296,7 +282,6 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 				<RangeControl
 					label={ __( 'Media width' ) }
 					value={ temporaryMediaWidth || mediaWidth }
-					marks={ WIDTH_SCALE_MARKS }
 					onChange={ commitWidthChange }
 					min={ WIDTH_CONSTRAINT_PERCENTAGE }
 					max={ 100 - WIDTH_CONSTRAINT_PERCENTAGE }


### PR DESCRIPTION
## Description
Adds new control for media width. Using `RangeControl` with three preset options as suggested snap points. Props to @sarahmonster for the original idea.

Fixes #16853.
Fixes #17672.
Closes #14483. 

## How has this been tested?
1. Add the "Media & Text" block.
2. Set the media.
3. New "Media width" control should be visible in the "Media & Text settings" panel.
4. Changing the value in the new control should change the width of the media.

## Screenshots <!-- if applicable -->
<img width="281" alt="media-text-width-controls-no-marks" src="https://user-images.githubusercontent.com/240569/115536147-838b0c00-a2aa-11eb-8ad3-0b73e05ed32d.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
