### PR TITLE
Widget screen: Remove widget screen empty link in admin

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -113,7 +113,7 @@ add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
  * @param WP_Admin_Bar $wp_admin_bar Core class used to implement the Toolbar API.
  */
 function modify_admin_bar( $wp_admin_bar ) {
-	if ( gutenberg_use_widgets_block_editor() ) {
+	if ( gutenberg_use_widgets_block_editor() && ! is_admin() ) {
 		$wp_admin_bar->add_menu(
 			array(
 				'id'   => 'widgets',

--- a/lib/init.php
+++ b/lib/init.php
@@ -113,7 +113,7 @@ add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
  * @param WP_Admin_Bar $wp_admin_bar Core class used to implement the Toolbar API.
  */
 function modify_admin_bar( $wp_admin_bar ) {
-	if ( gutenberg_use_widgets_block_editor() && $wp_admin_bar->get_node( 'widgets' ) !== NULL ) {
+	if ( gutenberg_use_widgets_block_editor() && $wp_admin_bar->get_node( 'widgets' ) !== null ) {
 		$wp_admin_bar->add_menu(
 			array(
 				'id'   => 'widgets',

--- a/lib/init.php
+++ b/lib/init.php
@@ -113,7 +113,7 @@ add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
  * @param WP_Admin_Bar $wp_admin_bar Core class used to implement the Toolbar API.
  */
 function modify_admin_bar( $wp_admin_bar ) {
-	if ( gutenberg_use_widgets_block_editor() && ! is_admin() ) {
+	if ( gutenberg_use_widgets_block_editor() && $wp_admin_bar->get_node( 'widgets' ) !== NULL ) {
 		$wp_admin_bar->add_menu(
 			array(
 				'id'   => 'widgets',


### PR DESCRIPTION
## Description
Fixes #31383.
Remove widget screen empty link in admin.

## How has this been tested?
1. Activate the Gutenberg plugin
2. Go to the site admin
3. The empty link for the widget screen should not be there any more.

## Screenshots <!-- if applicable -->
Before
<img width="409" alt="image" src="https://user-images.githubusercontent.com/33403964/116851690-c3c38600-abea-11eb-991b-b005244c8e96.png">

After
<img width="469" alt="image" src="https://user-images.githubusercontent.com/33403964/116851644-b27a7980-abea-11eb-9325-1f1f6578a544.png">


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [NA] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->