### PR TITLE
Navigation Screen: Sync menu name updates

### DIFF
--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { find } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { DropdownMenu } from '@wordpress/components';
@@ -15,6 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import SaveButton from './save-button';
 import MenuSwitcher from '../menu-switcher';
+import { useMenuEntity } from '../../hooks';
 
 export default function Header( {
 	isMenuSelected,
@@ -24,7 +20,7 @@ export default function Header( {
 	isPending,
 	navigationPost,
 } ) {
-	const selectedMenu = find( menus, { id: selectedMenuId } );
+	const { editedMenu: selectedMenu } = useMenuEntity( selectedMenuId );
 	const menuName = selectedMenu ? selectedMenu.name : undefined;
 	let actionHeaderText;
 

--- a/packages/edit-navigation/src/components/name-display/index.js
+++ b/packages/edit-navigation/src/components/name-display/index.js
@@ -1,23 +1,29 @@
 /**
  * WordPress dependencies
  */
+import { useContext } from '@wordpress/element';
 import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { BlockControls } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
 import {
+	untitledMenu,
+	useMenuEntity,
 	useSelectedMenuData,
 	IsMenuNameControlFocusedContext,
 } from '../../hooks';
-import { useContext } from '@wordpress/element';
 
 import { sprintf, __ } from '@wordpress/i18n';
 export default function NameDisplay() {
-	const { menuName } = useSelectedMenuData();
+	const { menuId } = useSelectedMenuData();
+	const { editedMenu } = useMenuEntity( menuId );
 	const [ , setIsMenuNameEditFocused ] = useContext(
 		IsMenuNameControlFocusedContext
 	);
+
+	const menuName = editedMenu?.name ?? untitledMenu;
+
 	return (
 		<BlockControls>
 			<ToolbarGroup>


### PR DESCRIPTION
## Description
Fixes the navigation screen to reflect menu name changes without needing to save the menu.

Fixes: #30327.

## How has this been tested?
1. Enable experimental navigation editor.
2. Create/edit a menu.
3. When changing the menu name, changes should be visible in the heading and menu switcher.

##
https://user-images.githubusercontent.com/240569/115730597-80217e80-a397-11eb-99e2-0ceb6bc67e47.mp4

## Types of changes
 Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
