### PR TITLE
Navigation Editor: move the delete menu button at the bottom

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/delete-menu.js
+++ b/packages/edit-navigation/src/components/inspector-additions/delete-menu.js
@@ -15,7 +15,9 @@ export default function DeleteMenu( { onDeleteMenu, isMenuBeingDeleted } ) {
 				if (
 					// eslint-disable-next-line no-alert
 					window.confirm(
-						__( 'Are you sure you want to delete this navigation?' )
+						__(
+							'Are you sure you want to delete this navigation? This action cannot be undone.'
+						)
 					)
 				) {
 					onDeleteMenu();

--- a/packages/edit-navigation/src/components/inspector-additions/index.js
+++ b/packages/edit-navigation/src/components/inspector-additions/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { InspectorControls } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -25,7 +28,7 @@ export default function InspectorAdditions( {
 	openManageLocationsModal,
 } ) {
 	const selectedBlock = useSelect(
-		( select ) => select( 'core/block-editor' ).getSelectedBlock(),
+		( select ) => select( blockEditorStore ).getSelectedBlock(),
 		[]
 	);
 
@@ -38,10 +41,6 @@ export default function InspectorAdditions( {
 			<PanelBody title={ __( 'Menu settings' ) }>
 				<NameEditor />
 				<AutoAddPages menuId={ menuId } />
-				<DeleteMenu
-					onDeleteMenu={ onDeleteMenu }
-					isMenuBeingDeleted={ isMenuBeingDeleted }
-				/>
 			</PanelBody>
 			<PanelBody title={ __( 'Theme locations' ) }>
 				<ManageLocations
@@ -51,6 +50,12 @@ export default function InspectorAdditions( {
 					isModalOpen={ isManageLocationsModalOpen }
 					closeModal={ closeManageLocationsModal }
 					openModal={ openManageLocationsModal }
+				/>
+			</PanelBody>
+			<PanelBody>
+				<DeleteMenu
+					onDeleteMenu={ onDeleteMenu }
+					isMenuBeingDeleted={ isMenuBeingDeleted }
 				/>
 			</PanelBody>
 		</InspectorControls>


### PR DESCRIPTION
## Description
PR moves the "Delete menu" button at the bottom of the navigation sidebar and updates confirmation modal text.

Fixes #30426.

## How has this been tested?
1. Go to the experimental navigation screen.
2. The "Delete menu" button should appear at the bottom.

## Screenshots <!-- if applicable -->
<img width="919" alt="navigation-editor-delete-btn" src="https://user-images.githubusercontent.com/240569/115497907-963b1c00-a27d-11eb-86ae-24b38192d5fb.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
