### PR TITLE
Try blue block chip in select mode and when dragging

### DIFF
--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -6,7 +6,7 @@
 }
 
 .block-editor-block-draggable-chip {
-	background-color: $gray-900;
+	background-color: var(--wp-admin-theme-color);
 	border-radius: $radius-block-ui;
 	box-shadow: 0 6px 8px rgba($black, 0.3);
 	color: $white;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -568,7 +568,7 @@
 
 	// Dark block UI appearance.
 	border-radius: $radius-block-ui;
-	background-color: $gray-900;
+	background-color: var(--wp-admin-theme-color);
 
 	font-size: $default-font-size;
 	height: $block-toolbar-height;


### PR DESCRIPTION
Generally block interaction styles are treated with blue accents, for example:

* A selected block in Select mode has a blue outline
* A selected block in the Site Editor has a blue outline
* The selected block in List View has a solid blue background
* The block inserter button in the top bar, inline inserters, and inline inserter lines are blue

This PR extends that heuristic to the block chip that appears when dragging a block (either from the inserter, or using the drag handle on the canvas), and when selecting a block in select mode.

### Before

<img width="777" alt="Screenshot 2021-04-28 at 12 02 26" src="https://user-images.githubusercontent.com/846565/116396659-8abb9800-a81d-11eb-81c9-ac323fc22bba.png">

### After

<img width="736" alt="Screenshot 2021-04-28 at 12 04 03" src="https://user-images.githubusercontent.com/846565/116396688-94dd9680-a81d-11eb-96f9-2da7599790da.png">


https://user-images.githubusercontent.com/846565/116396717-9e66fe80-a81d-11eb-83b9-c8e25430224c.mp4



