### PR TITLE
Update: Target global styles to the body element instead of :root

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -91,7 +91,7 @@ To address this need, we've started to experiment with CSS Custom Properties, ak
 {% Output %}
 
 ```css
-:root {
+body {
 	--wp--preset--color--black: #000000;
 	--wp--preset--color--white: #ffffff;
 }
@@ -122,7 +122,7 @@ To address this need, we've started to experiment with CSS Custom Properties, ak
 {% Output %}
 
 ```css
-:root {
+body {
 	--wp--custom--line-height--body: 1.7;
 	--wp--custom--line-height--heading: 1.3;
 }
@@ -292,7 +292,7 @@ For example:
 {% Output %}
 
 ```css
-:root {
+body {
 	--wp--preset--color--strong-magenta: #a156b4;
 	--wp--preset--color--very-dark-gray: #444;
 	--wp--preset--font-size--big: 32;
@@ -344,7 +344,7 @@ For example:
 {% Output %}
 
 ```css
-:root {
+body {
 	--wp--custom--base-font: 16;
 	--wp--custom--line-height--small: 1.2;
 	--wp--custom--line-height--medium: 1.4;
@@ -434,7 +434,7 @@ For example:
 {% Output %}
 
 ```css
-:root {
+body {
 	color: var( --wp--preset--color--primary );
 }
 h1 {
@@ -549,7 +549,7 @@ For example:
 {% Output %}
 
 ```css
-:root {
+body {
 	--wp--custom--line-height--body: 1.7;
 	--wp--custom--font-primary: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif";
 }

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -39,7 +39,7 @@ class WP_Theme_JSON {
 	 *
 	 * @var string
 	 */
-	const ALL_BLOCKS_SELECTOR = ':root';
+	const ALL_BLOCKS_SELECTOR = 'body';
 
 	/**
 	 * How to address the root block
@@ -54,7 +54,7 @@ class WP_Theme_JSON {
 	 *
 	 * @var string
 	 */
-	const ROOT_BLOCK_SELECTOR = ':root';
+	const ROOT_BLOCK_SELECTOR = 'body';
 
 	const VALID_TOP_LEVEL_KEYS = array(
 		'customTemplates',
@@ -356,7 +356,7 @@ class WP_Theme_JSON {
 	 *
 	 * {
 	 *   'root': {
-	 *     'selector': ':root'
+	 *     'selector': 'body'
 	 *   },
 	 *   'core/heading/h1': {
 	 *     'selector': 'h1'

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -13,9 +13,9 @@ import { store as editSiteStore } from '../../store';
 
 /* Supporting data */
 export const ALL_BLOCKS_NAME = 'defaults';
-export const ALL_BLOCKS_SELECTOR = ':root';
+export const ALL_BLOCKS_SELECTOR = 'body';
 export const ROOT_BLOCK_NAME = 'root';
-export const ROOT_BLOCK_SELECTOR = ':root';
+export const ROOT_BLOCK_SELECTOR = 'body';
 export const ROOT_BLOCK_SUPPORTS = [
 	'--wp--style--color--link',
 	'background',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -108,15 +108,15 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}:root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
+			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
 			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
+			'body{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(
-			':root{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}',
+			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}',
 			$theme_json->get_stylesheet( 'css_variables' )
 		);
 	}
@@ -187,7 +187,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			':root{--wp--preset--color--grey: grey;}h2.wp-block-post-title{background-color: blue;color: red;font-size: 12px;line-height: 1.3;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
+			'body{--wp--preset--color--grey: grey;}h2.wp-block-post-title{background-color: blue;color: red;font-size: 12px;line-height: 1.3;}.has-grey-color{color: grey !important;}.has-grey-background-color{background-color: grey !important;}.has-grey-border-color{border-color: grey !important;}',
 			$theme_json->get_stylesheet()
 		);
 	}


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/27478

Currently, the global styles target the :root selector. In a HTML element the :root selector maps to HTML element. It seems more correct to target body for the global styles use case. And will allow for things like margin and padding.


The body selector has lower specificity than :root so this change may have some impact.

## How has this been tested?
I verified global colors and typography settings still work as before.
I applied preset a global text color, and I changed that color using the palette editor and verified the text color of the editor live update for the new color value.
