### PR TITLE
Add link to `options-general.php` in the site title description

### DIFF
--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -20,7 +20,7 @@ export const settings = {
 			'Displays and allows editing the name of the site. The site title usually appears in the browser title bar, in search results, and more. Also available in <a>Settings > General</a>.'
 		),
 		// eslint-disable-next-line jsx-a11y/anchor-has-content
-		{ a: <a href="options-general.php" target="_blank" /> }
+		{ a: <a href="options-general.php" /> }
 	),
 	icon,
 	edit,

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import metadata from './block.json';
 import edit from './edit';
+import AccessibleSteps from './util/accessible-steps';
 
 const { name } = metadata;
 export { metadata, name };
@@ -17,10 +18,16 @@ export { metadata, name };
 export const settings = {
 	description: createInterpolateElement(
 		__(
-			'Displays and allows editing the name of the site. The site title usually appears in the browser title bar, in search results, and more. Also available in <a>Settings > General</a>.'
+			'Displays and allows editing the name of the site. The site title usually appears in the browser title bar, in search results, and more. Also available in <path/>.'
 		),
-		// eslint-disable-next-line jsx-a11y/anchor-has-content
-		{ a: <a href="options-general.php" /> }
+		{
+			path: (
+				<AccessibleSteps
+					elements={ [ __( 'Settings' ), __( 'General' ) ] }
+					link="options-general.php"
+				/>
+			),
+		}
 	),
 	icon,
 	edit,

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { mapMarker as icon } from '@wordpress/icons';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -13,6 +15,13 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
+	description: createInterpolateElement(
+		__(
+			'Displays and allows editing the name of the site. The site title usually appears in the browser title bar, in search results, and more. Also available in <a>Settings > General</a>.'
+		),
+		// eslint-disable-next-line jsx-a11y/anchor-has-content
+		{ a: <a href="options-general.php" target="_blank" /> }
+	),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/site-title/util/accessible-steps.js
+++ b/packages/block-library/src/site-title/util/accessible-steps.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+const PathSeparator = () => (
+	<>
+		&nbsp;
+		<span
+			aria-label={
+				// translators: accessibility text for describing steps with the > character
+				__( 'and then' )
+			}
+		>
+			{ '>' }
+		</span>{ ' ' }
+	</>
+);
+
+export default function AccessibleSteps( { elements, link } ) {
+	if ( isEmpty( elements ) ) {
+		return null;
+	}
+
+	const Wrapper = ( { children } ) =>
+		isEmpty( link ) ? <>{ children }</> : <a href={ link }>{ children }</a>;
+
+	return (
+		<Wrapper>
+			<b>
+				{ elements.reduce( ( acc, curr ) => (
+					<>
+						{ acc }
+						<PathSeparator />
+						{ curr }
+					</>
+				) ) }
+			</b>
+		</Wrapper>
+	);
+}


### PR DESCRIPTION
This adds a link to the general settings page by making use of `createInterpolateElement`, as described in https://github.com/WordPress/gutenberg/issues/30871. 