### PR TITLE
Post Editor: Persistent list view

### DIFF
--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -4,11 +4,7 @@
 import { Button, Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import {
-	useShortcut,
-	store as keyboardShortcutsStore,
-} from '@wordpress/keyboard-shortcuts';
-import { useCallback, forwardRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import { listView } from '@wordpress/icons';
 
 /**
@@ -24,22 +20,6 @@ function BlockNavigationDropdownToggle( {
 	innerRef,
 	...props
 } ) {
-	useShortcut(
-		'core/edit-post/toggle-block-navigation',
-		useCallback( onToggle, [ onToggle ] ),
-		{
-			bindGlobal: true,
-			isDisabled: ! isEnabled,
-		}
-	);
-	const shortcut = useSelect(
-		( select ) =>
-			select( keyboardShortcutsStore ).getShortcutRepresentation(
-				'core/edit-post/toggle-block-navigation'
-			),
-		[]
-	);
-
 	return (
 		<Button
 			{ ...props }
@@ -51,7 +31,6 @@ function BlockNavigationDropdownToggle( {
 			/* translators: button label text should, if possible, be under 16 characters. */
 			label={ __( 'List view' ) }
 			className="block-editor-block-navigation"
-			shortcut={ shortcut }
 			aria-disabled={ ! isEnabled }
 		/>
 	);

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -18,7 +18,7 @@ describe( 'Columns', () => {
 		await insertBlock( 'Columns' );
 		await closeGlobalBlockInserter();
 		await page.click( '[aria-label="Two columns; equal split"]' );
-		await page.click( '[aria-label="List view"]' );
+		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		const columnBlockMenuItem = (
 			await page.$x(
 				'//button[contains(concat(" ", @class, " "), " block-editor-block-navigation-block-select-button ")][text()="Column"]'

--- a/packages/e2e-tests/specs/editor/blocks/cover.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/cover.test.js
@@ -24,7 +24,7 @@ describe( 'Cover', () => {
 		);
 
 		// Select the cover block.By default the child paragraph gets selected.
-		await page.click( 'button[aria-label="List view"]' );
+		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		await page.click(
 			'.block-editor-block-navigation-block__contents-container button'
 		);

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -50,7 +50,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( 'First column' );
 
 		// Navigate to the columns blocks.
-		await page.click( '[aria-label="List view"]' );
+		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		const columnsBlockMenuItem = (
 			await page.$x(
 				"//button[contains(@class,'block-editor-block-navigation-block-select-button') and contains(text(), 'Columns')]"
@@ -69,7 +69,6 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( '3' );
 
 		// Navigate to the last column block.
-		await page.click( '[aria-label="List view"]' );
 		const lastColumnsBlockMenuItem = (
 			await page.$x(
 				"//button[contains(@class,'block-editor-block-navigation-block-select-button') and contains(text(), 'Column')]"
@@ -103,6 +102,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Navigate to the columns blocks using the keyboard.
 		await openBlockNavigator();
+		await pressKeyTimes( 'ArrowUp', 2 );
 		await page.keyboard.press( 'Enter' );
 
 		// Move focus to the sidebar area.
@@ -115,7 +115,9 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.press( 'ArrowRight' );
 
 		// Navigate to the last column in the columns block.
-		await openBlockNavigator();
+		await pressKeyWithModifier( 'ctrl', '`' );
+		await pressKeyWithModifier( 'ctrl', '`' );
+		await pressKeyTimes( 'Tab', 2 );
 		await pressKeyTimes( 'ArrowDown', 4 );
 		await page.keyboard.press( 'Enter' );
 		await page.waitForSelector( '.is-selected[data-type="core/column"]' );
@@ -145,6 +147,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Return to first block.
 		await openBlockNavigator();
+		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Space' );
 
 		// Replace its content.
@@ -175,7 +178,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '.editor-post-title' );
 
 		// Try selecting the group block using the Outline
-		await page.click( '[aria-label="List view"]' );
+		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		const groupMenuItem = (
 			await page.$x(
 				"//button[contains(@class,'block-editor-block-navigation-block-select-button') and contains(text(), 'Group')]"

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -68,6 +68,12 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.up( 'Shift' );
 		await page.keyboard.type( '3' );
 
+		// Wait for the new column block to appear in the list view
+		// 5 = Columns, Column, Paragraph, Column, *Column*
+		await page.waitForSelector(
+			'tr.block-editor-block-navigation-leaf:nth-of-type(5)'
+		);
+
 		// Navigate to the last column block.
 		const lastColumnsBlockMenuItem = (
 			await page.$x(

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -304,10 +304,10 @@ describe( 'Inserting blocks', () => {
 			inserterMenuInputSelector
 		);
 		inserterMenuSearchInput.type( 'cover' );
-		// Wait for the search results to load after typing the full search
-		// term. Previously this test would sometimes accidentally tab to the
-		// button for a code block.
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		// Wait for the search results to load (Cover block).
+		await page.waitForSelector(
+			'.block-editor-block-types-list__item.editor-block-list-item-cover'
+		);
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -374,7 +374,7 @@ describe( 'Inserting blocks', () => {
 
 		// The inserter panel should've closed.
 		const inserterPanels = await page.$$(
-			'.edit-post-layout__inserter-panel'
+			'.edit-post-editor__inserter-panel'
 		);
 		expect( inserterPanels.length ).toBe( 0 );
 

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -299,7 +299,7 @@ describe( 'Inserting blocks', () => {
 		);
 		await browseAll.click();
 		const inserterMenuInputSelector =
-			'.edit-post-layout__inserter-panel .block-editor-inserter__search-input';
+			'.edit-post-editor__inserter-panel .block-editor-inserter__search-input';
 		const inserterMenuSearchInput = await page.waitForSelector(
 			inserterMenuInputSelector
 		);

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -55,7 +55,9 @@ describe( 'Document Settings', () => {
 		describe( 'and a template part is clicked in the template', () => {
 			it.skip( "should display the selected template part's name in the document header", async () => {
 				// Select the header template part via list view.
-				await page.click( 'button[aria-label="List View"]' );
+				await page.click(
+					'.edit-post-header-toolbar__list-view-toggle'
+				);
 				const headerTemplatePartListViewButton = await page.waitForXPath(
 					'//button[contains(@class, "block-editor-block-navigation-block-select-button")][contains(., "Header")]'
 				);

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -232,7 +232,7 @@ describe( 'Multi-entity save flow', () => {
 			await navigationPanel.clickItemByText( 'Index' );
 
 			// Select the header template part via list view.
-			await page.click( 'button[aria-label="List View"]' );
+			await page.click( '.edit-site-header-toolbar__list-view-toggle' );
 			const headerTemplatePartListViewButton = await page.waitForXPath(
 				'//button[contains(@class, "block-editor-block-navigation-block-select-button")][contains(., "Header")]'
 			);

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -84,7 +84,7 @@ function HeaderToolbar() {
 			/>
 			<ToolbarItem
 				as={ Button }
-				className="edit-site-header-toolbar__list-view-toggle"
+				className="edit-post-header-toolbar__list-view-toggle"
 				icon={ listView }
 				disabled={ isTextModeEnabled }
 				isPressed={ isListViewOpen }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -63,7 +63,7 @@ function HeaderToolbar() {
 			showIconLabels: isFeatureActive( 'showIconLabels' ),
 			isListViewOpen: isListViewOpened(),
 			listViewShortcut: getShortcutRepresentation(
-				'core/edit-post/toggle-list-view'
+				'core/edit-post/toggle-block-navigation'
 			),
 		};
 	}, [] );

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -1,13 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	useShortcut,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
 import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -15,11 +17,15 @@ import { __ } from '@wordpress/i18n';
 import { store as editPostStore } from '../../store';
 
 function KeyboardShortcuts() {
-	const { getBlockSelectionStart } = useSelect( 'core/block-editor' );
-	const { getEditorMode, isEditorSidebarOpened } = useSelect( editPostStore );
+	const { getBlockSelectionStart } = useSelect( blockEditorStore );
+	const {
+		getEditorMode,
+		isEditorSidebarOpened,
+		isListViewOpened,
+	} = useSelect( editPostStore );
 	const isModeToggleDisabled = useSelect( ( select ) => {
 		const { richEditingEnabled, codeEditingEnabled } = select(
-			'core/editor'
+			editorStore
 		).getEditorSettings();
 		return ! richEditingEnabled || ! codeEditingEnabled;
 	}, [] );
@@ -29,6 +35,7 @@ function KeyboardShortcuts() {
 		openGeneralSidebar,
 		closeGeneralSidebar,
 		toggleFeature,
+		setIsListViewOpened,
 	} = useDispatch( editPostStore );
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
 
@@ -54,7 +61,7 @@ function KeyboardShortcuts() {
 		} );
 
 		registerShortcut( {
-			name: 'core/edit-post/toggle-block-navigation',
+			name: 'core/edit-post/toggle-list-view',
 			category: 'global',
 			description: __( 'Open the block list view.' ),
 			keyCombination: {
@@ -155,6 +162,12 @@ function KeyboardShortcuts() {
 				openGeneralSidebar( sidebarToOpen );
 			}
 		},
+		{ bindGlobal: true }
+	);
+
+	useShortcut(
+		'core/edit-post/toggle-list-view',
+		() => setIsListViewOpened( ! isListViewOpened() ),
 		{ bindGlobal: true }
 	);
 

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	useShortcut,
@@ -61,7 +61,7 @@ function KeyboardShortcuts() {
 		} );
 
 		registerShortcut( {
-			name: 'core/edit-post/toggle-list-view',
+			name: 'core/edit-post/toggle-block-navigation',
 			category: 'global',
 			description: __( 'Open the block list view.' ),
 			keyCombination: {
@@ -166,7 +166,7 @@ function KeyboardShortcuts() {
 	);
 
 	useShortcut(
-		'core/edit-post/toggle-list-view',
+		'core/edit-post/toggle-block-navigation',
 		() => setIsListViewOpened( ! isListViewOpened() ),
 		{ bindGlobal: true }
 	);

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -14,7 +14,7 @@ import {
 	EditorKeyboardShortcutsRegister,
 	store as editorStore,
 } from '@wordpress/editor';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { AsyncModeProvider, useSelect, useDispatch } from '@wordpress/data';
 import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -41,6 +41,7 @@ import PreferencesModal from '../preferences-modal';
 import BrowserURL from '../browser-url';
 import Header from '../header';
 import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
+import ListViewSidebar from '../secondary-sidebar/list-view-sidebar';
 import SettingsSidebar from '../sidebar/settings-sidebar';
 import MetaBoxes from '../meta-boxes';
 import WelcomeGuide from '../welcome-guide';
@@ -80,6 +81,7 @@ function Layout( { styles } ) {
 		nextShortcut,
 		hasBlockSelected,
 		isInserterOpened,
+		isListViewOpened,
 		showIconLabels,
 		hasReducedUI,
 		showBlockBreadcrumbs,
@@ -98,6 +100,7 @@ function Layout( { styles } ) {
 				'fullscreenMode'
 			),
 			isInserterOpened: select( editPostStore ).isInserterOpened(),
+			isListViewOpened: select( editPostStore ).isListViewOpened(),
 			mode: select( editPostStore ).getEditorMode(),
 			isRichEditingEnabled: editorSettings.richEditingEnabled,
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
@@ -162,6 +165,13 @@ function Layout( { styles } ) {
 	const secondarySidebar = () => {
 		if ( mode === 'visual' && isInserterOpened ) {
 			return <InserterSidebar />;
+		}
+		if ( mode === 'visual' && isListViewOpened ) {
+			return (
+				<AsyncModeProvider value="true">
+					<ListViewSidebar />
+				</AsyncModeProvider>
+			);
 		}
 		return null;
 	};

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -12,17 +12,12 @@ import {
 	UnsavedChangesWarning,
 	EditorNotices,
 	EditorKeyboardShortcutsRegister,
+	store as editorStore,
 } from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	BlockBreadcrumb,
-	__experimentalLibrary as Library,
-} from '@wordpress/block-editor';
+import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
-import {
-	useViewportMatch,
-	__experimentalUseDialog as useDialog,
-} from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
 import {
@@ -32,7 +27,6 @@ import {
 	store as interfaceStore,
 } from '@wordpress/interface';
 import { useState, useEffect, useCallback } from '@wordpress/element';
-import { close } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
@@ -46,6 +40,7 @@ import ManageBlocksModal from '../manage-blocks-modal';
 import PreferencesModal from '../preferences-modal';
 import BrowserURL from '../browser-url';
 import Header from '../header';
+import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
 import SettingsSidebar from '../sidebar/settings-sidebar';
 import MetaBoxes from '../meta-boxes';
 import WelcomeGuide from '../welcome-guide';
@@ -84,14 +79,12 @@ function Layout( { styles } ) {
 		previousShortcut,
 		nextShortcut,
 		hasBlockSelected,
-		showMostUsedBlocks,
 		isInserterOpened,
-		insertionPoint,
 		showIconLabels,
 		hasReducedUI,
 		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
-		const editorSettings = select( 'core/editor' ).getEditorSettings();
+		const editorSettings = select( editorStore ).getEditorSettings();
 		return {
 			hasFixedToolbar: select( editPostStore ).isFeatureActive(
 				'fixedToolbar'
@@ -104,13 +97,7 @@ function Layout( { styles } ) {
 			isFullscreenActive: select( editPostStore ).isFeatureActive(
 				'fullscreenMode'
 			),
-			showMostUsedBlocks: select( editPostStore ).isFeatureActive(
-				'mostUsedBlocks'
-			),
 			isInserterOpened: select( editPostStore ).isInserterOpened(),
-			insertionPoint: select(
-				editPostStore
-			).__experimentalGetInsertionPoint(),
 			mode: select( editPostStore ).getEditorMode(),
 			isRichEditingEnabled: editorSettings.richEditingEnabled,
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
@@ -171,9 +158,13 @@ function Layout( { styles } ) {
 		},
 		[ entitiesSavedStatesCallback ]
 	);
-	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: () => setIsInserterOpened( false ),
-	} );
+
+	const secondarySidebar = () => {
+		if ( mode === 'visual' && isInserterOpened ) {
+			return <InserterSidebar />;
+		}
+		return null;
+	};
 
 	return (
 		<>
@@ -195,36 +186,7 @@ function Layout( { styles } ) {
 						}
 					/>
 				}
-				secondarySidebar={
-					mode === 'visual' &&
-					isInserterOpened && (
-						<div
-							ref={ inserterDialogRef }
-							{ ...inserterDialogProps }
-							className="edit-post-layout__inserter-panel"
-						>
-							<div className="edit-post-layout__inserter-panel-header">
-								<Button
-									icon={ close }
-									onClick={ () =>
-										setIsInserterOpened( false )
-									}
-								/>
-							</div>
-							<div className="edit-post-layout__inserter-panel-content">
-								<Library
-									showMostUsedBlocks={ showMostUsedBlocks }
-									showInserterHelpPanel
-									shouldFocusBlock={ isMobileViewport }
-									rootClientId={ insertionPoint.rootClientId }
-									__experimentalInsertionIndex={
-										insertionPoint.insertionIndex
-									}
-								/>
-							</div>
-						</div>
-					)
-				}
+				secondarySidebar={ secondarySidebar() }
 				sidebar={
 					( ! isMobileViewport || sidebarIsOpened ) && (
 						<>

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -89,29 +89,3 @@
 .edit-post-layout .interface-interface-skeleton__content {
 	background-color: $gray-800;
 }
-
-.edit-post-layout__inserter-panel {
-	height: 100%;
-	display: flex;
-	flex-direction: column;
-}
-
-.edit-post-layout__inserter-panel-header {
-	padding-top: $grid-unit-10;
-	padding-right: $grid-unit-10;
-	display: flex;
-	justify-content: flex-end;
-
-	@include break-medium() {
-		display: none;
-	}
-}
-
-.edit-post-layout__inserter-panel-content {
-	// Leave space for the close button
-	height: calc(100% - #{$button-size} - #{$grid-unit-10});
-
-	@include break-medium() {
-		height: 100%;
-	}
-}

--- a/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
@@ -36,15 +36,15 @@ export default function InserterSidebar() {
 		<div
 			ref={ inserterDialogRef }
 			{ ...inserterDialogProps }
-			className="edit-post-layout__inserter-panel"
+			className="edit-post-editor__inserter-panel"
 		>
-			<div className="edit-post-layout__inserter-panel-header">
+			<div className="edit-post-editor__inserter-panel-header">
 				<Button
 					icon={ close }
 					onClick={ () => setIsInserterOpened( false ) }
 				/>
 			</div>
-			<div className="edit-post-layout__inserter-panel-content">
+			<div className="edit-post-editor__inserter-panel-content">
 				<Library
 					showMostUsedBlocks={ showMostUsedBlocks }
 					showInserterHelpPanel

--- a/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+import { __experimentalLibrary as Library } from '@wordpress/block-editor';
+import { close } from '@wordpress/icons';
+import {
+	useViewportMatch,
+	__experimentalUseDialog as useDialog,
+} from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../store';
+
+export default function InserterSidebar() {
+	const { insertionPoint, showMostUsedBlocks } = useSelect( ( select ) => {
+		const { isFeatureActive, __experimentalGetInsertionPoint } = select(
+			editPostStore
+		);
+		return {
+			insertionPoint: __experimentalGetInsertionPoint(),
+			showMostUsedBlocks: isFeatureActive( 'mostUsedBlocks' ),
+		};
+	} );
+	const { setIsInserterOpened } = useDispatch( editPostStore );
+
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
+		onClose: () => setIsInserterOpened( false ),
+	} );
+
+	return (
+		<div
+			ref={ inserterDialogRef }
+			{ ...inserterDialogProps }
+			className="edit-post-layout__inserter-panel"
+		>
+			<div className="edit-post-layout__inserter-panel-header">
+				<Button
+					icon={ close }
+					onClick={ () => setIsInserterOpened( false ) }
+				/>
+			</div>
+			<div className="edit-post-layout__inserter-panel-content">
+				<Library
+					showMostUsedBlocks={ showMostUsedBlocks }
+					showInserterHelpPanel
+					shouldFocusBlock={ isMobileViewport }
+					rootClientId={ insertionPoint.rootClientId }
+					__experimentalInsertionIndex={
+						insertionPoint.insertionIndex
+					}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
@@ -24,7 +24,7 @@ export default function InserterSidebar() {
 			insertionPoint: __experimentalGetInsertionPoint(),
 			showMostUsedBlocks: isFeatureActive( 'mostUsedBlocks' ),
 		};
-	} );
+	}, [] );
 	const { setIsInserterOpened } = useDispatch( editPostStore );
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -32,7 +32,7 @@ export default function ListViewSidebar() {
 			clientIdsTree: __unstableGetClientIdsTree(),
 			selectedBlockClientIds: getSelectedBlockClientIds(),
 		};
-	} );
+	}, [] );
 	const { setIsListViewOpened } = useDispatch( editPostStore );
 
 	const { clearSelectedBlock, selectBlock } = useDispatch( blockEditorStore );

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -38,7 +38,7 @@ export default function ListViewSidebar() {
 	const { clearSelectedBlock, selectBlock } = useDispatch( blockEditorStore );
 	async function selectEditorBlock( clientId ) {
 		await clearSelectedBlock();
-		selectBlock( clientId );
+		selectBlock( clientId, -1 );
 	}
 
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalBlockNavigationTree as BlockNavigationTree,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import {
+	useFocusOnMount,
+	useFocusReturn,
+	useInstanceId,
+	useMergeRefs,
+} from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
+import { ESCAPE } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../store';
+
+export default function ListViewSidebar() {
+	const { clientIdsTree, selectedBlockClientIds } = useSelect( ( select ) => {
+		const {
+			__unstableGetClientIdsTree,
+			getSelectedBlockClientIds,
+		} = select( blockEditorStore );
+		return {
+			clientIdsTree: __unstableGetClientIdsTree(),
+			selectedBlockClientIds: getSelectedBlockClientIds(),
+		};
+	} );
+	const { setIsListViewOpened } = useDispatch( editPostStore );
+
+	const { clearSelectedBlock, selectBlock } = useDispatch( blockEditorStore );
+	async function selectEditorBlock( clientId ) {
+		await clearSelectedBlock();
+		selectBlock( clientId );
+	}
+
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
+	const focusReturnRef = useFocusReturn();
+	function closeOnEscape( event ) {
+		if ( event.keyCode === ESCAPE ) {
+			event.stopPropagation();
+			setIsListViewOpened( false );
+		}
+	}
+
+	const instanceId = useInstanceId( ListViewSidebar );
+	const labelId = `edit-post-editor__list-view-panel-label-${ instanceId }`;
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
+			aria-labelledby={ labelId }
+			className="edit-post-editor__list-view-panel"
+			onKeyDown={ closeOnEscape }
+		>
+			<div className="edit-post-editor__list-view-panel-header">
+				<strong id={ labelId }>{ __( 'List view' ) }</strong>
+				<Button
+					icon={ closeSmall }
+					label={ __( 'Close list view sidebar' ) }
+					onClick={ () => setIsListViewOpened( false ) }
+				/>
+			</div>
+			<div
+				className="edit-post-editor__list-view-panel-content"
+				ref={ useMergeRefs( [ focusReturnRef, focusOnMountRef ] ) }
+			>
+				<BlockNavigationTree
+					blocks={ clientIdsTree }
+					selectBlock={ selectEditorBlock }
+					selectedBlockClientIds={ selectedBlockClientIds }
+					showNestedBlocks
+					__experimentalPersistentListViewFeatures
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -1,0 +1,50 @@
+.edit-post-editor__inserter-panel,
+.edit-post-editor__list-view-panel {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.edit-post-editor__list-view-panel {
+	// Same width as the Inserter.
+	// @see packages/block-editor/src/components/inserter/style.scss
+	min-width: 350px;
+}
+
+.edit-post-editor__inserter-panel-header {
+	padding-top: $grid-unit-10;
+	padding-right: $grid-unit-10;
+	display: flex;
+	justify-content: flex-end;
+
+	@include break-medium() {
+		display: none;
+	}
+}
+
+.edit-post-editor__inserter-panel-content,
+.edit-post-editor__list-view-panel-content {
+	// Leave space for the close button
+	height: calc(100% - #{$button-size} - #{$grid-unit-10});
+}
+
+.edit-post-editor__inserter-panel-content {
+	@include break-medium() {
+		height: 100%;
+	}
+}
+
+.edit-post-editor__list-view-panel-header {
+	align-items: center;
+	border-bottom: $border-width solid $gray-300;
+	display: flex;
+	justify-content: space-between;
+	height: $grid-unit-60;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-05;
+}
+
+.edit-post-editor__list-view-panel-content {
+	overflow-y: auto;
+	padding: $grid-unit-10;
+}

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -433,6 +433,19 @@ export function setIsInserterOpened( value ) {
 }
 
 /**
+ * Returns an action object used to open/close the list view.
+ *
+ * @param {boolean} isOpen A boolean representing whether the list view should be opened or closed.
+ * @return {Object} Action object.
+ */
+export function setIsListViewOpened( isOpen ) {
+	return {
+		type: 'SET_IS_LIST_VIEW_OPENED',
+		isOpen,
+	};
+}
+
+/**
  * Returns an action object used to switch to template editing.
  *
  * @param {boolean} value Is editing template.

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -239,15 +239,39 @@ export function deviceType( state = 'Desktop', action ) {
 }
 
 /**
- * Reducer tracking whether the inserter is open.
+ * Reducer to set the block inserter panel open or closed.
  *
- * @param {boolean|Object} state
- * @param {Object}         action
+ * Note: this reducer interacts with the list view panel reducer
+ * to make sure that only one of the two panels is open at the same time.
+ *
+ * @param {Object} state Current state.
+ * @param {Object} action Dispatched action.
  */
-function blockInserterPanel( state = false, action ) {
+export function blockInserterPanel( state = false, action ) {
 	switch ( action.type ) {
+		case 'SET_IS_LIST_VIEW_OPENED':
+			return action.value ? false : state;
 		case 'SET_IS_INSERTER_OPENED':
 			return action.value;
+	}
+	return state;
+}
+
+/**
+ * Reducer to set the list view panel open or closed.
+ *
+ * Note: this reducer interacts with the inserter panel reducer
+ * to make sure that only one of the two panels is open at the same time.
+ *
+ * @param {Object} state Current state.
+ * @param {Object} action Dispatched action.
+ */
+export function listViewPanel( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_IS_INSERTER_OPENED':
+			return action.value ? false : state;
+		case 'SET_IS_LIST_VIEW_OPENED':
+			return action.isOpen;
 	}
 	return state;
 }
@@ -279,5 +303,6 @@ export default combineReducers( {
 	removedPanels,
 	deviceType,
 	blockInserterPanel,
+	listViewPanel,
 	isEditingTemplate,
 } );

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -250,7 +250,7 @@ export function deviceType( state = 'Desktop', action ) {
 export function blockInserterPanel( state = false, action ) {
 	switch ( action.type ) {
 		case 'SET_IS_LIST_VIEW_OPENED':
-			return action.value ? false : state;
+			return action.isOpen ? false : state;
 		case 'SET_IS_INSERTER_OPENED':
 			return action.value;
 	}

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -340,6 +340,17 @@ export function __experimentalGetInsertionPoint( state ) {
 }
 
 /**
+ * Returns true if the list view is opened.
+ *
+ * @param  {Object}  state Global application state.
+ *
+ * @return {boolean} Whether the list view is opened.
+ */
+export function isListViewOpened( state ) {
+	return state.listViewPanel;
+}
+
+/**
  * Returns true if the template editing mode is enabled.
  *
  * @param  {Object}  state Global application state.

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -17,6 +17,7 @@ import {
 	closeModal,
 	toggleFeature,
 	requestMetaBoxUpdates,
+	setIsListViewOpened,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -111,6 +112,19 @@ describe( 'actions', () => {
 			expect( fulfillment.next() ).toEqual( {
 				done: false,
 				value: controls.select( 'core/editor', 'getCurrentPost' ),
+			} );
+		} );
+	} );
+
+	describe( 'setIsListViewOpened', () => {
+		it( 'should return the SET_IS_LIST_VIEW_OPENED action', () => {
+			expect( setIsListViewOpened( true ) ).toEqual( {
+				type: 'SET_IS_LIST_VIEW_OPENED',
+				isOpen: true,
+			} );
+			expect( setIsListViewOpened( false ) ).toEqual( {
+				type: 'SET_IS_LIST_VIEW_OPENED',
+				isOpen: false,
 			} );
 		} );
 	} );

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -12,8 +12,12 @@ import {
 	isSavingMetaBoxes,
 	metaBoxLocations,
 	removedPanels,
+	blockInserterPanel,
+	listViewPanel,
 } from '../reducer';
 import { PREFERENCES_DEFAULTS } from '../defaults';
+
+import { setIsInserterOpened, setIsListViewOpened } from '../actions';
 
 describe( 'state', () => {
 	describe( 'preferences()', () => {
@@ -278,6 +282,68 @@ describe( 'state', () => {
 				panelName: 'post-status',
 			} );
 			expect( state ).toBe( original );
+		} );
+	} );
+
+	describe( 'blockInserterPanel()', () => {
+		it( 'should apply default state', () => {
+			expect( blockInserterPanel( undefined, {} ) ).toEqual( false );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			expect( blockInserterPanel( true, {} ) ).toBe( true );
+		} );
+
+		it( 'should set the open state of the inserter panel', () => {
+			expect(
+				blockInserterPanel( false, setIsInserterOpened( true ) )
+			).toBe( true );
+			expect(
+				blockInserterPanel( true, setIsInserterOpened( false ) )
+			).toBe( false );
+		} );
+
+		it( 'should close the inserter when opening the list view panel', () => {
+			expect(
+				blockInserterPanel( true, setIsListViewOpened( true ) )
+			).toBe( false );
+		} );
+
+		it( 'should not change the state when closing the list view panel', () => {
+			expect(
+				blockInserterPanel( true, setIsListViewOpened( false ) )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'listViewPanel()', () => {
+		it( 'should apply default state', () => {
+			expect( listViewPanel( undefined, {} ) ).toEqual( false );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			expect( listViewPanel( true, {} ) ).toBe( true );
+		} );
+
+		it( 'should set the open state of the list view panel', () => {
+			expect( listViewPanel( false, setIsListViewOpened( true ) ) ).toBe(
+				true
+			);
+			expect( listViewPanel( true, setIsListViewOpened( false ) ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'should close the list view when opening the inserter panel', () => {
+			expect( listViewPanel( true, setIsInserterOpened( true ) ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'should not change the state when closing the inserter panel', () => {
+			expect( listViewPanel( true, setIsInserterOpened( false ) ) ).toBe(
+				true
+			);
 		} );
 	} );
 } );

--- a/packages/edit-post/src/store/test/selectors.js
+++ b/packages/edit-post/src/store/test/selectors.js
@@ -18,6 +18,8 @@ import {
 	isMetaBoxLocationActive,
 	isEditorPanelEnabled,
 	isEditorPanelRemoved,
+	isInserterOpened,
+	isListViewOpened,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -376,6 +378,28 @@ describe( 'selectors', () => {
 			const result = isMetaBoxLocationActive( state, 'side' );
 
 			expect( result ).toBe( true );
+		} );
+	} );
+
+	describe( 'isInserterOpened', () => {
+		it( 'returns the block inserter panel isOpened state', () => {
+			const state = {
+				blockInserterPanel: true,
+			};
+			expect( isInserterOpened( state ) ).toBe( true );
+			state.blockInserterPanel = false;
+			expect( isInserterOpened( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isListViewOpened', () => {
+		it( 'returns the list view panel isOpened state', () => {
+			const state = {
+				listViewPanel: true,
+			};
+			expect( isListViewOpened( state ) ).toBe( true );
+			state.listViewPanel = false;
+			expect( isListViewOpened( state ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -9,6 +9,7 @@
 @import "./components/manage-blocks-modal/style.scss";
 @import "./components/meta-boxes/meta-boxes-area/style.scss";
 @import "./components/preferences-modal/style.scss";
+@import "./components/secondary-sidebar/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/sidebar/last-revision/style.scss";
 @import "./components/sidebar/post-author/style.scss";

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -67,7 +67,7 @@ body.block-editor-page {
 .editor-post-publish-panel,
 .components-popover,
 .components-modal__frame,
-.edit-post-layout__inserter-panel {
+.edit-post-editor__inserter-panel {
 	@include reset;
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #29470
Fixes #22113

In the Post Editor, convert the List View dropdown into a persistent sidebar occupying the same interface skeleton slot as the Inserter (`secondarySidebar`), in the same way it has already been done [for the Site Editor](https://github.com/WordPress/gutenberg/pull/28637).

To achieve this, a number of widespread changes have been made:

- Create a new `components/secondary-sidebar` folder containing both the Inserter and the List View file, making the Post Editor's layout easier to read.
- Create a new `listViewPanel` reducer (and relative action and selector) in the same vein as the one for the inserter panel. These reducers are interconnected: only one can be open at any time, so the action that opens one will automatically close the other.
- Replace the use of `BlockNavigationDropdown` in the Post Editor header with a custom implementation that would fill the `secondarySidebar` with the `BlockNavigationTree` component, displaying the entire blocks hierarchy of the content.
- Clicking on an item in the List View sidebar will select the block in the canvas (This is a pre-existing functionality of `BlockNavigationTree` itself).
- Reuse the same toggle keyboard shortcut for the post editor List View dropdown: <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd> (letter o, not number 0).

### Note

We currently don't have a good way to focus back to the List View via keyboard, beside toggling it off and on again.
The issue is known and tracked in https://github.com/WordPress/gutenberg/issues/29466.
Any suggestion would be extremely welcome!

## How has this been tested?

- Open the Post Editor.
- Click on the "List View" icon, or use the Ctrl+Alt+O shortcut.
- Make sure the List View sidebar pops up.
- Play around with it to see if it works (or not) as expected.
- Make sure only one of these sidebar can be open at any time: list view, inserter.

## Screenshots

<img width="664" alt="Screenshot 2021-04-21 at 15 36 06" src="https://user-images.githubusercontent.com/2070010/115571887-5133db80-a2b7-11eb-9f94-571fe1845a62.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
