### PR TITLE
Multi-select: use ref callback for focus out, merge native selection hooks

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
@@ -166,7 +166,6 @@ export function useMultiSelection( clientId ) {
 				if ( event.shiftKey ) {
 					const blockSelectionStart = getBlockSelectionStart();
 					if ( blockSelectionStart !== clientId ) {
-						toggleRichText( node, false );
 						multiSelect( blockSelectionStart, clientId );
 						event.preventDefault();
 					}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
@@ -166,6 +166,7 @@ export function useMultiSelection( clientId ) {
 				if ( event.shiftKey ) {
 					const blockSelectionStart = getBlockSelectionStart();
 					if ( blockSelectionStart !== clientId ) {
+						toggleRichText( node, false );
 						multiSelect( blockSelectionStart, clientId );
 						event.preventDefault();
 					}

--- a/packages/block-editor/src/components/writing-flow/use-last-focus.js
+++ b/packages/block-editor/src/components/writing-flow/use-last-focus.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+export default function useLastFocus( lastFocus ) {
+	return useRefEffect( ( node ) => {
+		function onFocusOut( event ) {
+			lastFocus.current = event.target;
+		}
+
+		node.addEventListener( 'focusout', onFocusOut );
+		return () => {
+			node.removeEventListener( 'focusout', onFocusOut );
+		};
+	}, [] );
+}

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -6,7 +6,7 @@ import { first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useLayoutEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
@@ -87,7 +87,7 @@ export default function useMultiSelection() {
 	 * When the component updates, and there is multi selection, we need to
 	 * select the entire block contents.
 	 */
-	useLayoutEffect( () => {
+	useEffect( () => {
 		const { ownerDocument } = ref.current;
 		const { defaultView } = ownerDocument;
 

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -96,9 +96,8 @@ export default function useMultiSelection() {
 		}
 
 		if ( ! hasMultiSelection ) {
-			toggleRichText( ref.current, true );
-
 			if ( ! selectedBlockClientId ) {
+				toggleRichText( ref.current, true );
 				return;
 			}
 
@@ -119,6 +118,7 @@ export default function useMultiSelection() {
 				}
 			}
 
+			toggleRichText( ref.current, true );
 			return;
 		}
 
@@ -128,6 +128,10 @@ export default function useMultiSelection() {
 			return;
 		}
 
+		// For some browsers, like Safari, it is important that focus
+		// happens BEFORE selection.
+		ref.current.focus();
+
 		// Removing the contenteditable attributes within the block editor is
 		// essential for selection to work across editable areas. The edible
 		// hosts are removed, allowing selection to be extended outside the DOM
@@ -136,10 +140,6 @@ export default function useMultiSelection() {
 		// ensure the browser instantly removes the selection boundaries, we
 		// remove the contenteditable attributes manually.
 		toggleRichText( ref.current, false );
-
-		// For some browsers, like Safari, it is important that focus
-		// happens BEFORE selection.
-		ref.current.focus();
 
 		const selection = defaultView.getSelection();
 		const range = ownerDocument.createRange();

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -15,18 +15,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import { __unstableUseBlockRef as useBlockRef } from '../block-list/use-block-props/use-block-refs';
 
-function toggleRichText( container, toggle ) {
-	Array.from( container.querySelectorAll( '.rich-text' ) ).forEach(
-		( node ) => {
-			if ( toggle ) {
-				node.setAttribute( 'contenteditable', true );
-			} else {
-				node.removeAttribute( 'contenteditable' );
-			}
-		}
-	);
-}
-
 /**
  * Returns for the deepest node at the start or end of a container node. Ignores
  * any text nodes that only contain HTML formatting whitespace.
@@ -125,15 +113,6 @@ export default function useMultiSelection() {
 		// For some browsers, like Safari, it is important that focus
 		// happens BEFORE selection.
 		ref.current.focus();
-
-		// Removing the contenteditable attributes within the block editor is
-		// essential for selection to work across editable areas. The edible
-		// hosts are removed, allowing selection to be extended outside the DOM
-		// element. `multiSelect` sets a flag in the store so the rich text
-		// components are updated, but the rerender may happen asynchonously. To
-		// ensure the browser instantly removes the selection boundaries, we
-		// remove the contenteditable attributes manually.
-		toggleRichText( ref.current, false );
 
 		const selection = defaultView.getSelection();
 		const range = ownerDocument.createRange();

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -91,13 +91,8 @@ export default function useMultiSelection() {
 		const { ownerDocument } = ref.current;
 		const { defaultView } = ownerDocument;
 
-		if ( isMultiSelecting ) {
-			return;
-		}
-
-		if ( ! hasMultiSelection ) {
-			if ( ! selectedBlockClientId ) {
-				toggleRichText( ref.current, true );
+		if ( ! hasMultiSelection || isMultiSelecting ) {
+			if ( ! selectedBlockClientId || isMultiSelecting ) {
 				return;
 			}
 
@@ -118,7 +113,6 @@ export default function useMultiSelection() {
 				}
 			}
 
-			toggleRichText( ref.current, true );
 			return;
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Moves the "last focus" logic to a separate **ref** callback and merged multi-selection focus setting with the rest of the multi selection logic.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
