### PR TITLE
Fix Xcode 12.5 support

### DIFF
--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -416,9 +416,9 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 03edb8dcc2d3f43e55aa67ea13b61b6723bbf047
   react-native-keyboard-aware-scroll-view: 6cb84879bf07e4cc1caed18b11fb928e142adac6
   react-native-safe-area: c9cf765aa2dd96159476a99633e7d462ce5bb94f
-  react-native-safe-area-context: c8da723dcddabe15afe95c9d31c56a0cf2b0141c
+  react-native-safe-area-context: 133d77d86b13cf694e014ab03dc2944ee3125d97
   react-native-slider: 2e42dc91e7ab8b35a9c7f2eb3532729a41d0dbe2
-  react-native-video: b8767f54061e475ddd38c22375f46f4d93e5fdfd
+  react-native-video: e5dd0649534076cd6d09a0db51c617fa668d534a
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72
@@ -430,7 +430,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   ReactNativeDarkMode: 6d807bc8373b872472c8541fc3341817d979a6fb
-  RNCMaskedView: 66caacf33c86eaa7d22b43178dd998257d5c2e4d
+  RNCMaskedView: dfeba59697c44d36abec79c062aeb1ea343d610d
   RNGestureHandler: 7a377d0580c9f07df99e590bbcefd616ee0e2626
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b

--- a/patches/react-native+0.61.5.patch
+++ b/patches/react-native+0.61.5.patch
@@ -35,6 +35,19 @@ index 01aa75f..572572c 100644
    if (_currentFrame) {
      layer.contentsScale = self.animatedImageScale;
      layer.contents = (__bridge id)_currentFrame.CGImage;
+diff --git a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
+index bd48f44..d243ed0 100644
+--- a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
++++ b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
+@@ -767,7 +767,7 @@ - (void)registerExtraLazyModules
+ #endif
+ }
+ 
+-- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<id<RCTBridgeModule>> *)modules
++- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
+                                withDispatchGroup:(dispatch_group_t)dispatchGroup
+                                 lazilyDiscovered:(BOOL)lazilyDiscovered
+ {
 diff --git a/node_modules/react-native/React/Views/RCTShadowView.m b/node_modules/react-native/React/Views/RCTShadowView.m
 index 40c0cda..646f137 100644
 --- a/node_modules/react-native/React/Views/RCTShadowView.m
@@ -67,3 +80,16 @@ index 40c0cda..646f137 100644
    }
    return ancestor == shadowView;
  }
+diff --git a/node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm b/node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
+index 3cb73b5..e4a14b4 100644
+--- a/node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
++++ b/node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
+@@ -297,7 +297,7 @@ - (void)notifyAboutTurboModuleSetup:(const char *)name
+           @"%@ has no setter or ivar for its bridge, which is not "
+            "permitted. You must either @synthesize the bridge property, "
+            "or provide your own setter method.",
+-          RCTBridgeModuleNameForClass(module));
++          RCTBridgeModuleNameForClass(Class(module)));
+     }
+   }
+ 


### PR DESCRIPTION
## Description
There have been a few issue building React Native in Xcode 12.5. This applies a temporary fix via `patch-package` until we are able upgrade to `react-native` >=0.64.1.

- [Example Issue](https://git.io/J35zb)
- [0.64.1 Release Notes](https://git.io/J35zN)
- [Xcode 12.5 Troubleshooting Guide](https://git.io/J35zp)
- [Temporary Fix Applied](https://git.io/J35zj)

## How has this been tested?
Built, with both Xcode 12.5 and the RN CLI, and ran the mobile Demo app to verify the previous crashes (below) did not occur and no new crashes occurred. 

<details>
<summary>Xcode 12.5 build error</summary>

<img width="1552" alt="xcode-12 5-error" src="https://user-images.githubusercontent.com/438664/117678862-680e7500-b175-11eb-8304-1ce3233a49ee.png">

</details>

<details>
<summary>RN CLI build error</summary>

```
/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/gutenberg/packages/react-native-editor/ios/Pods/Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.5.99. (in target 'boost-for-react-native' from project 'Pods')
/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/gutenberg/packages/react-native-editor/ios/Pods/Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.5.99. (in target 'react-native-video' from project 'Pods')
/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/gutenberg/packages/react-native-editor/ios/Pods/Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.5.99. (in target 'react-native-safe-area' from project 'Pods')
/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/gutenberg/packages/react-native-editor/ios/Pods/Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.5.99. (in target 'react-native-keyboard-aware-scroll-view' from project 'Pods')
/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/gutenberg/packages/react-native-editor/ios/Pods/Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.5.99. (in target 'react-native-blur' from project 'Pods')
** BUILD FAILED **
The following build commands failed:
        CompileC /Users/davidcalhoun/Sites/a8c/gutenberg-mobile/gutenberg/packages/react-native-editor/ios/build/GutenbergDemo/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/React-Core.build/Objects-normal/x86_64/RCTCxxBridge.o /Users/davidcalhoun/Sites/a8c/gutenberg-mobile/gutenberg/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm normal x86_64 objective-c++ com.apple.compilers.llvm.clang.1_0.compiler
(1 failure)
```

</details>


## Screenshots
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
