### PR TITLE
Fix selection clearer ref passed to motion.div

### DIFF
--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -10,22 +10,18 @@ import { useRefEffect } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../store';
 
 export function useBlockSelectionClearer( onlySelfClicks = false ) {
-	const hasSelection = useSelect( ( select ) => {
-		const { hasSelectedBlock, hasMultiSelection } = select(
-			blockEditorStore
-		);
-
-		return hasSelectedBlock() || hasMultiSelection();
-	} );
+	const { hasSelectedBlock, hasMultiSelection } = useSelect(
+		blockEditorStore
+	);
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	return useRefEffect(
 		( node ) => {
-			if ( ! hasSelection ) {
-				return;
-			}
-
 			function onMouseDown( event ) {
+				if ( ! hasSelectedBlock() && ! hasMultiSelection() ) {
+					return;
+				}
+
 				// Only handle clicks on the canvas, not the content.
 				if (
 					event.target.closest( '.wp-block' ) ||
@@ -43,7 +39,7 @@ export function useBlockSelectionClearer( onlySelfClicks = false ) {
 				node.removeEventListener( 'mousedown', onMouseDown );
 			};
 		},
-		[ hasSelection, clearSelectedBlock ]
+		[ hasSelectedBlock, hasMultiSelection, clearSelectedBlock ]
 	);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Clicking on the padding around the template editor currently doesn't clear the selected block.

I tracked this down to `motion.div` not calling a ref callback when it changes, as React normally does.

When the clearer was added to the padding (#30658), `motion` wasn't introduced yet.

https://github.com/framer/motion/blob/f8d08b271ae9b021521d0b80cdf1b3f787ccde13/src/motion/utils/use-motion-ref.ts#L16-L34

`externalRef` is not passed as a dependency here, so our `useRefEffect` won't work properly when its dependencies change (`hasSelection`).

There's two solutions: wrap the ref in `useMergeRefs`, even though there's only one, but this hook will handle dependencies correctly, or call the selectors within the even callback, which we anyway want to move towards, so I opted for that.

Of course, it would be good if this gets fixed in https://github.com/framer/motion, so maybe we should submit a PR there.

## How has this been tested?

Edit a page and open the template editor. Select a block, then click on the dark frame. The selection should be cleared.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
