### PR TITLE
Fix: CSS variable reference mechanism regression.

### DIFF
--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -118,8 +118,8 @@ export function getPresetVariable( styles, blockName, propertyName, value ) {
 	}
 	const { valueKey, path, cssVarInfix } = presetData;
 	const presets =
-		get( styles, [ blockName, ...path ] ) ??
-		get( styles, [ ALL_BLOCKS_NAME, ...path ] );
+		get( styles, [ 'settings', blockName, ...path ] ) ??
+		get( styles, [ 'settings', ALL_BLOCKS_NAME, ...path ] );
 	const presetObject = find( presets, ( preset ) => {
 		return preset[ valueKey ] === value;
 	} );
@@ -141,8 +141,8 @@ function getValueFromPresetVariable(
 		return variable;
 	}
 	const presets =
-		get( styles, [ blockName, ...presetData.path ] ) ??
-		get( styles, [ ALL_BLOCKS_NAME, ...presetData.path ] );
+		get( styles, [ 'settings', blockName, ...presetData.path ] ) ??
+		get( styles, [ 'settings', ALL_BLOCKS_NAME, ...presetData.path ] );
 	if ( ! presets ) {
 		return variable;
 	}
@@ -159,8 +159,8 @@ function getValueFromPresetVariable(
 
 function getValueFromCustomVariable( styles, blockName, variable, path ) {
 	const result =
-		get( styles, [ blockName, 'settings', 'custom', ...path ] ) ??
-		get( styles, [ ALL_BLOCKS_NAME, 'settings', 'custom', ...path ] );
+		get( styles, [ 'settings', blockName, 'custom', ...path ] ) ??
+		get( styles, [ 'settings', ALL_BLOCKS_NAME, 'custom', ...path ] );
 	if ( ! result ) {
 		return variable;
 	}


### PR DESCRIPTION
The shape of the global styles data structure passed by some changes and those changes caused a regression where the global styles CSS variable mechanism stopped working.
This PR fixes the regression.

Fixes: https://github.com/WordPress/gutenberg/issues/28853

## How has this been tested?
With TT1 Blocks theme trunk version active I opened the site editor and did the following steps:

1. I verified the root colors set by the theme using preset CSS variables were reflected on the Global Styles sidebar UI (on trunk they are not).
2. I went to the global h2 global styles. I verified the UI correctly reflects an "Extra Large" Font size. (preset CSS variable reference).
3. I continued to the global h2 global styles. I verified the UI correctly reflects a 1.3 line-height. (custom CSS variable reference).
4. I globally applied a background color to the paragraph and I verified on the styles generated that they reference the color using a CSS variable (on the trunk branch the reference is by value).
