### PR TITLE
[WIP] Move title to header toolbar

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -35,6 +35,7 @@ import { useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import TemplateTitle from '../template-title';
+import PostTitle from '../post-title';
 import { store as editPostStore } from '../../../store';
 
 function HeaderToolbar() {
@@ -220,7 +221,9 @@ characters. */
 				) }
 			</div>
 
-			<TemplateTitle />
+			<div className="edit-post-header-toolbar__middle">
+				{ isTemplateMode ? <TemplateTitle /> : <PostTitle /> }
+			</div>
 
 			{ displayBlockToolbar && (
 				<div

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -92,6 +92,12 @@
 	}
 }
 
+.edit-post-header-toolbar__middle {
+	display: inline-flex;
+	flex-grow: 1;
+	justify-content: center;
+}
+
 // Block toolbar when fixed to the top of the screen.
 .edit-post-header-toolbar__block-toolbar {
 	// Stack toolbar below Editor Bar.

--- a/packages/edit-post/src/components/header/post-title/index.js
+++ b/packages/edit-post/src/components/header/post-title/index.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
+
+import {
+	Dropdown,
+	Button,
+	VisuallyHidden,
+	__experimentalText as Text,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+function PostTitle() {
+	const { entityTitle, entityLabel } = useSelect(
+		( select ) => ( {
+			entityTitle: select( editorStore ).getEditedPostAttribute(
+				'title'
+			),
+			entityLabel: select( editorStore ).getEditedPostAttribute( 'type' ),
+		} ),
+		[]
+	);
+
+	const titleRef = useRef();
+
+	if ( ! entityTitle ) {
+		return (
+			<div className="edit-post-title-actions">{ __( 'Loading…' ) }</div>
+		);
+	}
+
+	return (
+		<div className="edit-post-title-actions">
+			<div
+				ref={ titleRef }
+				className="edit-post-title-actions__title-wrapper"
+			>
+				<Text
+					variant="body.small"
+					className="edit-post-title-actions__title-prefix"
+				>
+					<VisuallyHidden as="span">
+						{ sprintf(
+							/* translators: %s: the entity being edited, like "template"*/
+							__( 'Editing %s:' ),
+							entityLabel
+						) }
+					</VisuallyHidden>
+				</Text>
+
+				<Text
+					variant="body.small"
+					className="edit-post-title-actions__title"
+					as="h1"
+				>
+					{ entityTitle.length === 0
+						? __( 'No Title' )
+						: entityTitle }
+				</Text>
+
+				<Dropdown
+					popoverProps={ {
+						anchorRef: titleRef.current,
+					} }
+					position="bottom center"
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							className="edit-post-title-actions__get-info"
+							icon={ chevronDown }
+							aria-expanded={ isOpen }
+							aria-haspopup="true"
+							onClick={ onToggle }
+							label={ sprintf(
+								/* translators: %s: the entity to see details about, like "template"*/
+								__( 'Show %s details' ),
+								entityLabel
+							) }
+						/>
+					) }
+					contentClassName="edit-post-title-actions__info-dropdown"
+					renderContent={ () => (
+						<span>{ __( 'Nothing here yet.' ) }</span>
+					) }
+				/>
+			</div>
+		</div>
+	);
+}
+
+export default PostTitle;

--- a/packages/edit-post/src/components/header/post-title/style.scss
+++ b/packages/edit-post/src/components/header/post-title/style.scss
@@ -1,0 +1,57 @@
+.edit-post-title-actions {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 100%;
+	// Flex items will, by default, refuse to shrink below a minimum
+	// intrinsic width. In order to shrink this flexbox item, and
+	// subsequently truncate child text, we set an explicit min-width.
+	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
+	min-width: 0;
+
+	.edit-post-title-actions__title-wrapper {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		align-items: center;
+
+		// See comment above about min-width
+		min-width: 0;
+
+		.components-dropdown {
+			display: inline-flex;
+			margin-left: $grid-unit-05;
+
+			.components-button {
+				min-width: 0;
+				padding: 0;
+			}
+		}
+	}
+
+	.edit-post-title-actions__title-wrapper > h1 {
+		margin: 0;
+
+		// See comment above about min-width
+		min-width: 0;
+	}
+
+	.edit-post-title-actions__title {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 120px;
+
+		@include break-medium() {
+			max-width: 75px;
+		}
+
+		@include break-xlarge() {
+			max-width: 180px;
+		}
+	}
+}
+.edit-post-title-actions__info-dropdown > .components-popover__content > div {
+	padding: 0;
+	min-width: 240px;
+}

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -3,7 +3,7 @@
 @import "./components/header/fullscreen-mode-close/style.scss";
 @import "./components/header/header-toolbar/style.scss";
 @import "./components/header/more-menu/style.scss";
-@import "./components/header/template-title/style.scss";
+@import "./components/header/post-title/style.scss";
 @import "./components/keyboard-shortcut-help-modal/style.scss";
 @import "./components/layout/style.scss";
 @import "./components/manage-blocks-modal/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR gives a go at moving the management of the entity title to the header toolbar area, as described in https://github.com/WordPress/gutenberg/issues/27093.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
