### PR TITLE
Try to make Reusable blocks inherit alignment

### DIFF
--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -13,7 +13,8 @@
 	"supports": {
 		"customClassName": false,
 		"html": false,
-		"inserter": false
+		"inserter": false,
+		"align": [ "wide", "full" ]
 	},
 	"editorStyle": "wp-block-editor"
 }

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -8,13 +8,15 @@
 	"attributes": {
 		"ref": {
 			"type": "number"
+		},
+		"inheritedAlignment": {
+			"type": "string"
 		}
 	},
 	"supports": {
 		"customClassName": false,
 		"html": false,
-		"inserter": false,
-		"align": [ "wide", "full" ]
+		"inserter": false
 	},
 	"editorStyle": "wp-block-editor"
 }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -28,11 +28,17 @@ import {
 } from '@wordpress/block-editor';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 import { ungroup } from '@wordpress/icons';
+import { useEffect } from '@wordpress/element';
 
-export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
+export default function ReusableBlockEdit( {
+	attributes: { ref, inheritedAlignment },
+	setAttributes,
+	clientId,
+} ) {
 	const [ hasAlreadyRendered, RecursionProvider ] = useNoRecursiveRenders(
 		ref
 	);
+
 	const { isMissing, hasResolved } = useSelect(
 		( select ) => {
 			const persistedBlock = select( coreStore ).getEntityRecord(
@@ -71,7 +77,29 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 		ref
 	);
 
-	const blockProps = useBlockProps();
+	useEffect( () => {
+		const alignments = [ 'wide', 'full' ];
+
+		// Determine the widest setting of all the contained blocks.
+		const widestAlignment = blocks.reduce( ( accumulator, block ) => {
+			const { align } = block.attributes;
+			return alignments.indexOf( align ) >
+				alignments.indexOf( accumulator )
+				? align
+				: accumulator;
+		}, undefined );
+
+		// Set the attribute of the Reusable block to match the widest
+		// alignment.
+
+		setAttributes( {
+			inheritedAlignment: widestAlignment ?? '',
+		} );
+	}, [ blocks ] );
+
+	const blockProps = useBlockProps( {
+		'data-align': inheritedAlignment,
+	} );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{},

--- a/packages/reusable-blocks/src/store/controls.js
+++ b/packages/reusable-blocks/src/store/controls.js
@@ -90,6 +90,24 @@ const controls = {
 	CONVERT_BLOCKS_TO_REUSABLE: createRegistryControl(
 		( registry ) =>
 			async function ( { clientIds, title } ) {
+				const blocks = registry
+					.select( 'core/block-editor' )
+					.getBlocksByClientId( clientIds );
+
+				const alignments = [ 'wide', 'full' ];
+
+				// Determine the widest setting of all the blocks to be grouped
+				const widestAlignment = blocks.reduce(
+					( accumulator, block ) => {
+						const { align } = block.attributes;
+						return alignments.indexOf( align ) >
+							alignments.indexOf( accumulator )
+							? align
+							: accumulator;
+					},
+					undefined
+				);
+
 				const reusableBlock = {
 					title: title || __( 'Untitled Reusable block' ),
 					content: serialize(
@@ -106,6 +124,7 @@ const controls = {
 
 				const newBlock = createBlock( 'core/block', {
 					ref: updatedRecord.id,
+					align: widestAlignment,
 				} );
 				registry
 					.dispatch( blockEditorStore )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Addresses https://github.com/WordPress/gutenberg/issues/8288.

Currently, when reusable blocks are created from a set of blocks which have various alignments set these are "lost". This is because the reusable block is always "centered" within the editor and has no concept of "wide" or "full".

This PR:

* adds alignment support to reusable blocks
* grabs the widest alignment setting of the blocks being placed into the reusable block and applies that setting to the reusable block itself.

~This sort of works, but this issue is that the blocks within reusable block that do not have an alignment set are no longer centered within the viewport. This is because they are missing the special CSS rules that are based on the root container which cause them to be centered.~ 

~@jasmussen mentioned that @youknowriad is working on some Layout controls which might help to solve this.~

~Essentially what we need is a way to make the alignment of blocks contained _within_ the reusable block behave (lay out) as they do within the normal editor canvas.~

**Update**: this layout centering issue now seems to be fixed.





Closes https://github.com/WordPress/gutenberg/issues/8288

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/128362768-ebcc18e8-f509-46d0-b7e8-4478bf4459ed.mp4



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

Uploading Screen Capture on 2021-04-22 at 12-32-58.mov…

