### PR TITLE
Cleanup unused function parameters

### DIFF
--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -8,13 +8,10 @@
 /**
  * Load the page templates in Gutenberg.
  *
- * @param array    $templates Page templates.
- * @param WP_Theme $theme     WP_Theme instance.
- * @param WP_Post  $post      The post being edited, provided for context, or null.
- * @param string   $post_type Post type to get the templates for.
+ * @param array $templates Page templates.
  * @return array (Maybe) modified page templates array.
  */
-function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
+function gutenberg_load_block_page_templates( $templates ) {
 	if ( ! gutenberg_supports_block_templates() ) {
 		return $templates;
 	}

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -24,4 +24,4 @@ function gutenberg_load_block_page_templates( $templates ) {
 
 	return $templates;
 }
-add_filter( 'theme_templates', 'gutenberg_load_block_page_templates', 10, 4 );
+add_filter( 'theme_templates', 'gutenberg_load_block_page_templates' );


### PR DESCRIPTION
## Description

Removes unused function parameters in the `gutenberg_load_block_page_templates` function & filter.
Fixes PHPCS warnings.

## How has this been tested?
Tested that templates don't break in an FSE theme

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
