### PR TITLE
Fix redo/undo icons on RTL

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -51,7 +51,7 @@ function HeaderToolbar( {
 			<ToolbarButton
 				key="undoButton"
 				title={ __( 'Undo' ) }
-				icon={ ! isRTL ? undoIcon : redo }
+				icon={ ! isRTL ? undoIcon : redoIcon }
 				isDisabled={ ! hasUndo }
 				onClick={ undo }
 				extraProps={ {
@@ -61,7 +61,7 @@ function HeaderToolbar( {
 			<ToolbarButton
 				key="redoButton"
 				title={ __( 'Redo' ) }
-				icon={ ! isRTL ? redoIcon : undo }
+				icon={ ! isRTL ? redoIcon : undoIcon }
 				isDisabled={ ! hasRedo }
 				onClick={ redo }
 				extraProps={ {

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -22,6 +22,7 @@ import {
 	undo as undoIcon,
 	redo as redoIcon,
 } from '@wordpress/icons';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -44,14 +45,13 @@ function HeaderToolbar( {
 	const scrollToStart = () => {
 		scrollViewRef.current.scrollTo( { x: 0 } );
 	};
-
 	const renderHistoryButtons = () => {
 		const buttons = [
 			/* TODO: replace with EditorHistoryRedo and EditorHistoryUndo */
 			<ToolbarButton
 				key="undoButton"
 				title={ __( 'Undo' ) }
-				icon={ undoIcon }
+				icon={ ! isRTL ? undoIcon : redo }
 				isDisabled={ ! hasUndo }
 				onClick={ undo }
 				extraProps={ {
@@ -61,7 +61,7 @@ function HeaderToolbar( {
 			<ToolbarButton
 				key="redoButton"
 				title={ __( 'Redo' ) }
-				icon={ redoIcon }
+				icon={ ! isRTL ? redoIcon : undo }
 				isDisabled={ ! hasRedo }
 				onClick={ redo }
 				extraProps={ {
@@ -111,22 +111,22 @@ function HeaderToolbar( {
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		hasRedo: select( 'core/editor' ).hasEditorRedo(),
-		hasUndo: select( 'core/editor' ).hasEditorUndo(),
+		hasRedo: select( editorStore ).hasEditorRedo(),
+		hasUndo: select( editorStore ).hasEditorUndo(),
 		// This setting (richEditingEnabled) should not live in the block editor's setting.
 		showInserter:
 			select( editPostStore ).getEditorMode() === 'visual' &&
-			select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+			select( editorStore ).getEditorSettings().richEditingEnabled,
 		isTextModeEnabled: select( editPostStore ).getEditorMode() === 'text',
 		isRTL: select( blockEditorStore ).getSettings().isRTL,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { clearSelectedBlock } = dispatch( blockEditorStore );
-		const { togglePostTitleSelection } = dispatch( 'core/editor' );
+		const { togglePostTitleSelection } = dispatch( editorStore );
 
 		return {
-			redo: dispatch( 'core/editor' ).redo,
-			undo: dispatch( 'core/editor' ).undo,
+			redo: dispatch( editorStore ).redo,
+			undo: dispatch( editorStore ).undo,
 			onHideKeyboard() {
 				clearSelectedBlock();
 				togglePostTitleSelection( false );

--- a/packages/edit-site/src/components/header/undo-redo/redo.js
+++ b/packages/edit-site/src/components/header/undo-redo/redo.js
@@ -4,7 +4,7 @@
 import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { redo as redoIcon, undo } from '@wordpress/icons';
+import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -13,7 +13,7 @@ export default function RedoButton() {
 	const { redo } = useDispatch( coreStore );
 	return (
 		<Button
-			icon={ ! isRTL() ? redoIcon : undo }
+			icon={ ! isRTL() ? redoIcon : undoIcon }
 			label={ __( 'Redo' ) }
 			shortcut={ displayShortcut.primaryShift( 'z' ) }
 			// If there are no undo levels we don't want to actually disable this

--- a/packages/edit-site/src/components/header/undo-redo/redo.js
+++ b/packages/edit-site/src/components/header/undo-redo/redo.js
@@ -1,18 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { redo as redoIcon } from '@wordpress/icons';
+import { redo as redoIcon, undo } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
+import { store as coreStore } from '@wordpress/core-data';
 
 export default function RedoButton() {
-	const hasRedo = useSelect( ( select ) => select( 'core' ).hasRedo() );
-	const { redo } = useDispatch( 'core' );
+	const hasRedo = useSelect( ( select ) => select( coreStore ).hasRedo() );
+	const { redo } = useDispatch( coreStore );
 	return (
 		<Button
-			icon={ redoIcon }
+			icon={ ! isRTL() ? redoIcon : undo }
 			label={ __( 'Redo' ) }
 			shortcut={ displayShortcut.primaryShift( 'z' ) }
 			// If there are no undo levels we don't want to actually disable this

--- a/packages/edit-site/src/components/header/undo-redo/undo.js
+++ b/packages/edit-site/src/components/header/undo-redo/undo.js
@@ -4,7 +4,7 @@
 import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { undo as undoIcon, redo } from '@wordpress/icons';
+import { undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -13,7 +13,7 @@ export default function UndoButton() {
 	const { undo } = useDispatch( coreStore );
 	return (
 		<Button
-			icon={ ! isRTL() ? undoIcon : redo }
+			icon={ ! isRTL() ? undoIcon : redoIcon }
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }
 			// If there are no undo levels we don't want to actually disable this

--- a/packages/edit-site/src/components/header/undo-redo/undo.js
+++ b/packages/edit-site/src/components/header/undo-redo/undo.js
@@ -1,18 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { undo as undoIcon } from '@wordpress/icons';
+import { undo as undoIcon, redo } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
+import { store as coreStore } from '@wordpress/core-data';
 
 export default function UndoButton() {
-	const hasUndo = useSelect( ( select ) => select( 'core' ).hasUndo() );
-	const { undo } = useDispatch( 'core' );
+	const hasUndo = useSelect( ( select ) => select( coreStore ).hasUndo() );
+	const { undo } = useDispatch( coreStore );
 	return (
 		<Button
-			icon={ undoIcon }
+			icon={ ! isRTL() ? undoIcon : redo }
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }
 			// If there are no undo levels we don't want to actually disable this

--- a/packages/edit-widgets/src/components/header/undo-redo/redo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/redo.js
@@ -4,7 +4,7 @@
 import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { redo as redoIcon, undo } from '@wordpress/icons';
+import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -13,7 +13,7 @@ export default function RedoButton() {
 	const { redo } = useDispatch( coreStore );
 	return (
 		<ToolbarButton
-			icon={ ! isRTL() ? redoIcon : undo }
+			icon={ ! isRTL() ? redoIcon : undoIcon }
 			label={ __( 'Redo' ) }
 			shortcut={ displayShortcut.primaryShift( 'z' ) }
 			// If there are no undo levels we don't want to actually disable this

--- a/packages/edit-widgets/src/components/header/undo-redo/redo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/redo.js
@@ -1,18 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { redo as redoIcon } from '@wordpress/icons';
+import { redo as redoIcon, undo } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
+import { store as coreStore } from '@wordpress/core-data';
 
 export default function RedoButton() {
-	const hasRedo = useSelect( ( select ) => select( 'core' ).hasRedo() );
-	const { redo } = useDispatch( 'core' );
+	const hasRedo = useSelect( ( select ) => select( coreStore ).hasRedo() );
+	const { redo } = useDispatch( coreStore );
 	return (
 		<ToolbarButton
-			icon={ redoIcon }
+			icon={ ! isRTL() ? redoIcon : undo }
 			label={ __( 'Redo' ) }
 			shortcut={ displayShortcut.primaryShift( 'z' ) }
 			// If there are no undo levels we don't want to actually disable this

--- a/packages/edit-widgets/src/components/header/undo-redo/undo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/undo.js
@@ -1,18 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { undo as undoIcon } from '@wordpress/icons';
+import { undo as undoIcon, redo } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
+import { store as coreStore } from '@wordpress/core-data';
 
 export default function UndoButton() {
-	const hasUndo = useSelect( ( select ) => select( 'core' ).hasUndo() );
-	const { undo } = useDispatch( 'core' );
+	const hasUndo = useSelect( ( select ) => select( coreStore ).hasUndo() );
+	const { undo } = useDispatch( coreStore );
 	return (
 		<ToolbarButton
-			icon={ undoIcon }
+			icon={ ! isRTL() ? undoIcon : redo }
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }
 			// If there are no undo levels we don't want to actually disable this

--- a/packages/edit-widgets/src/components/header/undo-redo/undo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/undo.js
@@ -4,7 +4,7 @@
 import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { undo as undoIcon, redo } from '@wordpress/icons';
+import { undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -13,7 +13,7 @@ export default function UndoButton() {
 	const { undo } = useDispatch( coreStore );
 	return (
 		<ToolbarButton
-			icon={ ! isRTL() ? undoIcon : redo }
+			icon={ ! isRTL() ? undoIcon : redoIcon }
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }
 			// If there are no undo levels we don't want to actually disable this

--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -5,7 +5,7 @@ import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
-import { redo as redoIcon, undo } from '@wordpress/icons';
+import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 import { forwardRef } from '@wordpress/element';
 
 /**
@@ -23,7 +23,7 @@ function EditorHistoryRedo( props, ref ) {
 		<Button
 			{ ...props }
 			ref={ ref }
-			icon={ ! isRTL() ? redoIcon : undo }
+			icon={ ! isRTL() ? redoIcon : undoIcon }
 			/* translators: button label text should, if possible, be under 16 characters. */
 			label={ __( 'Redo' ) }
 			shortcut={ displayShortcut.primaryShift( 'z' ) }

--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -1,24 +1,29 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
-import { redo as redoIcon } from '@wordpress/icons';
+import { redo as redoIcon, undo } from '@wordpress/icons';
 import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 function EditorHistoryRedo( props, ref ) {
 	const hasRedo = useSelect(
-		( select ) => select( 'core/editor' ).hasEditorRedo(),
+		( select ) => select( editorStore ).hasEditorRedo(),
 		[]
 	);
-	const { redo } = useDispatch( 'core/editor' );
+	const { redo } = useDispatch( editorStore );
 	return (
 		<Button
 			{ ...props }
 			ref={ ref }
-			icon={ redoIcon }
+			icon={ ! isRTL() ? redoIcon : undo }
 			/* translators: button label text should, if possible, be under 16 characters. */
 			label={ __( 'Redo' ) }
 			shortcut={ displayShortcut.primaryShift( 'z' ) }

--- a/packages/editor/src/components/editor-history/undo.js
+++ b/packages/editor/src/components/editor-history/undo.js
@@ -5,7 +5,7 @@ import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
-import { undo as undoIcon, redo } from '@wordpress/icons';
+import { undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 import { forwardRef } from '@wordpress/element';
 
 /**
@@ -23,7 +23,7 @@ function EditorHistoryUndo( props, ref ) {
 		<Button
 			{ ...props }
 			ref={ ref }
-			icon={ ! isRTL() ? undoIcon : redo }
+			icon={ ! isRTL() ? undoIcon : redoIcon }
 			/* translators: button label text should, if possible, be under 16 characters. */
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }

--- a/packages/editor/src/components/editor-history/undo.js
+++ b/packages/editor/src/components/editor-history/undo.js
@@ -1,24 +1,29 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
-import { undo as undoIcon } from '@wordpress/icons';
+import { undo as undoIcon, redo } from '@wordpress/icons';
 import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 function EditorHistoryUndo( props, ref ) {
 	const hasUndo = useSelect(
-		( select ) => select( 'core/editor' ).hasEditorUndo(),
+		( select ) => select( editorStore ).hasEditorUndo(),
 		[]
 	);
-	const { undo } = useDispatch( 'core/editor' );
+	const { undo } = useDispatch( editorStore );
 	return (
 		<Button
 			{ ...props }
 			ref={ ref }
-			icon={ undoIcon }
+			icon={ ! isRTL() ? undoIcon : redo }
 			/* translators: button label text should, if possible, be under 16 characters. */
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Part of: https://github.com/WordPress/gutenberg/issues/31206

Gutenberg RTL header icons like undo and redo have the wrong direction.

This PR handles the `undo` and `redo` icons but not in a css based solution.

Helpful reference: https://material.io/design/usability/bidirectionality.html#mirroring-elements

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
