### PR TITLE
FSE: Verify if php template exists for a hybrid/universal theme with a block-based parent

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -76,7 +76,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 		$has_php_template   = file_exists( get_stylesheet_directory() . '/' . $type . '.php' );
 		$has_block_template = false;
 		$block_template     = _gutenberg_get_template_file( 'wp_template', $type );
-		if ( null !==$block_template  && $block_template['theme'] === wp_get_theme()->get_stylesheet() ) {
+		if ( null !== $block_template && wp_get_theme()->get_stylesheet() === $block_template['theme'] ) {
 			$has_block_template = true;
 		}
 		if ( is_child_theme() && ( $has_php_template && ! $has_block_template ) ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -17,7 +17,7 @@ function gutenberg_add_template_loader_filters() {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
 			continue;
 		}
-		if( ! file_exists( get_stylesheet_directory() . '/' . $template_type . '.php' ) || null !== _gutenberg_get_template_file( 'wp_template', $template_type )){
+		if ( ! file_exists( get_stylesheet_directory() . '/' . $template_type . '.php' ) || null !== _gutenberg_get_template_file( 'wp_template', $template_type ) ) {
 			add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
 		}
 	}

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -17,7 +17,8 @@ function gutenberg_add_template_loader_filters() {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
 			continue;
 		}
-		if ( ! file_exists( get_stylesheet_directory() . '/' . $template_type . '.php' ) || null !== _gutenberg_get_template_file( 'wp_template', $template_type ) ) {
+		// Use block template if there is no php template exists OR it's a child theme with no corresponding block template.
+		if ( ! file_exists( get_stylesheet_directory() . '/' . $template_type . '.php' ) || ( ! is_child_theme() && null !== _gutenberg_get_template_file( 'wp_template', $template_type ) ) ) {
 			add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
 		}
 	}

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -17,12 +17,10 @@ function gutenberg_add_template_loader_filters() {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
 			continue;
 		}
-		// Use block template if there is no php template exists OR it's a child theme with no corresponding block template.
-		if ( ! file_exists( get_stylesheet_directory() . '/' . $template_type . '.php' ) || ( ! is_child_theme() && null !== _gutenberg_get_template_file( 'wp_template', $template_type ) ) ) {
-			add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
-		}
+		add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
 	}
 }
+
 add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
 
 /**
@@ -72,6 +70,19 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	$current_template_slug       = basename( $template, '.php' );
 	$current_block_template_slug = is_object( $current_template ) ? $current_template->slug : false;
 	foreach ( $templates as $template_item ) {
+
+		//if the theme is a child theme we want to check if a php template exists 
+		//and that a corresponding block template from the theme and not the parent doesn't exist
+		$has_php_template = file_exists( get_stylesheet_directory() . '/' . $type . '.php' );
+		$has_block_template = false;
+		$block_template = _gutenberg_get_template_file( 'wp_template', $type );
+		if($block_template !== null && $block_template['theme'] == wp_get_theme()->get_stylesheet()) {
+			$has_block_template = true;
+		}
+		if( is_child_theme() && ( $has_php_template && ! $has_block_template ) ) {
+			return $template;
+		}
+
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
 		// Break the loop if the block-template matches the template slug.

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -71,15 +71,15 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	$current_block_template_slug = is_object( $current_template ) ? $current_template->slug : false;
 	foreach ( $templates as $template_item ) {
 
-		//if the theme is a child theme we want to check if a php template exists 
-		//and that a corresponding block template from the theme and not the parent doesn't exist
-		$has_php_template = file_exists( get_stylesheet_directory() . '/' . $type . '.php' );
+		// if the theme is a child theme we want to check if a php template exists
+		// and that a corresponding block template from the theme and not the parent doesn't exist
+		$has_php_template   = file_exists( get_stylesheet_directory() . '/' . $type . '.php' );
 		$has_block_template = false;
-		$block_template = _gutenberg_get_template_file( 'wp_template', $type );
-		if($block_template !== null && $block_template['theme'] == wp_get_theme()->get_stylesheet()) {
+		$block_template     = _gutenberg_get_template_file( 'wp_template', $type );
+		if ( $block_template !== null && $block_template['theme'] == wp_get_theme()->get_stylesheet() ) {
 			$has_block_template = true;
 		}
-		if( is_child_theme() && ( $has_php_template && ! $has_block_template ) ) {
+		if ( is_child_theme() && ( $has_php_template && ! $has_block_template ) ) {
 			return $template;
 		}
 

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -72,11 +72,11 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	foreach ( $templates as $template_item ) {
 
 		// if the theme is a child theme we want to check if a php template exists
-		// and that a corresponding block template from the theme and not the parent doesn't exist
+		// and that a corresponding block template from the theme and not the parent doesn't exist.
 		$has_php_template   = file_exists( get_stylesheet_directory() . '/' . $type . '.php' );
 		$has_block_template = false;
 		$block_template     = _gutenberg_get_template_file( 'wp_template', $type );
-		if ( $block_template !== null && $block_template['theme'] == wp_get_theme()->get_stylesheet() ) {
+		if ( null !==$block_template  && $block_template['theme'] === wp_get_theme()->get_stylesheet() ) {
 			$has_block_template = true;
 		}
 		if ( is_child_theme() && ( $has_php_template && ! $has_block_template ) ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -17,7 +17,9 @@ function gutenberg_add_template_loader_filters() {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
 			continue;
 		}
-		add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
+		if( ! file_exists( get_stylesheet_directory() . '/' . $template_type . '.php' ) || null !== _gutenberg_get_template_file( 'wp_template', $template_type )){
+			add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
+		}
 	}
 }
 add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
@@ -129,7 +131,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 }
 
 /**
- * Return the correct 'wp_template' to render fot the request template type.
+ * Return the correct 'wp_template' to render for the request template type.
  *
  * Accepts an optional $template_hierarchy argument as a hint.
  *


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

If a theme is a child of a block-based parent theme but has php templates for some of its pages, the php templates from the child won't override the html ones from the parent theme. This PR makes sure that if a php template exists on the child theme and no html template exists, the php one will be loaded over the parent's.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
This has been tested with a [child of BCB](https://github.com/Automattic/themes/tree/trunk/blank-canvas-blocks). BCB provides FSE templates for singular, 404, and search. I created a child with a 404.php template. Before my PR, the template from BCB would load. After my PR, the php one from the child will load. 

I also tested creating a page + page-ID on the child theme, making sure that the page-ID one would always take priority over the page one.


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
