### PR TITLE
Show blocks from plugins in the widget customizer

### DIFF
--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -155,7 +155,7 @@ function gutenberg_customize_widgets_init() {
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_widgets_customize_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( is_callable( 'get_current_screen' ) && 'customize' === get_current_screen()->base ) {
+	if ( gutenberg_use_widgets_block_editor() && is_callable( 'get_current_screen' ) && 'customize' === get_current_screen()->base ) {
 		return true;
 	}
 

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -155,7 +155,11 @@ function gutenberg_customize_widgets_init() {
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_widgets_customize_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( gutenberg_use_widgets_block_editor() && is_callable( 'get_current_screen' ) && 'customize' === get_current_screen()->base ) {
+	if (
+		gutenberg_use_widgets_block_editor() &&
+		is_callable( 'get_current_screen' ) &&
+		'customize' === get_current_screen()->base
+	) {
 		return true;
 	}
 

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -137,7 +137,7 @@ function gutenberg_customize_widgets_init() {
 
 	wp_add_inline_script(
 		'wp-blocks',
-		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( 'widgets_customizer' ) ) ),
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( gutenberg_get_block_categories( 'widgets_customizer' ) ) ),
 		'after'
 	);
 

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -134,6 +134,13 @@ function gutenberg_customize_widgets_init() {
 			'editor_settings' => $settings,
 		)
 	);
+
+	wp_add_inline_script(
+		'wp-blocks',
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( 'widgets_customizer' ) ) ),
+		'after'
+	);
+
 	wp_enqueue_script( 'wp-customize-widgets' );
 	wp_enqueue_style( 'wp-customize-widgets' );
 	wp_enqueue_script( 'wp-format-library' );

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -141,8 +141,23 @@ function gutenberg_customize_widgets_init() {
 	do_action( 'enqueue_block_editor_assets' );
 }
 
+/**
+ * Tells the script loader to load the scripts and styles of custom block on widgets editor screen.
+ *
+ * @param bool $is_block_editor_screen Current decision about loading block assets.
+ * @return bool Filtered decision about loading block assets.
+ */
+function gutenberg_widgets_customize_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
+	if ( is_callable( 'get_current_screen' ) && 'customize' === get_current_screen()->base ) {
+		return true;
+	}
+
+	return $is_block_editor_screen;
+}
+
 if ( gutenberg_is_experiment_enabled( 'gutenberg-widgets-in-customizer' ) ) {
 	add_action( 'customize_register', 'gutenberg_widgets_customize_register' );
 	add_filter( 'widget_customizer_setting_args', 'gutenberg_widgets_customize_add_unstable_instance', 10, 2 );
 	add_action( 'customize_controls_enqueue_scripts', 'gutenberg_customize_widgets_init' );
+	add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_customize_load_block_editor_scripts_and_styles' );
 }

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -138,6 +138,7 @@ function gutenberg_customize_widgets_init() {
 	wp_enqueue_style( 'wp-customize-widgets' );
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-format-library' );
+	do_action( 'enqueue_block_editor_assets' );
 }
 
 if ( gutenberg_is_experiment_enabled( 'gutenberg-widgets-in-customizer' ) ) {

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -58,6 +58,12 @@ function gutenberg_widgets_init( $hook ) {
 		)
 	);
 
+	wp_add_inline_script(
+		'wp-blocks',
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( 'widgets_editor' ) ) ),
+		'after'
+	);
+
 	wp_enqueue_script( 'wp-edit-widgets' );
 	wp_enqueue_script( 'admin-widgets' );
 	wp_enqueue_script( 'wp-format-library' );


### PR DESCRIPTION
## Description
Fixes #31179

The widget customizer was missing the  `enqueue_block_editor_assets` action and handling of the `should_load_block_editor_scripts_and_styles` filter.

Both the customize widgets and standalone widgets screen also seemed to be missing the script that sets up block categories, so all third party blocks appear 'uncategorized' in the inserter menu.

Even with the addition of this code, categories are unlikely to work because the `block_categories_all` filter (https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/block-editor.php#L80) that handles third-party categories for non-post-editing screens is only set to be introduced in WordPress 5.8. Plugins will need to update to use this new filter.

The now deprecated `block_categories` filter is only configured to work in the post editor:
https://github.com/WordPress/wordpress-develop/blob/984c194bf2c38f6f38db39822baa9d5daf046763/src/wp-includes/block-editor.php#L81-L94

## How has this been tested?
1. Install and activate a third party plugin that adds blocks
2. Enable the customize widgets experiment in the gutenberg settings
3. Visit the customize widgets screen
4. Open the block library by clicking the main '+' button.
5. Third party blocks appear in the menu and can be inserted.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
