### PR TITLE
E2E testing: Use JSON serialization for getAllBlocks

### DIFF
--- a/packages/e2e-test-utils/src/get-all-blocks.js
+++ b/packages/e2e-test-utils/src/get-all-blocks.js
@@ -6,6 +6,16 @@
 export async function getAllBlocks() {
 	return page.evaluate( () => {
 		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+		/**
+		 * We are turning the result into a JSON object and back, to turn all the non-serializable
+		 * values into `null`.
+		 *
+		 * `page.evaluate` returns `undefined` if it encounters a non-serializable value.
+		 * To avoid returning `undefined`, we turn the result into a JSON string and back,
+		 * which results in a serializable value every time.
+		 *
+		 * For more information see: https://github.com/WordPress/gutenberg/pull/31199
+		 */
 		return JSON.parse( JSON.stringify( blocks ) );
 	} );
 }

--- a/packages/e2e-test-utils/src/get-all-blocks.js
+++ b/packages/e2e-test-utils/src/get-all-blocks.js
@@ -1,13 +1,11 @@
 /**
- * Internal dependencies
- */
-import { wpDataSelect } from './wp-data-select';
-
-/**
  * Returns an array with all blocks; Equivalent to calling wp.data.select( 'core/block-editor' ).getBlocks();
  *
  * @return {Promise} Promise resolving with an array containing all blocks in the document.
  */
 export async function getAllBlocks() {
-	return wpDataSelect( 'core/block-editor', 'getBlocks' );
+	return page.evaluate( () => {
+		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+		return JSON.parse( JSON.stringify( blocks ) );
+	} );
 }

--- a/packages/e2e-test-utils/src/wp-data-select.js
+++ b/packages/e2e-test-utils/src/wp-data-select.js
@@ -10,10 +10,9 @@
 export async function wpDataSelect( store, selector, ...parameters ) {
 	return page.evaluate(
 		( _store, _selector, ..._parameters ) => {
-			const data = window.wp.data
+			return window.wp.data
 				.select( _store )
 				[ _selector ]( ..._parameters );
-			return JSON.parse( JSON.stringify( data ) );
 		},
 		store,
 		selector,

--- a/packages/e2e-test-utils/src/wp-data-select.js
+++ b/packages/e2e-test-utils/src/wp-data-select.js
@@ -10,9 +10,10 @@
 export async function wpDataSelect( store, selector, ...parameters ) {
 	return page.evaluate(
 		( _store, _selector, ..._parameters ) => {
-			return window.wp.data
+			const data = window.wp.data
 				.select( _store )
 				[ _selector ]( ..._parameters );
+			return JSON.parse( JSON.stringify( data ) );
 		},
 		store,
 		selector,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
`page.evaluate` used in `wpDataSelect`, returns `undefined` when we return a non-serializable value from the evaluation. Non-serializable values are `function`, `DOM element` etc.

**Reference:**
https://pptr.dev/#?product=Puppeteer&version=v9.0.0&show=api-pageevaluatepagefunction-args
> If the function passed to the page.evaluate returns a non-Serializable value, then page.evaluate resolves to undefined. DevTools Protocol also supports transferring some additional values that are not serializable by JSON: -0, NaN, Infinity, -Infinity, and bigint literals.

For a real world example, we store `validationIssues` in the `block-editor` store for each block. When we have a validation issue, we store the ref and owner (DOM element handles). Those are non-serializable so the evaluation returns with `undefined`. Which is causing the tests to fail.

As a fix, we turn the result into a JSON string, then we parse it. JSON replaces all unserializable values with `null`, so the evaluation can return safely.

**Reference:**
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
> undefined, Functions, and Symbols are not valid JSON values. If any such values are encountered during conversion they are either omitted (when found in an object) or changed to null (when found in an array). JSON.stringify() can return undefined when passing in "pure" values like JSON.stringify(function(){}) or JSON.stringify(undefined).

This PR ensures we are returning an object that is serializable by Puppeteer.

## How has this been tested?
Tests are passing

## Types of changes
E2E tests consistency

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
