### PR TITLE
post-title: add text styling options

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -12,7 +12,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	useBlockProps,
-	PlainText,
+	RichText,
 } from '@wordpress/block-editor';
 import {
 	ToolbarGroup,
@@ -58,6 +58,14 @@ export default function PostTitleEdit( {
 
 	const { title = '', link } = post;
 
+	const allowedFormats = [
+		'core/bold',
+		'core/italic',
+		'core/strikethrough',
+		'core/subscript',
+		'core/superscript',
+	];
+
 	let titleElement = (
 		<TagName { ...( isLink ? {} : blockProps ) }>
 			{ __( 'An example title' ) }
@@ -66,9 +74,10 @@ export default function PostTitleEdit( {
 
 	if ( postType && postId ) {
 		titleElement = (
-			<PlainText
+			<RichText
 				tagName={ TagName }
 				placeholder={ __( 'No Title' ) }
+				allowedFormats={ allowedFormats }
 				value={ title }
 				onChange={ ( value ) =>
 					editEntityRecord( 'postType', postType, postId, {
@@ -84,7 +93,7 @@ export default function PostTitleEdit( {
 	if ( isLink ) {
 		titleElement = (
 			<TagName { ...blockProps }>
-				<PlainText
+				<RichText
 					tagName="a"
 					href={ link }
 					target={ linkTarget }


### PR DESCRIPTION
## Description
Currently, the Post Title block does not have any text styling options, like bold (or make the text normal weight if bold is the theme default), italics. So added a text styling options for creating more interesting blog pages.

issue: #31117

## How has this been tested?
Added a Post Title block and put text in it. Then change the style to Bold/italic or others, it's working fine.

## Screenshots <!-- if applicable -->
![06B64782-D2A9-4076-B18B-280E9B7D415D](https://user-images.githubusercontent.com/9963909/116790960-f67d5980-aad8-11eb-8206-b930893824f6.jpg)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- New feature (non-breaking change which adds functionality) -->
Added Text styling option eg: bold, italic, strikethrough


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
