### PR TITLE
Plugin: Unregister only registered block patterns

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -221,7 +221,10 @@ add_action(
 		}
 
 		foreach ( $core_block_patterns as $core_block_pattern ) {
-			unregister_block_pattern( 'core/' . $core_block_pattern );
+			$name = 'core/' . $core_block_pattern;
+			if ( WP_Block_Patterns_Registry::get_instance()->is_registered( $name ) ) {
+				unregister_block_pattern( $name );
+			}
 		}
 
 		foreach ( $new_core_block_patterns as $core_block_pattern ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Ensures there are no notices displayed in the debug mode:

```
Notice: WP_Block_Patterns_Registry::unregister was called incorrectly. Pattern "core/two-images" not found. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /var/www/html/wp-includes/functions.php on line 5319
Notice: WP_Block_Patterns_Registry::unregister was called incorrectly. Pattern "core/text-two-columns-with-images" not found. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /var/www/html/wp-includes/functions.php on line 5319
Notice: WP_Block_Patterns_Registry::unregister was called incorrectly. Pattern "core/text-three-columns-buttons" not found. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /var/www/html/wp-includes/functions.php on line 5319
Notice: WP_Block_Patterns_Registry::unregister was called incorrectly. Pattern "core/large-header" not found. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /var/www/html/wp-includes/functions.php on line 5319
Notice: WP_Block_Patterns_Registry::unregister was called incorrectly. Pattern "core/large-header-button" not found. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /var/www/html/wp-includes/functions.php on line 5319
Notice: WP_Block_Patterns_Registry::unregister was called incorrectly. Pattern "core/three-buttons" not found. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /var/www/html/wp-includes/functions.php on line 5319
Notice: WP_Block_Patterns_Registry::unregister was called incorrectly. Pattern "core/heading-paragraph" not found. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /var/www/html/wp-includes/functions.php on line 5319
```

## Testing

Ensure there are no notices displayed when `WP_DEBUG` flag is set to `true` and you use the most recent version of `wordpress-develop`.