### PR TITLE
Navigation Editor: Indicate unsaved changes

### DIFF
--- a/packages/edit-navigation/src/components/header/save-button.js
+++ b/packages/edit-navigation/src/components/header/save-button.js
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -11,7 +12,18 @@ import { __ } from '@wordpress/i18n';
 import { store as editNavigationStore } from '../../store';
 
 export default function SaveButton( { navigationPost } ) {
+	const { isDirty } = useSelect( ( select ) => {
+		const { __experimentalGetDirtyEntityRecords } = select( coreStore );
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+
+		return {
+			isDirty: dirtyEntityRecords.length > 0,
+		};
+	}, [] );
+
 	const { saveNavigationPost } = useDispatch( editNavigationStore );
+
+	const disabled = ! isDirty || ! navigationPost;
 
 	return (
 		<Button
@@ -20,7 +32,7 @@ export default function SaveButton( { navigationPost } ) {
 			onClick={ () => {
 				saveNavigationPost( navigationPost );
 			} }
-			disabled={ ! navigationPost }
+			disabled={ disabled }
 		>
 			{ __( 'Save' ) }
 		</Button>


### PR DESCRIPTION
## Description
Adds unsaved changes detection and only enables the save button when there are changes.

The `__experimentalGetDirtyEntityRecords` selector works mostly fine. There are only two issues that return false positives.

1. "Add new pages"doesn't make the state "dirty." #31132 should fix this.
2. Navigation post save doesn't update the state. I think this happens because we're using AJAX requests. This should be resolved after #24907.

See #30322.

## How has this been tested?
1. Got to the experimental navigation screen.
2. Select menu.
3. "Save" button should be disabled.
4. Editing name should enable button.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/240569/115838117-641aed00-a42a-11eb-9d1b-5f902b37c5df.mp4

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
