### PR TITLE
[Block Library - Query]: Show a spinner instead of the Loading text message

### DIFF
--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -16,6 +16,7 @@ import {
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 
 const TEMPLATE = [
@@ -127,7 +128,11 @@ export default function QueryLoopEdit( {
 	const innerBlocksProps = useInnerBlocksProps( {}, { template: TEMPLATE } );
 
 	if ( ! posts ) {
-		return <p { ...blockProps }>{ __( 'Loading…' ) }</p>;
+		return (
+			<p { ...blockProps }>
+				<Spinner />
+			</p>
+		);
 	}
 
 	if ( ! posts.length ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/31071