### PR TITLE
wp-env: Start pulling mapped git source branches

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -8,6 +8,11 @@
 -   Automatically add the environment's port to `WP_TESTS_DOMAIN`.
 -   `run` command now has a `--env-cwd` option to set the working directory in the container for the command to execute from.
 
+### Bug Fix
+
+-   `wp-env` is better at fetching git sources which use tags.
+-   `wp-env` now pulls branches of git sources -- previously it only fetched them. This restores the intended behavior.
+
 ## 5.16.0 (2023-04-12)
 
 ## 5.15.0 (2023-03-29)
@@ -47,52 +52,63 @@
 ## 5.2.0 (2022-08-16)
 
 ### Enhancement
+
 -   Query parameters can now be used in .zip source URLs.
 
 ## 5.1.1 (2022-08-16)
 
 ### Bug Fix
+
 -   Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the latest stable WordPress version.
 
 ## 5.1.0 (2022-08-10)
 
 ### Enhancement
+
 -   Previously, wp-env used the WordPress version provided by Docker in the WordPress image for installations which don't specify a WordPress version. Now, wp-env will find the latest stable version on WordPress.org and check out the https://github.com/WordPress/WordPress repository at the tag matching that version. In most cases, this will match what Docker provides. The benefit is that wp-env (and WordPress.org) now controls the default WordPress version rather than Docker.
 
 ### Bug Fix
+
 -   Downloading a default WordPress version also resolves a bug where the wrong WordPress test files were used if no core source was specified in wp-env.json. The current trunk test files were downloaded rather than the stable version. Now, the test files will match the default stable version.
 
 ## 5.0.0 (2022-07-27)
 
 ### Breaking Changes
+
 -   Removed the `WP_PHPUNIT__TESTS_CONFIG` environment variable from the `phpunit` container. **This removes automatic support for the `wp-phpunit/wp-phpunit` Composer package. To continue using the package, set the following two environment variables in your `phpunit.xml` file or similar: `WP_TESTS_DIR=""` and `WP_PHPUNIT__TESTS_CONFIG="/wordpress-phpunit/wp-tests-config.php"`.**
 -   Removed the generated `/var/www/html/phpunit-wp-config.php` file from the environment.
 
 ### Enhancement
+
 -   Read WordPress' version and include the corresponding PHPUnit test files in the environment.
 -   Set the `WP_TESTS_DIR` environment variable in all containers to point at the PHPUnit test files.
 
 ### Bug Fix
+
 -   Restrict `WP_TESTS_DOMAIN` constant to just hostname rather than an entire URL (e.g. it now excludes scheme, port, etc.) ([#41039](https://github.com/WordPress/gutenberg/pull/41039)).
 
 ## 4.8.0 (2022-06-01)
 
 ### Enhancement
+
 -   Removed the need for quotation marks when passing options to `wp-env run`.
 -   Setting a `config` key to `null` will prevent adding the constant to `wp-config.php` even if a default value is defined by `wp-env`.
 
 ## 4.7.0 (2022-05-18)
 
 ### Enhancement
+
 -   Added SSH protocol support for git sources
 
 ## 4.2.0 (2022-01-27)
 
 ### Enhancement
+
 -   Added command `wp-env install-path` to list the directory used for the environment.
 -   The help entry is now shown when no subcommand is passed to `wp-env`.
 
 ### Bug Fix
+
 -   Updated `yargs` to fix [CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807).
 
 ## 4.1.3 (2021-11-07)

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -135,6 +135,12 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 	log( 'Checking out the specified ref.' );
 	await git.checkout( source.ref );
 
+	const { detached, current } = await git.branch();
+	if ( ! detached && current ) {
+		log( "Running git pull since we're on a branch." );
+		await git.pull();
+	}
+
 	onProgress( 1 );
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The intention of git sources was always to pull the latest changes when `wp-env --update` is run. However, we were only ever fetching and then checking out branches. This does not make the changes available on the local branch. For example, with Gutenberg, it is likely that the WordPress source branch was never pulled for everyone's local environment unless they destroyed it. As a result, it could be out of date for some time.

Note that this does not affect CI, because CI is always cloning directly and not working with an existing checkout.

We now run `git pull` once we verify that we are not in a detached state and that there is a current branch name.

## How has this been tested?
- locally, with `npx wp-env start --update`

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
