### PR TITLE
Docgen: split `getIntermediateRepresentation` unit tests in smaller tests

### DIFF
--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -168,99 +168,109 @@ describe( 'Intermediate Representation', () => {
 				} );
 			} );
 		} );
-
-		it( 'named export', () => {
-			const tokenClass = fs.readFileSync(
-				path.join( __dirname, './fixtures/named-class/exports.json' ),
-				'utf-8'
-			);
-			const irNamedClass = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenClass )
-			);
-			expect( irNamedClass ).toHaveLength( 1 );
-			expect( irNamedClass[ 0 ] ).toEqual( {
-				path: null,
-				name: 'MyDeclaration',
-				description: 'My declaration example.',
-				tags: [
-					{
-						tag: 'type',
-						type: 'MyDeclaration',
-						name: '',
-						description: '',
-					},
-				],
-				lineStart: 4,
-				lineEnd: 4,
+		describe( 'named export', () => {
+			it( 'named class', () => {
+				const tokenClass = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-class/exports.json'
+					),
+					'utf-8'
+				);
+				const irNamedClass = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenClass )
+				);
+				expect( irNamedClass ).toHaveLength( 1 );
+				expect( irNamedClass[ 0 ] ).toEqual( {
+					path: null,
+					name: 'MyDeclaration',
+					description: 'My declaration example.',
+					tags: [
+						{
+							tag: 'type',
+							type: 'MyDeclaration',
+							name: '',
+							description: '',
+						},
+					],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
-			const tokenFn = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-function/exports.json'
-				),
-				'utf-8'
-			);
-			const irNamedFn = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenFn )
-			);
-			expect( irNamedFn ).toHaveLength( 1 );
-			expect( irNamedFn[ 0 ] ).toEqual( {
-				path: null,
-				name: 'myDeclaration',
-				description: 'My declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+			it( 'named function', () => {
+				const tokenFn = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-function/exports.json'
+					),
+					'utf-8'
+				);
+				const irNamedFn = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenFn )
+				);
+				expect( irNamedFn ).toHaveLength( 1 );
+				expect( irNamedFn[ 0 ] ).toEqual( {
+					path: null,
+					name: 'myDeclaration',
+					description: 'My declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
-			const tokenVariable = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-variable/exports.json'
-				),
-				'utf-8'
-			);
-			const irNamedVar = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenVariable )
-			);
-			expect( irNamedVar ).toHaveLength( 1 );
-			expect( irNamedVar[ 0 ] ).toEqual( {
-				path: null,
-				name: 'myDeclaration',
-				description: 'My declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+			it( 'named variable', () => {
+				const tokenVariable = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-variable/exports.json'
+					),
+					'utf-8'
+				);
+				const irNamedVar = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenVariable )
+				);
+				expect( irNamedVar ).toHaveLength( 1 );
+				expect( irNamedVar[ 0 ] ).toEqual( {
+					path: null,
+					name: 'myDeclaration',
+					description: 'My declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
-			const tokenVariables = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-variables/exports.json'
-				),
-				'utf-8'
-			);
-			const irNamedVars = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenVariables )
-			);
-			expect( irNamedVars ).toHaveLength( 2 );
-			expect( irNamedVars[ 0 ] ).toEqual( {
-				path: null,
-				name: 'firstDeclaration',
-				description: 'My declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 5,
-			} );
-			expect( irNamedVars[ 1 ] ).toEqual( {
-				path: null,
-				name: 'secondDeclaration',
-				description: 'My declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 5,
+			it( 'named variables', () => {
+				const tokenVariables = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-variables/exports.json'
+					),
+					'utf-8'
+				);
+				const irNamedVars = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenVariables )
+				);
+				expect( irNamedVars ).toHaveLength( 2 );
+				expect( irNamedVars[ 0 ] ).toEqual( {
+					path: null,
+					name: 'firstDeclaration',
+					description: 'My declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 5,
+				} );
+				expect( irNamedVars[ 1 ] ).toEqual( {
+					path: null,
+					name: 'secondDeclaration',
+					description: 'My declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 5,
+				} );
 			} );
 		} );
 	} );

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -359,163 +359,177 @@ describe( 'Intermediate Representation', () => {
 			} );
 		} );
 
-		it( 'named export', () => {
-			const token = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-identifier/exports.json'
-				),
-				'utf-8'
-			);
-			const ast = fs.readFileSync(
-				path.join( __dirname, './fixtures/named-identifier/ast.json' ),
-				'utf-8'
-			);
-			const irNamedId = getIntermediateRepresentation(
-				null,
-				JSON.parse( token ),
-				JSON.parse( ast )
-			);
-			expect( irNamedId ).toHaveLength( 1 );
-			expect( irNamedId[ 0 ] ).toEqual( {
-				path: null,
-				name: 'myDeclaration',
-				description: 'My declaration example.',
-				tags: [],
-				lineStart: 6,
-				lineEnd: 6,
+		describe( 'named export', () => {
+			it( 'named identifier', () => {
+				const token = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-identifier/exports.json'
+					),
+					'utf-8'
+				);
+				const ast = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-identifier/ast.json'
+					),
+					'utf-8'
+				);
+				const irNamedId = getIntermediateRepresentation(
+					null,
+					JSON.parse( token ),
+					JSON.parse( ast )
+				);
+				expect( irNamedId ).toHaveLength( 1 );
+				expect( irNamedId[ 0 ] ).toEqual( {
+					path: null,
+					name: 'myDeclaration',
+					description: 'My declaration example.',
+					tags: [],
+					lineStart: 6,
+					lineEnd: 6,
+				} );
 			} );
-			const tokenObject = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-identifier-destructuring/exports.json'
-				),
-				'utf-8'
-			);
-			const astObject = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-identifier-destructuring/ast.json'
-				),
-				'utf-8'
-			);
-			const irNamedIdDestructuring = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenObject ),
-				JSON.parse( astObject )
-			);
-			expect( irNamedIdDestructuring ).toHaveLength( 1 );
-			expect( irNamedIdDestructuring[ 0 ] ).toEqual( {
-				path: null,
-				name: 'myDeclaration',
-				description: 'My declaration example.',
-				tags: [],
-				lineStart: 6,
-				lineEnd: 6,
+			it( 'named identifier with destructuring', () => {
+				const tokenObject = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-identifier-destructuring/exports.json'
+					),
+					'utf-8'
+				);
+				const astObject = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-identifier-destructuring/ast.json'
+					),
+					'utf-8'
+				);
+				const irNamedIdDestructuring = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenObject ),
+					JSON.parse( astObject )
+				);
+				expect( irNamedIdDestructuring ).toHaveLength( 1 );
+				expect( irNamedIdDestructuring[ 0 ] ).toEqual( {
+					path: null,
+					name: 'myDeclaration',
+					description: 'My declaration example.',
+					tags: [],
+					lineStart: 6,
+					lineEnd: 6,
+				} );
 			} );
-			const tokens = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-identifiers/exports.json'
-				),
-				'utf-8'
-			);
-			const asts = fs.readFileSync(
-				path.join( __dirname, './fixtures/named-identifiers/ast.json' ),
-				'utf-8'
-			);
-			const irIds = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokens ),
-				JSON.parse( asts )
-			);
-			expect( irIds ).toHaveLength( 3 );
-			expect( irIds[ 0 ] ).toEqual( {
-				path: null,
-				name: 'functionDeclaration',
-				description: 'Function declaration example.',
-				tags: [],
-				lineStart: 16,
-				lineEnd: 16,
+			it( 'named identifiers', () => {
+				const tokens = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-identifiers/exports.json'
+					),
+					'utf-8'
+				);
+				const asts = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-identifiers/ast.json'
+					),
+					'utf-8'
+				);
+				const irIds = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokens ),
+					JSON.parse( asts )
+				);
+				expect( irIds ).toHaveLength( 3 );
+				expect( irIds[ 0 ] ).toEqual( {
+					path: null,
+					name: 'functionDeclaration',
+					description: 'Function declaration example.',
+					tags: [],
+					lineStart: 16,
+					lineEnd: 16,
+				} );
+				expect( irIds[ 1 ] ).toEqual( {
+					path: null,
+					name: 'variableDeclaration',
+					description: 'Variable declaration example.',
+					tags: [],
+					lineStart: 16,
+					lineEnd: 16,
+				} );
+				expect( irIds[ 2 ] ).toEqual( {
+					path: null,
+					name: 'ClassDeclaration',
+					description: 'Class declaration example.',
+					tags: [
+						{
+							tag: 'type',
+							type: 'ClassDeclaration',
+							name: '',
+							description: '',
+						},
+					],
+					lineStart: 16,
+					lineEnd: 16,
+				} );
 			} );
-			expect( irIds[ 1 ] ).toEqual( {
-				path: null,
-				name: 'variableDeclaration',
-				description: 'Variable declaration example.',
-				tags: [],
-				lineStart: 16,
-				lineEnd: 16,
-			} );
-			expect( irIds[ 2 ] ).toEqual( {
-				path: null,
-				name: 'ClassDeclaration',
-				description: 'Class declaration example.',
-				tags: [
-					{
-						tag: 'type',
-						type: 'ClassDeclaration',
-						name: '',
-						description: '',
-					},
-				],
-				lineStart: 16,
-				lineEnd: 16,
-			} );
-			const foo = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-identifiers-and-inline/exports.json'
-				),
-				'utf-8'
-			);
-			const bar = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-identifiers-and-inline/ast.json'
-				),
-				'utf-8'
-			);
-			const irIdInline0 = getIntermediateRepresentation(
-				null,
-				JSON.parse( foo )[ 0 ],
-				JSON.parse( bar )
-			);
-			expect( irIdInline0 ).toHaveLength( 2 );
-			expect( irIdInline0[ 0 ] ).toEqual( {
-				path: null,
-				name: 'functionDeclaration',
-				description: 'Function declaration example.',
-				tags: [],
-				lineStart: 11,
-				lineEnd: 11,
-			} );
-			expect( irIdInline0[ 1 ] ).toEqual( {
-				path: null,
-				name: 'ClassDeclaration',
-				description: 'Class declaration example.',
-				tags: [
-					{
-						tag: 'type',
-						type: 'ClassDeclaration',
-						name: '',
-						description: '',
-					},
-				],
-				lineStart: 11,
-				lineEnd: 11,
-			} );
-			const irIdInline1 = getIntermediateRepresentation(
-				null,
-				JSON.parse( foo )[ 1 ],
-				JSON.parse( bar )
-			);
-			expect( irIdInline1[ 0 ] ).toEqual( {
-				path: null,
-				name: 'variableDeclaration',
-				description: 'Variable declaration example.',
-				tags: [],
-				lineStart: 16,
-				lineEnd: 16,
+			it( 'named identifiers and inline', () => {
+				const foo = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-identifiers-and-inline/exports.json'
+					),
+					'utf-8'
+				);
+				const bar = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-identifiers-and-inline/ast.json'
+					),
+					'utf-8'
+				);
+				const irIdInline0 = getIntermediateRepresentation(
+					null,
+					JSON.parse( foo )[ 0 ],
+					JSON.parse( bar )
+				);
+				expect( irIdInline0 ).toHaveLength( 2 );
+				expect( irIdInline0[ 0 ] ).toEqual( {
+					path: null,
+					name: 'functionDeclaration',
+					description: 'Function declaration example.',
+					tags: [],
+					lineStart: 11,
+					lineEnd: 11,
+				} );
+				expect( irIdInline0[ 1 ] ).toEqual( {
+					path: null,
+					name: 'ClassDeclaration',
+					description: 'Class declaration example.',
+					tags: [
+						{
+							tag: 'type',
+							type: 'ClassDeclaration',
+							name: '',
+							description: '',
+						},
+					],
+					lineStart: 11,
+					lineEnd: 11,
+				} );
+				const irIdInline1 = getIntermediateRepresentation(
+					null,
+					JSON.parse( foo )[ 1 ],
+					JSON.parse( bar )
+				);
+				expect( irIdInline1[ 0 ] ).toEqual( {
+					path: null,
+					name: 'variableDeclaration',
+					description: 'Variable declaration example.',
+					tags: [],
+					lineStart: 16,
+					lineEnd: 16,
+				} );
 			} );
 		} );
 	} );

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -586,11 +586,7 @@ describe( 'Intermediate Representation', () => {
 			} );
 		} );
 
-		it( 'named default export', () => {
-			const tokenDefault = fs.readFileSync(
-				path.join( __dirname, './fixtures/named-default/exports.json' ),
-				'utf-8'
-			);
+		describe( 'named default export', () => {
 			const getModule = () =>
 				JSON.parse(
 					fs.readFileSync(
@@ -601,42 +597,53 @@ describe( 'Intermediate Representation', () => {
 						'utf-8'
 					)
 				);
-			const irNamedDefault = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenDefault ),
-				{ body: [] },
-				getModule
-			);
-			expect( irNamedDefault ).toHaveLength( 1 );
-			expect( irNamedDefault[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Module declaration.',
-				tags: [],
-				lineStart: 1,
-				lineEnd: 1,
+			it( 'default', () => {
+				const tokenDefault = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-default/exports.json'
+					),
+					'utf-8'
+				);
+				const irNamedDefault = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenDefault ),
+					{ body: [] },
+					getModule
+				);
+				expect( irNamedDefault ).toHaveLength( 1 );
+				expect( irNamedDefault[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Module declaration.',
+					tags: [],
+					lineStart: 1,
+					lineEnd: 1,
+				} );
 			} );
-			const tokenDefaultExported = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-default-exported/exports.json'
-				),
-				'utf-8'
-			);
-			const irNamedDefaultExported = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenDefaultExported ),
-				{ body: [] },
-				getModule
-			);
-			expect( irNamedDefaultExported ).toHaveLength( 1 );
-			expect( irNamedDefaultExported[ 0 ] ).toEqual( {
-				path: null,
-				name: 'moduleName',
-				description: 'Module declaration.',
-				tags: [],
-				lineStart: 1,
-				lineEnd: 1,
+			it( 'renamed', () => {
+				const tokenDefaultExported = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-default-exported/exports.json'
+					),
+					'utf-8'
+				);
+				const irNamedDefaultExported = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenDefaultExported ),
+					{ body: [] },
+					getModule
+				);
+				expect( irNamedDefaultExported ).toHaveLength( 1 );
+				expect( irNamedDefaultExported[ 0 ] ).toEqual( {
+					path: null,
+					name: 'moduleName',
+					description: 'Module declaration.',
+					tags: [],
+					lineStart: 1,
+					lineEnd: 1,
+				} );
 			} );
 		} );
 

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -276,82 +276,86 @@ describe( 'Intermediate Representation', () => {
 	} );
 
 	describe( 'JSDoc in same file', () => {
-		it( 'default export', () => {
-			const token = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-identifier/exports.json'
-				),
-				'utf-8'
-			);
-			const ast = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-identifier/ast.json'
-				),
-				'utf-8'
-			);
-			const irDefaultId = getIntermediateRepresentation(
-				null,
-				JSON.parse( token ),
-				JSON.parse( ast )
-			);
-			expect( irDefaultId ).toHaveLength( 1 );
-			expect( irDefaultId[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Class declaration example.',
-				tags: [
-					{
-						tag: 'type',
-						type: 'ClassDeclaration',
-						name: '',
-						description: '',
-					},
-				],
-				lineStart: 6,
-				lineEnd: 6,
+		describe( 'default export', () => {
+			it( 'named class', () => {
+				const token = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-identifier/exports.json'
+					),
+					'utf-8'
+				);
+				const ast = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-identifier/ast.json'
+					),
+					'utf-8'
+				);
+				const irDefaultId = getIntermediateRepresentation(
+					null,
+					JSON.parse( token ),
+					JSON.parse( ast )
+				);
+				expect( irDefaultId ).toHaveLength( 1 );
+				expect( irDefaultId[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Class declaration example.',
+					tags: [
+						{
+							tag: 'type',
+							type: 'ClassDeclaration',
+							name: '',
+							description: '',
+						},
+					],
+					lineStart: 6,
+					lineEnd: 6,
+				} );
 			} );
-			const namedExport = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-named-export/exports.json'
-				),
-				'utf-8'
-			);
-			const namedExportAST = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-named-export/ast.json'
-				),
-				'utf-8'
-			);
-			const irDefaultNamed0 = getIntermediateRepresentation(
-				null,
-				JSON.parse( namedExport )[ 0 ],
-				JSON.parse( namedExportAST )
-			);
-			expect( irDefaultNamed0 ).toHaveLength( 1 );
-			expect( irDefaultNamed0[ 0 ] ).toEqual( {
-				path: null,
-				name: 'functionDeclaration',
-				description: 'Function declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
-			} );
-			const irDefaultNamed1 = getIntermediateRepresentation(
-				null,
-				JSON.parse( namedExport )[ 1 ],
-				JSON.parse( namedExportAST )
-			);
-			expect( irDefaultNamed1[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Function declaration example.',
-				tags: [],
-				lineStart: 6,
-				lineEnd: 6,
+			it( 'named function', () => {
+				const namedExport = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-named-export/exports.json'
+					),
+					'utf-8'
+				);
+				const namedExportAST = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-named-export/ast.json'
+					),
+					'utf-8'
+				);
+				const irDefaultNamed0 = getIntermediateRepresentation(
+					null,
+					JSON.parse( namedExport )[ 0 ],
+					JSON.parse( namedExportAST )
+				);
+				expect( irDefaultNamed0 ).toHaveLength( 1 );
+				expect( irDefaultNamed0[ 0 ] ).toEqual( {
+					path: null,
+					name: 'functionDeclaration',
+					description: 'Function declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
+				const irDefaultNamed1 = getIntermediateRepresentation(
+					null,
+					JSON.parse( namedExport )[ 1 ],
+					JSON.parse( namedExportAST )
+				);
+				expect( irDefaultNamed1[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Function declaration example.',
+					tags: [],
+					lineStart: 6,
+					lineEnd: 6,
+				} );
 			} );
 		} );
 

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -58,104 +58,114 @@ describe( 'Intermediate Representation', () => {
 	} );
 
 	describe( 'JSDoc in export statement', () => {
-		it( 'default export', () => {
-			const tokenClassAnonymous = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-class-anonymous/exports.json'
-				),
-				'utf-8'
-			);
-			const irClassAnonymous = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenClassAnonymous )
-			);
-			expect( irClassAnonymous ).toHaveLength( 1 );
-			expect( irClassAnonymous[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Class declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+		describe( 'default export', () => {
+			it( 'anonymous class', () => {
+				const tokenClassAnonymous = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-class-anonymous/exports.json'
+					),
+					'utf-8'
+				);
+				const irClassAnonymous = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenClassAnonymous )
+				);
+				expect( irClassAnonymous ).toHaveLength( 1 );
+				expect( irClassAnonymous[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Class declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
-			const tokenClassNamed = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-class-named/exports.json'
-				),
-				'utf-8'
-			);
-			const irClassNamed = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenClassNamed )
-			);
-			expect( irClassNamed ).toHaveLength( 1 );
-			expect( irClassNamed[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Class declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+			it( 'named class', () => {
+				const tokenClassNamed = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-class-named/exports.json'
+					),
+					'utf-8'
+				);
+				const irClassNamed = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenClassNamed )
+				);
+				expect( irClassNamed ).toHaveLength( 1 );
+				expect( irClassNamed[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Class declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
-			const tokenFnAnonymous = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-function-anonymous/exports.json'
-				),
-				'utf-8'
-			);
-			const irFnAnonymous = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenFnAnonymous )
-			);
-			expect( irFnAnonymous ).toHaveLength( 1 );
-			expect( irFnAnonymous[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Function declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+			it( 'anonymous function', () => {
+				const tokenFnAnonymous = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-function-anonymous/exports.json'
+					),
+					'utf-8'
+				);
+				const irFnAnonymous = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenFnAnonymous )
+				);
+				expect( irFnAnonymous ).toHaveLength( 1 );
+				expect( irFnAnonymous[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Function declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
-			const tokenFnNamed = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-function-named/exports.json'
-				),
-				'utf-8'
-			);
-			const irFnNamed = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenFnNamed )
-			);
-			expect( irFnNamed[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Function declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+			it( 'named function', () => {
+				const tokenFnNamed = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-function-named/exports.json'
+					),
+					'utf-8'
+				);
+				const irFnNamed = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenFnNamed )
+				);
+				expect( irFnNamed[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Function declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
-			const tokenVariable = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-variable/exports.json'
-				),
-				'utf-8'
-			);
-			const irVar = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenVariable )
-			);
-			expect( irVar[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Variable declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+			it( 'variable', () => {
+				const tokenVariable = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-variable/exports.json'
+					),
+					'utf-8'
+				);
+				const irVar = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenVariable )
+				);
+				expect( irVar[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Variable declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
 		} );
 

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -535,54 +535,56 @@ describe( 'Intermediate Representation', () => {
 	} );
 
 	describe( 'JSDoc in module dependency', () => {
-		it( 'named export', () => {
-			const tokenImportNamed = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-import-named/exports.json'
-				),
-				'utf-8'
-			);
-			const getModuleImportNamed = () =>
-				JSON.parse(
-					fs.readFileSync(
-						path.join(
-							__dirname,
-							'./fixtures/named-identifiers/ir.json'
-						),
-						'utf-8'
-					)
+		describe( 'named export', () => {
+			it( 'named import', () => {
+				const tokenImportNamed = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-import-named/exports.json'
+					),
+					'utf-8'
 				);
-			const ir = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenImportNamed ),
-				{ body: [] },
-				getModuleImportNamed
-			);
-			expect( ir ).toHaveLength( 3 );
-			expect( ir[ 0 ] ).toEqual( {
-				path: null,
-				name: 'functionDeclaration',
-				description: 'Function declaration example.',
-				tags: [],
-				lineStart: 2,
-				lineEnd: 2,
-			} );
-			expect( ir[ 1 ] ).toEqual( {
-				path: null,
-				name: 'variableDeclaration',
-				description: 'Variable declaration example.',
-				tags: [],
-				lineStart: 3,
-				lineEnd: 3,
-			} );
-			expect( ir[ 2 ] ).toEqual( {
-				path: null,
-				name: 'ClassDeclaration',
-				description: 'Class declaration example.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+				const getModuleImportNamed = () =>
+					JSON.parse(
+						fs.readFileSync(
+							path.join(
+								__dirname,
+								'./fixtures/named-identifiers/ir.json'
+							),
+							'utf-8'
+						)
+					);
+				const ir = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenImportNamed ),
+					{ body: [] },
+					getModuleImportNamed
+				);
+				expect( ir ).toHaveLength( 3 );
+				expect( ir[ 0 ] ).toEqual( {
+					path: null,
+					name: 'functionDeclaration',
+					description: 'Function declaration example.',
+					tags: [],
+					lineStart: 2,
+					lineEnd: 2,
+				} );
+				expect( ir[ 1 ] ).toEqual( {
+					path: null,
+					name: 'variableDeclaration',
+					description: 'Variable declaration example.',
+					tags: [],
+					lineStart: 3,
+					lineEnd: 3,
+				} );
+				expect( ir[ 2 ] ).toEqual( {
+					path: null,
+					name: 'ClassDeclaration',
+					description: 'Class declaration example.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
 		} );
 

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -739,84 +739,88 @@ describe( 'Intermediate Representation', () => {
 	} );
 
 	describe( 'JSDoc in module dependency through import', () => {
-		it( 'default export', () => {
-			const tokenDefault = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-import-default/exports.json'
-				),
-				'utf-8'
-			);
-			const astDefault = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-import-default/ast.json'
-				),
-				'utf-8'
-			);
-			const getModuleDefault = () =>
-				JSON.parse(
-					fs.readFileSync(
-						path.join(
-							__dirname,
-							'./fixtures/default-import-default/module-ir.json'
-						),
-						'utf-8'
-					)
+		describe( 'default export', () => {
+			it( 'default import', () => {
+				const tokenDefault = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-import-default/exports.json'
+					),
+					'utf-8'
 				);
-			const irDefault = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenDefault ),
-				JSON.parse( astDefault ),
-				getModuleDefault
-			);
-			expect( irDefault ).toHaveLength( 1 );
-			expect( irDefault[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Function declaration.',
-				tags: [],
-				lineStart: 3,
-				lineEnd: 3,
+				const astDefault = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-import-default/ast.json'
+					),
+					'utf-8'
+				);
+				const getModuleDefault = () =>
+					JSON.parse(
+						fs.readFileSync(
+							path.join(
+								__dirname,
+								'./fixtures/default-import-default/module-ir.json'
+							),
+							'utf-8'
+						)
+					);
+				const irDefault = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenDefault ),
+					JSON.parse( astDefault ),
+					getModuleDefault
+				);
+				expect( irDefault ).toHaveLength( 1 );
+				expect( irDefault[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Function declaration.',
+					tags: [],
+					lineStart: 3,
+					lineEnd: 3,
+				} );
 			} );
-			const tokenNamed = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-import-named/exports.json'
-				),
-				'utf-8'
-			);
-			const astNamed = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-import-named/ast.json'
-				),
-				'utf-8'
-			);
-			const getModuleNamed = () =>
-				JSON.parse(
-					fs.readFileSync(
-						path.join(
-							__dirname,
-							'./fixtures/default-import-named/module-ir.json'
-						),
-						'utf-8'
-					)
+			it( 'named import', () => {
+				const tokenNamed = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-import-named/exports.json'
+					),
+					'utf-8'
 				);
-			const irNamed = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenNamed ),
-				JSON.parse( astNamed ),
-				getModuleNamed
-			);
-			expect( irNamed ).toHaveLength( 1 );
-			expect( irNamed[ 0 ] ).toEqual( {
-				path: null,
-				name: 'default',
-				description: 'Function declaration.',
-				tags: [],
-				lineStart: 3,
-				lineEnd: 3,
+				const astNamed = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/default-import-named/ast.json'
+					),
+					'utf-8'
+				);
+				const getModuleNamed = () =>
+					JSON.parse(
+						fs.readFileSync(
+							path.join(
+								__dirname,
+								'./fixtures/default-import-named/module-ir.json'
+							),
+							'utf-8'
+						)
+					);
+				const irNamed = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenNamed ),
+					JSON.parse( astNamed ),
+					getModuleNamed
+				);
+				expect( irNamed ).toHaveLength( 1 );
+				expect( irNamed[ 0 ] ).toEqual( {
+					path: null,
+					name: 'default',
+					description: 'Function declaration.',
+					tags: [],
+					lineStart: 3,
+					lineEnd: 3,
+				} );
 			} );
 		} );
 

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -824,57 +824,59 @@ describe( 'Intermediate Representation', () => {
 			} );
 		} );
 
-		it( 'named export', () => {
-			const tokenImportNamespace = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-import-namespace/exports.json'
-				),
-				'utf-8'
-			);
-			const astImportNamespace = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/named-import-namespace/ast.json'
-				),
-				'utf-8'
-			);
-			const getModuleImportNamespace = ( filePath ) => {
-				if ( filePath === './named-import-namespace-module' ) {
+		describe( 'named export', () => {
+			it( 'namespace import', () => {
+				const tokenImportNamespace = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-import-namespace/exports.json'
+					),
+					'utf-8'
+				);
+				const astImportNamespace = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/named-import-namespace/ast.json'
+					),
+					'utf-8'
+				);
+				const getModuleImportNamespace = ( filePath ) => {
+					if ( filePath === './named-import-namespace-module' ) {
+						return JSON.parse(
+							fs.readFileSync(
+								path.join(
+									__dirname,
+									'./fixtures/named-import-namespace/module-ir.json'
+								),
+								'utf-8'
+							)
+						);
+					}
 					return JSON.parse(
 						fs.readFileSync(
 							path.join(
 								__dirname,
-								'./fixtures/named-import-namespace/module-ir.json'
+								'./fixtures/default-function/ir.json'
 							),
 							'utf-8'
 						)
 					);
-				}
-				return JSON.parse(
-					fs.readFileSync(
-						path.join(
-							__dirname,
-							'./fixtures/default-function/ir.json'
-						),
-						'utf-8'
-					)
+				};
+				const ir = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenImportNamespace ),
+					JSON.parse( astImportNamespace ),
+					getModuleImportNamespace
 				);
-			};
-			const ir = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenImportNamespace ),
-				JSON.parse( astImportNamespace ),
-				getModuleImportNamespace
-			);
-			expect( ir ).toHaveLength( 1 );
-			expect( ir[ 0 ] ).toEqual( {
-				path: null,
-				name: 'variables',
-				description: 'Undocumented declaration.',
-				tags: [],
-				lineStart: 3,
-				lineEnd: 3,
+				expect( ir ).toHaveLength( 1 );
+				expect( ir[ 0 ] ).toEqual( {
+					path: null,
+					name: 'variables',
+					description: 'Undocumented declaration.',
+					tags: [],
+					lineStart: 3,
+					lineEnd: 3,
+				} );
 			} );
 		} );
 	} );

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -10,43 +10,50 @@ const path = require( 'path' );
 const getIntermediateRepresentation = require( '../lib/get-intermediate-representation' );
 
 describe( 'Intermediate Representation', () => {
-	it( 'undocumented', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-undocumented-nocomments/exports.json'
-			),
-			'utf-8'
-		);
-		const ir = getIntermediateRepresentation( null, JSON.parse( token ) );
-		expect( ir ).toHaveLength( 1 );
-		expect( ir[ 0 ] ).toEqual( {
-			path: null,
-			name: 'default',
-			description: 'Undocumented declaration.',
-			tags: [],
-			lineStart: 3,
-			lineEnd: 3,
+	describe( 'undocumented code', () => {
+		it( 'default export on multiple lines', () => {
+			const token = fs.readFileSync(
+				path.join(
+					__dirname,
+					'./fixtures/default-undocumented-nocomments/exports.json'
+				),
+				'utf-8'
+			);
+			const ir = getIntermediateRepresentation(
+				null,
+				JSON.parse( token )
+			);
+			expect( ir ).toHaveLength( 1 );
+			expect( ir[ 0 ] ).toEqual( {
+				path: null,
+				name: 'default',
+				description: 'Undocumented declaration.',
+				tags: [],
+				lineStart: 3,
+				lineEnd: 3,
+			} );
 		} );
-		const tokenOneliner = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-undocumented-oneliner/exports.json'
-			),
-			'utf-8'
-		);
-		const irOneliner = getIntermediateRepresentation(
-			null,
-			JSON.parse( tokenOneliner )
-		);
-		expect( irOneliner ).toHaveLength( 1 );
-		expect( irOneliner[ 0 ] ).toEqual( {
-			path: null,
-			name: 'default',
-			description: 'Undocumented declaration.',
-			tags: [],
-			lineStart: 2,
-			lineEnd: 2,
+		it( 'default export on one line', () => {
+			const tokenOneliner = fs.readFileSync(
+				path.join(
+					__dirname,
+					'./fixtures/default-undocumented-oneliner/exports.json'
+				),
+				'utf-8'
+			);
+			const irOneliner = getIntermediateRepresentation(
+				null,
+				JSON.parse( tokenOneliner )
+			);
+			expect( irOneliner ).toHaveLength( 1 );
+			expect( irOneliner[ 0 ] ).toEqual( {
+				path: null,
+				name: 'default',
+				description: 'Undocumented declaration.',
+				tags: [],
+				lineStart: 2,
+				lineEnd: 2,
+			} );
 		} );
 	} );
 

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -647,11 +647,7 @@ describe( 'Intermediate Representation', () => {
 			} );
 		} );
 
-		it( 'namespace export', () => {
-			const token = fs.readFileSync(
-				path.join( __dirname, './fixtures/namespace/exports.json' ),
-				'utf-8'
-			);
+		describe( 'namespace export', () => {
 			const getModule = () =>
 				JSON.parse(
 					fs.readFileSync(
@@ -662,74 +658,82 @@ describe( 'Intermediate Representation', () => {
 						'utf-8'
 					)
 				);
-			const irNamespace = getIntermediateRepresentation(
-				null,
-				JSON.parse( token ),
-				{ body: [] },
-				getModule
-			);
-			expect( irNamespace ).toHaveLength( 3 );
-			expect( irNamespace[ 0 ] ).toEqual( {
-				path: null,
-				name: 'MyClass',
-				description: 'Named class.',
-				tags: [],
-				lineStart: 1,
-				lineEnd: 1,
+			it( 'exports', () => {
+				const token = fs.readFileSync(
+					path.join( __dirname, './fixtures/namespace/exports.json' ),
+					'utf-8'
+				);
+				const irNamespace = getIntermediateRepresentation(
+					null,
+					JSON.parse( token ),
+					{ body: [] },
+					getModule
+				);
+				expect( irNamespace ).toHaveLength( 3 );
+				expect( irNamespace[ 0 ] ).toEqual( {
+					path: null,
+					name: 'MyClass',
+					description: 'Named class.',
+					tags: [],
+					lineStart: 1,
+					lineEnd: 1,
+				} );
+				expect( irNamespace[ 1 ] ).toEqual( {
+					path: null,
+					name: 'myFunction',
+					description: 'Named function.',
+					tags: [],
+					lineStart: 1,
+					lineEnd: 1,
+				} );
+				expect( irNamespace[ 2 ] ).toEqual( {
+					path: null,
+					name: 'myVariable',
+					description: 'Named variable.',
+					tags: [],
+					lineStart: 1,
+					lineEnd: 1,
+				} );
 			} );
-			expect( irNamespace[ 1 ] ).toEqual( {
-				path: null,
-				name: 'myFunction',
-				description: 'Named function.',
-				tags: [],
-				lineStart: 1,
-				lineEnd: 1,
-			} );
-			expect( irNamespace[ 2 ] ).toEqual( {
-				path: null,
-				name: 'myVariable',
-				description: 'Named variable.',
-				tags: [],
-				lineStart: 1,
-				lineEnd: 1,
-			} );
-			const tokenCommented = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/namespace-commented/exports.json'
-				),
-				'utf-8'
-			);
-			const irNamespaceCommented = getIntermediateRepresentation(
-				null,
-				JSON.parse( tokenCommented ),
-				{ body: [] },
-				getModule
-			);
-			expect( irNamespaceCommented ).toHaveLength( 3 );
-			expect( irNamespaceCommented[ 0 ] ).toEqual( {
-				path: null,
-				name: 'MyClass',
-				description: 'Named class.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
-			} );
-			expect( irNamespaceCommented[ 1 ] ).toEqual( {
-				path: null,
-				name: 'myFunction',
-				description: 'Named function.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
-			} );
-			expect( irNamespaceCommented[ 2 ] ).toEqual( {
-				path: null,
-				name: 'myVariable',
-				description: 'Named variable.',
-				tags: [],
-				lineStart: 4,
-				lineEnd: 4,
+			it( 'exports with comment', () => {
+				const tokenCommented = fs.readFileSync(
+					path.join(
+						__dirname,
+						'./fixtures/namespace-commented/exports.json'
+					),
+					'utf-8'
+				);
+				const irNamespaceCommented = getIntermediateRepresentation(
+					null,
+					JSON.parse( tokenCommented ),
+					{ body: [] },
+					getModule
+				);
+				expect( irNamespaceCommented ).toHaveLength( 3 );
+				expect( irNamespaceCommented[ 0 ] ).toEqual( {
+					path: null,
+					name: 'MyClass',
+					description: 'Named class.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
+				expect( irNamespaceCommented[ 1 ] ).toEqual( {
+					path: null,
+					name: 'myFunction',
+					description: 'Named function.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
+				expect( irNamespaceCommented[ 2 ] ).toEqual( {
+					path: null,
+					name: 'myVariable',
+					description: 'Named variable.',
+					tags: [],
+					lineStart: 4,
+					lineEnd: 4,
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
The [`getIntermediateRepresentation` unit tests](https://github.com/WordPress/gutenberg/blob/trunk/packages/docgen/test/get-intermediate-representation.js) currently have a lot of assertions per test, making them hard to read and debug in case of failure.
This PR aims at splitting the assertion into smaller tests.

The actual code for the tests hasn't been updated. The main changes are:
- Add one intermediate level of `describe` around most tests
- Split long tests into smaller ones

Most of the diff changes are caused by the change in indentation.

## How has this been tested?

- Run `npm run test-unit packages/docgen`
- Make sure that all tests are passing
- Check how the list of tests for `getIntermediateRepresentation` is more granular

## Screenshots <!-- if applicable -->

N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Refactor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] (N/A) I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
