### PR TITLE
Rich text: extract indent list item on space

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -9,7 +9,7 @@ import {
 	useMemo,
 	useLayoutEffect,
 } from '@wordpress/element';
-import { BACKSPACE, DELETE, ENTER, SPACE } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -22,8 +22,6 @@ import { toHTMLString } from '../to-html-string';
 import { remove } from '../remove';
 import { removeFormat } from '../remove-format';
 import { isCollapsed } from '../is-collapsed';
-import { LINE_SEPARATOR } from '../special-characters';
-import { indentListItems } from '../indent-list-items';
 import { getActiveFormats } from '../get-active-formats';
 import { updateFormats } from '../update-formats';
 import { removeLineSeparator } from '../remove-line-separator';
@@ -36,6 +34,7 @@ import { useCopyHandler } from './use-copy-handler';
 import { useFormatBoundaries } from './use-format-boundaries';
 import { useUndoAutomaticChange } from './use-undo-automatic-change';
 import { usePasteHandler } from './use-paste-handler';
+import { useIndentListItemOnSpace } from './use-indent-list-item-on-space';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -364,46 +363,6 @@ function RichText(
 		} );
 	}
 
-	/**
-	 * Indents list items on space keydown.
-	 *
-	 * @param {WPSyntheticEvent} event A synthetic keyboard event.
-	 */
-	function handleSpace( event ) {
-		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
-
-		if (
-			// Only override when no modifiers are pressed.
-			shiftKey ||
-			altKey ||
-			metaKey ||
-			ctrlKey ||
-			keyCode !== SPACE ||
-			multilineTag !== 'li'
-		) {
-			return;
-		}
-
-		const currentValue = createRecord();
-
-		if ( ! isCollapsed( currentValue ) ) {
-			return;
-		}
-
-		const { text, start } = currentValue;
-		const characterBefore = text[ start - 1 ];
-
-		// The caret must be at the start of a line.
-		if ( characterBefore && characterBefore !== LINE_SEPARATOR ) {
-			return;
-		}
-
-		handleChange(
-			indentListItems( currentValue, { type: multilineRootTag } )
-		);
-		event.preventDefault();
-	}
-
 	function handleKeyDown( event ) {
 		if ( event.defaultPrevented ) {
 			return;
@@ -411,7 +370,6 @@ function RichText(
 
 		handleDelete( event );
 		handleEnter( event );
-		handleSpace( event );
 	}
 
 	const lastHistoryValue = useRef( value );
@@ -819,6 +777,12 @@ function RichText(
 			useCopyHandler( { record, multilineTag, preserveWhiteSpace } ),
 			useFormatBoundaries( { record, applyRecord, setActiveFormats } ),
 			useUndoAutomaticChange( { didAutomaticChange, undo } ),
+			useIndentListItemOnSpace( {
+				multilineTag,
+				multilineRootTag,
+				createRecord,
+				handleChange,
+			} ),
 			usePasteHandler( {
 				isSelected,
 				disableFormats,

--- a/packages/rich-text/src/component/use-indent-list-item-on-space.js
+++ b/packages/rich-text/src/component/use-indent-list-item-on-space.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { SPACE } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { isCollapsed } from '../is-collapsed';
+import { LINE_SEPARATOR } from '../special-characters';
+import { indentListItems } from '../indent-list-items';
+
+export function useIndentListItemOnSpace( props ) {
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
+			const {
+				multilineTag,
+				multilineRootTag,
+				createRecord,
+				handleChange,
+			} = propsRef.current;
+
+			if (
+				// Only override when no modifiers are pressed.
+				shiftKey ||
+				altKey ||
+				metaKey ||
+				ctrlKey ||
+				keyCode !== SPACE ||
+				multilineTag !== 'li'
+			) {
+				return;
+			}
+
+			const currentValue = createRecord();
+
+			if ( ! isCollapsed( currentValue ) ) {
+				return;
+			}
+
+			const { text, start } = currentValue;
+			const characterBefore = text[ start - 1 ];
+
+			// The caret must be at the start of a line.
+			if ( characterBefore && characterBefore !== LINE_SEPARATOR ) {
+				return;
+			}
+
+			handleChange(
+				indentListItems( currentValue, { type: multilineRootTag } )
+			);
+			event.preventDefault();
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Preparatory work for putting all rich text behaviours into a single ref callback hook, while also splitting the large rich text file.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
