### PR TITLE
Page List: Add ability to only show child pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18769,6 +18769,7 @@
 				"@wordpress/date": "file:packages/date",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
+				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/hooks": "file:packages/hooks",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
+		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -3,10 +3,13 @@
 	"name": "core/page-list",
 	"title": "Page List",
 	"category": "widgets",
-	"description": "Display a list of all pages.",
+	"description": "Display a list of pages.",
 	"keywords": [ "menu", "navigation" ],
 	"textdomain": "default",
 	"attributes": {
+		"showOnlyChildPages": {
+			"type": "boolean"
+		}
 	},
 	"usesContext": [
 		"textColor",

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -95,14 +95,16 @@ export default function PageListEdit( { context, clientId } ) {
 				{ showChildPageToggle && (
 					<PanelBody>
 						<ToggleControl
-							label={ __( 'List child pages' ) }
+							label={ __( 'Limit to child pages' ) }
 							checked={ !! attributes.showOnlyChildPages }
 							onChange={ () =>
 								setAttributes( {
 									showOnlyChildPages: ! attributes.showOnlyChildPages,
 								} )
 							}
-							help={ __( 'Uses parent to list child pages.' ) }
+							help={ __(
+								'When enabled, the block lists only child pages of the current page.'
+							) }
 						/>
 					</PanelBody>
 				) }

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -47,8 +47,8 @@ export default function PageListEdit( { context, clientId } ) {
 	const showChildPageToggle = useSelect( ( select ) => {
 		const { getCurrentPostType } = select( editorStore );
 		const currentPostType = getCurrentPostType();
-		const allowedTypes = [ 'page', 'wp_template' ];
-		return allowedTypes.includes( currentPostType );
+		const hideToggleFrom = [ 'post' ];
+		return ! hideToggleFrom.includes( currentPostType );
 	} );
 
 	useEffect( () => {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -278,16 +278,9 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 			$active_page_ancestor_ids = get_post_ancestors( $page->ID );
 		}
 
-		// When showing only child pages of parent, set the pages to top level
-		// since there is no other top level page.
-		if ( $only_child_pages ) {
-			$top_level_pages[ $page->ID ] = array(
-				'page_id'   => $page->ID,
-				'title'     => $page->post_title,
-				'link'      => get_permalink( $page->ID ),
-				'is_active' => $is_active,
-			);
-		} else if ( $page->post_parent )  {
+		// Only set pages with children when only child pages is not set, since
+		// when set we want child pages to be top-level.
+		if ( $page->post_parent && ! $only_child_pages ) {
 			$pages_with_children[ $page->post_parent ][ $page->ID ] = array(
 				'page_id'   => $page->ID,
 				'title'     => $page->post_title,

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -227,6 +227,31 @@ function block_core_page_list_nest_pages( $current_level, $children ) {
 }
 
 /**
+ * Determines if page should be classified as top-level or child page. Broken
+ * out to this function to explain instead of a complex if statement.
+ * When only_child_pages is true, force child pages to be considered top level.
+ * Thy are top level since the parent is not shown (only child pages).
+ *
+ * @param int     $page_parent_id Parent id of the page being tested.
+ * @param boolean $only_child_pages Only showing child pages.
+ * @param int     $parent_id Top level parent id for child pages, needed so we can nest grand children.
+ * @return boolean True if page should be considered a child page.
+ */
+function block_core_page_list_treat_as_child( $page_parent_id, $only_child_pages, $parent_id ) {
+	if ( ! $page_parent_id ) {
+		return false;
+	}
+
+	// Check only child pages, and id matches parent, then it is top level and
+	// should not be treated like a child page.
+	if ( $only_child_pages && ( $page_parent_id === $parent_id ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Renders the `core/page-list` block on server.
  *
  * @param array $attributes The block attributes.
@@ -278,9 +303,8 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 			$active_page_ancestor_ids = get_post_ancestors( $page->ID );
 		}
 
-		// Only set pages with children when only child pages is not set, since
-		// when set we want child pages to be top-level.
-		if ( $page->post_parent && ! $only_child_pages ) {
+		// See function for logic when pages are treated like child pages.
+		if ( block_core_page_list_treat_as_child( $page->post_parent, $only_child_pages, $parent_id ) ) {
 			$pages_with_children[ $page->post_parent ][ $page->ID ] = array(
 				'page_id'   => $page->ID,
 				'title'     => $page->post_title,

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -236,15 +236,29 @@ function block_core_page_list_nest_pages( $current_level, $children ) {
  * @return string Returns the page list markup.
  */
 function render_block_core_page_list( $attributes, $content, $block ) {
+	global $post;
 	static $block_id = 0;
 	$block_id++;
 
-	$all_pages = get_pages(
-		array(
-			'sort_column' => 'menu_order,post_title',
-			'order'       => 'asc',
-		)
+	$only_child_pages = isset( $attributes['showOnlyChildPages'] ) && $attributes['showOnlyChildPages'];
+	// The pages will be siblings (same parent) or set parent id equal to self if no children.
+	$parent_id = ( $post->post_parent ) ? $post->post_parent : $post->ID;
+
+	// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby values is resolved,
+	// update 'sort_column' to 'menu_order, post_title'. Sorting by both menu_order and post_title ensures a stable sort.
+	// Otherwise with pages that have the same menu_order value, we can see different ordering depending on how DB
+	// queries are constructed internally. For example we might see a different order when a limit is set to <499
+	// versus >= 500.
+	$query_args = array(
+		'sort_column' => 'menu_order',
+		'order'       => 'asc',
 	);
+
+	if ( $only_child_pages && $parent_id ) {
+		$query_args['child_of'] = $parent_id;
+	}
+
+	$all_pages = get_pages( $query_args );
 
 	// If thare are no pages, there is nothing to show.
 	if ( empty( $all_pages ) ) {
@@ -264,7 +278,16 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 			$active_page_ancestor_ids = get_post_ancestors( $page->ID );
 		}
 
-		if ( $page->post_parent ) {
+		// When showing only child pages of parent, set the pages to top level
+		// since there is no other top level page.
+		if ( $only_child_pages ) {
+			$top_level_pages[ $page->ID ] = array(
+				'page_id'   => $page->ID,
+				'title'     => $page->post_title,
+				'link'      => get_permalink( $page->ID ),
+				'is_active' => $is_active,
+			);
+		} else if ( $page->post_parent )  {
 			$pages_with_children[ $page->post_parent ][ $page->ID ] = array(
 				'page_id'   => $page->ID,
 				'title'     => $page->post_title,


### PR DESCRIPTION
## Description

This scratches my own itch, I have a set of tutorial pages that has a single parent page, and then children pages off that parent. I want to build a table of contents that just include a listing of all the child pages.

Example [in old theme here](https://mkaz.blog/working-with-vim/) if curious the way it was built in the old theme is [in this template page](https://github.com/mkaz/mcbain/blob/trunk/page-tut.php).

So for a block theme, I want to use the Pages List to do the same, but need to be able to filter that block and only show the children of the current page.

Fixes #31063

**Implementation ?** This uses `global $post` to get the `$parent_id` which may not be ideal, but `post-comments` and `latest-posts` both use the same. Open to suggestions on a better way to fetch parent id.

## How has this been tested?

1. Create new page and a child of that page
2. Add Navigation block to the parent page
3. Add Page List to the page
4. Confirm that all pages show (default behavior)
5. Toggle Show children only
6. Confirm that only the child page shows


## Types of changes

- Adds new childrenOnly attribute to PageList block
- Updates server-side render to use attribute and filter pages

