### PR TITLE
Legacy Widget: Add 'Convert to blocks' button for text widgets

### DIFF
--- a/packages/block-library/src/legacy-widget/edit/convert-to-blocks-button.js
+++ b/packages/block-library/src/legacy-widget/edit/convert-to-blocks-button.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { ToolbarButton } from '@wordpress/components';
+import { createBlock, rawHandler } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+export default function ConvertToBlocksButton( { clientId, rawInstance } ) {
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+
+	return (
+		<ToolbarButton
+			onClick={ () => {
+				if ( rawInstance.title ) {
+					replaceBlocks( clientId, [
+						createBlock( 'core/heading', {
+							content: rawInstance.title,
+						} ),
+						...rawHandler( { HTML: rawInstance.text } ),
+					] );
+				} else {
+					replaceBlocks(
+						clientId,
+						rawHandler( { HTML: rawInstance.text } )
+					);
+				}
+			} }
+		>
+			{ __( 'Convert to blocks' ) }
+		</ToolbarButton>
+	);
+}

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -25,6 +25,7 @@ import Form from './form';
 import Preview from './preview';
 import NoPreview from './no-preview';
 import useForm from './use-form';
+import ConvertToBlocksButton from './convert-to-blocks-button';
 
 export default function Edit( props ) {
 	const { id, idBase } = props.attributes;
@@ -76,6 +77,7 @@ function Empty( { attributes: { id, idBase }, setAttributes } ) {
 function NotEmpty( {
 	attributes: { id, idBase, instance },
 	setAttributes,
+	clientId,
 	isSelected,
 } ) {
 	const {
@@ -147,6 +149,15 @@ function NotEmpty( {
 								instance: null,
 							} )
 						}
+					/>
+				</BlockControls>
+			) }
+
+			{ idBase === 'text' && (
+				<BlockControls group="other">
+					<ConvertToBlocksButton
+						clientId={ clientId }
+						rawInstance={ instance.raw }
 					/>
 				</BlockControls>
 			) }


### PR DESCRIPTION
## Description
Closes https://github.com/WordPress/gutenberg/issues/25100.
Requires https://github.com/WordPress/gutenberg/pull/30889.

Adds a 'Convert to blocks' button to the Legacy Widget block when a text widget is loaded. This uses the same mechanism that the Classic block uses.

## How has this been tested?
1. Manually navigate to `wp-admin/widgets.php` and add a Text widget with some `h1`s, etc.
2. Navigate to Appearance → Widgets.
3. Select the corresponding Legacy Widget.
4. Click 'Convert to blocks'.

## Screenshots 
<img width="727" alt="Screen Shot 2021-04-27 at 14 57 56" src="https://user-images.githubusercontent.com/612155/116187490-f859bc80-a768-11eb-8ce2-de2cce53c7ca.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->