### PR TITLE
Global Styles: Add theme origin to getStyle

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -142,6 +142,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 
 	const contexts = useMemo( () => getContexts( blockTypes ), [ blockTypes ] );
 
+	const { __experimentalGlobalStylesBaseStyles: themeStyles } = settings;
 	const { userStyles, mergedStyles } = useMemo( () => {
 		let newUserStyles;
 		try {
@@ -175,6 +176,17 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 		};
 	}, [ content ] );
 
+	const getStyleOrigin = ( origin ) => {
+		switch ( origin ) {
+			case 'user':
+				return userStyles;
+			case 'theme':
+				return themeStyles;
+			default:
+				return mergedStyles;
+		}
+	};
+
 	const nextValue = useMemo(
 		() => ( {
 			contexts,
@@ -191,14 +203,15 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				setContent( JSON.stringify( newContent ) );
 			},
 			getStyle: ( context, propertyName, origin = 'merged' ) => {
-				const styleOrigin =
-					'user' === origin ? userStyles : mergedStyles;
+				const styleOrigin = getStyleOrigin( origin );
 
 				const value = get(
 					styleOrigin?.styles?.[ context ],
 					STYLE_PROPERTY[ propertyName ].value
 				);
-				return getValueFromVariable( mergedStyles, context, value );
+
+				const styles = 'theme' === origin ? themeStyles : mergedStyles;
+				return getValueFromVariable( styles, context, value );
 			},
 			setStyle: ( context, propertyName, newValue ) => {
 				const newContent = { ...userStyles };
@@ -220,7 +233,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				setContent( JSON.stringify( newContent ) );
 			},
 		} ),
-		[ content, mergedStyles ]
+		[ content, mergedStyles, themeStyles ]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
## Description
Adds a `theme` origin to the `getStyle` function used to retrieve style values for Global Styles controls.

The aim is to allow retrieval of a value set by the theme itself so Global Style controls can be reset to that theme value rather than simply unset completely.

## How has this been tested?

#### Test Setup
1. Apply both the changes in https://github.com/WordPress/gutenberg/pull/30607 and this PR
2. Add default padding style values in your theme.json
```json
	"styles": {
		"core/group": {
			"spacing": {
				"padding": {
					"top": "50px",
					"bottom": "50px"
				}
			}
		}
	}
```
3. Update `edit-site/src/components/sidebar/spacing-panel.js` to set the `resetValues` prop on the padding's `BoxControl`
```js
resetValues={ getStyle( name, 'padding', 'theme' ) }
```

#### Test Instructions
1. Open the site editor
2. Navigate to the "Global Styles" sidebar > "By Block Type" tab > "Group" panel
3. Adjust the padding control values for the Group block
4. Hit the padding control's reset button and confirm the fields are reset to the values you set in your theme.json

## Screenshots
![ThemeOrigin](https://user-images.githubusercontent.com/60436221/116359812-966d8580-a842-11eb-94ac-bd3df58e6257.gif)

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
