### PR TITLE
Rich text: extract Enter

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -9,7 +9,7 @@ import {
 	useMemo,
 	useLayoutEffect,
 } from '@wordpress/element';
-import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -35,6 +35,7 @@ import { useUndoAutomaticChange } from './use-undo-automatic-change';
 import { usePasteHandler } from './use-paste-handler';
 import { useIndentListItemOnSpace } from './use-indent-list-item-on-space';
 import { useInputAndSelection } from './use-input-and-selection';
+import { useEnter } from './use-enter';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -296,36 +297,12 @@ function RichText(
 		event.preventDefault();
 	}
 
-	/**
-	 * Triggers the `onEnter` prop on keydown.
-	 *
-	 * @param {WPSyntheticEvent} event A synthetic keyboard event.
-	 */
-	function handleEnter( event ) {
-		if ( event.keyCode !== ENTER ) {
-			return;
-		}
-
-		event.preventDefault();
-
-		if ( ! onEnter ) {
-			return;
-		}
-
-		onEnter( {
-			value: removeEditorOnlyFormats( createRecord() ),
-			onChange: handleChange,
-			shiftKey: event.shiftKey,
-		} );
-	}
-
 	function handleKeyDown( event ) {
 		if ( event.defaultPrevented ) {
 			return;
 		}
 
 		handleDelete( event );
-		handleEnter( event );
 	}
 
 	const lastHistoryValue = useRef( value );
@@ -450,6 +427,12 @@ function RichText(
 			useSelectObject(),
 			useFormatBoundaries( { record, applyRecord, setActiveFormats } ),
 			useUndoAutomaticChange( { didAutomaticChange, undo } ),
+			useEnter( {
+				onEnter,
+				removeEditorOnlyFormats,
+				createRecord,
+				handleChange,
+			} ),
 			useIndentListItemOnSpace( {
 				multilineTag,
 				multilineRootTag,

--- a/packages/rich-text/src/component/use-enter.js
+++ b/packages/rich-text/src/component/use-enter.js
@@ -14,6 +14,10 @@ export function useEnter( props ) {
 				return;
 			}
 
+			if ( element.hasAttribute( 'aria-autocomplete' ) ) {
+				return;
+			}
+
 			if ( event.keyCode !== ENTER ) {
 				return;
 			}

--- a/packages/rich-text/src/component/use-enter.js
+++ b/packages/rich-text/src/component/use-enter.js
@@ -10,6 +10,10 @@ export function useEnter( props ) {
 	propsRef.current = props;
 	return useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
 			if ( event.keyCode !== ENTER ) {
 				return;
 			}

--- a/packages/rich-text/src/component/use-enter.js
+++ b/packages/rich-text/src/component/use-enter.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { ENTER } from '@wordpress/keycodes';
+
+export function useEnter( props ) {
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			if ( event.keyCode !== ENTER ) {
+				return;
+			}
+
+			event.preventDefault();
+
+			const {
+				onEnter,
+				removeEditorOnlyFormats,
+				createRecord,
+				handleChange,
+			} = propsRef.current;
+
+			if ( ! onEnter ) {
+				return;
+			}
+
+			onEnter( {
+				value: removeEditorOnlyFormats( createRecord() ),
+				onChange: handleChange,
+				shiftKey: event.shiftKey,
+			} );
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Preparatory work for putting all rich text behaviours into a single ref callback hook, while also splitting the large rich text file.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
