### PR TITLE
Fix nav screen margin.

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -84,6 +84,7 @@
 			background: $gray-100;
 			border-radius: $radius-block-ui;
 			pointer-events: none;
+			margin-right: 0;
 
 			.wp-block-pages-list__item {
 				color: $gray-700;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -34,6 +34,8 @@
 				opacity: 1;
 				visibility: visible;
 				display: none;
+				right: auto;
+				box-sizing: border-box;
 			}
 
 			// Fix focus outlines.
@@ -47,10 +49,15 @@
 			}
 
 			// Menu items.
-			// This needs high specificity.
+			// This needs high specificity to override inherited values.
+			&.wp-block-navigation-link.wp-block-navigation-link {
+				margin-right: 0;
+			}
+
 			.wp-block-navigation-link__content.wp-block-navigation-link__content.wp-block-navigation-link__content {
 				padding: 0.5em 1em;
 				margin-bottom: 6px;
+				margin-right: 0;
 				border-radius: $radius-block-ui;
 
 				&:hover {


### PR DESCRIPTION
## Description

Fixes #31454.

Before:

<img width="558" alt="Screenshot 2021-05-05 at 10 55 18" src="https://user-images.githubusercontent.com/1204802/117119371-3b7fe500-ad92-11eb-9054-df82b2b90f66.png">

After:

<img width="647" alt="Screenshot 2021-05-05 at 10 58 19" src="https://user-images.githubusercontent.com/1204802/117119374-3d49a880-ad92-11eb-947e-5d67f04aae4c.png">
<img width="535" alt="Screenshot 2021-05-05 at 11 06 53" src="https://user-images.githubusercontent.com/1204802/117119379-3e7ad580-ad92-11eb-8ac0-c84bd287fc91.png">



## How has this been tested?

Go to the new navigation screen and observe menu item widths are correct. Inspect a background color in, if you need to.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
