### PR TITLE
Block Library: Move translatable fields to `block.json` files

### DIFF
--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/archives",
+	"title": "Archives",
 	"category": "widgets",
+	"description": "Display a monthly archive of your posts.",
+	"textdomain": "default",
 	"attributes": {
 		"displayAsDropdown": {
 			"type": "boolean",

--- a/packages/block-library/src/archives/index.js
+++ b/packages/block-library/src/archives/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { archive as icon } from '@wordpress/icons';
-import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,8 +14,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Archives', 'block title' ),
-	description: __( 'Display a monthly archive of your posts.' ),
 	icon,
 	example: {},
 	edit,

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/audio",
+	"title": "Audio",
 	"category": "media",
+	"description": "Embed a simple audio player.",
+	"keywords": [ "music", "sound", "podcast", "recording" ],
+	"textdomain": "default",
 	"attributes": {
 		"src": {
 			"type": "string",

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
 
 /**
@@ -18,14 +17,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Audio', 'block title' ),
-	description: __( 'Embed a simple audio player.' ),
-	keywords: [
-		__( 'music' ),
-		__( 'sound' ),
-		__( 'podcast' ),
-		__( 'recording' ),
-	],
 	icon,
 	transforms,
 	deprecated,

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/block",
+	"title": "Reusable block",
 	"category": "reusable",
+	"description": "Create and save content to reuse across your site. Update the block, and the changes apply everywhere it’s used.",
+	"textdomain": "default",
 	"attributes": {
 		"ref": {
 			"type": "number"

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __, _x } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
@@ -14,9 +9,5 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Reusable block', 'block title' ),
-	description: __(
-		'Create and save content to reuse across your site. Update the block, and the changes apply everywhere it’s used.'
-	),
 	edit,
 };

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -1,8 +1,12 @@
 {
 	"apiVersion": 2,
 	"name": "core/button",
+	"title": "Button",
 	"category": "design",
 	"parent": [ "core/buttons" ],
+	"description": "Prompt visitors to take action with a button-style link.",
+	"keywords": [ "link" ],
+	"textdomain": "default",
 	"attributes": {
 		"url": {
 			"type": "string",
@@ -66,6 +70,10 @@
 		"__experimentalFontFamily": true,
 		"__experimentalSelector": ".wp-block-button__link"
 	},
+	"styles": [
+		{ "name": "fill", "label": "Fill", "isDefault": true },
+		{ "name": "outline", "label": "Outline" }
+	],
 	"editorStyle": "wp-block-button-editor",
 	"style": "wp-block-button"
 }

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { button as icon } from '@wordpress/icons';
 
 /**
@@ -17,12 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Button', 'block title' ),
-	description: __(
-		'Prompt visitors to take action with a button-style link.'
-	),
 	icon,
-	keywords: [ __( 'link' ) ],
 	example: {
 		attributes: {
 			className: 'is-style-fill',
@@ -30,10 +25,6 @@ export const settings = {
 			text: __( 'Call to Action' ),
 		},
 	},
-	styles: [
-		{ name: 'fill', label: __( 'Fill' ), isDefault: true },
-		{ name: 'outline', label: __( 'Outline' ) },
-	],
 	edit,
 	save,
 	deprecated,

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/buttons",
+	"title": "Buttons",
 	"category": "design",
+	"description": "Prompt visitors to take action with a group of button-style links.",
+	"keywords": [ "link" ],
+	"textdomain": "default",
 	"attributes": {
 		"contentJustification": {
 			"type": "string"

--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { buttons as icon } from '@wordpress/icons';
 
 /**
@@ -19,12 +19,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Buttons', 'block title' ),
-	description: __(
-		'Prompt visitors to take action with a group of button-style links.'
-	),
 	icon,
-	keywords: [ __( 'link' ) ],
 	example: {
 		innerBlocks: [
 			{

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/calendar",
+	"title": "Calendar",
 	"category": "widgets",
+	"description": "A calendar of your site’s posts.",
+	"keywords": [ "posts", "archive" ],
+	"textdomain": "default",
 	"attributes": {
 		"month": {
 			"type": "integer"

--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { calendar as icon } from '@wordpress/icons';
-import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,10 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Calendar', 'block title' ),
-	description: __( 'A calendar of your site’s posts.' ),
 	icon,
-	keywords: [ __( 'posts' ), __( 'archive' ) ],
 	example: {},
 	edit,
 };

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/categories",
+	"title": "Categories",
 	"category": "widgets",
+	"description": "Display a list of all categories.",
+	"textdomain": "default",
 	"attributes": {
 		"displayAsDropdown": {
 			"type": "boolean",

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { category as icon } from '@wordpress/icons';
-import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,8 +14,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Categories', 'block title' ),
-	description: __( 'Display a list of all categories.' ),
 	icon,
 	example: {},
 	edit,

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/code",
+	"title": "Code",
 	"category": "text",
+	"description": "Display code snippets that respect your spacing and tabs.",
+	"textdomain": "default",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { code as icon } from '@wordpress/icons';
 
 /**
@@ -17,10 +17,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Code', 'block title' ),
-	description: __(
-		'Display code snippets that respect your spacing and tabs.'
-	),
 	icon,
 	example: {
 		attributes: {

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -1,8 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/column",
+	"title": "Column",
 	"category": "text",
 	"parent": [ "core/columns" ],
+	"description": "A single column within a columns block.",
+	"textdomain": "default",
 	"attributes": {
 		"verticalAlignment": {
 			"type": "string"

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { column as icon } from '@wordpress/icons';
 
 /**
@@ -17,9 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Column', 'block title' ),
 	icon,
-	description: __( 'A single column within a columns block.' ),
 	edit,
 	save,
 	deprecated,

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/columns",
+	"title": "Columns",
 	"category": "design",
+	"description": "Add a block that displays content in multiple columns, then add whatever content blocks you’d like.",
+	"textdomain": "default",
 	"attributes": {
 		"verticalAlignment": {
 			"type": "string"

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { columns as icon } from '@wordpress/icons';
 
 /**
@@ -19,11 +19,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Columns', 'block title' ),
 	icon,
-	description: __(
-		'Add a block that displays content in multiple columns, then add whatever content blocks you’d like.'
-	),
 	variations,
 	example: {
 		innerBlocks: [

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/cover",
+	"title": "Cover",
 	"category": "media",
+	"description": "Add an image or video with a text overlay — great for headers.",
+	"textdomain": "default",
 	"attributes": {
 		"url": {
 			"type": "string"

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { cover as icon } from '@wordpress/icons';
 
 /**
@@ -18,10 +18,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Cover', 'block title' ),
-	description: __(
-		'Add an image or video with a text overlay — great for headers.'
-	),
 	icon,
 	example: {
 		attributes: {

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/embed",
+	"title": "Embed",
 	"category": "embed",
+	"description": "Add a block that displays content pulled from other sites, like Twitter, Instagram or YouTube.",
+	"textdomain": "default",
 	"attributes": {
 		"url": {
 			"type": "string"

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -8,8 +8,8 @@ import {
 	getAttributesFromPreview,
 	getEmbedInfoByProvider,
 } from './util';
-import { settings } from './index';
 import EmbedControls from './embed-controls';
+import { embedContentIcon } from './icons';
 import EmbedLoading from './embed-loading';
 import EmbedPlaceholder from './embed-placeholder';
 import EmbedPreview from './embed-preview';
@@ -22,7 +22,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
@@ -55,8 +55,8 @@ const EmbedEdit = ( props ) => {
 	} = props;
 
 	const defaultEmbedInfo = {
-		title: settings.title,
-		icon: settings.icon,
+		title: _x( 'Embed', 'block title' ),
+		icon: embedContentIcon,
 	};
 	const { icon, title } =
 		getEmbedInfoByProvider( providerNameSlug ) || defaultEmbedInfo;

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -9,19 +9,10 @@ import variations from './variations';
 import deprecated from './deprecated';
 import { embedContentIcon } from './icons';
 
-/**
- * WordPress dependencies
- */
-import { __, _x } from '@wordpress/i18n';
-
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Embed', 'block title' ),
-	description: __(
-		'Add a block that displays content pulled from other sites, like Twitter, Instagram or YouTube.'
-	),
 	icon: embedContentIcon,
 	edit,
 	save,

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/file",
+	"title": "File",
 	"category": "media",
+	"description": "Add a link to a downloadable file.",
+	"keywords": [ "document", "pdf", "download" ],
+	"textdomain": "default",
 	"attributes": {
 		"id": {
 			"type": "number"

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
 
 /**
@@ -17,10 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'File', 'block title' ),
-	description: __( 'Add a link to a downloadable file.' ),
 	icon,
-	keywords: [ __( 'document' ), __( 'pdf' ), __( 'download' ) ],
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/freeform/block.json
+++ b/packages/block-library/src/freeform/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/freeform",
+	"title": "Classic",
 	"category": "text",
+	"description": "Use the classic WordPress editor.",
+	"textdomain": "default",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/freeform/index.js
+++ b/packages/block-library/src/freeform/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { classic as icon } from '@wordpress/icons';
 
 /**
@@ -16,8 +15,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Classic', 'block title' ),
-	description: __( 'Use the classic WordPress editor.' ),
 	icon,
 	edit,
 	save,

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/gallery",
+	"title": "Gallery",
 	"category": "media",
+	"description": "Display multiple images in a rich gallery.",
+	"keywords": [ "images", "photos" ],
+	"textdomain": "default",
 	"attributes": {
 		"images": {
 			"type": "array",

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { gallery as icon } from '@wordpress/icons';
 
 /**
@@ -18,10 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Gallery', 'block title' ),
-	description: __( 'Display multiple images in a rich gallery.' ),
 	icon,
-	keywords: [ __( 'images' ), __( 'photos' ) ],
 	example: {
 		attributes: {
 			columns: 2,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/group",
+	"title": "Group",
 	"category": "design",
+	"description": "Combine blocks into a group.",
+	"keywords": [ "container", "wrapper", "row", "section" ],
+	"textdomain": "default",
 	"attributes": {
 		"tagName": {
 			"type": "string",

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { group as icon } from '@wordpress/icons';
 
@@ -18,15 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Group', 'block title' ),
 	icon,
-	description: __( 'Combine blocks into a group.' ),
-	keywords: [
-		__( 'container' ),
-		__( 'wrapper' ),
-		__( 'row' ),
-		__( 'section' ),
-	],
 	example: {
 		attributes: {
 			style: {

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/heading",
+	"title": "Heading",
 	"category": "text",
+	"description": "Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.",
+	"keywords": [ "title", "subtitle" ],
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -7,7 +7,7 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { heading as icon } from '@wordpress/icons';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -23,12 +23,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Heading', 'block title' ),
-	description: __(
-		'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.'
-	),
 	icon,
-	keywords: [ __( 'title' ), __( 'subtitle' ) ],
 	example: {
 		attributes: {
 			content: __( 'Code is Poetry' ),

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/html",
+	"title": "Custom HTML",
 	"category": "widgets",
+	"description": "Add custom HTML code and preview it as you edit.",
+	"keywords": [ "embed" ],
+	"textdomain": "default",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { html as icon } from '@wordpress/icons';
 
 /**
@@ -17,10 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Custom HTML', 'block title' ),
-	description: __( 'Add custom HTML code and preview it as you edit.' ),
 	icon,
-	keywords: [ __( 'embed' ) ],
 	example: {
 		attributes: {
 			content:

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/image",
+	"title": "Image",
 	"category": "media",
+	"description": "Insert an image to make a visual statement.",
+	"keywords": [ "img", "photo", "picture" ],
+	"textdomain": "default",
 	"attributes": {
 		"align": {
 			"type": "string"
@@ -81,6 +85,14 @@
 			"radius": true
 		}
 	},
+	"styles": [
+		{
+			"name": "default",
+			"label": "Default",
+			"isDefault": true
+		},
+		{ "name": "rounded", "label": "Rounded" }
+	],
 	"editorStyle": "wp-block-image-editor",
 	"style": "wp-block-image"
 }

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { image as icon } from '@wordpress/icons';
 
 /**
@@ -18,14 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Image', 'block title' ),
-	description: __( 'Insert an image to make a visual statement.' ),
 	icon,
-	keywords: [
-		'img', // "img" is not translated as it is intended to reflect the HTML <img> tag.
-		__( 'photo' ),
-		__( 'picture' ),
-	],
 	example: {
 		attributes: {
 			sizeSlug: 'large',
@@ -34,14 +27,6 @@ export const settings = {
 			caption: __( 'Mont Blanc appears—still, snowy, and serene.' ),
 		},
 	},
-	styles: [
-		{
-			name: 'default',
-			label: _x( 'Default', 'block style' ),
-			isDefault: true,
-		},
-		{ name: 'rounded', label: _x( 'Rounded', 'block style' ) },
-	],
 	__experimentalLabel( attributes, { context } ) {
 		if ( context === 'accessibility' ) {
 			const { caption, alt, url } = attributes;

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/latest-comments",
+	"title": "Latest Comments",
 	"category": "widgets",
+	"description": "Display a list of your most recent comments.",
+	"keywords": [ "recent comments" ],
+	"textdomain": "default",
 	"attributes": {
 		"commentsToShow": {
 			"type": "number",

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { comment as icon } from '@wordpress/icons';
-import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,10 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Latest Comments', 'block title' ),
-	description: __( 'Display a list of your most recent comments.' ),
 	icon,
-	keywords: [ __( 'recent comments' ) ],
 	example: {},
 	edit,
 };

--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/latest-posts",
+	"title": "Latest Posts",
 	"category": "widgets",
+	"description": "Display a list of your most recent posts.",
+	"keywords": [ "recent posts" ],
+	"textdomain": "default",
 	"attributes": {
 		"categories": {
 			"type": "array",

--- a/packages/block-library/src/latest-posts/index.js
+++ b/packages/block-library/src/latest-posts/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postList as icon } from '@wordpress/icons';
 
 /**
@@ -15,10 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Latest Posts', 'block title' ),
-	description: __( 'Display a list of your most recent posts.' ),
 	icon,
-	keywords: [ __( 'recent posts' ) ],
 	example: {},
 	edit,
 	deprecated,

--- a/packages/block-library/src/legacy-widget/block.json
+++ b/packages/block-library/src/legacy-widget/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/legacy-widget",
+	"title": "Legacy Widget",
 	"category": "widgets",
+	"description": "Display a legacy widget.",
+	"textdomain": "default",
 	"attributes": {
 		"id": {
 			"type": "string",

--- a/packages/block-library/src/legacy-widget/index.js
+++ b/packages/block-library/src/legacy-widget/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { widget as icon } from '@wordpress/icons';
 
 /**
@@ -15,8 +14,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Legacy Widget' ),
-	description: __( 'Display a legacy widget.' ),
 	icon,
 	edit,
 	transforms,

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/list",
+	"title": "List",
 	"category": "text",
+	"description": "Create a bulleted or numbered list.",
+	"keywords": [ "bullet list", "ordered list", "numbered list" ],
+	"textdomain": "default",
 	"attributes": {
 		"ordered": {
 			"type": "boolean",

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { list as icon } from '@wordpress/icons';
 
 /**
@@ -17,14 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'List', 'block title' ),
-	description: __( 'Create a bulleted or numbered list.' ),
 	icon,
-	keywords: [
-		__( 'bullet list' ),
-		__( 'ordered list' ),
-		__( 'numbered list' ),
-	],
 	example: {
 		attributes: {
 			values:

--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/loginout",
+	"title": "Login/out",
 	"category": "design",
+	"description": "Show login & logout links.",
+	"keywords": [ "login", "logout", "form" ],
+	"textdomain": "default",
 	"attributes": {
 		"displayLoginAsForm": {
 			"type": "boolean",

--- a/packages/block-library/src/loginout/index.js
+++ b/packages/block-library/src/loginout/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { login as icon } from '@wordpress/icons';
 
 /**
@@ -14,9 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Login/out', 'block title' ),
-	description: __( 'Show login & logout links.' ),
 	icon,
-	keywords: [ __( 'login' ), __( 'logout' ), __( 'form' ) ],
 	edit,
 };

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/media-text",
+	"title": "Media & Text",
 	"category": "media",
+	"description": "Set media and words side-by-side for a richer layout.",
+	"keywords": [ "image", "video" ],
+	"textdomain": "default",
 	"attributes": {
 		"align": {
 			"type": "string",

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { mediaAndText as icon } from '@wordpress/icons';
 
 /**
@@ -18,10 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Media & Text', 'block title' ),
-	description: __( 'Set media and words side-by-side for a richer layout.' ),
 	icon,
-	keywords: [ __( 'image' ), __( 'video' ) ],
 	example: {
 		attributes: {
 			mediaType: 'image',

--- a/packages/block-library/src/missing/block.json
+++ b/packages/block-library/src/missing/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/missing",
+	"title": "Unsupported",
 	"category": "text",
+	"description": "Your site doesn’t include support for this block.",
+	"textdomain": "default",
 	"attributes": {
 		"originalName": {
 			"type": "string"

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 
 /**
@@ -17,8 +16,6 @@ export { metadata, name };
 
 export const settings = {
 	name,
-	title: _x( 'Unsupported', 'block title' ),
-	description: __( 'Your site doesn’t include support for this block.' ),
 	__experimentalLabel( attributes, { context } ) {
 		if ( context === 'accessibility' ) {
 			const { originalName } = attributes;

--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/more",
+	"title": "More",
 	"category": "design",
+	"description": "Content before this block will be shown in the excerpt on your archives page.",
+	"keywords": [ "read more" ],
+	"textdomain": "default",
 	"attributes": {
 		"customText": {
 			"type": "string"

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { more as icon } from '@wordpress/icons';
 
 /**
@@ -17,11 +16,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'More', 'block title' ),
-	description: __(
-		'Content before this block will be shown in the excerpt on your archives page.'
-	),
-	keywords: [ __( 'read more' ) ],
 	icon,
 	example: {},
 	__experimentalLabel( attributes, { context } ) {

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -1,8 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/navigation-link",
+	"title": "Custom Link",
 	"category": "design",
 	"parent": [ "core/navigation" ],
+	"description": "Add a page, link, or another item to your navigation.",
+	"textdomain": "default",
 	"attributes": {
 		"label": {
 			"type": "string"

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { customLink as linkIcon } from '@wordpress/icons';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
@@ -19,11 +19,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Custom Link', 'block title' ),
-
 	icon: linkIcon,
-
-	description: __( 'Add a page, link, or another item to your navigation.' ),
 
 	__experimentalLabel: ( { label } ) => label,
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/navigation",
+	"title": "Navigation",
 	"category": "design",
+	"description": "A collection of blocks that allow visitors to get around your site.",
+	"keywords": [ "menu", "navigation", "links" ],
+	"textdomain": "default",
 	"attributes": {
 		"orientation": {
 			"type": "string"

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { navigation as icon } from '@wordpress/icons';
 
 /**
@@ -18,12 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Navigation', 'block title' ),
 	icon,
-	description: __(
-		'A collection of blocks that allow visitors to get around your site.'
-	),
-	keywords: [ __( 'menu' ), __( 'navigation' ), __( 'links' ) ],
 	variations,
 	example: {
 		innerBlocks: [

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -1,8 +1,12 @@
 {
 	"apiVersion": 2,
 	"name": "core/nextpage",
+	"title": "Page Break",
 	"category": "design",
+	"description": "Separate your content into a multi-page experience.",
+	"keywords": [ "next page", "pagination" ],
 	"parent": [ "core/post-content" ],
+	"textdomain": "default",
 	"supports": {
 		"customClassName": false,
 		"className": false,

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { pageBreak as icon } from '@wordpress/icons';
 
 /**
@@ -17,10 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Page Break', 'block title' ),
-	description: __( 'Separate your content into a multi-page experience.' ),
 	icon,
-	keywords: [ __( 'next page' ), __( 'pagination' ) ],
 	example: {},
 	transforms,
 	edit,

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/page-list",
+	"title": "Page List",
 	"category": "widgets",
+	"description": "Display a list of all pages.",
+	"keywords": [ "menu", "navigation" ],
+	"textdomain": "default",
 	"usesContext": [
 		"textColor",
 		"customTextColor",

--- a/packages/block-library/src/page-list/index.js
+++ b/packages/block-library/src/page-list/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { pages as icon } from '@wordpress/icons';
-import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,9 +14,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Page List', 'block title' ),
-	description: __( 'Display a list of all pages.' ),
-	keywords: [ __( 'menu' ), __( 'navigation' ) ],
 	icon,
 	example: {},
 	edit,

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/paragraph",
+	"title": "Paragraph",
 	"category": "text",
+	"description": "Start with the building block of all narrative.",
+	"keywords": [ "text" ],
+	"textdomain": "default",
 	"attributes": {
 		"align": {
 			"type": "string"

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -6,7 +6,7 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { paragraph as icon } from '@wordpress/icons';
 
 /**
@@ -23,10 +23,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Paragraph', 'block title' ),
-	description: __( 'Start with the building block of all narrative.' ),
 	icon,
-	keywords: [ __( 'text' ) ],
 	example: {
 		attributes: {
 			content: __(

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-author",
+	"title": "Post Author",
 	"category": "design",
+	"description": "Add the author of this post.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-author/index.js
+++ b/packages/block-library/src/post-author/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __, _x } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
@@ -14,8 +9,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Author', 'block title' ),
-	description: __( 'Add the author of this post.' ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-comment-author/block.json
+++ b/packages/block-library/src/post-comment-author/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-comment-author",
+	"title": "Post Comment Author",
 	"category": "design",
+	"parent": [ "core/post-comment" ],
+	"description": "Post comment author.",
+	"textdomain": "default",
 	"usesContext": [ "commentId" ],
 	"supports": {
 		"html": false

--- a/packages/block-library/src/post-comment-author/index.js
+++ b/packages/block-library/src/post-comment-author/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __, _x } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
@@ -14,9 +9,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Comment Author', 'block title' ),
-	description: __( 'Post Comment Author' ),
 	icon,
 	edit,
-	parent: [ 'core/post-comment' ],
 };

--- a/packages/block-library/src/post-comment-content/block.json
+++ b/packages/block-library/src/post-comment-content/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-comment-content",
+	"title": "Post Comment Content",
 	"category": "design",
+	"parent": [ "core/post-comment" ],
+	"description": "Post comment content",
+	"textdomain": "default",
 	"usesContext": [ "commentId" ],
 	"supports": {
 		"html": false

--- a/packages/block-library/src/post-comment-content/index.js
+++ b/packages/block-library/src/post-comment-content/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postContent as icon } from '@wordpress/icons';
 
 /**
@@ -14,9 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Comment Content', 'block title' ),
-	description: __( 'Post Comment Content' ),
 	icon,
 	edit,
-	parent: [ 'core/post-comment' ],
 };

--- a/packages/block-library/src/post-comment-date/block.json
+++ b/packages/block-library/src/post-comment-date/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-comment-date",
+	"title": "Post Comment Date",
 	"category": "design",
+	"parent": [ "core/post-comment" ],
+	"description": "Post comment date.",
+	"textdomain": "default",
 	"attributes": {
 		"format": {
 			"type": "string"

--- a/packages/block-library/src/post-comment-date/index.js
+++ b/packages/block-library/src/post-comment-date/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postDate as icon } from '@wordpress/icons';
 
 /**
@@ -14,9 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Comment Date', 'block title' ),
-	description: __( 'Post Comment Date' ),
 	icon,
 	edit,
-	parent: [ 'core/post-comment' ],
 };

--- a/packages/block-library/src/post-comment/block.json
+++ b/packages/block-library/src/post-comment/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-comment",
+	"title": "Post Comment",
 	"category": "design",
+	"description": "Post comment.",
+	"textdomain": "default",
 	"attributes": {
 		"commentId": {
 			"type": "number"

--- a/packages/block-library/src/post-comment/index.js
+++ b/packages/block-library/src/post-comment/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { comment as icon } from '@wordpress/icons';
 
 /**
@@ -15,8 +14,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Comment', 'block title' ),
-	description: __( 'Post Comment' ),
 	icon,
 	edit,
 	save,

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-comments-count",
+	"title": "Post Comments Count",
 	"category": "design",
+	"description": "Display a post's comments count.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-comments-count/index.js
+++ b/packages/block-library/src/post-comments-count/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postCommentsCount as icon } from '@wordpress/icons';
 
 /**
@@ -14,8 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Comments Count', 'block title' ),
-	description: __( "Display a post's comments count." ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-comments-form",
+	"title": "Post Comments Form",
 	"category": "design",
+	"description": "Display a post's comments form.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-comments-form/index.js
+++ b/packages/block-library/src/post-comments-form/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postCommentsForm as icon } from '@wordpress/icons';
 
 /**
@@ -14,8 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Comments Form', 'block title' ),
-	description: __( "Display a post's comments form." ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-comments-link/block.json
+++ b/packages/block-library/src/post-comments-link/block.json
@@ -1,11 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-comments-link",
+	"title": "Post Comments Link",
 	"category": "design",
-	"usesContext": [
-		"postType",
-		"postId"
-	],
+	"description": "Displays the link to the current post comments.",
+	"textdomain": "default",
+	"usesContext": [ "postType", "postId" ],
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-comments-link/index.js
+++ b/packages/block-library/src/post-comments-link/index.js
@@ -1,21 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { postCommentsCount as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import metadata from './block.json';
 import edit from './edit';
-import { postCommentsCount as icon } from '@wordpress/icons';
 
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Comments Link', 'block title' ),
-	description: __( 'Displays the link to the current post comments.' ),
 	edit,
 	icon,
 };

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-comments",
+	"title": "Post Comments",
 	"category": "design",
+	"description": "Display a post's comments.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-comments/index.js
+++ b/packages/block-library/src/post-comments/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postComments as icon } from '@wordpress/icons';
 
 /**
@@ -14,8 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Comments', 'block title' ),
-	description: __( "Display a post's comments." ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-content",
+	"title": "Post Content",
 	"category": "design",
+	"description": "Displays the contents of a post or page.",
+	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postContent as icon } from '@wordpress/icons';
 
 /**
@@ -14,8 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Content', 'block title' ),
-	description: __( 'Displays the contents of a post or page.' ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-date",
+	"title": "Post Date",
 	"category": "design",
+	"description": "Add the date of this post.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-date/index.js
+++ b/packages/block-library/src/post-date/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postDate as icon } from '@wordpress/icons';
 
 /**
@@ -14,8 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Date', 'block title' ),
-	description: __( 'Add the date of this post.' ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-excerpt",
+	"title": "Post Excerpt",
 	"category": "design",
+	"description": "Display a post's excerpt.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-excerpt/index.js
+++ b/packages/block-library/src/post-excerpt/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postExcerpt as icon } from '@wordpress/icons';
 
 /**
@@ -14,8 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Excerpt', 'block title' ),
-	description: __( "Display a post's excerpt." ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-featured-image",
+	"title": "Post Featured Image",
 	"category": "design",
+	"description": "Display a post's featured image.",
+	"textdomain": "default",
 	"attributes": {
 		"isLink": {
 			"type": "boolean",

--- a/packages/block-library/src/post-featured-image/index.js
+++ b/packages/block-library/src/post-featured-image/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postFeaturedImage as icon } from '@wordpress/icons';
 
 /**
@@ -14,8 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Featured Image', 'block title' ),
-	description: __( "Display a post's featured image." ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-hierarchical-terms/block.json
+++ b/packages/block-library/src/post-hierarchical-terms/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-hierarchical-terms",
+	"title": "Post Hierarchical Terms",
 	"category": "design",
+	"description": "Post hierarchical terms.",
+	"textdomain": "default",
 	"attributes": {
 		"term": {
 			"type": "string"

--- a/packages/block-library/src/post-hierarchical-terms/index.js
+++ b/packages/block-library/src/post-hierarchical-terms/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { _x } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
@@ -14,7 +9,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Hierarchical Terms', 'block title' ),
 	variations,
 	edit,
 };

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-navigation-link",
+	"title": "Post Navigation Link",
 	"category": "design",
+	"description": "Displays the next or previous post link that is adjacent to the current post.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-navigation-link/index.js
+++ b/packages/block-library/src/post-navigation-link/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { _x, __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
@@ -14,13 +9,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x(
-		'Post Navigation Link',
-		'name of the block that displays the next or previous post link that is adjacent to the current post'
-	),
-	description: __(
-		'Displays the next or previous post link that is adjacent to the current post.'
-	),
 	edit,
 	variations,
 };

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-tags",
+	"title": "Post Tags",
 	"category": "design",
+	"description": "Display a post's tags.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-tags/index.js
+++ b/packages/block-library/src/post-tags/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { tag as icon } from '@wordpress/icons';
 
 /**
@@ -14,8 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Tags', 'block title' ),
-	description: __( "Display a post's tags." ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/post-title",
+	"title": "Post Title",
 	"category": "design",
+	"description": "Displays the title of a post, page, or any other content-type.",
+	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
 	"attributes": {
 		"textAlign": {

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { postTitle as icon } from '@wordpress/icons';
 
 /**
@@ -14,10 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Post Title', 'block title' ),
-	description: __(
-		'Displays the title of a post, page, or any other content-type.'
-	),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/preformatted/block.json
+++ b/packages/block-library/src/preformatted/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/preformatted",
+	"title": "Preformatted",
 	"category": "text",
+	"description": "Add text that respects your spacing and tabs, and also allows styling.",
+	"textdomain": "default",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { preformatted as icon } from '@wordpress/icons';
 
 /**
@@ -17,10 +17,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Preformatted', 'block title' ),
-	description: __(
-		'Add text that respects your spacing and tabs, and also allows styling.'
-	),
 	icon,
 	example: {
 		attributes: {

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/pullquote",
+	"title": "Pullquote",
 	"category": "text",
+	"description": "Give special visual emphasis to a quote from your text.",
+	"textdomain": "default",
 	"attributes": {
 		"value": {
 			"type": "string",
@@ -34,6 +37,14 @@
 		"anchor": true,
 		"align": [ "left", "right", "wide", "full" ]
 	},
+	"styles": [
+		{
+			"name": "default",
+			"label": "Default",
+			"isDefault": true
+		},
+		{ "name": "solid-color", "label": "Solid color" }
+	],
 	"editorStyle": "wp-block-pullquote-editor",
 	"style": "wp-block-pullquote"
 }

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -1,13 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { pullquote as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { SOLID_COLOR_STYLE_NAME } from './shared';
 import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
@@ -19,10 +18,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Pullquote', 'block title' ),
-	description: __(
-		'Give special visual emphasis to a quote from your text.'
-	),
 	icon,
 	example: {
 		attributes: {
@@ -36,14 +31,6 @@ export const settings = {
 			citation: __( 'Matt Mullenweg' ),
 		},
 	},
-	styles: [
-		{
-			name: 'default',
-			label: _x( 'Default', 'block style' ),
-			isDefault: true,
-		},
-		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid color' ) },
-	],
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/pullquote/shared.js
+++ b/packages/block-library/src/pullquote/shared.js
@@ -1,2 +1,1 @@
-export const SOLID_COLOR_STYLE_NAME = 'solid-color';
-export const SOLID_COLOR_CLASS = `is-style-${ SOLID_COLOR_STYLE_NAME }`;
+export const SOLID_COLOR_CLASS = `is-style-solid-color`;

--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/query-loop",
+	"title": "Query Loop",
 	"category": "design",
+	"parent": [ "core/query" ],
+	"description": "Query loop.",
+	"textdomain": "default",
 	"usesContext": [
 		"queryId",
 		"query",

--- a/packages/block-library/src/query-loop/index.js
+++ b/packages/block-library/src/query-loop/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
 import { loop } from '@wordpress/icons';
 
 /**
@@ -15,9 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Query Loop', 'block title' ),
 	icon: loop,
 	edit,
 	save,
-	parent: [ 'core/query' ],
 };

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/query-pagination-next",
+	"title": "Query Pagination Next",
 	"category": "design",
+	"parent": [ "core/query-pagination" ],
+	"description": "Displays the next posts page link.",
+	"textdomain": "default",
 	"attributes": {
 		"label": {
 			"type": "string"

--- a/packages/block-library/src/query-pagination-next/index.js
+++ b/packages/block-library/src/query-pagination-next/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { _x, __ } from '@wordpress/i18n';
 import { queryPaginationNext as icon } from '@wordpress/icons';
 
 /**
@@ -14,9 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Query Pagination Next', 'block title' ),
-	description: __( 'Displays the next posts page link.' ),
 	icon,
 	edit,
-	parent: [ 'core/query-pagination' ],
 };

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/query-pagination-numbers",
+	"title": "Query Pagination Numbers",
 	"category": "design",
+	"parent": [ "core/query-pagination" ],
+	"description": "Displays a list of page numbers for pagination",
+	"textdomain": "default",
 	"usesContext": [ "queryId", "query" ],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/query-pagination-numbers/index.js
+++ b/packages/block-library/src/query-pagination-numbers/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { _x, __ } from '@wordpress/i18n';
 import { queryPaginationNumbers as icon } from '@wordpress/icons';
 
 /**
@@ -14,9 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Query Pagination Numbers', 'block title' ),
-	description: __( 'Displays a list of page numbers for pagination' ),
 	icon,
 	edit,
-	parent: [ 'core/query-pagination' ],
 };

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/query-pagination-previous",
+	"title": "Query Pagination Previous",
 	"category": "design",
+	"parent": [ "core/query-pagination" ],
+	"description": "Displays the previous posts page link.",
+	"textdomain": "default",
 	"attributes": {
 		"label": {
 			"type": "string"

--- a/packages/block-library/src/query-pagination-previous/index.js
+++ b/packages/block-library/src/query-pagination-previous/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { _x, __ } from '@wordpress/i18n';
 import { queryPaginationPrevious as icon } from '@wordpress/icons';
 
 /**
@@ -14,9 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Query Pagination Previous', 'block title' ),
-	description: __( 'Displays the previous posts page link.' ),
 	icon,
 	edit,
-	parent: [ 'core/query-pagination' ],
 };

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/query-pagination",
+	"title": "Query Pagination",
 	"category": "design",
+	"parent": [ "core/query" ],
+	"description": "Displays a paginated navigation to next/previous set of posts, when applicable.",
+	"textdomain": "default",
 	"usesContext": [ "queryId", "query" ],
 	"supports": {
 		"align": true,

--- a/packages/block-library/src/query-pagination/index.js
+++ b/packages/block-library/src/query-pagination/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { _x, __ } from '@wordpress/i18n';
 import { queryPagination as icon } from '@wordpress/icons';
 
 /**
@@ -15,12 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Query Pagination', 'block title' ),
-	description: __(
-		'Displays a paginated navigation to next/previous set of posts, when applicable.'
-	),
 	icon,
 	edit,
 	save,
-	parent: [ 'core/query' ],
 };

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/query-title",
+	"title": "Query Title",
 	"category": "design",
+	"description": "Display the query title.",
+	"textdomain": "default",
 	"attributes": {
 		"type": {
 			"type": "string"

--- a/packages/block-library/src/query-title/index.js
+++ b/packages/block-library/src/query-title/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
@@ -14,8 +9,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Query Title' ),
-	description: __( 'Display the query title.' ),
 	edit,
 	variations,
 };

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/query",
+	"title": "Query",
 	"category": "design",
+	"description": "Displays a list of posts as a result of a query.",
+	"textdomain": "default",
 	"attributes": {
 		"queryId": {
 			"type": "number"

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { loop as icon } from '@wordpress/icons';
 
 /**
@@ -17,9 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Query', 'block title' ),
 	icon,
-	description: __( 'Displays a list of posts as a result of a query.' ),
 	edit,
 	save,
 	variations,

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/quote",
+	"title": "Quote",
 	"category": "text",
+	"description": "Give quoted text visual emphasis. \"In quoting others, we cite ourselves.\" — Julio Cortázar",
+	"keywords": [ "blockquote", "cite" ],
+	"textdomain": "default",
 	"attributes": {
 		"value": {
 			"type": "string",
@@ -25,6 +29,14 @@
 	"supports": {
 		"anchor": true
 	},
+	"styles": [
+		{
+			"name": "default",
+			"label": "Default",
+			"isDefault": true
+		},
+		{ "name": "large", "label": "Large" }
+	],
 	"editorStyle": "wp-block-quote-editor",
 	"style": "wp-block-quote"
 }

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { quote as icon } from '@wordpress/icons';
 
 /**
@@ -18,12 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Quote', 'block title' ),
-	description: __(
-		'Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar'
-	),
 	icon,
-	keywords: [ __( 'blockquote' ), __( 'cite' ) ],
 	example: {
 		attributes: {
 			value:
@@ -32,14 +27,6 @@ export const settings = {
 			className: 'is-style-large',
 		},
 	},
-	styles: [
-		{
-			name: 'default',
-			label: _x( 'Default', 'block style' ),
-			isDefault: true,
-		},
-		{ name: 'large', label: _x( 'Large', 'block style' ) },
-	],
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/rss",
+	"title": "RSS",
 	"category": "widgets",
+	"description": "Display entries from any RSS or Atom feed.",
+	"keywords": [ "atom", "feed" ],
+	"textdomain": "default",
 	"attributes": {
 		"columns": {
 			"type": "number",

--- a/packages/block-library/src/rss/index.js
+++ b/packages/block-library/src/rss/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { rss as icon } from '@wordpress/icons';
-import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,10 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'RSS', 'block title' ),
-	description: __( 'Display entries from any RSS or Atom feed.' ),
 	icon,
-	keywords: [ __( 'atom' ), __( 'feed' ) ],
 	example: {
 		attributes: {
 			feedURL: 'https://wordpress.org',

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/search",
+	"title": "Search",
 	"category": "widgets",
+	"description": "Help visitors find your content.",
+	"keywords": [ "find" ],
+	"textdomain": "default",
 	"attributes": {
 		"label": {
 			"type": "string",

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { search as icon } from '@wordpress/icons';
 
 /**
@@ -16,10 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Search', 'block title' ),
-	description: __( 'Help visitors find your content.' ),
 	icon,
-	keywords: [ __( 'find' ) ],
 	example: {},
 	variations,
 	edit,

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/separator",
+	"title": "Separator",
 	"category": "design",
+	"description": "Create a break between ideas or sections with a horizontal separator.",
+	"keywords": [ "horizontal-line", "hr", "divider" ],
+	"textdomain": "default",
 	"attributes": {
 		"color": {
 			"type": "string"
@@ -14,6 +18,11 @@
 		"anchor": true,
 		"align": [ "center", "wide", "full" ]
 	},
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "wide", "label": "Wide Line" },
+		{ "name": "dots", "label": "Dots" }
+	],
 	"editorStyle": "wp-block-separator-editor",
 	"style": "wp-block-separator"
 }

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { separator as icon } from '@wordpress/icons';
 
 /**
@@ -17,23 +16,13 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Separator', 'block title' ),
-	description: __(
-		'Create a break between ideas or sections with a horizontal separator.'
-	),
 	icon,
-	keywords: [ __( 'horizontal-line' ), 'hr', __( 'divider' ) ],
 	example: {
 		attributes: {
 			customColor: '#065174',
 			className: 'is-style-wide',
 		},
 	},
-	styles: [
-		{ name: 'default', label: __( 'Default' ), isDefault: true },
-		{ name: 'wide', label: __( 'Wide Line' ) },
-		{ name: 'dots', label: __( 'Dots' ) },
-	],
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/shortcode/block.json
+++ b/packages/block-library/src/shortcode/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/shortcode",
+	"title": "Shortcode",
 	"category": "widgets",
+	"description": "Insert additional custom elements with a WordPress shortcode.",
+	"textdomain": "default",
 	"attributes": {
 		"text": {
 			"type": "string",

--- a/packages/block-library/src/shortcode/index.js
+++ b/packages/block-library/src/shortcode/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { shortcode as icon } from '@wordpress/icons';
 
 /**
@@ -17,10 +16,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Shortcode', 'block title' ),
-	description: __(
-		'Insert additional custom elements with a WordPress shortcode.'
-	),
 	icon,
 	transforms,
 	edit,

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/site-logo",
+	"title": "Site Logo",
 	"category": "layout",
+	"description": "Useful for displaying a graphic mark, design, or symbol to represent the site. Once a site logo is set, it can be reused in different places and templates. It should not be confused with the site icon, which is the small image used in the dashboard, browser tabs, public search results, etc, to help recognize a site.",
+	"textdomain": "default",
 	"attributes": {
 		"align": {
 			"type": "string"
@@ -13,6 +16,14 @@
 	"supports": {
 		"html": false
 	},
+	"styles": [
+		{
+			"name": "default",
+			"label": "Default",
+			"isDefault": true
+		},
+		{ "name": "rounded", "label": "Rounded" }
+	],
 	"editorStyle": "wp-block-site-logo-editor",
 	"style": "wp-block-site-logo"
 }

--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { siteLogo as icon } from '@wordpress/icons';
 
 /**
@@ -14,19 +13,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Site Logo', 'block title' ),
-	description: __(
-		'Useful for displaying a graphic mark, design, or symbol to represent the site. Once a site logo is set, it can be reused in different places and templates. It should not be confused with the site icon, which is the small image used in the dashboard, browser tabs, public search results, etc, to help recognize a site.'
-	),
 	icon,
-	styles: [
-		{
-			name: 'default',
-			label: _x( 'Default', 'block style' ),
-			isDefault: true,
-		},
-		{ name: 'rounded', label: _x( 'Rounded', 'block style' ) },
-	],
 	supports: {
 		align: true,
 		alignWide: false,

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/site-tagline",
+	"title": "Site Tagline",
 	"category": "design",
+	"description": "In a few words, what this site is about.",
+	"keywords": [ "description" ],
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/site-tagline/index.js
+++ b/packages/block-library/src/site-tagline/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __, _x } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
@@ -14,9 +9,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Site Tagline', 'block title' ),
-	description: __( 'In a few words, what this site is about.' ),
-	keywords: [ __( 'description' ) ],
 	icon,
 	edit,
 };

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/site-title",
+	"title": "Site Title",
 	"category": "design",
+	"description": "Displays and allows editing the name of the site. The site title usually appears in the browser title bar, in search results, and more. Also available in Settings > General.",
+	"textdomain": "default",
 	"attributes": {
 		"level": {
 			"type": "number",

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { mapMarker as icon } from '@wordpress/icons';
 
 /**
@@ -14,10 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Site Title', 'block title' ),
-	description: __(
-		'Displays and allows editing the name of the site. The site title usually appears in the browser title bar, in search results, and more. Also available in Settings > General.'
-	),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -1,8 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/social-link",
+	"title": "Social Icon",
 	"category": "widgets",
 	"parent": [ "core/social-links" ],
+	"description": "Display an icon linking to a social media profile or website.",
+	"textdomain": "default",
 	"attributes": {
 		"url": {
 			"type": "string"

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { share as icon } from '@wordpress/icons';
 
 /**
@@ -16,11 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Social Icon', 'block title' ),
 	icon,
 	edit,
-	description: __(
-		'Display an icon linking to a social media profile or website.'
-	),
 	variations,
 };

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/social-links",
+	"title": "Social Icons",
 	"category": "widgets",
+	"description": "Display icons linking to your social media profiles or websites.",
+	"keywords": [ "links" ],
+	"textdomain": "default",
 	"attributes": {
 		"iconColor": {
 			"type": "string"
@@ -38,6 +42,11 @@
 		"align": [ "left", "center", "right" ],
 		"anchor": true
 	},
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "logos-only", "label": "Logos Only" },
+		{ "name": "pill-shape", "label": "Pill Shape" }
+	],
 	"editorStyle": "wp-block-social-links-editor",
 	"style": "wp-block-social-links"
 }

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { share as icon } from '@wordpress/icons';
 
 /**
@@ -17,11 +16,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Social Icons', 'block title' ),
-	description: __(
-		'Display icons linking to your social media profiles or websites.'
-	),
-	keywords: [ _x( 'links', 'block keywords' ) ],
 	example: {
 		innerBlocks: [
 			{
@@ -47,11 +41,6 @@ export const settings = {
 			},
 		],
 	},
-	styles: [
-		{ name: 'default', label: __( 'Default' ), isDefault: true },
-		{ name: 'logos-only', label: __( 'Logos Only' ) },
-		{ name: 'pill-shape', label: __( 'Pill Shape' ) },
-	],
 	icon,
 	edit,
 	save,

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/spacer",
+	"title": "Spacer",
 	"category": "design",
+	"description": "Add white space between blocks and customize its height.",
+	"textdomain": "default",
 	"attributes": {
 		"height": {
 			"type": "number",

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { resizeCornerNE as icon } from '@wordpress/icons';
 
 /**
@@ -16,10 +15,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Spacer', 'block title' ),
-	description: __(
-		'Add white space between blocks and customize its height.'
-	),
 	icon,
 	edit,
 	save,

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/table-of-contents",
+	"title": "Table of Contents",
 	"category": "layout",
+	"description": "Summarize your post with a list of headings. Add HTML anchors to Heading blocks to link them here.",
+	"keywords": [ "document outline", "summary" ],
+	"textdomain": "default",
 	"attributes": {
 		"onlyIncludeCurrentPage": {
 			"type": "boolean",

--- a/packages/block-library/src/table-of-contents/index.js
+++ b/packages/block-library/src/table-of-contents/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
@@ -15,11 +10,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Table of Contents' ),
-	description: __(
-		'Summarize your post with a list of headings. Add HTML anchors to Heading blocks to link them here.'
-	),
 	icon,
-	keywords: [ __( 'document outline' ), __( 'summary' ) ],
 	edit,
 };

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/table",
+	"title": "Table",
 	"category": "text",
+	"description": "Insert a table — perfect for sharing charts and data.",
+	"textdomain": "default",
 	"attributes": {
 		"hasFixedLayout": {
 			"type": "boolean",
@@ -134,6 +137,14 @@
 		},
 		"__experimentalSelector": ".wp-block-table > table"
 	},
+	"styles": [
+		{
+			"name": "regular",
+			"label": "Default",
+			"isDefault": true
+		},
+		{ "name": "stripes", "label": "Stripes" }
+	],
 	"editorStyle": "wp-block-table-editor",
 	"style": "wp-block-table"
 }

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { blockTable as icon } from '@wordpress/icons';
 
 /**
@@ -18,8 +18,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Table', 'block title' ),
-	description: __( 'Insert a table — perfect for sharing charts and data.' ),
 	icon,
 	example: {
 		attributes: {
@@ -93,14 +91,6 @@ export const settings = {
 			],
 		},
 	},
-	styles: [
-		{
-			name: 'regular',
-			label: _x( 'Default', 'block style' ),
-			isDefault: true,
-		},
-		{ name: 'stripes', label: __( 'Stripes' ) },
-	],
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/tag-cloud",
+	"title": "Tag Cloud",
 	"category": "widgets",
+	"description": "A cloud of your most used tags.",
+	"textdomain": "default",
 	"attributes": {
 		"taxonomy": {
 			"type": "string",

--- a/packages/block-library/src/tag-cloud/index.js
+++ b/packages/block-library/src/tag-cloud/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { tag as icon } from '@wordpress/icons';
 
 /**
@@ -15,8 +14,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Tag Cloud', 'block title' ),
-	description: __( 'A cloud of your most used tags.' ),
 	icon,
 	example: {},
 	edit,

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/template-part",
+	"title": "Template Part",
 	"category": "theme",
+	"description": "Edit the different global regions of your site, like the header, footer, sidebar, or create your own.",
+	"textdomain": "default",
 	"attributes": {
 		"slug": {
 			"type": "string"

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -8,7 +8,6 @@ import { startCase } from 'lodash';
  */
 import { store as coreDataStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
-import { __, _x } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
 
 /**
@@ -22,12 +21,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Template Part', 'block title' ),
-	description: __(
-		'Edit the different global regions of your site, like the header, footer, sidebar, or create your own.'
-	),
 	icon: layout,
-	keywords: [ __( 'template part' ) ],
 	__experimentalLabel: ( { slug, theme } ) => {
 		// Attempt to find entity title if block is a template part.
 		// Require slug to request, otherwise entity is uncreated and will throw 404.

--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -1,7 +1,10 @@
 {
 	"apiVersion": 2,
 	"name": "core/term-description",
+	"title": "Term Description",
 	"category": "design",
+	"description": "Display the description of categories, tags and custom taxonomies when viewing an archive.",
+	"textdomain": "default",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/term-description/index.js
+++ b/packages/block-library/src/term-description/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { _x, __ } from '@wordpress/i18n';
 import { termDescription as icon } from '@wordpress/icons';
 
 /**
@@ -14,10 +13,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Term Description', 'block title' ),
-	description: __(
-		'Display the description of categories, tags and custom taxonomies when viewing an archive.'
-	),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/text-columns/block.json
+++ b/packages/block-library/src/text-columns/block.json
@@ -1,8 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/text-columns",
+	"title": "Text Columns (deprecated)",
 	"icon": "columns",
 	"category": "design",
+	"description": "This block is deprecated. Please use the Columns block instead.",
+	"textdomain": "default",
 	"attributes": {
 		"content": {
 			"type": "array",

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __, _x } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import edit from './edit';
@@ -16,10 +11,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Text Columns (deprecated)', 'block title' ),
-	description: __(
-		'This block is deprecated. Please use the Columns block instead.'
-	),
 	transforms,
 	getEditWrapperProps( attributes ) {
 		const { width } = attributes;

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/verse",
+	"title": "Verse",
 	"category": "text",
+	"description": "Insert poetry. Use special spacing formats. Or quote song lyrics.",
+	"keywords": [ "poetry", "poem" ],
+	"textdomain": "default",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { verse as icon } from '@wordpress/icons';
 
 /**
@@ -18,10 +18,6 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Verse', 'block title' ),
-	description: __(
-		'Insert poetry. Use special spacing formats. Or quote song lyrics.'
-	),
 	icon,
 	example: {
 		attributes: {
@@ -33,7 +29,6 @@ export const settings = {
 			/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 		},
 	},
-	keywords: [ __( 'poetry' ), __( 'poem' ) ],
 	transforms,
 	deprecated,
 	merge( attributes, attributesToMerge ) {

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -1,7 +1,11 @@
 {
 	"apiVersion": 2,
 	"name": "core/video",
+	"title": "Video",
 	"category": "media",
+	"description": "Embed a video from your media library or upload a new one.",
+	"keywords": [ "movie" ],
+	"textdomain": "default",
 	"attributes": {
 		"autoplay": {
 			"type": "boolean",

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { video as icon } from '@wordpress/icons';
 
 /**
@@ -17,12 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: _x( 'Video', 'block title' ),
-	description: __(
-		'Embed a video from your media library or upload a new one.'
-	),
 	icon,
-	keywords: [ __( 'movie' ) ],
 	example: {
 		attributes: {
 			src:


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Depends on #30293.
Fixes #23792.
Part of #16209.

All 77 blocks were updated. Fields that are wrapped with i18n helpers were moved from `registerBlockType` call to `block.json` files.

_Translatable fields sourced from `block.json` have automatically applied a translation context which mostly weren't present before. This means that many translations are missing for the time being. It should get resolved during the release cycle of WordPress 5.8._

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

All translatable fields for blocks should have their translations applied on the server when testing with WordPress.

When testing with the mobile app, all translations should still get applied as before on the client.

## Screenshots <!-- if applicable -->

No visual changes.

## Types of changes
Code quality.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
