### PR TITLE
Fix global styles settings retrieval for REST

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -112,11 +112,10 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	// In the site editor, the user can change styles, so the client
 	// needs the ability to create them. Hence, we pass it some data
 	// for this: base styles (core+theme) and the ID of the user CPT.
-	$screen = get_current_screen();
 	if (
-		! empty( $screen ) &&
+		is_callable( 'get_current_screen' ) &&
 		function_exists( 'gutenberg_is_edit_site_page' ) &&
-		gutenberg_is_edit_site_page( $screen->id ) &&
+		gutenberg_is_edit_site_page( get_current_screen()->id ) &&
 		WP_Theme_JSON_Resolver::theme_has_support() &&
 		gutenberg_supports_block_templates()
 	) {


### PR DESCRIPTION
Follow up https://github.com/WordPress/gutenberg/pull/29969

## How to test

- Load front, post-editor, and site editor with TT1-blocks. Verify that global styles are respected (colors looks as they should, etc).
- Go to `<your_site>/wp-json/__experimental/wp-block-editor/v1/settings` and verify that you have access to all the settings (including the ones provided by global styles such as `__experimentalFeatures`)

![Captura de ecrã de 2021-05-06 12-15-33](https://user-images.githubusercontent.com/583546/117282268-d5b05d80-ae64-11eb-83d4-50ea2714ee88.png)

A quick way to test the endpoint is to add a  `return true;` within `get_items_permissions_check` in the `lib/class-wp-rest-block-editor-settings-controller.php` file.