### PR TITLE
E2E wpDataSelect: Explain why it returns undefined sometimes

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -717,6 +717,19 @@ _Parameters_
 
 Queries the WordPress data module.
 
+`page.evaluate` - used in the function - returns `undefined`
+when it encounters a non-serializable value.
+Since we store many different values in the data module,
+you can end up with an `undefined` result. Before using
+this function, make sure the data you are querying
+doesn't contain non-serializable values, for example,
+functions, DOM element handles, etc.
+
+_Related_
+
+-   <https://pptr.dev/#?product=Puppeteer&version=v9.0.0&show=api-pageevaluatepagefunction-args>
+-   <https://github.com/WordPress/gutenberg/pull/31199>
+
 _Parameters_
 
 -   _store_ `string`: Store to query e.g: core/editor, core/blocks...

--- a/packages/e2e-test-utils/src/wp-data-select.js
+++ b/packages/e2e-test-utils/src/wp-data-select.js
@@ -1,6 +1,17 @@
 /**
  * Queries the WordPress data module.
  *
+ * `page.evaluate` - used in the function - returns `undefined`
+ * when it encounters a non-serializable value.
+ * Since we store many different values in the data module,
+ * you can end up with an `undefined` result. Before using
+ * this function, make sure the data you are querying
+ * doesn't contain non-serializable values, for example,
+ * functions, DOM element handles, etc.
+ *
+ * @see https://pptr.dev/#?product=Puppeteer&version=v9.0.0&show=api-pageevaluatepagefunction-args
+ * @see https://github.com/WordPress/gutenberg/pull/31199
+ *
  * @param {string}    store      Store to query e.g: core/editor, core/blocks...
  * @param {string}    selector   Selector to exectute e.g: getBlocks.
  * @param {...Object} parameters Parameters to pass to the selector.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Follow up based on https://github.com/WordPress/gutenberg/pull/31199#issuecomment-827152126

Adds an explanation to the `wpDataSelect` function about `undefined` return value.

## How has this been tested?
N/A

## Screenshots <!-- if applicable -->
N/A
## Types of changes
Documentation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
