### PR TITLE
[RNMobile] Mark TouchableRipple disabled if not editable or tappable

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -159,6 +159,11 @@ class BottomSheetCell extends Component {
 			cellRowContainerStyle,
 		];
 
+		const isInteractive =
+			isValueEditable ||
+			onPress !== undefined ||
+			onLongPress !== undefined;
+
 		const onCellPress = () => {
 			if ( isValueEditable ) {
 				startEditing();
@@ -308,7 +313,7 @@ class BottomSheetCell extends Component {
 						  __( 'Double tap to edit this value' )
 						: accessibilityHint
 				}
-				disabled={ disabled }
+				disabled={ disabled || ! isInteractive }
 				activeOpacity={ opacity }
 				onPress={ onCellPress }
 				onLongPress={ onLongPress }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/2633
Tweaks the bottom-sheet cell component to make it not respond to direct taps/long-presses if it's not actually hosting a direct action. Children are still interactive.

## How has this been tested?
#### Test 1:
0. In the native demo app
1. Add a Columns block and pick the 50/50 layout
2. Try tapping or long-tapping on the "Column 1" label or on any place around the sliders
3. Observe that nothing happens (in particular, there's no visual feedback that you tapped that space)

#### Test 2:
0. In the native demo app
1. Add a paragraph block and a link on some text
2. Notice that the various items on the link-editing bottom-sheet are giving visual feedback when tapped or long-tapped on.

## Types of changes
Tweak the `disabled` prop value we pass to `TouchableRipple` so the component will not provide feedback on taps when the cell is not offering a direct interaction.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
