### PR TITLE
[Mobile] - Bottom Sheet - Move back icon to component folder

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/chevron-back.native.js
+++ b/packages/components/src/mobile/bottom-sheet/chevron-back.native.js
@@ -3,7 +3,8 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const chevronBackIOS = (
+// Used for the back button of the iOS Bottom Sheet
+const chevronBack = (
 	<SVG
 		width="12"
 		height="21"
@@ -14,4 +15,4 @@ const chevronBackIOS = (
 	</SVG>
 );
 
-export default chevronBackIOS;
+export default chevronBack;

--- a/packages/components/src/mobile/bottom-sheet/navigation-header.native.js
+++ b/packages/components/src/mobile/bottom-sheet/navigation-header.native.js
@@ -7,19 +7,14 @@ import { View, TouchableWithoutFeedback, Text, Platform } from 'react-native';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	check,
-	Icon,
-	chevronBackIOS,
-	arrowLeft,
-	close,
-} from '@wordpress/icons';
+import { check, Icon, arrowLeft, close } from '@wordpress/icons';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import styles from './styles.scss';
+import chevronBack from './chevron-back';
 
 function BottomSheetNavigationHeader( {
 	leftButtonOnPress,
@@ -57,7 +52,7 @@ function BottomSheetNavigationHeader( {
 		if ( isIOS ) {
 			backIcon = isFullscreen ? undefined : (
 				<Icon
-					icon={ chevronBackIOS }
+					icon={ chevronBack }
 					size={ 21 }
 					style={ chevronLeftStyle }
 				/>

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -30,7 +30,6 @@ export { default as category } from './library/category';
 export { default as chartBar } from './library/chart-bar';
 export { default as chartLine } from './library/chart-line';
 export { default as check } from './library/check';
-export { default as chevronBackIOS } from './library/chevron-back-ios';
 export { default as chevronDown } from './library/chevron-down';
 export { default as chevronLeft } from './library/chevron-left';
 export { default as chevronRight } from './library/chevron-right';


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3456

## Description
Moves the back button (chevronBackiOS) used in the Bottom Sheet from the icons library to the component's folder. Since this icon is only being used on mobile and only for iOS.

## How has this been tested?

### Test case 1 (Mobile)

- Open the app with metro running (on iOS)
- Add a `Buttons` block
- Open the blocks settings
- Go to Background color setting
- Expect to see the back icon.

### Test case 2 (Storybook)

- Build storybook by running `npm run storybook:build`
- Start Storybook `npm run storybook:dev` 
- Go to the icon's library section `http://localhost:50240/?path=/story/icons-icon--library`
- Expect **not to see** the icon listed.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
Move icon to another folder

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
