### PR TITLE
Fix Dropdown/DropdownMenu toggle closing in all UAs

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -90,6 +90,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
         >
           <div
             className="components-dropdown components-circular-option-picker__dropdown-link-action"
+            tabIndex="-1"
           >
             <button
               aria-describedby={null}

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -179,9 +179,6 @@ export default function TemplatePartEdit( {
 								<ToolbarButton
 									aria-expanded={ isOpen }
 									onClick={ onToggle }
-									// Disable when open to prevent odd FireFox bug causing reopening.
-									// As noted in https://github.com/WordPress/gutenberg/pull/24990#issuecomment-689094119 .
-									disabled={ isOpen }
 								>
 									{ __( 'Replace' ) }
 								</ToolbarButton>

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -111,6 +111,7 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
 >
   <div
     className="components-dropdown components-circular-option-picker__dropdown-link-action"
+    tabIndex="-1"
   >
     <ForwardRef(Button)
       aria-expanded={false}
@@ -545,6 +546,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           >
             <div
               className="components-dropdown components-circular-option-picker__dropdown-link-action"
+              tabIndex="-1"
             >
               <ForwardRef(Button)
                 aria-expanded={false}

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -85,6 +85,7 @@ export default function Dropdown( {
 		<div
 			className={ classnames( 'components-dropdown', className ) }
 			ref={ containerRef }
+			tabIndex="-1"
 		>
 			{ renderToggle( args ) }
 			{ isOpen && (

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -85,6 +85,9 @@ export default function Dropdown( {
 		<div
 			className={ classnames( 'components-dropdown', className ) }
 			ref={ containerRef }
+			// Some UAs focus the closest focusable parent when the toggle is
+			// clicked. Making this div focusable ensures such UAs will focus
+			// it and `closeIfFocusOutside` can tell if the toggle was clicked.
 			tabIndex="-1"
 		>
 			{ renderToggle( args ) }


### PR DESCRIPTION
The Dropdown (and DropdownMenu) components have broken toggle behavior in some browsers (notably Safari and Firefox on macOS). Making the root element of the `Dropdown` component focusable makes its current toggling logic work as intended.

Before this PR, I'd tried alternate approaches (#30397, #30786) that were not nearly as simple.

## Explainer
The intended behavior depends on testing that the focused element is inside of the dropdown component:
https://github.com/WordPress/gutenberg/blob/745399800a3e894016ab547127d90ef502d9b127/packages/components/src/dropdown/index.js#L68
The UAs in which the current logic fails do not focus buttons when pressed. Instead, focus goes to the closest focusable containing element and ends up outside of the component. The change here ensures that focus won't leave the component and thus the current logic will work.

## Extra
I threw in an extraneous but related change b67dbcf469d1c962da305e755a3c79ee7267ab7b to remove a workaround that had been made due to the buggy dropdown behavior.

## How has this been tested?
Manually in Chrome, Firefox and Safari on macOS. In the post editor and site editor, toggling all the dropdowns.

## Types of changes
Bug fix #29746

## Screenshots
Before: the broken toggling of various dropdowns in Safari on macOS.

https://user-images.githubusercontent.com/9000376/115271103-d53c6680-a0f1-11eb-997f-0fc677149c1b.mp4


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
