### PR TITLE
Fix scrolling to the inserted block issue in the iFramed block editor

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -47,12 +47,23 @@ export function useScrollIntoView( clientId ) {
 			return;
 		}
 
-		const scrollContainer = getScrollContainer( extentNode );
+		let scrollContainer = getScrollContainer( extentNode );
 
-		// If there's no scroll container, it follows that there's no scrollbar
-		// and thus there's no need to try to scroll into view.
+		// If there's no scroll container, then we check whether the
+		// node is in an iframe. If it's in an iframe then we check
+		// if it's scrollable or not. If it's scrollable we proceed
+		// on and tell the `scrollIntoView` to scroll the iframe.
 		if ( ! scrollContainer ) {
-			return;
+			const { ownerDocument } = extentNode;
+			const isFramed = !! ownerDocument.defaultView?.frameElement;
+			const scrollingElement =
+				ownerDocument.scrollingElement || ownerDocument.body;
+			if (
+				isFramed &&
+				scrollingElement.scrollHeight > scrollingElement.clientHeight
+			) {
+				scrollContainer = ownerDocument.defaultView;
+			}
 		}
 
 		scrollIntoView( extentNode, scrollContainer, {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -63,6 +63,8 @@ export function useScrollIntoView( clientId ) {
 				scrollingElement.scrollHeight > scrollingElement.clientHeight
 			) {
 				scrollContainer = ownerDocument.defaultView;
+			} else {
+				return;
 			}
 		}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -47,25 +47,14 @@ export function useScrollIntoView( clientId ) {
 			return;
 		}
 
-		let scrollContainer = getScrollContainer( extentNode );
+		const scrollContainer =
+			getScrollContainer( extentNode ) ||
+			extentNode.ownerDocument.defaultView;
 
-		// If there's no scroll container, then we check whether the
-		// node is in an iframe. If it's in an iframe then we check
-		// if it's scrollable or not. If it's scrollable we proceed
-		// on and tell the `scrollIntoView` to scroll the iframe.
+		// If there's no scroll container, it follows that there's no scrollbar
+		// and thus there's no need to try to scroll into view.
 		if ( ! scrollContainer ) {
-			const { ownerDocument } = extentNode;
-			const isFramed = !! ownerDocument.defaultView?.frameElement;
-			const scrollingElement =
-				ownerDocument.scrollingElement || ownerDocument.body;
-			if (
-				isFramed &&
-				scrollingElement.scrollHeight > scrollingElement.clientHeight
-			) {
-				scrollContainer = ownerDocument.defaultView;
-			} else {
-				return;
-			}
+			return;
 		}
 
 		scrollIntoView( extentNode, scrollContainer, {

--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -15,7 +15,7 @@
 	line-height: initial;
 	color: initial;
 
-	.block-editor-block-list__layout.is-root-container {
+	& > .block-editor-writing-flow {
 		box-sizing: border-box;
 		padding: 8px;
 		width: 100%;

--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -6,6 +6,8 @@
  */
 
 .editor-styles-wrapper {
+	padding: 8px;
+
 	/**
 	* The following styles revert to the browser defaults overriding the WPAdmin styles.
 	* This is only needed while the block editor is not being loaded in an iframe.
@@ -14,14 +16,6 @@
 	font-size: initial;
 	line-height: initial;
 	color: initial;
-
-	& > .block-editor-writing-flow {
-		box-sizing: border-box;
-		padding: 8px;
-		width: 100%;
-		height: 100%;
-		overflow: auto;
-	}
 
 	// For full-wide blocks, we compensate for the base padding.
 	// These margins should match the padding value above.

--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -6,8 +6,6 @@
  */
 
 .editor-styles-wrapper {
-	padding: 8px;
-
 	/**
 	* The following styles revert to the browser defaults overriding the WPAdmin styles.
 	* This is only needed while the block editor is not being loaded in an iframe.
@@ -16,6 +14,14 @@
 	font-size: initial;
 	line-height: initial;
 	color: initial;
+
+	.block-editor-block-list__layout.is-root-container {
+		box-sizing: border-box;
+		padding: 8px;
+		width: 100%;
+		height: 100%;
+		overflow: auto;
+	}
 
 	// For full-wide blocks, we compensate for the base padding.
 	// These margins should match the padding value above.

--- a/patches/dom-scroll-into-view+1.2.1.patch
+++ b/patches/dom-scroll-into-view+1.2.1.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/dom-scroll-into-view/lib/dom-scroll-into-view.js b/node_modules/dom-scroll-into-view/lib/dom-scroll-into-view.js
+index 557ed5c..23dfbad 100644
+--- a/node_modules/dom-scroll-into-view/lib/dom-scroll-into-view.js
++++ b/node_modules/dom-scroll-into-view/lib/dom-scroll-into-view.js
+@@ -21,6 +21,7 @@ function scrollIntoView(elem, container, config) {
+   allowHorizontalScroll = allowHorizontalScroll === undefined ? true : allowHorizontalScroll;
+ 
+   var isWin = util.isWindow(container);
++  var isFramed = !!(isWin && container.frameElement);
+   var elemOffset = util.offset(elem);
+   var eh = util.outerHeight(elem);
+   var ew = util.outerWidth(elem);
+@@ -35,7 +36,11 @@ function scrollIntoView(elem, container, config) {
+   var ww = undefined;
+   var wh = undefined;
+ 
+-  if (isWin) {
++  if (isFramed) {
++    container = container.document.scrollingElement || container.document.body;
++  }
++
++  if (isWin || isFramed) {
+     win = container;
+     wh = util.height(win);
+     ww = util.width(win);


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/31251

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
`dom-scroll-into-view` library doesn't play nicely with iframes if there is no explicit scrolling container.

Here is a simple [CodeSandbox](https://codesandbox.io/s/vibrant-noyce-9v8o3?file=/index.html) explaining the issue.

This PR patches the package by checking whether the container is an iframe window. In that case it scrolls the `scrollingElement` instead of the window. We can't scroll the iframe window because it's an iframe so the typical `window.scrollTo()` doesn't work.

## How has this been tested?
Run `npm install` to patch the `dom-scroll-into-view` package.

1. Open site editor
2. Insert a couple of patterns so you can scroll up and down
3.1.1. Make sure the insertion point is outside of your viewport, and it's below your current position.
3.1.2. Insert a pattern, make sure it automatically scrolled down to the inserted pattern
3.2.1 Make sure the insertion point is outside of your viewport, and it's above your current position.
3.2.2. Insert a pattern, make sure it automatically scrolled up to the inserted pattern
4. Do the same for post editor (smoke test)
5. Play around a little bit in the editor and make sure nothing is broken


## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/2256104/116971904-8fb79600-acba-11eb-9a7d-21f86519a658.mov


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
