### PR TITLE
Use gutenberg_get_block_categories for getting block categories in widgets screen

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -60,7 +60,7 @@ function gutenberg_widgets_init( $hook ) {
 
 	wp_add_inline_script(
 		'wp-blocks',
-		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( 'widgets_editor' ) ) ),
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( gutenberg_get_block_categories( 'widgets_editor' ) ) ),
 		'after'
 	);
 


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/pull/31406#discussion_r626265856

Small change to address something missed in the above PR.