### PR TITLE
Navigation Editor: "Add new pages" use menu entity

### DIFF
--- a/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
+++ b/packages/edit-navigation/src/components/inspector-additions/auto-add-pages.js
@@ -1,25 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { useMenuEntityProp } from '../../hooks';
+
 export default function AutoAddPages( { menuId } ) {
-	const menu = useSelect( ( select ) => select( 'core' ).getMenu( menuId ), [
-		menuId,
-	] );
-
-	const [ autoAddPages, setAutoAddPages ] = useState( null );
-
-	useEffect( () => {
-		if ( autoAddPages === null && menu ) {
-			setAutoAddPages( menu.auto_add );
-		}
-	}, [ autoAddPages, menu ] );
-
-	const { saveMenu } = useDispatch( 'core' );
+	const [ autoAddPages, setAutoAddPages ] = useMenuEntityProp(
+		'auto_add',
+		menuId
+	);
 
 	return (
 		<ToggleControl
@@ -28,13 +22,7 @@ export default function AutoAddPages( { menuId } ) {
 				'Automatically add published top-level pages to this menu.'
 			) }
 			checked={ autoAddPages ?? false }
-			onChange={ ( newAutoAddPages ) => {
-				setAutoAddPages( newAutoAddPages );
-				saveMenu( {
-					...menu,
-					auto_add: newAutoAddPages,
-				} );
-			} }
+			onChange={ setAutoAddPages }
 		/>
 	);
 }


### PR DESCRIPTION
## Description
Currently,  the "Add new pages" option is saved immediately on a toggle. The PR updates component, so the option is saved when saving the menu.

Alternative to #30446. It doesn't require a state and uses the new `useMenuEntityProp` hook.

Fixes: #30425.

## How has this been tested?
1. Go to the Navigation Editor
2. Selected a menu.
3. Toggle the "Add new pages" option.
4. Refresh the page.
5. Changes shouldn't persist.
6. Toggle the "Add new pages" option again.
7. Save the menu.
8. See the changes persist.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
