### PR TITLE
Border Block Support: Add utilities to get border classes and styles

### DIFF
--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -12,4 +12,5 @@ import './font-size';
 import './border-color';
 import './layout';
 
+export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -9,4 +9,5 @@ import './style';
 import './color';
 import './font-size';
 
+export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';

--- a/packages/block-editor/src/hooks/use-border-props.js
+++ b/packages/block-editor/src/hooks/use-border-props.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { getInlineStyles } from './style';
+import {
+	getColorClassName,
+	getColorObjectByAttributeValues,
+} from '../components/colors';
+import useEditorFeature from '../components/use-editor-feature';
+
+// This utility is intended to assist where the serialization of the border
+// block support is being skipped for a block but the border related CSS classes
+// & styles still need to be generated so they can be applied to inner elements.
+
+const EMPTY_ARRAY = [];
+
+/**
+ * Provides the CSS class names and inline styles for a block's border support
+ * attributes.
+ *
+ * @param  {Object} attributes             Block attributes.
+ * @param  {string} attributes.borderColor Selected named border color.
+ * @param  {Object} attributes.style       Block's styles attribute.
+ *
+ * @return {Object} Border block support derived CSS classes & styles.
+ */
+export function getBorderClassesAndStyles( { borderColor, style } ) {
+	const borderStyles = style?.border || {};
+	const borderClass = getColorClassName( 'border-color', borderColor );
+
+	const className = classnames( {
+		[ borderClass ]: !! borderClass,
+		'has-border-color': borderColor || style?.border?.color,
+	} );
+
+	return {
+		className: className || undefined,
+		style: getInlineStyles( { border: borderStyles } ),
+	};
+}
+
+/**
+ * Derives the border related props for a block from its border block support
+ * attributes.
+ *
+ * Inline styles are forced for named colors to ensure these selections are
+ * reflected when themes do not load their color stylesheets in the editor.
+ *
+ * @param  {Object} attributes Block attributes.
+ * @return {Object}            ClassName & style props from border block support.
+ */
+export function useBorderProps( attributes ) {
+	const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
+	const borderProps = getBorderClassesAndStyles( attributes );
+
+	// Force inline style to apply border color when themes do not load their
+	// color stylesheets in the editor.
+	if ( attributes.borderColor ) {
+		const borderColorObject = getColorObjectByAttributeValues(
+			colors,
+			attributes.borderColor
+		);
+
+		borderProps.style.borderColor = borderColorObject.color;
+	}
+
+	return borderProps;
+}

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -8,6 +8,8 @@ import '@wordpress/rich-text';
  */
 import './hooks';
 export {
+	getBorderClassesAndStyles as __experimentalGetBorderClassesAndStyles,
+	useBorderProps as __experimentalUseBorderProps,
 	getColorClassesAndStyles as __experimentalGetColorClassesAndStyles,
 	useColorProps as __experimentalUseColorProps,
 } from './hooks';


### PR DESCRIPTION
## Description
This adds two utilities to assist in applying border block support classes and styles to inner block elements when choosing to skip serialization. 

The approach follows that taken in https://github.com/WordPress/gutenberg/pull/30869 for color block support.

## How has this been tested?

Initially tested by:
1. Opting into border support for the table block
2. Importing these utilities into the edit and save files as required
3. Using the utilities to retrieve classes and styles, then output them onto the inner table element
4. Confirmed correct classes and styles via dev tools.

A separate PR using these utilities for the table block has been created ( https://github.com/WordPress/gutenberg/pull/31265 ) and allows for easier testing of this PR.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
