### PR TITLE
Add e2e tests for Widgets Customizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13633,7 +13633,7 @@
 				"chalk": "^4.0.0",
 				"expect-puppeteer": "^4.4.0",
 				"lodash": "^4.17.19",
-				"puppeteer-testing-library": "^0.3.2",
+				"puppeteer-testing-library": "^0.4.0",
 				"uuid": "^8.3.0"
 			}
 		},
@@ -49666,9 +49666,9 @@
 			}
 		},
 		"puppeteer-testing-library": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/puppeteer-testing-library/-/puppeteer-testing-library-0.3.2.tgz",
-			"integrity": "sha512-XRW1HO8a8AQsRFlqiJ2tETvbSHROnJMFqu/7Yvk46VKaRMaF3pUdg6x029wCx+Y/hSbcqMZri7u0ZGljtvefkA==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-testing-library/-/puppeteer-testing-library-0.4.0.tgz",
+			"integrity": "sha512-7G2hZO/JbOgeZppEhh6jLP8J7y1cDExGZT2YtLAczgcDSXBWYz42aUGhVCUADU6BGj8ozp3vfiInWj/KrGUqIw==",
 			"dev": true,
 			"requires": {
 				"jest-diff": "^26.6.2"

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -31,7 +31,7 @@
 		"chalk": "^4.0.0",
 		"expect-puppeteer": "^4.4.0",
 		"lodash": "^4.17.19",
-		"puppeteer-testing-library": "^0.3.2",
+		"puppeteer-testing-library": "^0.4.0",
 		"uuid": "^8.3.0"
 	},
 	"peerDependencies": {

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -6,6 +6,8 @@ import {
 	activateTheme,
 	deactivatePlugin,
 	visitAdminPage,
+	showBlockToolbar,
+	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -181,6 +183,211 @@ describe( 'Widgets screen', () => {
 				root: frameContentDocument,
 			}
 		);
+	} );
+
+	it( 'should open the inspector panel', async () => {
+		const widgetsPanel = await find( {
+			role: 'heading',
+			name: /Widgets/,
+			level: 3,
+		} );
+		await widgetsPanel.click();
+
+		const footer1Section = await find( {
+			role: 'heading',
+			name: /Footer #1/,
+			level: 3,
+		} );
+		await footer1Section.click();
+
+		const emptyBlock = await find( {
+			role: 'button',
+			name: 'Add block',
+			value: 'Type / to choose a block',
+		} );
+		await emptyBlock.focus();
+
+		await page.keyboard.type( 'First Paragraph' );
+
+		await showBlockToolbar();
+		await clickBlockToolbarButton( 'Options' );
+		let showMoreSettingsButton = await find( {
+			role: 'menuitem',
+			name: 'Show more settings',
+		} );
+		await showMoreSettingsButton.click();
+
+		const backButton = await find( {
+			role: 'button',
+			name: 'Back',
+			focused: true,
+		} );
+		await expect( backButton ).toHaveFocus();
+
+		// Expect the inspector panel to be found.
+		let inspectorHeading = await find( {
+			role: 'heading',
+			name: 'Customizing ▸ Widgets ▸ Footer #1 Block Settings',
+			level: 3,
+		} );
+
+		// Expect the block title to be found.
+		await find( {
+			role: 'heading',
+			name: 'Paragraph',
+			level: 2,
+		} );
+
+		await backButton.click();
+
+		// Go back to the widgets editor.
+		await find( {
+			role: 'heading',
+			name: 'Customizing ▸ Widgets Footer #1',
+			level: 3,
+		} );
+
+		await expect( inspectorHeading ).not.toBeVisible();
+
+		await clickBlockToolbarButton( 'Options' );
+		showMoreSettingsButton = await find( {
+			role: 'menuitem',
+			name: 'Show more settings',
+		} );
+		await showMoreSettingsButton.click();
+
+		// Expect the inspector panel to be found.
+		inspectorHeading = await find( {
+			role: 'heading',
+			name: 'Customizing ▸ Widgets ▸ Footer #1 Block Settings',
+			level: 3,
+		} );
+
+		// Press Escape to close the inspector panel.
+		await page.keyboard.press( 'Escape' );
+
+		// Go back to the widgets editor.
+		await find( {
+			role: 'heading',
+			name: 'Customizing ▸ Widgets Footer #1',
+			level: 3,
+		} );
+
+		await expect( inspectorHeading ).not.toBeVisible();
+	} );
+
+	it( 'should handle the inserter outer section', async () => {
+		const widgetsPanel = await find( {
+			role: 'heading',
+			name: /Widgets/,
+			level: 3,
+		} );
+		await widgetsPanel.click();
+
+		const footer1Section = await find( {
+			role: 'heading',
+			name: /^Footer #1/,
+			level: 3,
+		} );
+		await footer1Section.click();
+
+		const emptyBlock = await find( {
+			role: 'button',
+			name: 'Add block',
+			value: 'Type / to choose a block',
+		} );
+		await emptyBlock.focus();
+
+		// We need to make some changes for the publish settings to appear.
+		await page.keyboard.type( 'First Paragraph' );
+
+		const documentTools = await find( {
+			role: 'toolbar',
+			name: 'Document tools',
+		} );
+
+		// Open the inserter outer section.
+		const addBlockButton = await find(
+			{
+				role: 'button',
+				name: 'Add block',
+			},
+			{ root: documentTools }
+		);
+		await addBlockButton.click();
+
+		// Expect the inserter outer section to be found.
+		await find( {
+			role: 'heading',
+			name: 'Add a block',
+			level: 2,
+		} );
+
+		// Expect to close the inserter outer section when pressing Escape.
+		await page.keyboard.press( 'Escape' );
+
+		// Open the inserter outer section again.
+		await addBlockButton.click();
+
+		// Expect the inserter outer section to be found again.
+		let inserterHeading = await find( {
+			role: 'heading',
+			name: 'Add a block',
+			level: 2,
+		} );
+
+		// Open the Publish Settings.
+		const publishSettingsButton = await find( {
+			role: 'button',
+			name: 'Publish Settings',
+		} );
+		await publishSettingsButton.click();
+
+		// Expect the Publish Settings outer section to be found.
+		const publishSettingsRadio = await find( {
+			role: 'radio',
+			name: 'Publish',
+		} );
+
+		// Expect the inserter outer section to be closed.
+		await expect( inserterHeading ).not.toBeVisible();
+
+		// Focus the block and start typing to hide the block toolbar.
+		// Shouldn't be needed if we automatically hide the toolbar on blur.
+		const paragraphBlock = await find( {
+			role: 'group',
+			name: 'Paragraph block',
+		} );
+		await paragraphBlock.focus();
+		await page.keyboard.type( ' ' );
+
+		// Open the inserter outer section.
+		await addBlockButton.click();
+
+		inserterHeading = await find( {
+			role: 'heading',
+			name: 'Add a block',
+			level: 2,
+		} );
+
+		// Expect the Publish Settings section to be closed.
+		expect( publishSettingsRadio ).not.toBeVisible();
+
+		// Back to the widget areas panel.
+		const backButton = await find( {
+			role: 'button',
+			name: 'Back',
+		} );
+		await backButton.click();
+
+		await find( {
+			role: 'heading',
+			name: /^Footer #1/,
+			level: 3,
+		} );
+
+		// Expect the inserter outer section to be closed.
+		expect( inserterHeading ).not.toBeVisible();
 	} );
 } );
 

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -106,9 +106,10 @@ describe( 'Widgets Customizer', () => {
 		} );
 		await inlineAddBlockButton.click();
 
-		const inlineInserterSearchBox = await page.waitForSelector(
-			'aria/Search for blocks and patterns[role="searchbox"]'
-		);
+		const inlineInserterSearchBox = await find( {
+			role: 'searchbox',
+			name: 'Search for blocks and patterns',
+		} );
 
 		await expect( inlineInserterSearchBox ).toHaveFocus();
 
@@ -136,18 +137,14 @@ describe( 'Widgets Customizer', () => {
 
 		await page.keyboard.type( 'My ' );
 
-		// TODO: It's the only reliable way for now to make sure the iframe is ready.
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitForTimeout( 3000 );
-
-		const sitePreviewIframe = await find( {
-			name: 'Site Preview',
-			selector: 'iframe',
-		} );
-		const contentFrame = await sitePreviewIframe.contentFrame();
-		const frameContentDocument = await contentFrame.evaluateHandle(
-			'document'
-		);
+		const findOptions = {
+			get root() {
+				return find( {
+					name: 'Site Preview',
+					selector: 'iframe',
+				} );
+			},
+		};
 
 		// Expect the paragraph to be found in the preview iframe.
 		await find(
@@ -155,9 +152,7 @@ describe( 'Widgets Customizer', () => {
 				text: 'First Paragraph',
 				selector: '.widget-content p',
 			},
-			{
-				root: frameContentDocument,
-			}
+			findOptions
 		);
 
 		// Expect the heading to be found in the preview iframe.
@@ -167,13 +162,18 @@ describe( 'Widgets Customizer', () => {
 				name: 'My Heading',
 				selector: '.widget-content *',
 			},
-			{
-				root: frameContentDocument,
-			}
+			findOptions
 		);
 
 		// Expect the search box to be found in the preview iframe.
-		await contentFrame.waitForSelector( 'input[type="search"]' );
+		await find(
+			{
+				role: 'searchbox',
+				name: 'My Search',
+				selector: '.widget-content *',
+			},
+			findOptions
+		);
 
 		expect( console ).toHaveWarned();
 	} );
@@ -339,7 +339,7 @@ describe( 'Widgets Customizer', () => {
 		await publishSettingsButton.click();
 
 		// Expect the Publish Settings outer section to be found.
-		const publishSettingsRadio = await find( {
+		const publishSettings = await find( {
 			selector: '#sub-accordion-section-publish_settings',
 		} );
 
@@ -365,7 +365,7 @@ describe( 'Widgets Customizer', () => {
 		} );
 
 		// Expect the Publish Settings section to be closed.
-		expect( publishSettingsRadio ).not.toBeVisible();
+		await expect( publishSettings ).not.toBeVisible();
 
 		// Back to the widget areas panel.
 		const backButton = await find( {
@@ -374,14 +374,12 @@ describe( 'Widgets Customizer', () => {
 		} );
 		await backButton.click();
 
-		await find( {
-			role: 'heading',
-			name: /^Footer #1/,
-			level: 3,
-		} );
-
 		// Expect the inserter outer section to be closed.
-		expect( inserterHeading ).not.toBeVisible();
+		await expect( {
+			role: 'heading',
+			name: 'Add a block',
+			level: 2,
+		} ).not.toBeFound();
 
 		expect( console ).toHaveWarned();
 	} );

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -174,6 +174,8 @@ describe( 'Widgets Customizer', () => {
 
 		// Expect the search box to be found in the preview iframe.
 		await contentFrame.waitForSelector( 'input[type="search"]' );
+
+		expect( console ).toHaveWarned();
 	} );
 
 	it( 'should open the inspector panel', async () => {
@@ -265,6 +267,8 @@ describe( 'Widgets Customizer', () => {
 		} );
 
 		await expect( inspectorHeading ).not.toBeVisible();
+
+		expect( console ).toHaveWarned();
 	} );
 
 	it( 'should handle the inserter outer section', async () => {
@@ -336,8 +340,7 @@ describe( 'Widgets Customizer', () => {
 
 		// Expect the Publish Settings outer section to be found.
 		const publishSettingsRadio = await find( {
-			role: 'radio',
-			name: 'Publish',
+			selector: '#sub-accordion-section-publish_settings',
 		} );
 
 		// Expect the inserter outer section to be closed.
@@ -379,6 +382,8 @@ describe( 'Widgets Customizer', () => {
 
 		// Expect the inserter outer section to be closed.
 		expect( inserterHeading ).not.toBeVisible();
+
+		expect( console ).toHaveWarned();
 	} );
 } );
 

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -18,6 +18,7 @@ import { find } from 'puppeteer-testing-library';
 
 describe( 'Widgets Customizer', () => {
 	beforeEach( async () => {
+		await cleanupWidgets();
 		await visitAdminPage( 'customize.php' );
 	} );
 
@@ -401,4 +402,26 @@ async function setWidgetsCustomizerExperiment( enabled ) {
 	} );
 
 	await Promise.all( [ submitButton.click(), page.waitForNavigation() ] );
+}
+
+/**
+ * TODO: Deleting widgets in the new widgets screen seems to be unreliable.
+ * We visit the old widgets screen to delete them.
+ * Refactor this to use real interactions in the new widgets screen once the bug is fixed.
+ */
+async function cleanupWidgets() {
+	await visitAdminPage( 'widgets.php' );
+
+	let widget = await page.$( '.widgets-sortables .widget' );
+
+	// We have to do this one-by-one since there might be race condition when deleting multiple widgets at once.
+	while ( widget ) {
+		const deleteButton = await widget.$( 'button.widget-control-remove' );
+		const id = await widget.evaluate( ( node ) => node.id );
+		await deleteButton.evaluate( ( node ) => node.click() );
+		// Wait for the widget to be removed from DOM.
+		await page.waitForSelector( `#${ id }`, { hidden: true } );
+
+		widget = await page.$( '.widgets-sortables .widget' );
+	}
 }

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -16,7 +16,7 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import { find } from 'puppeteer-testing-library';
 
-describe( 'Widgets screen', () => {
+describe( 'Widgets Customizer', () => {
 	beforeEach( async () => {
 		await visitAdminPage( 'customize.php' );
 	} );
@@ -105,10 +105,9 @@ describe( 'Widgets screen', () => {
 		} );
 		await inlineAddBlockButton.click();
 
-		const inlineInserterSearchBox = await find( {
-			role: 'searchbox',
-			name: 'Search for blocks and patterns',
-		} );
+		const inlineInserterSearchBox = await page.waitForSelector(
+			'aria/Search for blocks and patterns[role="searchbox"]'
+		);
 
 		await expect( inlineInserterSearchBox ).toHaveFocus();
 
@@ -173,16 +172,7 @@ describe( 'Widgets screen', () => {
 		);
 
 		// Expect the search box to be found in the preview iframe.
-		await find(
-			{
-				role: 'searchbox',
-				name: 'My Search',
-				selector: '.widget-content *',
-			},
-			{
-				root: frameContentDocument,
-			}
-		);
+		await contentFrame.waitForSelector( 'input[type="search"]' );
 	} );
 
 	it( 'should open the inspector panel', async () => {

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -147,35 +147,28 @@ describe( 'Widgets Customizer', () => {
 		};
 
 		// Expect the paragraph to be found in the preview iframe.
-		await find(
-			{
-				text: 'First Paragraph',
-				selector: '.widget-content p',
-			},
-			findOptions
-		);
+		await expect( {
+			text: 'First Paragraph',
+			selector: '.widget-content p',
+		} ).toBeFound( findOptions );
 
 		// Expect the heading to be found in the preview iframe.
-		await find(
-			{
-				role: 'heading',
-				name: 'My Heading',
-				selector: '.widget-content *',
-			},
-			findOptions
-		);
+		await expect( {
+			role: 'heading',
+			name: 'My Heading',
+			selector: '.widget-content *',
+		} ).toBeFound( findOptions );
 
 		// Expect the search box to be found in the preview iframe.
-		await find(
-			{
-				role: 'searchbox',
-				name: 'My Search',
-				selector: '.widget-content *',
-			},
-			findOptions
-		);
+		await expect( {
+			role: 'searchbox',
+			name: 'My Search',
+			selector: '.widget-content *',
+		} ).toBeFound( findOptions );
 
-		expect( console ).toHaveWarned();
+		expect( console ).toHaveWarned(
+			"The page delivered both an 'X-Frame-Options' header and a 'Content-Security-Policy' header with a 'frame-ancestors' directive. Although the 'X-Frame-Options' header alone would have blocked embedding, it has been ignored."
+		);
 	} );
 
 	it( 'should open the inspector panel', async () => {
@@ -225,11 +218,11 @@ describe( 'Widgets Customizer', () => {
 		} );
 
 		// Expect the block title to be found.
-		await find( {
+		await expect( {
 			role: 'heading',
 			name: 'Paragraph',
 			level: 2,
-		} );
+		} ).toBeFound();
 
 		await backButton.click();
 
@@ -260,15 +253,17 @@ describe( 'Widgets Customizer', () => {
 		await page.keyboard.press( 'Escape' );
 
 		// Go back to the widgets editor.
-		await find( {
+		await expect( {
 			role: 'heading',
 			name: 'Customizing ▸ Widgets Footer #1',
 			level: 3,
-		} );
+		} ).toBeFound();
 
 		await expect( inspectorHeading ).not.toBeVisible();
 
-		expect( console ).toHaveWarned();
+		expect( console ).toHaveWarned(
+			"The page delivered both an 'X-Frame-Options' header and a 'Content-Security-Policy' header with a 'frame-ancestors' directive. Although the 'X-Frame-Options' header alone would have blocked embedding, it has been ignored."
+		);
 	} );
 
 	it( 'should handle the inserter outer section', async () => {
@@ -312,11 +307,11 @@ describe( 'Widgets Customizer', () => {
 		await addBlockButton.click();
 
 		// Expect the inserter outer section to be found.
-		await find( {
+		await expect( {
 			role: 'heading',
 			name: 'Add a block',
 			level: 2,
-		} );
+		} ).toBeFound();
 
 		// Expect to close the inserter outer section when pressing Escape.
 		await page.keyboard.press( 'Escape' );
@@ -325,7 +320,7 @@ describe( 'Widgets Customizer', () => {
 		await addBlockButton.click();
 
 		// Expect the inserter outer section to be found again.
-		let inserterHeading = await find( {
+		const inserterHeading = await find( {
 			role: 'heading',
 			name: 'Add a block',
 			level: 2,
@@ -358,11 +353,11 @@ describe( 'Widgets Customizer', () => {
 		// Open the inserter outer section.
 		await addBlockButton.click();
 
-		inserterHeading = await find( {
+		await expect( {
 			role: 'heading',
 			name: 'Add a block',
 			level: 2,
-		} );
+		} ).toBeFound();
 
 		// Expect the Publish Settings section to be closed.
 		await expect( publishSettings ).not.toBeVisible();
@@ -381,7 +376,9 @@ describe( 'Widgets Customizer', () => {
 			level: 2,
 		} ).not.toBeFound();
 
-		expect( console ).toHaveWarned();
+		expect( console ).toHaveWarned(
+			"The page delivered both an 'X-Frame-Options' header and a 'Content-Security-Policy' header with a 'frame-ancestors' directive. Although the 'X-Frame-Options' header alone would have blocked embedding, it has been ignored."
+		);
 	} );
 } );
 

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -1,0 +1,207 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	activateTheme,
+	deactivatePlugin,
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
+
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import { find } from 'puppeteer-testing-library';
+
+describe( 'Widgets screen', () => {
+	beforeEach( async () => {
+		await visitAdminPage( 'customize.php' );
+	} );
+
+	beforeAll( async () => {
+		// TODO: Ideally we can bundle our test theme directly in the repo.
+		await activateTheme( 'twentytwenty' );
+		await deactivatePlugin(
+			'gutenberg-test-plugin-disables-the-css-animations'
+		);
+		await setWidgetsCustomizerExperiment( true );
+	} );
+
+	afterAll( async () => {
+		await activatePlugin(
+			'gutenberg-test-plugin-disables-the-css-animations'
+		);
+		await activateTheme( 'twentytwentyone' );
+		await setWidgetsCustomizerExperiment( false );
+	} );
+
+	it( 'should add blocks', async () => {
+		const widgetsPanel = await find( {
+			role: 'heading',
+			name: /Widgets/,
+			level: 3,
+		} );
+		await widgetsPanel.click();
+
+		const footer1Section = await find( {
+			role: 'heading',
+			name: /Footer #1/,
+			level: 3,
+		} );
+		await footer1Section.click();
+
+		const documentTools = await find( {
+			role: 'toolbar',
+			name: 'Document tools',
+		} );
+
+		const addBlockButton = await find(
+			{
+				role: 'button',
+				name: 'Add block',
+			},
+			{ root: documentTools }
+		);
+		await addBlockButton.click();
+
+		const paragraphOption = await find( {
+			role: 'option',
+			name: 'Paragraph',
+		} );
+		await paragraphOption.click();
+
+		const addedParagraphBlock = await find( {
+			role: 'group',
+			name: /^Empty block/,
+		} );
+		await addedParagraphBlock.focus();
+
+		await page.keyboard.type( 'First Paragraph' );
+
+		await addBlockButton.click();
+
+		const headingOption = await find( {
+			role: 'option',
+			name: 'Heading',
+		} );
+		await headingOption.click();
+
+		const addedHeadingBlock = await find( {
+			role: 'group',
+			name: 'Block: Heading',
+			level: 2,
+		} );
+		await addedHeadingBlock.focus();
+
+		await page.keyboard.type( 'My Heading' );
+
+		const inlineAddBlockButton = await find( {
+			role: 'combobox',
+			name: 'Add block',
+			haspopup: 'menu',
+		} );
+		await inlineAddBlockButton.click();
+
+		const inlineInserterSearchBox = await find( {
+			role: 'searchbox',
+			name: 'Search for blocks and patterns',
+		} );
+
+		await expect( inlineInserterSearchBox ).toHaveFocus();
+
+		await page.keyboard.type( 'Search' );
+
+		const searchOption = await find( {
+			role: 'option',
+			name: 'Search',
+		} );
+		await searchOption.click();
+
+		const addedSearchBlock = await find( {
+			role: 'group',
+			name: 'Block: Search',
+		} );
+
+		const searchTitle = await find(
+			{
+				role: 'textbox',
+				name: 'Label text',
+			},
+			{ root: addedSearchBlock }
+		);
+		await searchTitle.focus();
+
+		await page.keyboard.type( 'My ' );
+
+		// TODO: It's the only reliable way for now to make sure the iframe is ready.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitForTimeout( 3000 );
+
+		const sitePreviewIframe = await find( {
+			name: 'Site Preview',
+			selector: 'iframe',
+		} );
+		const contentFrame = await sitePreviewIframe.contentFrame();
+		const frameContentDocument = await contentFrame.evaluateHandle(
+			'document'
+		);
+
+		// Expect the paragraph to be found in the preview iframe.
+		await find(
+			{
+				text: 'First Paragraph',
+				selector: '.widget-content p',
+			},
+			{
+				root: frameContentDocument,
+			}
+		);
+
+		// Expect the heading to be found in the preview iframe.
+		await find(
+			{
+				role: 'heading',
+				name: 'My Heading',
+				selector: '.widget-content *',
+			},
+			{
+				root: frameContentDocument,
+			}
+		);
+
+		// Expect the search box to be found in the preview iframe.
+		await find(
+			{
+				role: 'searchbox',
+				name: 'My Search',
+				selector: '.widget-content *',
+			},
+			{
+				root: frameContentDocument,
+			}
+		);
+	} );
+} );
+
+async function setWidgetsCustomizerExperiment( enabled ) {
+	await visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
+
+	const checkbox = await find( {
+		role: 'checkbox',
+		name: 'Enable Widgets screen in Customizer',
+	} );
+
+	const snapshot = await page.accessibility.snapshot( { root: checkbox } );
+
+	if ( snapshot.checked !== enabled ) {
+		await checkbox.click();
+	}
+
+	const submitButton = await find( {
+		role: 'button',
+		name: 'Save Changes',
+	} );
+
+	await Promise.all( [ submitButton.click(), page.waitForNavigation() ] );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Close #30269. Add some basic e2e tests for Widgets Customizer.

This PR also updates `puppeteer-testing-library` to v0.4.0. The full [changelog](https://github.com/kevin940726/puppeteer-testing-library/compare/v0.3.2...v0.4.0) can be seen here.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
```sh
npm run test-e2e -- packages/e2e-tests/specs/experiments/customizing-widgets.test.js
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
