### PR TITLE
components: Remove wp-g2 imports from visually-hidden

### DIFF
--- a/packages/components/src/ui/visually-hidden/styles.js
+++ b/packages/components/src/ui/visually-hidden/styles.js
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { css, ui } from '@wp-g2/styles';
+import { css } from 'emotion';
+/**
+ * Internal dependencies
+ */
+import { COLORS } from '../../utils/colors-values';
 
 export const VisuallyHidden = css`
 	border: 0;
@@ -17,7 +21,7 @@ export const VisuallyHidden = css`
 	word-wrap: normal !important;
 
 	&:focus {
-		background-color: ${ ui.get( 'lightGray300' ) };
+		background-color: ${ COLORS.lightGray[ '300' ] };
 		clip: auto !important;
 		clip-path: none;
 		color: #444;

--- a/packages/components/src/ui/visually-hidden/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/visually-hidden/test/__snapshots__/index.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`VisuallyHidden should render correctly 1`] = `
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+.emotion-0 {
   border: 0;
   -webkit-clip: rect( 1px,1px,1px,1px );
   clip: rect( 1px,1px,1px,1px );
@@ -17,9 +17,8 @@ exports[`VisuallyHidden should render correctly 1`] = `
   word-wrap: normal !important;
 }
 
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
+.emotion-0:focus {
   background-color: #edeff0;
-  background-color: var(--wp-g2-light-gray-300);
   -webkit-clip: auto !important;
   clip: auto !important;
   -webkit-clip-path: none;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Does what it says on the tin, removes wp-g2 imports from VisuallyHidden. Simple as that.

## How has this been tested?
In storybook, visually hidden should continue to work as expected.

## Types of changes
Non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
