### PR TITLE
Fix preset class specificity in site editor

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -71,7 +71,7 @@ function getBlockPresetClasses( blockSelector, blockPresets = {} ) {
 					const value = preset[ valueKey ];
 					const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;
 					const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
-					declarations += `${ selectorToUse } {${ propertyName }: ${ value };}`;
+					declarations += `${ selectorToUse }{${ propertyName }: ${ value } !important;}`;
 				} );
 			} );
 			return declarations;


### PR DESCRIPTION
We missed the site editor when implementing https://github.com/WordPress/gutenberg/pull/29533