### PR TITLE
First pass at docs for the Widgets Block Editor

### DIFF
--- a/docs/how-to-guides/widgets/README.md
+++ b/docs/how-to-guides/widgets/README.md
@@ -1,0 +1,9 @@
+# Widgets
+
+The Gutenberg plugin replaces the Widgets Editor screen in WP Admin with a new screen based on the WordPress block editor.
+
+**Contents**
+
+- [Widgets Block Editor overview](/docs/how-to-guides/widgets/overview.md)
+- [Restoring the old Widgets Editor](/docs/how-to-guides/widgets/opting-out.md)
+- [Ensuring compatibility with the Legacy Widget block](/docs/how-to-guides/widgets/legacy-widget-block.md)

--- a/docs/how-to-guides/widgets/legacy-widget-block.md
+++ b/docs/how-to-guides/widgets/legacy-widget-block.md
@@ -1,12 +1,14 @@
-# Ensuring compatibility with the Legacy Widget block
+# About the Legacy Widget block
 
-The Legacy Widget block allows users to add, edit and preview third party widgets that are registered by plugins and widgets that were added using the old Widgets Editor.
+The Legacy Widget block allows users to add, edit and preview third party widgets that are registered by plugins and widgets that were added using the classic Widgets Editor.
 
 Third party widgets can be added by inserting a Legacy Widget block using the block inserter and selecting the widget from the block's dropdown.
 
 Third party widgets may also be added by searching for the name of the widget in the block inserter and selecting the widget. A variation of the Legacy Widget block will be inserted.
 
-## The `widget-added` event
+## Compatibility with the Legacy Widget block
+
+### The `widget-added` event
 
 The Legacy Widget block will display the widget's form in a way similar to the Customizer, and so is compatible with most third party widgets.
 
@@ -27,7 +29,7 @@ For example, a widget might want to show a "Password" field when the "Change pas
 
 Note that all of the widget's event handlers are added in the `widget-added` callback.
 
-## Displaying "No preview available."
+### Displaying "No preview available."
 
 The Legacy Widget block will display a preview of the widget when the Legacy Widget block is not selected.
 
@@ -52,13 +54,13 @@ class ExampleWidget extends WP_Widget {
 }
 ```
 
-## Allowing migration to a block
+### Allowing migration to a block
 
 You can allow users to easily migrate a Legacy Widget block containing a specific widget to a block or multiple blocks. This allows plugin authors to phase out their widgets in favour of blocks which are more intuitive and can be used in more places.
 
 The following steps show how to do this.
 
-### 1) Display the widget's instance in the REST API
+#### 1) Display the widget's instance in the REST API
 
 First, we need to tell WordPress that it is OK to display your widget's instance array in the REST API.
 
@@ -79,7 +81,7 @@ class ExampleWidget extends WP_Widget {
 
 This allows the block editor and other REST API clients to see your widget's instance array by accessing `instance.raw` in the REST API response.
 
-### 2) Add a block transform
+#### 2) Add a block transform
 
 Now, we can define a [block transform](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-transforms/) which tells the block editor what to replace the Legacy Widget block containing your widget with.
 
@@ -108,7 +110,7 @@ transforms: {
 },
 ```
 
-### 3) Hide the widget from the Legacy Widget block
+#### 3) Hide the widget from the Legacy Widget block
 
 As a final touch, we can tell the Legacy Widget block to hide your widget from the "Select widget" dropdown and from the block inserter. This encourages users to use the block that replaces your widget.
 

--- a/docs/how-to-guides/widgets/legacy-widget-block.md
+++ b/docs/how-to-guides/widgets/legacy-widget-block.md
@@ -1,0 +1,123 @@
+# Ensuring compatibility with the Legacy Widget block
+
+The Legacy Widget block allows users to add, edit and preview third party widgets that are registered by plugins and widgets that were added using the old Widgets Editor.
+
+Third party widgets can be added by inserting a Legacy Widget block using the block inserter and selecting the widget from the block's dropdown.
+
+Third party widgets may also be added by searching for the name of the widget in the block inserter and selecting the widget. A variation of the Legacy Widget block will be inserted.
+
+## The `widget-added` event
+
+The Legacy Widget block will display the widget's form in a way similar to the Customizer, and so is compatible with most third party widgets.
+
+If the widget uses JavaScript in its form, it is important that events are added to the DOM after the `'widget-added'` jQuery event is triggered on `document`.
+
+For example, a widget might want to show a "Password" field when the "Change password" checkbox is checked.
+
+```js
+( function( $ ) {
+	$( document ).on( 'widget-added', function( $control ) {
+		$control.find( '.change-password' ).on( 'change', function() {
+			var isChecked = $( this ).prop( 'checked' );
+			$control.find( '.password' ).toggleClass( 'hidden', ! isChecked );
+		} );
+	} );
+} )( jQuery );
+```
+
+Note that all of the widget's event handlers are added in the `widget-added` callback.
+
+## Displaying "No preview available."
+
+The Legacy Widget block will display a preview of the widget when the Legacy Widget block is not selected.
+
+A "No preview available." message is automatically shown by the Legacy Widget block when the widget's `widget()` function does not render anytihng or only renders empty HTML elements.
+
+Widgets may take advantage of this by returning early from `widget()` when a preview should not be displayed.
+
+```php
+class ExampleWidget extends WP_Widget {
+	...
+	public function widget( $instance ) {
+		if ( ! isset( $instance['name'] ) ) {
+			// Name is required, so display nothing if we don't have it.
+			return;
+		}
+		?>
+		<h3>Name: <?php echo esc_html( $instance['name'] ); ?></h3>
+		...
+		<?php
+	}
+	...
+}
+```
+
+## Allowing migration to a block
+
+You can allow users to easily migrate a Legacy Widget block containing a specific widget to a block or multiple blocks. This allows plugin authors to phase out their widgets in favour of blocks which are more intuitive and can be used in more places.
+
+The following steps show how to do this.
+
+### 1) Display the widget's instance in the REST API
+
+First, we need to tell WordPress that it is OK to display your widget's instance array in the REST API.
+
+This can be safely done if:
+
+- You know that all of the values stored by your widget in `$instance` can be represented as JSON; and
+- You know that your widget does not store any private data in `$instance` that should be kept hidden from users that have permission to customize the site.
+
+If it is safe to do so, then set `$show_instance_in_rest` to `true` in the class that extends `WP_Widget`.
+
+```php
+class ExampleWidget extends WP_Widget {
+	...
+	public $show_instance_in_rest = true;
+	...
+}
+```
+
+This allows the block editor and other REST API clients to see your widget's instance array by accessing `instance.raw` in the REST API response.
+
+### 2) Add a block transform
+
+Now, we can define a [block transform](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-transforms/) which tells the block editor what to replace the Legacy Widget block containing your widget with.
+
+This is done by adding JavaScript code to your block's definition. In this example, we define a transform that turns a widget with ID `'example_widget'` into a block with name `'example/block'`.
+
+```js
+transforms: {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/legacy-widget' ],
+			isMatch: ( { idBase, instance } ) => {
+				if ( ! instance?.raw ) {
+					// Can't transform if raw instance is not shown in REST API.
+					return false;
+				}
+				return idBase === 'example_widget';
+			},
+            transform: ( { instance } ) => {
+                return createBlock( 'example/block', {
+					name: instance.raw.name,
+                } );
+            },
+        },
+    ]
+},
+```
+
+### 3) Hide the widget from the Legacy Widget block
+
+As a final touch, we can tell the Legacy Widget block to hide your widget from the "Select widget" dropdown and from the block inserter. This encourages users to use the block that replaces your widget.
+
+This can be done using the `widget_types_to_hide_from_legacy_widget_block` filter.
+
+```php
+function hide_example_widget( $widget_types ) {
+	$widget_types[] = 'example_widget';
+	return $widget_types;
+}
+add_filter( 'widget_types_to_hide_from_legacy_widget_block', 'hide_example_widget' );
+```

--- a/docs/how-to-guides/widgets/opting-out.md
+++ b/docs/how-to-guides/widgets/opting-out.md
@@ -1,4 +1,4 @@
-# Restoring the old Widgets Editor
+# Restoring the classic Widgets Editor
 
 There are several ways to disable the new Widgets Block Editor.
 

--- a/docs/how-to-guides/widgets/opting-out.md
+++ b/docs/how-to-guides/widgets/opting-out.md
@@ -1,0 +1,44 @@
+# Restoring the old Widgets Editor
+
+There are several ways to disable the new Widgets Block Editor.
+
+## Using `remove_theme_support`
+
+Themes may disable the Widgets Block Editor by calling `remove_theme_support( 'widgets-block-editor' )`.
+
+For example, a theme may have the following PHP code in `functions.php`.
+
+```php
+function example_theme_support() {
+	remove_theme_support( 'widgets-block-editor' );
+}
+add_action( 'after_setup_theme', example_theme_support' );
+```
+
+## Using the Classic Widgets plugin
+
+End users may disable the Widgets Block Editor by installing and activating the [Classic Widgets plugin](https://wordpress.org/plugins/classic-widgets/).
+
+With this plugin installed, the Widgets Block Editor can be toggled on and off by deactivating and activating the plugin.
+
+## Using a filter
+
+the `gutenberg_use_widgets_block_editor` filter controls whether or not the Widgets Block Editor is enabled.
+
+For example, a site administrator may include the following PHP code in a mu-plugin to disable the Widgets Block Editor.
+
+```php
+add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
+```
+
+For more advanced uses, you may supply your own function. In this example, the Widgets Block Editor is disabled for a specific user.
+
+```php
+function example_use_widgets_block_editor( $use_widgets_block_editor ) {
+	if ( 123 === get_current_user_id() ) {
+		return false;
+	}
+	return $use_widgets_block_editor;
+}
+add_filter( 'gutenberg_use_widgets_block_editor', 'example_use_widgets_block_editor' );
+```

--- a/docs/how-to-guides/widgets/overview.md
+++ b/docs/how-to-guides/widgets/overview.md
@@ -1,0 +1,31 @@
+# Widgets Block Editor overview
+
+## Widgets Block Editor screen
+
+Gutenberg replaces the Widgets screen in WP Admin with a new screen built using the familiar WordPress block editor.
+
+You can access the new Widgets Block Editor by navigating to Appearance → Widgets.
+
+The Widgets Block Editor allows you to insert blocks and widgets into any of the [Widget Areas or Sidebars](https://developer.wordpress.org/themes/functionality/sidebars/) defined by the site's active theme.
+
+## Customizer Widgets Block Editor
+
+Gutenberg also replaces the Widgets editor in the Customizer with a new block-based editor.
+
+You can access the Customizer Widgets Block Editor by navigating to Appearance → Customize, selecting Widgets, and then selecting a Widget Area.
+
+The Customizer Widgets Block Editor allows you to insert blocks and widgets into the selected Widget Area. A live preview of the changes appears to the right of the editor.
+
+## Compatibility
+
+Widgets that were added to a Widget Area before activating Gutenberg will continue to work via the Legacy Widget block.
+
+The Legacy Widget block allows you to edit and preview changes to a widget within the block editor.
+
+Third party widgets registered by plugins can be inserted by adding a new Legacy Widget block.
+
+The Widgets Block Editor stores blocks using an underlying "Block" widget that is invisible to the user. This means that plugins and themes will contibue to work normally, and that the Widgets Block Editor can be disabled without any data loss.
+
+Themes may disable the Widgets Block Editor using `remove_theme_support( 'widgets-block-editor' )`.
+
+Users may disable the Widgets Block Editor by installing the [Classic Widgets plugin](https://wordpress.org/plugins/classic-widgets/).

--- a/docs/how-to-guides/widgets/overview.md
+++ b/docs/how-to-guides/widgets/overview.md
@@ -1,30 +1,30 @@
 # Widgets Block Editor overview
 
-## Widgets Block Editor screen
+## Widgets Block Editor
 
-Gutenberg replaces the Widgets screen in WP Admin with a new screen built using the familiar WordPress block editor.
+The new Widgets Editor is a WordPress feature which upgrades widget areas to allow using blocks alongside widgets. It offers a new widget management experience built using the familiar WordPress block editor.
 
-You can access the new Widgets Block Editor by navigating to Appearance → Widgets.
+You can access the new Widgets Editor by navigating to Appearance → Widgets or Appearance → Cusomize → Widgets and choose a widget area.
 
-The Widgets Block Editor allows you to insert blocks and widgets into any of the [Widget Areas or Sidebars](https://developer.wordpress.org/themes/functionality/sidebars/) defined by the site's active theme.
+The Widgets Block Editor allows you to insert blocks and widgets into any of the [Widget Areas or Sidebars](https://developer.wordpress.org/themes/functionality/sidebars/) defined by the site's active theme, via a standalone editor or through the Customizer.
 
-## Customizer Widgets Block Editor
+### Customizer Widgets Block Editor
 
-Gutenberg also replaces the Widgets editor in the Customizer with a new block-based editor.
+The new Widgets Editor also replaces the Widgets section in the Customizer with the new block-based editor.
 
 You can access the Customizer Widgets Block Editor by navigating to Appearance → Customize, selecting Widgets, and then selecting a Widget Area.
 
-The Customizer Widgets Block Editor allows you to insert blocks and widgets into the selected Widget Area. A live preview of the changes appears to the right of the editor.
+Using the new Widgets Editor through the Customizer goes beyond inserting blocks and widgets into a selected Widget Area, makeing use of the live preview of the changes, to the right of the editor, and of all the other Customizer specific features such as scheduling and sharing changes.
 
 ## Compatibility
 
-Widgets that were added to a Widget Area before activating Gutenberg will continue to work via the Legacy Widget block.
+Widgets that were added to a Widget Area before the new Widgets Editor will continue to work - via the Legacy Widget block.
 
-The Legacy Widget block allows you to edit and preview changes to a widget within the block editor.
+The Legacy Widget block is the compatibility mechanism which allows us to edit and preview changes to a classic widget within the new block based Widgets Editor.
 
-Third party widgets registered by plugins can be inserted by adding a new Legacy Widget block.
+Any third party widgets registered by plugins can still be inserted in widget areas by adding and setting them up through a Legacy Widget block.
 
-The Widgets Block Editor stores blocks using an underlying "Block" widget that is invisible to the user. This means that plugins and themes will contibue to work normally, and that the Widgets Block Editor can be disabled without any data loss.
+The Widgets Editor stores blocks using an underlying "Block" widget that is invisible to the user. This means that plugins and themes will contibue to work normally, and that the Widgets Block Editor can be disabled without any data loss.
 
 Themes may disable the Widgets Block Editor using `remove_theme_support( 'widgets-block-editor' )`.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -444,13 +444,13 @@
 		"parent": "widgets"
 	},
 	{
-		"title": "Restoring the old Widgets Editor",
+		"title": "Restoring the classic Widgets Editor",
 		"slug": "opting-out",
 		"markdown_source": "../docs/how-to-guides/widgets/opting-out.md",
 		"parent": "widgets"
 	},
 	{
-		"title": "Ensuring compatibility with the Legacy Widget block",
+		"title": "About the Legacy Widget block",
 		"slug": "legacy-widget-block",
 		"markdown_source": "../docs/how-to-guides/widgets/legacy-widget-block.md",
 		"parent": "widgets"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -432,6 +432,30 @@
 		"parent": "how-to-guides"
 	},
 	{
+		"title": "Widgets",
+		"slug": "widgets",
+		"markdown_source": "../docs/how-to-guides/widgets/README.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Widgets Block Editor overview",
+		"slug": "overview",
+		"markdown_source": "../docs/how-to-guides/widgets/overview.md",
+		"parent": "widgets"
+	},
+	{
+		"title": "Restoring the old Widgets Editor",
+		"slug": "opting-out",
+		"markdown_source": "../docs/how-to-guides/widgets/opting-out.md",
+		"parent": "widgets"
+	},
+	{
+		"title": "Ensuring compatibility with the Legacy Widget block",
+		"slug": "legacy-widget-block",
+		"markdown_source": "../docs/how-to-guides/widgets/legacy-widget-block.md",
+		"parent": "widgets"
+	},
+	{
 		"title": "Reference Guides",
 		"slug": "reference-guides",
 		"markdown_source": "../docs/reference-guides/README.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -177,7 +177,12 @@
 				]
 			},
 			{ "docs/how-to-guides/accessibility.md": [] },
-			{ "docs/how-to-guides/internationalization.md": [] }
+			{ "docs/how-to-guides/internationalization.md": [] },
+			{ "docs/how-to-guides/widgets/README.md": [
+				{ "docs/how-to-guides/widgets/overview.md": [] },
+				{ "docs/how-to-guides/widgets/opting-out.md": [] },
+				{ "docs/how-to-guides/widgets/legacy-widget-block.md": [] }
+			] }
 		]
 	},
 	{


### PR DESCRIPTION
Here's my first pass at some docs for the Widgets Block Editor. This checks off many of the items in https://github.com/WordPress/gutenberg/issues/25759.

I'm not really familiar with how `docs/manifest.json` works so please let me know if I did something wrong there.