### PR TITLE
Mark the inserter slot as unstable

### DIFF
--- a/packages/block-directory/README.md
+++ b/packages/block-directory/README.md
@@ -18,7 +18,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 This package builds a standalone JS file. When loaded on a page with the block editor, it extends the block inserter to search for blocks from WordPress.org.
 
-To do this, it uses the `__experimentalInserterMenuExtension`, a slot-fill area hooked into the block types list. When the user runs a search and there are no results currently installed, it fires off a request to WordPress.org for matching blocks. These are listed for the user to install with a one-click process that [installs, activates, and injects the block into the post.](./src/store/actions.js#L49) When the post is saved, if the block was not used, it will be [silently uninstalled](./src/store/actions.js#L129) to avoid clutter.
+To do this, it uses the `__unstableInserterMenuExtension`, a slot-fill area hooked into the block types list. When the user runs a search and there are no results currently installed, it fires off a request to WordPress.org for matching blocks. These are listed for the user to install with a one-click process that [installs, activates, and injects the block into the post.](./src/store/actions.js#L49) When the post is saved, if the block was not used, it will be [silently uninstalled](./src/store/actions.js#L129) to avoid clutter.
 
 See also the API endpoints for searching WordPress.org: `/wp/v2/block-directory/search`, and installing & activating plugins: `/wp/v2/plugins/`.
 

--- a/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
@@ -6,7 +6,7 @@ import { debounce } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __experimentalInserterMenuExtension } from '@wordpress/block-editor';
+import { __unstableInserterMenuExtension } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 
 /**
@@ -19,7 +19,7 @@ function InserterMenuDownloadableBlocksPanel() {
 	const debouncedSetFilterValue = debounce( setFilterValue, 400 );
 
 	return (
-		<__experimentalInserterMenuExtension>
+		<__unstableInserterMenuExtension>
 			{ ( {
 				onSelect,
 				onHover,
@@ -46,7 +46,7 @@ function InserterMenuDownloadableBlocksPanel() {
 					/>
 				);
 			} }
-		</__experimentalInserterMenuExtension>
+		</__unstableInserterMenuExtension>
 	);
 }
 

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -88,7 +88,7 @@ export { default as withColorContext } from './color-palette/with-color-context'
  */
 
 export { default as __unstableBlockSettingsMenuFirstItem } from './block-settings-menu/block-settings-menu-first-item';
-export { default as __experimentalInserterMenuExtension } from './inserter-menu-extension';
+export { default as __unstableInserterMenuExtension } from './inserter-menu-extension';
 export { default as __experimentalPreviewOptions } from './preview-options';
 export { default as __experimentalUseResizeCanvas } from './use-resize-canvas';
 export { default as BlockInspector } from './block-inspector';

--- a/packages/block-editor/src/components/inserter-menu-extension/index.js
+++ b/packages/block-editor/src/components/inserter-menu-extension/index.js
@@ -3,10 +3,10 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
-const { Fill: __experimentalInserterMenuExtension, Slot } = createSlotFill(
-	'__experimentalInserterMenuExtension'
+const { Fill: __unstableInserterMenuExtension, Slot } = createSlotFill(
+	'__unstableInserterMenuExtension'
 );
 
-__experimentalInserterMenuExtension.Slot = Slot;
+__unstableInserterMenuExtension.Slot = Slot;
 
-export default __experimentalInserterMenuExtension;
+export default __unstableInserterMenuExtension;

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -17,7 +17,7 @@ import { speak } from '@wordpress/a11y';
  */
 import BlockTypesList from '../block-types-list';
 import BlockPatternsList from '../block-patterns-list';
-import __experimentalInserterMenuExtension from '../inserter-menu-extension';
+import __unstableInserterMenuExtension from '../inserter-menu-extension';
 import InserterPanel from './panel';
 import InserterNoResults from './no-results';
 import useInsertionPoint from './hooks/use-insertion-point';
@@ -151,7 +151,7 @@ function InserterSearchResults( {
 			) }
 
 			{ showBlockDirectory && (
-				<__experimentalInserterMenuExtension.Slot
+				<__unstableInserterMenuExtension.Slot
 					fillProps={ {
 						onSelect: onSelectBlockType,
 						onHover,
@@ -169,7 +169,7 @@ function InserterSearchResults( {
 						}
 						return null;
 					} }
-				</__experimentalInserterMenuExtension.Slot>
+				</__unstableInserterMenuExtension.Slot>
 			) }
 		</InserterListbox>
 	);


### PR DESCRIPTION
Related #31416 

I think there's value in having an extension point in the inserter for third-party users. That said, the current slot is made specifically for the block directory needs and have the potential to break when/if we make UI changes to the inserter, in other words, it's more "internal" than something that is meant to be marked stable at some point as is. For these reasons, I'm marking it "unstable" instead of "experimental".