### PR TITLE
Add allowedBlocks and TemplateLock attributes in Cover Block

### DIFF
--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -62,6 +62,12 @@
 		"isDark": {
 			"type": "boolean",
 			"default": true
+		},
+		"allowedBlocks": {
+			"type": "array"
+		},
+		"templateLock": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -326,7 +326,7 @@ function CoverEdit( {
 		url,
 		alt,
 		allowedBlocks,
-		templateLock = false,
+		templateLock,
 	} = attributes;
 	const {
 		gradientClass,

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -325,6 +325,8 @@ function CoverEdit( {
 		style: styleAttribute,
 		url,
 		alt,
+		allowedBlocks,
+		templateLock = false,
 	} = attributes;
 	const {
 		gradientClass,
@@ -618,6 +620,8 @@ function CoverEdit( {
 		{
 			template: innerBlocksTemplate,
 			templateInsertUpdatesSelection: true,
+			allowedBlocks,
+			templateLock,
 		}
 	);
 

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -102,7 +102,7 @@ const Cover = ( {
 		customOverlayColor,
 		minHeightUnit = 'px',
 		allowedBlocks,
-		templateLock = false,
+		templateLock,
 	} = attributes;
 	const [ isScreenReaderEnabled, setIsScreenReaderEnabled ] = useState(
 		false

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -101,6 +101,8 @@ const Cover = ( {
 		style,
 		customOverlayColor,
 		minHeightUnit = 'px',
+		allowedBlocks,
+		templateLock = false,
 	} = attributes;
 	const [ isScreenReaderEnabled, setIsScreenReaderEnabled ] = useState(
 		false
@@ -504,7 +506,9 @@ const Cover = ( {
 				style={ [ styles.content, { minHeight: convertedMinHeight } ] }
 			>
 				<InnerBlocks
+					allowedBlocks={ allowedBlocks }
 					template={ INNER_BLOCKS_TEMPLATE }
+					templateLock={ templateLock }
 					templateInsertUpdatesSelection
 					blockWidth={ blockWidth }
 				/>


### PR DESCRIPTION
## Description
According to #31312 request, I added allowedBlocks attribute for Cover Block.

## How has this been tested? And Screenshots
Tested manually. 

- Without allowedBlocks (before changes & after changes with Cover without passing allowedBlocks attribute)
- [x] Expectations: Possibility to add all blocks

![image (1)](https://user-images.githubusercontent.com/15144546/116532995-2e21b100-a8e1-11eb-89e8-eb6cde0f5c79.png)

- With `allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/button' ]`
- [x] Expectations: Possibility to add only Paragraph, Heading and/or Button
![image (3)](https://user-images.githubusercontent.com/15144546/116533294-7e990e80-a8e1-11eb-8410-5728dadb54f9.png)

- With templateLock
- [x] Expectations: No 'add block' button and no possibility to add block
![image (11)](https://user-images.githubusercontent.com/15144546/116533365-9375a200-a8e1-11eb-9ee1-2e07235fb778.png)

## Types of changes
1. Add allowedBlocks and templateLock attributes with their types to `block.json`
2. Add allowedBlocks and templateLock (default `false`) attributes to edit.js
3. Add allowedBlocks and templateLock attributes to edit.native.js

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] I've tested my changes with keyboard and screen readers.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).
