### PR TITLE
Fix navigation screen collapsing regression.

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -48,6 +48,7 @@
 
 			// Menu items.
 			.wp-block-navigation-link__content {
+				padding: 0.5em 1em;
 				margin-bottom: 6px;
 				border-radius: $radius-block-ui;
 


### PR DESCRIPTION
## Description

I'm afraid I introduced an issue in the navigtation screen with #30805, which removed the padding:

![before](https://user-images.githubusercontent.com/1204802/116240793-841d1a00-a764-11eb-8e43-ec066ec38c4e.gif)

This PR fixes that:

![after](https://user-images.githubusercontent.com/1204802/116240520-386a7080-a764-11eb-883d-cc448658a04e.gif)

It does so by putting the menu item padding in the navigation editor screen, where it arguably should be from the start, since it's effectively redesigning the block.

## How has this been tested?

Please insert menu items and submenu items in the navigation screen and verify they work.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
