### PR TITLE
Left-align query patterns in the carousel

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/style.scss
+++ b/packages/block-editor/src/components/block-pattern-setup/style.scss
@@ -84,7 +84,6 @@
 
 		.carousel-container {
 			overflow: hidden;
-			text-align: center;
 			position: relative;
 			padding: 0;
 			margin: 0;


### PR DESCRIPTION
This PR removes a `text-align: center` rule applied to the Query block carousel. This rule was being inherited by all block patterns in the carousel, which meant all text there was center-aligned by default. This didn't match the intended pattern designs, and also didn't match the appearance of the pattern after it was inserted. 

Before|After
---|---
<img width="1276" alt="Screen Shot 2021-04-27 at 9 06 52 AM" src="https://user-images.githubusercontent.com/1202812/116247449-e06a4480-a738-11eb-9121-6b4a7505d0ed.png">|<img width="1276" alt="Screen Shot 2021-04-27 at 9 13 44 AM" src="https://user-images.githubusercontent.com/1202812/116247452-e102db00-a738-11eb-9c40-ba68dcb503c7.png">

Before|After
---|---
<img width="1277" alt="Screen Shot 2021-04-27 at 9 07 24 AM" src="https://user-images.githubusercontent.com/1202812/116247485-e829e900-a738-11eb-9322-cc3472894ccb.png">|<img width="1276" alt="Screen Shot 2021-04-27 at 9 10 55 AM" src="https://user-images.githubusercontent.com/1202812/116247489-e8c27f80-a738-11eb-9e52-88299030edd2.png">

