### PR TITLE
Fix 'move to widget area' item checkmark in standalone editor

### DIFF
--- a/packages/edit-widgets/src/filters/move-to-widget-area.js
+++ b/packages/edit-widgets/src/filters/move-to-widget-area.js
@@ -31,7 +31,7 @@ const withMoveToWidgetAreaToolbarItem = createHigherOrderComponent(
 				const selectors = select( editWidgetsStore );
 				return {
 					widgetAreas: selectors.getWidgetAreas(),
-					currentWidgetArea: widgetId
+					currentWidgetAreaId: widgetId
 						? selectors.getWidgetAreaForWidgetId( widgetId )?.id
 						: undefined,
 					canInsertBlockInWidgetArea: selectors.canInsertBlockInWidgetArea(


### PR DESCRIPTION
## Description
In the standalone widget editor, the checkmarks in the Move To Widget Area dropdown weren't being shown as expected.

This fixes.

## How has this been tested?
1. Open the standalone widget editor
2. Select a block
3. From the toolbar click the Move To Widget Area button
4. The current widget area should have a checkmark against it

## Screenshots <!-- if applicable -->
<img width="220" alt="Screenshot 2021-05-05 at 5 23 36 pm" src="https://user-images.githubusercontent.com/677833/117121022-a814d700-adc6-11eb-9acf-750dcbf4bada.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
