### PR TITLE
Handbook: Add docs for border styles

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -362,7 +362,10 @@ Each block declares which style properties it exposes via the [block supports me
 	"styles": {
 		"some/block/selector": {
 			"border": {
-				"radius": "value"
+				"color": "value",
+				"radius": "value",
+				"style": "value",
+				"width": "value"
 			},
 			"color": {
 				"background": "value",


### PR DESCRIPTION
Follow-up for https://github.com/WordPress/gutenberg/pull/30124