### PR TITLE
Expand the site tagline block description.

### DIFF
--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -3,7 +3,7 @@
 	"name": "core/site-tagline",
 	"title": "Site Tagline",
 	"category": "design",
-	"description": "In a few words, what this site is about.",
+	"description": "Describe in a few words what the website is about. The tagline can be used in search results or when sharing on social networks even if it's not displayed in the theme design.",
 	"keywords": [ "description" ],
 	"textdomain": "default",
 	"attributes": {


### PR DESCRIPTION
Tweaks the site tagline block description to reference the value it can have even if it's not actually displayed in the website.