### PR TITLE
Allow longhand and shorthand properties in `theme.json` and block attributes

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -58,12 +58,21 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	) {
 		$border_radius = $block_attributes['style']['border']['radius'];
 
-		// This check handles original unitless implementation.
-		if ( is_numeric( $border_radius ) ) {
-			$border_radius .= 'px';
-		}
+		if ( is_array( $border_radius ) ) {
+			// We have individual border radius corner values.
+			foreach ( $border_radius as $key => $radius ) {
+				// Convert CamelCase corner name to kebab-case.
+				$corner   = strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $key ) );
+				$styles[] = sprintf( 'border-%s-radius: %s;', $corner, $radius );
+			}
+		} else {
+			// This check handles original unitless implementation.
+			if ( is_numeric( $border_radius ) ) {
+				$border_radius .= 'px';
+			}
 
-		$styles[] = sprintf( 'border-radius: %s;', $border_radius );
+			$styles[] = sprintf( 'border-radius: %s;', $border_radius );
+		}
 	}
 
 	// Border style.

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -45,19 +45,25 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 
 	if ( $has_padding_support ) {
 		$padding_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'padding' ), null );
-		if ( null !== $padding_value ) {
+
+		if ( is_array( $padding_value ) ) {
 			foreach ( $padding_value as $key => $value ) {
 				$styles[] = sprintf( 'padding-%s: %s;', $key, $value );
 			}
+		} elseif ( null !== $padding_value ) {
+			$styles[] = sprintf( 'padding: %s;', $padding_value );
 		}
 	}
 
 	if ( $has_margin_support ) {
 		$margin_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'margin' ), null );
-		if ( null !== $margin_value ) {
+
+		if ( is_array( $margin_value ) ) {
 			foreach ( $margin_value as $key => $value ) {
 				$styles[] = sprintf( 'margin-%s: %s;', $key, $value );
 			}
+		} elseif ( null !== $margin_value ) {
+			$styles[] = sprintf( 'margin: %s;', $margin_value );
 		}
 	}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -198,80 +198,39 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Metadata for style properties.
 	 *
-	 * Each property declares:
-	 *
-	 * - 'value': path to the value in theme.json and block attributes.
+	 * Each element is a direct mapping from the CSS property name to the
+	 * path to the value in theme.json & block attributes.
 	 */
 	const PROPERTIES_METADATA = array(
-		'background'       => array(
-			'value' => array( 'color', 'gradient' ),
-		),
-		'background-color' => array(
-			'value' => array( 'color', 'background' ),
-		),
-		'border-radius'    => array(
-			'value'      => array( 'border', 'radius' ),
-			'properties' => array(
-				'border-top-left-radius'     => 'topLeft',
-				'border-top-right-radius'    => 'topRight',
-				'border-bottom-left-radius'  => 'bottomLeft',
-				'border-bottom-right-radius' => 'bottomRight',
-			),
-		),
-		'border-color'     => array(
-			'value' => array( 'border', 'color' ),
-		),
-		'border-width'     => array(
-			'value' => array( 'border', 'width' ),
-		),
-		'border-style'     => array(
-			'value' => array( 'border', 'style' ),
-		),
-		'color'            => array(
-			'value' => array( 'color', 'text' ),
-		),
-		'font-family'      => array(
-			'value' => array( 'typography', 'fontFamily' ),
-		),
-		'font-size'        => array(
-			'value' => array( 'typography', 'fontSize' ),
-		),
-		'font-style'       => array(
-			'value' => array( 'typography', 'fontStyle' ),
-		),
-		'font-weight'      => array(
-			'value' => array( 'typography', 'fontWeight' ),
-		),
-		'letter-spacing'   => array(
-			'value' => array( 'typography', 'letterSpacing' ),
-		),
-		'line-height'      => array(
-			'value' => array( 'typography', 'lineHeight' ),
-		),
-		'margin'           => array(
-			'value'      => array( 'spacing', 'margin' ),
-			'properties' => array(
-				'margin-top'    => 'top',
-				'margin-right'  => 'right',
-				'margin-bottom' => 'bottom',
-				'margin-left'   => 'left',
-			),
-		),
-		'padding'          => array(
-			'value'      => array( 'spacing', 'padding' ),
-			'properties' => array(
-				'padding-top'    => 'top',
-				'padding-right'  => 'right',
-				'padding-bottom' => 'bottom',
-				'padding-left'   => 'left',
-			),
-		),
-		'text-decoration'  => array(
-			'value' => array( 'typography', 'textDecoration' ),
-		),
-		'text-transform'   => array(
-			'value' => array( 'typography', 'textTransform' ),
-		),
+		'background'                 => array( 'color', 'gradient' ),
+		'background-color'           => array( 'color', 'background' ),
+		'border-radius'              => array( 'border', 'radius' ),
+		'border-top-left-radius'     => array( 'border', 'radius', 'topLeft' ),
+		'border-top-right-radius'    => array( 'border', 'radius', 'topRight' ),
+		'border-bottom-left-radius'  => array( 'border', 'radius', 'bottomLeft' ),
+		'border-bottom-right-radius' => array( 'border', 'radius', 'bottomRight' ),
+		'border-color'               => array( 'border', 'color' ),
+		'border-width'               => array( 'border', 'width' ),
+		'border-style'               => array( 'border', 'style' ),
+		'color'                      => array( 'color', 'text' ),
+		'font-family'                => array( 'typography', 'fontFamily' ),
+		'font-size'                  => array( 'typography', 'fontSize' ),
+		'font-style'                 => array( 'typography', 'fontStyle' ),
+		'font-weight'                => array( 'typography', 'fontWeight' ),
+		'letter-spacing'             => array( 'typography', 'letterSpacing' ),
+		'line-height'                => array( 'typography', 'lineHeight' ),
+		'margin'                     => array( 'spacing', 'margin' ),
+		'margin-top'                 => array( 'spacing', 'margin', 'top' ),
+		'margin-right'               => array( 'spacing', 'margin', 'right' ),
+		'margin-bottom'              => array( 'spacing', 'margin', 'bottom' ),
+		'margin-left'                => array( 'spacing', 'margin', 'left' ),
+		'padding'                    => array( 'spacing', 'padding' ),
+		'padding-top'                => array( 'spacing', 'padding', 'top' ),
+		'padding-right'              => array( 'spacing', 'padding', 'right' ),
+		'padding-bottom'             => array( 'spacing', 'padding', 'bottom' ),
+		'padding-left'               => array( 'spacing', 'padding', 'left' ),
+		'text-decoration'            => array( 'typography', 'textDecoration' ),
+		'text-transform'             => array( 'typography', 'textTransform' ),
 	);
 
 	const ELEMENTS = array(
@@ -378,29 +337,6 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		return $output;
-	}
-
-	/**
-	 * Given a CSS property name, returns the property it belongs
-	 * within the self::PROPERTIES_METADATA map.
-	 *
-	 * @param string $css_name The CSS property name.
-	 *
-	 * @return string The property name.
-	 */
-	private static function to_property( $css_name ) {
-		static $to_property;
-		if ( null === $to_property ) {
-			foreach ( self::PROPERTIES_METADATA as $key => $metadata ) {
-				$to_property[ $key ] = $key;
-				if ( self::has_properties( $metadata ) ) {
-					foreach ( $metadata['properties'] as $name => $property ) {
-						$to_property[ $name ] = $key;
-					}
-				}
-			}
-		}
-		return $to_property[ $css_name ];
 	}
 
 	/**
@@ -618,34 +554,16 @@ class WP_Theme_JSON_Gutenberg {
 			return $declarations;
 		}
 
-		$properties = array();
-		foreach ( self::PROPERTIES_METADATA as $name => $metadata ) {
-			$properties[] = array(
-				'name'  => $name,
-				'value' => $metadata['value'],
-			);
+		foreach ( self::PROPERTIES_METADATA as $css_property => $value_path ) {
+			$value = self::get_property_value( $styles, $value_path );
 
-			// Some properties can be shorthand properties, meaning that
-			// they contain multiple values instead of a single one.
-			// An example of this is the padding property.
-			if ( self::has_properties( $metadata ) ) {
-				foreach ( $metadata['properties'] as $key => $property ) {
-					$properties[] = array(
-						'name'  => $key,
-						'value' => array_merge( $metadata['value'], array( $property ) ),
-					);
-				}
-			}
-		}
-
-		foreach ( $properties as $prop ) {
-			$value = self::get_property_value( $styles, $prop['value'] );
+			// Skip if empty or value represents array of longhand values.
 			if ( empty( $value ) || is_array( $value ) ) {
 				continue;
 			}
 
 			$declarations[] = array(
-				'name'  => $prop['name'],
+				'name'  => $css_property,
 				'value' => $value,
 			);
 		}
@@ -1258,24 +1176,13 @@ class WP_Theme_JSON_Gutenberg {
 
 		foreach ( $declarations as $declaration ) {
 			if ( self::is_safe_css_declaration( $declaration['name'], $declaration['value'] ) ) {
-				$property = self::to_property( $declaration['name'] );
-				$path     = self::PROPERTIES_METADATA[ $property ]['value'];
+				$path = self::PROPERTIES_METADATA[ $declaration['name'] ];
 
-				// Add shorthand declaration e.g. `margin`.
+				// Check the value isn't an array before adding so as to not
+				// double up shorthand and longhand styles.
 				$value = _wp_array_get( $input, $path, array() );
 				if ( ! is_array( $value ) ) {
 					gutenberg_experimental_set( $output, $path, $value );
-				}
-
-				// Handle longhand css properties e.g. `margin-left`, `border-top-left-radius` etc.
-				if ( self::has_properties( self::PROPERTIES_METADATA[ $property ] ) ) {
-					$properties = self::PROPERTIES_METADATA[ $property ]['properties'];
-					$sub_path   = _wp_array_get( $properties, array( $declaration['name'] ), null );
-
-					if ( $sub_path ) {
-						$path[] = $sub_path;
-						gutenberg_experimental_set( $output, $path, _wp_array_get( $input, $path, array() ) );
-					}
 				}
 			}
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -519,21 +519,6 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Whether the metadata contains a key named properties.
-	 *
-	 * @param array $metadata Description of the style property.
-	 *
-	 * @return boolean True if properties exists, false otherwise.
-	 */
-	private static function has_properties( $metadata ) {
-		if ( array_key_exists( 'properties', $metadata ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Given a styles array, it extracts the style properties
 	 * and adds them to the $declarations array following the format:
 	 *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -182,6 +182,10 @@ add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post
  */
 function gutenberg_safe_style_attrs( $attrs ) {
 	$attrs[] = 'object-position';
+	$attrs[] = 'border-top-left-radius';
+	$attrs[] = 'border-top-right-radius';
+	$attrs[] = 'border-bottom-right-radius';
+	$attrs[] = 'border-bottom-left-radius';
 
 	return $attrs;
 }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -8,6 +8,7 @@ import {
 	get,
 	has,
 	isEmpty,
+	isString,
 	kebabCase,
 	map,
 	omit,
@@ -78,12 +79,25 @@ export function getInlineStyles( styles = {} ) {
 		const subPaths = STYLE_PROPERTY[ propKey ].properties;
 		// Ignore styles on elements because they are handled on the server.
 		if ( has( styles, path ) && 'elements' !== first( path ) ) {
-			if ( !! subPaths ) {
-				subPaths.forEach( ( suffix ) => {
-					output[
-						propKey + capitalize( suffix )
-					] = compileStyleValue( get( styles, [ ...path, suffix ] ) );
-				} );
+			// Checking if style value is a string allows for shorthand css
+			// option and backwards compatibility for border radius support.
+			const styleValue = get( styles, path );
+
+			if ( !! subPaths && ! isString( styleValue ) ) {
+				if ( Array.isArray( subPaths ) ) {
+					subPaths.forEach( ( suffix ) => {
+						output[
+							propKey + capitalize( suffix )
+						] = compileStyleValue( get( styleValue, [ suffix ] ) );
+					} );
+				} else {
+					Object.entries( subPaths ).forEach( ( entry ) => {
+						const [ name, suffix ] = entry;
+						output[ name ] = compileStyleValue(
+							get( styleValue, [ suffix ] )
+						);
+					} );
+				}
 			} else {
 				output[ propKey ] = compileStyleValue( get( styles, path ) );
 			}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -84,10 +84,12 @@ export function getInlineStyles( styles = {} ) {
 
 			if ( !! subPaths && ! isString( styleValue ) ) {
 				Object.entries( subPaths ).forEach( ( entry ) => {
-					const [ name, suffix ] = entry;
-					output[ name ] = compileStyleValue(
-						get( styleValue, [ suffix ] )
-					);
+					const [ name, subPath ] = entry;
+					const value = get( styleValue, [ subPath ] );
+
+					if ( value ) {
+						output[ name ] = compileStyleValue( value );
+					}
 				} );
 			} else {
 				output[ propKey ] = compileStyleValue( get( styles, path ) );

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	capitalize,
 	first,
 	forEach,
 	get,
@@ -84,20 +83,12 @@ export function getInlineStyles( styles = {} ) {
 			const styleValue = get( styles, path );
 
 			if ( !! subPaths && ! isString( styleValue ) ) {
-				if ( Array.isArray( subPaths ) ) {
-					subPaths.forEach( ( suffix ) => {
-						output[
-							propKey + capitalize( suffix )
-						] = compileStyleValue( get( styleValue, [ suffix ] ) );
-					} );
-				} else {
-					Object.entries( subPaths ).forEach( ( entry ) => {
-						const [ name, suffix ] = entry;
-						output[ name ] = compileStyleValue(
-							get( styleValue, [ suffix ] )
-						);
-					} );
-				}
+				Object.entries( subPaths ).forEach( ( entry ) => {
+					const [ name, suffix ] = entry;
+					output[ name ] = compileStyleValue(
+						get( styleValue, [ suffix ] )
+					);
+				} );
 			} else {
 				output[ propKey ] = compileStyleValue( get( styles, path ) );
 			}

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -41,4 +41,24 @@ describe( 'getInlineStyles', () => {
 			paddingTop: '10px',
 		} );
 	} );
+
+	it( 'should return individual border radius styles', () => {
+		expect(
+			getInlineStyles( {
+				border: {
+					radius: {
+						topLeft: '10px',
+						topRight: '0.5rem',
+						bottomLeft: '0.5em',
+						bottomRight: '1em',
+					},
+				},
+			} )
+		).toEqual( {
+			borderTopLeftRadius: '10px',
+			borderTopRightRadius: '0.5rem',
+			borderBottomLeftRadius: '0.5em',
+			borderBottomRightRadius: '1em',
+		} );
+	} );
 } );

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -61,4 +61,48 @@ describe( 'getInlineStyles', () => {
 			borderBottomRightRadius: '1em',
 		} );
 	} );
+
+	it( 'should support longhand spacing styles', () => {
+		expect(
+			getInlineStyles( {
+				spacing: {
+					margin: {
+						top: '10px',
+						right: '0.5rem',
+						bottom: '0.5em',
+						left: '1em',
+					},
+					padding: {
+						top: '20px',
+						right: '25px',
+						bottom: '30px',
+						left: '35px',
+					},
+				},
+			} )
+		).toEqual( {
+			marginTop: '10px',
+			marginRight: '0.5rem',
+			marginBottom: '0.5em',
+			marginLeft: '1em',
+			paddingTop: '20px',
+			paddingRight: '25px',
+			paddingBottom: '30px',
+			paddingLeft: '35px',
+		} );
+	} );
+
+	it( 'should support shorthand spacing styles', () => {
+		expect(
+			getInlineStyles( {
+				spacing: {
+					margin: '10px',
+					padding: '20px',
+				},
+			} )
+		).toEqual( {
+			margin: '10px',
+			padding: '20px',
+		} );
+	} );
 } );

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -33,6 +33,12 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	borderRadius: {
 		value: [ 'border', 'radius' ],
 		support: [ '__experimentalBorder', 'radius' ],
+		properties: {
+			borderTopLeftRadius: 'topLeft',
+			borderTopRightRadius: 'topRight',
+			borderBottomLeftRadius: 'bottomLeft',
+			borderBottomRightRadius: 'bottomRight',
+		},
 	},
 	borderStyle: {
 		value: [ 'border', 'style' ],

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -79,12 +79,22 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	margin: {
 		value: [ 'spacing', 'margin' ],
 		support: [ 'spacing', 'margin' ],
-		properties: [ 'top', 'right', 'bottom', 'left' ],
+		properties: {
+			marginTop: 'top',
+			marginRight: 'right',
+			marginBottom: 'bottom',
+			marginLeft: 'left',
+		},
 	},
 	padding: {
 		value: [ 'spacing', 'padding' ],
 		support: [ 'spacing', 'padding' ],
-		properties: [ 'top', 'right', 'bottom', 'left' ],
+		properties: {
+			paddingTop: 'top',
+			paddingRight: 'right',
+			paddingBottom: 'bottom',
+			paddingLeft: 'left',
+		},
 	},
 	textDecoration: {
 		value: [ 'typography', 'textDecoration' ],

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -7,6 +7,7 @@ import {
 	forEach,
 	get,
 	isEmpty,
+	isString,
 	kebabCase,
 	pickBy,
 	reduce,
@@ -134,24 +135,44 @@ function getStylesDeclarations( blockStyles = {} ) {
 			if ( first( pathToValue ) === 'elements' ) {
 				return declarations;
 			}
-			if ( !! properties ) {
-				properties.forEach( ( prop ) => {
-					if (
-						! get( blockStyles, [ ...pathToValue, prop ], false )
-					) {
-						// Do not create a declaration
-						// for sub-properties that don't have any value.
-						return;
-					}
-					const cssProperty = kebabCase(
-						`${ key }${ capitalize( prop ) }`
-					);
-					declarations.push(
-						`${ cssProperty }: ${ compileStyleValue(
-							get( blockStyles, [ ...pathToValue, prop ] )
-						) }`
-					);
-				} );
+
+			const styleValue = get( blockStyles, pathToValue );
+
+			if ( !! properties && ! isString( styleValue ) ) {
+				if ( Array.isArray( properties ) ) {
+					properties.forEach( ( prop ) => {
+						if ( ! get( styleValue, [ prop ], false ) ) {
+							// Do not create a declaration
+							// for sub-properties that don't have any value.
+							return;
+						}
+						const cssProperty = kebabCase(
+							`${ key }${ capitalize( prop ) }`
+						);
+						declarations.push(
+							`${ cssProperty }: ${ compileStyleValue(
+								get( styleValue, [ prop ] )
+							) }`
+						);
+					} );
+				} else {
+					Object.entries( properties ).forEach( ( entry ) => {
+						const [ name, prop ] = entry;
+
+						if ( ! get( styleValue, [ prop ], false ) ) {
+							// Do not create a declaration
+							// for sub-properties that don't have any value.
+							return;
+						}
+
+						const cssProperty = kebabCase( name );
+						declarations.push(
+							`${ cssProperty }: ${ compileStyleValue(
+								get( styleValue, [ prop ] )
+							) }`
+						);
+					} );
+				}
 			} else if ( get( blockStyles, pathToValue, false ) ) {
 				const cssProperty = key.startsWith( '--' )
 					? key

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	capitalize,
 	first,
 	forEach,
 	get,
@@ -139,40 +138,22 @@ function getStylesDeclarations( blockStyles = {} ) {
 			const styleValue = get( blockStyles, pathToValue );
 
 			if ( !! properties && ! isString( styleValue ) ) {
-				if ( Array.isArray( properties ) ) {
-					properties.forEach( ( prop ) => {
-						if ( ! get( styleValue, [ prop ], false ) ) {
-							// Do not create a declaration
-							// for sub-properties that don't have any value.
-							return;
-						}
-						const cssProperty = kebabCase(
-							`${ key }${ capitalize( prop ) }`
-						);
-						declarations.push(
-							`${ cssProperty }: ${ compileStyleValue(
-								get( styleValue, [ prop ] )
-							) }`
-						);
-					} );
-				} else {
-					Object.entries( properties ).forEach( ( entry ) => {
-						const [ name, prop ] = entry;
+				Object.entries( properties ).forEach( ( entry ) => {
+					const [ name, prop ] = entry;
 
-						if ( ! get( styleValue, [ prop ], false ) ) {
-							// Do not create a declaration
-							// for sub-properties that don't have any value.
-							return;
-						}
+					if ( ! get( styleValue, [ prop ], false ) ) {
+						// Do not create a declaration
+						// for sub-properties that don't have any value.
+						return;
+					}
 
-						const cssProperty = kebabCase( name );
-						declarations.push(
-							`${ cssProperty }: ${ compileStyleValue(
-								get( styleValue, [ prop ] )
-							) }`
-						);
-					} );
-				}
+					const cssProperty = kebabCase( name );
+					declarations.push(
+						`${ cssProperty }: ${ compileStyleValue(
+							get( styleValue, [ prop ] )
+						) }`
+					);
+				} );
 			} else if ( get( blockStyles, pathToValue, false ) ) {
 				const cssProperty = key.startsWith( '--' )
 					? key

--- a/packages/edit-site/src/components/editor/test/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/test/global-styles-renderer.js
@@ -293,6 +293,10 @@ describe( 'global styles renderer', () => {
 					},
 				},
 				styles: {
+					spacing: {
+						margin: '10px',
+						padding: '10px',
+					},
 					color: {
 						background: 'red',
 					},
@@ -304,6 +308,22 @@ describe( 'global styles renderer', () => {
 						},
 					},
 					blocks: {
+						'core/group': {
+							spacing: {
+								margin: {
+									top: '10px',
+									right: '20px',
+									bottom: '30px',
+									left: '40px',
+								},
+								padding: {
+									top: '11px',
+									right: '22px',
+									bottom: '33px',
+									left: '44px',
+								},
+							},
+						},
 						'core/heading': {
 							color: {
 								text: 'orange',
@@ -321,6 +341,9 @@ describe( 'global styles renderer', () => {
 			};
 
 			const blockSelectors = {
+				'core/group': {
+					selector: '.wp-block-group',
+				},
 				'core/heading': {
 					selector: 'h1,h2,h3,h4,h5,h6',
 					elements: {
@@ -342,7 +365,7 @@ describe( 'global styles renderer', () => {
 			};
 
 			expect( toStyles( tree, blockSelectors ) ).toEqual(
-				'body{background-color: red;}h1{font-size: 42px;}h1,h2,h3,h4,h5,h6{color: orange;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{color: hotpink;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}'
+				'body{background-color: red;margin: 10px;padding: 10px;}h1{font-size: 42px;}.wp-block-group{margin-top: 10px;margin-right: 20px;margin-bottom: 30px;margin-left: 40px;padding-top: 11px;padding-right: 22px;padding-bottom: 33px;padding-left: 44px;}h1,h2,h3,h4,h5,h6{color: orange;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{color: hotpink;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}'
 			);
 		} );
 	} );

--- a/packages/edit-site/src/components/sidebar/spacing-panel.js
+++ b/packages/edit-site/src/components/sidebar/spacing-panel.js
@@ -46,6 +46,21 @@ function filterValuesBySides( values, sides ) {
 	return filteredValues;
 }
 
+function splitStyleValue( value ) {
+	// Check for shorthand value ( a string value ).
+	if ( value && typeof value === 'string' ) {
+		// Convert to value for individual sides for BoxControl.
+		return {
+			top: value,
+			right: value,
+			bottom: value,
+			left: value,
+		};
+	}
+
+	return value;
+}
+
 export default function SpacingPanel( { context, getStyle, setStyle } ) {
 	const { name } = context;
 	const showPaddingControl = useHasPadding( context );
@@ -60,7 +75,7 @@ export default function SpacingPanel( { context, getStyle, setStyle } ) {
 		],
 	} );
 
-	const paddingValues = getStyle( name, 'padding' );
+	const paddingValues = splitStyleValue( getStyle( name, 'padding' ) );
 	const paddingSides = useCustomSides( name, 'padding' );
 
 	const setPaddingValues = ( newPaddingValues ) => {
@@ -68,7 +83,7 @@ export default function SpacingPanel( { context, getStyle, setStyle } ) {
 		setStyle( name, 'padding', padding );
 	};
 
-	const marginValues = getStyle( name, 'margin' );
+	const marginValues = splitStyleValue( getStyle( name, 'margin' ) );
 	const marginSides = useCustomSides( name, 'margin' );
 
 	const setMarginValues = ( newMarginValues ) => {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -236,6 +236,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 					'blocks'   => array(
 						'core/group'     => array(
+							'border'   => array(
+								'radius' => '10px',
+							),
 							'elements' => array(
 								'link' => array(
 									'color' => array(
@@ -279,6 +282,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 						),
+						'core/image'     => array(
+							'border' => array(
+								'radius' => array(
+									'topLeft'     => '10px',
+									'bottomRight' => '1em',
+								),
+							),
+						),
 					),
 				),
 				'misc'     => 'value',
@@ -286,11 +297,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{color: var(--wp--preset--color--grey);}a{background-color: #333;color: #111;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
+			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{color: var(--wp--preset--color--grey);}a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding-top: 12px;padding-bottom: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
 			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			'body{color: var(--wp--preset--color--grey);}a{background-color: #333;color: #111;}.wp-block-group{padding-top: 12px;padding-bottom: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
+			'body{color: var(--wp--preset--color--grey);}a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding-top: 12px;padding-bottom: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(
@@ -1004,7 +1015,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 									array(
 										'name'  => 'Blue',
 										'slug'  => 'blue',
-										'color' => 'var(--color, var(--unsafe--falback))',
+										'color' => 'var(--color, var(--unsafe--fallback))',
 									),
 									array(
 										'name'  => 'Pink',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -181,6 +181,52 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected_no_origin, $actual_no_origin );
 	}
 
+	function test_get_stylesheet_support_for_shorthand_and_longhand_values() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'border'  => array(
+								'radius' => '10px',
+							),
+							'spacing' => array(
+								'padding' => '24px',
+								'margin'  => '1em',
+							),
+						),
+						'core/image' => array(
+							'border'  => array(
+								'radius' => array(
+									'topLeft'     => '10px',
+									'bottomRight' => '1em',
+								),
+							),
+							'spacing' => array(
+								'padding' => array(
+									'top' => '15px',
+								),
+								'margin'  => array(
+									'bottom' => '30px',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertEquals(
+			'.wp-block-group{border-radius: 10px;margin: 1em;padding: 24px;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;padding-top: 15px;}',
+			$theme_json->get_stylesheet()
+		);
+		$this->assertEquals(
+			'.wp-block-group{border-radius: 10px;margin: 1em;padding: 24px;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;padding-top: 15px;}',
+			$theme_json->get_stylesheet( 'block_styles' )
+		);
+	}
+
 	function test_get_stylesheet() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
@@ -247,10 +293,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 							'spacing'  => array(
-								'padding' => array(
-									'top'    => '12px',
-									'bottom' => '24px',
-								),
+								'padding' => '24px',
 							),
 						),
 						'core/heading'   => array(
@@ -283,10 +326,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 						'core/image'     => array(
-							'border' => array(
+							'border'  => array(
 								'radius' => array(
 									'topLeft'     => '10px',
 									'bottomRight' => '1em',
+								),
+							),
+							'spacing' => array(
+								'margin' => array(
+									'bottom' => '30px',
 								),
 							),
 						),
@@ -297,11 +345,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{color: var(--wp--preset--color--grey);}a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding-top: 12px;padding-bottom: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
+			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{color: var(--wp--preset--color--grey);}a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
 			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			'body{color: var(--wp--preset--color--grey);}a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding-top: 12px;padding-bottom: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
+			'body{color: var(--wp--preset--color--grey);}a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(
@@ -739,6 +787,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'styles'  => array(
+					'border'   => array(
+						'radius' => array(
+							'topLeft'     => '6px',
+							'topRight'    => 'var(--top-right, var(--unsafe-fallback))',
+							'bottomRight' => '6px',
+							'bottomLeft'  => '6px',
+						),
+					),
 					'spacing'  => array(
 						'padding' => array(
 							'top'    => '1px',
@@ -761,6 +817,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 					'blocks'   => array(
 						'core/group' => array(
+							'border'   => array(
+								'radius' => array(
+									'topLeft'     => '5px',
+									'topRight'    => 'var(--top-right, var(--unsafe-fallback))',
+									'bottomRight' => '5px',
+									'bottomLeft'  => '5px',
+								),
+							),
 							'spacing'  => array(
 								'padding' => array(
 									'top'    => '3px',
@@ -791,6 +855,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'styles'  => array(
+				'border'   => array(
+					'radius' => array(
+						'topLeft'     => '6px',
+						'bottomRight' => '6px',
+						'bottomLeft'  => '6px',
+					),
+				),
 				'spacing'  => array(
 					'padding' => array(
 						'top'   => '1px',
@@ -811,6 +882,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'blocks'   => array(
 					'core/group' => array(
+						'border'   => array(
+							'radius' => array(
+								'topLeft'     => '5px',
+								'bottomRight' => '5px',
+								'bottomLeft'  => '5px',
+							),
+						),
 						'spacing'  => array(
 							'padding' => array(
 								'top'   => '3px',


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/31337, https://github.com/WordPress/gutenberg/pull/31585
~~Depends on: https://github.com/WordPress/gutenberg/pull/31483~~

## Description

This PR:
- Flattens the [configuration array used to map CSS property names](https://github.com/WordPress/gutenberg/pull/31641/files#diff-b03597cc3da199e5aa5a94950e8241135904853e7c3b82d758e42744878afae7R198) with paths to the appropriate value in theme.json and block attributes
- Updates border and spacing support so that border radius, margin and padding support allow both shorthand and longhand styles e.g. `margin: 10px` or `margin-left: 20px`
- Updates the theme.json and block support style tests to cover shorthand and longhand styles
- Updates global styles renderer to handle shorthand/longhand style values and configuration

The driving force behind this was achieving the refined border support UI in https://github.com/WordPress/gutenberg/issues/31337. To do so, the border block support needs to allow custom values for each corner's border radius. This PR addresses this need while also maintaining backwards compatibility for a single border radius value.

## How has this been tested?
Automated tests.

Theme.json stylesheet generation: 
`/var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-test.php`

Block support inline styles: 
`packages/block-editor/src/hooks/test/style.js`
`packages/edit-site/src/components/editor/test/global-styles-renderer.js`

Manual testing:
1. Apply this PR
2. Enable custom margin and padding support via theme.json
3. Add theme styles for the `core/group` block in the theme.json as well. Try simple shorthand margin and padding values
4. Open the site editor and in the global styles sidebar switch to the `By block type` tab, then expand the Group block panel.
5. Confirm the margin and padding controls work and their global style values can be updated and saved correctly
6. Edit the theme.json margin / padding styles to use split values per side
7. Reload the site editor and confirm the group block's margin/padding controls still function
8. Create a post within the normal block editor and add a group block
9. Select the group block and configure its margin and paddding
10. Save and confirm the spacing displays correctly.

_This PR does not update the border support UI, to test the border changes manually, try https://github.com/WordPress/gutenberg/pull/31585_

1. Checkout out the #31585 branch `update/border-block-support-ui`
    (that's all that is needed, it contains the changes from this PR)
2. Enable border support UI via theme.json - [example theme.json gist](https://gist.github.com/aaronrobertshaw/4deded861032467d4dccfe0797d3befd)
3. Build (you might need to run `npm install`)
4. Load editor, create post, add group block, and select it
5. Confirm border support panel and radius control display and function as expected

## Screenshots <!-- if applicable -->
Via use of these changes in https://github.com/WordPress/gutenberg/pull/31585

<img src="https://user-images.githubusercontent.com/60436221/117418310-9cf4af00-af5e-11eb-9cd5-3f7e5655b2f9.gif" width="400" />

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
