### PR TITLE
Docs: Add borders to block supports api doc

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -66,6 +66,29 @@ supports: {
 }
 ```
 
+## border
+
+-   Type: `Object`
+-   Default value: null
+-   Subproperties:
+    -   `color`: type `boolean`, default value `false`
+    -   `radius`: type `boolean`, default value `false`
+    -   `style`: type `boolean`, default value `false`
+    -   `width`: type `boolean`, default value `false`
+
+This signals that a block supports some border related CSS style properties. When it does, the block editor will show UI controls for the user to set their values, if [the theme declares support](/docs/how-to-guides/themes/theme-support.md##cover-block-padding).
+
+```js
+supports: {
+    border: {
+        color: true,  // Enable border color UI control.
+        radius: true, // Enable border radius UI control.
+        style: true,  // Enable border style UI control.
+        width: true,  // Enable border width UI control.
+    }
+}
+```
+
 ## className
 
 -   Type: `boolean`


### PR DESCRIPTION
## Description
Adds section to `block-supports.md` outlining the borders block support.

## How has this been tested?
Manual proof read.

## Screenshots

<img width="784" alt="Screen Shot 2021-04-22 at 4 05 55 pm" src="https://user-images.githubusercontent.com/60436221/115664086-befa0900-a384-11eb-9e0e-ed11dd887177.png">

## Types of changes
Documentation update.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
