### PR TITLE
Improve the navigation block setup state / placeholder.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -177,6 +177,10 @@ $color-control-label-height: 20px;
 	.components-placeholder__fieldset {
 		font-size: inherit;
 	}
+
+	.components-placeholder__fieldset .components-button {
+		margin-bottom: 0;
+	}
 }
 
 // Spinner.
@@ -272,10 +276,10 @@ $color-control-label-height: 20px;
 	// Block title
 	.wp-block-navigation-placeholder__actions__indicator {
 		margin-right: $grid-unit-15;
-		padding: ($grid-unit-15 / 2) 0;
+		padding: 0;
 		align-items: center;
 		justify-content: flex-start;
-		display: none;
+		display: inline-flex;
 		line-height: 0;
 
 		// line up with the icon in the toolbar.
@@ -288,10 +292,6 @@ $color-control-label-height: 20px;
 		.is-vertical & {
 			margin-bottom: $grid-unit-05;
 			margin-left: 0;
-		}
-
-		@include break-small {
-			display: inline-flex;
 		}
 	}
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -165,11 +165,18 @@ $color-control-label-height: 20px;
  * Setup state
  */
 
-// Ensure that an empty block has space around the appender.
-.wp-block-navigation-placeholder,
-.wp-block-navigation-placeholder__preview,
-.is-selected .wp-block-navigation__container {
-	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
+// Unstyle some inherited placeholder component styles.
+.components-placeholder.wp-block-navigation-placeholder {
+	outline: none;
+	padding: 0;
+	box-shadow: none;
+	background: none;
+	min-height: 0;
+
+	// Needed for the preview menu items to match actual menu items.
+	.components-placeholder__fieldset {
+		font-size: inherit;
+	}
 }
 
 // Spinner.
@@ -188,14 +195,19 @@ $color-control-label-height: 20px;
 	transition: all 0.1s ease-in-out;
 	@include reduce-motion("transition");
 
-	// Style skeleton elements.
+	// Style skeleton elements to mostly match the metrics of actual menu items.
 	// Needs specificity.
 	.wp-block-navigation-link.wp-block-navigation-link {
-		border-radius: $radius-block-ui;
-		background: currentColor;
+		position: relative;
 		min-width: 72px;
-		height: $grid-unit-20;
-		margin: $grid-unit-15 $grid-unit-30 $grid-unit-15 0;
+
+		&::before {
+			content: "";
+			border-radius: $radius-block-ui;
+			background: currentColor;
+			height: $grid-unit-20;
+			width: 100%;
+		}
 	}
 
 	svg {
@@ -207,16 +219,13 @@ $color-control-label-height: 20px;
 		opacity: 0.3;
 	}
 
+	// Don't show the preview boxes for an empty nav block,
+	// but be present to size it correctly.
 	.is-selected & {
-		// Don't show the preview boxes for an empty nav block.
 		opacity: 0;
-
-		// Need to show the placeholder box above the preview boxes.
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
+		width: 0;
+		overflow: hidden;
+		flex-wrap: nowrap;
 	}
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -196,6 +196,9 @@ $color-control-label-height: 20px;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	flex-wrap: nowrap;
+	width: 100%;
+	overflow: hidden;
 	transition: all 0.1s ease-in-out;
 	@include reduce-motion("transition");
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -223,9 +223,14 @@ $color-control-label-height: 20px;
 		opacity: 0.3;
 	}
 
-	// Don't show the preview boxes for an empty nav block,
-	// but be present to size it correctly.
+	// Don't show the preview boxes for an empty nav block.
 	.is-selected & {
+		display: none;
+	}
+
+	// ... but be present in larger contexts to size it correctly.
+	.is-selected .is-large & {
+		display: flex;
 		opacity: 0;
 		width: 0;
 		overflow: hidden;
@@ -256,7 +261,9 @@ $color-control-label-height: 20px;
 		display: flex;
 	}
 
-	// Vertical navigation.
+	// Show stacked for the vertical navigation, or small placeholders.
+	.is-small &,
+	.is-medium &,
 	.is-vertical & {
 		.wp-block-navigation-placeholder__actions {
 			flex-direction: column;
@@ -279,10 +286,9 @@ $color-control-label-height: 20px;
 		padding: 0;
 		align-items: center;
 		justify-content: flex-start;
-		display: inline-flex;
 		line-height: 0;
 
-		// line up with the icon in the toolbar.
+		// Line up with the icon in the toolbar.
 		margin-left: $grid-unit-05 + $border-width;
 
 		svg {
@@ -292,6 +298,12 @@ $color-control-label-height: 20px;
 		.is-vertical & {
 			margin-bottom: $grid-unit-05;
 			margin-left: 0;
+		}
+
+		// Show only in big placeholders.
+		display: none;
+		.is-large & {
+			display: inline-flex;
 		}
 	}
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -240,7 +240,7 @@ $color-control-label-height: 20px;
 
 // Selected state.
 .wp-block-navigation-placeholder__controls {
-	padding: $grid-unit-05 $grid-unit-10;
+	padding: $grid-unit-10;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
@@ -249,6 +249,11 @@ $color-control-label-height: 20px;
 	display: none;
 	position: relative;
 	z-index: 1;
+
+	// Adjust padding for when shown horizontally.
+	.is-large & {
+		padding: $grid-unit-05 $grid-unit-10;
+	}
 
 	// If an ancestor has a text-decoration property applied, it is inherited regardless of
 	// the specificity of a child element. Only pulling the child out of the flow fixes it.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -227,12 +227,12 @@ $color-control-label-height: 20px;
 
 	// Don't show the preview boxes for an empty nav block.
 	// Needs specificity to work for the navigation screen.
-	.is-selected &.wp-block-navigation-placeholder__preview {
+	.wp-block-navigation.is-selected &.wp-block-navigation-placeholder__preview {
 		display: none;
 	}
 
 	// ... but be present in larger contexts to size it correctly.
-	.is-selected .is-large & {
+	.wp-block-navigation.is-selected .is-large & {
 		display: flex;
 		opacity: 0;
 		width: 0;
@@ -265,7 +265,7 @@ $color-control-label-height: 20px;
 	width: 100%;
 
 	// Show when selected.
-	.is-selected & {
+	.wp-block-navigation.is-selected & {
 		display: flex;
 	}
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -199,8 +199,6 @@ $color-control-label-height: 20px;
 	flex-wrap: nowrap;
 	width: 100%;
 	overflow: hidden;
-	transition: all 0.1s ease-in-out;
-	@include reduce-motion("transition");
 
 	// Style skeleton elements to mostly match the metrics of actual menu items.
 	// Needs specificity.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -207,6 +207,7 @@ $color-control-label-height: 20px;
 		min-width: 72px;
 
 		&::before {
+			display: block;
 			content: "";
 			border-radius: $radius-block-ui;
 			background: currentColor;
@@ -225,7 +226,8 @@ $color-control-label-height: 20px;
 	}
 
 	// Don't show the preview boxes for an empty nav block.
-	.is-selected & {
+	// Needs specificity to work for the navigation screen.
+	.is-selected &.wp-block-navigation-placeholder__preview {
 		display: none;
 	}
 

--- a/packages/block-library/src/navigation/placeholder-preview.js
+++ b/packages/block-library/src/navigation/placeholder-preview.js
@@ -5,12 +5,12 @@ import { Icon, search } from '@wordpress/icons';
 
 const PlaceholderPreview = () => {
 	return (
-		<div className="wp-block-navigation-placeholder__preview">
-			<span className="wp-block-navigation-link"></span>
-			<span className="wp-block-navigation-link"></span>
-			<span className="wp-block-navigation-link"></span>
+		<ul className="wp-block-navigation-placeholder__preview wp-block-navigation__container">
+			<li className="wp-block-navigation-link">&#8203;</li>
+			<li className="wp-block-navigation-link">&#8203;</li>
+			<li className="wp-block-navigation-link">&#8203;</li>
 			<Icon icon={ search } />
-		</div>
+		</ul>
 	);
 };
 

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -182,7 +182,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 						</div>
 						{ hasMenus ? (
 							<DropdownMenu
-								text={ __( 'Existing menu' ) }
+								text={ __( 'Add existing menu' ) }
 								icon={ chevronDown }
 								toggleProps={ toggleProps }
 							>

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -3,6 +3,7 @@
  */
 import { createBlock } from '@wordpress/blocks';
 import {
+	Placeholder,
 	Button,
 	DropdownMenu,
 	MenuGroup,
@@ -162,7 +163,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
 	return (
-		<div className="wp-block-navigation-placeholder">
+		<Placeholder className="wp-block-navigation-placeholder">
 			<PlaceholderPreview />
 
 			<div className="wp-block-navigation-placeholder__controls">
@@ -222,7 +223,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 					</div>
 				) }
 			</div>
-		</div>
+		</Placeholder>
 	);
 }
 

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -46,8 +46,8 @@ function Placeholder( {
 	let modifierClassNames;
 	if ( typeof width === 'number' ) {
 		modifierClassNames = {
-			'is-large': width >= 320,
-			'is-medium': width >= 160 && width < 320,
+			'is-large': width >= 480,
+			'is-medium': width >= 160 && width < 480,
 			'is-small': width < 160,
 		};
 	}

--- a/packages/components/src/placeholder/test/index.js
+++ b/packages/components/src/placeholder/test/index.js
@@ -113,7 +113,7 @@ describe( 'Placeholder', () => {
 		it( 'should not assign modifier class in first-pass `null` width from `useResizeObserver`', () => {
 			useResizeObserver.mockReturnValue( [
 				<div key="1" />,
-				{ width: 320 },
+				{ width: 480 },
 			] );
 
 			const placeholder = shallow( <Placeholder /> );


### PR DESCRIPTION
## Description

Fixes #31352.

This PR does a number of things:

1. It brings back the `Placeholder` component so we can style according to container widths
2. It tweaks the placeholder skeleton indicators to match the height of actual menu items
3. It lets skeleton indicators wrap.
4. It adjusts the visual appearance of the setup state to be stacked in constrained contexts.
5. It rephases the verbiage of the button when you have existing menus.

1 was the key bit missing. The `Placeholder` component comes with a "resizeobserver" and assigns `is-small`, `is-medium` and `is-large` classes based on the width of the block. This allows us to stack the setup state in very small contexts.

2 and 3 are side-effects of general refactor efforts to remove an "on-select jump", which is better described in #31198 which this PR also replaces. While this onselect thing didn't need to be fixed in this PR, it touched the same code anyway, and made sense to me to include since I was refactoring for various container widths.

![onselect jump](https://user-images.githubusercontent.com/1204802/116670269-d1390000-a99f-11eb-886c-5b00e191f02a.gif)

<img width="267" alt="wrapping placeholder blobs" src="https://user-images.githubusercontent.com/1204802/116670277-d26a2d00-a99f-11eb-8488-cb4af249e996.png">

4 was the key one. The setup state could be very broken in constrained contexts, for example inside a columns block. This PR fixes that:

<img width="732" alt="Screenshot 2021-04-30 at 10 29 20" src="https://user-images.githubusercontent.com/1204802/116670388-f594dc80-a99f-11eb-9cc2-6e6c66d97c5d.png">

5 rephases the "Existing menu" button to instead say "Add existing menu":

<img width="782" alt="Screenshot 2021-04-30 at 10 27 43" src="https://user-images.githubusercontent.com/1204802/116670442-06455280-a9a0-11eb-884c-508d02b6488a.png">

Existing menus are created in the separate Navigation screen (both the legacy and the new block-based one). The clarification can hopefully help suggest that the existing menu is meant as a _starting point_, because there isn't actually a two-way connection between the two. In other words, if you add an existing menu to your navigation block, and later add new menu items on the menu screen, those will not show up in the Navigation block.

## How has this been tested?

Please test the navigation block in its setup state. Both the horizontal and vertical versions:

- Verify it looks correct just as-is.
- Verify it looks good when inserted inside a colums block or other narrow context.
- Test inserting any block inside the navigation.
- Test with "Start empty", and verify the skeleton indicators look good.

I'm still thinking about whether the skeleton indicators are a good idea at all, and that's something to ponder. But for now they work reasonably well, and most of all they share metrics of the theme now.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
