### PR TITLE
Try: fix Safari flickering issues.

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -127,7 +127,7 @@
 		transform: revert;
 	}
 
-	// Safari can have renderint issues with CSS3 transitions.
+	// Safari can have rendering issues with CSS3 transitions.
 	// By applying perspective and backface-visibility, it disappears.
 	.wp-block {
 		// Even though these properties get picked up by Chrome and Edge,

--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -126,4 +126,15 @@
 		cursor: revert;
 		transform: revert;
 	}
+
+	// Safari can have renderint issues with CSS3 transitions.
+	// By applying perspective and backface-visibility, it disappears.
+	.wp-block {
+		// Even though these properties get picked up by Chrome and Edge,
+		// by keeping the prefixes we're reminded that this is a hack.
+		/* eslint-disable property-no-vendor-prefix */
+		-webkit-perspective: 1;
+		-webkit-backface-visibility: none;
+		/* eslint-enable property-no-vendor-prefix */
+	}
 }


### PR DESCRIPTION
## Description

Hopefully/maybe fixes #30803.

Safari has trouble rendering elements that use CSS3 transitions. According to basic testing in this branch, and to [this document](https://coderwall.com/p/xbjtbg/fix-element-flickering-in-safari-caused-by-css3-transitions), the attached hack should fix it.

Note that if this works, we should consider scoping the hack to just the blocks causing the issue, or somehow otherwise limiting it as best we can. While it _seemed_ harmless in my testing, as far as I understand this changes the fundamental rendering method used for blocks, and if past experience tells us anything, it is that it a) makes it way more performant, and b) sometimes interferes with absolute or sticky positioning, especially in cases where you are intentionally applying `position: static;` to a parent to inherit from an ancestor itself — this property _might_ effectively apply `position: relative;`.

That's also a note to test #30047 with this.

## How has this been tested?

Please test various blocks in the editor, in Safari. Select blocks, scroll, and verify that nothing flickers.

Blocks that commonly cause flickering appear to be the Gallery block, but sometimes also the pullquote, it's a bit unclear and also seems to depend on amount of blocks on the page. Using the demo content might be a good way to start.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
