### PR TITLE
Remove tools dropdown menu from medium viewport when text labels mode is active

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -21,13 +21,7 @@ import {
 	EditorHistoryRedo,
 	EditorHistoryUndo,
 } from '@wordpress/editor';
-import {
-	Button,
-	DropdownMenu,
-	ToolbarItem,
-	MenuItemsChoice,
-	MenuGroup,
-} from '@wordpress/components';
+import { Button, ToolbarItem } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import { useRef } from '@wordpress/element';
 
@@ -47,7 +41,6 @@ function HeaderToolbar() {
 		isTextModeEnabled,
 		previewDeviceType,
 		showIconLabels,
-		isNavigationTool,
 		isTemplateMode,
 	} = useSelect( ( select ) => {
 		const {
@@ -76,14 +69,11 @@ function HeaderToolbar() {
 			showIconLabels: select( editPostStore ).isFeatureActive(
 				'showIconLabels'
 			),
-			isNavigationTool: select( blockEditorStore ).isNavigationMode(),
 			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideViewport = useViewportMatch( 'wide' );
-	const isSmallViewport = useViewportMatch( 'small', '<' );
-	const { setNavigationMode } = useDispatch( blockEditorStore );
 
 	const displayBlockToolbar =
 		! isLargeViewport || previewDeviceType !== 'Desktop' || hasFixedToolbar;
@@ -93,10 +83,6 @@ function HeaderToolbar() {
 		  __( 'Document and block tools' )
 		: /* translators: accessibility text for the editor toolbar when Top Toolbar is off */
 		  __( 'Document tools' );
-
-	const onSwitchMode = ( mode ) => {
-		setNavigationMode( mode === 'edit' ? false : true );
-	};
 
 	const overflowItems = (
 		<>
@@ -173,50 +159,6 @@ function HeaderToolbar() {
 						/>
 						{ overflowItems }
 					</>
-				) }
-				{ ! isWideViewport && ! isSmallViewport && showIconLabels && (
-					<DropdownMenu
-						position="bottom right"
-						label={
-							/* translators: button label text should, if possible, be under 16
-characters. */
-							__( 'Tools' )
-						}
-					>
-						{ () => (
-							<div className="edit-post-header__dropdown">
-								<MenuGroup label={ __( 'Modes' ) }>
-									<MenuItemsChoice
-										value={
-											isNavigationTool ? 'select' : 'edit'
-										}
-										onSelect={ onSwitchMode }
-										choices={ [
-											{
-												value: 'edit',
-												label: __( 'Edit' ),
-											},
-											{
-												value: 'select',
-												label: __( 'Select' ),
-											},
-										] }
-									/>
-								</MenuGroup>
-								<MenuGroup label={ __( 'Edit' ) }>
-									<EditorHistoryUndo
-										showTooltip={ ! showIconLabels }
-										isTertiary={ showIconLabels }
-									/>
-									<EditorHistoryRedo
-										showTooltip={ ! showIconLabels }
-										isTertiary={ showIconLabels }
-									/>
-								</MenuGroup>
-								<MenuGroup>{ overflowItems }</MenuGroup>
-							</div>
-						) }
-					</DropdownMenu>
 				) }
 			</div>
 


### PR DESCRIPTION
When "Display button labels" mode is enabled, we had this weird dropdown menu composed of several tools mixed together. Design wise and behavior wise, this menu was very confusing and would require to be rethought.

On small viewports, that menu is removed entirely, so this PR is just matching the "small" and "medium" viewports behavior which allows us to get rid of that dropdown menu.

This is the menu we're talking about.

<img width="745" alt="Capture d’écran 2021-05-03 à 4 21 06 PM" src="https://user-images.githubusercontent.com/272444/116897023-b929e080-ac2c-11eb-9af4-8e555fa2a135.png">
