### PR TITLE
Scripts: Add `postcss` as a dependency to ensure a correct version is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14348,6 +14348,7 @@
 				"mini-css-extract-plugin": "^1.3.9",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^5.0.0",
+				"postcss": "^8.2.2",
 				"postcss-loader": "^4.2.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"puppeteer-core": "^9.0.0",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Add `postcss` as a dependency to ensure that the correct version gets installed.
+
 ## 15.0.0 (2021-04-29)
 
 ### Breaking Changes

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -66,6 +66,7 @@
 		"mini-css-extract-plugin": "^1.3.9",
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^5.0.0",
+		"postcss": "^8.2.2",
 		"postcss-loader": "^4.2.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"puppeteer-core": "^9.0.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes https://github.com/WordPress/gutenberg/issues/31361.

> ## Step-by-step reproduction instructions
> 
> 1. run `npx @wordpress/create-block test-block-2`
> 
> ## Actual behaviour
> 
> This is the output of [npx @wordpress/create-block test-block-2`](https://gist.github.com/skorasaurus/19bd108acde4b22e7b368a6e078852f5#file-create-block) 
> 
> I've included part of the error message below. 
>  
> `ERROR in ./src/style.scss
> Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
> ModuleBuildError: Module build failed (from ./node_modules/postcss-loader/dist/cjs.js):
> Error: [object Object] is not a PostCSS plugin
>     at Processor.normalize `
> 
> When I run `npm run start` inside the directory of my newly created block, I receive the same error message, [here it is in full](https://gist.github.com/skorasaurus/19bd108acde4b22e7b368a6e078852f5#file-npm-run-start-log)

## How has this been tested?


I installed manually the same version of `postcss` v8.2.2 that Gutenberg uses in the scaffolded project. It resolves the issue, so the fix does the same on the `@wordpress/scripts` level.



## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
