### PR TITLE
[Block Library - Site Logo]: Fix `supports` declaration

### DIFF
--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -22,7 +22,9 @@
 		}
 	},
 	"supports": {
-		"html": false
+		"html": false,
+		"align": true,
+		"alignWide": false
 	},
 	"styles": [
 		{

--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -14,9 +14,5 @@ export { metadata, name };
 
 export const settings = {
 	icon,
-	supports: {
-		align: true,
-		alignWide: false,
-	},
 	edit,
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/31527

There was a duplicate declaration of `supports` in `Site Logo` settings (index.js and block.json) resulting in keeping one of them.
<!-- Please describe what you have changed or added -->
