### PR TITLE
Clear selected block when focusing on element outside the editor

### DIFF
--- a/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
+++ b/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
@@ -5,6 +5,15 @@ import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
+/**
+ * We can't just use <BlockSelectionClearer> because the customizer has
+ * many root nodes rather than just one in the post editor.
+ * We need to listen to the focus events in all those roots, and also in
+ * the preview iframe.
+ *
+ * @param {Object} sidebarControl The sidebar control instance.
+ * @param {Object} popoverRef The ref object of the popover node container.
+ */
 export default function useClearSelectedBlock( sidebarControl, popoverRef ) {
 	const { hasSelectedBlock, hasMultiSelection } = useSelect(
 		blockEditorStore

--- a/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
+++ b/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+export default function useClearSelectedBlock( sidebarControl, popoverRef ) {
+	const { hasSelectedBlock, hasMultiSelection } = useSelect(
+		blockEditorStore
+	);
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( popoverRef.current && sidebarControl ) {
+			const inspectorContainer =
+				sidebarControl.inspector.contentContainer[ 0 ];
+			const container = sidebarControl.container[ 0 ];
+			const ownerDocument = container.ownerDocument;
+			const ownerWindow = ownerDocument.defaultView;
+
+			function handleClearSelectedBlock( element ) {
+				if (
+					// 1. Make sure there are blocks being selected.
+					( hasSelectedBlock() || hasMultiSelection() ) &&
+					// 2. The element should exist in the DOM (not deleted).
+					element &&
+					ownerDocument.contains( element ) &&
+					// 3. It should also not exist in the container, inspector, nor the popover.
+					! container.contains( element ) &&
+					! popoverRef.current.contains( element ) &&
+					! inspectorContainer.contains( element )
+				) {
+					clearSelectedBlock();
+				}
+			}
+
+			// Handle focusing in the same document.
+			function handleFocus( event ) {
+				handleClearSelectedBlock( event.target );
+			}
+			// Handle focusing outside the current document, like to iframes.
+			function handleBlur() {
+				handleClearSelectedBlock( ownerDocument.activeElement );
+			}
+
+			ownerDocument.addEventListener( 'focusin', handleFocus );
+			ownerWindow.addEventListener( 'blur', handleBlur );
+
+			return () => {
+				ownerDocument.removeEventListener( 'focusin', handleFocus );
+				ownerWindow.removeEventListener( 'blur', handleBlur );
+			};
+		}
+	}, [
+		popoverRef,
+		sidebarControl,
+		hasSelectedBlock,
+		hasMultiSelection,
+		clearSelectedBlock,
+	] );
+}

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -19,7 +19,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	__unstableBlockSettingsMenuFirstItem,
 } from '@wordpress/block-editor';
-import { SlotFillProvider, Popover } from '@wordpress/components';
+import { Popover } from '@wordpress/components';
 import { uploadMedia } from '@wordpress/media-utils';
 
 /**
@@ -60,61 +60,48 @@ export default function SidebarBlockEditor( {
 			mediaUpload: mediaUploadBlockEditor,
 		};
 	}, [ hasUploadPermissions, blockEditorSettings ] );
-	const parentContainer = document.getElementById(
-		'customize-theme-controls'
-	);
 
 	return (
 		<>
 			<BlockEditorKeyboardShortcuts.Register />
-			<SlotFillProvider>
-				<SidebarEditorProvider
-					sidebar={ sidebar }
-					settings={ settings }
-				>
-					<BlockEditorKeyboardShortcuts />
 
-					<Header
-						inserter={ inserter }
-						isInserterOpened={ isInserterOpened }
-						setIsInserterOpened={ setIsInserterOpened }
+			<SidebarEditorProvider sidebar={ sidebar } settings={ settings }>
+				<BlockEditorKeyboardShortcuts />
+
+				<Header
+					inserter={ inserter }
+					isInserterOpened={ isInserterOpened }
+					setIsInserterOpened={ setIsInserterOpened }
+				/>
+
+				<BlockTools>
+					<BlockSelectionClearer>
+						<WritingFlow>
+							<ObserveTyping>
+								<BlockList />
+							</ObserveTyping>
+						</WritingFlow>
+					</BlockSelectionClearer>
+				</BlockTools>
+
+				{ createPortal(
+					// This is a temporary hack to prevent button component inside <BlockInspector>
+					// from submitting form when type="button" is not specified.
+					<form onSubmit={ ( event ) => event.preventDefault() }>
+						<BlockInspector />
+					</form>,
+					inspector.contentContainer[ 0 ]
+				) }
+			</SidebarEditorProvider>
+
+			<__unstableBlockSettingsMenuFirstItem>
+				{ ( { onClose } ) => (
+					<BlockInspectorButton
+						inspector={ inspector }
+						closeMenu={ onClose }
 					/>
-
-					<BlockTools>
-						<BlockSelectionClearer>
-							<WritingFlow>
-								<ObserveTyping>
-									<BlockList />
-								</ObserveTyping>
-							</WritingFlow>
-						</BlockSelectionClearer>
-					</BlockTools>
-
-					{ createPortal(
-						// This is a temporary hack to prevent button component inside <BlockInspector>
-						// from submitting form when type="button" is not specified.
-						<form onSubmit={ ( event ) => event.preventDefault() }>
-							<BlockInspector />
-						</form>,
-						inspector.contentContainer[ 0 ]
-					) }
-				</SidebarEditorProvider>
-
-				<__unstableBlockSettingsMenuFirstItem>
-					{ ( { onClose } ) => (
-						<BlockInspectorButton
-							inspector={ inspector }
-							closeMenu={ onClose }
-						/>
-					) }
-				</__unstableBlockSettingsMenuFirstItem>
-
-				{
-					// We have to portal this to the parent of both the editor and the inspector,
-					// so that the popovers will appear above both of them.
-					createPortal( <Popover.Slot />, parentContainer )
-				}
-			</SlotFillProvider>
+				) }
+			</__unstableBlockSettingsMenuFirstItem>
 		</>
 	);
 }

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -19,7 +19,6 @@ import {
 	BlockEditorKeyboardShortcuts,
 	__unstableBlockSettingsMenuFirstItem,
 } from '@wordpress/block-editor';
-import { Popover } from '@wordpress/components';
 import { uploadMedia } from '@wordpress/media-utils';
 
 /**

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -432,6 +432,72 @@ describe( 'Widgets Customizer', () => {
 			"The page delivered both an 'X-Frame-Options' header and a 'Content-Security-Policy' header with a 'frame-ancestors' directive. Although the 'X-Frame-Options' header alone would have blocked embedding, it has been ignored."
 		);
 	} );
+
+	it( 'should clear block selection', async () => {
+		const widgetsPanel = await find( {
+			role: 'heading',
+			name: /Widgets/,
+			level: 3,
+		} );
+		await widgetsPanel.click();
+
+		const footer1Section = await find( {
+			role: 'heading',
+			name: /^Footer #1/,
+			level: 3,
+		} );
+		await footer1Section.click();
+
+		const paragraphBlock = await addBlock( 'Paragraph' );
+		await page.keyboard.type( 'First Paragraph' );
+		await showBlockToolbar();
+
+		const sectionHeading = await find( {
+			role: 'heading',
+			name: 'Customizing ▸ Widgets Footer #1',
+			level: 3,
+		} );
+		await sectionHeading.click();
+
+		// Expect clicking on the section title should clear the selection.
+		await expect( {
+			role: 'toolbar',
+			name: 'Block tools',
+		} ).not.toBeFound();
+
+		await paragraphBlock.focus();
+		await showBlockToolbar();
+
+		const preview = await page.$( '#customize-preview' );
+		await preview.click();
+
+		// Expect clicking on the preview iframe should clear the selection.
+		await expect( {
+			role: 'toolbar',
+			name: 'Block tools',
+		} ).not.toBeFound();
+
+		await paragraphBlock.focus();
+		await showBlockToolbar();
+
+		const editorContainer = await page.$(
+			'#customize-control-sidebars_widgets-sidebar-1'
+		);
+		const { x, y, width, height } = await editorContainer.boundingBox();
+		// Simulate Clicking on the empty space at the end of the editor.
+		await page.mouse.click( x + width / 2, y + height + 10 );
+
+		// Expect clicking on the empty space at the end of the editor
+		// should clear the selection.
+		await expect( {
+			role: 'toolbar',
+			name: 'Block tools',
+		} ).not.toBeFound();
+
+		expect( console ).toHaveWarned(
+			"The page delivered both an 'X-Frame-Options' header and a 'Content-Security-Policy' header with a 'frame-ancestors' directive. Although the 'X-Frame-Options' header alone would have blocked embedding, it has been ignored."
+		);
+	} );
 } );
 
 async function setWidgetsCustomizerExperiment( enabled ) {
@@ -517,4 +583,6 @@ async function addBlock( blockName ) {
 		selector: '.is-selected[data-block]',
 	} );
 	await addedBlock.focus();
+
+	return addedBlock;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix #31141.

Listen `focusin` and `blur` events to handle focusing out of the editor and clear the selected block. We can't just rely on `<BlockSelectionClearer>` because the elements (editor, inspector, popover, preview iframe) are all over the place rather than only under a parent node. The only solution I can think of for now is to register those events and manually check it.

I also moved some common code from the editor to the entry component, hope that this doesn't break anything 😅.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Select any block and try to unfocus it by clicking outside the editor. The inspector should still work though.

We can write some e2e tests if it's proved to be needed. Not sure we should do that now though.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/117275318-7ec07d80-ae90-11eb-8cd6-790009c2961a.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
