### PR TITLE
Remove widget screen dead code

### DIFF
--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -196,7 +196,10 @@ class WP_Widget_Block extends WP_Widget {
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, $this->default_instance );
 		?>
-		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" rows="6" cols="50" class="widefat text wp-block-widget-textarea"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
+		<p>
+		<label for="<?php echo $this->get_field_id( 'content' ); ?>"><?php echo __( 'Block HTML:', 'gutenberg' ); ?></label>
+		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" rows="6" cols="50" class="widefat code"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
+		</p>
 		<?php
 	}
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -28,15 +28,6 @@ function the_gutenberg_widgets() {
  * @param string $hook Page.
  */
 function gutenberg_widgets_init( $hook ) {
-	if ( 'widgets.php' === $hook ) {
-		wp_enqueue_style( 'wp-block-library' );
-		wp_enqueue_style( 'wp-block-library-theme' );
-		wp_add_inline_style(
-			'wp-block-library-theme',
-			'.wp-block-widget-textarea { width: 100%; min-height: 5em; margin: 8px 0 16px 0; }'
-		);
-		return;
-	}
 	if ( ! in_array( $hook, array( 'appearance_page_gutenberg-widgets' ), true ) ) {
 		return;
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Removes some unused code from the widget screen (widget.php).

As discussed in a slack conversation (https://wordpress.slack.com/archives/C01D71823PB/p1620024718182900), this code was previously used for showing blocks in the current (non-block based) widget screen. That feature is no longer present so the code is no longer needed.