### PR TITLE
Create block metadata for all blocks

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -87,32 +87,25 @@ const getBlockMetadata = ( blockTypes ) => {
 	blockTypes.forEach( ( blockType ) => {
 		const name = blockType.name;
 		const supports = extractSupportKeys( blockType?.supports );
-		const hasSupport = supports.length > 0;
 
-		if ( hasSupport ) {
-			const selector =
-				blockType?.supports?.__experimentalSelector ??
-				'.wp-block-' + name.replace( 'core/', '' ).replace( '/', '-' );
-
-			const blockSelectors = selector.split( ',' );
-			const elements = [];
-			Object.keys( ELEMENTS ).forEach( ( key ) => {
-				const elementSelector = [];
-				blockSelectors.forEach( ( blockSelector ) => {
-					elementSelector.push(
-						blockSelector + ' ' + ELEMENTS[ key ]
-					);
-				} );
-				elements[ key ] = elementSelector.join( ',' );
+		const selector =
+			blockType?.supports?.__experimentalSelector ??
+			'.wp-block-' + name.replace( 'core/', '' ).replace( '/', '-' );
+		const blockSelectors = selector.split( ',' );
+		const elements = [];
+		Object.keys( ELEMENTS ).forEach( ( key ) => {
+			const elementSelector = [];
+			blockSelectors.forEach( ( blockSelector ) => {
+				elementSelector.push( blockSelector + ' ' + ELEMENTS[ key ] );
 			} );
-
-			result[ name ] = {
-				name,
-				selector,
-				supports,
-				elements,
-			};
-		}
+			elements[ key ] = elementSelector.join( ',' );
+		} );
+		result[ name ] = {
+			name,
+			selector,
+			supports,
+			elements,
+		};
 	} );
 
 	return result;


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/31560

The global styles sidebar uses the block supports to decide whether or not to show a specific UI panel for a block. However, independently from block supports, a block can always be styled via theme.json, hence we need to build the block metadata for all blocks ― and not only for those who declare support for a style property.

## How to test 

See https://github.com/WordPress/gutenberg/issues/31560
