### PR TITLE
Fix customize widget editor toolbar so that it overlaps preview

### DIFF
--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -138,6 +138,12 @@ export function computePopoverXAxisPosition(
 	if ( boundaryElement ) {
 		const boundaryRect = boundaryElement.getBoundingClientRect();
 		popoverLeft = Math.min( popoverLeft, boundaryRect.right - width );
+
+		// Avoid the popover being position beyond the left boundary if the
+		// direction is left to right.
+		if ( ! isRTL() ) {
+			popoverLeft = Math.max( popoverLeft, 0 );
+		}
 	}
 
 	return {

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -78,6 +78,10 @@ export default function SidebarBlockEditor( {
 						setIsInserterOpened={ setIsInserterOpened }
 					/>
 
+					<div className="customize-widgets__contextual-toolbar-wrapper">
+						<Popover.Slot name="block-toolbar" />
+					</div>
+
 					<BlockSelectionClearer>
 						<WritingFlow>
 							<ObserveTyping>
@@ -86,10 +90,6 @@ export default function SidebarBlockEditor( {
 						</WritingFlow>
 					</BlockSelectionClearer>
 				</SidebarEditorProvider>
-
-				<div className="customize-widgets__contextual-toolbar-wrapper">
-					<Popover.Slot name="block-toolbar" />
-				</div>
 
 				{ createPortal(
 					// This is a temporary hack to prevent button component inside <BlockInspector>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -87,7 +87,9 @@ export default function SidebarBlockEditor( {
 					</BlockSelectionClearer>
 				</SidebarEditorProvider>
 
-				<Popover.Slot name="block-toolbar" />
+				<div className="customize-widgets__contextual-toolbar-wrapper">
+					<Popover.Slot name="block-toolbar" />
+				</div>
 
 				{ createPortal(
 					// This is a temporary hack to prevent button component inside <BlockInspector>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -1,0 +1,3 @@
+.customize-widgets__contextual-toolbar-wrapper {
+	position: fixed;
+}

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -1,3 +1,5 @@
 .customize-widgets__contextual-toolbar-wrapper {
 	position: fixed;
+	// Appear over block placeholders, but under widgets page headings.
+	z-index: 8;
 }

--- a/packages/customize-widgets/src/style.scss
+++ b/packages/customize-widgets/src/style.scss
@@ -1,3 +1,4 @@
+@import "./components/sidebar-block-editor/style.scss";
 @import "./components/block-inspector-button/style.scss";
 @import "./components/header/style.scss";
 @import "./components/inserter/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes #30988

Solves the issue where the widgets toolbar is offscreen on desktop. 

Requires:
- Using a `position: fixed` container to pull the toolbar out of its normal layer
- Ensuring the popover positioning algorithm won't place items offscreen
- Adjusting some z-indices so that the block is under some elements and over others (might not be perfect).

Also fixes the tab order, so that shift-tabbing from the block goes to the toolbar. The element was in the wrong place in the DOM.

## How has this been tested?
1. Enable the block-based widget customizer experiment
2. Go to Appearance > Customize > Widgets
3. Add some paragraph blocks
4. See the toolbar

## Screenshots <!-- if applicable -->
<img width="453" alt="Screenshot 2021-04-22 at 6 00 11 pm" src="https://user-images.githubusercontent.com/677833/115695726-9f6adc80-a394-11eb-960b-92365a87a8e5.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
