### PR TITLE
[Fix] Inlined core block styles should not override user-added inline styles

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -253,8 +253,8 @@ function gutenberg_maybe_inline_styles() {
 			$style['css'] = file_get_contents( $style['path'] );
 
 			// Set `src` to `false` and add styles inline.
-			$wp_styles->registered[ $style['handle'] ]->src              = false;
-			$wp_styles->registered[ $style['handle'] ]->extra['after'][] = $style['css'];
+			$wp_styles->registered[ $style['handle'] ]->src = false;
+			array_unshift( $wp_styles->registered[ $style['handle'] ]->extra['after'], $style['css'] );
 
 			// Add the styles size to the $total_inline_size var.
 			$total_inline_size += (int) $style['size'];

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -254,6 +254,9 @@ function gutenberg_maybe_inline_styles() {
 
 			// Set `src` to `false` and add styles inline.
 			$wp_styles->registered[ $style['handle'] ]->src = false;
+			if ( empty( $wp_styles->registered[ $style['handle'] ]->extra['after'] ) ) {
+				$wp_styles->registered[ $style['handle'] ]->extra['after'] = array();
+			}
 			array_unshift( $wp_styles->registered[ $style['handle'] ]->extra['after'], $style['css'] );
 
 			// Add the styles size to the $total_inline_size var.


### PR DESCRIPTION
## Description
In an FSE theme, block styles may get inlined (depending on their size).
However, there is currently an issue and if a theme (or plugin) adds styles to these core block-styles using `wp_add_inline_style`, the core block styles are appended to the ones that were added, overriding them if the same selectors are used.

This PR changes the previous behavior and instead of adding the core block styles as the last item in the array, it adds them as the 1st item - therefore eliminating the problem.

## How has this been tested?

Tested in combination with https://github.com/WordPress/gutenberg/pull/31239 which adds `theme` styles using `wp_add_inline_style`.

You can also test by adding something like this in an FSE theme:
```php
add_action( 'wp_enqueue_scripts', function() {
	wp_add_inline_style(
		'wp-block-paragraph',
		'p.has-background{padding:10em}'
	);
} );
```
Prior to this PR, the padding does not apply because it gets overridden by core styles. After this PR, the padding gets properly appried.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
