### PR TITLE
Fixes vertical alignment

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/style.scss
+++ b/packages/edit-navigation/src/components/inspector-additions/style.scss
@@ -21,7 +21,7 @@
 
 .edit-navigation-manage-locations__menu-entry {
 	display: flex;
-	align-items: end;
+	align-items: flex-end;
 	margin-bottom: $grid-unit-15;
 	margin-top: $grid-unit-15;
 	.components-custom-select-control,


### PR DESCRIPTION
Fixes #30331.

Fix vertical alignment on the nav screen manage locations buttons.



## Screenshots

**Before**

![Screenshot 2021-04-30 at 13 20 39](https://user-images.githubusercontent.com/4933/116688416-f4bb7500-a9b6-11eb-827c-7d74766d8a51.png)

**After**

![Screenshot 2021-04-30 at 13 20 22](https://user-images.githubusercontent.com/4933/116688418-f5540b80-a9b6-11eb-999e-0ab085e01bba.png)



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
