### PR TITLE
Fix for template order logic bug introduced in 10.5

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -67,7 +67,11 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	$current_template = gutenberg_resolve_template( $type, $templates );
 
 	// Allow falling back to a PHP template if it has a higher priority than the block template.
-	$current_template_slug       = basename( $template, '.php' );
+	$current_template_slug       = str_replace(
+		array( trailingslashit( get_stylesheet_directory() ), '.php' ),
+		array( '', '' ),
+		$template
+	);
 	$current_block_template_slug = is_object( $current_template ) ? $current_template->slug : false;
 	foreach ( $templates as $template_item ) {
 

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -68,8 +68,8 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 
 	// Allow falling back to a PHP template if it has a higher priority than the block template.
 	$current_template_slug       = str_replace(
-		array( trailingslashit( get_stylesheet_directory() ), '.php' ),
-		array( '', '' ),
+		array( trailingslashit( get_stylesheet_directory() ), trailingslashit( get_template_directory() ), '.php' ),
+		'',
 		$template
 	);
 	$current_block_template_slug = is_object( $current_template ) ? $current_template->slug : false;


### PR DESCRIPTION
WIP PR that fixes #31399. 

The original code uses `basename` to determine a template's slug, but that doesn't take a template in a subdirectory into account. For at least the basic cases, it appears to be enough to strip the `get_stylesheet_directory()` from the path (and remove the php extension).

not sure whether to use `get_template_directory` or `get_stylesheet_directory`, or both to make it work for child themes as well, need to test that. 