### PR TITLE
Try: Obscure edit-ability of post content blocks in the template editor

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -73,3 +73,41 @@
 		color: $gray-100;
 	}
 }
+
+
+// Begin proof of concept
+.is-template-mode {
+	// Hide editability of all blocks inside the Post Content block
+	.wp-block-post-content {
+		> * {
+			pointer-events: none;
+		}
+	}
+
+	// Hide inline inserters
+	.popover-slot {
+		.block-editor-block-list__insertion-point {
+			display: none !important;
+		}
+	}
+
+	// Hide editability of text based post blocks
+	.wp-block-post-title,
+	.wp-block-post-author,
+	.wp-block-post-date,
+	.wp-block-post-hierarchical-terms,
+	.wp-block-post-tags,
+	.wp-block-post-comments,
+	.wp-block-post-comments-link,
+	.wp-block-post-excerpt {
+		cursor: default !important;
+		caret-color: transparent;
+	}
+
+	// Disable featured image uploading
+	.wp-block-post-featured-image {
+		.components-placeholder__fieldset {
+			display: none;
+		}
+	}
+}

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -102,6 +102,10 @@
 	.wp-block-post-excerpt {
 		cursor: default !important;
 		caret-color: transparent;
+
+		&::selection {
+			background: transparent;
+		}
 	}
 
 	// Disable featured image uploading

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -82,6 +82,14 @@
 		> * {
 			pointer-events: none;
 		}
+
+		&.is-selected,
+		&.is-hovered {
+			&::after {
+				background: rgba(#007cba, 0.2);
+				z-index: 1;
+			}
+		}
 	}
 
 	// Hide inline inserters
@@ -105,6 +113,14 @@
 
 		&::selection {
 			background: transparent;
+		}
+
+		&.is-selected,
+		&.is-hovered {
+			&::after {
+				background: rgba(#007cba, 0.2);
+				z-index: 1;
+			}
 		}
 	}
 


### PR DESCRIPTION
Upon engaging the template editor, it is possible to continue editing the post content. This experience can be a bit overwhelming, and blurs the lines between post editing and template editing.

In this (incredibly hacky) PR I am obscuring the edit-ability of blocks like the Post Title, Post Content etc with some CSS. The purpose is to serve as a proof of concept that explores how it feels to make these blocks semi-inert in the template editing context.

https://user-images.githubusercontent.com/846565/117006206-0fa42700-ace0-11eb-97bc-f7a5d3be337c.mp4

To test:

* Open a post / page
* Click the "Edit" or "New" link in the template panel
* See how interactions with blocks like Post Title and Post Content feel

cc @jasmussen 