### PR TITLE
[Mobile] - Refactor gallery - cherry pick v2 - step 1

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -35,9 +35,10 @@ const stylesMemo = {};
 const getStyles = (
 	isRootList,
 	isStackedHorizontally,
-	horizontalAlignment
+	horizontalAlignment,
+	numColumns
 ) => {
-	if ( isRootList ) {
+	if ( isRootList || numColumns ) {
 		return;
 	}
 	const styleName = `${ isStackedHorizontally }-${ horizontalAlignment }`;
@@ -207,6 +208,7 @@ export class BlockList extends Component {
 			horizontalAlignment,
 			contentResizeMode,
 			blockWidth,
+			numColumns,
 		} = this.props;
 		const { parentScrollRef } = extraProps;
 
@@ -267,14 +269,19 @@ export class BlockList extends Component {
 								? styles.horizontalContentContainerStretch
 								: styles.horizontalContentContainerCenter ),
 					] }
-					style={ getStyles(
-						isRootList,
-						isStackedHorizontally,
-						horizontalAlignment
-					) }
+					style={ [
+						getStyles(
+							isRootList,
+							isStackedHorizontally,
+							horizontalAlignment,
+							numColumns
+						),
+					] }
 					data={ blockClientIds }
 					keyExtractor={ identity }
 					renderItem={ this.renderItem }
+					numColumns={ numColumns }
+					key={ numColumns }
 					shouldPreventAutomaticScroll={
 						this.shouldFlatListPreventAutomaticScroll
 					}

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -207,6 +207,7 @@ export class BlockList extends Component {
 			isStackedHorizontally,
 			horizontalAlignment,
 			contentResizeMode,
+			// eslint-disable-next-line no-unused-vars
 			blockWidth,
 			numColumns,
 		} = this.props;
@@ -226,8 +227,11 @@ export class BlockList extends Component {
 			marginHorizontal: isRootList ? 0 : -marginHorizontal,
 		};
 
+		// eslint-disable-next-line no-unused-vars
 		const isContentStretch = contentResizeMode === 'stretch';
+		// eslint-disable-next-line no-unused-vars
 		const isMultiBlocks = blockClientIds.length > 1;
+		// eslint-disable-next-line no-unused-vars
 		const { isWider } = alignmentHelpers;
 
 		return (

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -262,21 +262,15 @@ export class BlockList extends Component {
 					horizontal={ horizontal }
 					extraData={ this.getExtraData() }
 					scrollEnabled={ isRootList }
-					contentContainerStyle={ [
-						horizontal && styles.horizontalContentContainer,
-						isWider( blockWidth, 'medium' ) &&
-							( isContentStretch && isMultiBlocks
-								? styles.horizontalContentContainerStretch
-								: styles.horizontalContentContainerCenter ),
-					] }
-					style={ [
-						getStyles(
-							isRootList,
-							isStackedHorizontally,
-							horizontalAlignment,
-							numColumns
-						),
-					] }
+					contentContainerStyle={
+						horizontal && styles.horizontalContentContainer
+					}
+					style={ getStyles(
+						isRootList,
+						isStackedHorizontally,
+						horizontalAlignment,
+						numColumns
+					) }
 					data={ blockClientIds }
 					keyExtractor={ identity }
 					renderItem={ this.renderItem }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -323,22 +323,24 @@ export class BlockList extends Component {
 		} = this.props;
 		const { blockWidth } = this.state;
 		return (
-			<BlockListItem
-				isStackedHorizontally={ isStackedHorizontally }
-				rootClientId={ rootClientId }
-				clientId={ clientId }
-				parentWidth={ parentWidth }
-				contentResizeMode={ contentResizeMode }
-				contentStyle={ contentStyle }
-				onAddBlock={ onAddBlock }
-				marginVertical={ marginVertical }
-				marginHorizontal={ marginHorizontal }
-				onDeleteBlock={ onDeleteBlock }
-				shouldShowInnerBlockAppender={
-					this.shouldShowInnerBlockAppender
-				}
-				blockWidth={ blockWidth }
-			/>
+			<View style={ { flex: 1 } }>
+				<BlockListItem
+					isStackedHorizontally={ isStackedHorizontally }
+					rootClientId={ rootClientId }
+					clientId={ clientId }
+					parentWidth={ parentWidth }
+					contentResizeMode={ contentResizeMode }
+					contentStyle={ contentStyle }
+					onAddBlock={ onAddBlock }
+					marginVertical={ marginVertical }
+					marginHorizontal={ marginHorizontal }
+					onDeleteBlock={ onDeleteBlock }
+					shouldShowInnerBlockAppender={
+						this.shouldShowInnerBlockAppender
+					}
+					blockWidth={ blockWidth }
+				/>
+			</View>
 		);
 	}
 

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -18,7 +18,10 @@ export * from './colors';
 export * from './gradients';
 export * from './font-sizes';
 export { AlignmentControl, AlignmentToolbar } from './alignment-control';
-export { default as InnerBlocks } from './inner-blocks';
+export {
+	default as InnerBlocks,
+	useInnerBlocksProps as __experimentalUseInnerBlocksProps,
+} from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
 export {

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { getBlockType, withBlockContentContext } from '@wordpress/blocks';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,6 +23,44 @@ import useBlockSync from '../provider/use-block-sync';
 import { BlockContextProvider } from '../block-context';
 import { defaultLayout, LayoutProvider } from '../block-list/layout';
 import { store as blockEditorStore } from '../../store';
+
+/**
+ * This hook is used to lightly mark an element as an inner blocks wrapper
+ * element. Call this hook and pass the returned props to the element to mark as
+ * an inner blocks wrapper, automatically rendering inner blocks as children. If
+ * you define a ref for the element, it is important to pass the ref to this
+ * hook, which the hook in turn will pass to the component through the props it
+ * returns. Optionally, you can also pass any other props through this hook, and
+ * they will be merged and returned.
+ *
+ * @param {Object} props   Optional. Props to pass to the element. Must contain
+ *                         the ref if one is defined.
+ * @param {Object} options Optional. Inner blocks options.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inner-blocks/README.md
+ */
+export function useInnerBlocksProps( props = {}, options = {} ) {
+	const fallbackRef = useRef();
+	const { clientId } = useBlockEditContext();
+
+	const ref = props.ref || fallbackRef;
+	const InnerBlocks =
+		options.value && options.onChange
+			? ControlledInnerBlocks
+			: UncontrolledInnerBlocks;
+
+	return {
+		...props,
+		ref,
+		children: (
+			<InnerBlocks
+				{ ...options }
+				clientId={ clientId }
+				wrapperRef={ ref }
+			/>
+		),
+	};
+}
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -53,6 +92,7 @@ function UncontrolledInnerBlocks( props ) {
 		filterInnerBlocks,
 		blockWidth,
 		__experimentalLayout: layout = defaultLayout,
+		numColumns,
 	} = props;
 
 	const block = useSelect(
@@ -87,6 +127,7 @@ function UncontrolledInnerBlocks( props ) {
 			onDeleteBlock={ onDeleteBlock }
 			filterInnerBlocks={ filterInnerBlocks }
 			blockWidth={ blockWidth }
+			numColumns={ numColumns }
 		/>
 	);
 

--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -38,6 +38,7 @@ function MediaPlaceholder( props ) {
 		labels = {},
 		icon,
 		onSelect,
+		onFocus,
 		__experimentalOnlyMediaLibrary,
 		isAppender,
 		disableMediaButtons,
@@ -171,7 +172,7 @@ function MediaPlaceholder( props ) {
 							accessibilityRole={ 'button' }
 							accessibilityHint={ accessibilityHint }
 							onPress={ ( event ) => {
-								props.onFocus( event );
+								onFocus?.( event );
 								open();
 							} }
 						>

--- a/packages/block-editor/src/store/defaults.native.js
+++ b/packages/block-editor/src/store/defaults.native.js
@@ -8,6 +8,8 @@ import {
 
 const SETTINGS_DEFAULTS = {
 	...SETTINGS,
+	// eslint-disable-next-line no-undef
+	__experimentalGalleryRefactor: __DEV__,
 	alignWide: true,
 };
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -490,7 +490,7 @@ function GalleryEdit( props ) {
 							hideCancelButton={ true }
 						/>
 					) }
-					{ ! imageSizeOptions && (
+					{/* { ! imageSizeOptions && (
 						<BaseControl className={ 'gallery-image-sizes' }>
 							<BaseControl.VisualLabel>
 								{ __( 'Image size' ) }
@@ -500,7 +500,7 @@ function GalleryEdit( props ) {
 								{ __( 'Loading options…' ) }
 							</View>
 						</BaseControl>
-					) }
+					) } */}
 				</PanelBody>
 			</InspectorControls>
 			{ noticeUI }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -9,12 +9,14 @@ import { concat, find } from 'lodash';
  */
 import { compose } from '@wordpress/compose';
 import {
+	// eslint-disable-next-line no-unused-vars
 	BaseControl,
 	PanelBody,
 	SelectControl,
 	ToggleControl,
 	withNotices,
 	RangeControl,
+	// eslint-disable-next-line no-unused-vars
 	Spinner,
 } from '@wordpress/components';
 import {
@@ -490,7 +492,7 @@ function GalleryEdit( props ) {
 							hideCancelButton={ true }
 						/>
 					) }
-					{/* { ! imageSizeOptions && (
+					{ /* { ! imageSizeOptions && (
 						<BaseControl className={ 'gallery-image-sizes' }>
 							<BaseControl.VisualLabel>
 								{ __( 'Image size' ) }
@@ -500,7 +502,7 @@ function GalleryEdit( props ) {
 								{ __( 'Loading options…' ) }
 							</View>
 						</BaseControl>
-					) } */}
+					) } */ }
 				</PanelBody>
 			</InspectorControls>
 			{ noticeUI }

--- a/packages/block-library/src/gallery/gallery-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-styles.native.scss
@@ -1,0 +1,5 @@
+@import './v1/gallery-styles.native.scss';
+
+.galleryAppender {
+  padding-top: 16px;
+}

--- a/packages/block-library/src/gallery/gallery-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-styles.native.scss
@@ -1,5 +1,5 @@
-@import './v1/gallery-styles.native.scss';
+@import "./v1/gallery-styles.native.scss";
 
 .galleryAppender {
-  padding-top: 16px;
+	padding-top: 16px;
 }

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -8,7 +8,7 @@ import { isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { defaultColumnsNumber } from './shared';
-import styles from './v1/gallery-styles.scss';
+import styles from './gallery-styles.native.scss';
 
 /**
  * WordPress dependencies
@@ -71,7 +71,14 @@ export const Gallery = ( props ) => {
 	return (
 		<View style={ [ isFullWidth && styles.fullWidth ] }>
 			<View { ...innerBlocksProps } />
-			{ mediaPlaceholder }
+			<View
+				style={ [
+					isFullWidth && styles.fullWidth,
+					styles.galleryAppender,
+				] }
+			>
+				{ mediaPlaceholder }
+			</View>
 		</View>
 	);
 };

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -8,7 +8,7 @@ import { isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { defaultColumnsNumber } from './shared';
-import styles from './gallery-styles.native.scss';
+import styles from './gallery-styles.scss';
 
 /**
  * WordPress dependencies
@@ -20,7 +20,6 @@ import {
 } from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
 import { mediaUploadSync } from '@wordpress/react-native-bridge';
-import { useSelect } from '@wordpress/data';
 import { WIDE_ALIGNMENTS } from '@wordpress/components';
 
 const TILE_SPACING = 8;
@@ -33,11 +32,14 @@ export const Gallery = ( props ) => {
 	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
 	useEffect( mediaUploadSync, [] );
 
-	const isRTL = useSelect( ( select ) => {
-		return !! select( 'core/block-editor' ).getSettings().isRTL;
-	}, [] );
-
-	const { mediaPlaceholder, attributes, isNarrow } = props;
+	const {
+		mediaPlaceholder,
+		attributes,
+		isNarrow,
+		onBlur,
+		insertBlocksAfter,
+		clientId,
+	} = props;
 
 	const {
 		imageCount,
@@ -52,9 +54,7 @@ export const Gallery = ( props ) => {
 	);
 
 	const innerBlocksProps = useInnerBlocksProps(
-		{
-			className: 'blocks-gallery-grid',
-		},
+		{},
 		{
 			contentResizeMode: 'stretch',
 			allowedBlocks: [ 'core/image' ],
@@ -66,10 +66,16 @@ export const Gallery = ( props ) => {
 		}
 	);
 
+	const focusGalleryCaption = () => {
+		if ( ! isCaptionSelected ) {
+			setIsCaptionSelected( true );
+		}
+	};
+
 	const isFullWidth = align === WIDE_ALIGNMENTS.alignments.full;
 
 	return (
-		<View style={ [ isFullWidth && styles.fullWidth ] }>
+		<View style={ isFullWidth && styles.fullWidth }>
 			<View { ...innerBlocksProps } />
 			<View
 				style={ [
@@ -79,6 +85,25 @@ export const Gallery = ( props ) => {
 			>
 				{ mediaPlaceholder }
 			</View>
+			<BlockCaption
+				clientId={ clientId }
+				isSelected={ isCaptionSelected }
+				accessible={ true }
+				accessibilityLabelCreator={ ( caption ) =>
+					isEmpty( caption )
+						? /* translators: accessibility text. Empty gallery caption. */
+
+						  'Gallery caption. Empty'
+						: sprintf(
+								/* translators: accessibility text. %s: gallery caption. */
+								__( 'Gallery caption. %s' ),
+								caption
+						  )
+				}
+				onFocus={ focusGalleryCaption }
+				onBlur={ onBlur } // always assign onBlur as props
+				insertBlocksAfter={ insertBlocksAfter }
+			/>
 		</View>
 	);
 };

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -23,7 +23,7 @@ import { mediaUploadSync } from '@wordpress/react-native-bridge';
 import { useSelect } from '@wordpress/data';
 import { WIDE_ALIGNMENTS } from '@wordpress/components';
 
-const TILE_SPACING = 15;
+const TILE_SPACING = 8;
 
 // we must limit displayed columns since readable content max-width is 580px
 const MAX_DISPLAYED_COLUMNS = 4;
@@ -61,17 +61,17 @@ export const Gallery = ( props ) => {
 			orientation: 'horizontal',
 			renderAppender: false,
 			numColumns: displayedColumns,
+			marginHorizontal: TILE_SPACING,
+			marginVertical: TILE_SPACING,
 		}
 	);
 
 	const isFullWidth = align === WIDE_ALIGNMENTS.alignments.full;
 
 	return (
-		<View style={ { flex: 1 } }>
-			<View style={ [ isFullWidth && styles.fullWidth ] }>
-				<View { ...innerBlocksProps } />
-				{ mediaPlaceholder }
-			</View>
+		<View style={ [ isFullWidth && styles.fullWidth ] }>
+			<View { ...innerBlocksProps } />
+			{ mediaPlaceholder }
 		</View>
 	);
 };

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { defaultColumnsNumber } from './shared';
+import styles from './v1/gallery-styles.scss';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	BlockCaption,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { useState, useEffect } from '@wordpress/element';
+import { mediaUploadSync } from '@wordpress/react-native-bridge';
+import { useSelect } from '@wordpress/data';
+import { WIDE_ALIGNMENTS } from '@wordpress/components';
+
+const TILE_SPACING = 15;
+
+// we must limit displayed columns since readable content max-width is 580px
+const MAX_DISPLAYED_COLUMNS = 4;
+const MAX_DISPLAYED_COLUMNS_NARROW = 2;
+
+export const Gallery = ( props ) => {
+	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
+	useEffect( mediaUploadSync, [] );
+
+	const isRTL = useSelect( ( select ) => {
+		return !! select( 'core/block-editor' ).getSettings().isRTL;
+	}, [] );
+
+	const { mediaPlaceholder, attributes, isNarrow } = props;
+
+	const {
+		imageCount,
+		align,
+		columns = defaultColumnsNumber( imageCount ),
+		imageCrop,
+	} = attributes;
+
+	const displayedColumns = Math.min(
+		columns,
+		isNarrow ? MAX_DISPLAYED_COLUMNS_NARROW : MAX_DISPLAYED_COLUMNS
+	);
+
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'blocks-gallery-grid',
+		},
+		{
+			contentResizeMode: 'stretch',
+			allowedBlocks: [ 'core/image' ],
+			orientation: 'horizontal',
+			renderAppender: false,
+			numColumns: displayedColumns,
+		}
+	);
+
+	const isFullWidth = align === WIDE_ALIGNMENTS.alignments.full;
+
+	return (
+		<View style={ { flex: 1 } }>
+			<View style={ [ isFullWidth && styles.fullWidth ] }>
+				<View { ...innerBlocksProps } />
+				{ mediaPlaceholder }
+			</View>
+		</View>
+	);
+};
+
+export default Gallery;

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -45,6 +45,7 @@ export const Gallery = ( props ) => {
 		imageCount,
 		align,
 		columns = defaultColumnsNumber( imageCount ),
+		// eslint-disable-next-line no-unused-vars
 		imageCrop,
 	} = attributes;
 


### PR DESCRIPTION
### Related PRs

* Main refactor PR: https://github.com/WordPress/gutenberg/pull/25940
* Mobile refactor PR: https://github.com/WordPress/gutenberg/pull/31306
  * This PR is targeting the main refactor PR to bring the changes needed for the mobile implementations.
* Former mobile refactor PR: https://github.com/WordPress/gutenberg/pull/26823
  * Changes from this PR are being extracted and included in this and subsequent PRs

## Description
This PR is the first step at adapting the former refactor implementation to the new approach used in the main PR. It mostly cherry-picks changes to the rebased branch, and omits certain changes that were later reverted. After the inclusion of these changes, it should be possible to create new v2 gallery blocks (as inner image blocks), but the UI will not be in it's final state.

Also, a temporary change was included in this PR (https://github.com/WordPress/gutenberg/commit/acf18caab2f8e0788fe8d39d6d51d0751d7d50b6) to enable the `__experimentalGalleryRefactor` flag for testing purposes. This will be removed once a more appropriate implementation is in place.

The relevant commits from the former mobile refactor PR are included or omitted as follows:

Commit | Included?
-|-
WIP - https://github.com/WordPress/gutenberg/pull/26823/commits/57abff0071b3d1a5c843625bc13490156bd43954 | :heavy_check_mark:
fix dirty-image-options - https://github.com/WordPress/gutenberg/pull/26823/commits/795fd474be1d45bdbe3f2fb5c9db7ab49a6e0f40 | :x: These changes were later reverted for a change in approach, so they are not included here
fix spacing - https://github.com/WordPress/gutenberg/pull/26823/commits/2ec63f118da7312c547b7c3f4e2ed41ad4f7825c | :heavy_check_mark:
Add imageCrop, blockProps to block-list and style fixes - https://github.com/WordPress/gutenberg/pull/26823/commits/c0f043d49a9da0bdc79dfbeb0e4a639b515a2621 | :x: These changes were not included, but will be deferred to a later step.
Temporary remove the gallery from initial-html - https://github.com/WordPress/gutenberg/pull/26823/commits/c2fbfa86ea4d74871bac76d686f2a435553c23bb | :x: This was not included, since we probably want to opposite in order to test v1 galleries
Add gallery caption - https://github.com/WordPress/gutenberg/pull/26823/commits/051a2b832882ddb43fe71621d32663601fd30f87 | :heavy_check_mark:

## How has this been tested?
In the block editor, create a gallery and add some images. They should behave as inner image blocks, and should allow reordering and removal. It should also be possible to add captions to both the image blocks, and the outer gallery block. When an inner image block has a setting (attribute) that is also present on the gallery block, a change to the setting on the gallery level should "overwrite" the setting for the individual image block. E.g. if you add a link to an image, and subsequently change the gallery "link to" setting to "media file", the individual image link should no longer be set. However, if the same settings were applied first at the gallery level, then at the image level, the image block should retain its unique setting(s).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
