### PR TITLE
Scripts: Fix the CHANGELOG for `@wordpress/scripts` package

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## Unreleased
 
-### Bug Fix
-
--   Add `postcss` as a dependency to ensure that the correct version gets installed.
-
-## 15.0.0 (2021-04-29)
-
 ### Breaking Changes
 
 -   Drop support for Internet Explorer 11 ([#31110](https://github.com/WordPress/gutenberg/pull/31110)). Learn more at https://make.wordpress.org/core/2021/04/22/ie-11-support-phase-out-plan/.
@@ -19,6 +13,12 @@
 -   Include a Jest Reporter that formats test results for GitHub Actions annotations ([#31041](https://github.com/WordPress/gutenberg/pull/31041)).
 -   Have the `format` command ignore files listed in a `.prettierignore` file, add a fallback `.prettierignore` to the package ([30844](https://github.com/WordPress/gutenberg/pull/30844)).
 -   The e2e tests are now using [`jest-circus`](https://github.com/facebook/jest/tree/master/packages/jest-circus) as the test runner. This enable us to capture screenshots at the time the tests failed. The unit tests are also using the same test runner for consistency ([#28449](https://github.com/WordPress/gutenberg/pull/28449), [#31178](https://github.com/WordPress/gutenberg/pull/31178)).
+
+### Bug Fix
+
+-   Add `postcss` as a dependency to ensure that the correct version gets installed.
+
+## 15.0.0 (2021-04-29)
 
 ### Breaking Changes
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #31526.
Related commit: https://github.com/WordPress/gutenberg/commit/ddb946674120ec27de94391b313f6bdfec64da6a.

We had a merge issue after publishing `@wordpress/scripts` to npm. The line with the version and publishing date landed in the wrong place creating confusion.

