### PR TITLE
useSelect: normalise getting selectors for callbacks

### DIFF
--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -100,33 +100,14 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 	}, [] );
 
 	const {
-		selectedBlockClientId,
-		selectionBeforeEndClientId,
-		selectionAfterEndClientId,
-	} = useSelect( ( select ) => {
-		const {
-			getSelectedBlockClientId,
-			getMultiSelectedBlocksEndClientId,
-			getPreviousBlockClientId,
-			getNextBlockClientId,
-		} = select( blockEditorStore );
-		const _selectedBlockClientId = getSelectedBlockClientId();
-		const selectionEndClientId = getMultiSelectedBlocksEndClientId();
-		return {
-			selectedBlockClientId: _selectedBlockClientId,
-			selectionBeforeEndClientId: getPreviousBlockClientId(
-				selectionEndClientId || _selectedBlockClientId
-			),
-			selectionAfterEndClientId: getNextBlockClientId(
-				selectionEndClientId || _selectedBlockClientId
-			),
-		};
-	}, [] );
-	const {
 		hasBlockMovingClientId,
 		getBlockIndex,
 		getBlockRootClientId,
 		getClientIdsOfDescendants,
+		getSelectedBlockClientId,
+		getMultiSelectedBlocksEndClientId,
+		getPreviousBlockClientId,
+		getNextBlockClientId,
 	} = useSelect( blockEditorStore );
 	const {
 		selectBlock,
@@ -152,6 +133,15 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 			event.preventDefault();
 			return;
 		}
+
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const selectionEndClientId = getMultiSelectedBlocksEndClientId();
+		const selectionBeforeEndClientId = getPreviousBlockClientId(
+			selectionEndClientId || selectedBlockClientId
+		);
+		const selectionAfterEndClientId = getNextBlockClientId(
+			selectionEndClientId || selectedBlockClientId
+		);
 
 		const navigateUp = ( isTab && isShift ) || isUp;
 		const navigateDown = ( isTab && ! isShift ) || isDown;

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -48,40 +48,6 @@ function isWindows() {
 	return window.navigator.platform.indexOf( 'Win' ) > -1;
 }
 
-function selector( select ) {
-	const {
-		getSelectedBlockClientId,
-		getMultiSelectedBlocksEndClientId,
-		getPreviousBlockClientId,
-		getNextBlockClientId,
-		hasBlockMovingClientId,
-		getBlockIndex,
-		getBlockRootClientId,
-		getClientIdsOfDescendants,
-		canInsertBlockType,
-		getBlockName,
-	} = select( blockEditorStore );
-
-	const selectedBlockClientId = getSelectedBlockClientId();
-	const selectionEndClientId = getMultiSelectedBlocksEndClientId();
-
-	return {
-		selectedBlockClientId,
-		selectionBeforeEndClientId: getPreviousBlockClientId(
-			selectionEndClientId || selectedBlockClientId
-		),
-		selectionAfterEndClientId: getNextBlockClientId(
-			selectionEndClientId || selectedBlockClientId
-		),
-		hasBlockMovingClientId,
-		getBlockIndex,
-		getBlockRootClientId,
-		getClientIdsOfDescendants,
-		canInsertBlockType,
-		getBlockName,
-	};
-}
-
 /**
  * Block selection button component, displaying the label of the block. If the block
  * descends from a root block, a button is displayed enabling the user to select
@@ -137,11 +103,31 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 		selectedBlockClientId,
 		selectionBeforeEndClientId,
 		selectionAfterEndClientId,
+	} = useSelect( ( select ) => {
+		const {
+			getSelectedBlockClientId,
+			getMultiSelectedBlocksEndClientId,
+			getPreviousBlockClientId,
+			getNextBlockClientId,
+		} = select( blockEditorStore );
+		const _selectedBlockClientId = getSelectedBlockClientId();
+		const selectionEndClientId = getMultiSelectedBlocksEndClientId();
+		return {
+			selectedBlockClientId: _selectedBlockClientId,
+			selectionBeforeEndClientId: getPreviousBlockClientId(
+				selectionEndClientId || _selectedBlockClientId
+			),
+			selectionAfterEndClientId: getNextBlockClientId(
+				selectionEndClientId || _selectedBlockClientId
+			),
+		};
+	}, [] );
+	const {
 		hasBlockMovingClientId,
 		getBlockIndex,
 		getBlockRootClientId,
 		getClientIdsOfDescendants,
-	} = useSelect( selector, [] );
+	} = useSelect( blockEditorStore );
 	const {
 		selectBlock,
 		clearSelectedBlock,

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -263,27 +263,25 @@ export default function useInsertionPoint( ref ) {
 		isInserterVisible,
 		selectedClientId,
 		selectedRootClientId,
-		getBlockListSettings,
 	} = useSelect( ( select ) => {
 		const {
 			isMultiSelecting: _isMultiSelecting,
 			isBlockInsertionPointVisible,
 			getBlockInsertionPoint,
 			getBlockOrder,
-			getBlockListSettings: _getBlockListSettings,
 		} = select( blockEditorStore );
 
 		const insertionPoint = getBlockInsertionPoint();
 		const order = getBlockOrder( insertionPoint.rootClientId );
 
 		return {
-			getBlockListSettings: _getBlockListSettings,
 			isMultiSelecting: _isMultiSelecting(),
 			isInserterVisible: isBlockInsertionPointVisible(),
 			selectedClientId: order[ insertionPoint.index - 1 ],
 			selectedRootClientId: insertionPoint.rootClientId,
 		};
 	}, [] );
+	const { getBlockListSettings } = useSelect( blockEditorStore );
 
 	const onMouseMove = useCallback(
 		( event ) => {

--- a/packages/block-editor/src/components/block-navigation/use-block-navigation-drop-zone.js
+++ b/packages/block-editor/src/components/block-navigation/use-block-navigation-drop-zone.js
@@ -201,16 +201,7 @@ export default function useBlockNavigationDropZone() {
 		getBlockCount,
 		getDraggedBlockClientIds,
 		canInsertBlocks,
-	} = useSelect( ( select ) => {
-		const selectors = select( blockEditorStore );
-		return {
-			canInsertBlocks: selectors.canInsertBlocks,
-			getBlockRootClientId: selectors.getBlockRootClientId,
-			getBlockIndex: selectors.getBlockIndex,
-			getBlockCount: selectors.getBlockCount,
-			getDraggedBlockClientIds: selectors.getDraggedBlockClientIds,
-		};
-	}, [] );
+	} = useSelect( blockEditorStore );
 	const [ target, setTarget ] = useState();
 	const { rootClientId: targetRootClientId, blockIndex: targetBlockIndex } =
 		target || {};

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -23,14 +23,8 @@ import { getPasteEventData } from '../../utils/get-paste-event-data';
 import { store as blockEditorStore } from '../../store';
 
 export function useNotifyCopy() {
-	const { getBlockName } = useSelect(
-		( select ) => select( blockEditorStore ),
-		[]
-	);
-	const { getBlockType } = useSelect(
-		( select ) => select( blocksStore ),
-		[]
-	);
+	const { getBlockName } = useSelect( blockEditorStore );
+	const { getBlockType } = useSelect( blocksStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	return useCallback( ( eventType, selectedBlockClientIds ) => {
@@ -84,7 +78,7 @@ export function useClipboardHandler() {
 		getSelectedBlockClientIds,
 		hasMultiSelection,
 		getSettings,
-	} = useSelect( ( select ) => select( blockEditorStore ), [] );
+	} = useSelect( blockEditorStore );
 	const { flashBlock, removeBlocks, replaceBlocks } = useDispatch(
 		blockEditorStore
 	);

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -40,10 +40,8 @@ export default function useInnerBlockTemplateSync(
 	templateLock,
 	templateInsertUpdatesSelection
 ) {
-	const getSelectedBlocksInitialCaretPosition = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSelectedBlocksInitialCaretPosition,
-		[]
+	const { getSelectedBlocksInitialCaretPosition } = useSelect(
+		blockEditorStore
 	);
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const innerBlocks = useSelect(

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -45,14 +45,10 @@ function useInsertionPoint( {
 	onSelect,
 	shouldFocusBlock = true,
 } ) {
-	const {
-		destinationRootClientId,
-		destinationIndex,
-		getSelectedBlock,
-	} = useSelect(
+	const { getSelectedBlock } = useSelect( blockEditorStore );
+	const { destinationRootClientId, destinationIndex } = useSelect(
 		( select ) => {
 			const {
-				getSelectedBlock: _getSelectedBlock,
 				getBlockIndex,
 				getBlockOrder,
 				getBlockInsertionPoint,
@@ -90,7 +86,6 @@ function useInsertionPoint( {
 			}
 
 			return {
-				getSelectedBlock: _getSelectedBlock,
 				destinationRootClientId: _destinationRootClientId,
 				destinationIndex: _destinationIndex,
 			};

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -53,18 +53,11 @@ function InserterMenu( {
 		insertDefaultBlock,
 	} = useDispatch( blockEditorStore );
 
-	const {
-		items,
-		destinationRootClientId,
-		getBlockOrder,
-		getBlockCount,
-		canInsertBlockType,
-	} = useSelect( ( select ) => {
+	const { items, destinationRootClientId } = useSelect( ( select ) => {
 		const {
 			getInserterItems,
 			getBlockRootClientId,
 			getBlockSelectionEnd,
-			...selectBlockEditorStore
 		} = select( blockEditorStore );
 
 		let targetRootClientId = rootClientId;
@@ -78,13 +71,12 @@ function InserterMenu( {
 		return {
 			items: getInserterItems( targetRootClientId ),
 			destinationRootClientId: targetRootClientId,
-			getBlockOrder: selectBlockEditorStore.getBlockOrder,
-			getBlockCount: selectBlockEditorStore.getBlockCount,
-			canInsertBlockType: selectBlockEditorStore.canInsertBlockType,
 		};
 	} );
-
-	const { getBlockType } = useSelect( ( select ) => select( blocksStore ) );
+	const { getBlockOrder, getBlockCount, canInsertBlockType } = useSelect(
+		blockEditorStore
+	);
+	const { getBlockType } = useSelect( blocksStore );
 
 	useEffect( () => {
 		// Show/Hide insertion point on Mount/Dismount

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -212,27 +212,15 @@ export function onHTMLDrop(
  * @return {Object} An object that contains the event handlers `onDrop`, `onFilesDrop` and `onHTMLDrop`.
  */
 export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
+	const hasUploadPermissions = useSelect(
+		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
+		[]
+	);
 	const {
 		canInsertBlockType,
 		getBlockIndex,
 		getClientIdsOfDescendants,
-		hasUploadPermissions,
-	} = useSelect( ( select ) => {
-		const {
-			canInsertBlockType: _canInsertBlockType,
-			getBlockIndex: _getBlockIndex,
-			getClientIdsOfDescendants: _getClientIdsOfDescendants,
-			getSettings,
-		} = select( blockEditorStore );
-
-		return {
-			canInsertBlockType: _canInsertBlockType,
-			getBlockIndex: _getBlockIndex,
-			getClientIdsOfDescendants: _getClientIdsOfDescendants,
-			hasUploadPermissions: getSettings().mediaUpload,
-		};
-	}, [] );
-
+	} = useSelect( blockEditorStore );
 	const {
 		insertBlocks,
 		moveBlocksToPosition,

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -42,7 +42,6 @@ function selector( select ) {
 		isMultiSelecting,
 		getMultiSelectedBlockClientIds,
 		hasMultiSelection,
-		getBlockParents,
 		getSelectedBlockClientId,
 	} = select( blockEditorStore );
 
@@ -51,7 +50,6 @@ function selector( select ) {
 		isMultiSelecting: isMultiSelecting(),
 		multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
 		hasMultiSelection: hasMultiSelection(),
-		getBlockParents,
 		selectedBlockClientId: getSelectedBlockClientId(),
 	};
 }
@@ -74,9 +72,9 @@ export default function useMultiSelection( ref ) {
 		isMultiSelecting,
 		multiSelectedBlockClientIds,
 		hasMultiSelection,
-		getBlockParents,
 		selectedBlockClientId,
 	} = useSelect( selector, [] );
+	const { getBlockParents } = useSelect( blockEditorStore );
 	const {
 		startMultiSelect,
 		stopMultiSelect,

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -41,11 +41,10 @@ export default function ButtonsEdit( {
 	const [ maxWidth, setMaxWidth ] = useState( 0 );
 	const { marginLeft: spacing } = styles.spacing;
 
-	const { getBlockOrder, isInnerButtonSelected, shouldDelete } = useSelect(
+	const { isInnerButtonSelected, shouldDelete } = useSelect(
 		( select ) => {
 			const {
 				getBlockCount,
-				getBlockOrder: _getBlockOrder,
 				getBlockParents,
 				getSelectedBlockClientId,
 			} = select( blockEditorStore );
@@ -56,7 +55,6 @@ export default function ButtonsEdit( {
 			);
 
 			return {
-				getBlockOrder: _getBlockOrder,
 				isInnerButtonSelected: selectedBlockParents[ 0 ] === clientId,
 				// The purpose of `shouldDelete` check is giving the ability to
 				// pass to mobile toolbar function called `onDelete` which removes
@@ -67,7 +65,7 @@ export default function ButtonsEdit( {
 		},
 		[ clientId ]
 	);
-
+	const { getBlockOrder } = useSelect( blockEditorStore );
 	const { insertBlock, removeBlock, selectBlock } = useDispatch(
 		blockEditorStore
 	);

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -796,6 +796,9 @@ not change because the dependency is just the currency.
 When data is only used in an event callback, the data should not be retrieved
 on render, so it may be useful to get the selectors function instead.
 
+**Don't use `useSelect` this way when calling the selectors in the render
+function because your component won't re-render on a data change.**
+
 ```js
 import { useSelect } from '@wordpress/data';
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -793,9 +793,25 @@ any price in the state for that currency is retrieved. If the currency prop
 doesn't change and other props are passed in that do change, the price will
 not change because the dependency is just the currency.
 
+When data is only used in an event callback, the data should not be retrieved
+on render, so it may be useful to get the selectors function instead.
+
+```js
+import { useSelect } from '@wordpress/data';
+
+function Paste( { children } ) {
+  const { getSettings } = useSelect( 'my-shop' );
+  function onPaste() {
+    // Do something with the settings.
+    const settings = getSettings();
+  }
+  return <div onPaste={ onPaste }>{ children }</div>;
+}
+```
+
 _Parameters_
 
--   _\_mapSelect_ `Function`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument.
+-   _\_mapSelect_ `Function|WPDataStore|string`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
 -   _deps_ `Array`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
 
 _Returns_

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -19,21 +19,28 @@ import useAsyncMode from '../async-mode-provider/use-async-mode';
 
 const renderQueue = createQueue();
 
+/** @typedef {import('./types').WPDataStore} WPDataStore */
+
 /**
  * Custom react hook for retrieving props from registered selectors.
  *
  * In general, this custom React hook follows the
  * [rules of hooks](https://reactjs.org/docs/hooks-rules.html).
  *
- * @param {Function} _mapSelect  Function called on every state change. The
- *                               returned value is exposed to the component
- *                               implementing this hook. The function receives
- *                               the `registry.select` method on the first
- *                               argument and the `registry` on the second
- *                               argument.
- * @param {Array}    deps        If provided, this memoizes the mapSelect so the
- *                               same `mapSelect` is invoked on every state
- *                               change unless the dependencies change.
+ * @param {Function|WPDataStore|string} _mapSelect  Function called on every state change. The
+ *                                                  returned value is exposed to the component
+ *                                                  implementing this hook. The function receives
+ *                                                  the `registry.select` method on the first
+ *                                                  argument and the `registry` on the second
+ *                                                  argument.
+ *                                                  When a store key is passed, all selectors for
+ *                                                  the store will be returned. This is only meant
+ *                                                  for usage of these selectors in event
+ *                                                  callbacks, not for data needed to create the
+ *                                                  element tree.
+ * @param {Array}                       deps        If provided, this memoizes the mapSelect so the
+ *                                                  same `mapSelect` is invoked on every state
+ *                                                  change unless the dependencies change.
  *
  * @example
  * ```js
@@ -59,6 +66,22 @@ const renderQueue = createQueue();
  * any price in the state for that currency is retrieved. If the currency prop
  * doesn't change and other props are passed in that do change, the price will
  * not change because the dependency is just the currency.
+ *
+ * When data is only used in an event callback, the data should not be retrieved
+ * on render, so it may be useful to get the selectors function instead.
+ *
+ * ```js
+ * import { useSelect } from '@wordpress/data';
+ *
+ * function Paste( { children } ) {
+ *   const { getSettings } = useSelect( 'my-shop' );
+ *   function onPaste() {
+ *     // Do something with the settings.
+ *     const settings = getSettings();
+ *   }
+ *   return <div onPaste={ onPaste }>{ children }</div>;
+ * }
+ * ```
  *
  * @return {Function}  A custom react hook.
  */

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -70,6 +70,9 @@ const renderQueue = createQueue();
  * When data is only used in an event callback, the data should not be retrieved
  * on render, so it may be useful to get the selectors function instead.
  *
+ * **Don't use `useSelect` this way when calling the selectors in the render
+ * function because your component won't re-render on a data change.**
+ *
  * ```js
  * import { useSelect } from '@wordpress/data';
  *

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -15,8 +15,8 @@ import { __ } from '@wordpress/i18n';
 import { store as editPostStore } from '../../store';
 
 function KeyboardShortcuts() {
+	const { getBlockSelectionStart } = useSelect( 'core/block-editor' );
 	const {
-		getBlockSelectionStart,
 		getEditorMode,
 		isEditorSidebarOpened,
 		richEditingEnabled,
@@ -24,8 +24,6 @@ function KeyboardShortcuts() {
 	} = useSelect( ( select ) => {
 		const settings = select( 'core/editor' ).getEditorSettings();
 		return {
-			getBlockSelectionStart: select( 'core/block-editor' )
-				.getBlockSelectionStart,
 			getEditorMode: select( editPostStore ).getEditorMode,
 			isEditorSidebarOpened: select( editPostStore )
 				.isEditorSidebarOpened,

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -16,21 +16,13 @@ import { store as editPostStore } from '../../store';
 
 function KeyboardShortcuts() {
 	const { getBlockSelectionStart } = useSelect( 'core/block-editor' );
-	const {
-		getEditorMode,
-		isEditorSidebarOpened,
-		richEditingEnabled,
-		codeEditingEnabled,
-	} = useSelect( ( select ) => {
-		const settings = select( 'core/editor' ).getEditorSettings();
-		return {
-			getEditorMode: select( editPostStore ).getEditorMode,
-			isEditorSidebarOpened: select( editPostStore )
-				.isEditorSidebarOpened,
-			richEditingEnabled: settings.richEditingEnabled,
-			codeEditingEnabled: settings.codeEditingEnabled,
-		};
-	} );
+	const { getEditorMode, isEditorSidebarOpened } = useSelect( editPostStore );
+	const isModeToggleDisabled = useSelect( ( select ) => {
+		const { richEditingEnabled, codeEditingEnabled } = select(
+			'core/editor'
+		).getEditorSettings();
+		return ! richEditingEnabled || ! codeEditingEnabled;
+	}, [] );
 
 	const {
 		switchEditorMode,
@@ -133,7 +125,7 @@ function KeyboardShortcuts() {
 		},
 		{
 			bindGlobal: true,
-			isDisabled: ! richEditingEnabled || ! codeEditingEnabled,
+			isDisabled: isModeToggleDisabled,
 		}
 	);
 

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -28,16 +28,16 @@ function getBlockDisplayText( block ) {
 }
 
 function useSecondaryText() {
-	const { activeEntityBlockId, getBlock } = useSelect( ( select ) => {
-		return {
-			activeEntityBlockId: select(
+	const { getBlock } = useSelect( 'core/block-editor' );
+	const activeEntityBlockId = useSelect(
+		( select ) =>
+			select(
 				'core/block-editor'
 			).__experimentalGetActiveBlockIdByBlockNames( [
 				'core/template-part',
 			] ),
-			getBlock: select( 'core/block-editor' ).getBlock,
-		};
-	} );
+		[]
+	);
 
 	if ( activeEntityBlockId ) {
 		return {

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -46,12 +46,7 @@ const hasSessionStorageSupport = once( () => {
  * restore a local autosave, if one exists.
  */
 function useAutosaveNotice() {
-	const {
-		postId,
-		isEditedPostNew,
-		getEditedPostAttribute,
-		hasRemoteAutosave,
-	} = useSelect(
+	const { postId, isEditedPostNew, hasRemoteAutosave } = useSelect(
 		( select ) => ( {
 			postId: select( 'core/editor' ).getCurrentPostId(),
 			isEditedPostNew: select( 'core/editor' ).isEditedPostNew(),
@@ -62,6 +57,7 @@ function useAutosaveNotice() {
 		} ),
 		[]
 	);
+	const { getEditedPostAttribute } = useSelect( 'core/editor' );
 
 	const { createWarningNotice, removeNotice } = useDispatch( noticesStore );
 	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The pattern of just getting selectors to be used for callbacks (vs for the render tree) becomes more widely used, yet it almost feels discouraged, wrong or awkward to return selectors in a select map instead of calling them immediately. `useSelect` has mostly been used that way: call selectors and return the result. Returning the selector functions almost feels like a hack that you're not supposed to do.

This PR adjusts `useSelect` to allow getting selectors in a way that's less verbose and that "feels" right. It's similar to how `useDispatch` works.

```js
const { getBlockCount } = useSelect( 'core/block-editor' );
```

Like this, you can get the selectors and call them in callbacks without it looking awkward and encourages this pattern to improve performance. We should generally avoid calling selectors more often if the result is not going to be used in the render tree.

With this pattern, you also don't have to provide dependencies since it will always be empty (`[]`).

Additionally, we can make some performance optimisations internally in `useSelect` when you're not mapping the results. We can just skip all mapping logic.

## How has this been tested?

Everything should work as before.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
