### PR TITLE
Update Versions in WordPress to include 5.7.1 & 5.8

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,8 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 10.0-10.7          | 5.8               |
+| 9.3-9.9            | 5.7.1             |
 | 9.3-9.9            | 5.7               |
 | 8.6-9.2            | 5.6.1             |
 | 8.6-9.2            | 5.6               |


### PR DESCRIPTION
A quick update to this doc to align with what shipped with 5.7.1 and what is planned for 5.8 in light of the next steps:

https://make.wordpress.org/core/2021/04/20/full-site-editing-go-no-go-next-steps/

Removed checklist since this is a doc update.