### PR TITLE
Fix template part selection searches to use title/area instead of slug/theme.

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -42,7 +42,13 @@ export default function TemplatePartEdit( {
 	// Set the postId block attribute if it did not exist,
 	// but wait until the inner blocks have loaded to allow
 	// new edits to trigger this.
-	const { isResolved, innerBlocks, isMissing, defaultWrapper } = useSelect(
+	const {
+		isResolved,
+		innerBlocks,
+		isMissing,
+		defaultWrapper,
+		area,
+	} = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, hasFinishedResolution } = select(
 				coreStore
@@ -57,6 +63,8 @@ export default function TemplatePartEdit( {
 			const entityRecord = templatePartId
 				? getEditedEntityRecord( ...getEntityArgs )
 				: null;
+			const _area = entityRecord?.area || attributes.area;
+
 			const hasResolvedEntity = templatePartId
 				? hasFinishedResolution(
 						'getEditedEntityRecord',
@@ -66,16 +74,14 @@ export default function TemplatePartEdit( {
 
 			const defaultWrapperElement = select( editorStore )
 				.__experimentalGetDefaultTemplatePartAreas()
-				.find(
-					( { area } ) =>
-						area === ( entityRecord?.area || attributes.area )
-				)?.area_tag;
+				.find( ( { area: value } ) => value === _area )?.area_tag;
 
 			return {
 				innerBlocks: getBlocks( clientId ),
 				isResolved: hasResolvedEntity,
 				isMissing: hasResolvedEntity && ! entityRecord,
 				defaultWrapper: defaultWrapperElement || 'div',
+				area: _area,
 			};
 		},
 		[ templatePartId, clientId ]
@@ -157,6 +163,7 @@ export default function TemplatePartEdit( {
 								<TemplatePartSelection
 									setAttributes={ setAttributes }
 									onClose={ onClose }
+									area={ area }
 								/>
 							) }
 						/>

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -93,6 +93,7 @@ export default function TemplatePartPlaceholder( {
 							<TemplatePartSelection
 								setAttributes={ setAttributes }
 								onClose={ onClose }
+								area={ area }
 							/>
 						) }
 					/>

--- a/packages/block-library/src/template-part/edit/selection/index.js
+++ b/packages/block-library/src/template-part/edit/selection/index.js
@@ -22,7 +22,11 @@ const stopKeyPropagation = ( event ) => event.stopPropagation();
 // Disable reason (no-static-element-interactions): Navigational key-presses within
 // the menu are prevented from triggering WritingFlow and ObserveTyping interactions.
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-export default function TemplatePartSelection( { setAttributes, onClose } ) {
+export default function TemplatePartSelection( {
+	setAttributes,
+	onClose,
+	area,
+} ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	return (
 		<div
@@ -39,6 +43,7 @@ export default function TemplatePartSelection( { setAttributes, onClose } ) {
 					setAttributes={ setAttributes }
 					filterValue={ filterValue }
 					onClose={ onClose }
+					area={ area }
 				/>
 			</div>
 		</div>

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -194,7 +194,7 @@ function TemplatePartSearchResults( {
 					.indexOf( normalizedFilterValue )
 			);
 		} );
-		// Group filtered resutls together if their neighbors share the same area.
+		// Group filtered results together if their neighbors share the same area.
 		// This helps not show redundant panel groups side by side in the results.
 		const _groupedResults = [];
 		for ( let i = 0; i < searchResults.length; i++ ) {

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy, deburr } from 'lodash';
+import { deburr } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -102,20 +102,21 @@ function PanelGroup( { title, icon, children } ) {
 	);
 }
 
-function TemplatePartsByTheme( {
+function TemplatePartsByArea( {
 	templateParts,
 	setAttributes,
 	onClose,
 	composite,
+	area,
 } ) {
-	const templatePartsByTheme = useMemo( () => {
-		return Object.values( groupBy( templateParts, 'theme' ) );
-	}, [ templateParts ] );
+	const templatePartsByArea = useMemo( () => {
+		return templateParts.filter( ( item ) => item.area === area );
+	}, [ templateParts, area ] );
 	const currentShownTPs = useAsyncList( templateParts );
 
-	return templatePartsByTheme.map( ( templatePartList ) => (
-		<PanelGroup key={ templatePartList[ 0 ].theme }>
-			{ templatePartList.map( ( templatePart ) => {
+	return (
+		<PanelGroup>
+			{ templatePartsByArea.map( ( templatePart ) => {
 				return currentShownTPs.includes( templatePart ) ? (
 					<TemplatePartItem
 						key={ templatePart.id }
@@ -129,7 +130,7 @@ function TemplatePartsByTheme( {
 				);
 			} ) }
 		</PanelGroup>
-	) );
+	);
 }
 
 function TemplatePartSearchResults( {
@@ -138,6 +139,7 @@ function TemplatePartSearchResults( {
 	filterValue,
 	onClose,
 	composite,
+	area,
 } ) {
 	const filteredTPs = useMemo( () => {
 		// Filter based on value.
@@ -203,13 +205,17 @@ export default function TemplatePartPreviews( {
 	setAttributes,
 	filterValue,
 	onClose,
+	area,
 } ) {
 	const composite = useCompositeState();
 	const templateParts = useSelect( ( select ) => {
 		return (
 			select( coreStore ).getEntityRecords(
 				'postType',
-				'wp_template_part'
+				'wp_template_part',
+				{
+					per_page: -1,
+				}
 			) || []
 		);
 	}, [] );
@@ -231,6 +237,7 @@ export default function TemplatePartPreviews( {
 					filterValue={ filterValue }
 					onClose={ onClose }
 					composite={ composite }
+					area={ area }
 				/>
 			</Composite>
 		);
@@ -242,11 +249,12 @@ export default function TemplatePartPreviews( {
 			role="listbox"
 			aria-label={ __( 'List of template parts' ) }
 		>
-			<TemplatePartsByTheme
+			<TemplatePartsByArea
 				templateParts={ templateParts }
 				setAttributes={ setAttributes }
 				onClose={ onClose }
 				composite={ composite }
+				area={ area }
 			/>
 		</Composite>
 	);

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -194,6 +194,8 @@ function TemplatePartSearchResults( {
 					.indexOf( normalizedFilterValue )
 			);
 		} );
+		// Group filtered resutls together if their neighbors share the same area.
+		// This helps not show redundant panel groups side by side in the results.
 		const _groupedResults = [];
 		for ( let i = 0; i < searchResults.length; i++ ) {
 			if (

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -108,7 +108,7 @@ function TemplatePartsByArea( {
 	setAttributes,
 	onClose,
 	composite,
-	area,
+	area = 'uncategorized',
 } ) {
 	const templatePartsByArea = useMemo( () => {
 		return templateParts.filter( ( item ) => item.area === area );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Currently, the template part selection search filters based off of `slug` and `theme` values.
* `slug` is no longer appropriate as all custom template parts have a slug of the form `template-part-*`, and only the title is editable and visible by the user.  Therefore the search input should now work based off of the title instead of the slug.
* `theme` is also no longer appropriate as all results are returned for the active theme.  Instead, we can replace this with the new `area` term which will allow both searching by area and label the results such that a user knows if the item corresponds to a different area.

New behavior:
* Searching by name (title) should now work as expected.
* With no search input, only results corresponding to the currently active area/variation will be shown.
* With a search input, results are shown for all areas and are labelled appropriately.

Note that the future of this selection interface is uncertain and may go through redesign or get scrapped altogether, so its probably not worth investing too much time into currently.  However, it is important that it at least continues to work with the more recent changes in FSE.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Check the following through both the placeholder 'choose' button ( block inserter -> header, footer, or template part) and through the block toolbar's "replace" button.
* Verify only template parts of the same `area` are shown by default in the selection component.
* Verify searching by `title` works as expected and that search results are labeled by their area.
* Verify searching by another `area` works as expected.
* Smoke test standard template part flows.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
