### PR TITLE
[Mobile] Refactor is container related function

### DIFF
--- a/packages/components/src/mobile/utils/alignments.native.js
+++ b/packages/components/src/mobile/utils/alignments.native.js
@@ -8,15 +8,6 @@ export const WIDE_ALIGNMENTS = {
 		wide: 'wide',
 		full: 'full',
 	},
-	// `innerContainers`: Group of blocks based on `InnerBlocks` component,
-	// used to nest other blocks inside
-	innerContainers: [
-		'core/group',
-		'core/columns',
-		'core/column',
-		'core/buttons',
-		'core/button',
-	],
 	excludeBlocks: [ 'core/heading' ],
 	notInnerContainers: [
 		'core/separator',

--- a/packages/components/src/mobile/utils/alignments.native.js
+++ b/packages/components/src/mobile/utils/alignments.native.js
@@ -44,27 +44,38 @@ const isContainerRelated = ( blockName ) => {
 	if ( WIDE_ALIGNMENTS.notInnerContainers.includes( blockName ) ) {
 		return false;
 	}
-	const blockType = getBlockType( blockName );
-	const blockAlign = blockType?.supports?.align;
-	if ( Array.isArray( blockAlign ) && blockAlign.includes( 'full' ) ) {
-		return true; // The block support align
-	}
 
-	if (
-		blockType?.parent?.some( ( parent ) => {
-			const blockTypeParent = getBlockType( parent );
-			const blockAlignParent = blockTypeParent?.supports?.align;
-			return (
-				Array.isArray( blockAlignParent ) &&
-				blockAlignParent.includes( 'full' )
-			);
-		} )
-	) {
+	if ( hasFullWidthSupport( blockName ) ) {
 		return true;
 	}
 
-	return false;
+	return hasParentFullWidthSupport( blockName );
 };
+
+/**
+ * Whether the block has support for full width alignment.
+ *
+ * @param {string} blockName
+ * @return {boolean} Return whether the block supports full width alignment.
+ */
+function hasFullWidthSupport( blockName ) {
+	const blockType = getBlockType( blockName );
+	const blockAlign = blockType?.supports?.align;
+	return (
+		!! Array.isArray( blockAlign ) &&
+		blockAlign.includes( WIDE_ALIGNMENTS.alignments.full )
+	);
+}
+/**
+ * Whether the block's parent has support for full width alignment.
+ *
+ * @param {string} blockName
+ * @return {boolean} Return whether the block's parent supports full width alignment.
+ */
+function hasParentFullWidthSupport( blockName ) {
+	const blockType = getBlockType( blockName );
+	return !! blockType?.parent?.some( hasFullWidthSupport );
+}
 
 export const alignmentHelpers = {
 	isFullWidth,

--- a/packages/components/src/mobile/utils/alignments.native.js
+++ b/packages/components/src/mobile/utils/alignments.native.js
@@ -16,8 +16,6 @@ export const WIDE_ALIGNMENTS = {
 		'core/column',
 		'core/buttons',
 		'core/button',
-		'jetpack/layout-grid-column',
-		'jetpack/layout-grid',
 	],
 	excludeBlocks: [ 'core/heading' ],
 	notInnerContainers: [
@@ -43,7 +41,6 @@ const isWider = ( width, breakpoint ) =>
 	width > ALIGNMENT_BREAKPOINTS[ breakpoint ];
 
 const isContainerRelated = ( blockName ) => {
-	
 	if ( WIDE_ALIGNMENTS.notInnerContainers.includes( blockName ) ) {
 		return false;
 	}
@@ -57,7 +54,10 @@ const isContainerRelated = ( blockName ) => {
 		blockType?.parent?.some( ( parent ) => {
 			const blockTypeParent = getBlockType( parent );
 			const blockAlignParent = blockTypeParent?.supports?.align;
-			return Array.isArray( blockAlignParent ) && blockAlignParent.includes( 'full' );
+			return (
+				Array.isArray( blockAlignParent ) &&
+				blockAlignParent.includes( 'full' )
+			);
 		} )
 	) {
 		return true;

--- a/packages/components/src/mobile/utils/alignments.native.js
+++ b/packages/components/src/mobile/utils/alignments.native.js
@@ -1,3 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+
 export const WIDE_ALIGNMENTS = {
 	alignments: {
 		wide: 'wide',
@@ -11,8 +16,15 @@ export const WIDE_ALIGNMENTS = {
 		'core/column',
 		'core/buttons',
 		'core/button',
+		'jetpack/layout-grid-column',
+		'jetpack/layout-grid',
 	],
 	excludeBlocks: [ 'core/heading' ],
+	notInnerContainers: [
+		'core/separator',
+		'core/media-text',
+		'core/pullquote',
+	],
 };
 
 export const ALIGNMENT_BREAKPOINTS = {
@@ -30,8 +42,29 @@ const isWideWidth = ( align ) => align === WIDE_ALIGNMENTS.alignments.wide;
 const isWider = ( width, breakpoint ) =>
 	width > ALIGNMENT_BREAKPOINTS[ breakpoint ];
 
-const isContainerRelated = ( blockName ) =>
-	WIDE_ALIGNMENTS.innerContainers.includes( blockName );
+const isContainerRelated = ( blockName ) => {
+	
+	if ( WIDE_ALIGNMENTS.notInnerContainers.includes( blockName ) ) {
+		return false;
+	}
+	const blockType = getBlockType( blockName );
+	const blockAlign = blockType?.supports?.align;
+	if ( Array.isArray( blockAlign ) && blockAlign.includes( 'full' ) ) {
+		return true; // The block support align
+	}
+
+	if (
+		blockType?.parent?.some( ( parent ) => {
+			const blockTypeParent = getBlockType( parent );
+			const blockAlignParent = blockTypeParent?.supports?.align;
+			return Array.isArray( blockAlignParent ) && blockAlignParent.includes( 'full' );
+		} )
+	) {
+		return true;
+	}
+
+	return false;
+};
 
 export const alignmentHelpers = {
 	isFullWidth,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

This PR refactor the current is_container_related function. 


## Description
It used the block's meta data to figure out is a container is related and removed the need to manage a whitelist. That needs to get updated every time we add support for a nested block.

This change was done so that it will be easier to add the full-width feature to other blocks.

## How has this been tested?
- Added tests that show that it works as before. 
- I loaded the code in the mobile editor and it works as expected. 

## Types of changes
Refactor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
