### PR TITLE
components: Remove wp-g2 imports from shortcut

### DIFF
--- a/packages/components/src/ui/shortcut/component.tsx
+++ b/packages/components/src/ui/shortcut/component.tsx
@@ -3,8 +3,13 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
-import type { ViewOwnProps } from '@wp-g2/create-styles';
-import { useContextSystem, contextConnect } from '@wp-g2/context';
+
+/**
+ * Internal dependencies
+ */
+import { useContextSystem, contextConnect } from '../context';
+// eslint-disable-next-line no-duplicate-imports
+import type { ViewOwnProps } from '../context';
 
 export interface ShortcutDescription {
 	display: string;

--- a/packages/components/src/ui/shortcut/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/shortcut/test/__snapshots__/index.js.snap
@@ -2,9 +2,9 @@
 
 exports[`Shortcut should render a span with the shortcut text 1`] = `
 <span
-  class="components-shortcut wp-components-shortcut ic-1x9nauu"
-  data-g2-c16t="true"
-  data-g2-component="Shortcut"
+  class="components-shortcut"
+  data-wp-c16t="true"
+  data-wp-component="Shortcut"
 >
   meta + P
 </span>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Removes wp-g2 imports from shortcut. There are no styles to convert here.

## How has this been tested?
Unit tests pass as expected. (snapshot updates make sense)

## Types of changes
Non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
