### PR TITLE
Fix generation of preset class for border color in site editor

### DIFF
--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -41,6 +41,10 @@ export const PRESET_METADATA = [
 				classSuffix: 'background-color',
 				propertyName: 'background-color',
 			},
+			{
+				classSuffix: 'border-color',
+				propertyName: 'border-color',
+			},
 		],
 	},
 	{


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/30124

We forgot to register the border color preset in the client, so the corresponding preset classes (`.has-<color>-border-color`) are generated in the site editor as well.
