### PR TITLE
[Block Library - Query]: Add semantic wrapper element

### DIFF
--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -27,6 +27,10 @@
 				"inherit": true
 			}
 		},
+		"tagName": {
+			"type": "string",
+			"default": "div"
+		},
 		"layout": {
 			"type": "object",
 			"default": {

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -6,11 +6,14 @@ import { useInstanceId } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
 import {
 	BlockControls,
+	InspectorAdvancedControls,
 	useBlockProps,
 	store as blockEditorStore,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	__experimentalBlockPatternSetup as BlockPatternSetup,
 } from '@wordpress/block-editor';
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,7 +25,7 @@ import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
 
 const TEMPLATE = [ [ 'core/query-loop' ] ];
 export function QueryContent( { attributes, setAttributes } ) {
-	const { queryId, query, layout } = attributes;
+	const { queryId, query, layout, tagName: TagName = 'div' } = attributes;
 	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
 		blockEditorStore
 	);
@@ -81,9 +84,24 @@ export function QueryContent( { attributes, setAttributes } ) {
 					setLayout={ updateLayout }
 				/>
 			</BlockControls>
-			<div { ...blockProps }>
+			<InspectorAdvancedControls>
+				<SelectControl
+					label={ __( 'HTML element' ) }
+					options={ [
+						{ label: __( 'Default (<div>)' ), value: 'div' },
+						{ label: '<main>', value: 'main' },
+						{ label: '<section>', value: 'section' },
+						{ label: '<aside>', value: 'aside' },
+					] }
+					value={ TagName }
+					onChange={ ( value ) =>
+						setAttributes( { tagName: value } )
+					}
+				/>
+			</InspectorAdvancedControls>
+			<TagName { ...blockProps }>
 				<div { ...innerBlocksProps } />
-			</div>
+			</TagName>
 		</>
 	);
 }

--- a/packages/block-library/src/query/save.js
+++ b/packages/block-library/src/query/save.js
@@ -3,10 +3,10 @@
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-export default function QuerySave() {
+export default function QuerySave( { attributes: { tagName: Tag = 'div' } } ) {
 	return (
-		<div { ...useBlockProps.save() }>
+		<Tag { ...useBlockProps.save() }>
 			<InnerBlocks.Content />
-		</div>
+		</Tag>
 	);
 }

--- a/packages/e2e-tests/fixtures/blocks/core__query.json
+++ b/packages/e2e-tests/fixtures/blocks/core__query.json
@@ -19,6 +19,7 @@
 				"sticky": "",
 				"inherit": true
 			},
+			"tagName": "div",
 			"layout": {
 				"type": "list"
 			}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/28555

Sometimes, theme templates will consist of just a header template part, a footer template part, and a query loop in the middle. Semantically, that query should be wrapped in a `main` tag. In other cases, the query should be wrapped in a `section` tag.

This PR adds the option in `Query` block to change the wrapper element, under `Advanced` inspector controls.
<!-- Please describe what you have changed or added -->

## Testing instructions
1. Everything should work as before
2. Under `Advanced` inspector controls in a Query block change the value of `HTML element` to a different `tag`, save and see that the selection is applied in both editor and front-end.

## Notes
I have added only `div, main, section and aside` as options. Should I add or remove something?
--cc @kjellr @jasmussen @jameskoster 