### PR TITLE
Fix padding and cursor for nav menu item placeholder.

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -72,7 +72,6 @@
 
 .wp-block-navigation-link__placeholder {
 	position: relative;
-	cursor: pointer;
 
 	// Provide a little margin to show each placeholder as a separate unit.
 	margin: 2px;
@@ -80,6 +79,14 @@
 	.wp-block-navigation-link__placeholder-text {
 		font-family: $default-font;
 		font-size: $default-font-size;
+		padding-left: 4px;
+		padding-right: 4px;
+
+	}
+
+	// This needs extra specificity.
+	&.wp-block-navigation-link__content {
+		cursor: pointer;
 	}
 
 	&::before {


### PR DESCRIPTION
## Description

The menu item setup state is lacking a bit of padding, and the cursor change stopped working:

![before](https://user-images.githubusercontent.com/1204802/116388900-a2dee780-a81c-11eb-992d-0a90e3cf406d.gif)

This PR fixes that by adding a little minimum padding, and by increasing the specificity of the cursor change:

![after](https://user-images.githubusercontent.com/1204802/116388955-af634000-a81c-11eb-9827-c0bcac967dc4.gif)

_Note, the cursor change is not visible in the above GIF, but it's fixed._

## How has this been tested?

- Insert an empty navigation block
- Insert a page link but don't select a page
- Observe it has padding

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
