### PR TITLE
components: Add ZStack

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1230,6 +1230,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "ZStack",
+		"slug": "z-stack",
+		"markdown_source": "../packages/components/src/z-stack/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "Package Reference",
 		"slug": "packages",
 		"markdown_source": "../docs/reference-guides/packages.md",

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -146,6 +146,7 @@ export {
 	useSlot as __experimentalUseSlot,
 } from './slot-fill';
 export { default as __experimentalStyleProvider } from './style-provider';
+export { ZStack as __experimentalZStack } from './z-stack';
 
 // Higher-Order Components
 export {

--- a/packages/components/src/ui/utils/get-valid-children.ts
+++ b/packages/components/src/ui/utils/get-valid-children.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import type { ReactNode, ReactNodeArray } from 'react';
+import type { ReactNode, ReactElement } from 'react';
 
 /**
  * WordPress dependencies
@@ -12,11 +12,13 @@ import { Children, isValidElement } from '@wordpress/element';
 /**
  * Gets a collection of available children elements from a React component's children prop.
  *
- * @param {import('react').ReactNode} children
+ * @param children
  *
- * @return {import('react').ReactNodeArray} An array of available children.
+ * @return An array of available children.
  */
-export function getValidChildren( children: ReactNode ): ReactNodeArray {
+export function getValidChildren(
+	children: ReactNode
+): ( ReactElement | ReactNode )[] {
 	if ( typeof children === 'string' ) return [ children ];
 
 	return Children.toArray( children ).filter( ( child ) =>

--- a/packages/components/src/ui/utils/get-valid-children.ts
+++ b/packages/components/src/ui/utils/get-valid-children.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import type { ReactNode, ReactElement } from 'react';
+import type { ReactNode, ReactNodeArray } from 'react';
 
 /**
  * WordPress dependencies
@@ -16,9 +16,7 @@ import { Children, isValidElement } from '@wordpress/element';
  *
  * @return An array of available children.
  */
-export function getValidChildren(
-	children: ReactNode
-): ( ReactElement | ReactNode )[] {
+export function getValidChildren( children: ReactNode ): ReactNodeArray {
 	if ( typeof children === 'string' ) return [ children ];
 
 	return Children.toArray( children ).filter( ( child ) =>

--- a/packages/components/src/z-stack/README.md
+++ b/packages/components/src/z-stack/README.md
@@ -1,0 +1,39 @@
+# ZStack
+
+> **Experimental!**
+
+## Usage
+
+`ZStack` allows you to stack things along the Z-axis.
+
+```jsx
+import { __experimentalZStack as ZStack } from '@wordpress/components';
+
+function Example() {
+	return (
+		<ZStack offset={ 20 } isLayered>
+			<ExampleImage />
+			<ExampleImage />
+			<ExampleImage />
+		</ZStack>
+	);
+}
+```
+
+## Props
+
+### `isLayered`: `boolean`
+
+Layers children elements on top of each other (first: highest z-index, last: lowest z-index). Defaults to `true`.
+
+### `isReversed`: `boolean`
+
+Reverse the layer ordering (first: lowest z-index, last: highest z-index). Defaults to `false`.
+
+### `offset`: `number`
+
+The amount of space between each child element. Defaults to `0`.
+
+### `children`: `ReactNode`
+
+The children to stack.

--- a/packages/components/src/z-stack/README.md
+++ b/packages/components/src/z-stack/README.md
@@ -24,11 +24,11 @@ function Example() {
 
 ### `isLayered`: `boolean`
 
-Layers children elements on top of each other (first: highest z-index, last: lowest z-index). Defaults to `true`.
+When `true`, the children are stacked on top of each other. When `false`, the children follow the normal flow of the layout. Defaults to `true`.
 
 ### `isReversed`: `boolean`
 
-Reverse the layer ordering (first: lowest z-index, last: highest z-index). Defaults to `false`.
+Reverse the layer ordering. When `true`, the first child has the lowest `z-index` and the last child has the highest `z-index`. When `false`, the first child has the highest `z-index` and the last child has the lowest `z-index`. Defaults to `false`.
 
 ### `offset`: `number`
 

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -35,11 +35,11 @@ export interface ZStackProps {
 	 */
 	isReversed?: boolean;
 	/**
-	 * The amount of overlap between each child element.
+	 * The amount of offset between each child element.
 	 *
 	 * @default 0
 	 */
-	overlap?: number;
+	offset?: number;
 	/**
 	 * Child elements.
 	 */
@@ -55,20 +55,23 @@ function ZStack(
 		className,
 		isLayered = true,
 		isReversed = false,
-		overlap = 0,
+		offset = 0,
 		...otherProps
 	} = useContextSystem( props, 'ZStack' );
 
 	const validChildren = getValidChildren( children );
-	const childrenCount = validChildren.length - 1;
+	const childrenLastIndex = validChildren.length - 1;
 
 	const clonedChildren = validChildren.map( ( child, index ) => {
-		const zIndex = isReversed ? childrenCount - index : index;
+		const zIndex = isReversed ? childrenLastIndex - index : index;
+		const offsetAmount = offset * index;
 
 		const classes = cx(
 			isLayered ? styles.positionAbsolute : styles.positionRelative,
 			css( {
-				marginLeft: ( ! isLayered && overlap * -1 ) || undefined,
+				...( isLayered
+					? { marginLeft: offsetAmount }
+					: { right: offsetAmount * -1 } ),
 			} )
 		);
 
@@ -87,17 +90,10 @@ function ZStack(
 		);
 	} );
 
-	const classes = cx(
-		css( {
-			paddingLeft: ! isLayered ? overlap : undefined,
-		} ),
-		className
-	);
-
 	return (
 		<ZStackView
 			{ ...otherProps }
-			className={ classes }
+			className={ className }
 			ref={ forwardedRef }
 		>
 			{ clonedChildren }

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -3,7 +3,7 @@
  */
 import { css, cx } from 'emotion';
 // eslint-disable-next-line no-restricted-imports
-import type { Ref } from 'react';
+import type { Ref, ReactNode } from 'react';
 
 /**
  * WordPress dependencies
@@ -40,6 +40,10 @@ export interface ZStackProps {
 	 * @default 0
 	 */
 	offset?: number;
+	/**
+	 * Child elements.
+	 */
+	children: ReactNode;
 }
 
 function ZStack(

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import { css, cx } from 'emotion';
+// eslint-disable-next-line no-restricted-imports
+import type { Ref } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { isValidElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getValidChildren } from '../ui/utils/get-valid-children';
+import { contextConnect, useContextSystem } from '../ui/context';
+// eslint-disable-next-line no-duplicate-imports
+import type { ViewOwnProps } from '../ui/context';
+import { View } from '../view';
+import * as styles from './styles';
+const { ZStackView } = styles;
+
+export interface ZStackProps {
+	/**
+	 * Layers children elements on top of each other (first: highest z-index, last: lowest z-index).
+	 *
+	 * @default true
+	 */
+	isLayered?: boolean;
+	/**
+	 * Reverse the layer ordering (first: lowest z-index, last: highest z-index).
+	 *
+	 * @default false
+	 */
+	isReversed?: boolean;
+	/**
+	 * The amount of space between each child element.
+	 *
+	 * @default 0
+	 */
+	offset?: number;
+}
+
+function ZStack(
+	props: ViewOwnProps< ZStackProps, 'div' >,
+	forwardedRef: Ref< any >
+) {
+	const {
+		children,
+		className,
+		isLayered = true,
+		isReversed = false,
+		offset = 0,
+		...otherProps
+	} = useContextSystem( props, 'ZStack' );
+
+	const validChildren = getValidChildren( children );
+	const childrenCount = validChildren.length - 1;
+
+	const clonedChildren = validChildren.map( ( child, index ) => {
+		const zIndex = isReversed ? childrenCount - index : index;
+
+		const classes = cx(
+			isLayered ? styles.positionAbsolute : styles.positionRelative,
+			css( {
+				marginLeft: ! isLayered && offset * -1,
+			} )
+		);
+
+		const key = isValidElement( child ) ? child.key : index;
+
+		return (
+			<View
+				className={ classes }
+				key={ key }
+				style={ {
+					zIndex,
+				} }
+			>
+				{ child }
+			</View>
+		);
+	} );
+
+	const classes = cx(
+		css( {
+			paddingLeft: ! isLayered ? offset : null,
+		} ),
+		className
+	);
+
+	return (
+		<ZStackView
+			{ ...otherProps }
+			className={ classes }
+			ref={ forwardedRef }
+		>
+			{ clonedChildren }
+		</ZStackView>
+	);
+}
+
+export default contextConnect( ZStack, 'ZStack' );

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -16,7 +16,7 @@ import { isValidElement } from '@wordpress/element';
 import { getValidChildren } from '../ui/utils/get-valid-children';
 import { contextConnect, useContextSystem } from '../ui/context';
 // eslint-disable-next-line no-duplicate-imports
-import type { ViewOwnProps } from '../ui/context';
+import type { PolymorphicComponentProps } from '../ui/context';
 import { View } from '../view';
 import * as styles from './styles';
 const { ZStackView } = styles;
@@ -47,7 +47,7 @@ export interface ZStackProps {
 }
 
 function ZStack(
-	props: ViewOwnProps< ZStackProps, 'div' >,
+	props: PolymorphicComponentProps< ZStackProps, 'div' >,
 	forwardedRef: Ref< any >
 ) {
 	const {

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -35,11 +35,11 @@ export interface ZStackProps {
 	 */
 	isReversed?: boolean;
 	/**
-	 * The amount of space between each child element.
+	 * The amount of overlap between each child element.
 	 *
 	 * @default 0
 	 */
-	offset?: number;
+	overlap?: number;
 	/**
 	 * Child elements.
 	 */
@@ -55,7 +55,7 @@ function ZStack(
 		className,
 		isLayered = true,
 		isReversed = false,
-		offset = 0,
+		overlap = 0,
 		...otherProps
 	} = useContextSystem( props, 'ZStack' );
 
@@ -68,7 +68,7 @@ function ZStack(
 		const classes = cx(
 			isLayered ? styles.positionAbsolute : styles.positionRelative,
 			css( {
-				marginLeft: ! isLayered && offset * -1,
+				marginLeft: ( ! isLayered && overlap * -1 ) || undefined,
 			} )
 		);
 
@@ -89,7 +89,7 @@ function ZStack(
 
 	const classes = cx(
 		css( {
-			paddingLeft: ! isLayered ? offset : null,
+			paddingLeft: ! isLayered ? overlap : undefined,
 		} ),
 		className
 	);

--- a/packages/components/src/z-stack/index.ts
+++ b/packages/components/src/z-stack/index.ts
@@ -1,0 +1,1 @@
+export { default as ZStack } from './component';

--- a/packages/components/src/z-stack/stories/index.js
+++ b/packages/components/src/z-stack/stories/index.js
@@ -17,7 +17,7 @@ import { ZStack } from '..';
 
 export default {
 	component: ZStack,
-	title: 'Components/ZStack',
+	title: 'Components (Experimental)/ZStack',
 };
 
 const Avatar = ( { backgroundColor } ) => {
@@ -43,9 +43,9 @@ const Avatar = ( { backgroundColor } ) => {
 
 const AnimatedAvatars = () => {
 	const [ isHover, setIsHover ] = useState( false );
-	const hoveredOffset = number( 'offset', 20 );
+	const overlap = number( 'overlap', 20 );
 	const props = {
-		offset: isHover ? 0 : hoveredOffset,
+		overlap: isHover ? 0 : overlap,
 		isLayered: boolean( 'isLayered', false ),
 		isReversed: boolean( 'isReversed', false ),
 	};

--- a/packages/components/src/z-stack/stories/index.js
+++ b/packages/components/src/z-stack/stories/index.js
@@ -1,8 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-/**
  * External dependencies
  */
 import { boolean, number } from '@storybook/addon-knobs';
@@ -42,20 +38,15 @@ const Avatar = ( { backgroundColor } ) => {
 };
 
 const AnimatedAvatars = () => {
-	const [ isHover, setIsHover ] = useState( false );
-	const overlap = number( 'overlap', 20 );
 	const props = {
-		overlap: isHover ? 0 : overlap,
-		isLayered: boolean( 'isLayered', false ),
+		offset: number( 'offset', 20 ),
+		isLayered: boolean( 'isLayered', true ),
 		isReversed: boolean( 'isReversed', false ),
 	};
 
 	return (
 		<HStack>
-			<View
-				onMouseLeave={ () => setIsHover( false ) }
-				onMouseEnter={ () => setIsHover( true ) }
-			>
+			<View>
 				<ZStack { ...props }>
 					<Avatar backgroundColor="#444" />
 					<Avatar backgroundColor="#777" />

--- a/packages/components/src/z-stack/stories/index.js
+++ b/packages/components/src/z-stack/stories/index.js
@@ -20,7 +20,7 @@ export default {
 	title: 'Components/ZStack',
 };
 
-const Avatar = () => {
+const Avatar = ( { backgroundColor } ) => {
 	return (
 		<View>
 			<View
@@ -29,7 +29,7 @@ const Avatar = () => {
 					borderRadius: '9999px',
 					height: '48px',
 					width: '48px',
-					backgroundColor: 'lightgray',
+					backgroundColor,
 				} }
 			/>
 			<Elevation
@@ -46,7 +46,8 @@ const AnimatedAvatars = () => {
 	const hoveredOffset = number( 'offset', 20 );
 	const props = {
 		offset: isHover ? 0 : hoveredOffset,
-		isLayered: boolean( 'isLayerd', false ),
+		isLayered: boolean( 'isLayered', false ),
+		isReversed: boolean( 'isReversed', false ),
 	};
 
 	return (
@@ -56,10 +57,10 @@ const AnimatedAvatars = () => {
 				onMouseEnter={ () => setIsHover( true ) }
 			>
 				<ZStack { ...props }>
-					<Avatar />
-					<Avatar />
-					<Avatar />
-					<Avatar />
+					<Avatar backgroundColor="#444" />
+					<Avatar backgroundColor="#777" />
+					<Avatar backgroundColor="#aaa" />
+					<Avatar backgroundColor="#fff" />
 				</ZStack>
 			</View>
 		</HStack>

--- a/packages/components/src/z-stack/stories/index.js
+++ b/packages/components/src/z-stack/stories/index.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Elevation } from '../../ui/elevation';
+import { HStack } from '../../h-stack';
+import { View } from '../../view';
+import { ZStack } from '..';
+
+export default {
+	component: ZStack,
+	title: 'Components/ZStack',
+};
+
+const Avatar = () => {
+	return (
+		<View>
+			<View
+				style={ {
+					border: '3px solid black',
+					borderRadius: '9999px',
+					height: '48px',
+					width: '48px',
+					backgroundColor: 'lightgray',
+				} }
+			/>
+			<Elevation
+				borderRadius={ 9999 }
+				isInteractive={ false }
+				value={ 3 }
+			/>
+		</View>
+	);
+};
+
+const AnimatedAvatars = () => {
+	const [ isHover, setIsHover ] = useState( false );
+	const offset = isHover ? 0 : 20;
+
+	return (
+		<HStack>
+			<View
+				onMouseLeave={ () => setIsHover( false ) }
+				onMouseEnter={ () => setIsHover( true ) }
+			>
+				<ZStack isLayered={ false } offset={ offset }>
+					<Avatar />
+					<Avatar />
+					<Avatar />
+					<Avatar />
+				</ZStack>
+			</View>
+		</HStack>
+	);
+};
+
+export const _default = () => {
+	return (
+		<View>
+			<AnimatedAvatars />
+		</View>
+	);
+};

--- a/packages/components/src/z-stack/stories/index.js
+++ b/packages/components/src/z-stack/stories/index.js
@@ -2,6 +2,10 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+/**
+ * External dependencies
+ */
+import { boolean, number } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -39,7 +43,11 @@ const Avatar = () => {
 
 const AnimatedAvatars = () => {
 	const [ isHover, setIsHover ] = useState( false );
-	const offset = isHover ? 0 : 20;
+	const hoveredOffset = number( 'offset', 20 );
+	const props = {
+		offset: isHover ? 0 : hoveredOffset,
+		isLayered: boolean( 'isLayerd', false ),
+	};
 
 	return (
 		<HStack>
@@ -47,7 +55,7 @@ const AnimatedAvatars = () => {
 				onMouseLeave={ () => setIsHover( false ) }
 				onMouseEnter={ () => setIsHover( true ) }
 			>
-				<ZStack isLayered={ false } offset={ offset }>
+				<ZStack { ...props }>
 					<Avatar />
 					<Avatar />
 					<Avatar />

--- a/packages/components/src/z-stack/styles.ts
+++ b/packages/components/src/z-stack/styles.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { css } from 'emotion';
+import styled from '@emotion/styled';
+
+export const ZStackView = styled.div`
+	display: flex;
+	position: relative;
+`;
+
+export const positionAbsolute = css`
+	position: absolute;
+`;
+
+export const positionRelative = css`
+	position: relative;
+`;

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -36,6 +36,7 @@
 		"src/__next/**/*",
 		"src/h-stack/**/*",
 		"src/v-stack/**/*",
+		"src/z-stack/**/*",
 		"src/view/**/*"
 	],
 	"exclude": [


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds a new ZStack component.

## How has this been tested?
Storybook.

## Screenshots <!-- if applicable -->
<img atl="Demo of ZStack component" src="http://g.recordit.co/BSAi9JSyrx.gif" />

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
