### PR TITLE
Calendar: Add loading and empty state

### DIFF
--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -33,15 +33,19 @@ export default function CalendarEdit( { attributes } ) {
 		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
 		const { getEditedPostAttribute } = select( editorStore );
 
-		const query = {
+		const singlePublishedPostQuery = {
 			status: 'publish',
 			per_page: 1,
 		};
-		const posts = getEntityRecords( 'postType', 'post', query );
+		const posts = getEntityRecords(
+			'postType',
+			'post',
+			singlePublishedPostQuery
+		);
 		const postsResolved = hasFinishedResolution( 'getEntityRecords', [
 			'postType',
 			'post',
-			query,
+			singlePublishedPostQuery,
 		] );
 
 		const postType = getEditedPostAttribute( 'type' );
@@ -53,8 +57,7 @@ export default function CalendarEdit( { attributes } ) {
 		return {
 			date: _date,
 			hasPostsResolved: postsResolved,
-			hasPosts:
-				postsResolved && Array.isArray( posts ) && posts.length === 1,
+			hasPosts: postsResolved && posts?.length === 1,
 		};
 	}, [] );
 

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -7,11 +7,14 @@ import memoize from 'memize';
 /**
  * WordPress dependencies
  */
-import { Disabled } from '@wordpress/components';
+import { calendar as icon } from '@wordpress/icons';
+import { Disabled, Placeholder, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import ServerSideRender from '@wordpress/server-side-render';
 import { useBlockProps } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 const getYearMonth = memoize( ( date ) => {
 	if ( ! date ) {
@@ -25,20 +28,46 @@ const getYearMonth = memoize( ( date ) => {
 } );
 
 export default function CalendarEdit( { attributes } ) {
-	const date = useSelect( ( select ) => {
+	const blockProps = useBlockProps();
+	const { date, hasPosts, hasPostsResolved } = useSelect( ( select ) => {
+		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
 		const { getEditedPostAttribute } = select( editorStore );
+
+		const query = {
+			status: 'publish',
+			per_page: 1,
+		};
+		const posts = getEntityRecords( 'postType', 'post', query );
+		const postsResolved = hasFinishedResolution( 'getEntityRecords', [
+			'postType',
+			'post',
+			query,
+		] );
 
 		const postType = getEditedPostAttribute( 'type' );
 		// Dates are used to overwrite year and month used on the calendar.
 		// This overwrite should only happen for 'post' post types.
 		// For other post types the calendar always displays the current month.
-		return postType === 'post'
-			? getEditedPostAttribute( 'date' )
-			: undefined;
+		const _date =
+			postType === 'post' ? getEditedPostAttribute( 'date' ) : undefined;
+		return {
+			date: _date,
+			hasPostsResolved: postsResolved,
+			hasPosts:
+				postsResolved && Array.isArray( posts ) && posts.length === 1,
+		};
 	}, [] );
 
+	if ( ! hasPosts ) {
+		return (
+			<Placeholder icon={ icon } label={ __( 'Calendar' ) }>
+				{ ! hasPostsResolved ? <Spinner /> : __( 'No posts found.' ) }
+			</Placeholder>
+		);
+	}
+
 	return (
-		<div { ...useBlockProps() }>
+		<div { ...blockProps }>
 			<Disabled>
 				<ServerSideRender
 					block="core/calendar"

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -60,9 +60,15 @@ export default function CalendarEdit( { attributes } ) {
 
 	if ( ! hasPosts ) {
 		return (
-			<Placeholder icon={ icon } label={ __( 'Calendar' ) }>
-				{ ! hasPostsResolved ? <Spinner /> : __( 'No posts found.' ) }
-			</Placeholder>
+			<div { ...blockProps }>
+				<Placeholder icon={ icon } label={ __( 'Calendar' ) }>
+					{ ! hasPostsResolved ? (
+						<Spinner />
+					) : (
+						__( 'No posts found.' )
+					) }
+				</Placeholder>
+			</div>
 		);
 	}
 

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -68,7 +68,7 @@ export default function CalendarEdit( { attributes } ) {
 					{ ! hasPostsResolved ? (
 						<Spinner />
 					) : (
-						__( 'No posts found.' )
+						__( 'No published posts found.' )
 					) }
 				</Placeholder>
 			</div>

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -15,6 +15,8 @@
 function render_block_core_calendar( $attributes ) {
 	global $monthnum, $year;
 
+	// Calendar shouldn't be rendered
+	// when there are no published posts on the site.
 	if ( ! block_core_calendar_get_has_published_posts() ) {
 		return '';
 	}

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -15,12 +15,7 @@
 function render_block_core_calendar( $attributes ) {
 	global $monthnum, $year;
 
-	$has_published_posts = get_option( 'gutenberg_calendar_block_has_published_posts', null );
-	if ( null === $has_published_posts ) {
-		$has_published_posts = block_core_calendar_update_has_published_posts();
-	}
-
-	if ( ! $has_published_posts ) {
+	if ( ! block_core_calendar_get_has_published_posts() ) {
 		return '';
 	}
 
@@ -68,6 +63,20 @@ function register_block_core_calendar() {
 }
 
 add_action( 'init', 'register_block_core_calendar' );
+
+/**
+ * Returns the cached value whether any published post exists or not.
+ * In case of missing cached value, it updates the cache.
+ *
+ * @return bool Has any published posts or not.
+ */
+function block_core_calendar_get_has_published_posts() {
+	$has_published_posts = get_option( 'gutenberg_calendar_block_has_published_posts', null );
+	if ( null === $has_published_posts ) {
+		$has_published_posts = block_core_calendar_update_has_published_posts();
+	}
+	return $has_published_posts;
+}
 
 /**
  * Queries the database for any published post and saves

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -18,6 +18,9 @@ function render_block_core_calendar( $attributes ) {
 	// Calendar shouldn't be rendered
 	// when there are no published posts on the site.
 	if ( ! block_core_calendar_has_published_posts() ) {
+		if ( is_user_logged_in() ) {
+			return '<div>' . __( 'The calendar block is hidden because there are no published posts.', 'gutenberg' ) . '</div>';
+		}
 		return '';
 	}
 

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -70,7 +70,7 @@ function register_block_core_calendar() {
 add_action( 'init', 'register_block_core_calendar' );
 
 /**
- * Returns whether or not there are currently published posts.
+ * Returns whether or not there are any published posts.
  *
  * Used to hide the calendar block when there are no published posts.
  * This compensates for a known Core bug: https://core.trac.wordpress.org/ticket/12016

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -70,8 +70,10 @@ function register_block_core_calendar() {
 add_action( 'init', 'register_block_core_calendar' );
 
 /**
- * Returns the cached value whether any published post exists or not.
- * In case of missing cached value, it updates the cache.
+ * Returns whether or not there are currently published posts.
+ * 
+ * Used to hide the calendar block when there are no published posts.
+ * This compensates for a known Core bug: https://core.trac.wordpress.org/ticket/12016
  *
  * @return bool Has any published posts or not.
  */
@@ -105,6 +107,8 @@ function block_core_calendar_update_has_published_posts() {
 	return $has_published_posts;
 }
 
+// We only want to register these functions and actions when
+// we are on single sites. On multi sites we use `post_count` option.
 if ( ! is_multisite() ) {
 	/**
 	 * Handler for updating the has published posts flag when a post is deleted.

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -71,7 +71,7 @@ add_action( 'init', 'register_block_core_calendar' );
 
 /**
  * Returns whether or not there are currently published posts.
- * 
+ *
  * Used to hide the calendar block when there are no published posts.
  * This compensates for a known Core bug: https://core.trac.wordpress.org/ticket/12016
  *

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -13,7 +13,12 @@
  * @return string Returns the block content.
  */
 function render_block_core_calendar( $attributes ) {
-	global $monthnum, $year;
+	global $monthnum, $year, $wpdb;
+
+	$has_posts = $wpdb->get_var( "SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'post' AND post_status = 'publish' LIMIT 1" );
+	if ( ! $has_posts ) {
+		return '';
+	}
 
 	$previous_monthnum = $monthnum;
 	$previous_year     = $year;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

**Calendar block**
* Add loading state
* Add empty state
* Make sure the calendar isn't rendered when there are no posts. e028f8a is required to make sure we are consistently rendering the Calendar block in the editor and the frontend. `get_calendar()` returns a calendar HTML output when we set the front page to a static page. When we visit the frontpage in this case, `$posts` is populated with the current static page. Which means the calendar will be rendered with empty posts. (https://core.trac.wordpress.org/ticket/12016)

## How has this been tested?
**Loading state**
1. Open post editor
2. Add Calendar block
3. Save post
4. Refresh
5. You should see a spinner
![image](https://user-images.githubusercontent.com/2256104/117153163-01770900-adbb-11eb-860b-130462465ef3.png)

**Empty state**
1. Delete all posts on your site (you can change them to draft too, just make sure none of them are in `publish` status)
2. Open post editor by creating a new post
3. Add Calendar block
4. It should say: "No posts found."
![image](https://user-images.githubusercontent.com/2256104/117153130-f91ece00-adba-11eb-91be-3feb7448df7f.png)

**Avoid rendering the calendar when there are no posts**
1. Delete all posts on your site (you can change them to draft too, just make sure none of them are in `publish` status)
2. Create a new page, add a Calendar block and save it
3. Go to wpadmin -> Settings -> Reading. Change "Your homepage displays" to "Your static page" and choose the page you just created
4. Open the front page (http://localhost:8888), make sure the calendar isn't rendered.

## Screenshots <!-- if applicable -->

See above

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
