### PR TITLE
[Block Library - Query]: Allow term addition from user case-insensitive input

### DIFF
--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -57,9 +57,9 @@ const CreateNewPostLink = ( { type } ) => {
 };
 
 // Helper function to get the term id based on user input in terms `FormTokenField`.
-const getTermIdByTermValue = ( termsMapedByName, termValue ) => {
+const getTermIdByTermValue = ( termsMappedByName, termValue ) => {
 	// First we check for exact match by `term.id` or case sensitive `term.name` match.
-	const termId = termValue?.id || termsMapedByName[ termValue ]?.id;
+	const termId = termValue?.id || termsMappedByName[ termValue ]?.id;
 	if ( termId ) return termId;
 	/**
 	 * Here we make an extra check for entered terms in a non case sensitive way,
@@ -71,9 +71,9 @@ const getTermIdByTermValue = ( termsMapedByName, termValue ) => {
 	 * In this edge case we always apply the first match from the terms list.
 	 */
 	const termValueLower = termValue.toLocaleLowerCase();
-	for ( const term in termsMapedByName ) {
+	for ( const term in termsMappedByName ) {
 		if ( term.toLocaleLowerCase() === termValueLower ) {
-			return termsMapedByName[ term ].id;
+			return termsMappedByName[ term ].id;
 		}
 	}
 };


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/31258

Currently `FormTokenField` which is used in `Query` block for adding categories and tags, shows suggestions that are case insensitive. The actual addition though was performed by trying to find a case sensitive match and that resulted in not adding a term if the user pressed `Enter` or tried to separate with `comma`.
 
This PR adds an extra check for entered terms in a non case sensitive way, to better match user expectations. I tried to find a better place for this behavior in `FormTokenField` but it seemed as a more specific case and added in Query for now.

## Testing instructions
1. Create at least one category.
2. In a block theme add a `Query` block with `inherit` set to `false` and `post type` to `post`, to be able to change the categories/tags
3. Type in `categories` field the category you created but in a case insensitive way (example if the category is `apple` type `APple`) and then press `Enter` or separate with `comma`.
4. Observe that the term will be added.