### PR TITLE
Widgets editor: Improve theme switching experience

### DIFF
--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -110,6 +110,10 @@ function gutenberg_widgets_customize_add_unstable_instance( $args, $id ) {
  * Initialize the Gutenberg customize widgets page.
  */
 function gutenberg_customize_widgets_init() {
+	if ( ! gutenberg_use_widgets_block_editor() ) {
+		return;
+	}
+
 	$settings = array_merge(
 		gutenberg_get_default_block_editor_settings(),
 		gutenberg_get_legacy_widget_settings()

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -246,21 +246,17 @@ function gutenberg_override_sidebar_params_for_block_widget( $arg ) {
 }
 
 /**
- * Registers the WP_Widget_Block widget
+ * Registers the WP_Widget_Block widget.
  */
-function gutenberg_register_widgets() {
-	if ( ! gutenberg_use_widgets_block_editor() ) {
-		return;
-	}
+function gutenberg_register_block_widget() {
+	global $pagenow;
 
 	register_widget( 'WP_Widget_Block' );
-	// By default every widget on widgets.php is wrapped with a <form>.
-	// This means that you can sometimes end up with invalid HTML, e.g. when
-	// one of the widgets is a Search block.
-	//
-	// To fix the problem, let's add a filter that moves the form below the actual
-	// widget content.
-	global $pagenow;
+
+	// By default every widget on widgets.php is wrapped with a <form>.  This
+	// means that you can sometimes end up with invalid HTML, e.g. when one of
+	// the widgets is a Search block. To fix the problem, let's add a filter
+	// that moves the form below the actual widget content.
 	if ( 'widgets.php' === $pagenow ) {
 		add_filter(
 			'dynamic_sidebar_params',
@@ -269,7 +265,7 @@ function gutenberg_register_widgets() {
 	}
 }
 
-add_action( 'widgets_init', 'gutenberg_register_widgets' );
+add_action( 'widgets_init', 'gutenberg_register_block_widget' );
 
 /**
  * Sets show_instance_in_rest to true on all of the core WP_Widget subclasses.


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/31176.

- Always register WP_Widget_Block regardless of whether the current theme uses the widgets block editor. This ensures that data is not lost when switching from a theme that supports block widgets to one that does not.
- Do not enqueue any of the widgets editor JavaScript in the Customizer when the theme has disabled the widgets block editor. This prevents an error in the console.

## How has this been tested?

Follow the steps in https://github.com/WordPress/gutenberg/issues/31176.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->