### PR TITLE
Add experimental util to allow fetch remote url data from REST API 

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
@@ -4,6 +4,33 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs, prependHTTP } from '@wordpress/url';
 
+/**
+ * @typedef WPRemoteUrlData
+ *
+ * @property {string} title     contents of the remote URL's `<title>` tag.
+ */
+
+/**
+ * Fetches data about a remote URL.
+ * eg: <title> tag, favicon...etc.
+ *
+ * @async
+ * @param {string}              url
+ *
+ * @example
+ * ```js
+ * import { __experimentalFetchRemoteUrlData as fetchRemoteUrlData } from '@wordpress/core-data';
+ *
+ * //...
+ *
+ * export function initialize( id, settings ) {
+ *
+ * settings.__experimentalFetchRemoteUrlData = (
+ *     url
+ * ) => fetchRemoteUrlData( url );
+ * ```
+ * @return {Promise< WPRemoteUrlData[] >} Remote URL data.
+ */
 const fetchRemoteUrlData = async ( url ) => {
 	const endpoint = '/__experimental/url-details';
 

--- a/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs, prependHTTP } from '@wordpress/url';
+
+const fetchRemoteUrlData = async ( url ) => {
+	const endpoint = '/__experimental/url-details';
+
+	const args = {
+		url: prependHTTP( url ),
+	};
+
+	return apiFetch( {
+		path: addQueryArgs( endpoint, args ),
+	} );
+};
+
+export default fetchRemoteUrlData;

--- a/packages/core-data/src/fetch/index.js
+++ b/packages/core-data/src/fetch/index.js
@@ -1,1 +1,2 @@
 export { default as __experimentalFetchLinkSuggestions } from './__experimental-fetch-link-suggestions';
+export { default as __experimentalFetchRemoteUrlData } from './__experimental-fetch-remote-url-data';

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -11,6 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
+	__experimentalFetchRemoteUrlData as fetchRemoteUrlData,
 } from '@wordpress/core-data';
 
 /**
@@ -107,6 +108,8 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, settings ),
+			__experimentalFetchRemoteUrlData: ( url ) =>
+				fetchRemoteUrlData( url ),
 			__experimentalCanUserUseUnfilteredHTML: canUseUnfilteredHTML,
 			__experimentalUndo: undo,
 			__experimentalShouldInsertAtTheTop: isTitleSelected,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Since https://github.com/WordPress/gutenberg/pull/18042 we've had a way to retrieve some data about a remote URL (currently just title but [more is coming](https://github.com/WordPress/gutenberg/pull/28791)). 

We'd like to start making use of this in the editor - specifically within the link UI to provide "rich" preview/details about external URLs. 

This PR is the first step which adds the ability to call the REST API via `@worpress/core-data`.

## How has this been tested?

* Checkout PR branch
* Build `npm run dev`.
* Create a new Post.
* Open browser devtools.
* Paste the following
```js
wp.coreData.__experimentalFetchRemoteUrlData('www.wordpress.org').then(data => console.log(data));
```
* Hit `Enter`.
* You should see an object returned with a `title` property which matches the contents of the `<title>` tag on `www.wordpress.org`.
```js
{
    title: "Blog Tool, Publishing Platform, and CMS &mdash; WordPress.org",
}
```
* Try changing the URL and see different title tag returned.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
