### PR TITLE
Add customize widgets editor white background

### DIFF
--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -3,3 +3,11 @@
 	// Appear over block placeholders, but under widgets page headings.
 	z-index: 8;
 }
+
+.customize-control-sidebar_block_editor {
+	margin: 0 -12px -12px -12px;
+	padding: 12px;
+	background: $white;
+	border-top: 1px solid #dcdcde;
+	border-bottom: 1px solid #dcdcde;
+}

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -5,8 +5,8 @@
 }
 
 .customize-control-sidebar_block_editor {
-	margin: 0 -12px -12px -12px;
-	padding: 12px;
+	margin: 0 ( -$grid-unit-15 ) ( -$grid-unit-15 ) ( -$grid-unit-15 );
+	padding: $grid-unit-15;
 	background: $white;
 	border-top: 1px solid #dcdcde;
 	border-bottom: 1px solid #dcdcde;


### PR DESCRIPTION
## Description
Adds a white background to the widget editor (and some borders).

The negative margin in this PR is a bit hacky, but there's a need to override the parent element's padding.

My first attempt was to try to set the entire sidebar's background, but that doesn't seem possible.

## How has this been tested?
1. Enable the block widget customizer experiment
2. Go the the editor
3. See the background

## Screenshots <!-- if applicable -->
<img width="302" alt="Screenshot 2021-05-05 at 3 46 03 pm" src="https://user-images.githubusercontent.com/677833/117110664-0fc42580-adb9-11eb-94be-acb4b2e1b5a5.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
