### PR TITLE
Add/disable fse support

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -96,6 +96,9 @@ class WP_Theme_JSON {
 	);
 
 	const VALID_SETTINGS = array(
+		'experience' => array(
+			'enable_fse' => null,
+		),
 		'border'     => array(
 			'customRadius' => null,
 			'customColor'  => null,

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -11,7 +11,7 @@
  * @return boolean Whether the current theme is an FSE theme or not.
  */
 function gutenberg_is_fse_theme() {
-	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' );
+	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) && !current_theme_supports( 'disable-fse' );
 }
 
 /**

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -11,7 +11,14 @@
  * @return boolean Whether the current theme is an FSE theme or not.
  */
 function gutenberg_is_fse_theme() {
-	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) && !current_theme_supports( 'disable-fse' );
+
+	$enable_fse     = true;
+	$theme_settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
+	if ( isset( $theme_settings['defaults']['experience']['enable_fse'] ) ) {
+		$enable_fse = $theme_settings['defaults']['experience']['enable_fse'];
+	}
+
+	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) && $enable_fse;
 }
 
 /**


### PR DESCRIPTION
Refactors https://github.com/WordPress/gutenberg/pull/30760 to use a theme.json setting instead of a theme_support flag.