### PR TITLE
Block Support: Update border support to allow non-pixel units

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -57,7 +57,13 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		isset( $block_attributes['style']['border']['radius'] )
 	) {
 		$border_radius = $block_attributes['style']['border']['radius'];
-		$styles[]      = sprintf( 'border-radius: %s;', $border_radius );
+
+		// This check handles original unitless implementation.
+		if ( is_numeric( $border_radius ) ) {
+			$border_radius .= 'px';
+		}
+
+		$styles[] = sprintf( 'border-radius: %s;', $border_radius );
 	}
 
 	// Border style.
@@ -75,7 +81,13 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		isset( $block_attributes['style']['border']['width'] )
 	) {
 		$border_width = $block_attributes['style']['border']['width'];
-		$styles[]     = sprintf( 'border-width: %s;', $border_width );
+
+		// This check handles original unitless implementation.
+		if ( is_numeric( $border_width ) ) {
+			$border_width .= 'px';
+		}
+
+		$styles[] = sprintf( 'border-width: %s;', $border_width );
 	}
 
 	// Border color.

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -56,8 +56,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		gutenberg_has_border_feature_support( $block_type, 'radius' ) &&
 		isset( $block_attributes['style']['border']['radius'] )
 	) {
-		$border_radius = (int) $block_attributes['style']['border']['radius'];
-		$styles[]      = sprintf( 'border-radius: %dpx;', $border_radius );
+		$border_radius = $block_attributes['style']['border']['radius'];
+		$styles[]      = sprintf( 'border-radius: %s;', $border_radius );
 	}
 
 	// Border style.
@@ -74,8 +74,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		gutenberg_has_border_feature_support( $block_type, 'width' ) &&
 		isset( $block_attributes['style']['border']['width'] )
 	) {
-		$border_width = intval( $block_attributes['style']['border']['width'] );
-		$styles[]     = sprintf( 'border-width: %dpx;', $border_width );
+		$border_width = $block_attributes['style']['border']['width'];
+		$styles[]     = sprintf( 'border-width: %s;', $border_width );
 	}
 
 	// Border color.

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -43,7 +43,7 @@ export function BorderRadiusEdit( props ) {
 			},
 		};
 
-		if ( newRadius === undefined ) {
+		if ( newRadius === undefined || newRadius === '' ) {
 			newStyle = cleanEmptyObject( newStyle );
 		}
 

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -1,16 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { RangeControl } from '@wordpress/components';
+import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { CSS_UNITS, parseUnit } from './border';
 import { cleanEmptyObject } from './utils';
 
 const MIN_BORDER_RADIUS_VALUE = 0;
-const MAX_BORDER_RADIUS_VALUE = 50;
 
 /**
  * Inspector control panel containing the border radius related configuration.
@@ -23,6 +24,15 @@ export function BorderRadiusEdit( props ) {
 		attributes: { style },
 		setAttributes,
 	} = props;
+
+	// Step value is maintained in state so step is appropriate for current unit
+	// even when current radius value is undefined.
+	const initialStep = parseUnit( style?.border?.radius ) === 'px' ? 1 : 0.25;
+	const [ step, setStep ] = useState( initialStep );
+
+	const onUnitChange = ( newUnit ) => {
+		setStep( newUnit === 'px' ? 1 : 0.25 );
+	};
 
 	const onChange = ( newRadius ) => {
 		let newStyle = {
@@ -41,14 +51,14 @@ export function BorderRadiusEdit( props ) {
 	};
 
 	return (
-		<RangeControl
+		<UnitControl
 			value={ style?.border?.radius }
 			label={ __( 'Border radius' ) }
 			min={ MIN_BORDER_RADIUS_VALUE }
-			max={ MAX_BORDER_RADIUS_VALUE }
-			initialPosition={ 0 }
-			allowReset
 			onChange={ onChange }
+			onUnitChange={ onUnitChange }
+			step={ step }
+			units={ CSS_UNITS }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -43,7 +43,7 @@ export const BorderWidthEdit = ( props ) => {
 			},
 		};
 
-		if ( newWidth === undefined ) {
+		if ( newWidth === undefined || newWidth === '' ) {
 			newStyle = cleanEmptyObject( newStyle );
 		}
 

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -1,16 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { RangeControl } from '@wordpress/components';
+import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { CSS_UNITS, parseUnit } from './border';
 import { cleanEmptyObject } from './utils';
 
 const MIN_BORDER_WIDTH = 0;
-const MAX_BORDER_WIDTH = 50;
 
 /**
  * Inspector control for configuring border width property.
@@ -24,8 +25,17 @@ export const BorderWidthEdit = ( props ) => {
 		setAttributes,
 	} = props;
 
+	// Step value is maintained in state so step is appropriate for current unit
+	// even when current radius value is undefined.
+	const initialStep = parseUnit( style?.border?.width ) === 'px' ? 1 : 0.25;
+	const [ step, setStep ] = useState( initialStep );
+
+	const onUnitChange = ( newUnit ) => {
+		setStep( newUnit === 'px' ? 1 : 0.25 );
+	};
+
 	const onChange = ( newWidth ) => {
-		const newStyle = {
+		let newStyle = {
 			...style,
 			border: {
 				...style?.border,
@@ -33,18 +43,22 @@ export const BorderWidthEdit = ( props ) => {
 			},
 		};
 
+		if ( newWidth === undefined ) {
+			newStyle = cleanEmptyObject( newStyle );
+		}
+
 		setAttributes( { style: cleanEmptyObject( newStyle ) } );
 	};
 
 	return (
-		<RangeControl
+		<UnitControl
 			value={ style?.border?.width }
 			label={ __( 'Border width' ) }
 			min={ MIN_BORDER_WIDTH }
-			max={ MAX_BORDER_WIDTH }
-			initialPosition={ 0 }
-			allowReset
 			onChange={ onChange }
+			onUnitChange={ onUnitChange }
+			step={ step }
+			units={ CSS_UNITS }
 		/>
 	);
 };

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -47,7 +47,7 @@ export const BorderWidthEdit = ( props ) => {
 			newStyle = cleanEmptyObject( newStyle );
 		}
 
-		setAttributes( { style: cleanEmptyObject( newStyle ) } );
+		setAttributes( { style: newStyle } );
 	};
 
 	return (

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -24,16 +24,19 @@ export const CSS_UNITS = [
 		value: 'px',
 		label: isWeb ? 'px' : __( 'Pixels (px)' ),
 		default: '',
+		a11yLabel: __( 'Pixels (px)' ),
 	},
 	{
 		value: 'em',
 		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
 		default: '',
+		a11yLabel: __( 'Relative to parent font size (em)' ),
 	},
 	{
 		value: 'rem',
 		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
 		default: '',
+		a11yLabel: __( 'Relative to root font size (rem)' ),
 	},
 ];
 

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -16,7 +16,41 @@ import { BorderRadiusEdit } from './border-radius';
 import { BorderStyleEdit } from './border-style';
 import { BorderWidthEdit } from './border-width';
 
+const isWeb = Platform.OS === 'web';
+
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
+export const CSS_UNITS = [
+	{
+		value: 'px',
+		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		default: '',
+	},
+	{
+		value: 'em',
+		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
+		default: '',
+	},
+	{
+		value: 'rem',
+		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
+		default: '',
+	},
+];
+
+/**
+ * Parses a CSS unit from a border CSS value.
+ *
+ * @param  {string} cssValue CSS value to parse e.g. `10px` or `1.5em`.
+ * @return {string}          CSS unit from provided value or default 'px'.
+ */
+export function parseUnit( cssValue ) {
+	const value = String( cssValue ).trim();
+	const unitMatch = value.match( /[\d.\-\+]*\s*(.*)/ )[ 1 ];
+	const unit = unitMatch !== undefined ? unitMatch.toLowerCase() : '';
+	const currentUnit = CSS_UNITS.find( ( item ) => item.value === unit );
+
+	return currentUnit?.value || 'px';
+}
 
 export function BorderPanel( props ) {
 	const isDisabled = useIsBorderDisabled( props );
@@ -44,7 +78,11 @@ export function BorderPanel( props ) {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Border settings' ) } initialOpen={ false }>
+			<PanelBody
+				className="block-editor-hooks__border-controls"
+				title={ __( 'Border settings' ) }
+				initialOpen={ false }
+			>
 				{ isStyleSupported && <BorderStyleEdit { ...props } /> }
 				{ isWidthSupported && <BorderWidthEdit { ...props } /> }
 				{ isRadiusSupported && <BorderRadiusEdit { ...props } /> }

--- a/packages/block-editor/src/hooks/border.scss
+++ b/packages/block-editor/src/hooks/border.scss
@@ -1,0 +1,10 @@
+.block-editor-hooks__border-controls {
+	.components-unit-control-wrapper {
+		margin-bottom: $grid-unit-30;
+
+		&:last-child {
+			margin-bottom: $grid-unit-10;
+		}
+	}
+}
+

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -18,8 +18,8 @@ describe( 'getInlineStyles', () => {
 				color: { text: 'red', background: 'black' },
 				typography: { lineHeight: 1.5, fontSize: 10 },
 				border: {
-					radius: 10,
-					width: 3,
+					radius: '10px',
+					width: '1em',
 					style: 'dotted',
 					color: '#21759b',
 				},
@@ -31,9 +31,9 @@ describe( 'getInlineStyles', () => {
 		).toEqual( {
 			backgroundColor: 'black',
 			borderColor: '#21759b',
-			borderRadius: 10,
+			borderRadius: '10px',
 			borderStyle: 'dotted',
-			borderWidth: 3,
+			borderWidth: '1em',
 			color: 'red',
 			lineHeight: 1.5,
 			fontSize: 10,

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -58,6 +58,7 @@
 @import "./components/warning/style.scss";
 @import "./hooks/anchor.scss";
 @import "./hooks/layout.scss";
+@import "./hooks/border.scss";
 
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
 #end-resizable-editor-section {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -225,9 +225,7 @@ function ButtonEdit( props ) {
 						}
 					) }
 					style={ {
-						borderRadius: borderRadius
-							? borderRadius + 'px'
-							: undefined,
+						borderRadius: borderRadius ? borderRadius : undefined,
 						...colorProps.style,
 					} }
 					onSplit={ ( value ) =>

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -38,7 +38,7 @@ export default function save( { attributes, className } ) {
 		}
 	);
 	const buttonStyle = {
-		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+		borderRadius: borderRadius ? borderRadius : undefined,
 		...colorProps.style,
 	};
 

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -50,7 +50,7 @@ import {
 
 // Used to calculate border radius adjustment to avoid "fat" corners when
 // button is placed inside wrapper.
-const DEFAULT_INNER_PADDING = 4;
+const DEFAULT_INNER_PADDING = '4px';
 
 export default function SearchEdit( {
 	className,
@@ -323,10 +323,16 @@ export default function SearchEdit( {
 		if ( 'button-inside' === buttonPosition && style?.border?.radius ) {
 			// We have button inside wrapper and a border radius value to apply.
 			// Add default padding so we don't get "fat" corners.
-			const outerRadius =
-				parseInt( style?.border?.radius, 10 ) + DEFAULT_INNER_PADDING;
+			//
+			// CSS calc() is used here to support non-pixel units. The inline
+			// style using calc() will only apply if both values have units.
+			const radius = Number.isInteger( borderRadius )
+				? `${ borderRadius }px`
+				: borderRadius;
 
-			return { borderRadius: `${ outerRadius }px` };
+			return {
+				borderRadius: `calc(${ radius } + ${ DEFAULT_INNER_PADDING })`,
+			};
 		}
 
 		return undefined;

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -190,7 +190,8 @@ function styles_for_block_core_search( $attributes ) {
 	if ( $has_border_radius ) {
 		// Shared style for button and input radius values.
 		$border_radius   = $attributes['style']['border']['radius'];
-		$shared_styles[] = sprintf( 'border-radius: %spx;', esc_attr( $border_radius ) );
+		$border_radius   = is_numeric( $border_radius ) ? $border_radius . 'px' : $border_radius;
+		$shared_styles[] = sprintf( 'border-radius: %s;', esc_attr( $border_radius ) );
 
 		// Apply wrapper border radius if button placed inside.
 		$button_inside = ! empty( $attributes['buttonPosition'] ) &&
@@ -199,10 +200,13 @@ function styles_for_block_core_search( $attributes ) {
 		if ( $button_inside ) {
 			// We adjust the border radius value for the outer wrapper element
 			// to make it visually consistent with the radius applied to inner
-			// elements.
-			$default_padding  = 4;
-			$adjusted_radius  = $border_radius + $default_padding;
-			$wrapper_styles[] = sprintf( 'border-radius: %dpx;', esc_attr( $adjusted_radius ) );
+			// elements. calc() is used to support non-pixel CSS units.
+			$default_padding  = '4px';
+			$wrapper_styles[] = sprintf(
+				'border-radius: calc(%s + %s);',
+				esc_attr( $border_radius ),
+				esc_attr( $default_padding )
+			);
 		}
 	}
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/31337
Related: https://github.com/WordPress/gutenberg/pull/31641, https://github.com/WordPress/gutenberg/pull/31585

## Description
- Updates border block support feature to allow custom CSS units for width and radius
- Replaces RangeControl use with UnitControl to support custom units in prep for UI updates in https://github.com/WordPress/gutenberg/issues/31337
- Tweaks the step value depending on current field's CSS unit type
- Adds custom CSS for border block support hook controls (will be extended for UI updates)

Given border block support is still `__experimental` no deprecation has been added for the moment.

## How has this been tested?
Manually.

1. Checkout this PR and enable border block support via your `experimental-theme.json`. To save time enabling it for multiple block contexts, just update the `settings.defaults.border` flags.
2. Create a new post, add a group block and select it.
3. Expand the border controls in the sidebar. The border width and radius should now show a `UnitControl`.
4. Adjust the border values, save and confirm the block updates as expected both in the editor and frontend.
5. Opt into border support for the post tags block via its `block.json` file.
6. Reload the editor and add a post tags block along with some tags to fill it.
7. Select the post tags block, adjust border values, then save.
8. Refresh the post on the frontend and confirm this dynamic block renders the border correctly.

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/60436221/117091250-05e0f900-ad9e-11eb-97ad-bb0805e19821.gif" width="400" />

## Types of changes
New feature. 
Breaking Change (Border block support is still experimental however)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
