### PR TITLE
Legacy Widget: Ensure the control form's IDs have a consistent number

### DIFF
--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -419,9 +419,13 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// Set the widget's number to 1 so that the `id` attributes in the HTML
-		// that we return are predictable.
-		$widget_object->_set( 1 );
+		// Set the widget's number so that the id attributes in the HTML that we
+		// return are predictable.
+		if ( isset( $request['number'] ) && is_numeric( $request['number'] ) ) {
+			$widget_object->_set( (int) $request['number'] );
+		} else {
+			$widget_object->_set( -1 );
+		}
 
 		if ( isset( $request['instance']['encoded'], $request['instance']['hash'] ) ) {
 			$serialized_instance = base64_decode( $request['instance']['encoded'] );

--- a/phpunit/class-rest-widget-types-controller-test.php
+++ b/phpunit/class-rest-widget-types-controller-test.php
@@ -260,8 +260,41 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		$data     = $response->get_data();
 		$this->assertEquals(
 			"<p>\n" .
-			"\t\t\t<label for=\"widget-search-1-title\">Title:</label>\n" .
-			"\t\t\t<input class=\"widefat\" id=\"widget-search-1-title\" name=\"widget-search[1][title]\" type=\"text\" value=\"\" />\n" .
+			"\t\t\t<label for=\"widget-search--1-title\">Title:</label>\n" .
+			"\t\t\t<input class=\"widefat\" id=\"widget-search--1-title\" name=\"widget-search[-1][title]\" type=\"text\" value=\"\" />\n" .
+			"\t\t</p>",
+			$data['form']
+		);
+		$this->assertStringMatchesFormat(
+			"<div class=\"widget widget_search\"><form role=\"search\" method=\"get\" id=\"searchform\" class=\"searchform\" action=\"%s\">\n" .
+			"\t\t\t\t<div>\n" .
+			"\t\t\t\t\t<label class=\"screen-reader-text\" for=\"s\">Search for:</label>\n" .
+			"\t\t\t\t\t<input type=\"text\" value=\"\" name=\"s\" id=\"s\" />\n" .
+			"\t\t\t\t\t<input type=\"submit\" id=\"searchsubmit\" value=\"Search\" />\n" .
+			"\t\t\t\t</div>\n" .
+			"\t\t\t</form></div>",
+			$data['preview']
+		);
+		$this->assertEqualSets(
+			array(
+				'encoded' => base64_encode( serialize( array() ) ),
+				'hash'    => wp_hash( serialize( array() ) ),
+				'raw'     => new stdClass,
+			),
+			$data['instance']
+		);
+	}
+
+	public function test_encode_form_data_with_number() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/widget-types/search/encode' );
+		$request->set_param( 'number', 8 );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			"<p>\n" .
+			"\t\t\t<label for=\"widget-search-8-title\">Title:</label>\n" .
+			"\t\t\t<input class=\"widefat\" id=\"widget-search-8-title\" name=\"widget-search[8][title]\" type=\"text\" value=\"\" />\n" .
 			"\t\t</p>",
 			$data['form']
 		);
@@ -299,8 +332,8 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		$data     = $response->get_data();
 		$this->assertEquals(
 			"<p>\n" .
-			"\t\t\t<label for=\"widget-search-1-title\">Title:</label>\n" .
-			"\t\t\t<input class=\"widefat\" id=\"widget-search-1-title\" name=\"widget-search[1][title]\" type=\"text\" value=\"Test title\" />\n" .
+			"\t\t\t<label for=\"widget-search--1-title\">Title:</label>\n" .
+			"\t\t\t<input class=\"widefat\" id=\"widget-search--1-title\" name=\"widget-search[-1][title]\" type=\"text\" value=\"Test title\" />\n" .
 			"\t\t</p>",
 			$data['form']
 		);
@@ -327,13 +360,13 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 	public function test_encode_form_data_with_form_data() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/widget-types/search/encode' );
-		$request->set_param( 'form_data', 'widget-search[1][title]=Updated+title' );
+		$request->set_param( 'form_data', 'widget-search[-1][title]=Updated+title' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals(
 			"<p>\n" .
-			"\t\t\t<label for=\"widget-search-1-title\">Title:</label>\n" .
-			"\t\t\t<input class=\"widefat\" id=\"widget-search-1-title\" name=\"widget-search[1][title]\" type=\"text\" value=\"Updated title\" />\n" .
+			"\t\t\t<label for=\"widget-search--1-title\">Title:</label>\n" .
+			"\t\t\t<input class=\"widefat\" id=\"widget-search--1-title\" name=\"widget-search[-1][title]\" type=\"text\" value=\"Updated title\" />\n" .
 			"\t\t</p>",
 			$data['form']
 		);
@@ -373,8 +406,8 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		$data     = $response->get_data();
 		$this->assertEquals(
 			"<p>\n" .
-			"\t\t\t<label for=\"widget-search-1-title\">Title:</label>\n" .
-			"\t\t\t<input class=\"widefat\" id=\"widget-search-1-title\" name=\"widget-search[1][title]\" type=\"text\" value=\"Test title\" />\n" .
+			"\t\t\t<label for=\"widget-search--1-title\">Title:</label>\n" .
+			"\t\t\t<input class=\"widefat\" id=\"widget-search--1-title\" name=\"widget-search[-1][title]\" type=\"text\" value=\"Test title\" />\n" .
 			"\t\t</p>",
 			$data['form']
 		);


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/28668.
Requires https://github.com/WordPress/gutenberg/pull/31444.

Ensures that all of the IDs in a Legacy Widget block's form's inputs have the same number.

<img width="635" alt="Screen Shot 2021-05-05 at 14 13 31" src="https://user-images.githubusercontent.com/612155/117096428-5a8b7080-adac-11eb-8bc2-8ea3da814795.png">

- Updates the `/widget-types/:type/encode` endpoint to accept a `number` param which controls the number used to generate the widget HTML that is returned.
- Updates `Control` to send its fake `number` to the endpoint so that all of the form fields in the control have a consistent ID.

## How has this been tested?

Follow the steps in https://github.com/WordPress/gutenberg/issues/28668#issuecomment-819437868.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->