### PR TITLE
Check for NaN when image sizes have changed

### DIFF
--- a/packages/block-editor/src/components/image-size-control/README.md
+++ b/packages/block-editor/src/components/image-size-control/README.md
@@ -57,7 +57,7 @@ The width of the image when displayed.
 
 ### onChange
 
-The function called when the image size changes. It is passed an object with `{ width, height }` (potentially just one if only one dimension changed).
+The function called when the image size changes. It is passed an object with `{ width, height }` (potentially just one if only one dimension changed). If the dimension value is invalid, the property value is set to `undefined`.
 
 -   Type: `Function`
 -   Required: Yes

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -33,6 +33,15 @@ export default function ImageSizeControl( {
 		};
 	}
 
+	// Normalize the changed dimension before passing it on.
+	function normalizeDimension( dimension ) {
+		const parsedDimension = parseInt( dimension, 10 );
+
+		return isNaN( parsedDimension ) || parsedDimension <= 0
+			? undefined
+			: parsedDimension;
+	}
+
 	return (
 		<>
 			{ ! isEmpty( imageSizeOptions ) && (
@@ -56,7 +65,9 @@ export default function ImageSizeControl( {
 							value={ width ?? imageWidth ?? '' }
 							min={ 1 }
 							onChange={ ( value ) =>
-								onChange( { width: parseInt( value, 10 ) } )
+								onChange( {
+									width: normalizeDimension( value ),
+								} )
 							}
 						/>
 						<TextControl
@@ -67,7 +78,7 @@ export default function ImageSizeControl( {
 							min={ 1 }
 							onChange={ ( value ) =>
 								onChange( {
-									height: parseInt( value, 10 ),
+									height: normalizeDimension( value ),
 								} )
 							}
 						/>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -361,7 +361,14 @@ export default function Image( {
 					) }
 					<ImageSizeControl
 						onChangeImage={ updateImage }
-						onChange={ ( value ) => setAttributes( value ) }
+						onChange={ ( { width: newWidth, height: newHeight } ) =>
+							setAttributes( {
+								width: isNaN( newWidth ) ? undefined : newWidth,
+								height: isNaN( newHeight )
+									? undefined
+									: newHeight,
+							} )
+						}
 						slug={ sizeSlug }
 						width={ width }
 						height={ height }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -361,14 +361,7 @@ export default function Image( {
 					) }
 					<ImageSizeControl
 						onChangeImage={ updateImage }
-						onChange={ ( { width: newWidth, height: newHeight } ) =>
-							setAttributes( {
-								width: isNaN( newWidth ) ? undefined : newWidth,
-								height: isNaN( newHeight )
-									? undefined
-									: newHeight,
-							} )
-						}
+						onChange={ ( value ) => setAttributes( value ) }
 						slug={ sizeSlug }
 						width={ width }
 						height={ height }


### PR DESCRIPTION
Fixes the issue where the core image block breaks if an empty value is passed back to the callback. The size attribute is set to NaN, causing the block to get corrupted after saving as well.

Closes #16942.  