### PR TITLE
Try: Blue parents.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -266,7 +266,7 @@
 			left: $border-width;
 			right: $border-width;
 			bottom: $border-width;
-			box-shadow: 0 0 0 $border-width $gray-900;
+			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 		}
 	}
@@ -275,7 +275,7 @@
 		cursor: unset;
 
 		&::after {
-			box-shadow: 0 0 0 $border-width $gray-900; // Selected not focussed
+			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color); // Selected not focussed.
 			top: $border-width;
 			left: $border-width;
 			right: $border-width;

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -42,7 +42,7 @@
 
 	.wp-block-template-part__selection-preview-item-title {
 		padding: $grid-unit-05;
-		font-size: 12px;
+		font-size: $helptext-font-size;
 		text-align: left;
 	}
 
@@ -66,7 +66,7 @@
 .block-editor-block-list__block[data-type="core/template-part"] {
 	&.has-child-selected {
 		&::after {
-			border: $border-width dotted $gray-900;
+			border: $border-width dotted var(--wp-admin-theme-color);
 		}
 
 		&.is-hovered,


### PR DESCRIPTION
## Description

Borders in the site editor are black when unfocused:

![before](https://user-images.githubusercontent.com/1204802/116093222-cb44d580-a6a6-11eb-87df-f9b67a26605e.gif)

While intentional, in practice it has felt less interactive, and more like the border could be part of the webdesign rather than the block UI.

This PR makes them blue, including ancestor borders, making it feel more interactive:

![after](https://user-images.githubusercontent.com/1204802/116093356-e0b9ff80-a6a6-11eb-87a7-ba29cdbe14d6.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
