### PR TITLE
place gradient span after image and video and wrap image and video in…

### DIFF
--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -89,21 +89,8 @@ export default function save( { attributes } ) {
 
 	return (
 		<div { ...useBlockProps.save( { className: classes, style } ) }>
-			{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
-				<span
-					aria-hidden="true"
-					className={ classnames(
-						'wp-block-cover__gradient-background',
-						gradientClass
-					) }
-					style={
-						customGradient
-							? { background: customGradient }
-							: undefined
-					}
-				/>
-			) }
 			{ isImageBackground && isImgElement && url && (
+			 <div className="wp-block-cover__media-container">
 				<img
 					className={ classnames(
 						'wp-block-cover__image-background',
@@ -115,8 +102,10 @@ export default function save( { attributes } ) {
 					data-object-fit="cover"
 					data-object-position={ objectPosition }
 				/>
+			</div>
 			) }
 			{ isVideoBackground && url && (
+			<div className="wp-block-cover__media-container">
 				<video
 					className={ classnames(
 						'wp-block-cover__video-background',
@@ -131,7 +120,23 @@ export default function save( { attributes } ) {
 					data-object-fit="cover"
 					data-object-position={ objectPosition }
 				/>
+			</div>
 			) }
+			{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
+				<span
+					aria-hidden="true"
+					className={ classnames(
+						'wp-block-cover__gradient-background',
+						gradientClass
+					) }
+					style={
+						customGradient
+							? { background: customGradient }
+							: undefined
+					}
+				/>
+			) }
+			</div>
 			<div className="wp-block-cover__inner-container">
 				<InnerBlocks.Content />
 			</div>


### PR DESCRIPTION
… a div

Placing the gradient span after the image and video instead of before the media (img, video) is easier to style. 
You don't have to set z-index for the gradient, because it's abofe the media anyway. 

And wrapping the img or video in a div allows it to add the solid overlay to be applied as :after the said container. 
Another way to remove the z-index from the wp-block-cover__inner-container.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
