### PR TITLE
Attempt to fix typewriter e2e test

### DIFF
--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -3,258 +3,229 @@
  */
 import { useRefEffect } from '@wordpress/compose';
 import { computeCaretRect, getScrollContainer } from '@wordpress/dom';
-import { useSelect } from '@wordpress/data';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
-
-/**
- * Internal dependencies
- */
-import { store as blockEditorStore } from '../../store';
 
 const isIE = window.navigator.userAgent.indexOf( 'Trident' ) !== -1;
 const arrowKeyCodes = new Set( [ UP, DOWN, LEFT, RIGHT ] );
 const initialTriggerPercentage = 0.75;
 
 export function useTypewriter() {
-	const hasSelectedBlock = useSelect( ( select ) =>
-		select( blockEditorStore ).hasSelectedBlock()
-	);
+	return useRefEffect( ( node ) => {
+		const { ownerDocument } = node;
+		const { defaultView } = ownerDocument;
 
-	return useRefEffect(
-		( node ) => {
-			if ( ! hasSelectedBlock ) {
+		let scrollResizeRafId;
+		let onKeyDownRafId;
+
+		let caretRect;
+
+		function onScrollResize() {
+			if ( scrollResizeRafId ) {
 				return;
 			}
 
-			const { ownerDocument } = node;
-			const { defaultView } = ownerDocument;
-
-			let scrollResizeRafId;
-			let onKeyDownRafId;
-
-			let caretRect;
-
-			function onScrollResize() {
-				if ( scrollResizeRafId ) {
-					return;
-				}
-
-				scrollResizeRafId = defaultView.requestAnimationFrame( () => {
-					computeCaretRectangle();
-					scrollResizeRafId = null;
-				} );
-			}
-
-			function onKeyDown( event ) {
-				// Ensure the any remaining request is cancelled.
-				if ( onKeyDownRafId ) {
-					defaultView.cancelAnimationFrame( onKeyDownRafId );
-				}
-
-				// Use an animation frame for a smooth result.
-				onKeyDownRafId = defaultView.requestAnimationFrame( () => {
-					maintainCaretPosition( event );
-					onKeyDownRafId = null;
-				} );
-			}
-
-			/**
-			 * Maintains the scroll position after a selection change caused by a
-			 * keyboard event.
-			 *
-			 * @param {KeyboardEvent} event Keyboard event.
-			 */
-			function maintainCaretPosition( { keyCode } ) {
-				if ( ! isSelectionEligibleForScroll() ) {
-					return;
-				}
-
-				const currentCaretRect = computeCaretRect( defaultView );
-
-				if ( ! currentCaretRect ) {
-					return;
-				}
-
-				// If for some reason there is no position set to be scrolled to, let
-				// this be the position to be scrolled to in the future.
-				if ( ! caretRect ) {
-					caretRect = currentCaretRect;
-					return;
-				}
-
-				// Even though enabling the typewriter effect for arrow keys results in
-				// a pleasant experience, it may not be the case for everyone, so, for
-				// now, let's disable it.
-				if ( arrowKeyCodes.has( keyCode ) ) {
-					// Reset the caret position to maintain.
-					caretRect = currentCaretRect;
-					return;
-				}
-
-				const diff = currentCaretRect.top - caretRect.top;
-
-				if ( diff === 0 ) {
-					return;
-				}
-
-				const scrollContainer = getScrollContainer( node );
-
-				// The page must be scrollable.
-				if ( ! scrollContainer ) {
-					return;
-				}
-
-				const windowScroll = scrollContainer === ownerDocument.body;
-				const scrollY = windowScroll
-					? defaultView.scrollY
-					: scrollContainer.scrollTop;
-				const scrollContainerY = windowScroll
-					? 0
-					: scrollContainer.getBoundingClientRect().top;
-				const relativeScrollPosition = windowScroll
-					? caretRect.top / defaultView.innerHeight
-					: ( caretRect.top - scrollContainerY ) /
-					  ( defaultView.innerHeight - scrollContainerY );
-
-				// If the scroll position is at the start, the active editable element
-				// is the last one, and the caret is positioned within the initial
-				// trigger percentage of the page, do not scroll the page.
-				// The typewriter effect should not kick in until an empty page has been
-				// filled with the initial trigger percentage or the user scrolls
-				// intentionally down.
-				if (
-					scrollY === 0 &&
-					relativeScrollPosition < initialTriggerPercentage &&
-					isLastEditableNode()
-				) {
-					// Reset the caret position to maintain.
-					caretRect = currentCaretRect;
-					return;
-				}
-
-				const scrollContainerHeight = windowScroll
-					? defaultView.innerHeight
-					: scrollContainer.clientHeight;
-
-				// Abort if the target scroll position would scroll the caret out of
-				// view.
-				if (
-					// The caret is under the lower fold.
-					caretRect.top + caretRect.height >
-						scrollContainerY + scrollContainerHeight ||
-					// The caret is above the upper fold.
-					caretRect.top < scrollContainerY
-				) {
-					// Reset the caret position to maintain.
-					caretRect = currentCaretRect;
-					return;
-				}
-
-				if ( windowScroll ) {
-					defaultView.scrollBy( 0, diff );
-				} else {
-					scrollContainer.scrollTop += diff;
-				}
-			}
-
-			/**
-			 * Adds a `selectionchange` listener to reset the scroll position to be
-			 * maintained.
-			 */
-			function addSelectionChangeListener() {
-				ownerDocument.addEventListener(
-					'selectionchange',
-					computeCaretRectOnSelectionChange
-				);
-			}
-
-			/**
-			 * Resets the scroll position to be maintained during a `selectionchange`
-			 * event. Also removes the listener, so it acts as a one-time listener.
-			 */
-			function computeCaretRectOnSelectionChange() {
-				ownerDocument.removeEventListener(
-					'selectionchange',
-					computeCaretRectOnSelectionChange
-				);
+			scrollResizeRafId = defaultView.requestAnimationFrame( () => {
 				computeCaretRectangle();
-			}
+				scrollResizeRafId = null;
+			} );
+		}
 
-			/**
-			 * Resets the scroll position to be maintained.
-			 */
-			function computeCaretRectangle() {
-				if ( isSelectionEligibleForScroll() ) {
-					caretRect = computeCaretRect( defaultView );
-				}
-			}
-
-			/**
-			 * Checks if the current situation is elegible for scroll:
-			 * - There should be one and only one block selected.
-			 * - The component must contain the selection.
-			 * - The active element must be contenteditable.
-			 */
-			function isSelectionEligibleForScroll() {
-				return (
-					node.contains( ownerDocument.activeElement ) &&
-					ownerDocument.activeElement.isContentEditable
-				);
-			}
-
-			function isLastEditableNode() {
-				const editableNodes = node.querySelectorAll(
-					'[contenteditable="true"]'
-				);
-				const lastEditableNode =
-					editableNodes[ editableNodes.length - 1 ];
-				return lastEditableNode === ownerDocument.activeElement;
-			}
-
-			// When the user scrolls or resizes, the scroll position should be
-			// reset.
-			defaultView.addEventListener( 'scroll', onScrollResize, true );
-			defaultView.addEventListener( 'resize', onScrollResize, true );
-
-			node.addEventListener( 'keydown', onKeyDown );
-			node.addEventListener( 'keyup', maintainCaretPosition );
-			node.addEventListener( 'mousedown', addSelectionChangeListener );
-			node.addEventListener( 'touchstart', addSelectionChangeListener );
-
-			return () => {
-				defaultView.removeEventListener(
-					'scroll',
-					onScrollResize,
-					true
-				);
-				defaultView.removeEventListener(
-					'resize',
-					onScrollResize,
-					true
-				);
-
-				node.removeEventListener( 'keydown', onKeyDown );
-				node.removeEventListener( 'keyup', maintainCaretPosition );
-				node.removeEventListener(
-					'mousedown',
-					addSelectionChangeListener
-				);
-				node.removeEventListener(
-					'touchstart',
-					addSelectionChangeListener
-				);
-
-				ownerDocument.removeEventListener(
-					'selectionchange',
-					computeCaretRectOnSelectionChange
-				);
-
-				defaultView.cancelAnimationFrame( scrollResizeRafId );
+		function onKeyDown( event ) {
+			// Ensure the any remaining request is cancelled.
+			if ( onKeyDownRafId ) {
 				defaultView.cancelAnimationFrame( onKeyDownRafId );
-			};
-		},
-		[ hasSelectedBlock ]
-	);
+			}
+
+			// Use an animation frame for a smooth result.
+			onKeyDownRafId = defaultView.requestAnimationFrame( () => {
+				maintainCaretPosition( event );
+				onKeyDownRafId = null;
+			} );
+		}
+
+		/**
+		 * Maintains the scroll position after a selection change caused by a
+		 * keyboard event.
+		 *
+		 * @param {KeyboardEvent} event Keyboard event.
+		 */
+		function maintainCaretPosition( { keyCode } ) {
+			if ( ! isSelectionEligibleForScroll() ) {
+				return;
+			}
+
+			const currentCaretRect = computeCaretRect( defaultView );
+
+			if ( ! currentCaretRect ) {
+				return;
+			}
+
+			// If for some reason there is no position set to be scrolled to, let
+			// this be the position to be scrolled to in the future.
+			if ( ! caretRect ) {
+				caretRect = currentCaretRect;
+				return;
+			}
+
+			// Even though enabling the typewriter effect for arrow keys results in
+			// a pleasant experience, it may not be the case for everyone, so, for
+			// now, let's disable it.
+			if ( arrowKeyCodes.has( keyCode ) ) {
+				// Reset the caret position to maintain.
+				caretRect = currentCaretRect;
+				return;
+			}
+
+			const diff = currentCaretRect.top - caretRect.top;
+
+			if ( diff === 0 ) {
+				return;
+			}
+
+			const scrollContainer = getScrollContainer( node );
+
+			// The page must be scrollable.
+			if ( ! scrollContainer ) {
+				return;
+			}
+
+			const windowScroll = scrollContainer === ownerDocument.body;
+			const scrollY = windowScroll
+				? defaultView.scrollY
+				: scrollContainer.scrollTop;
+			const scrollContainerY = windowScroll
+				? 0
+				: scrollContainer.getBoundingClientRect().top;
+			const relativeScrollPosition = windowScroll
+				? caretRect.top / defaultView.innerHeight
+				: ( caretRect.top - scrollContainerY ) /
+				  ( defaultView.innerHeight - scrollContainerY );
+
+			// If the scroll position is at the start, the active editable element
+			// is the last one, and the caret is positioned within the initial
+			// trigger percentage of the page, do not scroll the page.
+			// The typewriter effect should not kick in until an empty page has been
+			// filled with the initial trigger percentage or the user scrolls
+			// intentionally down.
+			if (
+				scrollY === 0 &&
+				relativeScrollPosition < initialTriggerPercentage &&
+				isLastEditableNode()
+			) {
+				// Reset the caret position to maintain.
+				caretRect = currentCaretRect;
+				return;
+			}
+
+			const scrollContainerHeight = windowScroll
+				? defaultView.innerHeight
+				: scrollContainer.clientHeight;
+
+			// Abort if the target scroll position would scroll the caret out of
+			// view.
+			if (
+				// The caret is under the lower fold.
+				caretRect.top + caretRect.height >
+					scrollContainerY + scrollContainerHeight ||
+				// The caret is above the upper fold.
+				caretRect.top < scrollContainerY
+			) {
+				// Reset the caret position to maintain.
+				caretRect = currentCaretRect;
+				return;
+			}
+
+			if ( windowScroll ) {
+				defaultView.scrollBy( 0, diff );
+			} else {
+				scrollContainer.scrollTop += diff;
+			}
+		}
+
+		/**
+		 * Adds a `selectionchange` listener to reset the scroll position to be
+		 * maintained.
+		 */
+		function addSelectionChangeListener() {
+			ownerDocument.addEventListener(
+				'selectionchange',
+				computeCaretRectOnSelectionChange
+			);
+		}
+
+		/**
+		 * Resets the scroll position to be maintained during a `selectionchange`
+		 * event. Also removes the listener, so it acts as a one-time listener.
+		 */
+		function computeCaretRectOnSelectionChange() {
+			ownerDocument.removeEventListener(
+				'selectionchange',
+				computeCaretRectOnSelectionChange
+			);
+			computeCaretRectangle();
+		}
+
+		/**
+		 * Resets the scroll position to be maintained.
+		 */
+		function computeCaretRectangle() {
+			if ( isSelectionEligibleForScroll() ) {
+				caretRect = computeCaretRect( defaultView );
+			}
+		}
+
+		/**
+		 * Checks if the current situation is elegible for scroll:
+		 * - There should be one and only one block selected.
+		 * - The component must contain the selection.
+		 * - The active element must be contenteditable.
+		 */
+		function isSelectionEligibleForScroll() {
+			return (
+				node.contains( ownerDocument.activeElement ) &&
+				ownerDocument.activeElement.isContentEditable
+			);
+		}
+
+		function isLastEditableNode() {
+			const editableNodes = node.querySelectorAll(
+				'[contenteditable="true"]'
+			);
+			const lastEditableNode = editableNodes[ editableNodes.length - 1 ];
+			return lastEditableNode === ownerDocument.activeElement;
+		}
+
+		// When the user scrolls or resizes, the scroll position should be
+		// reset.
+		defaultView.addEventListener( 'scroll', onScrollResize, true );
+		defaultView.addEventListener( 'resize', onScrollResize, true );
+
+		node.addEventListener( 'keydown', onKeyDown );
+		node.addEventListener( 'keyup', maintainCaretPosition );
+		node.addEventListener( 'mousedown', addSelectionChangeListener );
+		node.addEventListener( 'touchstart', addSelectionChangeListener );
+
+		return () => {
+			defaultView.removeEventListener( 'scroll', onScrollResize, true );
+			defaultView.removeEventListener( 'resize', onScrollResize, true );
+
+			node.removeEventListener( 'keydown', onKeyDown );
+			node.removeEventListener( 'keyup', maintainCaretPosition );
+			node.removeEventListener( 'mousedown', addSelectionChangeListener );
+			node.removeEventListener(
+				'touchstart',
+				addSelectionChangeListener
+			);
+
+			ownerDocument.removeEventListener(
+				'selectionchange',
+				computeCaretRectOnSelectionChange
+			);
+
+			defaultView.cancelAnimationFrame( scrollResizeRafId );
+			defaultView.cancelAnimationFrame( onKeyDownRafId );
+		};
+	}, [] );
 }
 
 function Typewriter( { children } ) {

--- a/packages/e2e-tests/specs/editor/various/typewriter.test.js
+++ b/packages/e2e-tests/specs/editor/various/typewriter.test.js
@@ -130,7 +130,6 @@ describe( 'TypeWriter', () => {
 				wp.dom.getScrollContainer( document.activeElement ).scrollTop >
 				2
 		);
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		expect( await getDiff( initialPosition ) ).toBe( 0 );
 	} );
 

--- a/packages/e2e-tests/specs/editor/various/typewriter.test.js
+++ b/packages/e2e-tests/specs/editor/various/typewriter.test.js
@@ -130,6 +130,7 @@ describe( 'TypeWriter', () => {
 				wp.dom.getScrollContainer( document.activeElement ).scrollTop >
 				2
 		);
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		expect( await getDiff( initialPosition ) ).toBe( 0 );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
