### PR TITLE
Set order of Widgets submenu item

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -36,7 +36,8 @@ function gutenberg_menu() {
 			__( 'Widgets', 'gutenberg' ),
 			'edit_theme_options',
 			'gutenberg-widgets',
-			'the_gutenberg_widgets'
+			'the_gutenberg_widgets',
+			2
 		);
 		remove_submenu_page( 'themes.php', 'widgets.php' );
 	}


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/26245.

The Widgets link should appear after Customize. A position of 2 does this.

| Before | After |
| - | - |
| <img width="168" alt="Screen Shot 2021-04-27 at 13 34 20" src="https://user-images.githubusercontent.com/612155/116181102-5d0f1a00-a75d-11eb-8d93-59f75345db9d.png"> | <img width="168" alt="Screen Shot 2021-04-27 at 13 34 10" src="https://user-images.githubusercontent.com/612155/116181103-5e404700-a75d-11eb-86ee-b712ed68f433.png"> |

## How has this been tested?

1. Open the Appearance tab.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->