### PR TITLE
'Move to widget area' iterations and fixes

### DIFF
--- a/packages/customize-widgets/src/filters/move-to-sidebar.js
+++ b/packages/customize-widgets/src/filters/move-to-sidebar.js
@@ -24,6 +24,7 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 		const widgetId = getWidgetIdFromBlock( props );
 		const sidebarControls = useSidebarControls();
 		const activeSidebarControl = useActiveSidebarControl();
+		const hasMultipleSidebars = sidebarControls?.length > 1;
 
 		function moveToSidebar( sidebarControlId ) {
 			const newSidebarControl = sidebarControls.find(
@@ -42,19 +43,22 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 		return (
 			<>
 				<BlockEdit { ...props } />
-				<BlockControls>
-					<MoveToWidgetArea
-						widgetAreas={ sidebarControls.map(
-							( sidebarControl ) => ( {
-								id: sidebarControl.id,
-								name: sidebarControl.params.label,
-								description: sidebarControl.params.description,
-							} )
-						) }
-						currentWidgetAreaId={ activeSidebarControl?.id }
-						onSelect={ moveToSidebar }
-					/>
-				</BlockControls>
+				{ hasMultipleSidebars && (
+					<BlockControls>
+						<MoveToWidgetArea
+							widgetAreas={ sidebarControls.map(
+								( sidebarControl ) => ( {
+									id: sidebarControl.id,
+									name: sidebarControl.params.label,
+									description:
+										sidebarControl.params.description,
+								} )
+							) }
+							currentWidgetAreaId={ activeSidebarControl?.id }
+							onSelect={ moveToSidebar }
+						/>
+					</BlockControls>
+				) }
 			</>
 		);
 	},

--- a/packages/customize-widgets/src/filters/move-to-sidebar.js
+++ b/packages/customize-widgets/src/filters/move-to-sidebar.js
@@ -6,8 +6,12 @@ import { without } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { BlockControls } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { MoveToWidgetArea, getWidgetIdFromBlock } from '@wordpress/widgets';
 
@@ -25,6 +29,18 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 		const sidebarControls = useSidebarControls();
 		const activeSidebarControl = useActiveSidebarControl();
 		const hasMultipleSidebars = sidebarControls?.length > 1;
+		const blockName = props.name;
+		const canInsertBlockInSidebar = useSelect(
+			( select ) => {
+				// Use an empty string to represent the root block list, which
+				// in the customizer editor represents a sidebar/widget area.
+				return select( blockEditorStore ).canInsertBlockType(
+					blockName,
+					''
+				);
+			},
+			[ blockName ]
+		);
 
 		function moveToSidebar( sidebarControlId ) {
 			const newSidebarControl = sidebarControls.find(
@@ -43,7 +59,7 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ hasMultipleSidebars && (
+				{ hasMultipleSidebars && canInsertBlockInSidebar && (
 					<BlockControls>
 						<MoveToWidgetArea
 							widgetAreas={ sidebarControls.map(

--- a/packages/edit-widgets/src/filters/move-to-widget-area.js
+++ b/packages/edit-widgets/src/filters/move-to-widget-area.js
@@ -30,11 +30,12 @@ const withMoveToWidgetAreaToolbarItem = createHigherOrderComponent(
 		);
 
 		const { moveBlockToWidgetArea } = useDispatch( editWidgetsStore );
+		const hasMultipleWidgetAreas = widgetAreas?.length > 1;
 
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ props.name !== 'core/widget-area' && (
+				{ props.name !== 'core/widget-area' && hasMultipleWidgetAreas && (
 					<BlockControls>
 						<MoveToWidgetArea
 							widgetAreas={ widgetAreas }

--- a/packages/edit-widgets/src/filters/move-to-widget-area.js
+++ b/packages/edit-widgets/src/filters/move-to-widget-area.js
@@ -16,26 +16,43 @@ import { store as editWidgetsStore } from '../store';
 const withMoveToWidgetAreaToolbarItem = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const widgetId = getWidgetIdFromBlock( props );
-		const { widgetAreas, currentWidgetAreaId } = useSelect(
+		const blockName = props.name;
+		const {
+			widgetAreas,
+			currentWidgetAreaId,
+			canInsertBlockInWidgetArea,
+		} = useSelect(
 			( select ) => {
+				// Component won't display for a widget area, so don't run selectors.
+				if ( blockName === 'core/widget-area' ) {
+					return {};
+				}
+
 				const selectors = select( editWidgetsStore );
 				return {
 					widgetAreas: selectors.getWidgetAreas(),
 					currentWidgetArea: widgetId
 						? selectors.getWidgetAreaForWidgetId( widgetId )?.id
 						: undefined,
+					canInsertBlockInWidgetArea: selectors.canInsertBlockInWidgetArea(
+						blockName
+					),
 				};
 			},
-			[ widgetId ]
+			[ widgetId, blockName ]
 		);
 
 		const { moveBlockToWidgetArea } = useDispatch( editWidgetsStore );
 		const hasMultipleWidgetAreas = widgetAreas?.length > 1;
+		const isMoveToWidgetAreaVisible =
+			blockName !== 'core/widget-area' &&
+			hasMultipleWidgetAreas &&
+			canInsertBlockInWidgetArea;
 
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ props.name !== 'core/widget-area' && hasMultipleWidgetAreas && (
+				{ isMoveToWidgetAreaVisible && (
 					<BlockControls>
 						<MoveToWidgetArea
 							widgetAreas={ widgetAreas }

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -196,3 +196,27 @@ export const getIsWidgetAreaOpen = ( state, clientId ) => {
 export function isInserterOpened( state ) {
 	return !! state.blockInserterPanel;
 }
+
+/**
+ * Returns true if a block can be inserted into a widget area.
+ *
+ * @param {Array}  state    The open state of the widget areas.
+ * @param {string} blockName The name of the block being inserted.
+ *
+ * @return {boolean} True if the block can be inserted in a widget area.
+ */
+export const canInsertBlockInWidgetArea = createRegistrySelector(
+	( select ) => ( state, blockName ) => {
+		// Widget areas are always top-level blocks, which getBlocks will return.
+		const widgetAreas = select( 'core/block-editor' ).getBlocks();
+
+		// Makes an assumption that a block that can be inserted into one
+		// widget area can be inserted into any widget area. Uses the first
+		// widget area for testing whether the block can be inserted.
+		const [ firstWidgetArea ] = widgetAreas;
+		return select( 'core/block-editor' ).canInsertBlockType(
+			blockName,
+			firstWidgetArea.clientId
+		);
+	}
+);


### PR DESCRIPTION
## Description
Fixes #31129, which points out that some blocks can't be moved to a widget area (e.g. button, which can only be added in the buttons block).

This adds a `canInsertBlockType` check to the customize and standalone widgets editors to determine if the Move to Widget Area dropdown should be shown.

Also fixes another issue where a theme might only have a single widget area, but the useless dropdown is still displayed.

## How has this been tested?
#### Move To Widget Area dropdown shows correctly for blocks that can be moved
1. Use a theme that has multiple widget areas (e.g. Twenty Twenty)
2. Add a buttons block to a widget area
3. Select the buttons block, and notice the move to widget area dropdown shows.
4. Select the inner button block, and notice the move to widget area dropdown isn't visible on the toolbar

#### Move To Widget Area dropdown isn't visible for themes with a single widget area
1. Use a theme that has a single widget area (e.g. Twenty Twenty One)
2. In the customizer editor, select a block
3. Notice the move to widget area dropdown isn't visible.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
