### PR TITLE
Moves hermes and react-native mirror to S3

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -82,10 +82,10 @@ repositories {
     google()
 
     maven { url "https://jitpack.io" }
-    maven { url "https://a8c-libs.s3.amazonaws.com/android" }
+    maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }
 
     if (willPublishReactNativeAztecBinary) {
-        maven { url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/" }
+        maven { url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror" }
     } else {
         maven { url("$rootDir/../../../node_modules/react-native/android") }
     }

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         if (willPublishReactNativeBridgeBinary) {
-            maven { url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/" }
+            maven { url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror" }
         } else {
             maven { url "$rootDir/../../../node_modules/react-native/android" }
         }

--- a/packages/react-native-bridge/android/publish-aztec-and-bridge.sh
+++ b/packages/react-native-bridge/android/publish-aztec-and-bridge.sh
@@ -50,3 +50,4 @@ if [ $? -ne 0 ]; then
     echo "Failed to publish 'react-native-bridge' version '$VERSION'."
     exit 1
 fi
+

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -63,9 +63,9 @@ android {
 repositories {
     google()
     jcenter()
-    maven { url  "https://dl.bintray.com/wordpress-mobile/maven" }
     maven { url "https://jitpack.io" }
     maven { url "https://a8c-libs.s3.amazonaws.com/android" }
+    maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }
 }
 
 dependencies {

--- a/packages/react-native-editor/android/build.gradle
+++ b/packages/react-native-editor/android/build.gradle
@@ -30,6 +30,6 @@ allprojects {
         google()
         jcenter()
         maven { url 'https://jitpack.io' }
-        maven { url "https://a8c-libs.s3.amazonaws.com/android" }
+        maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }
     }
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR updates `react-native-bridge`, `react-native-aztec` and `react-native-editor` projects to use react native mirror and hermes binaries from S3 repo instead of Bintray. This change is made due to [Bintray shutting down](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* From `react-native-aztec/android` run `./gradlew build --refresh-dependencies`
* From `react-native-editor/android` run `./gradlew :app:buildDebug --refresh-dependencies`
* From `react-native-bridge/android` run `./gradlew :react-native-bridge:build --refresh-dependencies`
* From `react-native-bridge/android` run `./gradlew :react-native-aztec:build --refresh-dependencies -PreactNativeAztecVersion=v1.52.0`
* From `react-native-bridge/android` run `./gradlew :react-native-bridge:build --refresh-dependencies -PpublishReactNativeBridgeVersion=v1.52.0 -PreactNativeAztecVersion=v1.52.0`
* Test the demo app

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Maven repository changes for `react-native-bridge`, `react-native-aztec` and `react-native-editor` projects

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
