### PR TITLE
FSE: Fix template loading order for child themes when no explicit template exists

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -80,7 +80,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 			if ( is_child_theme() ) {
 
 				$has_php_template   = file_exists( get_stylesheet_directory() . '/' . $current_template_slug . '.php' );
-				$block_template     = _gutenberg_get_template_file( 'wp_template', $type );
+				$block_template     = _gutenberg_get_template_file( 'wp_template', $current_block_template_slug );
 				$has_block_template = false;
 
 				if ( null !== $block_template && wp_get_theme()->get_stylesheet() === $block_template['theme'] ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -71,22 +71,27 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	$current_block_template_slug = is_object( $current_template ) ? $current_template->slug : false;
 	foreach ( $templates as $template_item ) {
 
-		// if the theme is a child theme we want to check if a php template exists
-		// and that a corresponding block template from the theme and not the parent doesn't exist.
-		$has_php_template   = file_exists( get_stylesheet_directory() . '/' . $type . '.php' );
-		$has_block_template = false;
-		$block_template     = _gutenberg_get_template_file( 'wp_template', $type );
-		if ( null !== $block_template && wp_get_theme()->get_stylesheet() === $block_template['theme'] ) {
-			$has_block_template = true;
-		}
-		if ( is_child_theme() && ( $has_php_template && ! $has_block_template ) ) {
-			return $template;
-		}
-
 		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
 
 		// Break the loop if the block-template matches the template slug.
 		if ( $current_block_template_slug === $template_item_slug ) {
+
+			// if the theme is a child theme we want to check if a php template exists.
+			if ( is_child_theme() ) {
+
+				$has_php_template   = file_exists( get_stylesheet_directory() . '/' . $current_template_slug . '.php' );
+				$block_template     = _gutenberg_get_template_file( 'wp_template', $type );
+				$has_block_template = false;
+
+				if ( null !== $block_template && wp_get_theme()->get_stylesheet() === $block_template['theme'] ) {
+					$has_block_template = true;
+				}
+				// and that a corresponding block template from the theme and not the parent doesn't exist.
+				if ( $has_php_template && ! $has_block_template ) {
+					return $template;
+				}
+			}
+
 			break;
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR covers a condition that was not being considered by https://github.com/WordPress/gutenberg/pull/31123: When a child theme has no explicit template for a certain page (such as the home.php) but it does have a fallback template available (such as index.php), the template that was being loaded was the one from the parent if it was using a block based template (in this example: index.html). This change encapsulates the previous PR to only consider child themes and covers this specific case that was not being considered.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Using a [child of BCB](https://github.com/Automattic/themes/tree/trunk/blank-canvas-blocks) I tested the following cases:
- Parent theme defines index.html, child theme defines index.php. When loading the home page, the child theme's template is being loaded.
- Parent theme defines 404.html, child theme defines 404.php. When loading a 404 page, the child theme's template is being loaded.
- Child theme defines archive.php, parent theme only defines index.html. Then loading a category page, the child theme's template is being loaded.
- Child theme defines page.html and page-2.php. When loading the page with ID 2, it loads the page-2.php

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
