### PR TITLE
Fix submenu direction justification regression

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -183,9 +183,11 @@
 
 	// When justified space-between, open submenus leftward for last menu item.
 	// When justified right, open all submenus leftwards.
-	&.items-justified-space-between > .submenu-container > .has-child:last-child,
-	&.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
-	&.items-justified-right .has-child {
+	// This needs high specificity.
+	&.wp-block-navigation.items-justified-space-between > .submenu-container > .has-child:last-child,
+	&.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
+	&.wp-block-navigation.items-justified-right .has-child {
+
 		// First submenu.
 		.submenu-container,
 		.wp-block-navigation-link__container {


### PR DESCRIPTION
## Description

In #30342, it was made so that submenus open in the opposite direction of the justification, i.e. if your navigation menu is right justified, submenus open leftwards.

That regressed in some of the recent refactors. This PR restores it:

<img width="563" alt="Screenshot 2021-05-03 at 10 54 55" src="https://user-images.githubusercontent.com/1204802/116858118-28d4a700-abfe-11eb-95c0-11cf0a7325f0.png">

## How has this been tested?

Insert a navigation menu with submenu items. Ideally we test both manual menu items and page list generated submenu items.

Justify right, and test that nested submenus open leftwards.

Bonus points, test space between, and ensure the right-most menu item has nested submenus. Then test that and verify it opens leftwards as well.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
