### PR TITLE
Fix: Adding buttons should respect the preferred style

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -52,14 +52,14 @@ function ButtonsEdit( {
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
-		template: [
-			[
-				'core/button',
-				preferredStyle
-					? { className: `is-style-${ preferredStyle }` }
-					: {},
-			],
-		],
+		template: preferredStyle
+			? [
+					[
+						'core/button',
+						{ className: `is-style-${ preferredStyle }` },
+					],
+			  ]
+			: [ [ 'core/button' ] ],
 		orientation,
 		__experimentalLayout: LAYOUT,
 		templateInsertUpdatesSelection: true,

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -52,14 +52,12 @@ function ButtonsEdit( {
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
-		template: preferredStyle
-			? [
-					[
-						'core/button',
-						{ className: `is-style-${ preferredStyle }` },
-					],
-			  ]
-			: [ [ 'core/button' ] ],
+		template: [
+			[
+				buttonBlockName,
+				{ className: preferredStyle && `is-style-${ preferredStyle }` },
+			],
+		],
 		orientation,
 		__experimentalLayout: LAYOUT,
 		templateInsertUpdatesSelection: true,

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -11,7 +11,9 @@ import {
 	useBlockProps,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	JustifyContentControl,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,7 +21,6 @@ import {
 import { name as buttonBlockName } from '../button';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
-const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
 const LAYOUT = {
 	type: 'default',
 	alignments: [],
@@ -42,9 +43,23 @@ function ButtonsEdit( {
 			'is-vertical': orientation === 'vertical',
 		} ),
 	} );
+	const preferredStyle = useSelect( ( select ) => {
+		const preferredStyleVariations = select(
+			blockEditorStore
+		).getSettings().__experimentalPreferredStyleVariations;
+		return preferredStyleVariations?.value?.[ 'core/button' ];
+	}, [] );
+
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
-		template: BUTTONS_TEMPLATE,
+		template: [
+			[
+				'core/button',
+				preferredStyle
+					? { className: `is-style-${ preferredStyle }` }
+					: {},
+			],
+		],
 		orientation,
 		__experimentalLayout: LAYOUT,
 		templateInsertUpdatesSelection: true,

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -47,7 +47,7 @@ function ButtonsEdit( {
 		const preferredStyleVariations = select(
 			blockEditorStore
 		).getSettings().__experimentalPreferredStyleVariations;
-		return preferredStyleVariations?.value?.[ 'core/button' ];
+		return preferredStyleVariations?.value?.[ buttonBlockName ];
 	}, [] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -140,18 +140,16 @@ export default function ButtonsEdit( {
 			{ resizeObserver }
 			<InnerBlocks
 				allowedBlocks={ ALLOWED_BLOCKS }
-				template={
-					preferredStyle
-						? [
-								[
-									'core/button',
-									{
-										className: `is-style-${ preferredStyle }`,
-									},
-								],
-						  ]
-						: [ [ 'core/button' ] ]
-				}
+				template={ [
+					[
+						buttonBlockName,
+						{
+							className:
+								preferredStyle &&
+								`is-style-${ preferredStyle }`,
+						},
+					],
+				] }
 				renderFooterAppender={
 					shouldRenderFooterAppender && renderFooterAppender.current
 				}

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -26,7 +26,6 @@ import { name as buttonBlockName } from '../button/';
 import styles from './editor.scss';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
-const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
 
 const layoutProp = { type: 'default', alignments: [] };
 
@@ -65,6 +64,14 @@ export default function ButtonsEdit( {
 		},
 		[ clientId ]
 	);
+
+	const preferredStyle = useSelect( ( select ) => {
+		const preferredStyleVariations = select(
+			blockEditorStore
+		).getSettings().__experimentalPreferredStyleVariations;
+		return preferredStyleVariations?.value?.[ 'core/button' ];
+	}, [] );
+
 	const { getBlockOrder } = useSelect( blockEditorStore );
 	const { insertBlock, removeBlock, selectBlock } = useDispatch(
 		blockEditorStore
@@ -133,7 +140,18 @@ export default function ButtonsEdit( {
 			{ resizeObserver }
 			<InnerBlocks
 				allowedBlocks={ ALLOWED_BLOCKS }
-				template={ BUTTONS_TEMPLATE }
+				template={
+					preferredStyle
+						? [
+								[
+									'core/button',
+									{
+										className: `is-style-${ preferredStyle }`,
+									},
+								],
+						  ]
+						: [ [ 'core/button' ] ]
+				}
 				renderFooterAppender={
 					shouldRenderFooterAppender && renderFooterAppender.current
 				}

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -69,7 +69,7 @@ export default function ButtonsEdit( {
 		const preferredStyleVariations = select(
 			blockEditorStore
 		).getSettings().__experimentalPreferredStyleVariations;
-		return preferredStyleVariations?.value?.[ 'core/button' ];
+		return preferredStyleVariations?.value?.[ buttonBlockName ];
 	}, [] );
 
 	const { getBlockOrder } = useSelect( blockEditorStore );


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/27217

## How has this been tested?

Testing instructions from #31084:

1. In the editor add a new block, set its style to "Outline", then in the "Default Style" dropdown below select "Outline"
2. Add a 2nd `buttons` block, and notice that the button is not an outline.
3. Add a 2nd button inside the same buttons block you just added and notice it's styled as an outline.

This PR fixes the above issue, so the 1st button has the right style.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
