### PR TITLE
Navigation Screen: warn the user about unsaved changes

### DIFF
--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -40,6 +40,7 @@ import Header from '../header';
 import Notices from '../notices';
 import Editor from '../editor';
 import InspectorAdditions from '../inspector-additions';
+import UnsavedChangesWarning from './unsaved-changes-warning';
 import { store as editNavigationStore } from '../../store';
 
 const interfaceLabels = {
@@ -206,6 +207,7 @@ export default function Layout( { blockEditorSettings } ) {
 						/>
 						<Sidebar hasPermanentSidebar={ hasPermanentSidebar } />
 					</IsMenuNameControlFocusedContext.Provider>
+					<UnsavedChangesWarning />
 				</BlockEditorProvider>
 				<Popover.Slot />
 			</SlotFillProvider>

--- a/packages/edit-navigation/src/components/layout/unsaved-changes-warning.js
+++ b/packages/edit-navigation/src/components/layout/unsaved-changes-warning.js
@@ -15,12 +15,10 @@ import { store as coreStore } from '@wordpress/core-data';
  * @return {WPComponent} The component.
  */
 export default function UnsavedChangesWarning() {
-	const getIsDirty = useSelect( ( select ) => {
-		return () => {
-			const { __experimentalGetDirtyEntityRecords } = select( coreStore );
-			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-			return dirtyEntityRecords.length > 0;
-		};
+	const isDirty = useSelect( ( select ) => {
+		const { __experimentalGetDirtyEntityRecords } = select( coreStore );
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+		return dirtyEntityRecords.length > 0;
 	}, [] );
 
 	useEffect( () => {
@@ -32,11 +30,7 @@ export default function UnsavedChangesWarning() {
 		 * @return {?string} Warning prompt message, if unsaved changes exist.
 		 */
 		const warnIfUnsavedChanges = ( event ) => {
-			// We need to call the selector directly in the listener to avoid race
-			// conditions with `BrowserURL` where `componentDidUpdate` gets the
-			// new value of `isEditedPostDirty` before this component does,
-			// causing this component to incorrectly think a trashed post is still dirty.
-			if ( getIsDirty() ) {
+			if ( isDirty ) {
 				event.returnValue = __(
 					'You have unsaved changes. If you proceed, they will be lost.'
 				);
@@ -49,7 +43,7 @@ export default function UnsavedChangesWarning() {
 		return () => {
 			window.removeEventListener( 'beforeunload', warnIfUnsavedChanges );
 		};
-	}, [ getIsDirty ] );
+	}, [ isDirty ] );
 
 	return null;
 }

--- a/packages/edit-navigation/src/components/layout/unsaved-changes-warning.js
+++ b/packages/edit-navigation/src/components/layout/unsaved-changes-warning.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Warns the user if there are unsaved changes before leaving the editor.
+ *
+ * This is a duplicate of the component implemented in the editor package.
+ * Duplicated here as edit-navigation doesn't depend on editor.
+ *
+ * @return {WPComponent} The component.
+ */
+export default function UnsavedChangesWarning() {
+	const getIsDirty = useSelect( ( select ) => {
+		return () => {
+			const { __experimentalGetDirtyEntityRecords } = select( coreStore );
+			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+			return dirtyEntityRecords.length > 0;
+		};
+	}, [] );
+
+	useEffect( () => {
+		/**
+		 * Warns the user if there are unsaved changes before leaving the editor.
+		 *
+		 * @param {Event} event `beforeunload` event.
+		 *
+		 * @return {?string} Warning prompt message, if unsaved changes exist.
+		 */
+		const warnIfUnsavedChanges = ( event ) => {
+			// We need to call the selector directly in the listener to avoid race
+			// conditions with `BrowserURL` where `componentDidUpdate` gets the
+			// new value of `isEditedPostDirty` before this component does,
+			// causing this component to incorrectly think a trashed post is still dirty.
+			if ( getIsDirty() ) {
+				event.returnValue = __(
+					'You have unsaved changes. If you proceed, they will be lost.'
+				);
+				return event.returnValue;
+			}
+		};
+
+		window.addEventListener( 'beforeunload', warnIfUnsavedChanges );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', warnIfUnsavedChanges );
+		};
+	}, [ getIsDirty ] );
+
+	return null;
+}


### PR DESCRIPTION
## Description
Adds warning for users that they will lose unsaved data when navigating away.

See #30322.
Closes #30423.

## How has this been tested?
1. Got to the experimental navigation screen.
2. Change menu name.
3. New warning prompt should appear when navigating away without saving changes.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/240569/116092388-d273df80-a6b6-11eb-94f6-b2a0d2b01199.mp4

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
