### PR TITLE
Standardize block styles cursor on hover

### DIFF
--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -36,6 +36,10 @@
 			border: 2px solid $gray-900;
 		}
 	}
+
+	.block-editor-block-preview__container {
+		cursor: inherit;
+	}
 }
 
 // Show a little preview thumbnail for style variations.

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -33,7 +33,7 @@
 	// color doesn't show through.
 	background-color: $white;
 
-	cursor: text;
+	cursor: inherit;
 
 	> * {
 		cursor: auto;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -33,7 +33,7 @@
 	// color doesn't show through.
 	background-color: $white;
 
-	cursor: inherit;
+	cursor: text;
 
 	> * {
 		cursor: auto;


### PR DESCRIPTION
## Description
I have unified the cursor of the block styles when hovering. Previously, a text cursor was displayed no matter what content was in there. This leads to confusion in my opinion. Gutenberg also uses pointer cursor for several interactive elements.

## How has this been tested?
Builded the newest version of gutenberg with my changes and tested it in several browsers.

## Screenshots <!-- if applicable -->
Before:
<img width="498" alt="before" src="https://user-images.githubusercontent.com/52854338/116075163-e3aaf500-a692-11eb-8ea4-e17f6c9d3de8.png">

After:
<img width="376" alt="after" src="https://user-images.githubusercontent.com/52854338/116075179-e9a0d600-a692-11eb-9001-00a9a3435205.png">



## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
