### PR TITLE
Only split block styles loading for block themes

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -14,7 +14,7 @@
  * @return bool
  */
 function gutenberg_should_load_separate_block_assets() {
-	$load_separate_styles = gutenberg_supports_block_templates();
+	$load_separate_styles = gutenberg_is_fse_theme();
 	/**
 	 * Determine if separate styles will be loaded for blocks on-render or not.
 	 *

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -169,7 +169,12 @@ function gutenberg_experimental_global_styles_register_user_cpt() {
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_user_cpt' );
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
-add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
+
+// In non-block themes using theme.json, load global styles in the footer.
+$global_styles_register_hook = ( ! gutenberg_is_fse_theme() && current_theme_supports( 'block-templates' ) )
+	? 'wp_footer'
+	: 'wp_enqueue_scripts';
+add_action( $global_styles_register_hook, 'gutenberg_experimental_global_styles_enqueue_assets' );
 
 
 /**

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -169,10 +169,7 @@ function gutenberg_experimental_global_styles_register_user_cpt() {
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_user_cpt' );
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
-
-// In non-block themes using theme.json, load global styles in the footer.
-$global_styles_register_hook = ! gutenberg_is_fse_theme() ? 'wp_footer' : 'wp_enqueue_scripts';
-add_action( $global_styles_register_hook, 'gutenberg_experimental_global_styles_enqueue_assets' );
+add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
 
 
 /**

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -171,9 +171,7 @@ add_action( 'init', 'gutenberg_experimental_global_styles_register_user_cpt' );
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
 
 // In non-block themes using theme.json, load global styles in the footer.
-$global_styles_register_hook = ( ! gutenberg_is_fse_theme() && current_theme_supports( 'block-templates' ) )
-	? 'wp_footer'
-	: 'wp_enqueue_scripts';
+$global_styles_register_hook = ! gutenberg_is_fse_theme() ? 'wp_footer' : 'wp_enqueue_scripts';
 add_action( $global_styles_register_hook, 'gutenberg_experimental_global_styles_enqueue_assets' );
 
 


### PR DESCRIPTION
## Description

If the theme is using `theme.json` - so has global styles enabled, but is NOT a block theme, global styles get overridden by other styles.
See https://github.com/WordPress/gutenberg/issues/31293 for a detailed description of the issue.

This PR fixes the issue by making sure that separate styles are only used in FSE themes - or when the theme opts in.

## How has this been tested?
Followed the instructions in #31293 and confirmed this fixes the issue.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
