### PR TITLE
Preset classes for site editor: generate them like in the front-end

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -64,9 +64,9 @@ function getBlockPresetClasses( blockSelector, blockPresets = {} ) {
 			if ( ! classes ) {
 				return declarations;
 			}
-			classes.forEach( ( { classSuffix, propertyName } ) => {
-				const presets = get( blockPresets, path, [] );
-				presets.forEach( ( preset ) => {
+			const presets = get( blockPresets, path, [] );
+			presets.forEach( ( preset ) => {
+				classes.forEach( ( { classSuffix, propertyName } ) => {
 					const slug = preset.slug;
 					const value = preset[ valueKey ];
 					const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;


### PR DESCRIPTION
I've noticed that preset classes are enqueued in a different order in the front end and the site editor.

Front end (per color):

```css
.has-white-color { ... }
.has-white-background-color { ... }
.has-white-border-color { ... }
.has-black-color { ... }
.has-black-background-color { ... }
.has-black-border-color { ... }
```

Site editor (per preset category):

```css
.has-white-color { ... }
.has-black-color { ... }
.has-white-background-color { ... }
.has-black-background-color { ... }
.has-white-border-color { ... }
.has-black-border-color { ... }
```

This PR makes the site editor work like the front-end.