### PR TITLE
Nav block placeholder, fix font inheritance

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -303,6 +303,7 @@ $color-control-label-height: 20px;
 .wp-block-navigation-placeholder__actions {
 	display: flex;
 	font-size: $default-font-size;
+	font-family: $default-font;
 
 	.components-button.components-dropdown-menu__toggle.has-icon {
 		padding: ($grid-unit-15 / 2) $grid-unit-05 ($grid-unit-15 / 2) $grid-unit-15;


### PR DESCRIPTION
## Description

Fixes #31353. Somehow regressed from #30011. 

Explicitly sets the font on the navigation block setup state so that it is correctly applied to buttons inside.

## How has this been tested?

Test primarily the site editor. The issue is also present in the post editor, but there it is only affecting the block type indicator.

Insert a navigation block, and without adding any menu items, set the font family to something other than default.

Before:

<img width="702" alt="Screenshot 2021-05-03 at 09 56 53" src="https://user-images.githubusercontent.com/1204802/116853470-67666380-abf6-11eb-873e-72b8722cc285.png">

After:

<img width="765" alt="Screenshot 2021-05-03 at 09 58 00" src="https://user-images.githubusercontent.com/1204802/116853477-69302700-abf6-11eb-9f30-d4c620ff33d4.png">

Also verify that when you later on add pages, they are set in the custom font chosen.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
