### PR TITLE
Fix recursive filewatching on linux

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -57,12 +57,16 @@ function isDirectory( pathname ) {
  * @return {boolean} True if the file a source file.
  */
 function isSourceFile( filename ) {
+	// Only run this regex on the relative path, otherwise we might run
+	// into some false positives when eg. the project directory contains `src`
+	const relativePath = path.relative( process.cwd(), filename );
+
 	return (
-		/\/src\/.+\.(js|json|scss)$/.test( filename ) &&
+		/\/src\/.+\.(js|json|scss)$/.test( relativePath ) &&
 		! [
 			/\/(benchmark|__mocks__|__tests__|test|storybook|stories)\/.+/,
 			/.\.(spec|test)\.js$/,
-		].some( ( regex ) => regex.test( filename ) )
+		].some( ( regex ) => regex.test( relativePath ) )
 	);
 }
 

--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -32,6 +32,20 @@ function exists( filename ) {
 }
 
 /**
+ * Is the path name a directory?
+ *
+ * @param {string} pathname
+ *
+ * @return {boolean} True if the directory should be watched.
+ */
+function isDirectory( pathname ) {
+	try {
+		return fs.statSync( pathname ).isDirectory();
+	} catch ( e ) {}
+	return false;
+}
+
+/**
  * Determine if a file is source code.
  *
  * Exclude test files including .js files inside of __tests__ or test folders
@@ -77,6 +91,13 @@ function isModulePackage( filename ) {
  * @return {boolean | symbol} True if the file should be watched.
  */
 function isWatchableFile( filename, skip ) {
+	// Recursive file watching is not available on a Linux-based OS. If this is the case,
+	// the watcher library falls back to watching changes in the subdirectories
+	// and passes the directories to this filter callback instead.
+	if ( isDirectory( filename ) ) {
+		return true;
+	}
+
 	return isSourceFile( filename ) && isModulePackage( filename )
 		? true
 		: skip;
@@ -147,6 +168,12 @@ watch(
 	PACKAGES_DIR,
 	{ recursive: true, delay: 500, filter: isWatchableFile },
 	( event, filename ) => {
+		// Double check whether we're dealing with a file that needs watching, to accomodate for
+		// the inability to watch recursively on linux-based operating systems.
+		if ( ! isSourceFile( filename ) || ! isModulePackage( filename ) ) {
+			return;
+		}
+
 		switch ( event ) {
 			case 'update':
 				updateBuildFile( event, filename );

--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -36,7 +36,7 @@ function exists( filename ) {
  *
  * @param {string} pathname
  *
- * @return {boolean} True if the directory should be watched.
+ * @return {boolean} True if the given path is a directory.
  */
 function isDirectory( pathname ) {
 	try {


### PR DESCRIPTION
This fixes the problem reported [here](https://github.com/WordPress/gutenberg/pull/29652#issuecomment-824864013). Watching files when running `npm run dev` was broking on Linux-based operating systems after the [performance update](https://github.com/WordPress/gutenberg/pull/29652#issuecomment-824864013) earlier today.

It appears as though [node-watch](https://github.com/yuanchuan/node-watch) is unable to provide proper support for recursively watching changes to files in a given directory. This is also documented in their documentation. 

When recursive watching is not natively available, node-watch appears to fall back to subdirectories of the path you pass it as a parameter. Hence, it calls the filter callback function for these directories in stead of just the files. The changes in this PR detect when this happens, and provide a fallback solution. As an added measure, it double checks validity of a file in the event handler too. 

As far as I can tell, this should work just fine on Windows and MacOS, but I'd appreciate it if someone could double check this, just to be sure. We're aiming for cross-platform compatibility after all :)