### PR TITLE
[Block Library - Post Featured Image]: Add basic dimension controls

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -9,6 +9,15 @@
 		"isLink": {
 			"type": "boolean",
 			"default": false
+		},
+		"width": {
+			"type": "string"
+		},
+		"height": {
+			"type": "string"
+		},
+		"scale": {
+			"type": "string"
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -17,7 +17,8 @@
 			"type": "string"
 		},
 		"scale": {
-			"type": "string"
+			"type": "string",
+			"default": "cover"
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -15,13 +15,18 @@ import { Platform } from '@wordpress/element';
 const isWeb = Platform.OS === 'web';
 const CSS_UNITS = [
 	{
+		value: 'px',
+		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		default: '',
+	},
+	{
 		value: '%',
 		label: isWeb ? '%' : __( 'Percentage (%)' ),
 		default: '',
 	},
 	{
-		value: 'px',
-		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		value: 'vw',
+		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
 		default: '',
 	},
 	{
@@ -32,11 +37,6 @@ const CSS_UNITS = [
 	{
 		value: 'rem',
 		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
-		default: '',
-	},
-	{
-		value: 'vw',
-		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
 		default: '',
 	},
 ];
@@ -50,7 +50,7 @@ const SCALE_OPTIONS = [
 		value: 'contain',
 	},
 	{
-		label: _x( 'Fill', 'Scale option for Image dimension control' ),
+		label: _x( 'Stretch', 'Scale option for Image dimension control' ),
 		value: 'fill',
 	},
 ];

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -59,7 +59,6 @@ const DimensionControls = ( {
 	attributes: { width, height, scale },
 	setAttributes,
 } ) => {
-	const dimensionsAreSet = width && height;
 	const onDimensionChange = ( dimension, nextValue ) => {
 		setAttributes( {
 			[ dimension ]: parseFloat( nextValue ) < 0 ? '0' : nextValue,
@@ -92,7 +91,7 @@ const DimensionControls = ( {
 					/>
 				</FlexItem>
 			</Flex>
-			{ dimensionsAreSet && (
+			{ !! height && (
 				<>
 					<BaseControl
 						aria-label={ scaleLabel }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -1,0 +1,138 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import {
+	PanelBody,
+	__experimentalUnitControl as UnitControl,
+	BaseControl,
+	Flex,
+	FlexItem,
+	Button,
+} from '@wordpress/components';
+import { Platform } from '@wordpress/element';
+
+const isWeb = Platform.OS === 'web';
+const CSS_UNITS = [
+	{
+		value: '%',
+		label: isWeb ? '%' : __( 'Percentage (%)' ),
+		default: '',
+	},
+	{
+		value: 'px',
+		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		default: '',
+	},
+	{
+		value: 'em',
+		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
+		default: '',
+	},
+	{
+		value: 'rem',
+		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
+		default: '',
+	},
+	{
+		value: 'vw',
+		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
+		default: '',
+	},
+];
+const SCALE_OPTIONS = [
+	{
+		label: _x( 'Cover', 'Scale option for Image dimension control' ),
+		value: 'cover',
+	},
+	{
+		label: _x( 'Contain', 'Scale option for Image dimension control' ),
+		value: 'contain',
+	},
+	{
+		label: _x( 'Fill', 'Scale option for Image dimension control' ),
+		value: 'fill',
+	},
+];
+
+const DimensionControls = ( {
+	attributes: { width, height, scale },
+	setAttributes,
+} ) => {
+	const dimensionsAreSet = width && height;
+	const onDimensionChange = ( dimension, nextValue ) => {
+		setAttributes( {
+			[ dimension ]: parseFloat( nextValue ) < 0 ? '0' : nextValue,
+		} );
+	};
+	const scaleLabel = _x( 'Scale', 'Image scaling options' );
+	return (
+		<PanelBody title={ __( 'Dimensions' ) }>
+			<Flex justify="space-between">
+				<FlexItem>
+					<UnitControl
+						label={ __( 'Height' ) }
+						labelPosition="top"
+						value={ height || '' }
+						onChange={ ( nextHeight ) => {
+							onDimensionChange( 'height', nextHeight );
+						} }
+						units={ CSS_UNITS }
+					/>
+				</FlexItem>
+				<FlexItem>
+					<UnitControl
+						label={ __( 'Width' ) }
+						labelPosition="top"
+						value={ width || '' }
+						onChange={ ( nextWidth ) => {
+							onDimensionChange( 'width', nextWidth );
+						} }
+						units={ CSS_UNITS }
+					/>
+				</FlexItem>
+			</Flex>
+			{ dimensionsAreSet && (
+				<>
+					<BaseControl
+						aria-label={ scaleLabel }
+						className="block-library-post-featured-image-scale-controls"
+					>
+						<div>
+							<BaseControl.VisualLabel>
+								{ scaleLabel }
+							</BaseControl.VisualLabel>
+						</div>
+						<Flex>
+							{ SCALE_OPTIONS.map( ( { value, label } ) => {
+								const isActive = value === scale;
+								return (
+									<FlexItem
+										key={ value }
+										style={ { width: '100%' } }
+									>
+										<Button
+											isPrimary={ isActive }
+											isPressed={ isActive }
+											onClick={ () =>
+												setAttributes( {
+													scale: isActive
+														? undefined
+														: value,
+												} )
+											}
+										>
+											{ label }
+										</Button>
+									</FlexItem>
+								);
+							} ) }
+						</Flex>
+					</BaseControl>
+				</>
+			) }
+		</PanelBody>
+	);
+};
+
+export default DimensionControls;

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -41,8 +41,9 @@ const DimensionControls = ( {
 	attributes: { width, height, scale },
 	setAttributes,
 } ) => {
+	const defaultUnits = [ 'px', '%', 'vw', 'em', 'rem' ];
 	const units = useCustomUnits( {
-		availableUnits: useSetting( 'spacing.units' ) || [ 'px', 'em', 'rem' ],
+		availableUnits: useSetting( 'spacing.units' ) || defaultUnits,
 	} );
 	const onDimensionChange = ( dimension, nextValue ) => {
 		const parsedValue = parseFloat( nextValue );

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -10,37 +10,9 @@ import {
 	FlexItem,
 	__experimentalSegmentedControl as SegmentedControl,
 	__experimentalSegmentedControlOption as SegmentedControlOption,
+	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
-import { Platform } from '@wordpress/element';
 
-const isWeb = Platform.OS === 'web';
-const CSS_UNITS = [
-	{
-		value: 'px',
-		label: isWeb ? 'px' : __( 'Pixels (px)' ),
-		default: '',
-	},
-	{
-		value: '%',
-		label: isWeb ? '%' : __( 'Percentage (%)' ),
-		default: '',
-	},
-	{
-		value: 'vw',
-		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
-		default: '',
-	},
-	{
-		value: 'em',
-		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
-		default: '',
-	},
-	{
-		value: 'rem',
-		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
-		default: '',
-	},
-];
 const SCALE_OPTIONS = (
 	<>
 		<SegmentedControlOption
@@ -68,6 +40,9 @@ const DimensionControls = ( {
 	attributes: { width, height, scale },
 	setAttributes,
 } ) => {
+	const units = useCustomUnits( {
+		availableUnits: [ 'px', '%', 'vw', 'em', 'rem' ],
+	} );
 	const onDimensionChange = ( dimension, nextValue ) => {
 		setAttributes( {
 			[ dimension ]: parseFloat( nextValue ) < 0 ? '0' : nextValue,
@@ -85,7 +60,7 @@ const DimensionControls = ( {
 						onChange={ ( nextHeight ) => {
 							onDimensionChange( 'height', nextHeight );
 						} }
-						units={ CSS_UNITS }
+						units={ units }
 					/>
 				</FlexItem>
 				<FlexItem>
@@ -96,7 +71,7 @@ const DimensionControls = ( {
 						onChange={ ( nextWidth ) => {
 							onDimensionChange( 'width', nextWidth );
 						} }
-						units={ CSS_UNITS }
+						units={ units }
 					/>
 				</FlexItem>
 			</Flex>

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -12,6 +12,7 @@ import {
 	__experimentalSegmentedControlOption as SegmentedControlOption,
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
+import { useSetting } from '@wordpress/block-editor';
 
 const SCALE_OPTIONS = (
 	<>
@@ -41,11 +42,13 @@ const DimensionControls = ( {
 	setAttributes,
 } ) => {
 	const units = useCustomUnits( {
-		availableUnits: [ 'px', '%', 'vw', 'em', 'rem' ],
+		availableUnits: useSetting( 'spacing.units' ) || [ 'px', 'em', 'rem' ],
 	} );
 	const onDimensionChange = ( dimension, nextValue ) => {
+		const parsedValue = parseFloat( nextValue );
+		if ( isNaN( parsedValue ) ) return;
 		setAttributes( {
-			[ dimension ]: parseFloat( nextValue ) < 0 ? '0' : nextValue,
+			[ dimension ]: parsedValue < 0 ? '0' : nextValue,
 		} );
 	};
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -47,7 +47,12 @@ const DimensionControls = ( {
 	} );
 	const onDimensionChange = ( dimension, nextValue ) => {
 		const parsedValue = parseFloat( nextValue );
-		if ( isNaN( parsedValue ) ) return;
+		/**
+		 * If we have no value set and we change the unit,
+		 * we don't want to set the attribute, as it would
+		 * end up having the unit as value without any number.
+		 */
+		if ( isNaN( parsedValue ) && nextValue ) return;
 		setAttributes( {
 			[ dimension ]: parsedValue < 0 ? '0' : nextValue,
 		} );

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -8,7 +8,8 @@ import {
 	BaseControl,
 	Flex,
 	FlexItem,
-	Button,
+	__experimentalSegmentedControl as SegmentedControl,
+	__experimentalSegmentedControlOption as SegmentedControlOption,
 } from '@wordpress/components';
 import { Platform } from '@wordpress/element';
 
@@ -40,20 +41,28 @@ const CSS_UNITS = [
 		default: '',
 	},
 ];
-const SCALE_OPTIONS = [
-	{
-		label: _x( 'Cover', 'Scale option for Image dimension control' ),
-		value: 'cover',
-	},
-	{
-		label: _x( 'Contain', 'Scale option for Image dimension control' ),
-		value: 'contain',
-	},
-	{
-		label: _x( 'Stretch', 'Scale option for Image dimension control' ),
-		value: 'fill',
-	},
-];
+const SCALE_OPTIONS = (
+	<>
+		<SegmentedControlOption
+			value="cover"
+			label={ _x( 'Cover', 'Scale option for Image dimension control' ) }
+		/>
+		<SegmentedControlOption
+			value="contain"
+			label={ _x(
+				'Contain',
+				'Scale option for Image dimension control'
+			) }
+		/>
+		<SegmentedControlOption
+			value="fill"
+			label={ _x(
+				'Stretch',
+				'Scale option for Image dimension control'
+			) }
+		/>
+	</>
+);
 
 const DimensionControls = ( {
 	attributes: { width, height, scale },
@@ -102,31 +111,18 @@ const DimensionControls = ( {
 								{ scaleLabel }
 							</BaseControl.VisualLabel>
 						</div>
-						<Flex>
-							{ SCALE_OPTIONS.map( ( { value, label } ) => {
-								const isActive = value === scale;
-								return (
-									<FlexItem
-										key={ value }
-										style={ { width: '100%' } }
-									>
-										<Button
-											isPrimary={ isActive }
-											isPressed={ isActive }
-											onClick={ () =>
-												setAttributes( {
-													scale: isActive
-														? undefined
-														: value,
-												} )
-											}
-										>
-											{ label }
-										</Button>
-									</FlexItem>
-								);
-							} ) }
-						</Flex>
+						<SegmentedControl
+							label={ scaleLabel }
+							value={ scale }
+							onChange={ ( value ) => {
+								setAttributes( {
+									scale: value,
+								} );
+							} }
+							isBlock
+						>
+							{ SCALE_OPTIONS }
+						</SegmentedControl>
 					</BaseControl>
 				</>
 			) }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -94,7 +94,7 @@ function PostFeaturedImageDisplay( {
 			<img
 				src={ media.source_url }
 				alt={ media.alt_text || __( 'Featured image' ) }
-				style={ { height, objectFit: height && width && scale } }
+				style={ { height, objectFit: height && scale } }
 			/>
 		);
 	}

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -20,6 +20,11 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { postFeaturedImage } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import DimensionControls from './dimension-controls';
+
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const placeholderChip = (
 	<div className="post-featured-image_placeholder">
@@ -29,13 +34,14 @@ const placeholderChip = (
 );
 
 function PostFeaturedImageDisplay( {
-	attributes: { isLink },
+	attributes,
 	setAttributes,
 	context: { postId, postType, queryId },
 	noticeUI,
 	noticeOperations,
 } ) {
 	const isDescendentOfQueryLoop = !! queryId;
+	const { isLink, height, width, scale } = attributes;
 	const [ featuredImage, setFeaturedImage ] = useEntityProp(
 		'postType',
 		postType,
@@ -47,7 +53,9 @@ function PostFeaturedImageDisplay( {
 			featuredImage && select( coreStore ).getMedia( featuredImage ),
 		[ featuredImage ]
 	);
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		style: { width },
+	} );
 	const onSelectImage = ( value ) => {
 		if ( value?.id ) {
 			setFeaturedImage( value.id );
@@ -86,6 +94,7 @@ function PostFeaturedImageDisplay( {
 			<img
 				src={ media.source_url }
 				alt={ media.alt_text || __( 'Featured image' ) }
+				style={ { height, objectFit: height && width && scale } }
 			/>
 		);
 	}
@@ -93,6 +102,10 @@ function PostFeaturedImageDisplay( {
 	return (
 		<>
 			<InspectorControls>
+				<DimensionControls
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+				/>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ sprintf(

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -25,3 +25,15 @@ div[data-type="core/post-featured-image"] {
 		}
 	}
 }
+
+// TODO this is temp styles.
+.block-library-post-featured-image-scale-controls {
+	margin-top: $grid-unit-20;
+	.components-flex {
+		border: $border-width solid $gray-700;
+	}
+	button {
+		width: 100%;
+		display: block;
+	}
+}

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -38,17 +38,14 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => "width:{$attributes['width']};" ) );
 	}
 
-	$image_styles = '';
 	if ( $has_height ) {
 		$image_styles = "height:{$attributes['height']};";
-	}
-	if ( $has_height && $has_width && ! empty( $attributes['scale'] ) ) {
-		$image_styles .= "object-fit:{$attributes['scale']};";
-	}
-
-	if ( $image_styles ) {
+		if ( ! empty( $attributes['scale'] ) ) {
+			$image_styles .= "object-fit:{$attributes['scale']};";
+		}
 		$featured_image = str_replace( 'src=', "style='$image_styles' src=", $featured_image );
 	}
+
 	return "<figure $wrapper_attributes>$featured_image</figure>";
 }
 

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -23,14 +23,33 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! $featured_image ) {
 		return '';
 	}
-
+	$wrapper_attributes = get_block_wrapper_attributes();
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$featured_image = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $post_ID ), $featured_image );
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$has_width  = ! empty( $attributes['width'] );
+	$has_height = ! empty( $attributes['height'] );
+	if ( ! $has_height && ! $has_width ) {
+		return "<figure $wrapper_attributes>$featured_image</figure>";
+	}
 
-	return '<figure ' . $wrapper_attributes . '>' . $featured_image . '</figure>';
+	if ( $has_width ) {
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => "width:{$attributes['width']};" ) );
+	}
+
+	$image_styles = '';
+	if ( $has_height ) {
+		$image_styles = "height:{$attributes['height']};";
+	}
+	if ( $has_height && $has_width && ! empty( $attributes['scale'] ) ) {
+		$image_styles .= "object-fit:{$attributes['scale']};";
+	}
+
+	if ( $image_styles ) {
+		$featured_image = str_replace( 'src=', "style='$image_styles' src=", $featured_image );
+	}
+	return "<figure $wrapper_attributes>$featured_image</figure>";
 }
 
 /**

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -6,6 +6,7 @@
 	}
 	img {
 		max-width: 100%;
+		width: 100%;
 		height: auto;
 	}
 

--- a/test/integration/fixtures/blocks/core__post-featured-image.json
+++ b/test/integration/fixtures/blocks/core__post-featured-image.json
@@ -4,7 +4,8 @@
 		"name": "core/post-featured-image",
 		"isValid": true,
 		"attributes": {
-			"isLink": false
+			"isLink": false,
+			"scale": "cover"
 		},
 		"innerBlocks": [],
 		"originalContent": ""


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/27620

This PR enables basic dimension controls (`width`, `height`) and allow `object-fit` properties to be configured. 
I believe landing at least a basic handling for now like this would be okay for now and gives value, in order to make it to 5.8.

## Notes
1. The `scale` control from the design does not exists now, so I've added some adhoc styles. We might improve those styles or consider adding a new component to match the design.
2. In order to set some `object-fit` properties we need to have set both `width` and `height` (see [comment](https://github.com/WordPress/gutenberg/issues/27620#issuecomment-833336369)).
3. In `scale` control I've implemented `toggle/unset` functionality. We can keep this or add a `reset/clear` button.
4. `height` in percentage (`%`) feels a bit unintuitive IMO - any suggestions?

## Testing instructions
1. Insert `Post Featured Image` block (single or in a `Query` block) and set `width`, `height` and `scale`. What feels natural to me is having `width` in `%` and `height` in `px`, but this is just subjective.
2. Observe editor and front-end changes.


