### PR TITLE
components: Remove wp-g2 from form-group and control-label

### DIFF
--- a/packages/components/src/ui/control-label/stories/index.js
+++ b/packages/components/src/ui/control-label/stories/index.js
@@ -5,7 +5,7 @@ import { ControlLabel } from '../index';
 
 export default {
 	component: ControlLabel,
-	title: 'Components/ControlLabel',
+	title: 'G2 Components (Experimental)/ControlLabel',
 };
 
 export const _default = () => {

--- a/packages/components/src/ui/control-label/styles.js
+++ b/packages/components/src/ui/control-label/styles.js
@@ -1,17 +1,21 @@
 /**
  * External dependencies
  */
-import { css, getHighDpi, ui } from '@wp-g2/styles';
+import { css } from 'emotion';
 
-const lineHeight = `calc(${ ui.get( 'fontSize' ) } * 1.2)`;
-
-/* eslint-disable jsdoc/valid-types */
 /**
- * @param {Parameters<typeof ui.get>[0]} size The padding size.
+ * Internal dependencies
  */
-/* eslint-enable jsdoc/valid-types */
+import CONFIG from '../../utils/config-values';
+import { getHighDpi } from '../utils/get-high-dpi';
+
+const lineHeight = `calc(${ CONFIG.fontSize } * 1.2)`;
+
+/**
+ * @param {keyof CONFIG} size The padding size.
+ */
 function getPadding( size ) {
-	return `calc((${ ui.get( size ) } - ${ lineHeight }) / 2)`;
+	return `calc((${ CONFIG[ size ] } - ${ lineHeight }) / 2)`;
 }
 
 const highDpiAdjust = getHighDpi`

--- a/packages/components/src/ui/control-label/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/control-label/test/__snapshots__/index.js.snap
@@ -1,45 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`props should render correctly 1`] = `
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+.emotion-0 {
   display: inline-block;
   line-height: calc(13px * 1.2);
-  line-height: calc(var(--wp-g2-font-size) * 1.2);
   margin: 0;
   max-width: 100%;
   padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
   padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:active {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-@media (-webkit-min-device-pixel-ratio:1.25), (min-resolution:120dpi) {
-  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 > * {
-    position: relative;
-    top: 0.5px;
-  }
-}
-
-.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
   padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
   padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.emotion-2 {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -49,10 +19,26 @@ exports[`props should render correctly 1`] = `
   margin: 0;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.emotion-0:active {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media ( -webkit-min-device-pixel-ratio:1.25 ),( min-resolution:120dpi ) {
+  .emotion-0 > * {
+    position: relative;
+    top: 0.5px;
+  }
 }
 
 <label
-  class="emotion-0 emotion-1 components-truncate components-text components-control-label emotion-2 emotion-3 emotion-4 emotion-5"
+  class="components-truncate components-text components-control-label emotion-0 emotion-1 emotion-2"
   data-wp-c16t="true"
   data-wp-component="ControlLabel"
 >
@@ -61,54 +47,40 @@ exports[`props should render correctly 1`] = `
 `;
 
 exports[`props should render no truncate 1`] = `
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+.emotion-0 {
   display: inline-block;
   line-height: calc(13px * 1.2);
-  line-height: calc(var(--wp-g2-font-size) * 1.2);
   margin: 0;
   max-width: 100%;
   padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
   padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
+  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
+  padding-top: calc((30px - calc(13px * 1.2)) / 2);
+  color: #000;
+  line-height: 1.2;
+  margin: 0;
+  font-size: calc((13 / 13) * 13px);
+  font-weight: normal;
+  display: inline-block;
+  vertical-align: middle;
 }
 
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:active {
+.emotion-0:active {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-@media (-webkit-min-device-pixel-ratio:1.25), (min-resolution:120dpi) {
-  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 > * {
+@media ( -webkit-min-device-pixel-ratio:1.25 ),( min-resolution:120dpi ) {
+  .emotion-0 > * {
     position: relative;
     top: 0.5px;
   }
 }
 
-.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
-  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-  padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.emotion-2 {
-  color: #000;
-  line-height: 1.2;
-  margin: 0;
-  font-size: calc((13 / 13) * 13px);
-  font-weight: normal;
-}
-
 <label
-  class="emotion-0 emotion-1 components-truncate components-text components-control-label emotion-2 emotion-3 emotion-4 emotion-5"
+  class="components-truncate components-text components-control-label emotion-0 emotion-1 emotion-2"
   data-wp-c16t="true"
   data-wp-component="ControlLabel"
 >
@@ -117,45 +89,15 @@ exports[`props should render no truncate 1`] = `
 `;
 
 exports[`props should render size 1`] = `
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+.emotion-0 {
   display: inline-block;
   line-height: calc(13px * 1.2);
-  line-height: calc(var(--wp-g2-font-size) * 1.2);
   margin: 0;
   max-width: 100%;
   padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
   padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:active {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-@media (-webkit-min-device-pixel-ratio:1.25), (min-resolution:120dpi) {
-  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 > * {
-    position: relative;
-    top: 0.5px;
-  }
-}
-
-.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
-  padding-bottom: calc((calc(30px * 0.8) - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height-small) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-  padding-top: calc((calc(30px * 0.8) - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height-small) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.emotion-2 {
+  padding-bottom: calc((calc( 30px * 0.8 ) - calc(13px * 1.2)) / 2);
+  padding-top: calc((calc( 30px * 0.8 ) - calc(13px * 1.2)) / 2);
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -165,10 +107,26 @@ exports[`props should render size 1`] = `
   margin: 0;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.emotion-0:active {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media ( -webkit-min-device-pixel-ratio:1.25 ),( min-resolution:120dpi ) {
+  .emotion-0 > * {
+    position: relative;
+    top: 0.5px;
+  }
 }
 
 <label
-  class="emotion-0 emotion-1 components-truncate components-text components-control-label emotion-2 emotion-3 emotion-4 emotion-5"
+  class="components-truncate components-text components-control-label emotion-0 emotion-1 emotion-2"
   data-wp-c16t="true"
   data-wp-component="ControlLabel"
 >

--- a/packages/components/src/ui/form-group/form-group-content.js
+++ b/packages/components/src/ui/form-group/form-group-content.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { ui } from '@wp-g2/styles';
-
-/**
  * WordPress dependencies
  */
 import { useMemo, memo } from '@wordpress/element';
@@ -37,11 +32,7 @@ function FormGroupContent( {
 	] );
 
 	const content = help ? (
-		<VStack
-			expanded={ false }
-			{ ...ui.$( 'FormGroupContentContainer' ) }
-			spacing={ spacing }
-		>
+		<VStack expanded={ false } spacing={ spacing }>
 			{ children }
 			<FormGroupHelp>{ help }</FormGroupHelp>
 		</VStack>

--- a/packages/components/src/ui/form-group/form-group-help.js
+++ b/packages/components/src/ui/form-group/form-group-help.js
@@ -1,11 +1,12 @@
 /**
- * External dependencies
- */
-import { ContextSystemProvider } from '@wp-g2/context';
-/**
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ContextSystemProvider } from '../context';
 
 const contextValue = { Text: { variant: 'muted' } };
 

--- a/packages/components/src/ui/form-group/stories/index.js
+++ b/packages/components/src/ui/form-group/stories/index.js
@@ -16,7 +16,7 @@ const TextInput = ( { id: idProp, ...props } ) => {
 
 export default {
 	component: FormGroup,
-	title: 'Components/FormGroup',
+	title: 'G2 Components (Experimental)/FormGroup',
 };
 
 export const _default = () => {

--- a/packages/components/src/ui/form-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/form-group/test/__snapshots__/index.js.snap
@@ -1,64 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`props should render alignLabel 1`] = `
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
-  display: inline-block;
-  line-height: calc(13px * 1.2);
-  line-height: calc(var(--wp-g2-font-size) * 1.2);
-  margin: 0;
-  max-width: 100%;
-  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-  padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:active {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-@media (-webkit-min-device-pixel-ratio:1.25), (min-resolution:120dpi) {
-  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 > * {
-    position: relative;
-    top: 0.5px;
-  }
-}
-
-.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
-  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-  padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.emotion-6 {
+.emotion-3 {
   width: 100%;
 }
 
-.emotion-2 {
+.emotion-0 {
+  display: inline-block;
+  line-height: calc(13px * 1.2);
+  margin: 0;
+  max-width: 100%;
+  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
+  padding-top: calc((30px - calc(13px * 1.2)) / 2);
+  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
+  padding-top: calc((30px - calc(13px * 1.2)) / 2);
   color: #000;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
   text-align: right;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.emotion-0:active {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media ( -webkit-min-device-pixel-ratio:1.25 ),( min-resolution:120dpi ) {
+  .emotion-0 > * {
+    position: relative;
+    top: 0.5px;
+  }
 }
 
 <div
-  class="emotion-6 components-form-group emotion-4 emotion-5"
+  class="emotion-3 components-form-group emotion-1 emotion-2"
   data-wp-c16t="true"
   data-wp-component="FormGroup"
 >
   <label
-    class="emotion-0 emotion-1 components-truncate components-text components-control-label emotion-2 emotion-3 emotion-4 emotion-5"
+    class="components-truncate components-text components-control-label emotion-0 emotion-1 emotion-2"
     data-wp-c16t="true"
     data-wp-component="ControlLabel"
     for="fname"
@@ -73,64 +59,50 @@ exports[`props should render alignLabel 1`] = `
 `;
 
 exports[`props should render vertically 1`] = `
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
-  display: inline-block;
-  line-height: calc(13px * 1.2);
-  line-height: calc(var(--wp-g2-font-size) * 1.2);
-  margin: 0;
-  max-width: 100%;
-  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-  padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:active {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-@media (-webkit-min-device-pixel-ratio:1.25), (min-resolution:120dpi) {
-  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 > * {
-    position: relative;
-    top: 0.5px;
-  }
-}
-
-.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
-  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
-  padding-bottom: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-  padding-top: calc((30px - calc(13px * 1.2)) / 2);
-  padding-top: calc((var(--wp-g2-control-height) - calc(var(--wp-g2-font-size) * 1.2)) / 2);
-}
-
-.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.emotion-6 {
+.emotion-3 {
   width: 100%;
 }
 
-.emotion-2 {
+.emotion-0 {
+  display: inline-block;
+  line-height: calc(13px * 1.2);
+  margin: 0;
+  max-width: 100%;
+  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
+  padding-top: calc((30px - calc(13px * 1.2)) / 2);
+  padding-bottom: calc((30px - calc(13px * 1.2)) / 2);
+  padding-top: calc((30px - calc(13px * 1.2)) / 2);
   color: #000;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
   text-align: left;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.emotion-0:active {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media ( -webkit-min-device-pixel-ratio:1.25 ),( min-resolution:120dpi ) {
+  .emotion-0 > * {
+    position: relative;
+    top: 0.5px;
+  }
 }
 
 <div
-  class="emotion-6 components-form-group emotion-4 emotion-5"
+  class="emotion-3 components-form-group emotion-1 emotion-2"
   data-wp-c16t="true"
   data-wp-component="FormGroup"
 >
   <label
-    class="emotion-0 emotion-1 components-truncate components-text components-control-label emotion-2 emotion-3 emotion-4 emotion-5"
+    class="components-truncate components-text components-control-label emotion-0 emotion-1 emotion-2"
     data-wp-c16t="true"
     data-wp-component="ControlLabel"
     for="fname"

--- a/packages/components/src/ui/utils/get-high-dpi.ts
+++ b/packages/components/src/ui/utils/get-high-dpi.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import type { Interpolation } from '@emotion/core';
+import { css } from 'emotion';
+
+export function getHighDpi(
+	strings: TemplateStringsArray,
+	...interpolations: Interpolation[]
+) {
+	const interpolatedStyles = css( strings, ...interpolations );
+
+	return css`
+		@media ( -webkit-min-device-pixel-ratio: 1.25 ),
+			( min-resolution: 120dpi ) {
+			${ interpolatedStyles }
+		}
+	`;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Remove wp-g2 imports from form-group and control-label. Relatively straghtforward as much of it was already done in a preivous PR.

## How has this been tested?
Storybook and unit tests.

## Types of changes
Non-breaking changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
