### PR TITLE
Fix Inserter Drag and Drop

### DIFF
--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -15,6 +15,7 @@ const InserterDraggableBlocks = ( { isEnabled, blocks, icon, children } ) => {
 
 	return (
 		<Draggable
+			__experimentalTransferDataType="wp-blocks"
 			transferData={ transferData }
 			__experimentalDragComponent={
 				<BlockDraggableChip count={ blocks.length } icon={ icon } />


### PR DESCRIPTION
The recent refactor to block drag and drop caused a regression on the inserter drag and drop because of the new transfer type prop. This PR fixes it.

Ideally, the "type" property in the data transfer object should be consolidated with this new prop.