### PR TITLE
[Issue] Task: Video Block Error State Dark Mode UI Fix

### DIFF
--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -170,7 +170,11 @@ class VideoEdit extends Component {
 		let iconStyle;
 		switch ( iconType ) {
 			case ICON_TYPE.RETRY:
-				return <Icon icon={ SvgIconRetry } { ...style.icon } />;
+				iconStyle = this.props.getStylesFromColorScheme(
+					style.icon,
+					style.iconDark
+				);
+				return <Icon icon={ SvgIconRetry } { ...iconStyle } />;
 			case ICON_TYPE.PLACEHOLDER:
 				iconStyle = this.props.getStylesFromColorScheme(
 					style.icon,
@@ -290,6 +294,11 @@ class VideoEdit extends Component {
 									? style.containerFocused
 									: style.container;
 
+							const uploadFailedTextStyle = this.props.getStylesFromColorScheme(
+								style.uploadFailedText,
+								style.uploadFailedTextDark
+							);
+
 							return (
 								<View
 									onLayout={ this.onVideoContanerLayout }
@@ -325,7 +334,7 @@ class VideoEdit extends Component {
 											{ isUploadFailed && (
 												<Text
 													style={
-														style.uploadFailedText
+														uploadFailedTextStyle
 													}
 												>
 													{ retryMessage }

--- a/packages/block-library/src/video/style.native.scss
+++ b/packages/block-library/src/video/style.native.scss
@@ -33,6 +33,10 @@
 	margin-top: 5;
 }
 
+.uploadFailedTextDark {
+	color: $white;
+}
+
 .modalIcon {
 	width: 40px;
 	height: 40px;


### PR DESCRIPTION
## Description
Fixes wordpress-mobile/gutenberg-mobile#2121

### Related PRs:
[Gutenberg-Mobile](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3398)

## How has this been tested?
- Manual Testing done following [this](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3383) PR by checking out local `gutenberg-mobile` using
```
LOCAL_GUTENBERG=true bundle exec pod install
```
- Screenshots attached below are on Device as `Add Video` seems like not working for me on simulator

## Screenshots <!-- if applicable -->

### Light Mode
|Before|After (Expectation: No Change)|
|---|---|
|![Before Light Mode](https://user-images.githubusercontent.com/16770566/115458226-14c69800-a243-11eb-9e46-b82726db1d31.PNG)|![After Light Mode](https://user-images.githubusercontent.com/16770566/115458248-1beda600-a243-11eb-9a06-8b357ebb2276.PNG)|

### Dark Mode
|Before|After|
|---|---|
|![Before Dark Mode](https://user-images.githubusercontent.com/16770566/115458408-4a6b8100-a243-11eb-8a12-6aa391934edc.PNG)|![After Dark Mode](https://user-images.githubusercontent.com/16770566/115458433-535c5280-a243-11eb-9aa1-aea71dc9d959.PNG)|

## Types of changes
- This PR fixes Video-Block Error State UI(**Icon + Error Text**) color on **Dark Mode**. Earlier the color was `gray-dark`, now the corrected color is `white`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [ ] **[N/A]** I've tested my changes with keyboard and screen readers.
- [ ] **[N/A]** My code has proper inline documentation.
- [ ] **[N/A]** I've included developer documentation if appropriate.
- [ ] **[N/A]** I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).

### Note:
- A big shoutout 🎊 🥳 to my buddy @ceyhun for guiding me
- @ceyhun Please have a 👀 & add `level` & `milestone`, give some ❤️ if you like it 🤝