### PR TITLE
Widget Screen: Add default notices support

### DIFF
--- a/packages/edit-widgets/src/components/notices/index.js
+++ b/packages/edit-widgets/src/components/notices/index.js
@@ -6,27 +6,47 @@ import { filter } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { SnackbarList } from '@wordpress/components';
+import { NoticeList, SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
 function Notices() {
+	const { removeNotice } = useDispatch( noticesStore );
 	const { notices } = useSelect( ( select ) => {
 		return {
 			notices: select( noticesStore ).getNotices(),
 		};
 	}, [] );
+
+	const dismissibleNotices = filter( notices, {
+		isDismissible: true,
+		type: 'default',
+	} );
+	const nonDismissibleNotices = filter( notices, {
+		isDismissible: false,
+		type: 'default',
+	} );
 	const snackbarNotices = filter( notices, {
 		type: 'snackbar',
 	} );
-	const { removeNotice } = useDispatch( noticesStore );
 
 	return (
-		<SnackbarList
-			notices={ snackbarNotices }
-			className="edit-widgets-notices__snackbar"
-			onRemove={ removeNotice }
-		/>
+		<>
+			<NoticeList
+				notices={ nonDismissibleNotices }
+				className="edit-widgets-notices__pinned"
+			/>
+			<NoticeList
+				notices={ dismissibleNotices }
+				className="edit-widgets-notices__dismissible"
+				onRemove={ removeNotice }
+			/>
+			<SnackbarList
+				notices={ snackbarNotices }
+				className="edit-widgets-notices__snackbar"
+				onRemove={ removeNotice }
+			/>
+		</>
 	);
 }
 

--- a/packages/edit-widgets/src/components/notices/style.scss
+++ b/packages/edit-widgets/src/components/notices/style.scss
@@ -6,3 +6,21 @@
 	padding-right: 16px;
 }
 @include editor-left(".edit-widgets-notices__snackbar");
+
+.edit-widgets-notices__dismissible,
+.edit-widgets-notices__pinned {
+	.components-notice {
+		box-sizing: border-box;
+		margin: 0;
+		border-bottom: $border-width solid rgba(0, 0, 0, 0.2);
+		padding: 0 $grid-unit-15;
+
+		// Min-height matches the height of a single-line notice with an action button.
+		min-height: $header-height;
+
+		// Margins ensure that the dismiss button aligns to the center of the first line of text.
+		.components-notice__dismiss {
+			margin-top: $grid-unit-15;
+		}
+	}
+}


### PR DESCRIPTION
## Description
Adds support for dismissible and non-dismissible notices to the widget screen.

P.S. Borrowed styles from the post editor.

Fixes #31576.

## How has this been tested?
1. Go to Appearance → Widgets.
2. Open DevTools.
3. Run: `wp.data.dispatch( 'core/notices' ).createErrorNotice( 'error' )`
4. Should create dismissable notice.
5. Run: `wp.data.dispatch( 'core/notices' ).createInfoNotice( 'info', { isDismissible: false }  )`

## Screenshots <!-- if applicable -->
![CleanShot 2021-05-07 at 10 29 43](https://user-images.githubusercontent.com/240569/117407165-38662f80-af1f-11eb-9d55-9e284d0093af.png)


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
