### PR TITLE
Workflows: Run tests on release branches

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -5,6 +5,7 @@ on:
     push:
         branches:
             - trunk
+            - 'release/**'
             - 'wp/**'
 
 jobs:

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -5,6 +5,7 @@ on:
     push:
         branches:
             - trunk
+            - 'release/**'
             - 'wp/**'
 
 jobs:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,6 +7,7 @@ on:
     push:
         branches:
             - trunk
+            - 'release/**'
             - 'wp/**'
 
 jobs:


### PR DESCRIPTION
## Description
Gutenberg v10.5.1 was [broken](https://wordpress.slack.com/archives/C02QB2JS7/p1619700188023700) because it was missing an API that had been introduced by https://github.com/WordPress/gutenberg/pull/31078 -- which had been merged into `trunk`, but not cherry-picked into the `release/10.5` branch. 

We aren't currently running our tests on `release/` branches. Thus, a look at the branch's commit history might inspire false confidence, as it shows ✔️  signs next to most commits (even though those only reflect that the only workflow that we're currently running against `release/` branches is passing -- the "Pull request automation" workflow):

![image](https://user-images.githubusercontent.com/96308/116603499-45868b80-a92d-11eb-8d96-9d562865f3df.png)

This PR enables 3 of our workflows (Static Analysis, Unit Tests, E2E Tests) to be run against `release/` branches, in order to surface breakage more quickly.

## How has this been tested?

Bit tricky, since this needs a `release/` branch. Maybe fork the repo, create a temporary `release/test` branch (based on this PR's branch), and check that branch's commit history?