### PR TITLE
[Block Library - Site Title]: Fix Site Title toolbar normalization

### DIFF
--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -10,7 +10,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
-	AlignmentToolbar,
+	AlignmentControl,
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
@@ -19,7 +19,7 @@ import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import LevelToolbar from './level-toolbar';
+import LevelControl from './level-toolbar';
 
 export default function SiteTitleEdit( {
 	attributes,
@@ -37,13 +37,13 @@ export default function SiteTitleEdit( {
 	return (
 		<>
 			<BlockControls group="block">
-				<LevelToolbar
+				<LevelControl
 					level={ level }
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}
 				/>
-				<AlignmentToolbar
+				<AlignmentControl
 					value={ textAlign }
 					onChange={ ( nextAlign ) => {
 						setAttributes( { textAlign: nextAlign } );

--- a/packages/block-library/src/site-title/edit/level-toolbar.js
+++ b/packages/block-library/src/site-title/edit/level-toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { ToolbarGroup } from '@wordpress/components';
+import { DropdownMenu } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -9,30 +9,26 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import LevelIcon from './level-icon';
 
-export default function LevelToolbar( { level, onChange } ) {
+export default function LevelControl( { level, onChange } ) {
+	const allControls = [ 1, 2, 3, 4, 5, 6, 0 ].map( ( currentLevel ) => {
+		const isActive = currentLevel === level;
+		return {
+			icon: <LevelIcon level={ currentLevel } isPressed={ isActive } />,
+			title:
+				currentLevel === 0
+					? __( 'Paragraph' )
+					: // translators: %s: heading level e.g: "1", "2", "3"
+					  sprintf( __( 'Heading %d' ), currentLevel ),
+			isActive,
+			onClick: () => onChange( currentLevel ),
+		};
+	} );
 	return (
-		<ToolbarGroup
-			isCollapsed
-			icon={ <LevelIcon level={ level } /> }
-			controls={ [ 1, 2, 3, 4, 5, 6, 0 ].map( ( currentLevel ) => {
-				const isActive = currentLevel === level;
-				return {
-					icon: (
-						<LevelIcon
-							level={ currentLevel }
-							isPressed={ isActive }
-						/>
-					),
-					title:
-						currentLevel === 0
-							? __( 'Paragraph' )
-							: // translators: %s: heading level e.g: "1", "2", "3"
-							  sprintf( __( 'Heading %d' ), currentLevel ),
-					isActive,
-					onClick: () => onChange( currentLevel ),
-				};
-			} ) }
+		<DropdownMenu
 			label={ __( 'Change heading level' ) }
+			icon={ <LevelIcon level={ level } /> }
+			controls={ allControls }
+			isToolbarButton
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Based on comment: https://github.com/WordPress/gutenberg/pull/30999#discussion_r617351848

>Inside a "BlockControls" with a "group" we shouldn't be using *Toolbar components otherwise we're adding a extra toolbar group to the Dom, we should be using "*Controlsdirectly as aToolbarGroupis already rendered by theBlockControls`

