### PR TITLE
FSE: Simplify template loader logic

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -85,21 +85,21 @@ function gutenberg_override_query_template( $template, $type, array $templates )
 		$templates = array_slice( $templates, 0, $index + 1 );
 	}
 
-	$current_template = gutenberg_resolve_template( $type, $templates );
+	$block_template = gutenberg_resolve_template( $type, $templates );
 
-	if ( $current_template ) {
-		if ( empty( $current_template->content ) && is_user_logged_in() ) {
+	if ( $block_template ) {
+		if ( empty( $block_template->content ) && is_user_logged_in() ) {
 			$_wp_current_template_content =
 			sprintf(
 				/* translators: %s: Template title */
 				__( 'Empty template: %s', 'gutenberg' ),
-				$current_template->title
+				$block_template->title
 			);
-		} elseif ( ! empty( $current_template->content ) ) {
-			$_wp_current_template_content = $current_template->content;
+		} elseif ( ! empty( $block_template->content ) ) {
+			$_wp_current_template_content = $block_template->content;
 		}
 		if ( isset( $_GET['_wp-find-template'] ) ) {
-			wp_send_json_success( $current_template );
+			wp_send_json_success( $block_template );
 		}
 	} else {
 		if ( $template ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -104,7 +104,9 @@ function gutenberg_override_query_template( $template, $type, array $templates )
 	} else {
 		if ( $template ) {
 			return $template;
-		} elseif ( 'index' === $type ) {
+		}
+
+		if ( 'index' === $type ) {
 			if ( isset( $_GET['_wp-find-template'] ) ) {
 				wp_send_json_error( array( 'message' => __( 'No matching template found.', 'gutenberg' ) ) );
 			}

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -64,56 +64,28 @@ function get_template_hierarchy( $template_type ) {
  */
 function gutenberg_override_query_template( $template, $type, array $templates ) {
 	global $_wp_current_template_content;
-	$current_template = gutenberg_resolve_template( $type, $templates );
 
-	// Allow falling back to a PHP template if it has a higher priority than the block template.
-	$current_template_slug       = str_replace(
-		array( trailingslashit( get_stylesheet_directory() ), trailingslashit( get_template_directory() ), '.php' ),
-		'',
-		$template
-	);
-	$current_block_template_slug = is_object( $current_template ) ? $current_template->slug : false;
-	foreach ( $templates as $template_item ) {
+	if ( $template ) {
+		// locate_template() has found a PHP template at the path specified by $template.
+		// That means that we have a fallback candidate if we cannot find a block template
+		// with higher specificity.
+		// Thus, before looking for matching block themes, we shorten our list of candidate
+		// templates accordingly.
 
-		$template_item_slug = gutenberg_strip_php_suffix( $template_item );
+		// Locate the index of $template (without the theme directory path) in $templates.
+		$relative_template_path = str_replace(
+			array( get_stylesheet_directory() . '/', get_template_directory() . '/' ),
+			'',
+			$template
+		);
+		$index                  = array_search( $relative_template_path, $templates, true );
 
-		// Break the loop if the block-template matches the template slug.
-		if ( $current_block_template_slug === $template_item_slug ) {
-
-			// if the theme is a child theme we want to check if a php template exists.
-			if ( is_child_theme() ) {
-
-				$has_php_template   = file_exists( get_stylesheet_directory() . '/' . $current_template_slug . '.php' );
-				$block_template     = _gutenberg_get_template_file( 'wp_template', $current_block_template_slug );
-				$has_block_template = false;
-
-				if ( null !== $block_template && wp_get_theme()->get_stylesheet() === $block_template['theme'] ) {
-					$has_block_template = true;
-				}
-				// and that a corresponding block template from the theme and not the parent doesn't exist.
-				if ( $has_php_template && ! $has_block_template ) {
-					return $template;
-				}
-			}
-
-			break;
-		}
-
-		// Is this a custom template?
-		// This check should be removed when merged in core.
-		// Instead, wp_templates should be considered valid in locate_template.
-		$is_custom_template = 0 === strpos( $current_block_template_slug, 'wp-custom-template-' );
-
-		// Don't override the template if we find a template matching the slug we look for
-		// and which does not match a block template slug.
-		if (
-			! $is_custom_template &&
-			$current_template_slug !== $current_block_template_slug &&
-			$current_template_slug === $template_item_slug
-		) {
-			return $template;
-		}
+		// If the template hiearchy algorithm has successfully located a PHP template file,
+		// we will only consider block templates with higher or equal specificity.
+		$templates = array_slice( $templates, 0, $index + 1 );
 	}
+
+	$current_template = gutenberg_resolve_template( $type, $templates );
 
 	if ( $current_template ) {
 		if ( empty( $current_template->content ) && is_user_logged_in() ) {
@@ -130,7 +102,9 @@ function gutenberg_override_query_template( $template, $type, array $templates )
 			wp_send_json_success( $current_template );
 		}
 	} else {
-		if ( 'index' === $type ) {
+		if ( $template ) {
+			return $template;
+		} elseif ( 'index' === $type ) {
 			if ( isset( $_GET['_wp-find-template'] ) ) {
 				wp_send_json_error( array( 'message' => __( 'No matching template found.', 'gutenberg' ) ) );
 			}


### PR DESCRIPTION
## Description
Based on #31498 (which adds unit test coverage for `lib/full-site-editing/template-loader.php`).
**Don't merge this PR before #31498!**

The template loader logic has grown a bit convoluted due to the recent addition of the concept of hybrid themes (i.e. both PHP and block templates allowed in one theme) and subsequent bug fixes (some of them related to child themes, others to custom page templates). #31498 had added unit test coverage to (hopefully!) cover exemplary cases from all those categories.

This allows us to more confidently simplify (and later, if needed, further extend) the template loader algorithm.

The core idea for simplifcation in this PR is as follows: 

`gutenberg_override_query_template( $template, $type, $templates)` is fed the results of Core's own template resolution algorithm. It provides a list of candidate `$templates` (e.g. `array( 'page-home.php', 'page-123.php', 'page.php' )`), and, if a matching template PHP file could be found in the current theme (including child and parent themes), that file's path in `$template` (e.g. `/var/www/html/wp-content/themes/test-theme/page-123.php`).

This means when attempting to find a block template, we iterate over `$templates`, but we cut off at the entry corresponding to our fallback PHP template (in the example case, we only pass `array( 'page-home.php', 'page-123.php' )` to `gutenberg_resolve_template` (the function that retrieves block templates)), since we're only interested to find block template counterparts for those candidate slugs (which have higher or equal specificity as our fallback PHP template), but not in any matches with lower specificity (e.g. `/var/www/html/wp-content/themes/test-theme/block-templates/page.html`).

The new logic is further explained in code comments. I'll add some GH comments to the old logic for more clarification.

## How has this been tested?
Verify that unit tests go green in CI.

Locally:

```
npm run test-unit-php -- /var/www/html/wp-content/plugins/gutenberg/phpunit/class-template-loader-test.php
```