### PR TITLE
Block Library: Stabilize some theme blocks for WP 5.8 release

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -167,6 +167,26 @@ export const __experimentalGetCoreBlocks = () => [
 	textColumns,
 	verse,
 	video,
+
+	// Theme blocks
+	siteLogo,
+	siteTagline,
+	siteTitle,
+
+	query,
+	queryLoop,
+	queryTitle,
+	queryPagination,
+	queryPaginationNext,
+	queryPaginationNumbers,
+	queryPaginationPrevious,
+
+	postTitle,
+	postContent,
+	postAuthor,
+	postDate,
+	postExcerpt,
+	postFeaturedImage,
 ];
 
 /**
@@ -218,21 +238,8 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 					// Register Full Site Editing Blocks.
 					...( enableFSEBlocks
 						? [
-								siteLogo,
-								siteTagline,
-								siteTitle,
 								templatePart,
-								query,
-								queryLoop,
-								queryTitle,
-								queryPagination,
-								queryPaginationNext,
-								queryPaginationNumbers,
-								queryPaginationPrevious,
 								logInOut,
-								postTitle,
-								postContent,
-								postAuthor,
 								postComment,
 								postCommentAuthor,
 								postCommentContent,
@@ -241,9 +248,6 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postCommentsCount,
 								postCommentsForm,
 								postCommentsLink,
-								postDate,
-								postExcerpt,
-								postFeaturedImage,
 								postHierarchicalTerms,
 								postTags,
 								postNavigationLink,


### PR DESCRIPTION
Theme blocks (or FSE blocks) are meant to be released in WP 5.8. This PR makes stable stable so they can be back ported to WP Core and show up there without the plugin. 

I omitted some blocks from this list:

 - Post comments related blocks: these are still uncertain, we might want to build smaller blocks (list post related blocks) for comments. I think this means these blocks won't make it to 5.8.
 - Terms/taxonomies related blocks: we need to clear this first #31422 
 - A couple other blocks that I don't know much about and that I still need to audit 