### PR TITLE
Gallery block refactor: fix focus issue with gallery figcaption

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -103,6 +103,7 @@
 	figcaption {
 		flex-grow: 1;
 		flex-basis: 100%;
+		text-align: center;
 	}
 
 	// Non cropped images.


### PR DESCRIPTION
## Description

Fixes: #29998, #29994 and  part of #30001 (delete with delete key after adding gallery via drag n drop)

Currently if select a Gallery the figcaption immediately grabs focused so the parent gallery is never shown as selected, and can't be deleted with delete key when selected.

## Testing
Check out the PR and enable gallery refactor experiment
Add a gallery with some images
Select the gallery from either an image block parent block menu item or the block navigator
Check that the blue selection line appears around the block and that it can be deleted with the delete key once selected
Also check that you can select and edit the gallery fig caption

## Screenshots 
Before:
![focus-before](https://user-images.githubusercontent.com/3629020/116194798-71670d00-a785-11eb-9cda-051725733e36.gif)

After:
![focus-after](https://user-images.githubusercontent.com/3629020/116194812-79bf4800-a785-11eb-8a72-138a488efe7f.gif)
