### PR TITLE
Add Dropdown feature and fix/replace ad hoc dropdowns

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { useState } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
 import {
 	AlignmentControl,
@@ -16,9 +16,10 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import {
+	Dropdown,
+	ToolbarGroup,
 	ToolbarButton,
 	ToggleControl,
-	Popover,
 	DateTimePicker,
 	PanelBody,
 	CustomSelectControl,
@@ -37,7 +38,6 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 		'date',
 		postId
 	);
-	const [ isPickerOpen, setIsPickerOpen ] = useState( false );
 	const settings = __experimentalGetSettings();
 	// To know if the current time format is a 12 hour time, look for "a".
 	// Also make sure this "a" is not escaped by a "/".
@@ -62,18 +62,11 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 		} ),
 	} );
 
+	const timeRef = useRef();
+
 	let postDate = date ? (
-		<time dateTime={ dateI18n( 'c', date ) }>
+		<time dateTime={ dateI18n( 'c', date ) } ref={ timeRef }>
 			{ dateI18n( resolvedFormat, date ) }
-			{ isPickerOpen && (
-				<Popover onClose={ setIsPickerOpen.bind( null, false ) }>
-					<DateTimePicker
-						currentDate={ date }
-						onChange={ setDate }
-						is12Hour={ is12Hour }
-					/>
-				</Popover>
-			) }
 		</time>
 	) : (
 		__( 'No Date' )
@@ -99,15 +92,26 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 				/>
 
 				{ date && (
-					<ToolbarButton
-						icon={ edit }
-						title={ __( 'Change Date' ) }
-						onClick={ () =>
-							setIsPickerOpen(
-								( _isPickerOpen ) => ! _isPickerOpen
-							)
-						}
-					/>
+					<ToolbarGroup>
+						<Dropdown
+							popoverProps={ { anchorRef: timeRef.current } }
+							renderContent={ () => (
+								<DateTimePicker
+									currentDate={ date }
+									onChange={ setDate }
+									is12Hour={ is12Hour }
+								/>
+							) }
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<ToolbarButton
+									aria-expanded={ isOpen }
+									icon={ edit }
+									title={ __( 'Change Date' ) }
+									onClick={ onToggle }
+								/>
+							) }
+						/>
+					</ToolbarGroup>
 				) }
 			</BlockControls>
 

--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -8,7 +8,7 @@ import { isEmpty, kebabCase } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { edit, close, chevronDown, chevronUp, plus } from '@wordpress/icons';
 
 /**
@@ -20,15 +20,6 @@ import ColorPicker from '../color-picker';
 import Button from '../button';
 import TextControl from '../text-control';
 import BaseControl from '../base-control';
-
-function DropdownOpenOnMount( { shouldOpen, isOpen, onToggle } ) {
-	useEffect( () => {
-		if ( shouldOpen && ! isOpen ) {
-			onToggle();
-		}
-	}, [] );
-	return null;
-}
 
 function ColorOption( {
 	color,
@@ -77,21 +68,15 @@ function ColorOption( {
 		>
 			<div className="components-color-edit__color-option-main-area">
 				<Dropdown
+					openOnMount={ isEditingColorOnMount }
 					renderToggle={ ( { isOpen, onToggle } ) => (
-						<>
-							<DropdownOpenOnMount
-								shouldOpen={ isEditingColorOnMount }
-								isOpen={ isOpen }
-								onToggle={ onToggle }
-							/>
-							<CircularOptionPicker.Option
-								style={ { backgroundColor: color, color } }
-								aria-expanded={ isOpen }
-								aria-haspopup="true"
-								onClick={ onToggle }
-								aria-label={ __( 'Edit color value' ) }
-							/>
-						</>
+						<CircularOptionPicker.Option
+							style={ { backgroundColor: color, color } }
+							aria-expanded={ isOpen }
+							aria-haspopup="true"
+							onClick={ onToggle }
+							aria-label={ __( 'Edit color value' ) }
+						/>
 					) }
 					renderContent={ () => (
 						<ColorPicker

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -27,20 +27,21 @@ function useObservableState( initialState, onStateChange ) {
 }
 
 export default function Dropdown( {
-	renderContent,
-	renderToggle,
-	position = 'bottom right',
 	className,
 	contentClassName,
 	expandOnMobile,
-	headerTitle,
 	focusOnMount,
-	popoverProps,
+	headerTitle,
 	onClose,
 	onToggle,
+	openOnMount = false,
+	popoverProps,
+	position = 'bottom right',
+	renderContent,
+	renderToggle,
 } ) {
 	const containerRef = useRef();
-	const [ isOpen, setIsOpen ] = useObservableState( false, onToggle );
+	const [ isOpen, setIsOpen ] = useObservableState( openOnMount, onToggle );
 
 	useEffect(
 		() => () => {

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -6,7 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useState } from '@wordpress/element';
+import {
+	forwardRef,
+	useImperativeHandle,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -26,20 +32,23 @@ function useObservableState( initialState, onStateChange ) {
 	];
 }
 
-export default function Dropdown( {
-	className,
-	contentClassName,
-	expandOnMobile,
-	focusOnMount,
-	headerTitle,
-	onClose,
-	onToggle,
-	openOnMount = false,
-	popoverProps,
-	position = 'bottom right',
-	renderContent,
-	renderToggle,
-} ) {
+function Dropdown(
+	{
+		className,
+		contentClassName,
+		expandOnMobile,
+		focusOnMount,
+		headerTitle,
+		onClose,
+		onToggle,
+		openOnMount = false,
+		popoverProps,
+		position = 'bottom right',
+		renderContent,
+		renderToggle,
+	},
+	ref
+) {
 	const containerRef = useRef();
 	const [ isOpen, setIsOpen ] = useObservableState( openOnMount, onToggle );
 
@@ -82,6 +91,8 @@ export default function Dropdown( {
 
 	const args = { isOpen, onToggle: toggle, onClose: close };
 
+	useImperativeHandle( ref, () => ( { toggle, close } ), [] );
+
 	return (
 		<div
 			className={ classnames( 'components-dropdown', className ) }
@@ -112,3 +123,5 @@ export default function Dropdown( {
 		</div>
 	);
 }
+
+export default forwardRef( Dropdown );


### PR DESCRIPTION
`openOnMount` is a new prop/feature added to `Dropdown`. There is an existing use case for this to replace the clever solution here:
https://github.com/WordPress/gutenberg/blob/a8b9dc2025a3022ef56a972fa51e55ee6812b121/packages/components/src/color-edit/index.js#L82-L86 
Replacing that is included in this PR.

More constructively, adding the new prop makes it possible to refactor a few dropdown-like components in order to fix their broken toggle closing behavior. Doing so in the Button and PostDate blocks is included in this PR. (Though, the latter doesn't need the new prop). Another dropdown-like candidate for such a refactor is in the NavigationLink block but with its complexity, it's better done in a separate PR.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
