### PR TITLE
Update: Use wp_theme taxonomy for wp_global_styles cpt.

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -311,7 +311,6 @@ class WP_Theme_JSON_Resolver {
 	private static function get_user_data_from_custom_post_type( $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
 		$user_cpt         = array();
 		$post_type_filter = 'wp_global_styles';
-		$post_name_filter = 'wp-global-styles-' . urlencode( wp_get_theme()->get_stylesheet() );
 		$recent_posts     = wp_get_recent_posts(
 			array(
 				'numberposts' => 1,
@@ -319,7 +318,13 @@ class WP_Theme_JSON_Resolver {
 				'order'       => 'desc',
 				'post_type'   => $post_type_filter,
 				'post_status' => $post_status_filter,
-				'name'        => $post_name_filter,
+				'tax_query'      => array(
+					array(
+						'taxonomy' => 'wp_theme',
+						'field'    => 'name',
+						'terms'    => wp_get_theme()->get_stylesheet(),
+					),
+				),
 			)
 		);
 
@@ -332,7 +337,10 @@ class WP_Theme_JSON_Resolver {
 					'post_status'  => 'publish',
 					'post_title'   => __( 'Custom Styles', 'default' ),
 					'post_type'    => $post_type_filter,
-					'post_name'    => $post_name_filter,
+					'post_name'    => 'wp-global-styles-' . urlencode( wp_get_theme()->get_stylesheet() ),
+					'tax_input'    => array(
+						'wp_theme' => array( wp_get_theme()->get_stylesheet() ),
+					),
 				),
 				true
 			);

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -84,13 +84,13 @@ add_action( 'init', 'gutenberg_register_template_post_type' );
  * Registers block editor 'wp_theme' taxonomy.
  */
 function gutenberg_register_wp_theme_taxonomy() {
-	if ( ! gutenberg_supports_block_templates() ) {
+	if ( ! gutenberg_supports_block_templates() && ! WP_Theme_JSON_Resolver::theme_has_support() ) {
 		return;
 	}
 
 	register_taxonomy(
 		'wp_theme',
-		array( 'wp_template', 'wp_template_part' ),
+		array( 'wp_template', 'wp_template_part', 'wp_global_styles' ),
 		array(
 			'public'            => false,
 			'hierarchical'      => false,


### PR DESCRIPTION
Templates and template parts rely on wp_theme taxonomy to associate template and template posts with a given theme. Global styles was using a different mechanism (appending theme id to the name of the post). This PR makes global styles use the same mechanism being used on templates and template parts.

Fixes:https://github.com/WordPress/gutenberg/issues/30191




## How has this been tested?
I enabled a global styles theme.
I went to the site editor. I applied some user changes to the global styles and saved them.
I verified the changes were applied to the front end.
I reload the site editor and verified the changes were still present.
I switched to another global style enable theme.
I verified my previous changes did not appeared anymore-
I applied other changes and verified they were applied on the front and persisted after site editor reload.
I switched back to the initial theme and loaded the site editor.
I verified the changes I made while that theme was enabled appeared again.
