### PR TITLE
Fix navigation screen padding again.

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -47,7 +47,8 @@
 			}
 
 			// Menu items.
-			.wp-block-navigation-link__content {
+			// This needs high specificity.
+			.wp-block-navigation-link__content.wp-block-navigation-link__content.wp-block-navigation-link__content {
 				padding: 0.5em 1em;
 				margin-bottom: 6px;
 				border-radius: $radius-block-ui;


### PR DESCRIPTION
## Description

You might have seen this before, sorry about that. This PR fixes the navigation screen from looking like this:

<img width="522" alt="Screenshot 2021-04-30 at 10 49 07" src="https://user-images.githubusercontent.com/1204802/116672178-2a099800-a9a2-11eb-9d7e-5e4967eb3472.png">

to this:

<img width="525" alt="Screenshot 2021-04-30 at 10 50 21" src="https://user-images.githubusercontent.com/1204802/116672184-2bd35b80-a9a2-11eb-9cab-4fc6f83f9d9d.png">

In this case the regression happened due to needing to [increase the specificity](https://github.com/WordPress/gutenberg/pull/31195#issuecomment-828285550) to make sure the navigation block worked correctly in a few specific themes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
