### PR TITLE
In-between inserter (on hover): preserve original behaviour

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -15,7 +15,6 @@ import { InsertionPointOpenRef } from './insertion-point';
 export function useInBetweenInserter() {
 	const openRef = useContext( InsertionPointOpenRef );
 	const {
-		getBlockInsertionPoint,
 		getBlockListSettings,
 		getBlockRootClientId,
 		getBlockIndex,
@@ -68,7 +67,7 @@ export function useInBetweenInserter() {
 				const offsetLeft = event.clientX - rect.left;
 
 				const children = Array.from( event.target.children );
-				const nextElement = children.find( ( blockEl ) => {
+				let element = children.find( ( blockEl ) => {
 					return (
 						( blockEl.classList.contains( 'wp-block' ) &&
 							orientation === 'vertical' &&
@@ -78,8 +77,6 @@ export function useInBetweenInserter() {
 							blockEl.offsetLeft > offsetLeft )
 					);
 				} );
-
-				let element = nextElement || children[ children.length - 1 ];
 
 				if ( ! element ) {
 					return;
@@ -117,11 +114,20 @@ export function useInBetweenInserter() {
 					return;
 				}
 
-				showInsertionPoint(
-					rootClientId,
-					getBlockIndex( clientId, rootClientId ),
-					{ __unstableWithInserter: true }
-				);
+				const index = getBlockIndex( clientId, rootClientId );
+
+				// Don't show the in-between inserter before the first block in
+				// the list (preserves the original behaviour).
+				if ( index === 0 ) {
+					if ( isBlockInsertionPointVisible() ) {
+						hideInsertionPoint();
+					}
+					return;
+				}
+
+				showInsertionPoint( rootClientId, index, {
+					__unstableWithInserter: true,
+				} );
 			}
 
 			node.addEventListener( 'mousemove', onMouseMove );
@@ -132,7 +138,6 @@ export function useInBetweenInserter() {
 		},
 		[
 			openRef,
-			getBlockInsertionPoint,
 			getBlockListSettings,
 			getBlockRootClientId,
 			getBlockIndex,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

See #30285.

Don't show before the first or after the last block, which was the original behaviour. Additionally the insertion point is showing up in the wrong position. If we ever enable this, we'd have to fix the insertion point, which doesn't currently support rendering before the first block. I will address this in a follow-up because it is needed for drag and drop.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
