### PR TITLE
Fix: Make media playable on video and audio block backend.

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -178,10 +178,11 @@ function AudioEdit( {
 			</InspectorControls>
 			<figure { ...blockProps }>
 				{ /*
-					Disable the audio tag so the user clicking on it won't play the
+					Disable the audio tag if the block is not selected
+					so the user clicking on it won't play the
 					file or change the position slider when the controls are enabled.
 				*/ }
-				<Disabled>
+				<Disabled isDisabled={ ! isSelected }>
 					<audio controls="controls" src={ src } />
 				</Disabled>
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -236,10 +236,11 @@ function VideoEdit( {
 			</InspectorControls>
 			<figure { ...blockProps }>
 				{ /*
-					Disable the video tag so the user clicking on it won't play the
+					Disable the video tag if the block is not selected
+					so the user clicking on it won't play the
 					video when the controls are enabled.
 				*/ }
-				<Disabled>
+				<Disabled isDisabled={ ! isSelected }>
 					<video
 						controls={ controls }
 						poster={ poster }


### PR DESCRIPTION
This PR makes the video and audio block able to play their contents on the editor. Currently it is impossible to play the contents on the editor and according to the conversation on https://github.com/WordPress/gutenberg/issues/14072 it is a bug.

Fixes: https://github.com/WordPress/gutenberg/issues/14072


## How has this been tested?
I added a video block with a file.
I verified I could play the video after selecting the video block.
I repeated the test for the audio block.