### PR TITLE
Site Editor: Add show more settings to block toolbars

### DIFF
--- a/packages/edit-site/src/components/block-editor/block-inspector-button.js
+++ b/packages/edit-site/src/components/block-editor/block-inspector-button.js
@@ -57,8 +57,8 @@ export default function BlockInspectorButton( { onClick = () => {} } ) {
 					disableComplementaryArea( STORE_NAME );
 				} else {
 					enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
-					speakMessage();
 				}
+				speakMessage();
 				// Close dropdown menu.
 				onClick();
 			} }

--- a/packages/edit-site/src/components/block-editor/block-inspector-button.js
+++ b/packages/edit-site/src/components/block-editor/block-inspector-button.js
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+import { MenuItem } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as interfaceStore } from '@wordpress/interface';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+import { SIDEBAR_BLOCK } from '../sidebar/constants';
+
+export default function BlockInspectorButton( { onClick = () => {} } ) {
+	const { shortcut, isBlockInspectorOpen } = useSelect(
+		( select ) => ( {
+			// shortcut: select(
+			// 	keyboardShortcutsStore
+			// ).getShortcutRepresentation( 'core/edit-site/toggle-sidebar' ),
+			isBlockInspectorOpen:
+				select( interfaceStore ).getActiveComplementaryArea(
+					editSiteStore.name
+				) === SIDEBAR_BLOCK,
+		} ),
+		[]
+	);
+	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
+		interfaceStore
+	);
+
+	const speakMessage = () => {
+		if ( isBlockInspectorOpen ) {
+			speak( __( 'Block settings closed' ) );
+		} else {
+			speak(
+				__(
+					'Additional settings are now available in the Editor block settings sidebar'
+				)
+			);
+		}
+	};
+
+	const label = isBlockInspectorOpen
+		? __( 'Hide more settings' )
+		: __( 'Show more settings' );
+
+	return (
+		<MenuItem
+			onClick={ () => {
+				if ( isBlockInspectorOpen ) {
+					disableComplementaryArea( 'core/edit-site' );
+				} else {
+					enableComplementaryArea(
+						'core/edit-site',
+						'edit-site/block-inspector'
+					);
+					speakMessage();
+				}
+				// Close dropdown menu.
+				onClick();
+			} }
+			shortcut={ shortcut }
+		>
+			{ label }
+		</MenuItem>
+	);
+}

--- a/packages/edit-site/src/components/block-editor/block-inspector-button.js
+++ b/packages/edit-site/src/components/block-editor/block-inspector-button.js
@@ -34,18 +34,6 @@ export default function BlockInspectorButton( { onClick = () => {} } ) {
 		interfaceStore
 	);
 
-	const speakMessage = () => {
-		if ( isBlockInspectorOpen ) {
-			speak( __( 'Block settings closed' ) );
-		} else {
-			speak(
-				__(
-					'Additional settings are now available in the Editor block settings sidebar'
-				)
-			);
-		}
-	};
-
 	const label = isBlockInspectorOpen
 		? __( 'Hide more settings' )
 		: __( 'Show more settings' );
@@ -55,10 +43,15 @@ export default function BlockInspectorButton( { onClick = () => {} } ) {
 			onClick={ () => {
 				if ( isBlockInspectorOpen ) {
 					disableComplementaryArea( STORE_NAME );
+					speak( __( 'Block settings closed' ) );
 				} else {
 					enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
+					speak(
+						__(
+							'Additional settings are now available in the Editor block settings sidebar'
+						)
+					);
 				}
-				speakMessage();
 				// Close dropdown menu.
 				onClick();
 			} }

--- a/packages/edit-site/src/components/block-editor/block-inspector-button.js
+++ b/packages/edit-site/src/components/block-editor/block-inspector-button.js
@@ -12,14 +12,17 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
+import { STORE_NAME } from '../../store/constants';
 import { SIDEBAR_BLOCK } from '../sidebar/constants';
 
 export default function BlockInspectorButton( { onClick = () => {} } ) {
 	const { shortcut, isBlockInspectorOpen } = useSelect(
 		( select ) => ( {
-			// shortcut: select(
-			// 	keyboardShortcutsStore
-			// ).getShortcutRepresentation( 'core/edit-site/toggle-sidebar' ),
+			shortcut: select(
+				keyboardShortcutsStore
+			).getShortcutRepresentation(
+				'core/edit-site/toggle-block-settings-sidebar'
+			),
 			isBlockInspectorOpen:
 				select( interfaceStore ).getActiveComplementaryArea(
 					editSiteStore.name
@@ -51,12 +54,9 @@ export default function BlockInspectorButton( { onClick = () => {} } ) {
 		<MenuItem
 			onClick={ () => {
 				if ( isBlockInspectorOpen ) {
-					disableComplementaryArea( 'core/edit-site' );
+					disableComplementaryArea( STORE_NAME );
 				} else {
-					enableComplementaryArea(
-						'core/edit-site',
-						'edit-site/block-inspector'
-					);
+					enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
 					speakMessage();
 				}
 				// Close dropdown menu.

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -1,8 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { speak } from '@wordpress/a11y';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useRef } from '@wordpress/element';
 import { useEntityBlockEditor } from '@wordpress/core-data';
@@ -21,10 +19,8 @@ import {
 	__unstableEditorStyles as EditorStyles,
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
-import { MenuItem, Popover } from '@wordpress/components';
+import { Popover } from '@wordpress/components';
 import { useMergeRefs } from '@wordpress/compose';
-import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -33,59 +29,7 @@ import TemplatePartConverter from '../template-part-converter';
 import NavigateToLink from '../navigate-to-link';
 import { SidebarInspectorFill } from '../sidebar';
 import { store as editSiteStore } from '../../store';
-
-export function BlockInspectorButton( { onClick = () => {}, small = false } ) {
-	const { shortcut, areAdvancedSettingsOpened } = useSelect(
-		( select ) => ( {
-			// shortcut: select(
-			// 	keyboardShortcutsStore
-			// ).getShortcutRepresentation( 'core/edit-site/toggle-sidebar' ),
-			areAdvancedSettingsOpened: !! select(
-				interfaceStore
-			).getActiveComplementaryArea( editSiteStore.name ),
-		} ),
-		[]
-	);
-	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
-		interfaceStore
-	);
-
-	const speakMessage = () => {
-		if ( areAdvancedSettingsOpened ) {
-			speak( __( 'Block settings closed' ) );
-		} else {
-			speak(
-				__(
-					'Additional settings are now available in the Editor block settings sidebar'
-				)
-			);
-		}
-	};
-
-	const label = areAdvancedSettingsOpened
-		? __( 'Hide more settings' )
-		: __( 'Show more settings' );
-
-	return (
-		<MenuItem
-			onClick={ () => {
-				if ( areAdvancedSettingsOpened ) {
-					disableComplementaryArea( 'core/edit-site' );
-				} else {
-					enableComplementaryArea(
-						'core/edit-site',
-						'edit-site/block-inspector'
-					);
-					speakMessage();
-					onClick();
-				}
-			} }
-			shortcut={ shortcut }
-		>
-			{ ! small && label }
-		</MenuItem>
-	);
-}
+import BlockInspectorButton from './block-inspector-button';
 
 export default function BlockEditor( { setIsInserterOpen } ) {
 	const { settings, templateType, page, deviceType } = useSelect(

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -9,18 +9,31 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
+import { SIDEBAR_BLOCK } from '../sidebar/constants';
+import { STORE_NAME } from '../../store/constants';
 
 function KeyboardShortcuts() {
 	const isListViewOpen = useSelect( ( select ) =>
 		select( editSiteStore ).isListViewOpened()
 	);
+	const isBlockInspectorOpen = useSelect(
+		( select ) =>
+			select( interfaceStore ).getActiveComplementaryArea(
+				editSiteStore.name
+			) === SIDEBAR_BLOCK,
+		[]
+	);
 	const { redo, undo } = useDispatch( coreStore );
 	const { setIsListViewOpened } = useDispatch( editSiteStore );
+	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
+		interfaceStore
+	);
 
 	useShortcut(
 		'core/edit-site/undo',
@@ -45,6 +58,22 @@ function KeyboardShortcuts() {
 		useCallback( () => {
 			setIsListViewOpened( ! isListViewOpen );
 		}, [ isListViewOpen, setIsListViewOpened ] ),
+		{ bindGlobal: true }
+	);
+
+	useShortcut(
+		'core/edit-site/toggle-block-settings-sidebar',
+		( event ) => {
+			// This shortcut has no known clashes, but use preventDefault to prevent any
+			// obscure shortcuts from triggering.
+			event.preventDefault();
+
+			if ( isBlockInspectorOpen ) {
+				disableComplementaryArea( STORE_NAME );
+			} else {
+				enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
+			}
+		},
 		{ bindGlobal: true }
 	);
 
@@ -81,6 +110,16 @@ function KeyboardShortcutsRegister() {
 			keyCombination: {
 				modifier: 'access',
 				character: 'o',
+			},
+		} );
+
+		registerShortcut( {
+			name: 'core/edit-site/toggle-block-settings-sidebar',
+			category: 'global',
+			description: __( 'Show or hide the block settings sidebar.' ),
+			keyCombination: {
+				modifier: 'primaryShift',
+				character: ',',
 			},
 		} );
 	}, [ registerShortcut ] );


### PR DESCRIPTION
## Description

Within the site editor

- Adds a keyboard shortcut `Cmd/Ctrl + Shift + ,` to toggle the block inspector sidebar
- Adds a menu item on the block inspector toolbar to toggle the block inspector sidebar

Both of these mirror how the post editor works, bring parity between the post and site editors.

## How has this been tested?

- Open the site editor
- Select a block
- Click the options menu in the block toolbar
- Select the item to Show/Hide more settings, which should toggle the block inspector sidebar
- Press `Cmd/Ctrl + Shift + ,`, which should toggle the block inspector sidebar

## Screenshots

| Hide | Show |
| - | - |
| <img width="469" alt="image" src="https://user-images.githubusercontent.com/1699996/116492506-08a19280-a862-11eb-8184-947be545a654.png"> | <img width="473" alt="image" src="https://user-images.githubusercontent.com/1699996/116492509-0a6b5600-a862-11eb-8352-bf02050e4b4e.png"> |


## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
