### PR TITLE
Nav block: Fix onselect jump

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -165,19 +165,18 @@ $color-control-label-height: 20px;
  * Setup state
  */
 
-// Ensure that an empty block has space around the appender.
-.wp-block-navigation-placeholder,
-.wp-block-navigation-placeholder__preview {
-	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
-}
-
 // Output a zero width space before the appender, so the appender is the same height as a default menu item.
-.wp-block-navigation:not(.is-vertical) .block-list-appender {
-	display: flex;
-	align-items: center;
+// Doing the same for the horizontal placeholder preview accomplishes the same.
+.wp-block-navigation:not(.is-vertical) {
+	.wp-block-navigation-placeholder,
+	.wp-block-navigation-placeholder__preview,
+	.block-list-appender {
+		display: flex;
+		align-items: center;
 
-	&::before {
-		content: "\200B";
+		&::before {
+			content: "\200B";
+		}
 	}
 }
 
@@ -204,7 +203,7 @@ $color-control-label-height: 20px;
 		background: currentColor;
 		min-width: 72px;
 		height: $grid-unit-20;
-		margin: $grid-unit-15 $grid-unit-30 $grid-unit-15 0;
+		margin: auto $grid-unit-30 auto 0;
 	}
 
 	svg {
@@ -219,13 +218,7 @@ $color-control-label-height: 20px;
 	.is-selected & {
 		// Don't show the preview boxes for an empty nav block.
 		opacity: 0;
-
-		// Need to show the placeholder box above the preview boxes.
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
+		width: 0;
 	}
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -171,6 +171,16 @@ $color-control-label-height: 20px;
 	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
 }
 
+// Output a zero width space before the appender, so the appender is the same height as a default menu item.
+.wp-block-navigation:not(.is-vertical) .block-list-appender {
+	display: flex;
+	align-items: center;
+
+	&::before {
+		content: "\200B";
+	}
+}
+
 // Spinner.
 .wp-block-navigation-placeholder .components-spinner {
 	margin-top: -4px;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -167,8 +167,7 @@ $color-control-label-height: 20px;
 
 // Ensure that an empty block has space around the appender.
 .wp-block-navigation-placeholder,
-.wp-block-navigation-placeholder__preview,
-.is-selected .wp-block-navigation__container {
+.wp-block-navigation-placeholder__preview {
 	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
 }
 


### PR DESCRIPTION
## Description

The nav block had a min height on select, which caused a jump:

![before](https://user-images.githubusercontent.com/1204802/116094301-b74da380-a6a7-11eb-8c7e-971c53b96295.gif)

This PR fixes that:

![after](https://user-images.githubusercontent.com/1204802/116094316-b9affd80-a6a7-11eb-90a7-2f97ccf3820f.gif)

Why was it there? Well, the placeholder state needs it to not collapse. But it doesn't need it in the configured state:

![before after](https://user-images.githubusercontent.com/1204802/116094420-ce8c9100-a6a7-11eb-8aa3-1cdb27410699.gif)


## How has this been tested?

Test a navigation block, both empty and populated, horizontal, check that it looks good.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
