### PR TITLE
[WIP] Move title to header toolbar

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -23,8 +23,6 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
-import TemplateTitle from '../template-title';
-import PostTitle from '../post-title';
 import { store as editPostStore } from '../../../store';
 
 const preventDefault = ( event ) => {
@@ -43,7 +41,6 @@ function HeaderToolbar() {
 		showIconLabels,
 		isListViewOpen,
 		listViewShortcut,
-		isTemplateMode,
 	} = useSelect( ( select ) => {
 		const {
 			hasInserterItems,
@@ -71,7 +68,6 @@ function HeaderToolbar() {
 			listViewShortcut: getShortcutRepresentation(
 				'core/edit-post/toggle-list-view'
 			),
-			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -167,10 +163,6 @@ function HeaderToolbar() {
 						{ overflowItems }
 					</>
 				) }
-			</div>
-
-			<div className="edit-post-header-toolbar__middle">
-				{ isTemplateMode ? <TemplateTitle /> : <PostTitle /> }
 			</div>
 		</NavigableToolbar>
 	);

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -23,6 +23,8 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
+import TemplateTitle from '../template-title';
+import PostTitle from '../post-title';
 import { store as editPostStore } from '../../../store';
 
 const preventDefault = ( event ) => {
@@ -41,6 +43,7 @@ function HeaderToolbar() {
 		showIconLabels,
 		isListViewOpen,
 		listViewShortcut,
+		isTemplateMode,
 	} = useSelect( ( select ) => {
 		const {
 			hasInserterItems,
@@ -68,6 +71,7 @@ function HeaderToolbar() {
 			listViewShortcut: getShortcutRepresentation(
 				'core/edit-post/toggle-list-view'
 			),
+			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -163,6 +167,10 @@ function HeaderToolbar() {
 						{ overflowItems }
 					</>
 				) }
+			</div>
+
+			<div className="edit-post-header-toolbar__middle">
+				{ isTemplateMode ? <TemplateTitle /> : <PostTitle /> }
 			</div>
 		</NavigableToolbar>
 	);

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -22,6 +22,7 @@ import { default as DevicePreview } from '../device-preview';
 import MainDashboardButton from './main-dashboard-button';
 import { store as editPostStore } from '../../store';
 import TemplateTitle from './template-title';
+import PostTitle from './post-title';
 
 function Header( { setEntitiesSavedStatesCallback } ) {
 	const {
@@ -30,6 +31,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		isSaving,
 		showIconLabels,
 		hasReducedUI,
+		isTemplateMode,
 	} = useSelect(
 		( select ) => ( {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
@@ -43,6 +45,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 			hasReducedUI: select( editPostStore ).isFeatureActive(
 				'reducedUI'
 			),
+			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 		} ),
 		[]
 	);
@@ -55,47 +58,53 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 
 	return (
 		<div className={ classes }>
-			<MainDashboardButton.Slot>
-				<FullscreenModeClose />
-			</MainDashboardButton.Slot>
-			<div className="edit-post-header__toolbar">
-				<HeaderToolbar />
-				<TemplateTitle />
+			<div className="edit-post-header_start">
+				<div className="edit-post-header__toolbar">
+					<MainDashboardButton.Slot>
+						<FullscreenModeClose />
+					</MainDashboardButton.Slot>
+					<HeaderToolbar />
+				</div>
 			</div>
-			<div className="edit-post-header__settings">
-				{ ! isPublishSidebarOpened && (
-					// This button isn't completely hidden by the publish sidebar.
-					// We can't hide the whole toolbar when the publish sidebar is open because
-					// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
-					// We track that DOM node to return focus to the PostPublishButtonOrToggle
-					// when the publish sidebar has been closed.
-					<PostSavedState
+			<div className="edit-post-header_center">
+				{ isTemplateMode ? <TemplateTitle /> : <PostTitle /> }
+			</div>
+			<div className="edit-post-header_end">
+				<div className="edit-post-header__settings">
+					{ ! isPublishSidebarOpened && (
+						// This button isn't completely hidden by the publish sidebar.
+						// We can't hide the whole toolbar when the publish sidebar is open because
+						// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
+						// We track that DOM node to return focus to the PostPublishButtonOrToggle
+						// when the publish sidebar has been closed.
+						<PostSavedState
+							forceIsDirty={ hasActiveMetaboxes }
+							forceIsSaving={ isSaving }
+							showIconLabels={ showIconLabels }
+						/>
+					) }
+					<DevicePreview />
+					<PostPreviewButton
+						forceIsAutosaveable={ hasActiveMetaboxes }
+						forcePreviewLink={ isSaving ? null : undefined }
+					/>
+					<PostPublishButtonOrToggle
 						forceIsDirty={ hasActiveMetaboxes }
 						forceIsSaving={ isSaving }
-						showIconLabels={ showIconLabels }
+						setEntitiesSavedStatesCallback={
+							setEntitiesSavedStatesCallback
+						}
 					/>
-				) }
-				<DevicePreview />
-				<PostPreviewButton
-					forceIsAutosaveable={ hasActiveMetaboxes }
-					forcePreviewLink={ isSaving ? null : undefined }
-				/>
-				<PostPublishButtonOrToggle
-					forceIsDirty={ hasActiveMetaboxes }
-					forceIsSaving={ isSaving }
-					setEntitiesSavedStatesCallback={
-						setEntitiesSavedStatesCallback
-					}
-				/>
-				{ ( isLargeViewport || ! showIconLabels ) && (
-					<>
-						<PinnedItems.Slot scope="core/edit-post" />
+					{ ( isLargeViewport || ! showIconLabels ) && (
+						<>
+							<PinnedItems.Slot scope="core/edit-post" />
+							<MoreMenu showIconLabels={ showIconLabels } />
+						</>
+					) }
+					{ showIconLabels && ! isLargeViewport && (
 						<MoreMenu showIconLabels={ showIconLabels } />
-					</>
-				) }
-				{ showIconLabels && ! isLargeViewport && (
-					<MoreMenu showIconLabels={ showIconLabels } />
-				) }
+					) }
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/edit-post/src/components/header/post-title/edit-post-title.js
+++ b/packages/edit-post/src/components/header/post-title/edit-post-title.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+export default function EditPostTitle() {
+	const { editPost } = useDispatch( editorStore );
+
+	const { postTitle } = useSelect(
+		( select ) => ( {
+			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
+		} ),
+		[]
+	);
+
+	return (
+		<div className="edit-post-title-panel">
+			<TextControl
+				label={ __( 'Title' ) }
+				value={ postTitle ?? '' }
+				min={ 1 }
+				onChange={ ( newTitle ) => editPost( { title: newTitle } ) }
+			/>
+		</div>
+	);
+}

--- a/packages/edit-post/src/components/header/post-title/index.js
+++ b/packages/edit-post/src/components/header/post-title/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -11,14 +11,32 @@ import {
 	Dropdown,
 	Button,
 	VisuallyHidden,
+	TextControl,
 	__experimentalText as Text,
 } from '@wordpress/components';
 
 /**
- * Internal dependencies
+ * External dependencies
  */
+import { noop } from 'lodash';
+
+const EditPostTitlePanel = ( { entityTitle, onChange = noop } ) => {
+	return (
+		<div className="edit-post-title-panel">
+			<TextControl
+				className=""
+				label={ __( 'Title' ) }
+				value={ entityTitle ?? '' }
+				min={ 1 }
+				onChange={ onChange }
+			/>
+		</div>
+	);
+};
 
 function PostTitle() {
+	const { editPost } = useDispatch( editorStore );
+
 	const { entityTitle, entityLabel } = useSelect(
 		( select ) => ( {
 			entityTitle: select( editorStore ).getEditedPostAttribute(
@@ -49,7 +67,7 @@ function PostTitle() {
 				>
 					<VisuallyHidden as="span">
 						{ sprintf(
-							/* translators: %s: the entity being edited, like "template"*/
+							/* translators: %s: the entity being edited, like "post"*/
 							__( 'Editing %s:' ),
 							entityLabel
 						) }
@@ -87,7 +105,12 @@ function PostTitle() {
 					) }
 					contentClassName="edit-post-title-actions__info-dropdown"
 					renderContent={ () => (
-						<span>{ __( 'Nothing here yet.' ) }</span>
+						<EditPostTitlePanel
+							entityTitle={ entityTitle }
+							onChange={ ( value ) =>
+								editPost( { title: value } )
+							}
+						/>
 					) }
 				/>
 			</div>

--- a/packages/edit-post/src/components/header/post-title/index.js
+++ b/packages/edit-post/src/components/header/post-title/index.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
+
+import {
+	Dropdown,
+	Button,
+	VisuallyHidden,
+	__experimentalText as Text,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+function PostTitle() {
+	const { entityTitle, entityLabel } = useSelect(
+		( select ) => ( {
+			entityTitle: select( editorStore ).getEditedPostAttribute(
+				'title'
+			),
+			entityLabel: select( editorStore ).getEditedPostAttribute( 'type' ),
+		} ),
+		[]
+	);
+
+	const titleRef = useRef();
+
+	if ( ! entityTitle ) {
+		return (
+			<div className="edit-post-title-actions">{ __( 'Loading…' ) }</div>
+		);
+	}
+
+	return (
+		<div className="edit-post-title-actions">
+			<div
+				ref={ titleRef }
+				className="edit-post-title-actions__title-wrapper"
+			>
+				<Text
+					variant="body.small"
+					className="edit-post-title-actions__title-prefix"
+				>
+					<VisuallyHidden as="span">
+						{ sprintf(
+							/* translators: %s: the entity being edited, like "template"*/
+							__( 'Editing %s:' ),
+							entityLabel
+						) }
+					</VisuallyHidden>
+				</Text>
+
+				<Text
+					variant="body.small"
+					className="edit-post-title-actions__title"
+					as="h1"
+				>
+					{ entityTitle.length === 0
+						? __( 'No Title' )
+						: entityTitle }
+				</Text>
+
+				<Dropdown
+					popoverProps={ {
+						anchorRef: titleRef.current,
+					} }
+					position="bottom center"
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							className="edit-post-title-actions__get-info"
+							icon={ chevronDown }
+							aria-expanded={ isOpen }
+							aria-haspopup="true"
+							onClick={ onToggle }
+							label={ sprintf(
+								/* translators: %s: the entity to see details about, like "template"*/
+								__( 'Show %s details' ),
+								entityLabel
+							) }
+						/>
+					) }
+					contentClassName="edit-post-title-actions__info-dropdown"
+					renderContent={ () => (
+						<span>{ __( 'Nothing here yet.' ) }</span>
+					) }
+				/>
+			</div>
+		</div>
+	);
+}
+
+export default PostTitle;

--- a/packages/edit-post/src/components/header/post-title/index.js
+++ b/packages/edit-post/src/components/header/post-title/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -11,45 +11,30 @@ import {
 	Dropdown,
 	Button,
 	VisuallyHidden,
-	TextControl,
 	__experimentalText as Text,
 } from '@wordpress/components';
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { noop } from 'lodash';
-
-const EditPostTitlePanel = ( { entityTitle, onChange = noop } ) => {
-	return (
-		<div className="edit-post-title-panel">
-			<TextControl
-				className=""
-				label={ __( 'Title' ) }
-				value={ entityTitle ?? '' }
-				min={ 1 }
-				onChange={ onChange }
-			/>
-		</div>
-	);
-};
+import EditPostTitle from './edit-post-title';
 
 function PostTitle() {
-	const { editPost } = useDispatch( editorStore );
+	const { entityTitle, entityLabel, isLoaded } = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( editorStore );
+		const postId = getEditedPostAttribute( 'id' );
+		const _isLoaded = !! postId;
 
-	const { entityTitle, entityLabel } = useSelect(
-		( select ) => ( {
-			entityTitle: select( editorStore ).getEditedPostAttribute(
-				'title'
-			),
-			entityLabel: select( editorStore ).getEditedPostAttribute( 'type' ),
-		} ),
-		[]
-	);
+		return {
+			entityTitle: getEditedPostAttribute( 'title' ),
+			entityLabel: getEditedPostAttribute( 'type' ),
+			isLoaded: _isLoaded,
+		};
+	}, [] );
 
 	const titleRef = useRef();
 
-	if ( ! entityTitle ) {
+	if ( ! isLoaded ) {
 		return (
 			<div className="edit-post-title-actions">{ __( 'Loading…' ) }</div>
 		);
@@ -62,7 +47,7 @@ function PostTitle() {
 				className="edit-post-title-actions__title-wrapper"
 			>
 				<Text
-					variant="body.small"
+					size="body"
 					className="edit-post-title-actions__title-prefix"
 				>
 					<VisuallyHidden as="span">
@@ -75,11 +60,11 @@ function PostTitle() {
 				</Text>
 
 				<Text
-					variant="body.small"
+					size="body"
 					className="edit-post-title-actions__title"
 					as="h1"
 				>
-					{ entityTitle.length === 0
+					{ ! entityTitle || entityTitle.length === 0
 						? __( 'No Title' )
 						: entityTitle }
 				</Text>
@@ -96,22 +81,11 @@ function PostTitle() {
 							aria-expanded={ isOpen }
 							aria-haspopup="true"
 							onClick={ onToggle }
-							label={ sprintf(
-								/* translators: %s: the entity to see details about, like "template"*/
-								__( 'Show %s details' ),
-								entityLabel
-							) }
+							label={ __( 'Edit Title' ) }
 						/>
 					) }
 					contentClassName="edit-post-title-actions__info-dropdown"
-					renderContent={ () => (
-						<EditPostTitlePanel
-							entityTitle={ entityTitle }
-							onChange={ ( value ) =>
-								editPost( { title: value } )
-							}
-						/>
-					) }
+					renderContent={ () => <EditPostTitle /> }
 				/>
 			</div>
 		</div>

--- a/packages/edit-post/src/components/header/post-title/style.scss
+++ b/packages/edit-post/src/components/header/post-title/style.scss
@@ -1,0 +1,57 @@
+.edit-post-title-actions {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 100%;
+	// Flex items will, by default, refuse to shrink below a minimum
+	// intrinsic width. In order to shrink this flexbox item, and
+	// subsequently truncate child text, we set an explicit min-width.
+	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
+	min-width: 0;
+
+	.edit-post-title-actions__title-wrapper {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		align-items: center;
+
+		// See comment above about min-width
+		min-width: 0;
+
+		.components-dropdown {
+			display: inline-flex;
+			margin-left: $grid-unit-05;
+
+			.components-button {
+				min-width: 0;
+				padding: 0;
+			}
+		}
+	}
+
+	.edit-post-title-actions__title-wrapper > h1 {
+		margin: 0;
+
+		// See comment above about min-width
+		min-width: 0;
+	}
+
+	.edit-post-title-actions__title {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 120px;
+
+		@include break-medium() {
+			max-width: 75px;
+		}
+
+		@include break-xlarge() {
+			max-width: 180px;
+		}
+	}
+}
+.edit-post-title-actions__info-dropdown > .components-popover__content > div {
+	padding: 0;
+	min-width: 240px;
+}

--- a/packages/edit-post/src/components/header/post-title/style.scss
+++ b/packages/edit-post/src/components/header/post-title/style.scss
@@ -55,3 +55,8 @@
 	padding: 0;
 	min-width: 240px;
 }
+
+.edit-post-title-panel {
+	max-width: 240px;
+	padding: 16px;
+}

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -6,6 +6,7 @@
 	align-items: center;
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
+	justify-content: space-between;
 
 	// Make toolbar sticky on larger breakpoints
 	@include break-zoomed-in {
@@ -28,6 +29,26 @@
 		@supports (position: sticky) {
 			order: initial;
 		}
+	}
+
+	.edit-post-header_start,
+	.edit-post-header_end {
+		display: flex;
+	}
+
+	.edit-post-header_center {
+		display: flex;
+		align-items: center;
+		height: 100%;
+		// Flex items will, by default, refuse to shrink below a minimum
+		// intrinsic width. In order to shrink this flexbox item, and
+		// subsequently truncate child text, we set an explicit min-width.
+		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
+		min-width: 0;
+	}
+
+	.edit-post-header_end {
+		justify-content: flex-end;
 	}
 }
 

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -4,6 +4,7 @@
 @import "./components/header/header-toolbar/style.scss";
 @import "./components/header/more-menu/style.scss";
 @import "./components/header/post-title/style.scss";
+@import "./components/header/template-title/style.scss";
 @import "./components/keyboard-shortcut-help-modal/style.scss";
 @import "./components/layout/style.scss";
 @import "./components/block-manager/style.scss";

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -3,7 +3,7 @@
 @import "./components/header/fullscreen-mode-close/style.scss";
 @import "./components/header/header-toolbar/style.scss";
 @import "./components/header/more-menu/style.scss";
-@import "./components/header/template-title/style.scss";
+@import "./components/header/post-title/style.scss";
 @import "./components/keyboard-shortcut-help-modal/style.scss";
 @import "./components/layout/style.scss";
 @import "./components/block-manager/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR gives a go at moving the management of the entity title to the header toolbar area, as described in #27093.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
