### PR TITLE
Update Modal styling

### DIFF
--- a/packages/block-editor/src/components/block-compare/style.scss
+++ b/packages/block-editor/src/components/block-compare/style.scss
@@ -6,6 +6,7 @@
 .block-editor-block-compare {
 	overflow: auto;
 	height: auto;
+	width: auto;
 
 	@include break-small() {
 		max-height: 70%;
@@ -23,6 +24,7 @@
 		width: 50%;
 		padding: 0 $grid-unit-20 0 0;
 		min-width: 200px;
+		max-width: 600px;
 
 		button {
 			float: right;

--- a/packages/block-editor/src/components/block-compare/style.scss
+++ b/packages/block-editor/src/components/block-compare/style.scss
@@ -1,16 +1,8 @@
 /**
  * Invalid block comparison
  */
-
-// Ensure the modal fits the content, otherwise it could be too big
 .block-editor-block-compare {
-	overflow: auto;
 	height: auto;
-	width: auto;
-
-	@include break-small() {
-		max-height: 70%;
-	}
 }
 
 .block-editor-block-compare__wrapper {
@@ -24,7 +16,7 @@
 		width: 50%;
 		padding: 0 $grid-unit-20 0 0;
 		min-width: 200px;
-		max-width: 600px;
+		max-width: $break-small;
 
 		button {
 			float: right;

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -6,12 +6,21 @@
 		width: 600px;
 	}
 
+	.components-modal__content {
+		padding: 0;
+		margin-top: 0;
+		border-radius: $radius-block-ui;
+
+		&::before {
+			content: none;
+		}
+	}
+
 	.components-modal__header {
 		background: none;
 		border-bottom: none;
-		width: 100%;
 		padding: 0;
-		margin: 0;
+		position: sticky;
 
 		.components-button {
 			align-self: flex-start;
@@ -75,10 +84,6 @@
 			min-width: 20px;
 			margin: -6px 0;
 		}
-	}
-
-	.components-modal__content {
-		padding: 0;
 	}
 }
 

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -17,7 +17,6 @@
 	}
 
 	.components-modal__header {
-		background: none;
 		border-bottom: none;
 		padding: 0;
 		position: sticky;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -7,6 +7,7 @@
 	left: 0;
 	background-color: rgba($black, 0.35);
 	z-index: z-index(".components-modal__screen-overlay");
+	display: flex;
 
 	// This animates the appearance of the white background.
 	@include edit-post__fade-in-animation();
@@ -14,30 +15,21 @@
 
 // The modal window element.
 .components-modal__frame {
-	// On small screens the content needs to be full width because of limited
-	// space.
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	box-sizing: border-box;
+	// Use the entire viewport on smaller screens.
 	margin: 0;
 	background: $white;
 	box-shadow: $shadow-modal;
 	border-radius: $radius-block-ui;
-	overflow: auto;
+	// Have the content element fill the vertical space yet not overflow.
+	display: flex;
 
 	// Show a centered modal on bigger screens.
 	@include break-small() {
-		top: 50%;
-		right: auto;
-		bottom: auto;
-		left: 50%;
+		margin: auto;
+		width: 50%;
 		min-width: $modal-min-width;
 		max-width: calc(100% - #{ $grid-unit-20 } - #{ $grid-unit-20 });
 		max-height: 90%;
-		transform: translate(-50%, -50%);
 
 		// Animate the modal frame/contents appearing on the page.
 		animation: components-modal__appear-animation 0.1s ease-out;
@@ -48,10 +40,10 @@
 
 @keyframes components-modal__appear-animation {
 	from {
-		margin-top: $grid-unit-40;
+		transform: translateY($grid-unit-40);
 	}
 	to {
-		margin-top: 0;
+		transform: translateY(0);
 	}
 }
 
@@ -59,7 +51,7 @@
 // if the content needs to be scrolled (for example, on the keyboard shortcuts
 // modal screen).
 .components-modal__header {
-	box-sizing: border-box;
+	border-radius: $radius-block-ui $radius-block-ui 0 0;
 	border-bottom: $border-width solid $gray-300;
 	padding: 0 $grid-unit-40;
 	display: flex;
@@ -68,22 +60,11 @@
 	background: $white;
 	align-items: center;
 	height: $header-height;
+	width: 100%;
 	z-index: z-index(".components-modal__header");
-	// For z-index to take effect, the element must be positioned. A "sticky"
-	// element is positioned, but since this is not supported in IE11,
-	// "relative" is used as a fallback.
-	position: relative;
-	position: sticky;
+	position: absolute;
 	top: 0;
-	margin: 0 -#{$grid-unit-40} $grid-unit-30;
-
-	// Rules inside this query are only run by Microsoft Edge.
-	// Edge has bugs around position: sticky;, so it needs a separate top rule.
-	// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
-	@supports (-ms-ime-align:auto) {
-		position: fixed;
-		width: 100%;
-	}
+	left: 0;
 
 	.components-modal__header-heading {
 		font-size: 1rem;
@@ -121,13 +102,19 @@
 
 // Modal contents.
 .components-modal__content {
-	box-sizing: border-box;
-	height: 100%;
+	flex: 1;
+	border-radius: 0 0 $radius-block-ui $radius-block-ui;
+	margin-top: $header-height;
 	padding: 0 $grid-unit-40 $grid-unit-30;
+	overflow: auto;
 
-	// Rules inside this query are only run by Microsoft Edge.
-	// This is a companion top padding to the fixed rule in line 77.
-	@supports (-ms-ime-align:auto) {
-		padding-top: $header-height;
+	// Emulate margin-bottom for the header. Uses a pseudo-element since the
+	// absolutely positioned header’s margins wouldn’t effect siblings and
+	// padding-top on the content element would effect positioning of any
+	// sticky elements within.
+	&::before {
+		content: "";
+		display: block;
+		margin-bottom: $grid-unit-30;
 	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -59,11 +59,11 @@
 	justify-content: space-between;
 	align-items: center;
 	height: $header-height;
-	width: 100%;
 	z-index: z-index(".components-modal__header");
 	position: absolute;
 	top: 0;
 	left: 0;
+	right: 0;
 
 	.components-modal__header-heading {
 		font-size: 1rem;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -57,6 +57,7 @@
 // if the content needs to be scrolled (for example, on the keyboard shortcuts
 // modal screen).
 .components-modal__header {
+	box-sizing: border-box;
 	border-bottom: $border-width solid $gray-300;
 	padding: 0 $grid-unit-40;
 	display: flex;
@@ -64,11 +65,11 @@
 	justify-content: space-between;
 	align-items: center;
 	height: $header-height;
+	width: 100%;
 	z-index: z-index(".components-modal__header");
 	position: absolute;
 	top: 0;
 	left: 0;
-	right: 0;
 
 	.components-modal__header-heading {
 		font-size: 1rem;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -57,7 +57,6 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	background: $white;
 	align-items: center;
 	height: $header-height;
 	width: 100%;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -17,6 +17,7 @@
 .components-modal__frame {
 	// Use the entire viewport on smaller screens.
 	margin: 0;
+	width: 100%;
 	background: $white;
 	box-shadow: $shadow-modal;
 	border-radius: $radius-block-ui;
@@ -27,15 +28,19 @@
 	// Show a centered modal on bigger screens.
 	@include break-small() {
 		margin: auto;
-		width: 50%;
+		width: auto;
 		min-width: $modal-min-width;
-		max-width: calc(100% - #{ $grid-unit-20 } - #{ $grid-unit-20 });
-		max-height: 90%;
+		max-width: calc(100% - #{ $grid-unit-20 * 2 });
+		max-height: calc(100% - #{ $header-height * 2 });
 
 		// Animate the modal frame/contents appearing on the page.
 		animation: components-modal__appear-animation 0.1s ease-out;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");
+	}
+
+	@include break-large() {
+		max-height: 70%;
 	}
 }
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -20,6 +20,7 @@
 	background: $white;
 	box-shadow: $shadow-modal;
 	border-radius: $radius-block-ui;
+	overflow: hidden;
 	// Have the content element fill the vertical space yet not overflow.
 	display: flex;
 
@@ -51,7 +52,6 @@
 // if the content needs to be scrolled (for example, on the keyboard shortcuts
 // modal screen).
 .components-modal__header {
-	border-radius: $radius-block-ui $radius-block-ui 0 0;
 	border-bottom: $border-width solid $gray-300;
 	padding: 0 $grid-unit-40;
 	display: flex;
@@ -103,7 +103,6 @@
 // Modal contents.
 .components-modal__content {
 	flex: 1;
-	border-radius: 0 0 $radius-block-ui $radius-block-ui;
 	margin-top: $header-height;
 	padding: 0 $grid-unit-40 $grid-unit-30;
 	overflow: auto;

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -4,24 +4,6 @@
 	}
 }
 
-.edit-post-manage-blocks-modal .components-modal__content {
-	padding-bottom: 0;
-	display: flex;
-	flex-direction: column;
-}
-
-.edit-post-manage-blocks-modal .components-modal__header {
-	flex-shrink: 0;
-	margin-bottom: 0;
-}
-
-.edit-post-manage-blocks-modal__content {
-	display: flex;
-	flex-direction: column;
-	flex: 0 1 100%;
-	min-height: 0;
-}
-
 .edit-post-manage-blocks-modal__no-results {
 	font-style: italic;
 	padding: 24px 0;
@@ -46,13 +28,14 @@
 }
 
 .edit-post-manage-blocks-modal__disabled-blocks-count {
-	border-top: 1px solid $gray-300;
-	margin-left: -$grid-unit-30;
-	margin-right: -$grid-unit-30;
+	border: 1px solid $gray-300;
+	border-width: 1px 0;
+	margin-left: -$grid-unit-40;
+	margin-right: -$grid-unit-40;
 	padding-top: 0.6rem;
 	padding-bottom: 0.6rem;
-	padding-left: $grid-unit-30;
-	padding-right: $grid-unit-30;
+	padding-left: $grid-unit-40;
+	padding-right: $grid-unit-40;
 	background-color: $gray-100;
 }
 
@@ -85,14 +68,14 @@
 	margin-top: 0;
 }
 
+.edit-post-manage-blocks-modal__category-title,
+.edit-post-manage-blocks-modal__checklist-item {
+	border-bottom: 1px solid $gray-300;
+}
+
 .edit-post-manage-blocks-modal__checklist-item {
 	margin-bottom: 0;
 	padding-left: $grid-unit-20;
-	border-top: 1px solid $gray-300;
-
-	&:last-child {
-		border-bottom: 1px solid $gray-300;
-	}
 
 	.components-base-control__field {
 		align-items: center;
@@ -119,11 +102,10 @@
 }
 
 .edit-post-manage-blocks-modal__results {
-	height: 100%;
-	overflow: auto;
-	margin-left: -$grid-unit-40;
-	margin-right: -$grid-unit-40;
-	padding-left: $grid-unit-40;
-	padding-right: $grid-unit-40;
 	border-top: $border-width solid $gray-300;
+}
+
+// Remove the top border from results when adjacent to the disabled block count
+.edit-post-manage-blocks-modal__disabled-blocks-count + .edit-post-manage-blocks-modal__results {
+	border-top-width: 0;
 }

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -1,9 +1,3 @@
-.edit-post-manage-blocks-modal {
-	@include break-small() {
-		height: calc(100% - #{ $header-height } - #{ $header-height });
-	}
-}
-
 .edit-post-manage-blocks-modal__no-results {
 	font-style: italic;
 	padding: 24px 0;

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -81,7 +81,7 @@
 		}
 	}
 
-	&__section {
+	&__section:not(:last-child) {
 		margin: 0 0 2.5rem 0;
 	}
 

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -1,14 +1,18 @@
 .edit-post-preferences-modal {
-	min-width: 360px;
-
-	// Better use the space on mobile.
-	width: 100%;
-	@include break-medium() {
-		width: auto;
-	}
-
+	// To keep modal dimensions consistent as subsections are navigated, width
+	// and height are used instead of max-(width/height).
 	@include break-small() {
-		height: calc(100% - #{$header-height} - #{$header-height});
+		width: calc(100% - #{ $grid-unit-20 * 2 });
+		height: calc(100% - #{ $header-height * 2 });
+	}
+	@include break-medium() {
+		width: $break-medium - $grid-unit-20 * 2;
+	}
+	@include break-large() {
+		height: 70%;
+	}
+	@include break-huge() {
+		height: 50%;
 	}
 
 	.components-navigation {

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -81,8 +81,12 @@
 		}
 	}
 
-	&__section:not(:last-child) {
+	&__section {
 		margin: 0 0 2.5rem 0;
+
+		&:last-child {
+			margin: 0;
+		}
 	}
 
 	&__section-title {


### PR DESCRIPTION
To allow easier sticky positioning for modal content elements and avoid modal sub-pixel positioning that can cause fuzzy rendering.
## Primary changes
- Let flex and auto margins provide modal centering instead of transform
- Animate transform instead of margin for appear animation
- Use absolute position instead of sticky for modal header
- Remove redundant box-sizing rules
- Cleanup of obviated rules

## Motivation and Details
This began from wanting to help move #31191 along. Specifically to fix `position: sticky` styling problem there. That immediate problem can be fixed with a simple change, but looking into it, it seemed more changes may be welcome to facilitate sticky positioning within modals and also fix their sometimes fuzzy rendering. 

### Sticky fix and facilitation
Currently, the modal header is `sticky` and can, in some cases, be scrolled out of view https://github.com/WordPress/gutenberg/pull/31191#issuecomment-827413166. This PR fixes it by removing the header from the flow of the modal content. Doing so also simplifies positioning of other sticky elements within the modal. As it is now, to avoid overlap with the header, other sticky elements either have to be nested inside an additional overflowing context (as done in the Block Manager) or add the height of the header to their `top` positions. Here are before/after demos of a custom modal with sticky elements styled with `top: 0`:

Before | After
-------|-------
![before-sticky-in-modal](https://user-images.githubusercontent.com/9000376/117713645-c4c85a80-b18a-11eb-9103-716e8ded684d.gif) | ![after-sticky-in-modal](https://user-images.githubusercontent.com/9000376/117713683-d447a380-b18a-11eb-826c-340dc9dcf759.gif)
<details>
<summary>Snippet to run in console to add a sidebar with button to launch the modal seen above</summary>

```javascript
( function ( wp ) {
    const registerPlugin = wp.plugins.registerPlugin;
    const PluginSidebar = wp.editPost.PluginSidebar;
    const { createElement:el, Fragment } = wp.element;
    const { Button, DropdownMenu, Modal } = wp.components;

    const Stickem = ({ dotColor, bgColor, title, children }) =>
        el( 'div', { style: { padding: '1px 0' } },
            el( 'h2',
                {
                    style: {
                        position:'sticky',
                        top: 0,
                        background: `radial-gradient(${ dotColor } 1px, ${ bgColor } 2px) 50%/1em 1em`,
                        margin: '0 -32px',
                        padding: '2em 1em',
                        zIndex: 2,
                        textAlign: 'center',
                    }
                },
                title
            ),
            children
        );

    const MModal = () => {
        const [ isOpen, setOpen ] = wp.element.useState( false );
        const openModal = () => setOpen( true );
        const closeModal = () => setOpen( false );

        return el( Fragment,{},
            el( 'style', {}, '.mmodal-frame{ max-width: 360px; max-height: 400px; }'),
            el( Button, {isSecondary: true, onClick: openModal }, 'Modal me' ),
            ( isOpen &&
                el( Modal, {
                    title: "Modalazo",
                    onRequestClose: closeModal,
                    className: 'mmodal-frame',
                },                                    
                    el( 'p', {}, 'A memory is a composition from the right perspective. Authors often misinterpret the male as a marching ghost, when in actuality it feels more like a dapper slipper. A lisa can hardly be considered a timeous airport without also being a flare. Their gallon was, in this moment, a burlesque trade.'),

                    el( Stickem, { title: 'Got Sticky?', bgColor: 'peachpuff', dotColor: 'orange' },
                        el( 'p', {}, 'A pan of the particle is assumed to be an untorn trout. We can assume that any instance of a lawyer can be construed as a peevish page. A dietician is a plushest pamphlet. The testy aunt comes from an ebon halibut.'),
                        el( 'p', {}, 'A dish is the basement of a romania. If this was somewhat unclear, their picture was, in this moment, a rustred sink. A precipitation is a bridgeless need. Before begonias, aprils were only snowflakes.'),
                    ),
                    
                    el( Stickem, { title: 'Got some more?', bgColor: 'pink', dotColor: 'deeppink' },
                        el( 'p', {}, 'Those toes are nothing more than violets. A blithesome map without ghanas is truly a equinox of sicklied squirrels. Those acknowledgments are nothing more than brians. Their salad was, in this moment, a steadfast step-grandmother.'),
                        el( 'p', {}, 'However, a profit can hardly be considered a doughy subway without also being a maid. They were lost without the pictured melody that composed their cheese. The halibut of a betty becomes a model care. A match is a sunlike owner.'),
                    ),
                    
                    el( Stickem, { title: 'Cool thanks!', bgColor: 'azure', dotColor: 'cyan' },
                        el( 'p', {}, 'A loopy clarinet’s year comes with it the thought that the fenny step-son is an ophthalmologist. The literature would have us believe that a glabrate country is not but a rhythm. A beech is a rub from the right perspective. In ancient times few can name an unglossed walrus that isn’t an unspilt trial.'),
                        el( 'p', {}, 'Authors often misinterpret the afterthought as a roseless mother-in-law, when in actuality it feels more like an uncapped thunderstorm. In recent years, some posit the tarry bottle to be less than acerb. They were lost without the unkissed timbale that composed their customer. A donna is a springtime breath.'),
                        el( 'p', {}, 'It’s an undeniable fact, really; their museum was, in this moment, a snotty beef. The swordfishes could be said to resemble prowessed lasagnas. However, the rainier authority comes from a cureless soup. Unfortunately, that is wrong; on the contrary, the cover is a powder.'),
                    ),
                )
            )
        );
    };

    registerPlugin( 'sidebarino', {
        render: function () {
            return el(
                PluginSidebar,
                {
                    name: 'sidebarino',
                    icon: 'admin-post',
                    title: 'Sidebarino',
                },
                el( MModal )
            );
        },
    } );

} )( window.wp );
```

</details>

------

### The sometimes fuzzy rendering issue
If the modal has odd width or height values the `transform: translate(-50%, -50%)` rule on the modal frame causes sub-pixel shifts resulting in gaps and fuzzy rendering of some children. These are likely best seen on a 1x resolution screen. Can be seen in some of the before screenshots to follow and in the following screen recording:

https://user-images.githubusercontent.com/9000376/117595708-62257f00-b0f6-11eb-95a0-9a3e8b8c6805.mp4

https://user-images.githubusercontent.com/9000376/117595738-78cbd600-b0f6-11eb-9623-f6aab5d77520.mp4

------

### Affected modals 
I searched the codebase for implementors of `Modal`, found and tested thirteen. Of those, four have changes in this PR that were needed due to the updated `Modal` styles. Mostly the aim was to avoid any visual changes but a few deviations are made intentionally as proposed improvements.

#### Block Compare Modal
This one had horizontal scrolling after the Modal style changes so it was updated to allow horizontal expansion. As a followup this one could probably use some small screen adjustments (preexistent issue).
Before | After
-------|-------
![before-block-compare](https://user-images.githubusercontent.com/9000376/117592809-e4aa4080-b0ee-11eb-96c0-d703d3aaedb4.png) | ![after-block-compare](https://user-images.githubusercontent.com/9000376/117592814-ec69e500-b0ee-11eb-8f25-b122b89edd1c.png)

#### Guide Component
Testing this with the Welcome Guide in the Post Editor and later in the Widgets Editor. It had a few issues after the Modal style changes but mostly just needed to override a different set of rules.
Before | After
-------|-------
![before-welcome-guide](https://user-images.githubusercontent.com/9000376/117593162-035d0700-b0f0-11eb-9d92-fae617bfc88b.png) | ![after-welcome-guide](https://user-images.githubusercontent.com/9000376/117593171-0c4dd880-b0f0-11eb-9ef9-4629118776a5.png)

#### Block Manager Modal
This one mostly had padding/margin issues after the Modal style changes and I took some liberty in proposing some design changes. This modal is planned to be absorbed into the Preferences modal so I'm not sure if it requires too much scrutiny here.
Before | After
-------|-------
![before-block-manager](https://user-images.githubusercontent.com/9000376/117593318-2e475b00-b0f0-11eb-9a06-3e7d351fd801.png) | ![after-block-manager](https://user-images.githubusercontent.com/9000376/117593619-2f2cbc80-b0f1-11eb-9b3f-3f0ffc529f8b.png)

#### Preferences Modal
This one overflowed vertically at slightly greater heights after the changes to Modal styling. I made a tweak for last-child sections to leave off their bottom margin. Kind of arbitrary, not necessary but seems safe and a slight improvement besides.
Before | After
-------|-------
![before-preferences-panels](https://user-images.githubusercontent.com/9000376/117594175-5fc12600-b0f2-11eb-88ad-d16b2f9cedc5.png) | ![after-preferences-panels](https://user-images.githubusercontent.com/9000376/117594192-69e32480-b0f2-11eb-9061-0e49152e5452.png)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Bug fix
Code Quality
Breaking Change?: Though the changes are purely CSS they did affect the visual rendering of a few implementors in the codebase and could do the same for third parties. It seems very unlikely the change could create any sort of catastrophic breakage so I wouldn't think it truly classifies as breaking but I don't know if we have a policy around this.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
