### PR TITLE
Color-palette: Match color value and color variable from palette

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { every, isEmpty } from 'lodash';
+import { every, isEmpty, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,7 +21,10 @@ import { sprintf, __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getColorObjectByColorValue } from '../colors';
+import {
+	getColorObjectByColorValue,
+	getVariableColorFromAttributeValue,
+} from '../colors';
 import { __experimentalGetGradientObjectByGradientValue } from '../gradients';
 import useEditorFeature from '../use-editor-feature';
 
@@ -46,13 +49,20 @@ function VisualLabel( {
 	colorValue,
 	gradientValue,
 } ) {
-	let value, ariaLabel;
+	let value, ariaLabel, colorObject;
 	if ( currentTab === 'color' ) {
 		if ( colorValue ) {
 			value = colorValue;
-			const colorObject = getColorObjectByColorValue( colors, value );
-			const colorName = colorObject && colorObject.name;
-			ariaLabel = sprintf( colorIndicatorAriaLabel, colorName || value );
+			if ( startsWith( colorValue, 'var:' ) ) {
+				colorObject = getVariableColorFromAttributeValue(
+					colors,
+					value
+				);
+				value = colorObject?.color || value;
+			} else {
+				colorObject = getColorObjectByColorValue( colors, value );
+			}
+			ariaLabel = sprintf( colorIndicatorAriaLabel, value );
 		}
 	} else if ( currentTab === 'gradient' && gradientValue ) {
 		value = gradientValue;
@@ -115,6 +125,7 @@ function ColorGradientControlInner( {
 						<BaseControl.VisualLabel>
 							<VisualLabel
 								currentTab={ currentTab }
+								colors={ colors }
 								label={ label }
 								colorValue={ colorValue }
 								gradientValue={ gradientValue }

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { every, isEmpty } from 'lodash';
+import { every, isEmpty, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,7 +14,10 @@ import { sprintf, __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ColorGradientControl from './control';
-import { getColorObjectByColorValue } from '../colors';
+import {
+	getColorObjectByColorValue,
+	getVariableColorFromAttributeValue,
+} from '../colors';
 import { __experimentalGetGradientObjectByGradientValue } from '../gradients';
 import useEditorFeature from '../use-editor-feature';
 
@@ -48,10 +51,19 @@ const Indicators = ( { colors, gradients, settings } ) => {
 			}
 			let ariaLabel;
 			if ( colorValue ) {
-				const colorObject = getColorObjectByColorValue(
-					availableColors || colors,
-					colorValue
-				);
+				let colorObject;
+				if ( startsWith( colorValue, 'var:' ) ) {
+					colorObject = getVariableColorFromAttributeValue(
+						availableColors || colors,
+						colorValue
+					);
+					colorValue = colorObject?.color || colorValue;
+				} else {
+					colorObject = getColorObjectByColorValue(
+						availableColors || colors,
+						colorValue
+					);
+				}
 				ariaLabel = sprintf(
 					colorIndicatorAriaLabel,
 					label.toLowerCase(),

--- a/packages/block-editor/src/components/colors/index.js
+++ b/packages/block-editor/src/components/colors/index.js
@@ -1,7 +1,9 @@
 export {
+	compileStyleValue,
 	getColorClassName,
 	getColorObjectByAttributeValues,
 	getColorObjectByColorValue,
+	getVariableColorFromAttributeValue,
 } from './utils';
 export { createCustomColorsHOC, default as withColors } from './with-colors';
 export { default as __experimentalUseColors } from './use-colors';

--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, kebabCase, map } from 'lodash';
+import { find, kebabCase, map, startsWith } from 'lodash';
 import tinycolor from 'tinycolor2';
 
 /**
@@ -31,6 +31,28 @@ export const getColorObjectByAttributeValues = (
 	return {
 		color: customColor,
 	};
+};
+
+export const getVariableColorFromAttributeValue = ( colors, value ) => {
+	const attributeParsed = /var:preset\|color\|(.+)/.exec( value );
+	if ( attributeParsed && attributeParsed[ 1 ] ) {
+		return getColorObjectByAttributeValues( colors, attributeParsed[ 1 ] );
+	}
+	return value;
+};
+
+export const compileStyleValue = ( uncompiledValue ) => {
+	const VARIABLE_REFERENCE_PREFIX = 'var:';
+	const VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE = '|';
+	const VARIABLE_PATH_SEPARATOR_TOKEN_STYLE = '--';
+	if ( startsWith( uncompiledValue, VARIABLE_REFERENCE_PREFIX ) ) {
+		const variable = uncompiledValue
+			.slice( VARIABLE_REFERENCE_PREFIX.length )
+			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
+			.join( VARIABLE_PATH_SEPARATOR_TOKEN_STYLE );
+		return `var(--wp--${ variable })`;
+	}
+	return uncompiledValue;
 };
 
 /**

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { capitalize, get, has, omitBy, startsWith } from 'lodash';
+import { capitalize, get, has, omitBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +22,7 @@ import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
 import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
 import SpacingPanelControl from '../components/spacing-panel-control';
+import { compileStyleValue } from '../components/colors';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -32,20 +33,6 @@ const styleSupportKeys = [
 
 const hasStyleSupport = ( blockType ) =>
 	styleSupportKeys.some( ( key ) => hasBlockSupport( blockType, key ) );
-
-const VARIABLE_REFERENCE_PREFIX = 'var:';
-const VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE = '|';
-const VARIABLE_PATH_SEPARATOR_TOKEN_STYLE = '--';
-function compileStyleValue( uncompiledValue ) {
-	if ( startsWith( uncompiledValue, VARIABLE_REFERENCE_PREFIX ) ) {
-		const variable = uncompiledValue
-			.slice( VARIABLE_REFERENCE_PREFIX.length )
-			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
-			.join( VARIABLE_PATH_SEPARATOR_TOKEN_STYLE );
-		return `var(--wp--${ variable })`;
-	}
-	return uncompiledValue;
-}
 
 /**
  * Returns the inline styles to add depending on the style object

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -5,7 +5,7 @@ $blocks-block__margin: 0.5em;
 // to support the previous markup in addition to the new one.
 .wp-block-button__link {
 	color: $white;
-	background-color: #32373c;
+	background-color: inherit;
 	border-radius: 9999px; // 100% causes an oval, but any explicit but really high value retains the pill shape.
 	box-shadow: none;
 	cursor: pointer;

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+import { map, startsWith } from 'lodash';
 import tinycolor from 'tinycolor2';
 
 /**
@@ -25,13 +25,22 @@ export default function ColorPalette( {
 	value,
 } ) {
 	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
+	function match( val, color, slug ) {
+		if ( startsWith( val, 'var:' ) ) {
+			val = /var:preset\|color\|(.+)/.exec( val ).pop();
+		}
+		if ( val === color || val === slug ) {
+			return true;
+		}
+		return false;
+	}
 	const colorOptions = useMemo( () => {
-		return map( colors, ( { color, name } ) => (
+		return map( colors, ( { color, name, slug } ) => (
 			<CircularOptionPicker.Option
 				key={ color }
-				isSelected={ value === color }
+				isSelected={ match( value, color, slug ) }
 				selectedIconProps={
-					value === color
+					match( value, color, slug )
 						? {
 								fill: tinycolor
 									.mostReadable( color, [ '#000', '#fff' ] )
@@ -46,7 +55,9 @@ export default function ColorPalette( {
 				}
 				style={ { backgroundColor: color, color } }
 				onClick={
-					value === color ? clearColor : () => onChange( color )
+					match( value, color, slug )
+						? clearColor
+						: () => onChange( `var:preset|color|${ slug }` )
 				}
 				aria-label={
 					name

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -157,7 +157,7 @@ export default ( blockData, tree, type = 'all' ) => {
 				];
 
 				if ( variableDeclarations.length > 0 ) {
-					styles.push(
+					styles.unshift(
 						`${ selector } { ${ variableDeclarations.join(
 							';'
 						) } }`
@@ -170,7 +170,7 @@ export default ( blockData, tree, type = 'all' ) => {
 				);
 
 				if ( blockStyleDeclarations.length > 0 ) {
-					styles.push(
+					styles.unshift(
 						`${ selector } { ${ blockStyleDeclarations.join(
 							';'
 						) } }`
@@ -182,7 +182,7 @@ export default ( blockData, tree, type = 'all' ) => {
 					tree?.settings?.[ context ]
 				);
 				if ( presetClasses ) {
-					styles.push( presetClasses );
+					styles.unshift( presetClasses );
 				}
 			}
 			return styles;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The color-palette component could only handle real color values like hex, rgba and hsla. I enhanced the component by handling also color variable definitions like background-color : var:preset|color|{slug}.
Now you can define the color value where the component is used as an variable reference and the palette matches it from the given colors inside.

## How has this been tested?
I tested it with Theme TT1 Blocks and added following in the experimental-theme.json
```
"styles": {
    "root": {
        "color": {
            "background": "var:preset|color|green",
            "text": "var:preset|color|dark-gray",
            "link": "var:preset|color|white"
        }
    }
},
```
I also tested the locale changes inside global-styles, global-styles by block type and the local block settings.

## Screenshots
https://user-images.githubusercontent.com/5269059/115425237-bb894500-a1ff-11eb-8aa5-5c72bce1ab65.mp4

## Types of changes
Color-Palette component allows, matches and saves a variable form like `var:preset|color|{slug}`, so we just have a reference  for this color and not the real value.
So if you choose a global color for any element and the global color changes afterwards, you can see the change of the element color too. This is very important if you do not want to change every element that uses this global color.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [ ] I've tested my changes with keyboard and screen readers.
- [ ] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).
