### PR TITLE
ESLint Plugin: Load the prettier config object from a file

### DIFF
--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -13,8 +13,17 @@ const defaultPrettierConfig = require( '@wordpress/prettier-config' );
  */
 const { isPackageInstalled } = require( '../utils' );
 
-const { config: localPrettierConfig } =
+let { config: localPrettierConfig } =
 	cosmiconfigSync( 'prettier' ).search() || {};
+
+// If the local config is a string, it's a file path, and we need to load it to
+// get the config object.
+if ( typeof localPrettierConfig === 'string' ) {
+	localPrettierConfig = (
+		cosmiconfigSync().load( localPrettierConfig ) || {}
+	).config;
+}
+
 const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
 
 const config = {


### PR DESCRIPTION
## Description
An attempt to fix #31557 - If the local `prettier` value found by cosmicConfig is a string, we can assume it's a file name and that we should try loading that from `cosmicConfig`.

## How has this been tested?
You can use my proof of issue project - it adds eslint and prettier configs to change the max line length to 115 characters, and the file `src/index.js` has a line longer than the 80 character default.

I had trouble testing this locally, and finally ended up just copying the edited (gutenberg) file `eslint-plugin/configs/recommended.js` into the test project's `node_modules/@wordpress/eslint-plugin/configs/recommended.js`.

1. Clone/download [test-prettier-lint](https://github.com/ryelle/test-prettier-lint)
2. `npm install` to set up dependencies, copy over the changed file
3. Try running `npm format:js`, it shouldn't change any files
4. Now run `npm lint:js`, it should not find any errors

## Types of changes
Bug fix (non-breaking change which fixes an issue)
