### PR TITLE
Scripts: Update `puppeteer-core` to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14364,7 +14364,7 @@
 				"npm-package-json-lint": "^5.0.0",
 				"postcss-loader": "^4.2.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
-				"puppeteer-core": "^5.5.0",
+				"puppeteer-core": "^9.0.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
 				"sass": "^1.26.11",
@@ -28425,9 +28425,9 @@
 			}
 		},
 		"devtools-protocol": {
-			"version": "0.0.818844",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-			"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+			"version": "0.0.869402",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+			"integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA==",
 			"dev": true
 		},
 		"dezalgo": {
@@ -49554,19 +49554,19 @@
 			"dev": true
 		},
 		"puppeteer-core": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-			"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-9.0.0.tgz",
+			"integrity": "sha512-cgrnFLg5td0ciW3seGmLPlAf7e2jlIEjZlBOij/byS4iD3DRMHxItzVHv5OwEntkC1eamZqt8+WJJpAaGk6zPw==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
-				"devtools-protocol": "0.0.818844",
+				"devtools-protocol": "0.0.869402",
 				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"node-fetch": "^2.6.1",
 				"pkg-dir": "^4.2.0",
 				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
+				"proxy-from-env": "^1.1.0",
 				"rimraf": "^3.0.2",
 				"tar-fs": "^2.0.0",
 				"unbzip2-stream": "^1.3.3",
@@ -49574,10 +49574,13 @@
 			},
 			"dependencies": {
 				"agent-base": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-					"dev": true
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"dev": true,
+					"requires": {
+						"debug": "4"
+					}
 				},
 				"debug": {
 					"version": "4.3.1",
@@ -49620,12 +49623,12 @@
 					}
 				},
 				"https-proxy-agent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 					"dev": true,
 					"requires": {
-						"agent-base": "5",
+						"agent-base": "6",
 						"debug": "4"
 					}
 				},
@@ -56867,12 +56870,6 @@
 				"tar-stream": "^2.1.4"
 			},
 			"dependencies": {
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				},
 				"pump": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   The bundled `puppeteer-core` (`5.5.0`) dependency has been upgraded to version `9.0.0`. Puppeteer uses Chromium v91 instead of Chromium v81. See the full list of breaking changes of [9.0.0](https://github.com/puppeteer/puppeteer/releases/tag/v9.0.0) and lower versions.
+-   The bundled `puppeteer-core` (`^5.5.0`) dependency has been upgraded to version `^9.0.0`. Puppeteer uses Chromium v91 instead of Chromium v88. See the full list of breaking changes of [9.0.0](https://github.com/puppeteer/puppeteer/releases/tag/v9.0.0) and lower versions ([#31138](https://github.com/WordPress/gutenberg/pull/31138)).
 
 ### New Features
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The bundled `puppeteer-core` (`5.5.0`) dependency has been upgraded to version `9.0.0`. Puppeteer uses Chromium v91 instead of Chromium v81. See the full list of breaking changes of [9.0.0](https://github.com/puppeteer/puppeteer/releases/tag/v9.0.0) and lower versions.
+
 ### New Features
 
 -   Include a Jest Reporter that formats test results for GitHub Actions annotations ([#31041](https://github.com/WordPress/gutenberg/pull/31041)).

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -68,7 +68,7 @@
 		"npm-package-json-lint": "^5.0.0",
 		"postcss-loader": "^4.2.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
-		"puppeteer-core": "^5.5.0",
+		"puppeteer-core": "^9.0.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",
 		"sass": "^1.26.11",


### PR DESCRIPTION
## Description

The bundled `puppeteer-core` (`^5.5.0`) dependency has been upgraded to version `^9.0.0`. Puppeteer uses Chromium v91 instead of Chromium v88. See the full list of breaking changes of [9.0.0](https://github.com/puppeteer/puppeteer/releases/tag/v9.0.0) and lower versions.

## Testing

Run `npm run test-e2e` and make sure all tests still pass.

