### PR TITLE
Navigation: add unit tests for onChange handler and fix cases around custom links tags and post-format

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -135,45 +135,48 @@ function getSuggestionsQuery( type, kind ) {
 
 export const updateNavigationLinkBlockAttributes = (
 	updatedValue = {},
-	{ setAttributes, label = '' }
+	{
+		setAttributes,
+		label: originalLabel = '',
+		kind: originalKind = '',
+		type: originalType = '',
+	}
 ) => {
 	const {
 		title = '',
 		url = '',
 		opensInNewTab,
 		id,
-		kind = '',
-		type = '',
+		kind: newKind = originalKind,
+		type: newType = originalType,
 	} = updatedValue;
 
 	const normalizedTitle = title.replace( /http(s?):\/\//gi, '' );
 	const normalizedURL = url.replace( /http(s?):\/\//gi, '' );
 	const escapeTitle =
-		title !== '' && normalizedTitle !== normalizedURL && label !== title;
-	const newLabel = escapeTitle
+		title !== '' &&
+		normalizedTitle !== normalizedURL &&
+		originalLabel !== title;
+	const label = escapeTitle
 		? escape( title )
-		: label || escape( normalizedURL );
+		: originalLabel || escape( normalizedURL );
+
+	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );
 
 	const isBuiltInType =
-		[ 'post', 'page', 'tag', 'category', 'post_type' ].indexOf( type ) > -1;
+		[ 'post', 'page', 'tag', 'category' ].indexOf( type ) > -1;
 
-	if ( ! kind && ! isBuiltInType ) {
-		return setAttributes( {
-			url: encodeURI( url ),
-			label: newLabel,
-			opensInNewTab,
-			...( Number.isInteger( id ) && { id } ),
-			kind: 'custom',
-		} );
-	}
+	const isCustomLink =
+		( ! newKind && ! isBuiltInType ) || newKind === 'custom';
+	const kind = isCustomLink ? 'custom' : newKind;
 
 	return setAttributes( {
 		url: encodeURI( url ),
-		label: newLabel,
+		label,
 		opensInNewTab,
 		...( Number.isInteger( id ) && { id } ),
 		...( kind && { kind } ),
-		...( type && { type } ),
+		...( type && ! isCustomLink && { type } ),
 	} );
 };
 
@@ -566,7 +569,7 @@ export default function NavigationLinkEdit( {
 								onChange={ ( updatedValue ) =>
 									updateNavigationLinkBlockAttributes(
 										updatedValue,
-										{ setAttributes, label }
+										{ setAttributes, label, kind, type }
 									)
 								}
 							/>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -133,15 +133,44 @@ function getSuggestionsQuery( type, kind ) {
 	}
 }
 
+/**
+ * @typedef {'post-type'|'custom'|'taxonomy'} WPNavigationLinkKind
+ */
+
+/**
+ * Navigation Link Block Attributes
+ *
+ * @typedef {Object} WPNavigationLinkBlockAttributes
+ *
+ * @property {string}                [label]          Link text.
+ * @property {WPNavigationLinkKind}  [kind]           Kind is used to differentiate between term and post ids to check post draft status.
+ * @property {string}                [type]           The type such as post, page, tag, category and other custom types.
+ * @property {string}                [rel]            The relationship of the linked URL.
+ * @property {number}                [id]             A post or term id.
+ * @property {boolean}               [opensInNewTab]  Sets link target to _blank when true.
+ * @property {string}                [url]            Link href.
+ * @property {string}                [title]          Link title attribute.
+ */
+
+/**
+ * OnChange handler that updates block attributes when a link suggestion is chosen, a url is updated, or
+ * opensInNewTab is toggled
+ *
+ * @param {Object}                          updatedValue    New block attributes to update.
+ * @param {Function}                        setAttributes   Block attribute update function.
+ * @param {WPNavigationLinkBlockAttributes} blockAttributes Current block attributes.
+ *
+ */
 export const updateNavigationLinkBlockAttributes = (
 	updatedValue = {},
-	{
-		setAttributes,
+	setAttributes,
+	blockAttributes = {}
+) => {
+	const {
 		label: originalLabel = '',
 		kind: originalKind = '',
 		type: originalType = '',
-	}
-) => {
+	} = blockAttributes;
 	const {
 		title = '',
 		url = '',
@@ -170,7 +199,7 @@ export const updateNavigationLinkBlockAttributes = (
 		( ! newKind && ! isBuiltInType ) || newKind === 'custom';
 	const kind = isCustomLink ? 'custom' : newKind;
 
-	return setAttributes( {
+	setAttributes( {
 		url: encodeURI( url ),
 		label,
 		opensInNewTab,
@@ -569,7 +598,8 @@ export default function NavigationLinkEdit( {
 								onChange={ ( updatedValue ) =>
 									updateNavigationLinkBlockAttributes(
 										updatedValue,
-										{ setAttributes, label, kind, type }
+										setAttributes,
+										attributes
 									)
 								}
 							/>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -134,7 +134,7 @@ function getSuggestionsQuery( type, kind ) {
 }
 
 /**
- * @typedef {'post-type'|'custom'|'taxonomy'} WPNavigationLinkKind
+ * @typedef {'post-type'|'custom'|'taxonomy'|'post-type-archive'} WPNavigationLinkKind
  */
 
 /**
@@ -153,8 +153,7 @@ function getSuggestionsQuery( type, kind ) {
  */
 
 /**
- * OnChange handler that updates block attributes when a link suggestion is chosen, a url is updated, or
- * opensInNewTab is toggled
+ * Link Control onChange handler that updates block attributes when a setting is changed.
  *
  * @param {Object}                          updatedValue    New block attributes to update.
  * @param {Function}                        setAttributes   Block attribute update function.

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -200,10 +200,10 @@ export const updateNavigationLinkBlockAttributes = (
 	const kind = isCustomLink ? 'custom' : newKind;
 
 	setAttributes( {
-		url: encodeURI( url ),
-		label,
-		opensInNewTab,
-		...( Number.isInteger( id ) && { id } ),
+		...( url && { url: encodeURI( url ) } ),
+		...( label && { label } ),
+		...( undefined !== opensInNewTab && { opensInNewTab } ),
+		...( id && Number.isInteger( id ) && { id } ),
 		...( kind && { kind } ),
 		...( type && ! isCustomLink && { type } ),
 	} );

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -189,6 +189,7 @@ export const updateNavigationLinkBlockAttributes = (
 		? escape( title )
 		: originalLabel || escape( normalizedURL );
 
+	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
 	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );
 
 	const isBuiltInType =
@@ -204,7 +205,7 @@ export const updateNavigationLinkBlockAttributes = (
 		...( undefined !== opensInNewTab && { opensInNewTab } ),
 		...( id && Number.isInteger( id ) && { id } ),
 		...( kind && { kind } ),
-		...( type && ! isCustomLink && { type } ),
+		...( type && type !== 'URL' && { type } ),
 	} );
 };
 

--- a/packages/block-library/src/navigation-link/test/edit.js
+++ b/packages/block-library/src/navigation-link/test/edit.js
@@ -1,0 +1,296 @@
+/**
+ * Internal dependencies
+ */
+import { updateNavigationLinkBlockAttributes } from '../edit';
+
+describe( 'edit', () => {
+	describe( 'updateNavigationLinkBlockAttributes', () => {
+		// data shapes are linked to fetchLinkSuggestions from
+		// core-data/src/fetch/__experimental-fetch-link-suggestions.js
+		it( 'can update a post link', () => {
+			const setAttributes = jest.fn();
+			const linkSuggestion = {
+				opensInNewTab: false,
+				id: 1337,
+				url: 'https://wordpress.local/menu-test/',
+				kind: 'post-type',
+				title: 'Menu Test',
+				type: 'post',
+			};
+
+			updateNavigationLinkBlockAttributes( linkSuggestion, {
+				setAttributes,
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 1337,
+				label: 'Menu Test',
+				opensInNewTab: false,
+				kind: 'post-type',
+				type: 'post',
+				url: 'https://wordpress.local/menu-test/',
+			} );
+		} );
+
+		it( 'can update a page link', () => {
+			const setAttributes = jest.fn();
+			const linkSuggestion = {
+				id: 2,
+				kind: 'post-type',
+				opensInNewTab: false,
+				title: 'Sample Page',
+				type: 'page',
+				url: 'http://wordpress.local/sample-page/',
+			};
+			updateNavigationLinkBlockAttributes( linkSuggestion, {
+				setAttributes,
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 2,
+				kind: 'post-type',
+				label: 'Sample Page',
+				opensInNewTab: false,
+				type: 'page',
+				url: 'http://wordpress.local/sample-page/',
+			} );
+		} );
+
+		it( 'can update a tag link', () => {
+			const setAttributes = jest.fn();
+			const linkSuggestion = {
+				id: 15,
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				title: 'bar',
+				type: 'post_tag',
+				url: 'http://wordpress.local/tag/bar/',
+			};
+			updateNavigationLinkBlockAttributes( linkSuggestion, {
+				setAttributes,
+			} );
+			// TODO: existing bug: if url is not set, placeholder has "tag" and set value has "post_tag"
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 15,
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				label: 'bar',
+				type: 'tag',
+				url: 'http://wordpress.local/tag/bar/',
+			} );
+		} );
+
+		it( 'can update a category link', () => {
+			const setAttributes = jest.fn();
+			const linkSuggestion = {
+				id: 9,
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				title: 'Cats',
+				type: 'category',
+				url: 'http://wordpress.local/category/cats/',
+			};
+			updateNavigationLinkBlockAttributes( linkSuggestion, {
+				setAttributes,
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 9,
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				label: 'Cats',
+				type: 'category',
+				url: 'http://wordpress.local/category/cats/',
+			} );
+		} );
+
+		it( 'can update a custom post type link', () => {
+			const setAttributes = jest.fn();
+			const linkSuggestion = {
+				id: 131,
+				kind: 'post-type',
+				opensInNewTab: false,
+				title: 'Fall',
+				type: 'portfolio',
+				url: 'http://wordpress.local/portfolio/fall/',
+			};
+			updateNavigationLinkBlockAttributes( linkSuggestion, {
+				setAttributes,
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 131,
+				kind: 'post-type',
+				opensInNewTab: false,
+				label: 'Fall',
+				type: 'portfolio',
+				url: 'http://wordpress.local/portfolio/fall/',
+			} );
+		} );
+
+		it( 'can update a custom tag link', () => {
+			const setAttributes = jest.fn();
+			const linkSuggestion = {
+				id: 4,
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				title: 'PortfolioTag',
+				type: 'portfolio_tag',
+				url: 'http://wordpress.local/portfolio_tag/portfoliotag/',
+			};
+			updateNavigationLinkBlockAttributes( linkSuggestion, {
+				setAttributes,
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 4,
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				label: 'PortfolioTag',
+				type: 'portfolio_tag',
+				url: 'http://wordpress.local/portfolio_tag/portfoliotag/',
+			} );
+		} );
+
+		it( 'can update a custom category link', () => {
+			const setAttributes = jest.fn();
+			const linkSuggestion = {
+				id: 2,
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				title: 'Portfolioz Category',
+				type: 'portfolio_category',
+				url:
+					'http://wordpress.local/portfolio_category/portfolioz-category/',
+			};
+			updateNavigationLinkBlockAttributes( linkSuggestion, {
+				setAttributes,
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 2,
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				label: 'Portfolioz Category',
+				type: 'portfolio_category',
+				url:
+					'http://wordpress.local/portfolio_category/portfolioz-category/',
+			} );
+		} );
+
+		it( 'can update a post format', () => {
+			const setAttributes = jest.fn();
+			const linkSuggestion = {
+				id: 'video',
+				kind: undefined, //TODO also fix this in experimental fetch link suggestions
+				opensInNewTab: false,
+				title: 'Video',
+				type: 'post-format',
+				url: 'http://wordpress.local/type/video/',
+			};
+			updateNavigationLinkBlockAttributes( linkSuggestion, {
+				setAttributes,
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				kind: 'taxonomy',
+				opensInNewTab: false,
+				label: 'Video',
+				type: 'post_format',
+				url: 'http://wordpress.local/type/video/',
+			} );
+		} );
+
+		describe( 'various link protocols save as custom links', () => {
+			it( 'when typing a url, but not selecting a search suggestion', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					opensInNewTab: false,
+					url: 'www.wordpress.org',
+				};
+				updateNavigationLinkBlockAttributes( linkSuggestion, {
+					setAttributes,
+				} );
+				expect( setAttributes ).toHaveBeenCalledWith( {
+					opensInNewTab: false,
+					url: 'www.wordpress.org',
+					label: 'www.wordpress.org',
+					kind: 'custom',
+				} );
+			} );
+
+			it( 'url', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: 'www.wordpress.org',
+					opensInNewTab: false,
+					title: 'www.wordpress.org',
+					type: 'URL',
+					url: 'http://www.wordpress.org',
+				};
+				updateNavigationLinkBlockAttributes( linkSuggestion, {
+					setAttributes,
+				} );
+				expect( setAttributes ).toHaveBeenCalledWith( {
+					opensInNewTab: false,
+					label: 'www.wordpress.org',
+					kind: 'custom',
+					url: 'http://www.wordpress.org',
+				} );
+			} );
+
+			it( 'email', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: 'mailto:foo@example.com',
+					opensInNewTab: false,
+					title: 'mailto:foo@example.com',
+					type: 'mailto',
+					url: 'mailto:foo@example.com',
+				};
+				updateNavigationLinkBlockAttributes( linkSuggestion, {
+					setAttributes,
+				} );
+				expect( setAttributes ).toHaveBeenCalledWith( {
+					opensInNewTab: false,
+					label: 'mailto:foo@example.com',
+					kind: 'custom',
+					url: 'mailto:foo@example.com',
+				} );
+			} );
+
+			it( 'anchor links (internal links)', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: '#foo',
+					opensInNewTab: false,
+					title: '#foo',
+					type: 'internal',
+					url: '#foo',
+				};
+				updateNavigationLinkBlockAttributes( linkSuggestion, {
+					setAttributes,
+				} );
+				expect( setAttributes ).toHaveBeenCalledWith( {
+					opensInNewTab: false,
+					label: '#foo',
+					kind: 'custom',
+					url: '#foo',
+				} );
+			} );
+
+			it( 'telephone', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: 'tel:5555555',
+					opensInNewTab: false,
+					title: 'tel:5555555',
+					type: 'tel',
+					url: 'tel:5555555',
+				};
+				updateNavigationLinkBlockAttributes( linkSuggestion, {
+					setAttributes,
+				} );
+				expect( setAttributes ).toHaveBeenCalledWith( {
+					opensInNewTab: false,
+					label: 'tel:5555555',
+					kind: 'custom',
+					url: 'tel:5555555',
+				} );
+			} );
+		} );
+	} );
+} );

--- a/packages/block-library/src/navigation-link/test/edit.js
+++ b/packages/block-library/src/navigation-link/test/edit.js
@@ -18,9 +18,10 @@ describe( 'edit', () => {
 				type: 'post',
 			};
 
-			updateNavigationLinkBlockAttributes( linkSuggestion, {
-				setAttributes,
-			} );
+			updateNavigationLinkBlockAttributes(
+				linkSuggestion,
+				setAttributes
+			);
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 1337,
 				label: 'Menu Test',
@@ -41,9 +42,10 @@ describe( 'edit', () => {
 				type: 'page',
 				url: 'http://wordpress.local/sample-page/',
 			};
-			updateNavigationLinkBlockAttributes( linkSuggestion, {
-				setAttributes,
-			} );
+			updateNavigationLinkBlockAttributes(
+				linkSuggestion,
+				setAttributes
+			);
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 2,
 				kind: 'post-type',
@@ -64,9 +66,10 @@ describe( 'edit', () => {
 				type: 'post_tag',
 				url: 'http://wordpress.local/tag/bar/',
 			};
-			updateNavigationLinkBlockAttributes( linkSuggestion, {
-				setAttributes,
-			} );
+			updateNavigationLinkBlockAttributes(
+				linkSuggestion,
+				setAttributes
+			);
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 15,
 				kind: 'taxonomy',
@@ -87,9 +90,10 @@ describe( 'edit', () => {
 				type: 'category',
 				url: 'http://wordpress.local/category/cats/',
 			};
-			updateNavigationLinkBlockAttributes( linkSuggestion, {
-				setAttributes,
-			} );
+			updateNavigationLinkBlockAttributes(
+				linkSuggestion,
+				setAttributes
+			);
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 9,
 				kind: 'taxonomy',
@@ -110,9 +114,10 @@ describe( 'edit', () => {
 				type: 'portfolio',
 				url: 'http://wordpress.local/portfolio/fall/',
 			};
-			updateNavigationLinkBlockAttributes( linkSuggestion, {
-				setAttributes,
-			} );
+			updateNavigationLinkBlockAttributes(
+				linkSuggestion,
+				setAttributes
+			);
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 131,
 				kind: 'post-type',
@@ -133,9 +138,10 @@ describe( 'edit', () => {
 				type: 'portfolio_tag',
 				url: 'http://wordpress.local/portfolio_tag/portfoliotag/',
 			};
-			updateNavigationLinkBlockAttributes( linkSuggestion, {
-				setAttributes,
-			} );
+			updateNavigationLinkBlockAttributes(
+				linkSuggestion,
+				setAttributes
+			);
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 4,
 				kind: 'taxonomy',
@@ -157,9 +163,10 @@ describe( 'edit', () => {
 				url:
 					'http://wordpress.local/portfolio_category/portfolioz-category/',
 			};
-			updateNavigationLinkBlockAttributes( linkSuggestion, {
-				setAttributes,
-			} );
+			updateNavigationLinkBlockAttributes(
+				linkSuggestion,
+				setAttributes
+			);
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 2,
 				kind: 'taxonomy',
@@ -181,9 +188,10 @@ describe( 'edit', () => {
 				type: 'post-format',
 				url: 'http://wordpress.local/type/video/',
 			};
-			updateNavigationLinkBlockAttributes( linkSuggestion, {
-				setAttributes,
-			} );
+			updateNavigationLinkBlockAttributes(
+				linkSuggestion,
+				setAttributes
+			);
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				kind: 'taxonomy',
 				opensInNewTab: false,
@@ -200,9 +208,10 @@ describe( 'edit', () => {
 					opensInNewTab: false,
 					url: 'www.wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					url: 'www.wordpress.org',
@@ -220,9 +229,10 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'http://www.wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'www.wordpress.org',
@@ -240,9 +250,10 @@ describe( 'edit', () => {
 					type: 'mailto',
 					url: 'mailto:foo@example.com',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'mailto:foo@example.com',
@@ -260,9 +271,10 @@ describe( 'edit', () => {
 					type: 'internal',
 					url: '#foo',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: '#foo',
@@ -280,9 +292,10 @@ describe( 'edit', () => {
 					type: 'tel',
 					url: 'tel:5555555',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'tel:5555555',
@@ -303,9 +316,10 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'https://www.wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'www.wordpress.org',
@@ -322,9 +336,10 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'Custom Title',
@@ -341,9 +356,10 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'https://wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'Custom Title',
@@ -360,9 +376,10 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'https://wordpress.local?p=1',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: '&lt;Navigation /&gt;',
@@ -380,9 +397,10 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'http://wordpress.org/?s=<>',
 				};
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
-					setAttributes,
-				} );
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
+					setAttributes
+				);
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'Custom Title',
@@ -407,10 +425,11 @@ describe( 'edit', () => {
 					type: 'post',
 				};
 
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
 					setAttributes,
-					...mockState,
-				} );
+					mockState
+				);
 				expect( mockState ).toEqual( {
 					id: 1337,
 					label: 'Menu Test',
@@ -425,10 +444,8 @@ describe( 'edit', () => {
 						url: 'https://wordpress.local/menu-test/',
 						opensInNewTab: true,
 					},
-					{
-						setAttributes,
-						...mockState,
-					}
+					setAttributes,
+					mockState
 				);
 				expect( mockState ).toEqual( {
 					id: 1337,
@@ -453,10 +470,11 @@ describe( 'edit', () => {
 					type: 'post',
 				};
 
-				updateNavigationLinkBlockAttributes( linkSuggestion, {
+				updateNavigationLinkBlockAttributes(
+					linkSuggestion,
 					setAttributes,
-					...mockState,
-				} );
+					mockState
+				);
 				expect( mockState ).toEqual( {
 					id: 1337,
 					label: 'Menu Test',
@@ -471,10 +489,8 @@ describe( 'edit', () => {
 						url: 'https://wordpress.local/foo/',
 						opensInNewTab: false,
 					},
-					{
-						setAttributes,
-						...mockState,
-					}
+					setAttributes,
+					mockState
 				);
 				expect( mockState ).toEqual( {
 					id: 1337,

--- a/packages/block-library/src/navigation-link/test/edit.js
+++ b/packages/block-library/src/navigation-link/test/edit.js
@@ -134,9 +134,9 @@ describe( 'edit', () => {
 				id: 4,
 				kind: 'taxonomy',
 				opensInNewTab: false,
-				title: 'PortfolioTag',
+				title: 'Portfolio Tag',
 				type: 'portfolio_tag',
-				url: 'http://wordpress.local/portfolio_tag/portfoliotag/',
+				url: 'http://wordpress.local/portfolio_tag/PortfolioTag/',
 			};
 			updateNavigationLinkBlockAttributes(
 				linkSuggestion,
@@ -146,9 +146,9 @@ describe( 'edit', () => {
 				id: 4,
 				kind: 'taxonomy',
 				opensInNewTab: false,
-				label: 'PortfolioTag',
+				label: 'Portfolio Tag',
 				type: 'portfolio_tag',
-				url: 'http://wordpress.local/portfolio_tag/portfoliotag/',
+				url: 'http://wordpress.local/portfolio_tag/PortfolioTag/',
 			} );
 		} );
 
@@ -158,10 +158,10 @@ describe( 'edit', () => {
 				id: 2,
 				kind: 'taxonomy',
 				opensInNewTab: false,
-				title: 'Portfolioz Category',
+				title: 'Portfolio Category',
 				type: 'portfolio_category',
 				url:
-					'http://wordpress.local/portfolio_category/portfolioz-category/',
+					'http://wordpress.local/portfolio_category/Portfolio-category/',
 			};
 			updateNavigationLinkBlockAttributes(
 				linkSuggestion,
@@ -171,10 +171,10 @@ describe( 'edit', () => {
 				id: 2,
 				kind: 'taxonomy',
 				opensInNewTab: false,
-				label: 'Portfolioz Category',
+				label: 'Portfolio Category',
 				type: 'portfolio_category',
 				url:
-					'http://wordpress.local/portfolio_category/portfolioz-category/',
+					'http://wordpress.local/portfolio_category/Portfolio-category/',
 			} );
 		} );
 

--- a/packages/block-library/src/navigation-link/test/edit.js
+++ b/packages/block-library/src/navigation-link/test/edit.js
@@ -178,7 +178,7 @@ describe( 'edit', () => {
 			} );
 		} );
 
-		it( 'can update a post format', () => {
+		it( 'can update a post format and ignores id slug', () => {
 			const setAttributes = jest.fn();
 			const linkSuggestion = {
 				id: 'video',
@@ -192,6 +192,8 @@ describe( 'edit', () => {
 				linkSuggestion,
 				setAttributes
 			);
+			// post_format returns a slug ID value from the Search API
+			// we do not persist this ID since we expect this value to be a post or term ID
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				kind: 'taxonomy',
 				opensInNewTab: false,

--- a/packages/block-library/src/navigation-link/test/edit.js
+++ b/packages/block-library/src/navigation-link/test/edit.js
@@ -259,6 +259,7 @@ describe( 'edit', () => {
 					label: 'mailto:foo@example.com',
 					kind: 'custom',
 					url: 'mailto:foo@example.com',
+					type: 'mailto',
 				} );
 			} );
 
@@ -280,6 +281,7 @@ describe( 'edit', () => {
 					label: '#foo',
 					kind: 'custom',
 					url: '#foo',
+					type: 'internal',
 				} );
 			} );
 
@@ -301,6 +303,7 @@ describe( 'edit', () => {
 					label: 'tel:5555555',
 					kind: 'custom',
 					url: 'tel:5555555',
+					type: 'tel',
 				} );
 			} );
 		} );

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -140,7 +140,16 @@ const fetchLinkSuggestions = async (
 					type: 'post-format',
 					subtype,
 				} ),
-			} ).catch( () => [] )
+			} )
+				.then( ( results ) => {
+					return results.map( ( result ) => {
+						return {
+							...result,
+							meta: { kind: 'taxonomy', subtype },
+						};
+					} );
+				} )
+				.catch( () => [] )
 		);
 	}
 

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -40,12 +40,14 @@ jest.mock( '@wordpress/api-fetch', () =>
 						title: 'Gallery',
 						url: 'http://wordpress.local/type/gallery/',
 						type: 'post-format',
+						kind: 'taxonomy',
 					},
 					{
 						id: 'quote',
 						title: 'Quote',
 						url: 'http://wordpress.local/type/quote/',
 						type: 'post-format',
+						kind: 'taxonomy',
 					},
 				] );
 			case '/wp/v2/search?search=&per_page=3&type=post&subtype=page':
@@ -131,12 +133,14 @@ describe( 'fetchLinkSuggestions', () => {
 					title: 'Gallery',
 					url: 'http://wordpress.local/type/gallery/',
 					type: 'post-format',
+					kind: 'taxonomy',
 				},
 				{
 					id: 'quote',
 					title: 'Quote',
 					url: 'http://wordpress.local/type/quote/',
 					type: 'post-format',
+					kind: 'taxonomy',
 				},
 			] )
 		);
@@ -179,12 +183,14 @@ describe( 'fetchLinkSuggestions', () => {
 					title: 'Gallery',
 					url: 'http://wordpress.local/type/gallery/',
 					type: 'post-format',
+					kind: 'taxonomy',
 				},
 				{
 					id: 'quote',
 					title: 'Quote',
 					url: 'http://wordpress.local/type/quote/',
 					type: 'post-format',
+					kind: 'taxonomy',
 				},
 			] )
 		);

--- a/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
@@ -46,7 +46,7 @@ exports[`Navigation Creating from existing Pages allows a navigation block to be
 
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://wordpress.org\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\"} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\",\\"kind\\":\\"post-type\\"} /-->
 <!-- /wp:navigation -->"

--- a/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
@@ -46,7 +46,7 @@ exports[`Navigation Creating from existing Pages allows a navigation block to be
 
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"id\\":\\"https://wordpress.org\\",\\"url\\":\\"https://wordpress.org\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\",\\"kind\\":\\"post-type\\"} /-->
 <!-- /wp:navigation -->"


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/31254 https://github.com/WordPress/gutenberg/issues/31379

https://user-images.githubusercontent.com/1270189/116925012-802e4380-ac0d-11eb-84d1-58d4b9e8f0d5.mp4

### Changes of interest:

* **Pulls out the LinkControl onChange function** in Navigation Link so we can add **unit test cases**
* **Custom links are now persisted with "kind:custom"** instead of serializing misc link control specific items, like (tel, URL, internal mailto).
* **Consistently save as type:tag**. We were inconsistently saving "type:tag" as a tag variation placeholder and "type:post_tag" when a full tag link was inserted. I'm not sure of the original reasons for favoring "tag" versus the actual "post_tag" name.
* **Toggling opensInNewTab on an existing link no longer wipes out other block attributes**
* **Updates fetchLinkSuggestions to return a type:post-format and kind:taxonomy**

~~Main feedback questions~~:
* ~~Did we intend to persist "internal/tel/URL/mailto" or is it okay to map these to a plain custom type?~~ A: good to map to custom
* ~~Are post-formats and post type archives similar or different use cases?~~ post-format is a `taxonomy` with a name of `post_format`
* ~~If folks prefer, instead of adding a `getNavigationLinkType` helper I can create a function for the LinkControl onChange function. It'd be a little bit of a refactor, but nice for unit testing, as we can isolate the data transform cases.~~ I think it's worth the unit tests at this point, so I'll isolate and refactor this.

### Testing Instructions

Unit Tests:
- Verify that the new test cases make sense. Run them locally with `npm run test-unit packages/block-library/src/navigation-link/test/edit.js`

Custom Links:
- Visit the post or site editor
- Add a navigation block 
- Add a custom link variation
- Type email link like "mailto:foo@example.com", Type a custom url like "wordpress.org", Type a telephone link like: "tel:1234567", Type an internal link like "#foo"
- Save, and check in code view that the type value for the navigation link is "custom"

Tag:
- Visit the post or site editor
- Add a navigation block 
- Add an item, select tag variation
- Do not click on a tag suggestion. Click out then inspect code view.
- Verify that type = tag
- Select a tag suggestion
- Verify that type = tag in code view

Opens In New Tab
- Visit the post or site editor
- Add a navigation block 
- Add a post link
- Click on the link symbol, then toggle opensInNewTab.
- Verify that id is still set in code view

Post Formats
- A post format link looks like http://wordpress.local/type/quote/. This points at the archive of a post type format like quote or image.
- Install a theme that supports post-formats like Twenty Thirteen
- Create a post using one of the post-format types like "Quote"
- Add a navigation block
- Add a navigation link using the general link variation
- Search for the post-format and individual quote
- Verify that the link to the post-format has a type of "post_format" and a kind of "taxonomy"



