### PR TITLE
Fix nav color regression

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -26,8 +26,9 @@
 	}
 
 	// Menu item link.
-	.wp-block-pages-list__item__link,
-	.wp-block-navigation-link__content {
+	// The addition of :not(.wp-block-button_link) is necessary to override generic link colors from global styles.
+	.wp-block-pages-list__item__link:not(.wp-block-button_link),
+	.wp-block-navigation-link__content:not(.wp-block-button_link) {
 		// Inherit colors set by the block color definition.
 		color: inherit;
 		display: block;


### PR DESCRIPTION
## Description

Fixes navigation block color regression from #30541.

Before:

<img width="1180" alt="Screenshot 2021-05-05 at 11 54 23" src="https://user-images.githubusercontent.com/1204802/117125105-6b7eb680-ad99-11eb-884d-d0e1a0b89997.png">

After:

<img width="1172" alt="Screenshot 2021-05-05 at 11 57 41" src="https://user-images.githubusercontent.com/1204802/117125112-6cafe380-ad99-11eb-95bd-c79bfa35531b.png">


## How has this been tested?

Insert a navigation block and add a background and foreground color. The text color of menu items should be correct.

## Types of changes

This isn't a great change — it adds specificity to override specificity. But it may still be necessary.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
