### PR TITLE
Block Support: Fix server-side border color support check

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -128,6 +128,11 @@ function gutenberg_skip_border_serialization( $block_type ) {
 /**
  * Checks whether the current block type supports the border feature requested.
  *
+ * If the `__experimentalBorder` support flag is a boolean `true` all border
+ * support features are available. Otherwise, the specific feature's support
+ * flag nested under `experimentalBorder` must be enabled for the feature
+ * to be opted into.
+ *
  * @param WP_Block_Type $block_type Block type to check for support.
  * @param string        $feature    Name of the feature to check support for.
  * @param mixed         $default    Fallback value for feature support, defaults to false.
@@ -135,13 +140,17 @@ function gutenberg_skip_border_serialization( $block_type ) {
  * @return boolean                  Whether or not the feature is supported.
  */
 function gutenberg_has_border_feature_support( $block_type, $feature, $default = false ) {
-	$block_support = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$block_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), $default );
+	// Check if all border support features have been opted into via `"__experimentalBorder": true`.
+	if (
+		property_exists( $block_type, 'supports' ) &&
+		( true === _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), $default ) )
+	) {
+		return true;
 	}
 
-	return true === $block_support ||
-		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', $feature ), $default );
+	// Check if the specific feature has been opted into individually
+	// via nested flag under `__experimentalBorder`.
+	return gutenberg_block_has_support( $block_type, array( '__experimentalBorder', $feature ), $default );
 }
 
 // Register the block support.

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -14,7 +14,7 @@
 function gutenberg_register_border_support( $block_type ) {
 	// Determine if any border related features are supported.
 	$has_border_support       = gutenberg_block_has_support( $block_type, array( '__experimentalBorder' ) );
-	$has_border_color_support = gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'color' ) );
+	$has_border_color_support = gutenberg_has_border_feature_support( $block_type, 'color' );
 
 	// Setup attributes and styles within that if needed.
 	if ( ! $block_type->attributes ) {
@@ -53,7 +53,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 
 	// Border radius.
 	if (
-		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'radius' ) ) &&
+		gutenberg_has_border_feature_support( $block_type, 'radius' ) &&
 		isset( $block_attributes['style']['border']['radius'] )
 	) {
 		$border_radius = (int) $block_attributes['style']['border']['radius'];
@@ -62,7 +62,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 
 	// Border style.
 	if (
-		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'style' ) ) &&
+		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
 		isset( $block_attributes['style']['border']['style'] )
 	) {
 		$border_style = $block_attributes['style']['border']['style'];
@@ -71,7 +71,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 
 	// Border width.
 	if (
-		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'width' ) ) &&
+		gutenberg_has_border_feature_support( $block_type, 'width' ) &&
 		isset( $block_attributes['style']['border']['width'] )
 	) {
 		$border_width = intval( $block_attributes['style']['border']['width'] );
@@ -79,7 +79,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	}
 
 	// Border color.
-	if ( gutenberg_block_has_support( $block_type, array( '__experimentalBorder', 'color' ) ) ) {
+	if ( gutenberg_has_border_feature_support( $block_type, 'color' ) ) {
 		$has_named_border_color  = array_key_exists( 'borderColor', $block_attributes );
 		$has_custom_border_color = isset( $block_attributes['style']['border']['color'] );
 
@@ -123,6 +123,25 @@ function gutenberg_skip_border_serialization( $block_type ) {
 	return is_array( $border_support ) &&
 		array_key_exists( '__experimentalSkipSerialization', $border_support ) &&
 		$border_support['__experimentalSkipSerialization'];
+}
+
+/**
+ * Checks whether the current block type supports the border feature requested.
+ *
+ * @param WP_Block_Type $block_type Block type to check for support.
+ * @param string        $feature    Name of the feature to check support for.
+ * @param mixed         $default    Fallback value for feature support, defaults to false.
+ *
+ * @return boolean                  Whether or not the feature is supported.
+ */
+function gutenberg_has_border_feature_support( $block_type, $feature, $default = false ) {
+	$block_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$block_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), $default );
+	}
+
+	return true === $block_support ||
+		gutenberg_block_has_support( $block_type, array( '__experimentalBorder', $feature ), $default );
 }
 
 // Register the block support.


### PR DESCRIPTION
## Description
This update for the server side border color support check allows for `__experimentalBorder` to be set to `true` and all border support features to be opted into. This brings the server side checks inline with those in the editor so static and dynamic blocks get consistent border support.

When the [border support was refactored](https://github.com/WordPress/gutenberg/pull/30124/commits/d87a2999b0cac30d479628b24ed4b9169a40fd93) to use `gutenberg_block_has_support` it lost this check.

**Note: `gutenberg_block_has_support` was not updated to automatically check all prior elements in the feature path as I couldn't be sure that all block supports would wish to allow the blanket opt in.**

## How has this been tested?
Manually.

1. Turned on the border support in theme.json
2. Turned on border support for a static block such as the group block
3. Added a group block to a post and confirmed the border support still functioned and displayed correctly on the frontend
4. Update a dynamic block such as the `core/post-tags` block to use border support in its `block.json`  `"__experimentalBorder": true`
5. Add the post tags block to a post, the border controls should appear in the sidebar
6. Update the border settings, save and confirm border displayed on the frontend

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/60436221/115485542-4c136400-a298-11eb-99d4-63c8cb38e585.gif" width="400" />

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
