### PR TITLE
Gallery block refactor: Fix bug with alt text not being copied from media library

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -139,7 +139,7 @@ function GalleryEdit( props ) {
 	useEffect( () => {
 		newImages?.forEach( ( newImage ) => {
 			updateBlockAttributes( newImage.clientId, {
-				...buildImageAttributes( false, newImage ),
+				...buildImageAttributes( false, newImage.attributes ),
 				id: newImage.id,
 			} );
 		} );
@@ -277,6 +277,7 @@ function GalleryEdit( props ) {
 				id: image.id,
 				url: image.url,
 				caption: image.caption,
+				alt: image.alt,
 			} );
 		} );
 


### PR DESCRIPTION
## Description

Fixes:  #30263

The alt text was not being copied to gallery images inserted from media library

## Testing

- Checkout this PR to local dev env and enable gallery refactor experiment
- Add an image to media library and set the alt text
- Add a gallery block and select that image from the media gallery
- Make sure the alt text is set correctly on the image block in the gallery
