### PR TITLE
E2E Site Editor Test: Evaluate getEditedPostContent on the page

### DIFF
--- a/packages/e2e-tests/experimental-features.js
+++ b/packages/e2e-tests/experimental-features.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { visitAdminPage, wpDataSelect } from '@wordpress/e2e-test-utils';
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 async function setExperimentalFeaturesState( features, enable ) {
 	const query = addQueryArgs( '', {
@@ -131,34 +131,28 @@ export const siteEditor = {
 	},
 
 	async getEditedPostContent() {
-		const postId = await wpDataSelect(
-			'core/edit-site',
-			'getEditedPostId'
-		);
-		const postType = await wpDataSelect(
-			'core/edit-site',
-			'getEditedPostType'
-		);
-		const record = await wpDataSelect(
-			'core',
-			'getEditedEntityRecord',
-			'postType',
-			postType,
-			postId
-		);
-		if ( record ) {
-			if ( typeof record.content === 'function' ) {
-				return record.content( record );
-			} else if ( record.blocks ) {
-				return await page.evaluate(
-					( blocks ) =>
-						window.wp.blocks.__unstableSerializeAndClean( blocks ),
-					record.blocks
-				);
-			} else if ( record.content ) {
-				return record.content;
+		return await page.evaluate( async () => {
+			const postId = window.wp.data
+				.select( 'core/edit-site' )
+				.getEditedPostId();
+			const postType = window.wp.data
+				.select( 'core/edit-site' )
+				.getEditedPostType();
+			const record = window.wp.data
+				.select( 'core' )
+				.getEditedEntityRecord( 'postType', postType, postId );
+			if ( record ) {
+				if ( typeof record.content === 'function' ) {
+					return record.content( record );
+				} else if ( record.blocks ) {
+					return window.wp.blocks.__unstableSerializeAndClean(
+						record.blocks
+					);
+				} else if ( record.content ) {
+					return record.content;
+				}
 			}
-		}
-		return '';
+			return '';
+		} );
 	},
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
`page.evaluate` returns undefined if we are trying to return something that contains unserializable value(s). This might be a function, DOM reference, or something similar.

An `edited` entity may contain a `content` property as `function`. Since this is unserializable, `await page.evaluate()` returns `undefined`.

As a fix, we move the logic to the page so we only get back a `string` which is always serializable.

## How has this been tested?

1.
Make sure tests are passing.

2.
Checkout to https://github.com/WordPress/gutenberg/pull/30804

Apply this PR

Make sure tests are not failing with `getEditedPostContent` returning undefined. (`getAllBlocks` will still return `undefined`)

## Screenshots <!-- if applicable -->

## Types of changes
Improve E2E tests consistency

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
