### PR TITLE
Block popover: move scroll handling to block tools

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -238,6 +238,7 @@ _Parameters_
 
 -   _$0_ `Object`: Props.
 -   _$0.children_ `Object`: The block content and style container.
+-   _$0.\_\_unstableContentRef_ `Object`: Ref holding the content scroll container.
 
 <a name="BlockVerticalAlignmentControl" href="#BlockVerticalAlignmentControl">#</a> **BlockVerticalAlignmentControl**
 

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -23,6 +23,7 @@ import BlockContextualToolbar from './block-contextual-toolbar';
 import Inserter from '../inserter';
 import { store as blockEditorStore } from '../../store';
 import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-block-props/use-block-refs';
+import { usePopoverScroll } from './use-popover-scroll';
 
 function selector( select ) {
 	const {
@@ -52,6 +53,7 @@ function BlockPopover( {
 	isEmptyDefaultBlock,
 	capturingClientId,
 	__unstablePopoverSlot,
+	__unstableContentRef,
 } ) {
 	const {
 		isNavigationMode,
@@ -111,6 +113,8 @@ function BlockPopover( {
 	const selectedElement = useBlockElement( clientId );
 	const lastSelectedElement = useBlockElement( lastClientId );
 	const capturingElement = useBlockElement( capturingClientId );
+
+	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
 
 	if (
 		! shouldShowBreadcrumb &&
@@ -174,6 +178,7 @@ function BlockPopover( {
 
 	return (
 		<Popover
+			ref={ popoverScrollRef }
 			noArrow
 			animate={ false }
 			position={ popoverPosition }
@@ -296,7 +301,10 @@ function wrapperSelector( select ) {
 	};
 }
 
-export default function WrappedBlockPopover( { __unstablePopoverSlot } ) {
+export default function WrappedBlockPopover( {
+	__unstablePopoverSlot,
+	__unstableContentRef,
+} ) {
 	const selected = useSelect( wrapperSelector, [] );
 
 	if ( ! selected ) {
@@ -324,6 +332,7 @@ export default function WrappedBlockPopover( { __unstablePopoverSlot } ) {
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }
 			capturingClientId={ capturingClientId }
 			__unstablePopoverSlot={ __unstablePopoverSlot }
+			__unstableContentRef={ __unstableContentRef }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -12,6 +12,7 @@ import InsertionPoint from './insertion-point';
 import BlockPopover from './block-popover';
 import { store as blockEditorStore } from '../../store';
 import BlockContextualToolbar from './block-contextual-toolbar';
+import { usePopoverScroll } from './use-popover-scroll';
 
 /**
  * Renders block tools (the block toolbar, select/navigation mode toolbar, the
@@ -20,8 +21,9 @@ import BlockContextualToolbar from './block-contextual-toolbar';
  *
  * @param {Object} $0          Props.
  * @param {Object} $0.children The block content and style container.
+ * @param {Object} $0.__unstableContentRef Ref holding the content scroll container.
  */
-export default function BlockTools( { children } ) {
+export default function BlockTools( { children, __unstableContentRef } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const hasFixedToolbar = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().hasFixedToolbar,
@@ -29,15 +31,18 @@ export default function BlockTools( { children } ) {
 	);
 
 	return (
-		<InsertionPoint>
+		<InsertionPoint __unstableContentRef={ __unstableContentRef }>
 			{ ( hasFixedToolbar || ! isLargeViewport ) && (
 				<BlockContextualToolbar isFixed />
 			) }
 			{ /* Even if the toolbar is fixed, the block popover is still
                  needed for navigation mode. */ }
-			<BlockPopover />
+			<BlockPopover __unstableContentRef={ __unstableContentRef } />
 			{ /* Used for the inline rich text toolbar. */ }
-			<Popover.Slot name="block-toolbar" />
+			<Popover.Slot
+				name="block-toolbar"
+				ref={ usePopoverScroll( __unstableContentRef ) }
+			/>
 			{ children }
 			{ /* Forward compatibility: a place to render block tools behind the
                  content so it can be tabbed to properly. */ }

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -23,10 +23,14 @@ import { isRTL } from '@wordpress/i18n';
 import Inserter from '../inserter';
 import { store as blockEditorStore } from '../../store';
 import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-block-props/use-block-refs';
+import { usePopoverScroll } from './use-popover-scroll';
 
 export const InsertionPointOpenRef = createContext();
 
-function InsertionPointPopover( { __unstablePopoverSlot } ) {
+function InsertionPointPopover( {
+	__unstablePopoverSlot,
+	__unstableContentRef,
+} ) {
 	const { selectBlock } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
 	const ref = useRef();
@@ -161,6 +165,8 @@ function InsertionPointPopover( { __unstablePopoverSlot } ) {
 		};
 	}, [ previousElement, nextElement ] );
 
+	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
+
 	if ( ! previousElement ) {
 		return null;
 	}
@@ -205,6 +211,7 @@ function InsertionPointPopover( { __unstablePopoverSlot } ) {
 	// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 	return (
 		<Popover
+			ref={ popoverScrollRef }
 			noArrow
 			animate={ false }
 			getAnchorRect={ getAnchorRect }
@@ -253,7 +260,11 @@ function InsertionPointPopover( { __unstablePopoverSlot } ) {
 	/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 }
 
-export default function InsertionPoint( { children } ) {
+export default function InsertionPoint( {
+	children,
+	__unstablePopoverSlot,
+	__unstableContentRef,
+} ) {
 	const isVisible = useSelect( ( select ) => {
 		const { isMultiSelecting, isBlockInsertionPointVisible } = select(
 			blockEditorStore
@@ -264,7 +275,12 @@ export default function InsertionPoint( { children } ) {
 
 	return (
 		<InsertionPointOpenRef.Provider value={ useRef( false ) }>
-			{ isVisible && <InsertionPointPopover /> }
+			{ isVisible && (
+				<InsertionPointPopover
+					__unstablePopoverSlot={ __unstablePopoverSlot }
+					__unstableContentRef={ __unstableContentRef }
+				/>
+			) }
 			{ children }
 		</InsertionPointOpenRef.Provider>
 	);

--- a/packages/block-editor/src/components/block-tools/use-popover-scroll.js
+++ b/packages/block-editor/src/components/block-tools/use-popover-scroll.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+/**
+ * Allow scrolling "through" popovers over the canvas. This is only called for
+ * as long as the pointer is over a popover. Do not use React events because it
+ * will bubble through portals.
+ *
+ * @param {Object} scrollableRef
+ */
+export function usePopoverScroll( scrollableRef ) {
+	return useRefEffect(
+		( node ) => {
+			if ( ! scrollableRef ) {
+				return;
+			}
+
+			function onWheel( event ) {
+				const { deltaX, deltaY } = event;
+				scrollableRef.current.scrollBy( deltaX, deltaY );
+			}
+			node.addEventListener( 'wheel', onWheel );
+			return () => {
+				node.removeEventListener( 'wheel', onWheel );
+			};
+		},
+		[ scrollableRef ]
+	);
+}

--- a/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`URLPopover matches the snapshot in its default state 1`] = `
-<Popover
+<ForwardRef(Popover)
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"
@@ -33,11 +33,11 @@ exports[`URLPopover matches the snapshot in its default state 1`] = `
       />
     </div>
   </div>
-</Popover>
+</ForwardRef(Popover)>
 `;
 
 exports[`URLPopover matches the snapshot when the settings are toggled open 1`] = `
-<Popover
+<ForwardRef(Popover)
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"
@@ -76,11 +76,11 @@ exports[`URLPopover matches the snapshot when the settings are toggled open 1`] 
       </div>
     </div>
   </div>
-</Popover>
+</ForwardRef(Popover)>
 `;
 
 exports[`URLPopover matches the snapshot when there are no settings 1`] = `
-<Popover
+<ForwardRef(Popover)
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"
@@ -96,5 +96,5 @@ exports[`URLPopover matches the snapshot when there are no settings 1`] = `
       </div>
     </div>
   </div>
-</Popover>
+</ForwardRef(Popover)>
 `;

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -6,7 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useState, useLayoutEffect } from '@wordpress/element';
+import {
+	useRef,
+	useState,
+	useLayoutEffect,
+	forwardRef,
+} from '@wordpress/element';
 import { getRectangleFromRange } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
 import deprecated from '@wordpress/deprecated';
@@ -223,36 +228,39 @@ function getAnchorDocument( anchor ) {
 	return anchor.ownerDocument;
 }
 
-const Popover = ( {
-	headerTitle,
-	onClose,
-	onKeyDown,
-	children,
-	className,
-	noArrow = true,
-	isAlternate,
-	// Disable reason: We generate the `...contentProps` rest as remainder
-	// of props which aren't explicitly handled by this component.
-	/* eslint-disable no-unused-vars */
-	position = 'bottom right',
-	range,
-	focusOnMount = 'firstElement',
-	anchorRef,
-	shouldAnchorIncludePadding,
-	anchorRect,
-	getAnchorRect,
-	expandOnMobile,
-	animate = true,
-	onClickOutside,
-	onFocusOutside,
-	__unstableStickyBoundaryElement,
-	__unstableSlotName = SLOT_NAME,
-	__unstableObserveElement,
-	__unstableBoundaryParent,
-	__unstableForcePosition,
-	/* eslint-enable no-unused-vars */
-	...contentProps
-} ) => {
+const Popover = (
+	{
+		headerTitle,
+		onClose,
+		onKeyDown,
+		children,
+		className,
+		noArrow = true,
+		isAlternate,
+		// Disable reason: We generate the `...contentProps` rest as remainder
+		// of props which aren't explicitly handled by this component.
+		/* eslint-disable no-unused-vars */
+		position = 'bottom right',
+		range,
+		focusOnMount = 'firstElement',
+		anchorRef,
+		shouldAnchorIncludePadding,
+		anchorRect,
+		getAnchorRect,
+		expandOnMobile,
+		animate = true,
+		onClickOutside,
+		onFocusOutside,
+		__unstableStickyBoundaryElement,
+		__unstableSlotName = SLOT_NAME,
+		__unstableObserveElement,
+		__unstableBoundaryParent,
+		__unstableForcePosition,
+		/* eslint-enable no-unused-vars */
+		...contentProps
+	},
+	ref
+) => {
 	const anchorRefFallback = useRef( null );
 	const contentRef = useRef( null );
 	const containerRef = useRef();
@@ -474,6 +482,7 @@ const Popover = ( {
 	const focusOnMountRef = useFocusOnMount( focusOnMount );
 	const focusOutsideProps = useFocusOutside( handleOnFocusOutside );
 	const mergedRefs = useMergeRefs( [
+		ref,
 		containerRef,
 		focusOnMount ? constrainedTabbingRef : null,
 		focusOnMount ? focusReturnRef : null,
@@ -616,10 +625,19 @@ const Popover = ( {
 	return <span ref={ anchorRefFallback }>{ content }</span>;
 };
 
-const PopoverContainer = Popover;
+const PopoverContainer = forwardRef( Popover );
 
-PopoverContainer.Slot = ( { name = SLOT_NAME } ) => (
-	<Slot bubblesVirtually name={ name } className="popover-slot" />
-);
+function PopoverSlot( { name = SLOT_NAME }, ref ) {
+	return (
+		<Slot
+			bubblesVirtually
+			name={ name }
+			className="popover-slot"
+			ref={ ref }
+		/>
+	);
+}
+
+PopoverContainer.Slot = forwardRef( PopoverSlot );
 
 export default PopoverContainer;

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -1,19 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useLayoutEffect, useContext } from '@wordpress/element';
+import {
+	useRef,
+	useLayoutEffect,
+	useContext,
+	forwardRef,
+} from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import SlotFillContext from './slot-fill-context';
 
-export default function Slot( {
-	name,
-	fillProps = {},
-	as: Component = 'div',
-	...props
-} ) {
+function Slot(
+	{ name, fillProps = {}, as: Component = 'div', ...props },
+	forwardedRef
+) {
 	const registry = useContext( SlotFillContext );
 	const ref = useRef();
 
@@ -34,5 +38,9 @@ export default function Slot( {
 		registry.updateSlot( name, fillProps );
 	} );
 
-	return <Component ref={ ref } { ...props } />;
+	return (
+		<Component ref={ useMergeRefs( [ forwardedRef, ref ] ) } { ...props } />
+	);
 }
+
+export default forwardRef( Slot );

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import BaseFill from './fill';
@@ -20,13 +25,12 @@ export function Fill( props ) {
 		</>
 	);
 }
-
-export function Slot( { bubblesVirtually, ...props } ) {
+export const Slot = forwardRef( ( { bubblesVirtually, ...props }, ref ) => {
 	if ( bubblesVirtually ) {
-		return <BubblesVirtuallySlot { ...props } />;
+		return <BubblesVirtuallySlot { ...props } ref={ ref } />;
 	}
 	return <BaseSlot { ...props } />;
-}
+} );
 
 export function Provider( { children, ...props } ) {
 	return (

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -51,11 +51,11 @@ describe( 'Tooltip', () => {
 			wrapper.simulate( 'focus', event );
 
 			const button = wrapper.find( 'button' );
-			const popover = wrapper.find( 'Popover' );
+			const popover = wrapper.find( 'ForwardRef(Popover)' );
 			expect( wrapper.type() ).toBe( 'button' );
 			expect( button.children() ).toHaveLength( 2 );
 			expect( button.childAt( 0 ).text() ).toBe( 'Hover Me!' );
-			expect( button.childAt( 1 ).name() ).toBe( 'Popover' );
+			expect( button.childAt( 1 ).name() ).toBe( 'ForwardRef(Popover)' );
 			expect( popover.prop( 'focusOnMount' ) ).toBe( false );
 			expect( popover.prop( 'position' ) ).toBe( 'bottom right' );
 			expect( popover.children().first().text() ).toBe( 'Help text' );
@@ -78,7 +78,7 @@ describe( 'Tooltip', () => {
 			const button = wrapper.find( 'button' );
 			button.simulate( 'focus', event );
 
-			const popover = wrapper.find( 'Popover' );
+			const popover = wrapper.find( 'ForwardRef(Popover)' );
 			expect( originalFocus ).toHaveBeenCalledWith( event );
 			expect( popover ).toHaveLength( 1 );
 		} );

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -32,7 +32,7 @@ import {
 import { useRef } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMergeRefs, useRefEffect } from '@wordpress/compose';
+import { useMergeRefs } from '@wordpress/compose';
 import { arrowLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -148,19 +148,6 @@ export default function VisualEditor( { styles } ) {
 
 	const blockSelectionClearerRef = useBlockSelectionClearer( true );
 
-	// Allow scrolling "through" popovers over the canvas. This is only called
-	// for as long as the pointer is over a popover. Do not use React events
-	// because it will bubble through portals.
-	const toolWrapperRef = useRefEffect( ( node ) => {
-		function onWheel( { deltaX, deltaY } ) {
-			ref.current.scrollBy( deltaX, deltaY );
-		}
-		node.addEventListener( 'wheel', onWheel );
-		return () => {
-			node.removeEventListener( 'wheel', onWheel );
-		};
-	}, [] );
-
 	return (
 		<motion.div
 			className={ classnames( 'edit-post-visual-editor', {
@@ -191,11 +178,10 @@ export default function VisualEditor( { styles } ) {
 				</Button>
 			) }
 			<motion.div
-				ref={ toolWrapperRef }
 				animate={ animatedStyles }
 				initial={ desktopCanvasStyles }
 			>
-				<BlockTools>
+				<BlockTools __unstableContentRef={ ref }>
 					<MaybeIframe
 						isTemplateMode={ isTemplateMode }
 						contentRef={ contentRef }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -20,7 +20,7 @@ import {
 	__unstableEditorStyles as EditorStyles,
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
-import { useMergeRefs, useRefEffect } from '@wordpress/compose';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -63,19 +63,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		useTypingObserver(),
 	] );
 
-	// Allow scrolling "through" popovers over the canvas. This is only called
-	// for as long as the pointer is over a popover. Do not use React events
-	// because it will bubble through portals.
-	const toolWrapperRef = useRefEffect( ( node ) => {
-		function onWheel( { deltaX, deltaY } ) {
-			contentRef.current.scrollBy( deltaX, deltaY );
-		}
-		node.addEventListener( 'wheel', onWheel );
-		return () => {
-			node.addEventListener( 'wheel', onWheel );
-		};
-	}, [] );
-
 	return (
 		<BlockEditorProvider
 			settings={ settings }
@@ -101,8 +88,8 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			<SidebarInspectorFill>
 				<BlockInspector />
 			</SidebarInspectorFill>
-			<div className="edit-site-visual-editor" ref={ toolWrapperRef }>
-				<BlockTools>
+			<div className="edit-site-visual-editor">
+				<BlockTools __unstableContentRef={ contentRef }>
 					<Iframe
 						style={ resizedCanvasStyles }
 						headHTML={ window.__editorStyles.html }

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DotTip should render correctly 1`] = `
-<Popover
+<ForwardRef(Popover)
   aria-label="Editor tips"
   className="nux-dot-tip"
   focusOnMount="container"
@@ -36,5 +36,5 @@ exports[`DotTip should render correctly 1`] = `
     }
     label="Disable tips"
   />
-</Popover>
+</ForwardRef(Popover)>
 `;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Required for #31600.

Makes the scroll-through behaviour for block popovers built-in the `BlockTools` component.

Addresses https://github.com/WordPress/gutenberg/pull/31375#discussion_r625619239 by targeting popovers explicitly rather than all the content in the element.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
