### PR TITLE
compose: Add types useAsyncList

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -127,11 +127,11 @@ This behavior is useful if we want to render a list of items asynchronously for 
 
 _Parameters_
 
--   _list_ `Array`: Source array.
+-   _list_ `T[]`: Source array.
 
 _Returns_
 
--   `Array`: Async array.
+-   `T[]`: Async array.
 
 <a name="useConstrainedTabbing" href="#useConstrainedTabbing">#</a> **useConstrainedTabbing**
 

--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { Reducer } from 'react';
+
+/**
  * WordPress dependencies
  */
 import { useEffect, useReducer } from '@wordpress/element';
@@ -7,11 +13,11 @@ import { createQueue } from '@wordpress/priority-queue';
 /**
  * Returns the first items from list that are present on state.
  *
- * @param {Array} list  New array.
- * @param {Array} state Current state.
- * @return {Array} First items present iin state.
+ * @param list  New array.
+ * @param state Current state.
+ * @return First items present iin state.
  */
-function getFirstItemsPresentInState( list, state ) {
+function getFirstItemsPresentInState< T >( list: T[], state: T[] ): T[] {
 	const firstItems = [];
 
 	for ( let i = 0; i < list.length; i++ ) {
@@ -26,15 +32,22 @@ function getFirstItemsPresentInState( list, state ) {
 	return firstItems;
 }
 
+type ResetAction< T > = { type: 'reset'; list: T[] };
+type AppendAction< T > = { type: 'append'; item: T };
+
 /**
  * Reducer keeping track of a list of appended items.
  *
- * @param {Array}  state  Current state
- * @param {Object} action Action
+ * @template T
+ * @param state  Current state
+ * @param action Action
  *
- * @return {Array} update state.
+ * @return update state.
  */
-function listReducer( state, action ) {
+function listReducer< T >(
+	state: T[],
+	action: ResetAction< T > | AppendAction< T >
+): T[] {
 	if ( action.type === 'reset' ) {
 		return action.list;
 	}
@@ -50,11 +63,14 @@ function listReducer( state, action ) {
  * React hook returns an array which items get asynchronously appended from a source array.
  * This behavior is useful if we want to render a list of items asynchronously for performance reasons.
  *
- * @param {Array} list Source array.
- * @return {Array} Async array.
+ * @param list Source array.
+ * @return Async array.
  */
-function useAsyncList( list ) {
-	const [ current, dispatch ] = useReducer( listReducer, [] );
+function useAsyncList< T >( list: T[] ): T[] {
+	const [ current, dispatch ] = useReducer(
+		listReducer as Reducer< T[], ResetAction< T > | AppendAction< T > >,
+		[] as T[]
+	);
 
 	useEffect( () => {
 		// On reset, we keep the first items that were previously rendered.
@@ -64,7 +80,7 @@ function useAsyncList( list ) {
 			list: firstItems,
 		} );
 		const asyncQueue = createQueue();
-		const append = ( index ) => () => {
+		const append = ( index: number ) => () => {
 			if ( list.length <= index ) {
 				return;
 			}

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -2,8 +2,12 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types"
+		"declarationDir": "build-types",
 	},
+	"references": [
+		{ "path": "../element" },
+		{ "path": "../priority-queue" },
+	],
 	"include": [
 		"src/higher-order/if-condition/**/*",
 		"src/higher-order/pure/**/*",

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -8,6 +8,7 @@
 		"src/higher-order/if-condition/**/*",
 		"src/higher-order/pure/**/*",
 		"src/higher-order/with-instance-id/**/*",
+		"src/hooks/use-async-list/**/*",
 		"src/hooks/use-instance-id/**/*",
 		"src/utils/**/*"
 	]


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useAsyncList`. This also simplifies the logic inside of `useAsyncList` to use `useState` instead of `useReducer`. This removes about a dozen lines of code.

Are there unit tests for this function?

## How has this been tested?
Type checks and unit tests continue to pass.

## Types of changes
Non-breaking changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
