### PR TITLE
Cover block: remove fixed background when cover block previewed in patterns list

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -106,6 +106,8 @@
 	}
 }
 
+// Remove the parallax fixed background when in the patterns preview panel as it
+// doesn't work with the transforms that are applied to resize the block in that context.
 .block-editor-block-patterns-list__list-item .has-parallax.wp-block-cover {
 	background-attachment: scroll;
 }

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -105,3 +105,7 @@
 		font-size: $default-font-size;
 	}
 }
+
+.block-editor-block-patterns-list__list-item .has-parallax.wp-block-cover {
+	background-attachment: scroll;
+}


### PR DESCRIPTION
## Description
Fixes: #30814

If the cover block has parallax set, and is contained in a pattern, the background image does not cover correctly due to the transforms that are applied to resize the block for the pattern preview panel size.

Due to the small size of the pattern preview version it probably makes more sense to just disable the fixed background in the this context.

## To test
1. Add a block pattern that uses a full-height cover block with a fixed background, eg.

```
<!-- wp:cover {"url":"https://cldup.com/7zTYWtDXdo.jpg","id":2653,"hasParallax":true,"minHeight":100,"minHeightUnit":"vh"} -->
<div class="wp-block-cover has-background-dim has-parallax" style="background-image:url(https://cldup.com/7zTYWtDXdo.jpg);min-height:100vh"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">This is a cover block pattern.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
```

2. View the pattern preview in the block inserter.

Before:
<img width="345" alt="Screen Shot 2021-05-10 at 3 10 27 PM" src="https://user-images.githubusercontent.com/3629020/117602270-5db79f80-b1a4-11eb-93ef-f8c9c65b60ae.png">

After:
<img width="343" alt="Screen Shot 2021-05-10 at 3 09 53 PM" src="https://user-images.githubusercontent.com/3629020/117602281-64dead80-b1a4-11eb-82cc-9ca9a6040d37.png">

