### PR TITLE
Mark the loginout block as stable for 5.8 release

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -187,6 +187,8 @@ export const __experimentalGetCoreBlocks = () => [
 	postExcerpt,
 	postFeaturedImage,
 	postTerms,
+
+	logInOut,
 ];
 
 /**
@@ -239,7 +241,6 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 					...( enableFSEBlocks
 						? [
 								templatePart,
-								logInOut,
 								postComment,
 								postCommentAuthor,
 								postCommentContent,


### PR DESCRIPTION
closes #28744 

I think this is the last block that is meant to be made stable for 5.8 which should close #28744 