### PR TITLE
Add padding for nav screen.

### DIFF
--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -31,8 +31,9 @@
 	}
 
 	.edit-navigation-layout__content-area {
-		// Add some margin above the fixed mobile toolbar.
-		padding-top: $grid-unit-15;
+		// The 10px match that of similar settings pages.
+		padding: $grid-unit-15 10px 10px 10px;
+
 		@include break-medium() {
 			// Provide space for the floating block toolbar.
 			padding-top: $navigation-editor-spacing-top;
@@ -60,6 +61,14 @@
 		// Hide the toggle as the sidebar should be permanently open.
 		.interface-complementary-area-header {
 			display: none;
+		}
+	}
+
+	.edit-navigation-header {
+		background: $white;
+
+		@include break-medium() {
+			background: transparent;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fixes #31543.

This PR adds padding to the mobile breakpoint for the nav screen. It also makes the header white, to match the docked toolbar. Before:

<img width="611" alt="Screenshot 2021-05-07 at 09 46 11" src="https://user-images.githubusercontent.com/1204802/117417847-0eab0980-af1b-11eb-9e20-bd451bacaba0.png">

After:

<img width="488" alt="Screenshot 2021-05-07 at 09 51 15" src="https://user-images.githubusercontent.com/1204802/117417851-1074cd00-af1b-11eb-86aa-dd4b1e0cb3c3.png">

Responsive:

![responsive](https://user-images.githubusercontent.com/1204802/117417864-136fbd80-af1b-11eb-9362-a33d7265cebd.gif)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
