### PR TITLE
 Packages: Fix linting warnings for `core/editor` store

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -52,6 +52,7 @@ import {
 	textColor,
 } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -601,7 +602,7 @@ export default compose( [
 		const { getSettings, wasBlockJustInserted } = select(
 			blockEditorStore
 		);
-		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getEditedPostAttribute } = select( editorStore );
 		const {
 			attributes: { id, url },
 			isSelected,

--- a/packages/components/src/mobile/html-text-input/index.native.js
+++ b/packages/components/src/mobile/html-text-input/index.native.js
@@ -16,6 +16,7 @@ import {
 	compose,
 	withPreferredColorScheme,
 } from '@wordpress/compose';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -116,7 +117,7 @@ export class HTMLTextInput extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const { getEditedPostAttribute, getEditedPostContent } = select(
-			'core/editor'
+			editorStore
 		);
 
 		return {
@@ -125,7 +126,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { editPost, resetEditorBlocks } = dispatch( 'core/editor' );
+		const { editPost, resetEditorBlocks } = dispatch( editorStore );
 		return {
 			editTitle( title ) {
 				editPost( { title } );

--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -4,6 +4,7 @@
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Returns the Post's Edit URL.
@@ -98,7 +99,7 @@ export class BrowserURL extends Component {
 }
 
 export default withSelect( ( select ) => {
-	const { getCurrentPost, isSavingPost } = select( 'core/editor' );
+	const { getCurrentPost, isSavingPost } = select( editorStore );
 	const post = getCurrentPost();
 	let { id, status, type } = post;
 	const isTemplate = [ 'wp_template', 'wp_template_part' ].includes( type );

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Icon, MenuGroup } from '@wordpress/components';
-import { PostPreviewButton } from '@wordpress/editor';
+import { PostPreviewButton, store as editorStore } from '@wordpress/editor';
 import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { __experimentalPreviewOptions as PreviewOptions } from '@wordpress/block-editor';
@@ -23,7 +23,7 @@ export default function DevicePreview() {
 		( select ) => ( {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			isSaving: select( editPostStore ).isSavingMetaBoxes(),
-			isPostSaveable: select( 'core/editor' ).isEditedPostSaveable(),
+			isPostSaveable: select( editorStore ).isEditedPostSaveable(),
 			deviceType: select(
 				editPostStore
 			).__experimentalGetPreviewDeviceType(),

--- a/packages/edit-post/src/components/editor-initialization/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/listener-hooks.js
@@ -3,6 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -53,7 +54,7 @@ export const useBlockSelectionListener = ( postId ) => {
 export const useUpdatePostLinkListener = ( postId ) => {
 	const { newPermalink } = useSelect(
 		( select ) => ( {
-			newPermalink: select( 'core/editor' ).getCurrentPost().link,
+			newPermalink: select( editorStore ).getCurrentPost().link,
 		} ),
 		[ postId ]
 	);

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -11,6 +11,7 @@ import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { wordpress } from '@wordpress/icons';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -20,7 +21,7 @@ import { store as editPostStore } from '../../../store';
 function FullscreenModeClose( { showTooltip, icon, href } ) {
 	const { isActive, isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
 		( select ) => {
-			const { getCurrentPostType } = select( 'core/editor' );
+			const { getCurrentPostType } = select( editorStore );
 			const { isFeatureActive } = select( editPostStore );
 			const { isResolving } = select( 'core/data' );
 			const { getEntityRecord, getPostType } = select( 'core' );

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -20,6 +20,7 @@ import {
 	TableOfContents,
 	EditorHistoryRedo,
 	EditorHistoryUndo,
+	store as editorStore,
 } from '@wordpress/editor';
 import {
 	Button,
@@ -62,8 +63,7 @@ function HeaderToolbar() {
 			// This setting (richEditingEnabled) should not live in the block editor's setting.
 			isInserterEnabled:
 				select( editPostStore ).getEditorMode() === 'visual' &&
-				select( 'core/editor' ).getEditorSettings()
-					.richEditingEnabled &&
+				select( editorStore ).getEditorSettings().richEditingEnabled &&
 				hasInserterItems(
 					getBlockRootClientId( getBlockSelectionEnd() )
 				),

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -22,6 +22,7 @@ import {
 	undo as undoIcon,
 	redo as redoIcon,
 } from '@wordpress/icons';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -111,22 +112,22 @@ function HeaderToolbar( {
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		hasRedo: select( 'core/editor' ).hasEditorRedo(),
-		hasUndo: select( 'core/editor' ).hasEditorUndo(),
+		hasRedo: select( editorStore ).hasEditorRedo(),
+		hasUndo: select( editorStore ).hasEditorUndo(),
 		// This setting (richEditingEnabled) should not live in the block editor's setting.
 		showInserter:
 			select( editPostStore ).getEditorMode() === 'visual' &&
-			select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+			select( editorStore ).getEditorSettings().richEditingEnabled,
 		isTextModeEnabled: select( editPostStore ).getEditorMode() === 'text',
 		isRTL: select( blockEditorStore ).getSettings().isRTL,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { clearSelectedBlock } = dispatch( blockEditorStore );
-		const { togglePostTitleSelection } = dispatch( 'core/editor' );
+		const { togglePostTitleSelection } = dispatch( editorStore );
 
 		return {
-			redo: dispatch( 'core/editor' ).redo,
-			undo: dispatch( 'core/editor' ).undo,
+			redo: dispatch( editorStore ).redo,
+			undo: dispatch( editorStore ).undo,
 			onHideKeyboard() {
 				clearSelectedBlock();
 				togglePostTitleSelection( false );

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -38,9 +39,9 @@ function ModeSwitcher() {
 			shortcut: select(
 				keyboardShortcutsStore
 			).getShortcutRepresentation( 'core/edit-post/toggle-mode' ),
-			isRichEditingEnabled: select( 'core/editor' ).getEditorSettings()
+			isRichEditingEnabled: select( editorStore ).getEditorSettings()
 				.richEditingEnabled,
-			isCodeEditingEnabled: select( 'core/editor' ).getEditorSettings()
+			isCodeEditingEnabled: select( editorStore ).getEditorSettings()
 				.codeEditingEnabled,
 			mode: select( editPostStore ).getEditorMode(),
 		} ),

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { useViewportMatch, compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { PostPublishButton } from '@wordpress/editor';
+import { PostPublishButton, store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -84,20 +84,20 @@ export function PostPublishButtonOrToggle( {
 export default compose(
 	withSelect( ( select ) => ( {
 		hasPublishAction: get(
-			select( 'core/editor' ).getCurrentPost(),
+			select( editorStore ).getCurrentPost(),
 			[ '_links', 'wp:action-publish' ],
 			false
 		),
-		isBeingScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
-		isPending: select( 'core/editor' ).isCurrentPostPending(),
-		isPublished: select( 'core/editor' ).isCurrentPostPublished(),
+		isBeingScheduled: select( editorStore ).isEditedPostBeingScheduled(),
+		isPending: select( editorStore ).isCurrentPostPending(),
+		isPublished: select( editorStore ).isCurrentPostPublished(),
 		isPublishSidebarEnabled: select(
-			'core/editor'
+			editorStore
 		).isPublishSidebarEnabled(),
 		isPublishSidebarOpened: select(
 			editPostStore
 		).isPublishSidebarOpened(),
-		isScheduled: select( 'core/editor' ).isCurrentPostScheduled(),
+		isScheduled: select( editorStore ).isCurrentPostScheduled(),
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { togglePublishSidebar } = dispatch( editPostStore );

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -8,6 +8,7 @@ import {
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
 import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ function KeyboardShortcuts() {
 	const { getEditorMode, isEditorSidebarOpened } = useSelect( editPostStore );
 	const isModeToggleDisabled = useSelect( ( select ) => {
 		const { richEditingEnabled, codeEditingEnabled } = select(
-			'core/editor'
+			editorStore
 		).getEditorSettings();
 		return ! richEditingEnabled || ! codeEditingEnabled;
 	}, [] );

--- a/packages/edit-post/src/components/layout/actions-panel.js
+++ b/packages/edit-post/src/components/layout/actions-panel.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { EntitiesSavedStates, PostPublishPanel } from '@wordpress/editor';
+import {
+	EntitiesSavedStates,
+	PostPublishPanel,
+	store as editorStore,
+} from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, createSlotFill } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -38,7 +42,7 @@ export default function ActionsPanel( {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			isSavingMetaBoxes: select( editPostStore ).isSavingMetaBoxes(),
 			hasNonPostEntityChanges: select(
-				'core/editor'
+				editorStore
 			).hasNonPostEntityChanges(),
 		};
 	}, [] );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -12,6 +12,7 @@ import {
 	UnsavedChangesWarning,
 	EditorNotices,
 	EditorKeyboardShortcutsRegister,
+	store as editorStore,
 } from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
@@ -91,7 +92,7 @@ function Layout( { styles } ) {
 		hasReducedUI,
 		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
-		const editorSettings = select( 'core/editor' ).getEditorSettings();
+		const editorSettings = select( editorStore ).getEditorSettings();
 		return {
 			hasFixedToolbar: select( editPostStore ).isFeatureActive(
 				'fixedToolbar'

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -16,7 +16,7 @@ import {
 	KeyboardAvoidingView,
 	NoticeList,
 } from '@wordpress/components';
-import { AutosaveMonitor } from '@wordpress/editor';
+import { AutosaveMonitor, store as editorStore } from '@wordpress/editor';
 import { sendNativeEditorDidLayout } from '@wordpress/react-native-bridge';
 
 /**
@@ -163,7 +163,7 @@ class Layout extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const { __unstableIsEditorReady: isEditorReady } = select(
-			'core/editor'
+			editorStore
 		);
 		const { getEditorMode } = select( editPostStore );
 		return {

--- a/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
@@ -8,6 +8,7 @@ import { filter, map } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -48,7 +49,7 @@ export function MetaBoxesSection( {
 }
 
 export default withSelect( ( select ) => {
-	const { getEditorSettings } = select( 'core/editor' );
+	const { getEditorSettings } = select( editorStore );
 	const { getAllMetaBoxes } = select( editPostStore );
 
 	return {

--- a/packages/edit-post/src/components/preferences-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/options/enable-custom-fields.js
@@ -5,6 +5,7 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -58,6 +59,6 @@ export function EnableCustomFieldsOption( { label, areCustomFieldsEnabled } ) {
 }
 
 export default withSelect( ( select ) => ( {
-	areCustomFieldsEnabled: !! select( 'core/editor' ).getEditorSettings()
+	areCustomFieldsEnabled: !! select( editorStore ).getEditorSettings()
 		.enableCustomFields,
 } ) )( EnableCustomFieldsOption );

--- a/packages/edit-post/src/components/preferences-modal/options/enable-publish-sidebar.js
+++ b/packages/edit-post/src/components/preferences-modal/options/enable-publish-sidebar.js
@@ -4,6 +4,7 @@
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { ifViewportMatches } from '@wordpress/viewport';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -12,11 +13,11 @@ import BaseOption from './base';
 
 export default compose(
 	withSelect( ( select ) => ( {
-		isChecked: select( 'core/editor' ).isPublishSidebarEnabled(),
+		isChecked: select( editorStore ).isPublishSidebarEnabled(),
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { enablePublishSidebar, disablePublishSidebar } = dispatch(
-			'core/editor'
+			editorStore
 		);
 		return {
 			onChange: ( isEnabled ) =>

--- a/packages/edit-post/src/components/sidebar/featured-image/index.js
+++ b/packages/edit-post/src/components/sidebar/featured-image/index.js
@@ -8,7 +8,11 @@ import { get, partial } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { PostFeaturedImage, PostFeaturedImageCheck } from '@wordpress/editor';
+import {
+	PostFeaturedImage,
+	PostFeaturedImageCheck,
+	store as editorStore,
+} from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -45,7 +49,7 @@ function FeaturedImage( { isEnabled, isOpened, postType, onTogglePanel } ) {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getEditedPostAttribute } = select( editorStore );
 	const { getPostType } = select( 'core' );
 	const { isEditorPanelEnabled, isEditorPanelOpened } = select(
 		editPostStore

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -5,6 +5,7 @@ import { ComplementaryArea } from '@wordpress/interface';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -79,9 +80,7 @@ import { store as editPostStore } from '../../../store';
 export default function PluginSidebarEditPost( { className, ...props } ) {
 	const { postTitle, shortcut, showIconLabels } = useSelect( ( select ) => {
 		return {
-			postTitle: select( 'core/editor' ).getEditedPostAttribute(
-				'title'
-			),
+			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
 			shortcut: select(
 				keyboardShortcutsStore
 			).getShortcutRepresentation( 'core/edit-post/toggle-sidebar' ),

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, ifCondition, withState } from '@wordpress/compose';
-import { cleanForSlug } from '@wordpress/editor';
+import { cleanForSlug, store as editorStore } from '@wordpress/editor';
 import { safeDecodeURIComponent } from '@wordpress/url';
 
 /**
@@ -136,7 +136,7 @@ export default compose( [
 			getPermalinkParts,
 			getEditedPostAttribute,
 			getEditedPostSlug,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		const { isEditorPanelEnabled, isEditorPanelOpened } = select(
 			editPostStore
 		);
@@ -167,7 +167,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { toggleEditorPanelOpened } = dispatch( editPostStore );
-		const { editPost } = dispatch( 'core/editor' );
+		const { editPost } = dispatch( editorStore );
 		return {
 			onTogglePanel: () => toggleEditorPanelOpened( PANEL_NAME ),
 			editPermalink: ( newSlug ) => {

--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -4,6 +4,7 @@
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ const SettingsHeader = ( { sidebarName } ) => {
 	const openBlockSettings = () => openGeneralSidebar( 'edit-post/block' );
 
 	const { documentLabel, isTemplateMode } = useSelect( ( select ) => {
-		const currentPostType = select( 'core/editor' ).getCurrentPostType();
+		const currentPostType = select( editorStore ).getCurrentPostType();
 		const postType = select( 'core' ).getPostType( currentPostType );
 
 		return {

--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -5,6 +5,7 @@ import {
 	PostTextEditor,
 	PostTitle,
 	TextEditorGlobalKeyboardShortcuts,
+	store as editorStore,
 } from '@wordpress/editor';
 import { Button } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -43,7 +44,7 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 
 export default compose(
 	withSelect( ( select ) => ( {
-		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings()
+		isRichEditingEnabled: select( editorStore ).getEditorSettings()
 			.richEditingEnabled,
 	} ) ),
 	withDispatch( ( dispatch ) => {

--- a/packages/edit-post/src/components/visual-editor/header.native.js
+++ b/packages/edit-post/src/components/visual-editor/header.native.js
@@ -5,7 +5,7 @@ import { memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
-import { PostTitle } from '@wordpress/editor';
+import { PostTitle, store as editorStore } from '@wordpress/editor';
 import { ReadableContentView } from '@wordpress/components';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
@@ -44,14 +44,14 @@ const Header = memo(
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getEditedPostAttribute } = select( editorStore );
 
 		return {
 			title: getEditedPostAttribute( 'title' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { editPost } = dispatch( 'core/editor' );
+		const { editPost } = dispatch( editorStore );
 
 		const { clearSelectedBlock } = dispatch( blockEditorStore );
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -12,6 +12,7 @@ import {
 	EditorProvider,
 	ErrorBoundary,
 	PostLockedModal,
+	store as editorStore,
 } from '@wordpress/editor';
 import { StrictMode, useMemo } from '@wordpress/element';
 import { KeyboardShortcuts, SlotFillProvider } from '@wordpress/components';
@@ -57,7 +58,7 @@ function Editor( {
 		const { getEntityRecord, getPostType, getEntityRecords } = select(
 			'core'
 		);
-		const { getEditorSettings } = select( 'core/editor' );
+		const { getEditorSettings } = select( editorStore );
 		const { getBlockTypes } = select( blocksStore );
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			postType

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -13,6 +13,7 @@ import { controls, dispatch, select, subscribe } from '@wordpress/data';
 import { speak } from '@wordpress/a11y';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -272,17 +273,14 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 		metaBoxesPerLocation,
 	};
 
-	const postType = yield controls.select(
-		'core/editor',
-		'getCurrentPostType'
-	);
+	const postType = yield controls.select( editorStore, 'getCurrentPostType' );
 	if ( window.postboxes.page !== postType ) {
 		window.postboxes.add_postbox_toggles( postType );
 	}
 
-	let wasSavingPost = yield controls.select( 'core/editor', 'isSavingPost' );
+	let wasSavingPost = yield controls.select( editorStore, 'isSavingPost' );
 	let wasAutosavingPost = yield controls.select(
-		'core/editor',
+		editorStore,
 		'isAutosavingPost'
 	);
 
@@ -302,8 +300,8 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 
 	// Save metaboxes when performing a full save on the post.
 	saveMetaboxUnsubscribe = subscribe( () => {
-		const isSavingPost = select( 'core/editor' ).isSavingPost();
-		const isAutosavingPost = select( 'core/editor' ).isAutosavingPost();
+		const isSavingPost = select( editorStore ).isSavingPost();
+		const isAutosavingPost = select( editorStore ).isAutosavingPost();
 
 		// Save metaboxes on save completion, except for autosaves that are not a post preview.
 		const shouldTriggerMetaboxesSave =
@@ -339,7 +337,7 @@ export function* requestMetaBoxUpdates() {
 
 	// Additional data needed for backward compatibility.
 	// If we do not provide this data, the post will be overridden with the default values.
-	const post = yield controls.select( 'core/editor', 'getCurrentPost' );
+	const post = yield controls.select( editorStore, 'getCurrentPost' );
 	const additionalData = [
 		post.comment_status ? [ 'comment_status', post.comment_status ] : false,
 		post.ping_status ? [ 'ping_status', post.ping_status ] : false,
@@ -459,7 +457,7 @@ export function* __unstableSwitchToTemplateMode( template ) {
 			'wp_template',
 			template
 		);
-		const post = yield controls.select( 'core/editor', 'getCurrentPost' );
+		const post = yield controls.select( editorStore, 'getCurrentPost' );
 
 		yield controls.dispatch(
 			coreStore,

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
@@ -15,6 +15,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, plus } from '@wordpress/icons';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ export default function NewTemplateDropdown() {
 	const { defaultTemplateTypes, templates } = useSelect( ( select ) => {
 		const {
 			__experimentalGetDefaultTemplateTypes: getDefaultTemplateTypes,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		const templateEntities = select( 'core' ).getEntityRecords(
 			'postType',
 			'wp_template'

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/search-results.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/search-results.js
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { normalizedSearch } from './utils';
 import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import TemplateNavigationItem from './template-navigation-item';
 import ContentNavigationItem from './content-navigation-item';
 
@@ -37,7 +38,7 @@ export default function SearchResults( { items, search, disableFilter } ) {
 			if ( itemType === 'wp_template' ) {
 				const {
 					__experimentalGetTemplateInfo: getTemplateInfo,
-				} = select( 'core/editor' );
+				} = select( editorStore );
 
 				return items.map( ( item ) => ( {
 					slug: item.slug,

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -8,6 +8,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -20,7 +21,7 @@ export default function TemplateNavigationItem( { item } ) {
 	const { title, description } = useSelect(
 		( select ) =>
 			'wp_template' === item.type
-				? select( 'core/editor' ).__experimentalGetTemplateInfo( item )
+				? select( editorStore ).__experimentalGetTemplateInfo( item )
 				: {
 						title: item?.title?.rendered || item?.slug,
 						description: '',

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -8,6 +8,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ import { store as editSiteStore } from '../../store';
 export default function TemplateDetails( { template, onClose } ) {
 	const { title, description } = useSelect(
 		( select ) =>
-			select( 'core/editor' ).__experimentalGetTemplateInfo( template ),
+			select( editorStore ).__experimentalGetTemplateInfo( template ),
 		[]
 	);
 	const { openNavigationPanelToMenu, revertTemplate } = useDispatch(


### PR DESCRIPTION
## Description

Fixes linting errors for string literals (`core/editor`):

`warning  Do not use string literals ( 'core/editor' ) for accessing @wordpress/data stores. Pass the store definition instead`

See #27088

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
