### PR TITLE
Updates relative block-support asset path

### DIFF
--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -51,7 +51,7 @@ android {
     sourceSets {
         main {
             assets.srcDirs += buildAssetsFolder
-            assets.srcDirs += '../../../../src/block-support'
+            assets.srcDirs += '../../../../../src/block-support'
             // Despite being in a folder called "resources", the files in
             // unsupported-block-editor are accessed as assets by their
             // consumers: the WordPressEditor library.


### PR DESCRIPTION
*Fixes:* https://github.com/wordpress-mobile/gutenberg-mobile/issues/3417

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3418
`WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/14528

## Description
During the composite build project, changes made here https://github.com/WordPress/gutenberg/pull/28216 caused the `supported-blocks` path to break (this issue is similar with https://github.com/wordpress-mobile/gutenberg-mobile/issues/3349). This PR updates the relative block-support asset path to handle this change. 

## How has this been tested?
1. Open the Android app (use a build from the [Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14528))
2. In the *My Site* screen tap the Fab (➕ ) button
3. Select *Site Page*
4. **Verify** that only layouts with supported blocks are returned (e.g. the first/blog category has only 3 layouts)

## Screenshots <!-- if applicable -->

## Types of changes
 Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
