### PR TITLE
[Block Library - Post Featured Image]: Change wrapper element to `figure`

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -112,7 +112,7 @@ function PostFeaturedImageDisplay( {
 					/>
 				) }
 			</BlockControls>
-			<div { ...useBlockProps() }>{ image }</div>
+			<figure { ...useBlockProps() }>{ image }</figure>
 		</>
 	);
 }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -30,7 +30,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 
-	return '<p ' . $wrapper_attributes . '>' . $featured_image . '</p>';
+	return '<figure ' . $wrapper_attributes . '>' . $featured_image . '</figure>';
 }
 
 /**

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -1,4 +1,6 @@
 .wp-block-post-featured-image {
+	margin-left: 0;
+	margin-right: 0;
 	a {
 		display: inline-block;
 	}


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/30475

Currently, the Post Featured Image block outputs the featured image wrapped in a paragraph element. A figure element would be more semantic, and match the structure of the gallery and image blocks.