### PR TITLE
Rich text: extract paste handler

### DIFF
--- a/packages/rich-text/src/component/use-paste-handler.js
+++ b/packages/rich-text/src/component/use-paste-handler.js
@@ -1,0 +1,112 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { getFilesFromDataTransfer } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import { insert } from '../insert';
+
+export function usePasteHandler( props ) {
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	return useRefEffect( ( element ) => {
+		function _onPaste( event ) {
+			const {
+				isSelected,
+				disableFormats,
+				handleChange,
+				record,
+				formatTypes,
+				onPaste,
+				removeEditorOnlyFormats,
+				activeFormats,
+			} = propsRef.current;
+
+			if ( ! isSelected ) {
+				event.preventDefault();
+				return;
+			}
+
+			const { clipboardData } = event;
+
+			let plainText = '';
+			let html = '';
+
+			// IE11 only supports `Text` as an argument for `getData` and will
+			// otherwise throw an invalid argument error, so we try the standard
+			// arguments first, then fallback to `Text` if they fail.
+			try {
+				plainText = clipboardData.getData( 'text/plain' );
+				html = clipboardData.getData( 'text/html' );
+			} catch ( error1 ) {
+				try {
+					html = clipboardData.getData( 'Text' );
+				} catch ( error2 ) {
+					// Some browsers like UC Browser paste plain text by default and
+					// don't support clipboardData at all, so allow default
+					// behaviour.
+					return;
+				}
+			}
+
+			event.preventDefault();
+
+			// Allows us to ask for this information when we get a report.
+			window.console.log( 'Received HTML:\n\n', html );
+			window.console.log( 'Received plain text:\n\n', plainText );
+
+			if ( disableFormats ) {
+				handleChange( insert( record.current, plainText ) );
+				return;
+			}
+
+			const transformed = formatTypes.reduce(
+				( accumlator, { __unstablePasteRule } ) => {
+					// Only allow one transform.
+					if (
+						__unstablePasteRule &&
+						accumlator === record.current
+					) {
+						accumlator = __unstablePasteRule( record.current, {
+							html,
+							plainText,
+						} );
+					}
+
+					return accumlator;
+				},
+				record.current
+			);
+
+			if ( transformed !== record.current ) {
+				handleChange( transformed );
+				return;
+			}
+
+			if ( onPaste ) {
+				const files = getFilesFromDataTransfer( clipboardData );
+				const isInternal =
+					clipboardData.getData( 'rich-text' ) === 'true';
+
+				onPaste( {
+					value: removeEditorOnlyFormats( record.current ),
+					onChange: handleChange,
+					html,
+					plainText,
+					isInternal,
+					files: [ ...files ],
+					activeFormats,
+				} );
+			}
+		}
+
+		element.addEventListener( 'paste', _onPaste );
+		return () => {
+			element.removeEventListener( 'paste', _onPaste );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Preparatory work for putting all rich text behaviours into a single ref callback hook, while also splitting the large rich text file.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
