### PR TITLE
Fix wp-env can't checkout git repositories of a specific tag.

### DIFF
--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -123,7 +123,7 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 		await git.clone( source.url, source.clonePath, {
 			'--depth': '1',
 			'--no-single-branch': null,
-			'--branch': source.ref
+			'--branch': source.ref,
 		} );
 		await git.cwd( source.clonePath );
 	}

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -123,10 +123,17 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 		await git.clone( source.url, source.clonePath, {
 			'--depth': '1',
 			'--no-single-branch': null,
-			'--branch': source.ref,
 		} );
 		await git.cwd( source.clonePath );
 	}
+
+	log( 'Fetching the specified ref.' );
+	await git.fetch( 'origin', source.ref, {
+		'--tags': null
+	} );	
+
+	log( 'Checking out the specified ref.' );
+	await git.checkout( source.ref );
 
 	onProgress( 1 );
 }

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -123,15 +123,10 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 		await git.clone( source.url, source.clonePath, {
 			'--depth': '1',
 			'--no-single-branch': null,
+			'--branch': source.ref
 		} );
 		await git.cwd( source.clonePath );
 	}
-
-	log( 'Fetching the specified ref.' );
-	await git.fetch( 'origin', source.ref );
-
-	log( 'Checking out the specified ref.' );
-	await git.checkout( source.ref );
 
 	onProgress( 1 );
 }

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -129,8 +129,8 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 
 	log( 'Fetching the specified ref.' );
 	await git.fetch( 'origin', source.ref, {
-		'--tags': null
-	} );	
+		'--tags': null,
+	} );
 
 	log( 'Checking out the specified ref.' );
 	await git.checkout( source.ref );


### PR DESCRIPTION
## Description

Whenever I run `npm run wp-env start`, I'm getting the error `GitError: error: pathspec 'tt1-blocks@0.4.5' did not match any file(s) known to git`.

Here's the full log.
```
GitError: error: pathspec 'tt1-blocks@0.4.5' did not match any file(s) known to git

    at GitExecutorChain.onFatalException (/Users/yansern/A8C/gutenberg/packages/env/node_modules/simple-git/src/lib/runners/git-executor-chain.js:65:87)
    at GitExecutorChain.<anonymous> (/Users/yansern/A8C/gutenberg/packages/env/node_modules/simple-git/src/lib/runners/git-executor-chain.js:56:28)
    at Generator.throw (<anonymous>)
    at rejected (/Users/yansern/A8C/gutenberg/packages/env/node_modules/simple-git/src/lib/runners/git-executor-chain.js:6:65)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  task: {
    commands: [ 'checkout', 'tt1-blocks@0.4.5' ],
    format: 'utf-8',
    parser: [Function: parser]
  }
}
```

## Why it failed?

It appears that using the git clone option for `depth=1 --no-single-branch` only pulls the tip of all branches, not all tags.

The `tt1-blocks@0.4.5` is a tag of `WordPress/theme-experiments`.

## How has this been tested?


**Test wp-env with newly cloned repo**
1. Start with a clean slate by running `rm -fr ~/.wp-env/*`.
2. Run `npm run wp-env start`.
3. Once all done, run `cat ~/.wp-env/*/theme-experiments/tt1-blocks/style.css | grep Version`.
4. You should see `Version: 0.4.5`.

![image](https://user-images.githubusercontent.com/1287077/116614836-1ed34f80-a943-11eb-9e78-ad6b0bb634de.png)

**Test wp-env with previously cloned repo**

5. Go to the repo folder, e.g. `cd ~/.wp-env/*/theme-experiments`.
6. Checkout the previous version `git checkout tt1-blocks@0.4.3`.
7. Delete the new version `git tag -d tt1-blocks@0.4.5`.
8. Go back to the gutenberg folder and run `npm run wp-env start`.
9. Once all done, run `cat ~/.wp-env/*/theme-experiments/tt1-blocks/style.css | grep Version`.
4. You should see `Version: 0.4.5` as well.

## Screenshots
![image](https://user-images.githubusercontent.com/1287077/116365489-f5fd6e00-a80d-11eb-9438-462115455344.png)
![image](https://user-images.githubusercontent.com/1287077/116365496-f85fc800-a80d-11eb-85f0-36ef2670262c.png)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
