### PR TITLE
Keep id on paste if internal link points to it

### DIFF
--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { wrap, unwrap, replaceTag } from '@wordpress/dom';
+import { wrap, replaceTag } from '@wordpress/dom';
 
 export default function phrasingContentReducer( node, doc ) {
 	// In jsdom-jscore, 'node.style' can be null.
@@ -61,8 +61,6 @@ export default function phrasingContentReducer( node, doc ) {
 		if ( node.name && ! node.id ) {
 			node.id = node.name;
 		}
-		// Removes obsolete name attribute in any case
-		node.removeAttribute( 'name' );
 
 		// Keeps id only if there is an internal link pointing to it
 		if (
@@ -70,11 +68,6 @@ export default function phrasingContentReducer( node, doc ) {
 			! node.ownerDocument.querySelector( `[href="#${ node.id }"]` )
 		) {
 			node.removeAttribute( 'id' );
-		}
-
-		// Remove anchor tag if no href nor id
-		if ( ! node.id && ! node.href ) {
-			unwrap( node );
 		}
 	}
 }

--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { wrap, replaceTag } from '@wordpress/dom';
+import { wrap, unwrap, replaceTag } from '@wordpress/dom';
 
 export default function phrasingContentReducer( node, doc ) {
 	// In jsdom-jscore, 'node.style' can be null.
@@ -55,6 +55,26 @@ export default function phrasingContentReducer( node, doc ) {
 		} else {
 			node.removeAttribute( 'target' );
 			node.removeAttribute( 'rel' );
+		}
+
+		// Saves anchor elements name attribute as id
+		if ( node.name && ! node.id ) {
+			node.id = node.name;
+		}
+		// Removes obsolete name attribute in any case
+		node.removeAttribute( 'name' );
+
+		// Keeps id only if there is an internal link pointing to it
+		if (
+			node.id &&
+			! node.ownerDocument.querySelector( `[href="#${ node.id }"]` )
+		) {
+			node.removeAttribute( 'id' );
+		}
+
+		// Remove anchor tag if no href nor id
+		if ( ! node.id && ! node.href ) {
+			unwrap( node );
 		}
 	}
 }

--- a/packages/blocks/src/api/raw-handling/readme.md
+++ b/packages/blocks/src/api/raw-handling/readme.md
@@ -4,22 +4,24 @@ This folder contains all paste specific logic (filters, converters, normalisers.
 
 ## Support table
 
-| Source           | Formatting | Headings | Lists | Image | Separator | Table |
-| ---------------- | ---------- | -------- | ----- | ----- | --------- | ----- |
-| Google Docs      | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     |
-| Apple Pages      | ✓          | ✘ [1]    | ✓     | ✘ [1] | n/a       | ✓     |
-| MS Word          | ✓          | ✓        | ✓     | ✘ [2] | n/a       | ✓     |
-| MS Word Online   | ✓          | ✘ [3]    | ✓     | ✓     | n/a       | ✓     |
-| Evernote         | ✓          | ✘ [4]    | ✓     | ✓     | ✓         | ✓     |
-| Markdown         | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     |
-| Legacy WordPress | ✓          | ✓        | ✓     | … [5] | ✓         | ✓     |
-| Web              | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     |
+| Source           | Formatting | Headings | Lists | Image | Separator | Table | Footnotes, endnotes |
+| ---------------- | ---------- | -------- | ----- | ----- | --------- | ----- | ------------------- |
+| Google Docs      | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | ✘ [1]               |
+| Apple Pages      | ✓          | ✘ [2]    | ✓     | ✘ [2] | n/a       | ✓     | ✘ [1]               |
+| MS Word          | ✓          | ✓        | ✓     | ✘ [3] | n/a       | ✓     | ✓                   |
+| MS Word Online   | ✓          | ✘ [4]    | ✓     | ✓     | n/a       | ✓     | ✘ [1]               |
+| LibreOffice      | ✓          | ✓        | ✓     | ✘ [3] | ✓         | ✓     | ✓                   |
+| Evernote         | ✓          | ✘ [5]    | ✓     | ✓     | ✓         | ✓     | n/a                 |
+| Markdown         | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | n/a                 |
+| Legacy WordPress | ✓          | ✓        | ✓     | … [6] | ✓         | ✓     | n/a                 |
+| Web              | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | n/a                 |
 
-1. Apple Pages does not pass heading and image information.
-2. MS Word only provides a local file path, which cannot be accessed in JavaScript for security reasons. Image placeholders will be provided instead. Single images, however, _can_ be copied and pasted without any problem.
-3. Still to do for MS Word Online.
-4. Evernote does not have headings.
-5. For caption and gallery shortcodes, see #2874.
+1. Google Docs, Apple Pages and MS Word online don't pass footnote nor endnote information.
+2. Apple Pages does not pass heading and image information.
+3. MS Word and LibreOffice only provide a local file path, which cannot be accessed in JavaScript for security reasons. Image placeholders will be provided instead. Single images, however, _can_ be copied and pasted without any problem.
+4. Still to do for MS Word Online.
+5. Evernote does not have headings.
+6. For caption and gallery shortcodes, see #2874.
 
 ## Other notable capabilities
 

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -32,7 +32,7 @@ const textContentSchema = {
 	s: {},
 	del: {},
 	ins: {},
-	a: { attributes: [ 'href', 'target', 'rel', 'id', 'name' ] },
+	a: { attributes: [ 'href', 'target', 'rel', 'id' ] },
 	code: {},
 	abbr: { attributes: [ 'title' ] },
 	sub: {},

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -32,7 +32,7 @@ const textContentSchema = {
 	s: {},
 	del: {},
 	ins: {},
-	a: { attributes: [ 'href', 'target', 'rel' ] },
+	a: { attributes: [ 'href', 'target', 'rel', 'id', 'name' ] },
 	code: {},
 	abbr: { attributes: [ 'title' ] },
 	sub: {},

--- a/test/integration/fixtures/documents/ms-word-in.html
+++ b/test/integration/fixtures/documents/ms-word-in.html
@@ -201,3 +201,79 @@ style='mso-ansi-language:EN-US'><o:p>&nbsp;</o:p></span></p>
 src="file:LOW-RES.png"
 v:shapes="Picture_x0020_1"><![endif]></span><span lang=EN-US style='mso-ansi-language:
 EN-US'><o:p></o:p></span></p>
+
+<p class=MsoNormal><a href="#anchor"><span lang=EN-US style='mso-ansi-language:
+EN-US'>This is an anchor link</span></a><span lang=EN-US style='mso-ansi-language:
+EN-US'> that leads to the next paragraph.<o:p></o:p></span></p>
+
+<p class=MsoNormal><a name=anchor><span lang=EN-US style='mso-ansi-language:
+EN-US'>This is the paragraph with the anchor.<o:p></o:p></span></a></p>
+
+<span style='mso-bookmark:anchor'></span>
+
+<p class=MsoNormal><a href="#nowhere"><span lang=EN-US style='mso-ansi-language:
+EN-US'>This is an anchor link</span></a><span lang=EN-US style='mso-ansi-language:
+EN-US'> that leads nowhere.<o:p></o:p></span></p>
+
+<p class=MsoNormal><a name=anchor2><span lang=EN-US style='mso-ansi-language:
+EN-US'>This is a paragraph with an anchor with no link pointing to it.<o:p></o:p></span></a></p>
+
+<span style='mso-bookmark:anchor2'></span>
+
+<p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'>This is a
+reference to a footnote</span><a style='mso-footnote-id:ftn1' href="#_ftn1"
+name="_ftnref1" title=""><span class=MsoFootnoteReference><span
+style='mso-special-character:footnote'><![if !supportFootnotes]><span
+class=MsoFootnoteReference><span style='font-size:11.0pt;line-height:105%;
+font-family:"Calibri",sans-serif;mso-ascii-theme-font:minor-latin;
+mso-ansi-language:EN-US'>[1]</span></span><![endif]></span></span></a><span
+lang=EN-US style='mso-ansi-language:EN-US'>.<o:p></o:p></span></p>
+
+<p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'>This is a
+reference to an endnote</span><a style='mso-endnote-id:edn1' href="#_edn1"
+name="_ednref1" title=""><span class=MsoEndnoteReference><span
+style='mso-special-character:footnote'><![if !supportFootnotes]><span
+class=MsoEndnoteReference><span style='font-size:11.0pt;line-height:105%;
+font-family:"Calibri",sans-serif;mso-ascii-theme-font:minor-latin;
+mso-ansi-language:EN-US'>[i]</span></span><![endif]></span></span></a><span
+lang=EN-US style='mso-ansi-language:EN-US'>.<o:p></o:p></span></p>
+
+<div style='mso-element:footnote-list'><![if !supportFootnotes]><br clear=all>
+
+<hr align=left size=1 width="33%">
+
+<![endif]>
+
+<div style='mso-element:footnote' id=ftn1>
+
+<p class=MsoFootnoteText><a style='mso-footnote-id:ftn1' href="#_ftnref1"
+name="_ftn1" title=""><span class=MsoFootnoteReference><span style='mso-special-character:
+footnote'><![if !supportFootnotes]><span class=MsoFootnoteReference><span
+style='font-size:10.0pt;line-height:105%;font-family:"Calibri",sans-serif;
+mso-bidi-theme-font:minor-latin;
+mso-ansi-language:EN-US'>[1]</span></span><![endif]></span></span></a> This is
+a footnote.</p>
+
+</div>
+
+</div>
+
+<div style='mso-element:endnote-list'><![if !supportEndnotes]><br clear=all>
+
+<hr align=left size=1 width="33%">
+
+<![endif]>
+
+<div style='mso-element:endnote' id=edn1>
+
+<p class=MsoEndnoteText><a style='mso-endnote-id:edn1' href="#_ednref1"
+name="_edn1" title=""><span class=MsoEndnoteReference><span style='mso-special-character:
+footnote'><![if !supportFootnotes]><span class=MsoEndnoteReference><span
+style='font-size:10.0pt;line-height:105%;font-family:"Calibri",sans-serif;
+mso-bidi-theme-font:minor-latin;
+mso-ansi-language:EN-US'>[i]</span></span><![endif]></span></span></a> This is
+an endnote.</p>
+
+</div>
+
+</div>

--- a/test/integration/fixtures/documents/ms-word-out.html
+++ b/test/integration/fixtures/documents/ms-word-out.html
@@ -37,3 +37,43 @@
 <!-- wp:image -->
 <figure class="wp-block-image"><img src="" alt=""/></figure>
 <!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p><a href="#anchor">This is an anchor link</a> that leads to the next paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a id="anchor">This is the paragraph with the anchor.</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="#nowhere">This is an anchor link</a> that leads nowhere.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a>This is a paragraph with an anchor with no link pointing to it.</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is a reference to a footnote<a href="#_ftn1" id="_ftnref1">[1]</a>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is a reference to an endnote<a href="#_edn1" id="_ednref1">[i]</a>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator"/>
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p><a href="#_ftnref1" id="_ftn1">[1]</a> This is a footnote.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator"/>
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p><a href="#_ednref1" id="_edn1">[i]</a> This is an endnote.</p>
+<!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
With these changes, the block editor will keep the IDs in links when there's another link pointing to that ID. This is useful when pasting documents with internal links, e.g. when pasting text with footnotes from Microsoft Word, which used to work with the TinyMCE editor. Fixes #12784.

Sometimes internal links leverage the "name" attribute as the anchor instead of "id". However, the use of the `name` attribute for `a` elements [is obsolete in HTML5](https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features); use of `id` is recommended instead; [W3C Markup Validator](https://validator.w3.org/) also shows a warning. This code also saves the `name` attribute in links as the link's `id` (unless there's an `id` attribute already), and then removes it.

(Following @ellatrix feedback in #27677, these changes affect all links, not only footnotes and endnotes)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested locally with wp-env.
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->(Doesn't apply)