### PR TITLE
Fix: Possible CSS units not passed to useCustomUnits. 

### DIFF
--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -14,6 +14,35 @@ import { useCustomUnits } from '../components/unit-control';
 
 export const SPACING_SUPPORT_KEY = 'spacing';
 
+const isWeb = Platform.OS === 'web';
+const CSS_UNITS = [
+	{
+		value: '%',
+		label: isWeb ? '%' : __( 'Percentage (%)' ),
+		default: '',
+	},
+	{
+		value: 'px',
+		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		default: '',
+	},
+	{
+		value: 'em',
+		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
+		default: '',
+	},
+	{
+		value: 'rem',
+		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
+		default: '',
+	},
+	{
+		value: 'vw',
+		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
+		default: '',
+	},
+];
+
 const hasPaddingSupport = ( blockName ) => {
 	const spacingSupport = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
 	return spacingSupport && spacingSupport.padding !== false;
@@ -33,7 +62,7 @@ export function PaddingEdit( props ) {
 		setAttributes,
 	} = props;
 
-	const units = useCustomUnits();
+	const units = useCustomUnits( CSS_UNITS );
 
 	if ( ! hasPaddingSupport( blockName ) ) {
 		return null;

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalBoxControl as BoxControl,
@@ -11,6 +12,35 @@ import {
  * Internal dependencies
  */
 import { useEditorFeature } from '../editor/utils';
+
+const isWeb = Platform.OS === 'web';
+const CSS_UNITS = [
+	{
+		value: '%',
+		label: isWeb ? '%' : __( 'Percentage (%)' ),
+		default: '',
+	},
+	{
+		value: 'px',
+		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		default: '',
+	},
+	{
+		value: 'em',
+		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
+		default: '',
+	},
+	{
+		value: 'rem',
+		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
+		default: '',
+	},
+	{
+		value: 'vw',
+		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
+		default: '',
+	},
+];
 
 export function useHasSpacingPanel( { supports, name } ) {
 	return (
@@ -40,7 +70,7 @@ export default function SpacingPanel( {
 	getStyle,
 	setStyle,
 } ) {
-	const units = useCustomUnits( { contextName: name } );
+	const units = useCustomUnits( { contextName: name, units: CSS_UNITS } );
 	const paddingValues = getStyle( name, 'padding' );
 	const setPaddingValues = ( { top, right, bottom, left } ) => {
 		setStyle( name, 'padding', {


### PR DESCRIPTION
The lack of possible CSS units makes non-px units not work on padding controls.

## How has this been tested?
With the TT-1 Blocks theme:
I added a cover block on the post editor. I verified I could correctly select non-px units for the padding (on the trunk I can't).
I went to the global styles sidebar selected the cover block and I verified I could also correctly select non-px units for the padding (on the trunk I can't).
