### PR TITLE
Rename "Modes" to "Tools" in the header.

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -52,13 +52,13 @@ function ToolSelector( props, ref ) {
 					aria-haspopup="true"
 					onClick={ onToggle }
 					/* translators: button label text should, if possible, be under 16 characters. */
-					label={ __( 'Modes' ) }
+					label={ __( 'Tools' ) }
 				/>
 			) }
 			position="bottom right"
 			renderContent={ () => (
 				<>
-					<NavigableMenu role="menu" aria-label={ __( 'Modes' ) }>
+					<NavigableMenu role="menu" aria-label={ __( 'Tools' ) }>
 						<MenuItemsChoice
 							value={ isNavigationTool ? 'select' : 'edit' }
 							onSelect={ onSwitchMode }
@@ -86,7 +86,7 @@ function ToolSelector( props, ref ) {
 					</NavigableMenu>
 					<div className="block-editor-tool-selector__help">
 						{ __(
-							'Tools offer different interactions for block selection & editing. To select, press Escape, to go back to editing, press Enter.'
+							'Tools provide different interactions for selecting, navigating, and editing blocks. Toggle between select and edit by pressing Escape and Enter.'
 						) }
 					</div>
 				</>


### PR DESCRIPTION
Also rewords the description a bit for more clarity.

Tooltip:
![image](https://user-images.githubusercontent.com/548849/116894365-41f74b00-ac32-11eb-8b9a-4f9731d22cef.png)

Description:
![image](https://user-images.githubusercontent.com/548849/116894429-53405780-ac32-11eb-9be8-5a95644446af.png)

Text buttons:
![image](https://user-images.githubusercontent.com/548849/116894484-605d4680-ac32-11eb-972b-dbfcabe5b752.png)
