### PR TITLE
Multi-selection: move shift+click logic to hook

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
@@ -36,9 +36,13 @@ export function useMultiSelection( clientId ) {
 		multiSelect,
 		selectBlock,
 	} = useDispatch( blockEditorStore );
-	const { isSelectionEnabled, isBlockSelected, getBlockParents } = useSelect(
-		blockEditorStore
-	);
+	const {
+		isSelectionEnabled,
+		isBlockSelected,
+		getBlockParents,
+		getBlockSelectionStart,
+		hasMultiSelection,
+	} = useSelect( blockEditorStore );
 	return useRefEffect(
 		( node ) => {
 			const { ownerDocument } = node;
@@ -152,9 +156,34 @@ export function useMultiSelection( clientId ) {
 				toggleRichText( node, false );
 			}
 
+			function onMouseDown( event ) {
+				// The main button.
+				// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+				if ( ! isSelectionEnabled() || event.button !== 0 ) {
+					return;
+				}
+
+				if ( event.shiftKey ) {
+					const blockSelectionStart = getBlockSelectionStart();
+					toggleRichText( node, false );
+					multiSelect( blockSelectionStart, clientId );
+					event.preventDefault();
+				} else if ( hasMultiSelection() ) {
+					// Allow user to escape out of a multi-selection to a
+					// singular selection of a block via click. This is handled
+					// here since focus handling excludes blocks when there is
+					// multiselection, as focus can be incurred by starting a
+					// multiselection (focus moved to first block's multi-
+					// controls).
+					selectBlock( clientId );
+				}
+			}
+
+			node.addEventListener( 'mousedown', onMouseDown );
 			node.addEventListener( 'mouseleave', onMouseLeave );
 
 			return () => {
+				node.removeEventListener( 'mousedown', onMouseDown );
 				node.removeEventListener( 'mouseleave', onMouseLeave );
 				ownerDocument.removeEventListener(
 					'selectionchange',

--- a/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
@@ -165,9 +165,11 @@ export function useMultiSelection( clientId ) {
 
 				if ( event.shiftKey ) {
 					const blockSelectionStart = getBlockSelectionStart();
-					toggleRichText( node, false );
-					multiSelect( blockSelectionStart, clientId );
-					event.preventDefault();
+					if ( blockSelectionStart !== clientId ) {
+						toggleRichText( node, false );
+						multiSelect( blockSelectionStart, clientId );
+						event.preventDefault();
+					}
 				} else if ( hasMultiSelection() ) {
 					// Allow user to escape out of a multi-selection to a
 					// singular selection of a block via click. This is handled

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -32,7 +32,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { isInSameBlock, getBlockClientId } from '../../utils/dom';
+import { isInSameBlock } from '../../utils/dom';
 import useMultiSelection from './use-multi-selection';
 import { store as blockEditorStore } from '../../store';
 
@@ -188,43 +188,14 @@ export default function WritingFlow( { children } ) {
 		getFirstMultiSelectedBlockClientId,
 		getLastMultiSelectedBlockClientId,
 		getBlockOrder,
-		isSelectionEnabled,
-		getBlockSelectionStart,
 		getSettings,
 	} = useSelect( blockEditorStore );
 	const { multiSelect, selectBlock, setNavigationMode } = useDispatch(
 		blockEditorStore
 	);
 
-	function onMouseDown( event ) {
+	function onMouseDown() {
 		verticalRect.current = null;
-
-		// Multi-select blocks when Shift+clicking.
-		if (
-			isSelectionEnabled() &&
-			// The main button.
-			// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
-			event.button === 0
-		) {
-			const clientId = getBlockClientId( event.target );
-
-			if ( clientId ) {
-				if ( event.shiftKey ) {
-					const blockSelectionStart = getBlockSelectionStart();
-					if ( blockSelectionStart !== clientId ) {
-						multiSelect( blockSelectionStart, clientId );
-						event.preventDefault();
-					}
-					// Allow user to escape out of a multi-selection to a singular
-					// selection of a block via click. This is handled here since
-					// focus handling excludes blocks when there is multiselection,
-					// as focus can be incurred by starting a multiselection (focus
-					// moved to first block's multi-controls).
-				} else if ( hasMultiSelection ) {
-					selectBlock( clientId );
-				}
-			}
-		}
 	}
 
 	function expandSelection( isReverse ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Moves the logic out of writing flow to the multi selection hook.

## How has this been tested?

Select a block, hold shift and click on a different block. There should now be a multi selection.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
