### PR TITLE
Use UnitControl for font-size

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -7,21 +7,39 @@ import { isNumber, isString } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useInstanceId } from '@wordpress/compose';
 import { textColor } from '@wordpress/icons';
-import { useMemo, forwardRef } from '@wordpress/element';
+import { useMemo, forwardRef, Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Button from '../button';
 import RangeControl from '../range-control';
+import UnitControl from '../unit-control';
 import CustomSelectControl from '../custom-select-control';
 import VisuallyHidden from '../visually-hidden';
 
 const DEFAULT_FONT_SIZE = 'default';
 const CUSTOM_FONT_SIZE = 'custom';
 const MAX_FONT_SIZE_DISPLAY = '25px';
+const isWeb = Platform.OS === 'web';
+const CSS_UNITS = [
+	{
+		value: 'px',
+		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		default: '',
+	},
+	{
+		value: 'em',
+		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
+		default: '',
+	},
+	{
+		value: 'rem',
+		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
+		default: '',
+	},
+];
 
 function getSelectValueFromFontSize( fontSizes, value ) {
 	if ( value ) {
@@ -77,8 +95,6 @@ function FontSizePicker(
 	const isPixelValue =
 		isNumber( value ) || ( isString( value ) && value.endsWith( 'px' ) );
 
-	const instanceId = useInstanceId( FontSizePicker );
-
 	const options = useMemo(
 		() => getSelectOptions( fontSizes, disableCustomFontSizes ),
 		[ fontSizes, disableCustomFontSizes ]
@@ -89,8 +105,6 @@ function FontSizePicker(
 	}
 
 	const selectedFontSizeSlug = getSelectValueFromFontSize( fontSizes, value );
-
-	const fontSizePickerNumberId = `components-font-size-picker__number#${ instanceId }`;
 
 	return (
 		<fieldset
@@ -117,33 +131,16 @@ function FontSizePicker(
 					/>
 				) }
 				{ ! withSlider && ! disableCustomFontSizes && (
-					<div className="components-font-size-picker__number-container">
-						<label htmlFor={ fontSizePickerNumberId }>
-							{ __( 'Custom' ) }
-						</label>
-						<input
-							id={ fontSizePickerNumberId }
-							className="components-font-size-picker__number"
-							type="number"
-							min={ 1 }
-							onChange={ ( event ) => {
-								if (
-									! event.target.value &&
-									event.target.value !== 0
-								) {
-									onChange( undefined );
-									return;
-								}
-								if ( hasUnits ) {
-									onChange( event.target.value + 'px' );
-								} else {
-									onChange( Number( event.target.value ) );
-								}
-							} }
-							aria-label={ __( 'Custom' ) }
-							value={ ( isPixelValue && noUnitsValue ) || '' }
-						/>
-					</div>
+					<UnitControl
+						label={ __( 'Custom' ) }
+						labelPosition="top"
+						__unstableInputWidth="80px"
+						value={ value }
+						onChange={ ( nextSize ) => {
+							onChange( nextSize );
+						} }
+						units={ CSS_UNITS }
+					/>
 				) }
 				<Button
 					className="components-color-palette__clear"

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -134,7 +134,7 @@ function FontSizePicker(
 					<UnitControl
 						label={ __( 'Custom' ) }
 						labelPosition="top"
-						__unstableInputWidth="80px"
+						__unstableInputWidth="60px"
 						value={ value }
 						onChange={ ( nextSize ) => {
 							onChange( nextSize );

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -137,7 +137,11 @@ function FontSizePicker(
 						__unstableInputWidth="60px"
 						value={ value }
 						onChange={ ( nextSize ) => {
-							onChange( nextSize );
+							if ( 0 === parseFloat( nextSize ) || ! nextSize ) {
+								onChange( undefined );
+							} else {
+								onChange( nextSize );
+							}
 						} }
 						units={ CSS_UNITS }
 					/>

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	.components-custom-select-control__button {
-		min-width: 110px;
+		min-width: 120px;
 	}
 
 	// Apply the same height as the isSmall Reset button.

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -5,6 +5,20 @@
 	align-items: center;
 	margin-bottom: $grid-unit-30;
 
+	.components-unit-control-wrapper {
+		margin-right: $grid-unit-10;
+
+		.components-input-control__label {
+			font-weight: 300;
+			padding-bottom: 0 !important;
+			margin-bottom: $grid-unit-10 !important;
+		}
+	}
+
+	.components-custom-select-control__button {
+		min-width: 110px;
+	}
+
 	// Apply the same height as the isSmall Reset button.
 	.components-font-size-picker__number {
 		@include input-control;

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -96,6 +96,7 @@ describe( 'Font Size Picker', () => {
 
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
 
 		await page.keyboard.press( 'Enter' );
 


### PR DESCRIPTION
## Description
This PR allows using non-px values for font-sizes, by using `UnitControl` instead of the custom number input we were previously using.
Font-sizes were previously saved using `px` as a hardcoded unit, so there are no backwards-compatibility issues I could find. This just allows using `em`/`rem` units.

## How has this been tested?
Tested in new blocks, tested in existing posts, nothing breaks. Tested using px, em & rem values. nothing breaks.

## Screenshots <!-- if applicable -->

### Before:

![Screenshot from 2021-04-29 10-39-17](https://user-images.githubusercontent.com/588688/116517743-0843de80-a8d8-11eb-9023-b91f84e4e87f.png)

### After:

![Screenshot from 2021-04-29 10-52-53](https://user-images.githubusercontent.com/588688/116518650-3118a380-a8d9-11eb-9698-e01686b9fc15.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
