### PR TITLE
Fix submenu hover issue.

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -70,11 +70,19 @@
 		}
 	}
 
+	// Some themes have added custom padding to the link, which does not consider the Page List block.
+	// Unfortunately we now need to add extra specificity and undo that, so that the block still works.
+	.wp-block-pages-list__item .wp-block-pages-list__item__link,
+	.wp-block-navigation-link .wp-block-navigation-link__content.wp-block-navigation-link__content.wp-block-navigation-link__content {
+		padding: 0;
+	}
+
 	// Styles for submenu flyout.
 	.has-child {
+		// This adds a little space between the link and the dropdown icon.
 		> .wp-block-pages-list__item__link,
 		> .wp-block-navigation-link__content {
-			padding-right: 0.5em;
+			margin-right: 0.5em;
 		}
 
 		.submenu-container,
@@ -223,9 +231,13 @@
 	// Spacing in all submenus.
 	.has-child .submenu-container,
 	.has-child .wp-block-navigation-link__container {
+		.wp-block-pages-list__item,
+		.wp-block-navigation-link {
+			margin: 0;
+		}
+
 		.wp-block-pages-list__item__link,
 		.wp-block-navigation-link__content {
-			margin: 0;
 			padding: 0.5em 1em;
 		}
 

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -214,17 +214,17 @@
 			margin: 0 0.5em 0 0;
 		}
 
-		.wp-block-page-list > .wp-block-pages-list__item,
-		.wp-block-navigation__container > .wp-block-navigation-link {
+		.wp-block-page-list .wp-block-pages-list__item__link,
+		.wp-block-navigation__container .wp-block-navigation-link__content {
 			padding: 0.5em 1em;
 		}
 	}
 
-	// Margins in all submenus.
+	// Spacing in all submenus.
 	.has-child .submenu-container,
 	.has-child .wp-block-navigation-link__container {
-		.wp-block-pages-list__item,
-		.wp-block-navigation-link {
+		.wp-block-pages-list__item__link,
+		.wp-block-navigation-link__content {
 			margin: 0;
 			padding: 0.5em 1em;
 		}
@@ -253,6 +253,7 @@
 		@include break-medium {
 			.submenu-container,
 			.wp-block-navigation-link__container {
+				left: 100%;
 				top: 0;
 			}
 		}

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -220,43 +220,39 @@
 		}
 	}
 
-	// Margins in submenus.
+	// Margins in all submenus.
 	.has-child .submenu-container,
 	.has-child .wp-block-navigation-link__container {
-		.wp-block-pages-list__item,
-		.wp-block-navigation-link {
-			margin: 0 0 1em 0;
-		}
-
-		// Submenu indentation.
-		left: -1em;
-		top: calc(100% + 1em);
-
-		@include break-medium {
-			.submenu-container,
-			.wp-block-navigation-link__container {
-				left: calc(100% + 1em);
-				top: calc(-1px - 1em);
-			}
-		}
-	}
-
-	&.has-background .has-child .submenu-container,
-	&.has-background .has-child .wp-block-navigation-link__container {
 		.wp-block-pages-list__item,
 		.wp-block-navigation-link {
 			margin: 0;
 			padding: 0.5em 1em;
 		}
 
-		// Submenu indentation.
-		left: 0;
+		// Submenu indentation when there's no background.
+		left: -1em;
 		top: 100%;
 
+		// Indentation for all submenus.
 		@include break-medium {
 			.submenu-container,
 			.wp-block-navigation-link__container {
 				left: 100%;
+				top: -1px; // Border width.
+			}
+		}
+	}
+
+	// Submenu indentation when there's a background.
+	&.has-background .has-child .submenu-container,
+	&.has-background .has-child .wp-block-navigation-link__container {
+		left: 0;
+		top: 100%;
+
+		// There's no border on submenus when there are backgrounds.
+		@include break-medium {
+			.submenu-container,
+			.wp-block-navigation-link__container {
 				top: 0;
 			}
 		}
@@ -274,8 +270,5 @@
 		background-color: #fff;
 		color: #000;
 		border: 1px solid rgba(0, 0, 0, 0.15);
-
-		// Add some padding to menus even if the parent menu item doesn't have.
-		padding: 1em;
 	}
 }

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -191,7 +191,7 @@
 
 // Margins, paddings, and submenu positions.
 // These need extra specificity to override potentially inherited properties.
-.wp-block.wp-block-navigation {
+.wp-block-navigation.wp-block-navigation {
 
 	// Menu items with no background.
 	.wp-block-page-list,


### PR DESCRIPTION
## Description

This is a small followup to #30805, which refactored navigation menu margins and paddings. Turned out that margins weren't a good choice for submenu items:

![before](https://user-images.githubusercontent.com/1204802/116092086-cc293780-a6a5-11eb-8e92-79393ea2d967.gif)

This PR realizes that mistake, and that submenus since they're already inside a box, can be spaced with paddings instead of margins, and look the same, and so it does just that, also fixing the hover issue:

![after](https://user-images.githubusercontent.com/1204802/116092165-dc411700-a6a5-11eb-949d-4dc81da3be70.gif)


## How has this been tested?

Test a navigation menu with no background, then hover submenus.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
