### PR TITLE
Use a darker frame for template mode and previews

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -5,6 +5,7 @@
 // WordPress grays.
 $black: #000;			// Use only when you truly need pure black. For UI, use $gray-900.
 $gray-900: #1e1e1e;
+$gray-800: #2f2f2f;
 $gray-700: #757575;		// Meets 4.6:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
 $gray-400: #ccc;

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -14,10 +14,10 @@
 		background: #23282e; // WP-admin gray.
 		color: $white;
 		border-radius: 0;
-		height: $header-height + 1px;
+		height: $header-height + $border-width;
 		width: $header-height;
 		position: relative;
-		margin-bottom: -1px;
+		margin-bottom: - $border-width;
 
 		&:active {
 			color: $white;

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -14,9 +14,10 @@
 		background: #23282e; // WP-admin gray.
 		color: $white;
 		border-radius: 0;
-		height: $header-height;
+		height: $header-height + 1px;
 		width: $header-height;
 		position: relative;
+		margin-bottom: -1px;
 
 		&:active {
 			color: $white;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -87,7 +87,7 @@
 }
 
 .edit-post-layout .interface-interface-skeleton__content {
-	background-color: $gray-100;
+	background-color: $gray-800;
 }
 
 .edit-post-layout__inserter-panel {

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -66,4 +66,9 @@
 	position: absolute;
 	top: $grid-unit-10;
 	left: $grid-unit-10;
+	color: $white;
+
+	&:hover {
+		color: $gray-100;
+	}
 }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -68,6 +68,8 @@
 	left: $grid-unit-10;
 	color: $white;
 
+	&:active:not([aria-disabled="true"]),
+	&:focus:not([aria-disabled="true"]),
 	&:hover {
 		color: $gray-100;
 	}


### PR DESCRIPTION
Based on the latest designs, it seems we now want a darker frame for template mode and previews.