### PR TITLE
Mark the __experimentalBlockSettingsMenuFirstItem slot as unstable

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -22,7 +22,7 @@ import { useCopyToClipboard } from '@wordpress/compose';
 import BlockActions from '../block-actions';
 import BlockModeToggle from './block-mode-toggle';
 import BlockHTMLConvertButton from './block-html-convert-button';
-import __experimentalBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
+import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
 
 const POPOVER_PROPS = {
@@ -105,7 +105,7 @@ export function BlockSettingsDropdown( {
 					{ ( { onClose } ) => (
 						<>
 							<MenuGroup>
-								<__experimentalBlockSettingsMenuFirstItem.Slot
+								<__unstableBlockSettingsMenuFirstItem.Slot
 									fillProps={ { onClose } }
 								/>
 								{ count === 1 && (

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-menu-first-item.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-menu-first-item.js
@@ -3,10 +3,10 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
-const { Fill: __experimentalBlockSettingsMenuFirstItem, Slot } = createSlotFill(
-	'__experimentalBlockSettingsMenuFirstItem'
+const { Fill: __unstableBlockSettingsMenuFirstItem, Slot } = createSlotFill(
+	'__unstableBlockSettingsMenuFirstItem'
 );
 
-__experimentalBlockSettingsMenuFirstItem.Slot = Slot;
+__unstableBlockSettingsMenuFirstItem.Slot = Slot;
 
-export default __experimentalBlockSettingsMenuFirstItem;
+export default __unstableBlockSettingsMenuFirstItem;

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -87,7 +87,7 @@ export { default as withColorContext } from './color-palette/with-color-context'
  * Content Related Components
  */
 
-export { default as __experimentalBlockSettingsMenuFirstItem } from './block-settings-menu/block-settings-menu-first-item';
+export { default as __unstableBlockSettingsMenuFirstItem } from './block-settings-menu/block-settings-menu-first-item';
 export { default as __experimentalInserterMenuExtension } from './inserter-menu-extension';
 export { default as __experimentalPreviewOptions } from './preview-options';
 export { default as __experimentalUseResizeCanvas } from './use-resize-canvas';

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -16,7 +16,7 @@ import {
 	ObserveTyping,
 	WritingFlow,
 	BlockEditorKeyboardShortcuts,
-	__experimentalBlockSettingsMenuFirstItem,
+	__unstableBlockSettingsMenuFirstItem,
 } from '@wordpress/block-editor';
 import { SlotFillProvider, Popover } from '@wordpress/components';
 import { uploadMedia } from '@wordpress/media-utils';
@@ -100,14 +100,14 @@ export default function SidebarBlockEditor( {
 					) }
 				</SidebarEditorProvider>
 
-				<__experimentalBlockSettingsMenuFirstItem>
+				<__unstableBlockSettingsMenuFirstItem>
 					{ ( { onClose } ) => (
 						<BlockInspectorButton
 							inspector={ inspector }
 							closeMenu={ onClose }
 						/>
 					) }
-				</__experimentalBlockSettingsMenuFirstItem>
+				</__unstableBlockSettingsMenuFirstItem>
 
 				{
 					// We have to portal this to the parent of both the editor and the inspector,

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -19,7 +19,7 @@ import {
 	__unstableUseTypewriter as useTypewriter,
 	__unstableUseClipboardHandler as useClipboardHandler,
 	__unstableUseTypingObserver as useTypingObserver,
-	__experimentalBlockSettingsMenuFirstItem,
+	__unstableBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableUseCanvasClickRedirect as useCanvasClickRedirect,
 	__unstableEditorStyles as EditorStyles,
@@ -162,11 +162,11 @@ export default function VisualEditor( { styles } ) {
 					</motion.div>
 				</AnimatePresence>
 			</motion.div>
-			<__experimentalBlockSettingsMenuFirstItem>
+			<__unstableBlockSettingsMenuFirstItem>
 				{ ( { onClose } ) => (
 					<BlockInspectorButton onClick={ onClose } />
 				) }
-			</__experimentalBlockSettingsMenuFirstItem>
+			</__unstableBlockSettingsMenuFirstItem>
 		</motion.div>
 	);
 }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -11,7 +11,7 @@ import {
 	BlockInspector,
 	WritingFlow,
 	BlockList,
-	__experimentalBlockSettingsMenuFirstItem,
+	__unstableBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 	__unstableUseTypingObserver as useTypingObserver,
@@ -121,11 +121,11 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 						/>
 					</WritingFlow>
 				</Iframe>
-				<__experimentalBlockSettingsMenuFirstItem>
+				<__unstableBlockSettingsMenuFirstItem>
 					{ ( { onClose } ) => (
 						<BlockInspectorButton onClick={ onClose } />
 					) }
-				</__experimentalBlockSettingsMenuFirstItem>
+				</__unstableBlockSettingsMenuFirstItem>
 			</div>
 		</BlockEditorProvider>
 	);


### PR DESCRIPTION
Related #31416 

This is an old slot that is meant for internal usage (add the close to sidebar link). We do have an officially supported slot to add items to the block menu which means the need for this particular one is less important and we don't want "order related" hooks. I think we can probably consider refactoring our own usage of it to use the regular slot but for now, I'm just marking it unstable instead of experimental.