### PR TITLE
Gallery block refactor: fix bug with image style being lost when gallery grouped

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -139,7 +139,7 @@ function GalleryEdit( props ) {
 	useEffect( () => {
 		newImages?.forEach( ( newImage ) => {
 			updateBlockAttributes( newImage.clientId, {
-				...buildImageAttributes( false, newImage ),
+				...buildImageAttributes( false, newImage.attributes ),
 				id: newImage.id,
 			} );
 		} );
@@ -189,13 +189,21 @@ function GalleryEdit( props ) {
 		if ( existingBlock ) {
 			return existingBlock.attributes;
 		}
+
+		let newClassName;
+		if ( image.className && image.className !== '' ) {
+			newClassName = image.className;
+		} else {
+			newClassName = preferredStyle
+				? `is-style-${ preferredStyle }`
+				: undefined;
+		}
+
 		return {
 			...pickRelevantMediaFiles( image, sizeSlug ),
 			...getHrefAndDestination( image, linkTo ),
 			...getUpdatedLinkTargetSettings( linkTarget, attributes ),
-			className: preferredStyle
-				? `is-style-${ preferredStyle }`
-				: undefined,
+			className: newClassName,
 			sizeSlug,
 		};
 	}


### PR DESCRIPTION
## Description
Fixes: #30250

If styles are applied to an Image in the refactored gallery, eg. 'rounded', if the gallery is then grouped, or if you switch between code and editor view, the style is lost

## Testinging
Check out this PR to local dev env and enable gallery refactor experiment
Add a gallery, insert and image, and with image selected choose the 'rounded' style from right controls panel
Select the parent gallery and from other options on block toolbar select group
Rounded style should remain applied

Before:

![before-rounded](https://user-images.githubusercontent.com/3629020/115661507-a3e1c600-a391-11eb-9003-3765135667f0.gif)

After:

![after-round](https://user-images.githubusercontent.com/3629020/115661523-aa703d80-a391-11eb-9122-011378ea5056.gif)



