### PR TITLE
compose: Add types useConstrainedTabbing

### DIFF
--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -27,11 +27,15 @@ import { useCallback } from '@wordpress/element';
  * ```
  */
 function useConstrainedTabbing() {
-	const ref = useCallback( ( node ) => {
+	const ref = useCallback( ( /** @type {Element} */ node ) => {
 		if ( ! node ) {
 			return;
 		}
-		node.addEventListener( 'keydown', ( event ) => {
+		node.addEventListener( 'keydown', ( /** @type {Event} */ event ) => {
+			if ( ! ( event instanceof window.KeyboardEvent ) ) {
+				return;
+			}
+
 			if ( event.keyCode !== TAB ) {
 				return;
 			}
@@ -45,17 +49,19 @@ function useConstrainedTabbing() {
 
 			if ( event.shiftKey && event.target === firstTabbable ) {
 				event.preventDefault();
-				lastTabbable.focus();
+				/** @type {HTMLElement} */ ( lastTabbable ).focus();
 			} else if ( ! event.shiftKey && event.target === lastTabbable ) {
 				event.preventDefault();
-				firstTabbable.focus();
+				/** @type {HTMLElement} */ ( firstTabbable ).focus();
 				/*
 				 * When pressing Tab and none of the tabbables has focus, the keydown
 				 * event happens on the wrapper div: move focus on the first tabbable.
 				 */
-			} else if ( ! tabbables.includes( event.target ) ) {
+			} else if (
+				! tabbables.includes( /** @type {Element} */ ( event.target ) )
+			) {
 				event.preventDefault();
-				firstTabbable.focus();
+				/** @type {HTMLElement} */ ( firstTabbable ).focus();
 			}
 		} );
 	}, [] );

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -7,12 +7,15 @@
 	"references": [
 		{ "path": "../element" },
 		{ "path": "../priority-queue" },
+		{ "path": "../dom" },
+		{ "path": "../keycodes" }
 	],
 	"include": [
 		"src/higher-order/if-condition/**/*",
 		"src/higher-order/pure/**/*",
 		"src/higher-order/with-instance-id/**/*",
 		"src/hooks/use-async-list/**/*",
+		"src/hooks/use-constrained-tabbing/**/*",
 		"src/hooks/use-instance-id/**/*",
 		"src/utils/**/*"
 	]

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -261,7 +261,7 @@ _Parameters_
 
 _Returns_
 
--   `element is HTMLElement`: True if the element is an text field, false if not.
+-   `node is HTMLElement`: True if the element is an text field, false if not.
 
 <a name="isVerticalEdge" href="#isVerticalEdge">#</a> **isVerticalEdge**
 

--- a/packages/dom/src/dom/is-text-field.js
+++ b/packages/dom/src/dom/is-text-field.js
@@ -11,7 +11,7 @@ import isHTMLInputElement from './is-html-input-element';
  * See: https://html.spec.whatwg.org/#textFieldSelection
  *
  * @param {Node} node The HTML element.
- * @return {element is HTMLElement} True if the element is an text field, false if not.
+ * @return {node is HTMLElement} True if the element is an text field, false if not.
  */
 export default function isTextField( node ) {
 	/* eslint-enable jsdoc/valid-types */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useConstrainedTabbing`. Only one runtime change was necessary to assert that the event is a KeyboardEvent (which it always will be but `addEventListener` only passes a plain `Event` so we need the assertion for the rest of the function).

Also fixes a bug in the types for `isTextField`.

Part of #18838

## How has this been tested?
Unit tests and type check passes.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
