### PR TITLE
Iframe the template editor

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -740,6 +740,8 @@ function gutenberg_extend_block_editor_styles_html() {
 	echo "<script>window.__editorStyles = $editor_styles</script>";
 }
 add_action( 'admin_footer-toplevel_page_gutenberg-edit-site', 'gutenberg_extend_block_editor_styles_html' );
+add_action( 'admin_footer-post.php', 'gutenberg_extend_block_editor_styles_html' );
+add_action( 'admin_footer-post-new.php', 'gutenberg_extend_block_editor_styles_html' );
 
 /**
  * Adds a polyfill for object-fit in environments which do not support it.

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -107,7 +107,7 @@ export default function VisualEditor( { styles } ) {
 		borderRadius: '2px',
 		border: '1px solid #ddd',
 	};
-	const resizedCanvasStyles = useResizeCanvas( deviceType );
+	const resizedCanvasStyles = useResizeCanvas( deviceType, isTemplateMode );
 	const defaultLayout = useEditorFeature( 'layout' );
 	const { contentSize, wideSize } = defaultLayout || {};
 	const alignments =

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -60,7 +60,7 @@ function MaybeIframe( { children, contentRef, isTemplateMode, styles } ) {
 			head={ <EditorStyles styles={ styles } /> }
 			ref={ ref }
 			contentRef={ contentRef }
-			style={ { width: '100%', height: '100%' } }
+			style={ { width: '100%', height: '100%', display: 'block' } }
 		>
 			{ children }
 		</Iframe>
@@ -113,7 +113,10 @@ export default function VisualEditor( { styles } ) {
 		? templateModeStyles
 		: desktopCanvasStyles;
 	if ( resizedCanvasStyles ) {
-		animatedStyles = resizedCanvasStyles;
+		animatedStyles = {
+			...resizedCanvasStyles,
+			paddingBottom: null,
+		};
 	}
 
 	const contentRef = useMergeRefs( [

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -56,7 +56,7 @@ function MaybeIframe( {
 				<div
 					ref={ contentRef }
 					className="editor-styles-wrapper"
-					style={ style }
+					style={ { width: '100%', height: '100%', ...style } }
 				>
 					{ children }
 				</div>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -106,8 +106,9 @@ export default function VisualEditor( { styles } ) {
 	};
 	const templateModeStyles = {
 		...desktopCanvasStyles,
-		borderRadius: '2px',
+		borderRadius: '2px 2px 0 0',
 		border: '1px solid #ddd',
+		borderBottom: 0,
 	};
 	const resizedCanvasStyles = useResizeCanvas( deviceType, isTemplateMode );
 	const defaultLayout = useEditorFeature( 'layout' );

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -40,14 +40,24 @@ import { __ } from '@wordpress/i18n';
 import BlockInspectorButton from './block-inspector-button';
 import { store as editPostStore } from '../../store';
 
-function MaybeIframe( { children, contentRef, isTemplateMode, styles } ) {
+function MaybeIframe( {
+	children,
+	contentRef,
+	isTemplateMode,
+	styles,
+	style,
+} ) {
 	const ref = useMouseMoveTypingReset();
 
 	if ( ! isTemplateMode ) {
 		return (
 			<>
 				<EditorStyles styles={ styles } />
-				<div ref={ contentRef } className="editor-styles-wrapper">
+				<div
+					ref={ contentRef }
+					className="editor-styles-wrapper"
+					style={ style }
+				>
 					{ children }
 				</div>
 			</>
@@ -91,15 +101,11 @@ export default function VisualEditor( { styles } ) {
 		height: '100%',
 		width: '100%',
 		margin: 0,
-		// Add a constant padding for the typewritter effect. When typing at the
-		// bottom, there needs to be room to scroll up.
-		paddingBottom: hasMetaBoxes ? null : '40vh',
 	};
 	const templateModeStyles = {
 		...desktopCanvasStyles,
 		borderRadius: '2px',
 		border: '1px solid #ddd',
-		paddingBottom: null,
 	};
 	const resizedCanvasStyles = useResizeCanvas( deviceType );
 	const defaultLayout = useEditorFeature( 'layout' );
@@ -113,10 +119,15 @@ export default function VisualEditor( { styles } ) {
 		? templateModeStyles
 		: desktopCanvasStyles;
 	if ( resizedCanvasStyles ) {
-		animatedStyles = {
-			...resizedCanvasStyles,
-			paddingBottom: null,
-		};
+		animatedStyles = resizedCanvasStyles;
+	}
+
+	let paddingBottom;
+
+	// Add a constant padding for the typewritter effect. When typing at the
+	// bottom, there needs to be room to scroll up.
+	if ( ! hasMetaBoxes && ! resizedCanvasStyles && ! isTemplateMode ) {
+		paddingBottom = '40vh';
 	}
 
 	const contentRef = useMergeRefs( [
@@ -162,6 +173,7 @@ export default function VisualEditor( { styles } ) {
 					isTemplateMode={ isTemplateMode }
 					contentRef={ contentRef }
 					styles={ styles }
+					style={ { paddingBottom } }
 				>
 					<AnimatePresence>
 						<motion.div

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -162,7 +162,9 @@ export default function VisualEditor( { styles } ) {
 			className={ classnames( 'edit-post-visual-editor', {
 				'is-template-mode': isTemplateMode,
 			} ) }
-			animate={ isTemplateMode ? { padding: '48px' } : { padding: 0 } }
+			animate={
+				isTemplateMode ? { padding: '48px 48px 0' } : { padding: 0 }
+			}
 			ref={ blockSelectionClearerRef }
 		>
 			{ themeSupportsLayout && (

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -313,7 +313,7 @@ export function isSavingMetaBoxes( state ) {
  * @return {string} Device type.
  */
 export function __experimentalGetPreviewDeviceType( state ) {
-	return state.isEditingTemplate ? 'Desktop' : state.deviceType;
+	return state.deviceType;
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

(Also enables the device previews which previously didn't work.)

Why is this important?

For the users, it will make the editor more like the front end. Imagine using `vw` units, a cover background, or responsive fonts, this will now work correctly.
For block authors, it is perfect for easing into iframe context and making sure blocks work there.

Eventually all editors that have theme styles should be iframed, see #21102 for the reasoning, but it's not trivial to implement in the post editor because of backwards compatibility. All block need to continue to work, but with the iframe, some blocks may need to be updated to not use globals and refs instead.

Since the template editor is new, we don't need all blocks to work here (same as FSE) while it also offers us a nice transitioning place for pushing plugins to work with the iframe.

If we don't do this before we release the template editor, we will need to make blocks work flawlessly that have already been saved here before.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
