### PR TITLE
Polish the switcher for horizontal blocks.

### DIFF
--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -70,6 +70,7 @@
 		margin: 0 auto;
 		display: flex;
 		align-items: center;
+		min-width: 100%;
 	}
 
 	// Position the focus style correctly.

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -86,6 +86,9 @@
 		}
 	}
 
+	// Match the parent selector button.
+	margin-left: -$border-width;
+
 	// Compensate for width of block switcher.
 	.block-editor-block-mover {
 		margin-left: -$grid-unit-15 / 2;


### PR DESCRIPTION
## Description

This PR polishes the parent button, and the switcher for horizontally moving blocks. It's best explained with a GIF. Before:

![before](https://user-images.githubusercontent.com/1204802/117626082-03ecb080-b177-11eb-8e13-ba751afbc2fd.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/117626091-05b67400-b177-11eb-9f13-be3dbda4097a.gif)

What you see here is:

- The parent button now exactly overlays the icon of the parent block, so when clicked there's no pixel shift.
- The block type icon for blocks that move horizontally is now correctly positioned.

## How has this been tested?

Please test blocks that move horizontally and verify the type icon is correctly positioned.

Please test child blocks where you select the parent block.

Please test on mobile, desktop, and with top toolbar enabled. 

BONUS points if you check with some plugins that add buttons. 

All of it should be fine.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
