### PR TITLE
placeCaretAtHorizontalEdge: allow scrolling on initial call

### DIFF
--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -284,7 +284,6 @@ _Parameters_
 
 -   _container_ `HTMLElement`: Focusable element.
 -   _isReverse_ `boolean`: True for end, false for start.
--   _mayUseScroll_ `[boolean]`: Whether to allow scrolling.
 
 <a name="placeCaretAtVerticalEdge" href="#placeCaretAtVerticalEdge">#</a> **placeCaretAtVerticalEdge**
 

--- a/packages/dom/src/dom/place-caret-at-horizontal-edge.js
+++ b/packages/dom/src/dom/place-caret-at-horizontal-edge.js
@@ -13,14 +13,14 @@ import isRTL from './is-rtl';
 /**
  * Places the caret at start or end of a given element.
  *
- * @param {HTMLElement} container    Focusable element.
- * @param {boolean} isReverse    True for end, false for start.
- * @param {boolean} [mayUseScroll=false] Whether to allow scrolling.
+ * @param {HTMLElement} container           Focusable element.
+ * @param {boolean}     isReverse           True for end, false for start.
+ * @param {boolean}     [mayUseScroll=true] Whether to allow scrolling.
  */
 export default function placeCaretAtHorizontalEdge(
 	container,
 	isReverse,
-	mayUseScroll = false
+	mayUseScroll = true
 ) {
 	if ( ! container ) {
 		return;

--- a/packages/dom/src/dom/place-caret-at-horizontal-edge.js
+++ b/packages/dom/src/dom/place-caret-at-horizontal-edge.js
@@ -11,17 +11,32 @@ import isInputOrTextArea from './is-input-or-text-area';
 import isRTL from './is-rtl';
 
 /**
+ * Gets the range to place.
+ *
+ * @param {HTMLElement} container Focusable element.
+ * @param {boolean}     isReverse True for end, false for start.
+ *
+ * @return {Range|null} The range to place.
+ */
+function getRange( container, isReverse ) {
+	const { ownerDocument } = container;
+	// In the case of RTL scripts, the horizontal edge is at the opposite side.
+	const isReverseDir = isRTL( container ) ? ! isReverse : isReverse;
+	const containerRect = container.getBoundingClientRect();
+	// When placing at the end (isReverse), find the closest range to the bottom
+	// right corner. When placing at the start, to the top left corner.
+	const x = isReverse ? containerRect.right - 1 : containerRect.left + 1;
+	const y = isReverseDir ? containerRect.bottom - 1 : containerRect.top + 1;
+	return hiddenCaretRangeFromPoint( ownerDocument, x, y, container );
+}
+
+/**
  * Places the caret at start or end of a given element.
  *
- * @param {HTMLElement} container           Focusable element.
- * @param {boolean}     isReverse           True for end, false for start.
- * @param {boolean}     [mayUseScroll=true] Whether to allow scrolling.
+ * @param {HTMLElement} container Focusable element.
+ * @param {boolean}     isReverse True for end, false for start.
  */
-export default function placeCaretAtHorizontalEdge(
-	container,
-	isReverse,
-	mayUseScroll = true
-) {
+export default function placeCaretAtHorizontalEdge( container, isReverse ) {
 	if ( ! container ) {
 		return;
 	}
@@ -49,15 +64,7 @@ export default function placeCaretAtHorizontalEdge(
 		return;
 	}
 
-	const { ownerDocument } = container;
-	// In the case of RTL scripts, the horizontal edge is at the opposite side.
-	const isReverseDir = isRTL( container ) ? ! isReverse : isReverse;
-	const containerRect = container.getBoundingClientRect();
-	// When placing at the end (isReverse), find the closest range to the bottom
-	// right corner. When placing at the start, to the top left corner.
-	const x = isReverse ? containerRect.right - 1 : containerRect.left + 1;
-	const y = isReverseDir ? containerRect.bottom - 1 : containerRect.top + 1;
-	const range = hiddenCaretRangeFromPoint( ownerDocument, x, y, container );
+	let range = getRange( container, isReverse );
 
 	// If no range range can be created or it is outside the container, the
 	// element may be out of view.
@@ -66,17 +73,19 @@ export default function placeCaretAtHorizontalEdge(
 		! range.startContainer ||
 		! container.contains( range.startContainer )
 	) {
-		if ( ! mayUseScroll ) {
+		container.scrollIntoView( isReverse );
+		range = getRange( container, isReverse );
+
+		if (
+			! range ||
+			! range.startContainer ||
+			! container.contains( range.startContainer )
+		) {
 			return;
 		}
-
-		// Only try to scroll into view once to avoid an infinite loop.
-		mayUseScroll = false;
-		container.scrollIntoView( isReverse );
-		placeCaretAtHorizontalEdge( container, isReverse, mayUseScroll );
-		return;
 	}
 
+	const { ownerDocument } = container;
 	const { defaultView } = ownerDocument;
 	assertIsDefined( defaultView, 'defaultView' );
 	const selection = defaultView.getSelection();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes caret placing when the target is out of view.

Additionally, avoid exposing the parameter.

## How has this been tested?

Select a few blocks and scroll the element before the selection out of view. Press `Backspace`. The caret should be at the end of the previous block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
