### PR TITLE
Make the entire customize widgets editor sidebar have a white background

### DIFF
--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -4,10 +4,10 @@
 	z-index: 8;
 }
 
-.customize-control-sidebar_block_editor {
-	margin: 0 ( -$grid-unit-15 ) ( -$grid-unit-15 ) ( -$grid-unit-15 );
-	padding: $grid-unit-15;
-	background: $white;
-	border-top: 1px solid #dcdcde;
-	border-bottom: 1px solid #dcdcde;
+// Style the customizer accordion section with a white background.
+// This selector matches against the first part of the id, which is typically
+// postfixed with a number when there are multiple sidebars.
+#customize-theme-controls *[id^="sub-accordion-section-sidebar-widgets-sidebar"] {
+	min-height: 100%;
+	background-color: $white;
 }

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -3,11 +3,3 @@
 	// Appear over block placeholders, but under widgets page headings.
 	z-index: 8;
 }
-
-// Style the customizer accordion section with a white background.
-// This selector matches against the first part of the id, which is typically
-// postfixed with a number when there are multiple sidebars.
-#customize-theme-controls *[id^="sub-accordion-section-sidebar-widgets-sidebar"] {
-	min-height: 100%;
-	background-color: $white;
-}

--- a/packages/customize-widgets/src/controls/sidebar-section.js
+++ b/packages/customize-widgets/src/controls/sidebar-section.js
@@ -32,6 +32,9 @@ export default function getSidebarSection() {
 				}
 			);
 			customize.section.add( this.inspector );
+			this.contentContainer[ 0 ].classList.add(
+				'customize-widgets__sidebar-section'
+			);
 		}
 		hasSubSectionOpened() {
 			return this.inspector.expanded();

--- a/packages/customize-widgets/src/controls/style.scss
+++ b/packages/customize-widgets/src/controls/style.scss
@@ -1,0 +1,6 @@
+// Adds a white background to the block based widget section.
+// #customize-theme-controls id is required to add specificity.
+#customize-theme-controls .customize-widgets__sidebar-section {
+	min-height: 100%;
+	background-color: $white;
+}

--- a/packages/customize-widgets/src/style.scss
+++ b/packages/customize-widgets/src/style.scss
@@ -2,3 +2,4 @@
 @import "./components/block-inspector-button/style.scss";
 @import "./components/header/style.scss";
 @import "./components/inserter/style.scss";
+@import "./controls/style.scss";


### PR DESCRIPTION
## Description
Followup to #31487

Makes the entire customize widget sidebar white.

<img width="509" alt="Screenshot 2021-05-05 at 4 42 51 pm" src="https://user-images.githubusercontent.com/677833/117116597-21113000-adc1-11eb-8a6b-1bf6bc72a5b9.png">
