### PR TITLE
Fix entity saving intermittent test failure

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -177,7 +177,7 @@ describe( 'Multi-entity save flow', () => {
 
 			await insertBlock( 'Site Title' );
 			// Ensure title is retrieved before typing.
-			await page.waitForXPath( '//a[contains(text(), "Gutenberg")]' );
+			await page.waitForXPath( '//a[contains(text(), "gutenberg")]' );
 			await page.keyboard.type( '...' );
 			await insertBlock( 'Site Tagline' );
 			// Ensure tagline is retrieved before typing.

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -8,6 +8,7 @@ import {
 	publishPost,
 	trashAllPosts,
 	activateTheme,
+	clickButton,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -175,15 +176,17 @@ describe( 'Multi-entity save flow', () => {
 			await disablePrePublishChecks();
 
 			await insertBlock( 'Site Title' );
-			await page.waitForXPath( '//a[contains(text(), "gutenberg")]' ); // Ensure title is retrieved before typing.
+			// Ensure title is retrieved before typing.
+			await page.waitForXPath( '//a[contains(text(), "Gutenberg")]' );
 			await page.keyboard.type( '...' );
 			await insertBlock( 'Site Tagline' );
+			// Ensure tagline is retrieved before typing.
 			await page.waitForXPath(
 				'//p[contains(text(), "Just another WordPress site")]'
-			); // Esnure tagline is retrieved before typing.
+			);
 			await page.keyboard.type( '...' );
 
-			await page.click( savePostSelector );
+			await clickButton( 'Publish' );
 			await page.waitForSelector( savePanelSelector );
 			let checkboxInputs = await page.$$( checkboxInputSelector );
 			expect( checkboxInputs ).toHaveLength( 3 );
@@ -191,7 +194,7 @@ describe( 'Multi-entity save flow', () => {
 			await checkboxInputs[ 1 ].click();
 			await page.click( entitiesSaveSelector );
 
-			await page.click( savePostSelector );
+			await clickButton( 'Update…' );
 			await page.waitForSelector( savePanelSelector );
 			checkboxInputs = await page.$$( checkboxInputSelector );
 			expect( checkboxInputs ).toHaveLength( 1 );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The test doesn't wait for the post to publish, which is believe is causing the intermittent failure.
`clickButton` waits for the selector to appear on the page and thus also for the post to save. In addition is more readable.
Please use `clickButton` more! :)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
