### PR TITLE
Site Editor: List view improvements

### DIFF
--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -43,12 +43,8 @@ function KeyboardShortcuts() {
 	useShortcut(
 		'core/edit-site/toggle-list-view',
 		useCallback( () => {
-			if ( isListViewOpen ) {
-				setIsListViewOpened( false );
-			} else {
-				setIsListViewOpened( true );
-			}
-		}, [ isListViewOpen, isListViewOpen ] ),
+			setIsListViewOpened( ! isListViewOpen );
+		}, [ isListViewOpen, setIsListViewOpened ] ),
 		{ bindGlobal: true }
 	);
 

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -38,7 +38,7 @@ export default function ListViewSidebar() {
 	const { clearSelectedBlock, selectBlock } = useDispatch( blockEditorStore );
 	async function selectEditorBlock( clientId ) {
 		await clearSelectedBlock();
-		selectBlock( clientId );
+		selectBlock( clientId, -1 );
 	}
 
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -32,7 +32,7 @@ export default function ListViewSidebar() {
 			clientIdsTree: __unstableGetClientIdsTree(),
 			selectedBlockClientIds: getSelectedBlockClientIds(),
 		};
-	} );
+	}, [] );
 	const { setIsListViewOpened } = useDispatch( editSiteStore );
 
 	const { clearSelectedBlock, selectBlock } = useDispatch( blockEditorStore );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

When selecting a block from the sidebar, automatically move the caret to the end of the block.

Also fix some incorrect `useSelect` dependencies.

## How has this been tested?

- Install a FSE theme such as TT1-Blocks and open the Site Editor.
- Open the List View and select a textual block (e.g. Paragraph, Site Title, etc.) with pre-existing text.
- Start typing, and make sure the text shows _appended_ to the pre-existing text, instead of prepended.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
