### PR TITLE
Remove figure margins consistently in image blocks.

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -89,3 +89,7 @@
 		}
 	}
 }
+
+.wp-block-image figure {
+	margin: 0;
+}


### PR DESCRIPTION
Related to #29517 

in #29517 we removed the figure margins from all blocks but in the image block, when it's left, right or center aligned the figure is actually not the block wrapper, too the rule there don't apply. This PR adds an additional style to fix that.

**Testing instructions**

 - Use empty theme
 - left/right/center align an image
 - Check that the figure doesn't have margins in either editor or frontend.