### PR TITLE
Persistent List View: Fix the list stealing focus from the canvas on item mount

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -78,6 +78,7 @@ export default function BlockNavigationBlock( {
 	const {
 		__experimentalFeatures: withExperimentalFeatures,
 		__experimentalPersistentListViewFeatures: withExperimentalPersistentListViewFeatures,
+		isTreeGridMounted,
 	} = useBlockNavigationContext();
 	const blockNavigationBlockSettingsClassName = classnames(
 		'block-editor-block-navigation-block__menu-cell',
@@ -88,7 +89,11 @@ export default function BlockNavigationBlock( {
 	// only focus the selected list item on mount; otherwise the list would always
 	// try to steal the focus from the editor canvas.
 	useEffect( () => {
-		if ( withExperimentalPersistentListViewFeatures && isSelected ) {
+		if (
+			withExperimentalPersistentListViewFeatures &&
+			! isTreeGridMounted &&
+			isSelected
+		) {
 			cellRef.current.focus();
 		}
 	}, [] );

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -3,7 +3,7 @@
  */
 
 import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -31,6 +31,11 @@ export default function BlockNavigationTree( {
 		target: blockDropTarget,
 	} = useBlockNavigationDropZone();
 
+	const isMounted = useRef( false );
+	useEffect( () => {
+		isMounted.current = true;
+	}, [] );
+
 	if ( ! __experimentalFeatures ) {
 		blockDropTarget = undefined;
 	}
@@ -40,11 +45,13 @@ export default function BlockNavigationTree( {
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
 			blockDropTarget,
+			isTreeGridMounted: isMounted.current,
 		} ),
 		[
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
 			blockDropTarget,
+			isMounted.current,
 		]
 	);
 


### PR DESCRIPTION
## Description

When a block is selected, opening the persistent list view moves the focus away from the canvas to the corresponding list item.
To prevent the list view from stealing focus every time the selected block changes if the list view is open, the focus change only happened on list item mount.
This approach didn't take into account newly created blocks, which inherently spawn new list items, which of course mount and steal focus from the canvas.

This fix makes sure that the focus change only happens when the entire list view mounts for the first time.
Creating new blocks while the list view is open, will keep the focus in the canvas, as expected.

## How has this been tested?

- Install a FSE theme such as TT1-Blocks, and open the Site Editor.
- Select a block.
- Open the List View and make sure the corresponding list item is selected and focused (it has a border).
<img width="330" alt="Screenshot 2021-04-21 at 19 49 33" src="https://user-images.githubusercontent.com/2070010/115605728-c7960500-a2da-11eb-9ed3-928bc00d6bc1.png">

- Select another block, either by clicking in the List View, or in the editor canvas.
- Make sure the corresponding list item is selected but **not** focused (no border).
<img width="328" alt="Screenshot 2021-04-21 at 19 49 42" src="https://user-images.githubusercontent.com/2070010/115605873-f57b4980-a2da-11eb-8983-38441db4f5e3.png">

- Add a new paragraph by hitting <kbd>enter</kbd> in the canvas.
  (Don't open the Inserter which would close the List View)
- Make sure the corresponding list item is selected but not focused.
- Try typing something, and make sure the text shows up in the block as expected.

### Repro steps

To clarify the issue, here are some simple repro steps:

- Install a FSE theme such as TT1-Blocks, and open the Site Editor.
- Open the List View.
- Add a new paragraph by hitting <kbd>enter</kbd> in the canvas.
  (Don't open the Inserter which would close the List View)
- The new block's corresponding list item appears in the List View, stealing the focus.
- Type something.

#### What I expected

To see what I typed show up in the paragraph block.

#### What happened instead

Nothing showed up, because the focus was not on the actual block, but on its corresponding list item.

To be able to actually type something (or generally, to interact with the block), I would have needed to hit <kbd>enter</kbd>, "activating" the list item, and moving the focus back to the canvas.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
