### PR TITLE
Prevent PostDate as link to load inside an iframe

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -80,7 +80,14 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 		__( 'No Date' )
 	);
 	if ( isLink && date ) {
-		postDate = <a href="#post-date-pseudo-link">{ postDate }</a>;
+		postDate = (
+			<a
+				href="#post-date-pseudo-link"
+				onClick={ ( event ) => event.preventDefault() }
+			>
+				{ postDate }
+			</a>
+		);
 	}
 	return (
 		<>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/30647

This is just a remaining piece that could trigger the load of a page inside the FSE iframe.
<!-- Please describe what you have changed or added -->

