### PR TITLE
Block editor: deprecate ObserveTyping and integrate it in the block editor

### DIFF
--- a/docs/how-to-guides/platform/custom-block-editor/tutorial.md
+++ b/docs/how-to-guides/platform/custom-block-editor/tutorial.md
@@ -337,9 +337,7 @@ return (
 			<div className="editor-styles-wrapper">
 				<BlockEditorKeyboardShortcuts />
 				<WritingFlow>
-					<ObserveTyping>
-						<BlockList className="getdavesbe-block-editor__block-list" />
-					</ObserveTyping>
+					<BlockList className="getdavesbe-block-editor__block-list" />
 				</WritingFlow>
 			</div>
 		</BlockEditorProvider>
@@ -435,12 +433,8 @@ Jumping back to our own custom `<BlockEditor>` component, it is also worth notin
 
 <div className="editor-styles-wrapper">
 	<BlockEditorKeyboardShortcuts /> /* 1. */
-	<WritingFlow>
-		/* 2. */
-		<ObserveTyping>
-			/* 3. */
-			<BlockList className="getdavesbe-block-editor__block-list" />
-		</ObserveTyping>
+	<WritingFlow> /* 2. */
+		<BlockList className="getdavesbe-block-editor__block-list" />
 	</WritingFlow>
 </div>
 ```
@@ -449,7 +443,6 @@ These provide other important elements of functionality for our editor instance.
 
 1. [`<BlockEditorKeyboardShortcuts />`](https://github.com/WordPress/gutenberg/blob/e38dbe958c04d8089695eb686d4f5caff2707505/packages/block-editor/src/components/keyboard-shortcuts/index.js) - enables and usage of keyboard shortcuts within the editor.
 2. [`<WritingFlow>`](https://github.com/WordPress/gutenberg/blob/e38dbe958c04d8089695eb686d4f5caff2707505/packages/block-editor/src/components/writing-flow/index.js) - handles selection, focus management and navigation across blocks.
-3. [`<ObserveTyping>`](https://github.com/WordPress/gutenberg/tree/e38dbe958c04d8089695eb686d4f5caff2707505/packages/block-editor/src/components/observe-typing)- used to manage the editor's internal `isTyping` flag. This is used in various places, most commonly to show/hide the Block toolbar in response to typing.
 
 ## Reviewing the Sidebar
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -464,9 +464,7 @@ Undocumented declaration.
 
 <a name="ObserveTyping" href="#ObserveTyping">#</a> **ObserveTyping**
 
-_Related_
-
--   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/observe-typing/README.md>
+> **Deprecated** 
 
 <a name="PanelColorSettings" href="#PanelColorSettings">#</a> **PanelColorSettings**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -19,7 +19,6 @@ import {
 	BlockEditorProvider,
 	BlockList,
 	WritingFlow,
-	ObserveTyping,
 } from '@wordpress/block-editor';
 import { SlotFillProvider, Popover } from '@wordpress/components';
 import { useState } from '@wordpress/element';
@@ -36,9 +35,7 @@ function MyEditorComponent() {
 			<SlotFillProvider>
 				<Popover.Slot name="block-toolbar" />
 				<WritingFlow>
-					<ObserveTyping>
-						<BlockList />
-					</ObserveTyping>
+					<BlockList />
 				</WritingFlow>
 				<Popover.Slot />
 			</SlotFillProvider>

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -21,6 +21,7 @@ import BlockPopover from './block-popover';
 import { store as blockEditorStore } from '../../store';
 import { usePreParsePatterns } from '../../utils/pre-parse-patterns';
 import { LayoutProvider, defaultLayout } from './layout';
+import { useTypingObserver } from '../observe-typing';
 
 function Root( { className, children } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -48,6 +49,7 @@ function Root( { className, children } ) {
 			ref={ useMergeRefs( [
 				useBlockDropZone(),
 				useInBetweenInserter(),
+				useTypingObserver(),
 			] ) }
 			className={ classnames(
 				'block-editor-block-list__layout is-root-container',

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -11,6 +11,11 @@ import { __ } from '@wordpress/i18n';
 import { useMergeRefs } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { useMouseMoveTypingReset } from '../observe-typing';
+
 const BODY_CLASS_NAME = 'editor-styles-wrapper';
 const BLOCK_PREFIX = 'wp-block';
 
@@ -178,7 +183,7 @@ function Iframe( { contentRef, children, head, headHTML, ...props }, ref ) {
 	return (
 		<iframe
 			{ ...props }
-			ref={ useMergeRefs( [ ref, setRef ] ) }
+			ref={ useMergeRefs( [ ref, setRef, useMouseMoveTypingReset() ] ) }
 			tabIndex="0"
 			title={ __( 'Editor canvas' ) }
 			name="editor-canvas"

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -118,11 +118,7 @@ export { default as __experimentalSearchForm } from './inserter/search-form';
 export { default as BlockEditorKeyboardShortcuts } from './keyboard-shortcuts';
 export { MultiSelectScrollIntoView } from './selection-scroll-into-view';
 export { default as NavigableToolbar } from './navigable-toolbar';
-export {
-	default as ObserveTyping,
-	useTypingObserver as __unstableUseTypingObserver,
-	useMouseMoveTypingReset as __unstableUseMouseMoveTypingReset,
-} from './observe-typing';
+export { default as ObserveTyping } from './observe-typing';
 export { default as PreserveScrollInReorder } from './preserve-scroll-in-reorder';
 export { default as SkipToSelectedBlock } from './skip-to-selected-block';
 export {

--- a/packages/block-editor/src/components/observe-typing/README.md
+++ b/packages/block-editor/src/components/observe-typing/README.md
@@ -1,5 +1,7 @@
 # Observe Typing
 
+**Deprecated*
+
 `<ObserveTyping />` is a component used in managing the editor's internal typing flag. When used to wrap content — typically the top-level block list — it observes keyboard and mouse events to set and unset the typing flag. The typing flag is used in considering whether the block border and controls should be visible. While typing, these elements are hidden for a distraction-free experience.
 
 ## Usage

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -14,6 +14,7 @@ import {
 	ESCAPE,
 	TAB,
 } from '@wordpress/keycodes';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -248,10 +249,13 @@ export function useTypingObserver() {
 }
 
 function ObserveTyping( { children } ) {
+	deprecated( 'wp.blockEditor.ObserveTyping', {
+		hint: 'This behaviour is now built-in.',
+	} );
 	return <div ref={ useTypingObserver() }>{ children }</div>;
 }
 
 /**
- * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/observe-typing/README.md
+ * @deprecated
  */
 export default ObserveTyping;

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -13,7 +13,6 @@ import {
 	BlockList,
 	BlockSelectionClearer,
 	BlockInspector,
-	ObserveTyping,
 	WritingFlow,
 	BlockEditorKeyboardShortcuts,
 	__experimentalBlockSettingsMenuFirstItem,
@@ -84,9 +83,7 @@ export default function SidebarBlockEditor( {
 
 					<BlockSelectionClearer>
 						<WritingFlow>
-							<ObserveTyping>
-								<BlockList />
-							</ObserveTyping>
+							<BlockList />
 						</WritingFlow>
 					</BlockSelectionClearer>
 

--- a/packages/edit-navigation/src/components/editor/index.js
+++ b/packages/edit-navigation/src/components/editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { BlockList, ObserveTyping, WritingFlow } from '@wordpress/block-editor';
+import { BlockList, WritingFlow } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 
 export default function Editor( { isPending } ) {
@@ -12,9 +12,7 @@ export default function Editor( { isPending } ) {
 			) : (
 				<div className="editor-styles-wrapper">
 					<WritingFlow>
-						<ObserveTyping>
-							<BlockList />
-						</ObserveTyping>
+						<BlockList />
 					</WritingFlow>
 				</div>
 			) }

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -18,7 +18,6 @@ import {
 	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 	__unstableUseTypewriter as useTypewriter,
 	__unstableUseClipboardHandler as useClipboardHandler,
-	__unstableUseTypingObserver as useTypingObserver,
 	__experimentalBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableUseCanvasClickRedirect as useCanvasClickRedirect,
@@ -95,7 +94,6 @@ export default function VisualEditor( { styles } ) {
 		useClipboardHandler(),
 		useCanvasClickRedirect(),
 		useTypewriter(),
-		useTypingObserver(),
 		useBlockSelectionClearer(),
 	] );
 

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -13,8 +13,6 @@ import {
 	BlockList,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
-	__unstableUseTypingObserver as useTypingObserver,
-	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
 	__unstableEditorStyles as EditorStyles,
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
@@ -53,12 +51,10 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	);
 	const { setPage } = useDispatch( editSiteStore );
 	const resizedCanvasStyles = useResizeCanvas( deviceType, true );
-	const ref = useMouseMoveTypingReset();
 	const contentRef = useRef();
 	const mergedRefs = useMergeRefs( [
 		contentRef,
 		useBlockSelectionClearer(),
-		useTypingObserver(),
 	] );
 
 	// Allow scrolling "through" popovers over the canvas. This is only called
@@ -98,7 +94,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					style={ resizedCanvasStyles }
 					headHTML={ window.__editorStyles.html }
 					head={ <EditorStyles styles={ settings.styles } /> }
-					ref={ ref }
 					contentRef={ mergedRefs }
 				>
 					<WritingFlow>

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -7,7 +7,6 @@ import {
 	BlockEditorKeyboardShortcuts,
 	BlockSelectionClearer,
 	WritingFlow,
-	ObserveTyping,
 	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 
@@ -29,9 +28,7 @@ export default function WidgetAreasBlockEditorContent( {
 			<Popover.Slot name="block-toolbar" />
 			<BlockSelectionClearer>
 				<WritingFlow>
-					<ObserveTyping>
-						<BlockList className="edit-widgets-main-block-list" />
-					</ObserveTyping>
+					<BlockList className="edit-widgets-main-block-list" />
 				</WritingFlow>
 			</BlockSelectionClearer>
 		</div>

--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -8,7 +8,6 @@ import {
 	BlockList,
 	BlockInspector,
 	WritingFlow,
-	ObserveTyping,
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider } from '@wordpress/components';
 import { registerCoreBlocks } from '@wordpress/block-library';
@@ -42,9 +41,7 @@ function App() {
 						<BlockEditorKeyboardShortcuts.Register />
 						<BlockEditorKeyboardShortcuts />
 						<WritingFlow>
-							<ObserveTyping>
-								<BlockList />
-							</ObserveTyping>
+							<BlockList />
 						</WritingFlow>
 					</div>
 					<Popover.Slot />


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This reduces the verbosity of implementing a block editor, but most of all for an iframed block editor that needs extra handlers on the iframe.

It also makes sense to build this in because the typing state is strongly tied to the block list.

The only reason I can think of to leave it outside the block list is to disable hiding the toolbar, but that doesn't make much sense if you have a floating toolbar, and in case of a fixed toolbar, tying wouldn't hide it anyway. If we do want to allow disabling it, we could add a block editor setting instead.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
