### PR TITLE
Rich text: move format boundaries to ref callback and separate file

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -9,15 +9,7 @@ import {
 	useMemo,
 	useLayoutEffect,
 } from '@wordpress/element';
-import {
-	BACKSPACE,
-	DELETE,
-	ENTER,
-	LEFT,
-	RIGHT,
-	SPACE,
-	ESCAPE,
-} from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, ENTER, SPACE, ESCAPE } from '@wordpress/keycodes';
 import { getFilesFromDataTransfer } from '@wordpress/dom';
 import { useMergeRefs } from '@wordpress/compose';
 
@@ -42,6 +34,7 @@ import { useBoundaryStyle } from './use-boundary-style';
 import { useInlineWarning } from './use-inline-warning';
 import { insert } from '../insert';
 import { useCopyHandler } from './use-copy-handler';
+import { useFormatBoundaries } from './use-format-boundaries';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -537,122 +530,6 @@ function RichText(
 		event.preventDefault();
 	}
 
-	/**
-	 * Handles horizontal keyboard navigation when no modifiers are pressed. The
-	 * navigation is handled separately to move correctly around format
-	 * boundaries.
-	 *
-	 * @param {WPSyntheticEvent} event A synthetic keyboard event.
-	 */
-	function handleHorizontalNavigation( event ) {
-		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
-
-		if (
-			// Only override left and right keys without modifiers pressed.
-			shiftKey ||
-			altKey ||
-			metaKey ||
-			ctrlKey ||
-			( keyCode !== LEFT && keyCode !== RIGHT )
-		) {
-			return;
-		}
-
-		const {
-			text,
-			formats,
-			start,
-			end,
-			activeFormats: currentActiveFormats = [],
-		} = record.current;
-		const collapsed = isCollapsed( record.current );
-		// To do: ideally, we should look at visual position instead.
-		const { direction } = getWin().getComputedStyle( ref.current );
-		const reverseKey = direction === 'rtl' ? RIGHT : LEFT;
-		const isReverse = event.keyCode === reverseKey;
-
-		// If the selection is collapsed and at the very start, do nothing if
-		// navigating backward.
-		// If the selection is collapsed and at the very end, do nothing if
-		// navigating forward.
-		if ( collapsed && currentActiveFormats.length === 0 ) {
-			if ( start === 0 && isReverse ) {
-				return;
-			}
-
-			if ( end === text.length && ! isReverse ) {
-				return;
-			}
-		}
-
-		// If the selection is not collapsed, let the browser handle collapsing
-		// the selection for now. Later we could expand this logic to set
-		// boundary positions if needed.
-		if ( ! collapsed ) {
-			return;
-		}
-
-		const formatsBefore = formats[ start - 1 ] || EMPTY_ACTIVE_FORMATS;
-		const formatsAfter = formats[ start ] || EMPTY_ACTIVE_FORMATS;
-
-		let newActiveFormatsLength = currentActiveFormats.length;
-		let source = formatsAfter;
-
-		if ( formatsBefore.length > formatsAfter.length ) {
-			source = formatsBefore;
-		}
-
-		// If the amount of formats before the caret and after the caret is
-		// different, the caret is at a format boundary.
-		if ( formatsBefore.length < formatsAfter.length ) {
-			if (
-				! isReverse &&
-				currentActiveFormats.length < formatsAfter.length
-			) {
-				newActiveFormatsLength++;
-			}
-
-			if (
-				isReverse &&
-				currentActiveFormats.length > formatsBefore.length
-			) {
-				newActiveFormatsLength--;
-			}
-		} else if ( formatsBefore.length > formatsAfter.length ) {
-			if (
-				! isReverse &&
-				currentActiveFormats.length > formatsAfter.length
-			) {
-				newActiveFormatsLength--;
-			}
-
-			if (
-				isReverse &&
-				currentActiveFormats.length < formatsBefore.length
-			) {
-				newActiveFormatsLength++;
-			}
-		}
-
-		if ( newActiveFormatsLength === currentActiveFormats.length ) {
-			record.current._newActiveFormats = isReverse
-				? formatsBefore
-				: formatsAfter;
-			return;
-		}
-
-		event.preventDefault();
-
-		const newActiveFormats = source.slice( 0, newActiveFormatsLength );
-		const newValue = {
-			...record.current,
-			activeFormats: newActiveFormats,
-		};
-		record.current = newValue;
-		applyRecord( newValue );
-		setActiveFormats( newActiveFormats );
-	}
-
 	function handleKeyDown( event ) {
 		if ( event.defaultPrevented ) {
 			return;
@@ -661,7 +538,6 @@ function RichText(
 		handleDelete( event );
 		handleEnter( event );
 		handleSpace( event );
-		handleHorizontalNavigation( event );
 	}
 
 	const lastHistoryValue = useRef( value );
@@ -1064,6 +940,7 @@ function RichText(
 			forwardedRef,
 			ref,
 			useCopyHandler( { record, multilineTag, preserveWhiteSpace } ),
+			useFormatBoundaries( { record, applyRecord, setActiveFormats } ),
 		] ),
 		style: defaultStyle,
 		className: 'rich-text',

--- a/packages/rich-text/src/component/use-format-boundaries.js
+++ b/packages/rich-text/src/component/use-format-boundaries.js
@@ -1,0 +1,144 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+import { LEFT, RIGHT } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { isCollapsed } from '../is-collapsed';
+
+const EMPTY_ACTIVE_FORMATS = [];
+
+export function useFormatBoundaries( {
+	record,
+	applyRecord,
+	setActiveFormats,
+} ) {
+	return useRefEffect(
+		( element ) => {
+			function onKeyDown( event ) {
+				const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
+
+				if (
+					// Only override left and right keys without modifiers pressed.
+					shiftKey ||
+					altKey ||
+					metaKey ||
+					ctrlKey ||
+					( keyCode !== LEFT && keyCode !== RIGHT )
+				) {
+					return;
+				}
+
+				const {
+					text,
+					formats,
+					start,
+					end,
+					activeFormats: currentActiveFormats = [],
+				} = record.current;
+				const collapsed = isCollapsed( record.current );
+				const { ownerDocument } = element;
+				const { defaultView } = ownerDocument;
+				// To do: ideally, we should look at visual position instead.
+				const { direction } = defaultView.getComputedStyle( element );
+				const reverseKey = direction === 'rtl' ? RIGHT : LEFT;
+				const isReverse = event.keyCode === reverseKey;
+
+				// If the selection is collapsed and at the very start, do nothing if
+				// navigating backward.
+				// If the selection is collapsed and at the very end, do nothing if
+				// navigating forward.
+				if ( collapsed && currentActiveFormats.length === 0 ) {
+					if ( start === 0 && isReverse ) {
+						return;
+					}
+
+					if ( end === text.length && ! isReverse ) {
+						return;
+					}
+				}
+
+				// If the selection is not collapsed, let the browser handle collapsing
+				// the selection for now. Later we could expand this logic to set
+				// boundary positions if needed.
+				if ( ! collapsed ) {
+					return;
+				}
+
+				const formatsBefore =
+					formats[ start - 1 ] || EMPTY_ACTIVE_FORMATS;
+				const formatsAfter = formats[ start ] || EMPTY_ACTIVE_FORMATS;
+
+				let newActiveFormatsLength = currentActiveFormats.length;
+				let source = formatsAfter;
+
+				if ( formatsBefore.length > formatsAfter.length ) {
+					source = formatsBefore;
+				}
+
+				// If the amount of formats before the caret and after the caret is
+				// different, the caret is at a format boundary.
+				if ( formatsBefore.length < formatsAfter.length ) {
+					if (
+						! isReverse &&
+						currentActiveFormats.length < formatsAfter.length
+					) {
+						newActiveFormatsLength++;
+					}
+
+					if (
+						isReverse &&
+						currentActiveFormats.length > formatsBefore.length
+					) {
+						newActiveFormatsLength--;
+					}
+				} else if ( formatsBefore.length > formatsAfter.length ) {
+					if (
+						! isReverse &&
+						currentActiveFormats.length > formatsAfter.length
+					) {
+						newActiveFormatsLength--;
+					}
+
+					if (
+						isReverse &&
+						currentActiveFormats.length < formatsBefore.length
+					) {
+						newActiveFormatsLength++;
+					}
+				}
+
+				if ( newActiveFormatsLength === currentActiveFormats.length ) {
+					record.current._newActiveFormats = isReverse
+						? formatsBefore
+						: formatsAfter;
+					return;
+				}
+
+				event.preventDefault();
+
+				const newActiveFormats = source.slice(
+					0,
+					newActiveFormatsLength
+				);
+				const newValue = {
+					...record.current,
+					activeFormats: newActiveFormats,
+				};
+				record.current = newValue;
+				applyRecord( newValue );
+				setActiveFormats( newActiveFormats );
+			}
+
+			element.addEventListener( 'keydown', onKeyDown );
+			return () => {
+				element.removeEventListener( 'keydown', onKeyDown );
+			};
+		},
+		[ record, applyRecord, setActiveFormats ]
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Necessary for #31396, because we want to look at `event.defaultPrevented` on a native event.
Also a necessary step in turning rich text into a hook.
In addition it's a welcome split of this big file.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
