### PR TITLE
components: Stop auto-memo antipattern and remove senseless default values

### DIFF
--- a/packages/components/src/ui/context/context-connect.js
+++ b/packages/components/src/ui/context/context-connect.js
@@ -28,12 +28,12 @@ import { getStyledClassNameFromKey } from './get-styled-class-name-from-key';
  * @param {(props: P, ref: import('react').Ref<any>) => JSX.Element | null} Component The component to register into the Context system.
  * @param {string} namespace The namespace to register the component under.
  * @param {Object} options
- * @param {boolean} [options.memo=true]
+ * @param {boolean} [options.memo=false]
  * @return {import('./polymorphic-component').PolymorphicComponent<import('./polymorphic-component').ElementTypeFromViewOwnProps<P>, import('./polymorphic-component').PropsFromViewOwnProps<P>>} The connected PolymorphicComponent
  */
 export function contextConnect( Component, namespace, options = {} ) {
 	/* eslint-enable jsdoc/valid-types */
-	const { memo: memoProp = true } = options;
+	const { memo: memoProp = false } = options;
 
 	let WrappedComponent = forwardRef( Component );
 	if ( memoProp ) {

--- a/packages/components/src/ui/utils/create-component.tsx
+++ b/packages/components/src/ui/utils/create-component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { identity } from 'lodash';
 // eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 import type { As } from 'reakit-utils/types';
@@ -41,9 +40,9 @@ export const createComponent = <
 	P extends ViewOwnProps< {}, A >
 >( {
 	as,
-	name = 'Component',
-	useHook = identity,
-	memo = true,
+	name,
+	useHook,
+	memo = false,
 }: Options< A, P > ): PolymorphicComponent<
 	ElementTypeFromViewOwnProps< P >,
 	PropsFromViewOwnProps< P >

--- a/packages/components/src/ui/utils/test/create-component.js
+++ b/packages/components/src/ui/utils/test/create-component.js
@@ -23,6 +23,7 @@ describe( 'createComponent', () => {
 		as: 'output',
 		name,
 		useHook,
+		memo: true,
 	} );
 	const Output = createComponent( {
 		as: 'output',
@@ -40,7 +41,7 @@ describe( 'createComponent', () => {
 		expect( container.firstChild.innerHTML ).toBe( 'Example output' );
 	} );
 
-	it( 'should create a memoized, ref-forwarded component by default', () => {
+	it( 'should create a memoized, ref-forwarded component', () => {
 		expect( MemoizedOutput.$$typeof ).toEqual( Symbol.for( 'react.memo' ) );
 		const ref = createRef();
 		const wrapper = render(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Stops auto-memoization which is an anti-pattern. Also removes default values that make no sense from `createComponent`.

Eventually we should take a look at what components _do_ need to be memoized, but the answer is probably that only a few of them need it.

## How has this been tested?
Unit tests pass.

## Types of changes
Non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
