### PR TITLE
Fix the broken links of register block type documentation

### DIFF
--- a/packages/create-block/lib/templates/es5/index.js.mustache
+++ b/packages/create-block/lib/templates/es5/index.js.mustache
@@ -30,7 +30,7 @@
 	/**
 	 * Every block starts by registering a new block type definition.
 	 *
-	 * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
 	 */
 	registerBlockType( '{{namespace}}/{{slug}}', {
 		/**

--- a/packages/create-block/lib/templates/es5/index.js.mustache
+++ b/packages/create-block/lib/templates/es5/index.js.mustache
@@ -2,7 +2,7 @@
 	/**
 	 * Registers a new block provided a unique name and an object defining its behavior.
 	 *
-	 * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
 	 */
 	var registerBlockType = wp.blocks.registerBlockType;
 

--- a/packages/create-block/lib/templates/es5/index.js.mustache
+++ b/packages/create-block/lib/templates/es5/index.js.mustache
@@ -2,7 +2,7 @@
 	/**
 	 * Registers a new block provided a unique name and an object defining its behavior.
 	 *
-	 * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+	 * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration
 	 */
 	var registerBlockType = wp.blocks.registerBlockType;
 
@@ -30,7 +30,7 @@
 	/**
 	 * Every block starts by registering a new block type definition.
 	 *
-	 * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+	 * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration
 	 */
 	registerBlockType( '{{namespace}}/{{slug}}', {
 		/**

--- a/packages/create-block/lib/templates/esnext/src/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/index.js.mustache
@@ -1,7 +1,7 @@
 /**
  * Registers a new block provided a unique name and an object defining its behavior.
  *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
  */
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -23,7 +23,7 @@ import save from './save';
 /**
  * Every block starts by registering a new block type definition.
  *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
  */
 registerBlockType( '{{namespace}}/{{slug}}', {
 	/**

--- a/packages/create-block/lib/templates/esnext/src/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/index.js.mustache
@@ -1,7 +1,7 @@
 /**
  * Registers a new block provided a unique name and an object defining its behavior.
  *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration
  */
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -23,7 +23,7 @@ import save from './save';
 /**
  * Every block starts by registering a new block type definition.
  *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration
  */
 registerBlockType( '{{namespace}}/{{slug}}', {
 	/**


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

The Links to Register Block Type Documentation in the comments where redirecting to the [this page](https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block).

It should be directed to [Register Block Type Documentation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/)

