### PR TITLE
Plugin: Call deprecated hooks only when new filters not present

### DIFF
--- a/lib/block-editor.php
+++ b/lib/block-editor.php
@@ -86,7 +86,7 @@ function gutenberg_get_block_categories( $editor_name_or_post ) {
 	 *
 	 * @param array[] $default_categories Array of categories for block types.
 	 */
-	$block_categories = apply_filters( "block_categories_{$editor_name}", $default_categories );
+	$block_categories = apply_filters( 'block_categories_all', $default_categories );
 	if ( 'post-editor' === $editor_name ) {
 		$post = is_object( $editor_name_or_post ) ? $editor_name_or_post : get_post();
 
@@ -99,7 +99,7 @@ function gutenberg_get_block_categories( $editor_name_or_post ) {
 		 * @param array[] $block_categories Array of categories for block types.
 		 * @param WP_Post $post             Post being loaded.
 		 */
-		$block_categories = apply_filters_deprecated( 'block_categories', array( $block_categories, $post ), '5.8.0', "block_categories_{$editor_name}" );
+		$block_categories = apply_filters_deprecated( 'block_categories', array( $block_categories, $post ), '5.8.0', 'block_categories_all' );
 	}
 
 	return $block_categories;
@@ -131,7 +131,7 @@ function gutenberg_get_allowed_block_types( $editor_name ) {
 	 * @param bool|array $allowed_block_types Array of block type slugs, or
 	 *                                        boolean to enable/disable all.
 	 */
-	$allowed_block_types = apply_filters( "allowed_block_types_{$editor_name}", $allowed_block_types );
+	$allowed_block_types = apply_filters( 'allowed_block_types_all', $allowed_block_types );
 	if ( 'post-editor' === $editor_name ) {
 		$post = get_post();
 
@@ -146,7 +146,7 @@ function gutenberg_get_allowed_block_types( $editor_name ) {
 		 *                                        boolean to enable/disable all.
 		 * @param WP_Post    $post                The post resource data.
 		 */
-		$allowed_block_types = apply_filters_deprecated( 'allowed_block_types', array( $allowed_block_types, $post ), '5.8.0', "allowed_block_types_{$editor_name}" );
+		$allowed_block_types = apply_filters_deprecated( 'allowed_block_types', array( $allowed_block_types, $post ), '5.8.0', 'allowed_block_types_all' );
 	}
 
 	return $allowed_block_types;
@@ -267,13 +267,13 @@ function gutenberg_get_block_editor_settings( $editor_name, $custom_settings = a
 	);
 
 	/**
-	 * Filters the settings to pass to the block editor for a given editor type.
+	 * Filters the settings to pass to the block editor for all editor types.
 	 *
 	 * @since 5.8.0
 	 *
 	 * @param array $editor_settings Default editor settings.
 	 */
-	$editor_settings = apply_filters( "block_editor_settings_{$editor_name}", $editor_settings );
+	$editor_settings = apply_filters( 'block_editor_settings_all', $editor_settings );
 	if ( 'post-editor' === $editor_name ) {
 		$post = get_post();
 
@@ -286,7 +286,7 @@ function gutenberg_get_block_editor_settings( $editor_name, $custom_settings = a
 		 * @param array   $editor_settings Default editor settings.
 		 * @param WP_Post $post            Post being edited.
 		 */
-		$editor_settings = apply_filters_deprecated( 'block_editor_settings', array( $editor_settings, $post ), '5.8.0', "block_editor_settings_{$editor_name}" );
+		$editor_settings = apply_filters_deprecated( 'block_editor_settings', array( $editor_settings, $post ), '5.8.0', 'block_editor_settings_all' );
 	}
 
 	return $editor_settings;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -380,8 +380,10 @@ function gutenberg_register_theme_block_category( $categories ) {
 	);
 	return $categories;
 }
-
-add_filter( 'block_categories', 'gutenberg_register_theme_block_category' );
+// This can be removed when plugin support requires WordPress 5.8.0+.
+if ( ! function_exists( 'get_default_block_categories' ) ) {
+	add_filter( 'block_categories', 'gutenberg_register_theme_block_category' );
+}
 
 /**
  * Checks whether the current block type supports the feature requested.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -620,6 +620,8 @@ function gutenberg_register_vendor_script( $scripts, $handle, $src, $deps = arra
 /**
  * Extends block editor settings to remove the Gutenberg's `editor-styles.css`;
  *
+ * This can be removed when plugin support requires WordPress 5.8.0+.
+ *
  * @param array $settings Default editor settings.
  *
  * @return array Filtered editor settings.
@@ -671,10 +673,17 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 
 	return $settings;
 }
-add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
+// This can be removed when plugin support requires WordPress 5.8.0+.
+if ( function_exists( 'get_block_editor_settings' ) ) {
+	add_filter( 'block_editor_settings_all', 'gutenberg_extend_block_editor_styles' );
+} else {
+	add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
+}
 
 /**
  * Adds a flag to the editor settings to know whether we're in FSE theme or not.
+ *
+ * This can be removed when plugin support requires WordPress 5.8.0+.
  *
  * @param array $settings Default editor settings.
  *
@@ -688,7 +697,12 @@ function gutenberg_extend_block_editor_settings_with_fse_theme_flag( $settings )
 
 	return $settings;
 }
-add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_settings_with_fse_theme_flag' );
+// This can be removed when plugin support requires WordPress 5.8.0+.
+if ( function_exists( 'get_block_editor_settings' ) ) {
+	add_filter( 'block_editor_settings_all', 'gutenberg_extend_block_editor_settings_with_fse_theme_flag' );
+} else {
+	add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_settings_with_fse_theme_flag' );
+}
 
 /**
  * Sets the editor styles to be consumed by JS.

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -30,7 +30,12 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 
 	return $settings;
 }
-add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );
+// This can be removed when plugin support requires WordPress 5.8.0+.
+if ( function_exists( 'get_block_editor_settings' ) ) {
+	add_filter( 'block_editor_settings_all', 'gutenberg_extend_post_editor_settings' );
+} else {
+	add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );
+}
 
 /**
  * Initialize a block-based editor.

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -81,6 +81,8 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 /**
  * Adds the necessary data for the Global Styles client UI to the block settings.
  *
+ * This can be removed when plugin support requires WordPress 5.8.0+.
+ *
  * @param array $settings Existing block editor settings.
  * @return array New block editor settings
  */
@@ -168,7 +170,13 @@ function gutenberg_experimental_global_styles_register_user_cpt() {
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_user_cpt' );
-add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
+// This can be removed when plugin support requires WordPress 5.8.0+.
+if ( function_exists( 'get_block_editor_settings' ) ) {
+	add_filter( 'block_editor_settings_all', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
+} else {
+	add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
+
+}
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
 
 

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -210,6 +210,8 @@ function gutenberg_get_legacy_widget_settings() {
 /**
  * Extends default editor settings with values supporting legacy widgets.
  *
+ * This can be removed when plugin support requires WordPress 5.8.0+.
+ *
  * @param array $settings Default editor settings.
  *
  * @return array Filtered editor settings.
@@ -217,7 +219,12 @@ function gutenberg_get_legacy_widget_settings() {
 function gutenberg_legacy_widget_settings( $settings ) {
 	return array_merge( $settings, gutenberg_get_legacy_widget_settings() );
 }
-add_filter( 'block_editor_settings', 'gutenberg_legacy_widget_settings' );
+// This can be removed when plugin support requires WordPress 5.8.0+.
+if ( function_exists( 'get_block_editor_settings' ) ) {
+	add_filter( 'block_editor_settings_all', 'gutenberg_legacy_widget_settings' );
+} else {
+	add_filter( 'block_editor_settings', 'gutenberg_legacy_widget_settings' );
+}
 
 /**
  * Function to enqueue admin-widgets as part of the block editor assets.

--- a/phpunit/block-editor-test.php
+++ b/phpunit/block-editor-test.php
@@ -297,7 +297,6 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 52920
-	 * @expectedDeprecated block_categories
 	 * @expectedDeprecated block_editor_settings
 	 */
 	function test_get_block_editor_settings_deprecated_filter_post_editor() {

--- a/phpunit/block-editor-test.php
+++ b/phpunit/block-editor-test.php
@@ -242,17 +242,7 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	/**
 	 * @ticket 52920
 	 */
-	function test_get_block_editor_settings_returns_default_settings() {
-		$this->assertSameSets(
-			gutenberg_get_block_editor_settings( 'my-editor' ),
-			gutenberg_get_default_block_editor_settings()
-		);
-	}
-
-	/**
-	 * @ticket 52920
-	 */
-	function test_get_block_editor_settings_overrides_default_settings_my_editor() {
+	function test_get_block_editor_settings_overrides_default_settings_all_editors() {
 		function filter_allowed_block_types_my_editor() {
 			return array( 'test/filtered-my-block' );
 		}
@@ -271,15 +261,15 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 			return $editor_settings;
 		}
 
-		add_filter( 'allowed_block_types_my-editor', 'filter_allowed_block_types_my_editor', 10, 1 );
-		add_filter( 'block_categories_my-editor', 'filter_block_categories_my_editor', 10, 1 );
-		add_filter( 'block_editor_settings_my-editor', 'filter_block_editor_settings_my_editor', 10, 1 );
+		add_filter( 'allowed_block_types_all', 'filter_allowed_block_types_my_editor', 10, 1 );
+		add_filter( 'block_categories_all', 'filter_block_categories_my_editor', 10, 1 );
+		add_filter( 'block_editor_settings_all', 'filter_block_editor_settings_my_editor', 10, 1 );
 
 		$settings = gutenberg_get_block_editor_settings( 'my-editor' );
 
-		remove_filter( 'allowed_block_types_my-editor', 'filter_allowed_block_types_my_editor' );
-		remove_filter( 'block_categories_my-editor', 'filter_block_categories_my_editor' );
-		remove_filter( 'block_editor_settings_my-editor', 'filter_block_editor_settings_my_editor' );
+		remove_filter( 'allowed_block_types_all', 'filter_allowed_block_types_my_editor' );
+		remove_filter( 'block_categories_all', 'filter_block_categories_my_editor' );
+		remove_filter( 'block_editor_settings_all', 'filter_block_editor_settings_my_editor' );
 
 		$this->assertSameSets( array( 'test/filtered-my-block' ), $settings['allowedBlockTypes'] );
 		$this->assertSameSets(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes the issue raised in https://github.com/WordPress/wordpress-develop/pull/1118#issuecomment-823507573:

> When `WP_DEBUG` is set to `true`, I see a few deprecation warnings when testing with the Gutenberg plugin enabled:
> 
> >   | <b>Deprecated</b>: block_categories is <strong>deprecated</strong> since version 5.8.0! Use block_categories_post-editor instead. in <b>/var/www/src/wp-includes/functions.php</b> on line <b>5242</b><br />
> >   | <b>Deprecated</b>: block_categories is <strong>deprecated</strong> since version 5.8.0! Use block_categories_post-editor instead. in <b>/var/www/src/wp-includes/functions.php</b> on line <b>5242</b><br />
> >   | <b>Deprecated</b>: block_editor_settings is <strong>deprecated</strong> since version 5.8.0! Use block_editor_settings_post-editor instead. in <b>/var/www/src/wp-includes/functions.php</b> on line <b>5242</b><br />
> 
> It feels like we should run those deprecated filters in the Gutenberg plugin only when new functions aren't declared because they mostly add the same functionalities.

I added a detection based on the existence of newly added functions in WordPress core that best approximate calling deprecations.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Open the block editor on all possible screens and make sure there are no deprecation warnings when `WP_DEBUG` flag is enabled:
- edit post
- edit site
- edit widgets
- edit navigation

You need to ensure that you have the latest version of `wordpress-develop`.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Backward compatibility fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
