### PR TITLE
Navigation Editor: Fix menu location assignment

### DIFF
--- a/packages/edit-navigation/src/hooks/use-menu-locations.js
+++ b/packages/edit-navigation/src/hooks/use-menu-locations.js
@@ -51,7 +51,7 @@ export default function useMenuLocations() {
 
 			setMenuLocationsByName( newMenuLocationsByName );
 
-			const activeMenuId = oldMenuId || newMenuId;
+			const activeMenuId = newMenuId || oldMenuId;
 			editMenuEntityRecord( ...menuEntityData, {
 				locations: locationsForMenuId(
 					newMenuLocationsByName,


### PR DESCRIPTION
## Description
PR fixes the issue when the editor incorrectly assigned the menu location if another menu was already using the selected location.

Fixes #31550.

## How has this been tested?
* Go to `/wp-admin/admin.php?page=gutenberg-navigation`.
* Create two menus.
* Assign a location to the first menu.
* Select the second menu and select the same location.
* New location should be correctly assigned after saving the menu.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
