### PR TITLE
Widget editor: Update toolbar and notice positioning.

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -21,12 +21,12 @@ export default function WidgetAreasBlockEditorContent( {
 	blockEditorSettings,
 } ) {
 	return (
-		<div className="edit-widgets-block-editor editor-styles-wrapper">
-			<EditorStyles styles={ blockEditorSettings.styles } />
+		<BlockTools>
 			<KeyboardShortcuts />
 			<BlockEditorKeyboardShortcuts />
 			<Notices />
-			<BlockTools>
+			<div className="edit-widgets-block-editor editor-styles-wrapper">
+				<EditorStyles styles={ blockEditorSettings.styles } />
 				<BlockSelectionClearer>
 					<WritingFlow>
 						<ObserveTyping>
@@ -34,7 +34,7 @@ export default function WidgetAreasBlockEditorContent( {
 						</ObserveTyping>
 					</WritingFlow>
 				</BlockSelectionClearer>
-			</BlockTools>
-		</div>
+			</div>
+		</BlockTools>
 	);
 }


### PR DESCRIPTION
## Description
Updates the edit widgets fixed toolbar positioning after #31134.

This just required some reordering of the components to more closely match the post editor. Notices have also been moved to render below the toolbar.

## How has this been tested?
1. Open the widget editor
2. Use a mobile-ish screen size
3. Click a block

## Screenshots <!-- if applicable -->

#### Before Before
<img width="728" alt="Screenshot 2021-05-07 at 3 48 40 pm" src="https://user-images.githubusercontent.com/677833/117416240-ba6c4d80-af4b-11eb-8acc-ca251660feb1.png">

#### Before (after before before)
<img width="727" alt="Screenshot 2021-05-07 at 3 47 44 pm" src="https://user-images.githubusercontent.com/677833/117416072-96a90780-af4b-11eb-8da7-9f07140174db.png">

#### After
<img width="730" alt="Screenshot 2021-05-07 at 3 46 21 pm" src="https://user-images.githubusercontent.com/677833/117415919-70836780-af4b-11eb-8e80-9de1dacb57b6.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
