### PR TITLE
Handbook: Add a deprecation notice to meta block attribute sources

### DIFF
--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -167,7 +167,10 @@ _Example_: Extract `src` and `alt` from each image element in the block's markup
 // }
 ```
 
-## Meta
+## Meta (deprecated)
+
+> **Although attributes may be obtained from a post's meta, meta attribute sources are considered deprecated; [EntityProvider and related hook APIs](https://github.com/WordPress/gutenberg/blob/c367c4e2765f9e6b890d1565db770147efca5d66/packages/core-data/src/entity-provider.js) should be used instead, as shown in the [Create Meta Block how-to](/docs/how-to-guides/metabox/meta-block-3-add.md).**
+
 
 Attributes may be obtained from a post's meta rather than from the block's representation in saved post content. For this, an attribute is required to specify its corresponding meta key under the `meta` key:
 

--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -169,8 +169,9 @@ _Example_: Extract `src` and `alt` from each image element in the block's markup
 
 ## Meta (deprecated)
 
-> **Although attributes may be obtained from a post's meta, meta attribute sources are considered deprecated; [`EntityProvider` and related hook APIs](https://github.com/WordPress/gutenberg/blob/c367c4e2765f9e6b890d1565db770147efca5d66/packages/core-data/src/entity-provider.js) should be used instead, as shown in the [Create Meta Block how-to](/docs/how-to-guides/metabox/meta-block-3-add.md).**
-
+<div class="callout callout-alert">
+Although attributes may be obtained from a post's meta, meta attribute sources are considered deprecated; <a href="https://github.com/WordPress/gutenberg/blob/c367c4e2765f9e6b890d1565db770147efca5d66/packages/core-data/src/entity-provider.js">EntityProvider and related hook APIs</a> should be used instead, as shown in the <a href="/block-editor/how-to-guides/metabox/meta-block-3-add/">Create Meta Block how-to</a>.
+</div>
 
 Attributes may be obtained from a post's meta rather than from the block's representation in saved post content. For this, an attribute is required to specify its corresponding meta key under the `meta` key:
 

--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -169,7 +169,7 @@ _Example_: Extract `src` and `alt` from each image element in the block's markup
 
 ## Meta (deprecated)
 
-> **Although attributes may be obtained from a post's meta, meta attribute sources are considered deprecated; [EntityProvider and related hook APIs](https://github.com/WordPress/gutenberg/blob/c367c4e2765f9e6b890d1565db770147efca5d66/packages/core-data/src/entity-provider.js) should be used instead, as shown in the [Create Meta Block how-to](/docs/how-to-guides/metabox/meta-block-3-add.md).**
+> **Although attributes may be obtained from a post's meta, meta attribute sources are considered deprecated; [`EntityProvider` and related hook APIs](https://github.com/WordPress/gutenberg/blob/c367c4e2765f9e6b890d1565db770147efca5d66/packages/core-data/src/entity-provider.js) should be used instead, as shown in the [Create Meta Block how-to](/docs/how-to-guides/metabox/meta-block-3-add.md).**
 
 
 Attributes may be obtained from a post's meta rather than from the block's representation in saved post content. For this, an attribute is required to specify its corresponding meta key under the `meta` key:


### PR DESCRIPTION
## Description
Meta attribute sources [were deprecated in WordPress 5.4](https://make.wordpress.org/core/2020/03/02/general-block-editor-api-updates/). This PR adds a deprecation notice to the `Meta` block attributes documentation, referencing the `Create Meta Block` how-to as a way to use the `EntityProvider` instead.

