### PR TITLE
Writing flow: fix edge detection in Chrome

### DIFF
--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -15,7 +15,25 @@ export default function getRectangleFromRange( range ) {
 	// range; this a rectangle enclosing the union of the bounding rectangles
 	// for all the elements in the range.
 	if ( ! range.collapsed ) {
-		return range.getBoundingClientRect();
+		// Ignore tiny selection at the edge of a range.
+		const rects = Array.from( range.getClientRects() ).filter(
+			( { width } ) => width > 1
+		);
+		const furthestTop = Math.min( ...rects.map( ( { top } ) => top ) );
+		const furthestBottom = Math.max(
+			...rects.map( ( { bottom } ) => bottom )
+		);
+		const furthestLeft = Math.min( ...rects.map( ( { left } ) => left ) );
+		const furthestRight = Math.max(
+			...rects.map( ( { right } ) => right )
+		);
+
+		return new window.DOMRect(
+			furthestLeft,
+			furthestTop,
+			furthestRight - furthestLeft,
+			furthestBottom - furthestTop
+		);
 	}
 
 	const { startContainer } = range;

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -15,18 +15,38 @@ export default function getRectangleFromRange( range ) {
 	// range; this a rectangle enclosing the union of the bounding rectangles
 	// for all the elements in the range.
 	if ( ! range.collapsed ) {
+		const rects = Array.from( range.getClientRects() );
+
+		// If there's just a single rect, return it.
+		if ( rects.length === 1 ) {
+			return rects[ 0 ];
+		}
+
 		// Ignore tiny selection at the edge of a range.
-		const rects = Array.from( range.getClientRects() ).filter(
-			( { width } ) => width > 1
-		);
-		const furthestTop = Math.min( ...rects.map( ( { top } ) => top ) );
-		const furthestBottom = Math.max(
-			...rects.map( ( { bottom } ) => bottom )
-		);
-		const furthestLeft = Math.min( ...rects.map( ( { left } ) => left ) );
-		const furthestRight = Math.max(
-			...rects.map( ( { right } ) => right )
-		);
+		const filteredRects = rects.filter( ( { width } ) => width > 1 );
+
+		// If it's full of tiny selections, return browser default.
+		if ( filteredRects.length === 0 ) {
+			return range.getBoundingClientRect();
+		}
+
+		if ( filteredRects.length === 1 ) {
+			return filteredRects[ 0 ];
+		}
+
+		let {
+			top: furthestTop,
+			bottom: furthestBottom,
+			left: furthestLeft,
+			right: furthestRight,
+		} = filteredRects[ 0 ];
+
+		for ( const { top, bottom, left, right } of filteredRects ) {
+			if ( top < furthestTop ) furthestTop = top;
+			if ( bottom > furthestBottom ) furthestBottom = bottom;
+			if ( left < furthestLeft ) furthestLeft = left;
+			if ( right > furthestRight ) furthestRight = right;
+		}
 
 		return new window.DOMRect(
 			furthestLeft,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

For #31138.
We need to manually create a union of all client rectangles because some browsers like Chrome might add a tiny 0.0001px-width rectangle if a whole line is selected. This tiny rectangle would be at the line above or under the selected line depending on the selection direction.

## How has this been tested?
```js
await page.keyboard.press( 'Enter' );
await page.keyboard.type( 'a' );
await page.keyboard.press( 'Enter' );
await page.keyboard.type( '* b' );
await page.keyboard.press( 'Enter' );
await page.keyboard.type( 'cd' );
await pressKeyWithModifier( 'shift', 'ArrowUp' );
await pressKeyWithModifier( 'shift', 'ArrowUp' );
// Ensure multi selection is not triggered and selection stays within
// the list.
await page.keyboard.press( 'Backspace' );
```
## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
