### PR TITLE
Fix stylesheet dependency for the post-comment-form block

### DIFF
--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -61,3 +61,17 @@ function gutenberg_comment_form_block_form_defaults( $fields ) {
 	return $fields;
 }
 add_filter( 'comment_form_defaults', 'gutenberg_comment_form_block_form_defaults' );
+
+add_action(
+	'wp_enqueue_scripts',
+	/**
+	 * Add the button stylesheet as a dependency for the post-comment form stylesheet.
+	 */
+	function() {
+		global $wp_styles;
+		if ( ! empty( $wp_styles->registered ) && ! empty( $wp_styles->registered['wp-block-post-comments-form'] ) ) {
+			$wp_styles->registered['wp-block-post-comments-form']->deps[] = 'wp-block-button';
+		}
+	},
+	1
+);


### PR DESCRIPTION
## Description
After https://github.com/WordPress/gutenberg/pull/31338 the `post-comments-form` block inherits styles from the button block for the form-submit button. In block themes (or classic themes that opted-in), block styles get loaded separately. So if a page has a post-comments-form block but not a button block, styles for the button don't get loaded and the form-submit button is unstyled.

This PR adds a dependency to the stylesheet.
Ideally this would be handled from the block.json file, but currently styles handling is pretty limited there, so hooking in `$wp_styles` to inject the dependency was the simplest way to handle this.

## How has this been tested?

Tested in [a block theme](https://github.com/aristath/q), by visiting a post. The template for the single posts in the FSE theme has a post-comments form, and no button.

## Screenshots

Before:

![before](https://user-images.githubusercontent.com/588688/117259502-c62a1800-ae56-11eb-82c4-f6e19fcf1e17.png)

After:

![after](https://user-images.githubusercontent.com/588688/117259533-ccb88f80-ae56-11eb-8e89-2b724298165c.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
