### PR TITLE
Customizer: Implement mobile responsive block toolbar

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -176,6 +176,12 @@ $z-layers: (
 	// Needs to be higher than .components-circular-option-picker__option.is-pressed.
 	".components-circular-option-picker__option.is-pressed + svg": 2,
 	".edit-navigation-layout__overlay": 999,
+
+	// Appear under the customizer heading UI, but over anything else.
+	".customize-widgets__topbar": 8,
+
+	// Appear under the topbar.
+	".customize-widgets__block-toolbar": 7,
 );
 
 @function z-index( $key ) {

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -1,7 +1,4 @@
 .customize-widgets-header {
-	position: sticky;
-	top: 0;
-
 	@include break-medium() {
 		// The mobile fixed block toolbar should be snug under the header.
 		margin-bottom: $grid-unit-60 + $default-block-margin;

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -2,16 +2,21 @@
 	position: sticky;
 	top: 0;
 
+	@include break-medium() {
+		// The mobile fixed block toolbar should be snug under the header.
+		margin-bottom: $grid-unit-60 + $default-block-margin;
+	}
+
 	// Offset the customizer's sidebar padding.
-	margin: -15px ( -$grid-unit-15 ) 0 ( -$grid-unit-15 );
+	// Provide enough bottom margin to ensure the floating block toolbar isn't overlapped.
+	margin: -15px ( -$grid-unit-15 ) ( 0 ) ( -$grid-unit-15 );
 	padding: $grid-unit-15;
 
 	// Match the customizer grey background.
 	background: #f0f0f1;
 	border-bottom: 1px solid $gray-200;
 
-	// Ensure widget UI doesn't overlap when scrolling
-	z-index: 8;
+	z-index: z-index(".customize-widgets__topbar");
 }
 
 .customize-widgets-header-toolbar {

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -1,5 +1,6 @@
 .customize-widgets-header {
 	position: sticky;
+	top: 0;
 
 	// Offset the customizer's sidebar padding.
 	margin: -15px ( -$grid-unit-15 ) 0 ( -$grid-unit-15 );
@@ -8,6 +9,9 @@
 	// Match the customizer grey background.
 	background: #f0f0f1;
 	border-bottom: 1px solid $gray-200;
+
+	// Ensure widget UI doesn't overlap when scrolling
+	z-index: 8;
 }
 
 .customize-widgets-header-toolbar {

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -1,3 +1,15 @@
+.customize-widgets-header {
+	position: sticky;
+
+	// Offset the customizer's sidebar padding.
+	margin: -15px ( -$grid-unit-15 ) 0 ( -$grid-unit-15 );
+	padding: $grid-unit-15;
+
+	// Match the customizer grey background.
+	background: #f0f0f1;
+	border-bottom: 1px solid $gray-200;
+}
+
 .customize-widgets-header-toolbar {
 	display: flex;
 	border: none;

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -1,6 +1,6 @@
 .block-editor-block-contextual-toolbar.is-fixed {
 	// The top position used for the 'sticky' positioning.
-	top: $grid-unit-60 + $border-width;
+	top: 0;
 
 	// Offset the customizer's sidebar padding.
 	margin-left: -$grid-unit-15;

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -1,3 +1,16 @@
+.block-editor-block-contextual-toolbar.is-fixed {
+	// Offset the customizer's sidebar padding.
+	margin-left: -$grid-unit-15;
+	margin-right: -$grid-unit-15;
+	width: calc(100% + #{ $grid-unit-30 });
+
+	// Scroll sideways.
+	overflow-y: auto;
+
+	// Appear underneath overlapping customizer UI.
+	z-index: 8;
+}
+
 .customize-control-sidebar_block_editor .block-editor-block-list__block-popover {
 	position: fixed;
 	// Appear over block placeholders, but under widgets page headings.

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -1,4 +1,7 @@
 .block-editor-block-contextual-toolbar.is-fixed {
+	// The top position used for the 'sticky' positioning.
+	top: $grid-unit-60 + $border-width;
+
 	// Offset the customizer's sidebar padding.
 	margin-left: -$grid-unit-15;
 	margin-right: -$grid-unit-15;

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -9,13 +9,10 @@
 
 	// Scroll sideways.
 	overflow-y: auto;
-
-	// Appear underneath overlapping customizer UI.
-	z-index: 8;
+	z-index: z-index(".customize-widgets__block-toolbar");
 }
 
 .customize-control-sidebar_block_editor .block-editor-block-list__block-popover {
 	position: fixed;
-	// Appear over block placeholders, but under widgets page headings.
-	z-index: 8;
+	z-index: z-index(".customize-widgets__block-toolbar");
 }

--- a/packages/customize-widgets/src/controls/style.scss
+++ b/packages/customize-widgets/src/controls/style.scss
@@ -1,6 +1,11 @@
-// Adds a white background to the block based widget section.
-// #customize-theme-controls id is required to add specificity.
-#customize-theme-controls .customize-widgets__sidebar-section {
+// Additional ids and class names are used in the selector for
+// added specificity.
+#customize-theme-controls .customize-pane-child.customize-widgets__sidebar-section {
+	// Override the default 'overflow' to allow the
+	// editor toolbars to be sticky.
+	overflow: unset;
+
+	// Make the entire sidebar background white.
 	min-height: 100%;
 	background-color: $white;
 }


### PR DESCRIPTION
## Description
Follow up to #31134
<strike>Progresses #30912</strike>
Closes #30720

Styles the fixed (mobile responsive) toolbar that #31134 introduced to look like the design in https://github.com/WordPress/gutenberg/issues/30720#issuecomment-818278219.

I've also styled the top bar a bit and set it to `position: sticky` (#30912), but for some reason it doesn't stick while the toolbar does. Not sure if any CSS pros have any ideas how to solve that? There's still a separate issue open for it, so it doesn't have to be solved in this PR, but it might be nice.

The stickyness of the block toolbar itself isn't perfect as the customizer has it's own JavaScript-y scrolling thing happening with the sidebar description container above it.

## How has this been tested?
1. Open the customizer widget editor (after having enabled the Gutenberg experiment)
2. Make your browser viewport a mobile-ish size
3. Select a block and see the block toolbar
4. Add enough blocks that the sidebar scrolls
5. Scroll and see the sticky behavior

## Screenshots <!-- if applicable -->
<img width="301" alt="Screenshot 2021-05-07 at 5 01 16 pm" src="https://user-images.githubusercontent.com/677833/117425910-dd9bfa80-af55-11eb-8c64-4d423cbb4628.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
