### PR TITLE
Plugin: Add missing textdomains

### DIFF
--- a/lib/block-editor.php
+++ b/lib/block-editor.php
@@ -23,37 +23,37 @@ function gutenberg_get_default_block_categories() {
 	return array(
 		array(
 			'slug'  => 'text',
-			'title' => _x( 'Text', 'block category' ),
+			'title' => _x( 'Text', 'block category', 'gutenberg' ),
 			'icon'  => null,
 		),
 		array(
 			'slug'  => 'media',
-			'title' => _x( 'Media', 'block category' ),
+			'title' => _x( 'Media', 'block category', 'gutenberg' ),
 			'icon'  => null,
 		),
 		array(
 			'slug'  => 'design',
-			'title' => _x( 'Design', 'block category' ),
+			'title' => _x( 'Design', 'block category', 'gutenberg' ),
 			'icon'  => null,
 		),
 		array(
 			'slug'  => 'widgets',
-			'title' => _x( 'Widgets', 'block category' ),
+			'title' => _x( 'Widgets', 'block category', 'gutenberg' ),
 			'icon'  => null,
 		),
 		array(
 			'slug'  => 'theme',
-			'title' => _x( 'Theme', 'block category' ),
+			'title' => _x( 'Theme', 'block category', 'gutenberg' ),
 			'icon'  => null,
 		),
 		array(
 			'slug'  => 'embed',
-			'title' => _x( 'Embeds', 'block category' ),
+			'title' => _x( 'Embeds', 'block category', 'gutenberg' ),
 			'icon'  => null,
 		),
 		array(
 			'slug'  => 'reusable',
-			'title' => _x( 'Reusable Blocks', 'block category' ),
+			'title' => _x( 'Reusable Blocks', 'block category', 'gutenberg' ),
 			'icon'  => null,
 		),
 	);
@@ -175,10 +175,10 @@ function gutenberg_get_default_block_editor_settings() {
 	$image_size_names = apply_filters(
 		'image_size_names_choose',
 		array(
-			'thumbnail' => __( 'Thumbnail' ),
-			'medium'    => __( 'Medium' ),
-			'large'     => __( 'Large' ),
-			'full'      => __( 'Full Size' ),
+			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
+			'medium'    => __( 'Medium', 'gutenberg' ),
+			'large'     => __( 'Large', 'gutenberg' ),
+			'full'      => __( 'Full Size', 'gutenberg' ),
 		)
 	);
 


### PR DESCRIPTION
## Description
Some translation functions were missing their textdomain.

## How has this been tested?
Nothing to test.

## Types of changes
Added textdomains where missing. Checked that this fixes some phpcs warnings and confirmed we're now OK.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
