### PR TITLE
Packages: Add required “directory” prop to package.json template in packages docs

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -18,7 +18,8 @@ When creating a new package, you need to provide at least the following:
     	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/package-name/README.md",
     	"repository": {
     		"type": "git",
-    		"url": "https://github.com/WordPress/gutenberg.git"
+    		"url": "https://github.com/WordPress/gutenberg.git",
+    		"directory": "packages/package-name"
     	},
     	"bugs": {
     		"url": "https://github.com/WordPress/gutenberg/issues"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
When creating a new package using the `package.json` template shown in the packages docs, the linter will complain that you are missing a `directory` property within the `repository` section.

This PR adds the required property to the `package.json` template.

## How has this been tested?

Tried to create a package. Tried to commit changes. Saw warning about missing `directory`. Added property. Committed. No more linting errors.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
