### PR TITLE
Rich text: move implementation specific delete and enter handling

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -36,10 +36,12 @@ import {
 	__UNSTABLE_LINE_SEPARATOR as LINE_SEPARATOR,
 	toHTMLString,
 	slice,
+	isCollapsed,
 } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
 import { isURL } from '@wordpress/url';
 import { regexp } from '@wordpress/shortcode';
+import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -270,23 +272,6 @@ function RichTextWrapper(
 		[ clientId, identifier ]
 	);
 
-	const onDelete = useCallback(
-		( { value, isReverse } ) => {
-			if ( onMerge ) {
-				onMerge( ! isReverse );
-			}
-
-			// Only handle remove on Backspace. This serves dual-purpose of being
-			// an intentional user interaction distinguishing between Backspace and
-			// Delete to remove the empty field, but also to avoid merge & remove
-			// causing destruction of two fields (merge, then removed merged).
-			if ( onRemove && isEmpty( value ) && isReverse ) {
-				onRemove( ! isReverse );
-			}
-		},
-		[ onMerge, onRemove ]
-	);
-
 	/**
 	 * Signals to the RichText owner that the block can be replaced with two
 	 * blocks as a result of splitting the block by pressing enter, or with
@@ -366,62 +351,6 @@ function RichTextWrapper(
 			onReplace( blocks, indexToSelect, initialPosition );
 		},
 		[ onReplace, onSplit, multilineTag, onSplitMiddle ]
-	);
-
-	const onEnter = useCallback(
-		( { value, onChange, shiftKey } ) => {
-			const canSplit = onReplace && onSplit;
-
-			if ( onReplace ) {
-				const transforms = getBlockTransforms( 'from' ).filter(
-					( { type } ) => type === 'enter'
-				);
-				const transformation = findTransform( transforms, ( item ) => {
-					return item.regExp.test( value.text );
-				} );
-
-				if ( transformation ) {
-					onReplace( [
-						transformation.transform( { content: value.text } ),
-					] );
-					__unstableMarkAutomaticChange();
-				}
-			}
-
-			if ( multiline ) {
-				if ( shiftKey ) {
-					if ( ! disableLineBreaks ) {
-						onChange( insert( value, '\n' ) );
-					}
-				} else if ( canSplit && isEmptyLine( value ) ) {
-					splitValue( value );
-				} else {
-					onChange( insertLineSeparator( value ) );
-				}
-			} else {
-				const { text, start, end } = value;
-				const canSplitAtEnd =
-					onSplitAtEnd && start === end && end === text.length;
-
-				if ( shiftKey || ( ! canSplit && ! canSplitAtEnd ) ) {
-					if ( ! disableLineBreaks ) {
-						onChange( insert( value, '\n' ) );
-					}
-				} else if ( ! canSplit && canSplitAtEnd ) {
-					onSplitAtEnd();
-				} else if ( canSplit ) {
-					splitValue( value );
-				}
-			}
-		},
-		[
-			onReplace,
-			onSplit,
-			__unstableMarkAutomaticChange,
-			multiline,
-			splitValue,
-			onSplitAtEnd,
-		]
 	);
 
 	const onPaste = useCallback(
@@ -598,8 +527,6 @@ function RichTextWrapper(
 			placeholder={ placeholder }
 			allowedFormats={ adjustedAllowedFormats }
 			withoutInteractiveFormatting={ withoutInteractiveFormatting }
-			onEnter={ onEnter }
-			onDelete={ onDelete }
 			onPaste={ onPaste }
 			__unstableIsSelected={ isSelected }
 			__unstableInputRule={ inputRule }
@@ -656,55 +583,149 @@ function RichTextWrapper(
 				onFocus,
 				editableProps,
 				editableTagName: TagName,
-			} ) => (
-				<>
-					{ children && children( { value, onChange, onFocus } ) }
-					{ nestedIsSelected && hasFormats && (
-						<FormatToolbarContainer
-							inline={ inlineToolbar }
-							anchorRef={ fallbackRef.current }
-						/>
-					) }
-					{ nestedIsSelected && <RemoveBrowserShortcuts /> }
-					<Autocomplete
-						onReplace={ onReplace }
-						completers={ autocompleters }
-						record={ value }
-						onChange={ onChange }
-						isSelected={ nestedIsSelected }
-						contentRef={ fallbackRef }
-					>
-						{ ( { listBoxId, activeId, onKeyDown } ) => (
-							<TagName
-								{ ...editableProps }
-								{ ...props }
-								style={
-									props.style
-										? {
-												...props.style,
-												...editableProps.style,
-										  }
-										: editableProps.style
+				activeFormats,
+				removeEditorOnlyFormats,
+			} ) => {
+				function _onKeyDown( event ) {
+					const { keyCode } = event;
+
+					if ( event.keyCode === ENTER ) {
+						event.preventDefault();
+
+						const _value = removeEditorOnlyFormats( value );
+						const canSplit = onReplace && onSplit;
+
+						if ( onReplace ) {
+							const transforms = getBlockTransforms(
+								'from'
+							).filter( ( { type } ) => type === 'enter' );
+							const transformation = findTransform(
+								transforms,
+								( item ) => {
+									return item.regExp.test( _value.text );
 								}
-								className={ classnames(
-									classes,
-									props.className,
-									editableProps.className
-								) }
-								aria-autocomplete={
-									listBoxId ? 'list' : undefined
+							);
+
+							if ( transformation ) {
+								onReplace( [
+									transformation.transform( {
+										content: _value.text,
+									} ),
+								] );
+								__unstableMarkAutomaticChange();
+							}
+						}
+
+						if ( multiline ) {
+							if ( event.shiftKey ) {
+								if ( ! disableLineBreaks ) {
+									onChange( insert( _value, '\n' ) );
 								}
-								aria-owns={ listBoxId }
-								aria-activedescendant={ activeId }
-								onKeyDown={ ( event ) => {
-									onKeyDown( event );
-									editableProps.onKeyDown( event );
-								} }
+							} else if ( canSplit && isEmptyLine( _value ) ) {
+								splitValue( _value );
+							} else {
+								onChange( insertLineSeparator( _value ) );
+							}
+						} else {
+							const { text, start, end } = _value;
+							const canSplitAtEnd =
+								onSplitAtEnd &&
+								start === end &&
+								end === text.length;
+
+							if (
+								event.shiftKey ||
+								( ! canSplit && ! canSplitAtEnd )
+							) {
+								if ( ! disableLineBreaks ) {
+									onChange( insert( _value, '\n' ) );
+								}
+							} else if ( ! canSplit && canSplitAtEnd ) {
+								onSplitAtEnd();
+							} else if ( canSplit ) {
+								splitValue( _value );
+							}
+						}
+					} else if ( keyCode === DELETE || keyCode === BACKSPACE ) {
+						const { start, end, text } = value;
+						const isReverse = keyCode === BACKSPACE;
+
+						// Only process delete if the key press occurs at an uncollapsed edge.
+						if (
+							! isCollapsed( value ) ||
+							activeFormats.length ||
+							( isReverse && start !== 0 ) ||
+							( ! isReverse && end !== text.length )
+						) {
+							return;
+						}
+
+						if ( onMerge ) {
+							onMerge( ! isReverse );
+						}
+
+						// Only handle remove on Backspace. This serves dual-purpose of being
+						// an intentional user interaction distinguishing between Backspace and
+						// Delete to remove the empty field, but also to avoid merge & remove
+						// causing destruction of two fields (merge, then removed merged).
+						if ( onRemove && isEmpty( value ) && isReverse ) {
+							onRemove( ! isReverse );
+						}
+
+						event.preventDefault();
+					}
+				}
+
+				return (
+					<>
+						{ children && children( { value, onChange, onFocus } ) }
+						{ nestedIsSelected && hasFormats && (
+							<FormatToolbarContainer
+								inline={ inlineToolbar }
+								anchorRef={ fallbackRef.current }
 							/>
 						) }
-					</Autocomplete>
-				</>
-			) }
+						{ nestedIsSelected && <RemoveBrowserShortcuts /> }
+						<Autocomplete
+							onReplace={ onReplace }
+							completers={ autocompleters }
+							record={ value }
+							onChange={ onChange }
+							isSelected={ nestedIsSelected }
+							contentRef={ fallbackRef }
+						>
+							{ ( { listBoxId, activeId, onKeyDown } ) => (
+								<TagName
+									{ ...editableProps }
+									{ ...props }
+									style={
+										props.style
+											? {
+													...props.style,
+													...editableProps.style,
+											  }
+											: editableProps.style
+									}
+									className={ classnames(
+										classes,
+										props.className,
+										editableProps.className
+									) }
+									aria-autocomplete={
+										listBoxId ? 'list' : undefined
+									}
+									aria-owns={ listBoxId }
+									aria-activedescendant={ activeId }
+									onKeyDown={ ( event ) => {
+										onKeyDown( event );
+										_onKeyDown( event );
+									} }
+								/>
+							) }
+						</Autocomplete>
+					</>
+				);
+			} }
 		</RichText>
 	);
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -589,6 +589,10 @@ function RichTextWrapper(
 				function _onKeyDown( event ) {
 					const { keyCode } = event;
 
+					if ( event.defaultPrevented ) {
+						return;
+					}
+
 					if ( event.keyCode === ENTER ) {
 						event.preventDefault();
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -8,7 +8,6 @@ import {
 	useState,
 	useLayoutEffect,
 } from '@wordpress/element';
-import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -19,7 +18,6 @@ import { create } from '../create';
 import { apply } from '../to-dom';
 import { toHTMLString } from '../to-html-string';
 import { removeFormat } from '../remove-format';
-import { isCollapsed } from '../is-collapsed';
 import { useFormatTypes } from './use-format-types';
 import { useDefaultStyle } from './use-default-style';
 import { useBoundaryStyle } from './use-boundary-style';
@@ -57,8 +55,6 @@ function RichText(
 		preserveWhiteSpace,
 		onPaste,
 		format = 'string',
-		onDelete,
-		onEnter,
 		onSelectionChange,
 		onChange,
 		unstableOnFocus: onFocus,
@@ -208,42 +204,6 @@ function RichText(
 			__unstableDomOnly: domOnly,
 			placeholder,
 		} );
-	}
-
-	function handleKeyDown( event ) {
-		if ( event.defaultPrevented ) {
-			return;
-		}
-
-		const { keyCode } = event;
-
-		if ( event.keyCode === ENTER ) {
-			event.preventDefault();
-			if ( onEnter ) {
-				onEnter( {
-					value: removeEditorOnlyFormats( record.current ),
-					onChange: handleChange,
-					shiftKey: event.shiftKey,
-				} );
-			}
-		} else if ( keyCode === DELETE || keyCode === BACKSPACE ) {
-			const { start, end, text } = record.current;
-			const isReverse = keyCode === BACKSPACE;
-
-			// Only process delete if the key press occurs at an uncollapsed edge.
-			if (
-				! onDelete ||
-				! isCollapsed( record.current ) ||
-				activeFormats.length ||
-				( isReverse && start !== 0 ) ||
-				( ! isReverse && end !== text.length )
-			) {
-				return;
-			}
-
-			onDelete( { isReverse, value: record.current } );
-			event.preventDefault();
-		}
 	}
 
 	// Internal values are updated synchronously, unlike props and state.
@@ -414,7 +374,6 @@ function RichText(
 			} ),
 		] ),
 		className: 'rich-text',
-		onKeyDown: handleKeyDown,
 		onFocus,
 		// Do not set the attribute if disabled.
 		contentEditable: disabled ? undefined : true,
@@ -440,6 +399,8 @@ function RichText(
 					onFocus: focus,
 					editableProps,
 					editableTagName: TagName,
+					activeFormats,
+					removeEditorOnlyFormats,
 				} ) }
 			{ ! children && <TagName { ...editableProps } /> }
 		</>

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -3,7 +3,6 @@
  */
 import {
 	forwardRef,
-	useEffect,
 	useRef,
 	useState,
 	useLayoutEffect,
@@ -276,6 +275,7 @@ function RichText(
 
 	const didMount = useRef( false );
 
+	// Value updates must happen synchonously to avoid overwriting newer values.
 	useLayoutEffect( () => {
 		if ( didMount.current ) {
 			applyFromProps();
@@ -286,12 +286,14 @@ function RichText(
 		didMount.current = true;
 	}, [ TagName, placeholder, ...dependencies ] );
 
-	useEffect( () => {
+	// Value updates must happen synchonously to avoid overwriting newer values.
+	useLayoutEffect( () => {
 		if ( didMount.current && value !== _value.current ) {
 			applyFromProps();
 		}
 	}, [ value ] );
 
+	// Value updates must happen synchonously to avoid overwriting newer values.
 	useLayoutEffect( () => {
 		if ( ! didMount.current ) {
 			return;

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -292,7 +292,7 @@ function RichText(
 		}
 	}, [ value ] );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( ! didMount.current ) {
 			return;
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up to #31637 and generally separating rich text specific handling for block and general rich text handling.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Everything should work as before. We have plenty of test coverage for delete, split and enter behaviour.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
