### PR TITLE
Navigation Editor: Correctly display menu used on location text

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/manage-locations.js
+++ b/packages/edit-navigation/src/components/inspector-additions/manage-locations.js
@@ -76,7 +76,7 @@ export default function ManageLocations( {
 							sprintf(
 								// translators: menu name.
 								__( 'Currently using %s' ),
-								menuOnLocation.description
+								menuOnLocation.name
 							)
 						}
 					/>


### PR DESCRIPTION
## Description
Fixes minor regression where "Currently using" menu name wasn't displayed for the location.

## Screenshots <!-- if applicable -->
| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-05-05 at 16 14 21](https://user-images.githubusercontent.com/240569/117139865-c88c6380-adbd-11eb-8029-c60ce8345f28.png)  | ![CleanShot 2021-05-05 at 16 13 30](https://user-images.githubusercontent.com/240569/117139857-c75b3680-adbd-11eb-9e3d-cea96ddd82e8.png) |

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
