### PR TITLE
Navigation Editor: use 'ajaxurl' global in batchSave action

### DIFF
--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -26,6 +26,8 @@ import {
 	computeCustomizedAttribute,
 } from './utils';
 
+const { ajaxurl } = window;
+
 /**
  * Creates a menu item for every block that doesn't have an associated menuItem.
  * Requests POST /wp/v2/menu-items once for every menu item created.
@@ -184,7 +186,7 @@ function* batchSave( menuId, menuItemsByClientId, navigationBlock ) {
 	);
 
 	return yield apiFetch( {
-		url: '/wp-admin/admin-ajax.php',
+		url: ajaxurl,
 		method: 'POST',
 		body,
 	} );

--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -186,7 +186,7 @@ function* batchSave( menuId, menuItemsByClientId, navigationBlock ) {
 	);
 
 	return yield apiFetch( {
-		url: ajaxurl,
+		url: ajaxurl || '/wp-admin/admin-ajax.php',
 		method: 'POST',
 		body,
 	} );


### PR DESCRIPTION
## Description
PR fixes navigation saving issue when WordPress is in a subdirectory.

Fixes #25181.

## How has this been tested?
1. On the site where WP is in a subdirectory (you can find instructions [here](https://wordpress.org/support/article/giving-wordpress-its-own-directory/)).
2. Go to the experimental Navigation screen.
3. Create a menu.
4. You should be able to save the menu without an error.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
