### PR TITLE
Hook maybe_inline_styles in the footer

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -261,7 +261,10 @@ function gutenberg_maybe_inline_styles() {
 		}
 	}
 }
+// Run for styles enqueued in <head>.
 add_action( 'wp_head', 'gutenberg_maybe_inline_styles', 1 );
+// Run for late-loaded styles in the footer.
+add_action( 'wp_footer', 'gutenberg_maybe_inline_styles', 1 );
 
 /**
  * Complements the implementation of block type `core/social-icon`, whether it


### PR DESCRIPTION
## Description
non-block themes opting in separate styles using `load_separate_block_assets` are currently unable to have inlined styles. This PR fixes the issue by hooking `gutenberg_maybe_inline_styles` in the footer.

See https://github.com/WordPress/gutenberg/issues/31013#issuecomment-823799200 for details.

## How has this been tested?
Tested in a classic theme by adding `add_filter( 'load_separate_block_assets', '__return_true' );`.
Confirmed in https://github.com/WordPress/gutenberg/issues/31013#issuecomment-824226367

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
