### PR TITLE
Handbook: Add docs for border block supports

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -178,7 +178,10 @@ The settings section has the following structure and default values:
         "wideSize": "1000px",
       }
       "border": {
-        "customRadius": false /* true to opt-in */
+        "customColor": false, /* true to opt-in */
+        "customRadius": false,
+        "customStyle": false,
+        "customWidth": false
       },
       "color": {
         "custom": true, /* false to opt-out, as in add_theme_support('disable-custom-colors') */


### PR DESCRIPTION
Follow-up from https://github.com/WordPress/gutenberg/pull/30124
