### PR TITLE
FSE: Add a filter to determine whether a theme should use the Site Editor

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -11,7 +11,8 @@
  * @return boolean Whether the current theme is an FSE theme or not.
  */
 function gutenberg_is_fse_theme() {
-	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' );
+	$is_fse_theme = is_readable( get_stylesheet_directory() . '/block-templates/index.html' );
+	return apply_filters( 'gutenberg_is_fse_theme', $is_fse_theme );
 }
 
 /**


### PR DESCRIPTION
## Description
This is a different approach to https://github.com/WordPress/gutenberg/pull/30760.

A universal theme should work with both Classic site editing tools (Customizer/Menus/Widgets) or the new Site Editor. If a theme wants to use the Site Editors, it needs to have template in the `block-templates` directory, so to enable FSE for a universal theme, changes would be necessary to the theme file structure. This filter allows themes to opt out of the Site Editor by changing the value it returns, without having to move files around. This would allow us to enable/disable FSE for particular users/themes as we need without updating themes themselves.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
