### PR TITLE
Rich text: extract internal delete handling

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -18,11 +18,8 @@ import FormatEdit from './format-edit';
 import { create } from '../create';
 import { apply } from '../to-dom';
 import { toHTMLString } from '../to-html-string';
-import { remove } from '../remove';
 import { removeFormat } from '../remove-format';
 import { isCollapsed } from '../is-collapsed';
-import { removeLineSeparator } from '../remove-line-separator';
-import { isEmptyLine } from '../is-empty';
 import { useFormatTypes } from './use-format-types';
 import { useDefaultStyle } from './use-default-style';
 import { useBoundaryStyle } from './use-boundary-style';
@@ -34,6 +31,7 @@ import { useUndoAutomaticChange } from './use-undo-automatic-change';
 import { usePasteHandler } from './use-paste-handler';
 import { useIndentListItemOnSpace } from './use-indent-list-item-on-space';
 import { useInputAndSelection } from './use-input-and-selection';
+import { useDelete } from './use-delete';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -212,103 +210,40 @@ function RichText(
 		} );
 	}
 
-	/**
-	 * Handles delete on keydown:
-	 * - outdent list items,
-	 * - delete content if everything is selected,
-	 * - trigger the onDelete prop when selection is uncollapsed and at an edge.
-	 *
-	 * @param {WPSyntheticEvent} event A synthetic keyboard event.
-	 */
-	function handleDelete( event ) {
-		const { keyCode } = event;
-
-		if ( event.defaultPrevented ) {
-			return;
-		}
-
-		if ( keyCode !== DELETE && keyCode !== BACKSPACE ) {
-			return;
-		}
-
-		const currentValue = createRecord();
-		const { start, end, text } = currentValue;
-		const isReverse = keyCode === BACKSPACE;
-
-		// Always handle full content deletion ourselves.
-		if ( start === 0 && end !== 0 && end === text.length ) {
-			handleChange( remove( currentValue ) );
-			event.preventDefault();
-			return;
-		}
-
-		if ( multilineTag ) {
-			let newValue;
-
-			// Check to see if we should remove the first item if empty.
-			if (
-				isReverse &&
-				currentValue.start === 0 &&
-				currentValue.end === 0 &&
-				isEmptyLine( currentValue )
-			) {
-				newValue = removeLineSeparator( currentValue, ! isReverse );
-			} else {
-				newValue = removeLineSeparator( currentValue, isReverse );
-			}
-
-			if ( newValue ) {
-				handleChange( newValue );
-				event.preventDefault();
-				return;
-			}
-		}
-
-		// Only process delete if the key press occurs at an uncollapsed edge.
-		if (
-			! onDelete ||
-			! isCollapsed( currentValue ) ||
-			activeFormats.length ||
-			( isReverse && start !== 0 ) ||
-			( ! isReverse && end !== text.length )
-		) {
-			return;
-		}
-
-		onDelete( { isReverse, value: currentValue } );
-		event.preventDefault();
-	}
-
-	/**
-	 * Triggers the `onEnter` prop on keydown.
-	 *
-	 * @param {WPSyntheticEvent} event A synthetic keyboard event.
-	 */
-	function handleEnter( event ) {
-		if ( event.keyCode !== ENTER ) {
-			return;
-		}
-
-		event.preventDefault();
-
-		if ( ! onEnter ) {
-			return;
-		}
-
-		onEnter( {
-			value: removeEditorOnlyFormats( createRecord() ),
-			onChange: handleChange,
-			shiftKey: event.shiftKey,
-		} );
-	}
-
 	function handleKeyDown( event ) {
 		if ( event.defaultPrevented ) {
 			return;
 		}
 
-		handleDelete( event );
-		handleEnter( event );
+		const { keyCode } = event;
+
+		if ( event.keyCode === ENTER ) {
+			event.preventDefault();
+			if ( onEnter ) {
+				onEnter( {
+					value: removeEditorOnlyFormats( createRecord() ),
+					onChange: handleChange,
+					shiftKey: event.shiftKey,
+				} );
+			}
+		} else if ( keyCode === DELETE || keyCode === BACKSPACE ) {
+			const { start, end, text } = record.current;
+			const isReverse = keyCode === BACKSPACE;
+
+			// Only process delete if the key press occurs at an uncollapsed edge.
+			if (
+				! onDelete ||
+				! isCollapsed( record.current ) ||
+				activeFormats.length ||
+				( isReverse && start !== 0 ) ||
+				( ! isReverse && end !== text.length )
+			) {
+				return;
+			}
+
+			onDelete( { isReverse, value: record.current } );
+			event.preventDefault();
+		}
 	}
 
 	// Internal values are updated synchronously, unlike props and state.
@@ -437,6 +372,11 @@ function RichText(
 			useSelectObject(),
 			useFormatBoundaries( { record, applyRecord, setActiveFormats } ),
 			useUndoAutomaticChange( { didAutomaticChange, undo } ),
+			useDelete( {
+				createRecord,
+				handleChange,
+				multilineTag,
+			} ),
 			useIndentListItemOnSpace( {
 				multilineTag,
 				multilineRootTag,

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -221,7 +221,7 @@ function RichText(
 			event.preventDefault();
 			if ( onEnter ) {
 				onEnter( {
-					value: removeEditorOnlyFormats( createRecord() ),
+					value: removeEditorOnlyFormats( record.current ),
 					onChange: handleChange,
 					shiftKey: event.shiftKey,
 				} );

--- a/packages/rich-text/src/component/use-delete.js
+++ b/packages/rich-text/src/component/use-delete.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { BACKSPACE, DELETE } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { remove } from '../remove';
+import { removeLineSeparator } from '../remove-line-separator';
+import { isEmptyLine } from '../is-empty';
+
+export function useDelete( props ) {
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			const { keyCode } = event;
+			const {
+				createRecord,
+				handleChange,
+				multilineTag,
+			} = propsRef.current;
+
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			if ( keyCode !== DELETE && keyCode !== BACKSPACE ) {
+				return;
+			}
+
+			const currentValue = createRecord();
+			const { start, end, text } = currentValue;
+			const isReverse = keyCode === BACKSPACE;
+
+			// Always handle full content deletion ourselves.
+			if ( start === 0 && end !== 0 && end === text.length ) {
+				handleChange( remove( currentValue ) );
+				event.preventDefault();
+				return;
+			}
+
+			if ( multilineTag ) {
+				let newValue;
+
+				// Check to see if we should remove the first item if empty.
+				if (
+					isReverse &&
+					currentValue.start === 0 &&
+					currentValue.end === 0 &&
+					isEmptyLine( currentValue )
+				) {
+					newValue = removeLineSeparator( currentValue, ! isReverse );
+				} else {
+					newValue = removeLineSeparator( currentValue, isReverse );
+				}
+
+				if ( newValue ) {
+					handleChange( newValue );
+					event.preventDefault();
+				}
+			}
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Preparatory work for putting all rich text behaviours into a single ref callback hook, while also splitting the large rich text file.

The remaining part of key down handling (Enter and Delete that splits the text areas) should eventually move to the block specific implementation of rich text.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Everything should work as before and we have plenty of e2e test coverage.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
