### PR TITLE
Add undo redo to Widgets Customizer

### DIFF
--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -58,7 +58,7 @@ function Header( {
 						// See: https://github.com/WordPress/gutenberg/issues/3486
 						aria-disabled={ ! hasUndo }
 						onClick={ sidebar.undo }
-						className="customize-widgets-editor-history-button"
+						className="customize-widgets-editor-history-button undo-button"
 					/>
 					<ToolbarButton
 						icon={ ! isRTL() ? redoIcon : undoIcon }
@@ -70,7 +70,7 @@ function Header( {
 						// See: https://github.com/WordPress/gutenberg/issues/3486
 						aria-disabled={ ! hasRedo }
 						onClick={ sidebar.redo }
-						className="customize-widgets-editor-history-button"
+						className="customize-widgets-editor-history-button redo-button"
 					/>
 
 					<ToolbarButton

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -6,11 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createPortal } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { createPortal, useState, useEffect } from '@wordpress/element';
+import { __, _x, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { NavigableToolbar } from '@wordpress/block-editor';
-import { plus } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
+import { plus, undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -19,11 +20,23 @@ import Inserter from '../inserter';
 import MoreMenu from '../more-menu';
 
 function Header( {
+	sidebar,
 	inserter,
 	isInserterOpened,
 	setIsInserterOpened,
 	isFixedToolbarActive,
 } ) {
+	const [ [ hasUndo, hasRedo ], setUndoRedo ] = useState( [
+		sidebar.hasUndo(),
+		sidebar.hasRedo(),
+	] );
+
+	useEffect( () => {
+		return sidebar.subscribeHistory( () => {
+			setUndoRedo( [ sidebar.hasUndo(), sidebar.hasRedo() ] );
+		} );
+	}, [ sidebar ] );
+
 	return (
 		<>
 			<div
@@ -35,6 +48,31 @@ function Header( {
 					className="customize-widgets-header-toolbar"
 					aria-label={ __( 'Document tools' ) }
 				>
+					<ToolbarButton
+						icon={ ! isRTL() ? undoIcon : redoIcon }
+						/* translators: button label text should, if possible, be under 16 characters. */
+						label={ __( 'Undo' ) }
+						shortcut={ displayShortcut.primary( 'z' ) }
+						// If there are no undo levels we don't want to actually disable this
+						// button, because it will remove focus for keyboard users.
+						// See: https://github.com/WordPress/gutenberg/issues/3486
+						aria-disabled={ ! hasUndo }
+						onClick={ sidebar.undo }
+						className="editor-history__undo"
+					/>
+					<ToolbarButton
+						icon={ ! isRTL() ? redoIcon : undoIcon }
+						/* translators: button label text should, if possible, be under 16 characters. */
+						label={ __( 'Redo' ) }
+						shortcut={ displayShortcut.primaryShift( 'z' ) }
+						// If there are no undo levels we don't want to actually disable this
+						// button, because it will remove focus for keyboard users.
+						// See: https://github.com/WordPress/gutenberg/issues/3486
+						aria-disabled={ ! hasRedo }
+						onClick={ sidebar.redo }
+						className="editor-history__redo"
+					/>
+
 					<ToolbarButton
 						className="customize-widgets-header-toolbar__inserter-toggle"
 						isPressed={ isInserterOpened }

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -58,7 +58,7 @@ function Header( {
 						// See: https://github.com/WordPress/gutenberg/issues/3486
 						aria-disabled={ ! hasUndo }
 						onClick={ sidebar.undo }
-						className="editor-history__undo"
+						className="customize-widgets-editor-history-button"
 					/>
 					<ToolbarButton
 						icon={ ! isRTL() ? redoIcon : undoIcon }
@@ -70,7 +70,7 @@ function Header( {
 						// See: https://github.com/WordPress/gutenberg/issues/3486
 						aria-disabled={ ! hasRedo }
 						onClick={ sidebar.redo }
-						className="editor-history__redo"
+						className="customize-widgets-editor-history-button"
 					/>
 
 					<ToolbarButton

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -27,6 +27,8 @@
 	display: flex;
 	border: none;
 	width: 100%;
+	align-items: center;
+	margin: -4px 0;
 
 	.customize-widgets-header-toolbar__inserter-toggle.components-button.has-icon {
 		border-radius: 2px;
@@ -42,6 +44,18 @@
 
 		&.is-pressed {
 			background: $gray-900;
+		}
+	}
+
+	.components-button.has-icon.customize-widgets-editor-history-button {
+		padding: 0;
+		width: 32px;
+		height: 32px;
+		min-width: 32px;
+
+		&::before {
+			left: 0;
+			right: 0;
 		}
 	}
 }

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -20,12 +20,13 @@
 	background: #f0f0f1;
 	border-bottom: 1px solid $gray-200;
 
-	z-index: z-index(".customize-widgets__topbar");
+	z-index: z-index( '.customize-widgets__topbar' );
 }
 
 .customize-widgets-header-toolbar {
 	display: flex;
 	border: none;
+	width: 100%;
 
 	.customize-widgets-header-toolbar__inserter-toggle.components-button.has-icon {
 		border-radius: 2px;
@@ -33,7 +34,7 @@
 		padding: 0;
 		min-width: $grid-unit-30;
 		height: $grid-unit-30;
-		margin: $grid-unit-15 0 $grid-unit-15;
+		margin: $grid-unit-15 0 $grid-unit-15 auto;
 
 		&::before {
 			content: none;

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -20,7 +20,7 @@
 	background: #f0f0f1;
 	border-bottom: 1px solid $gray-200;
 
-	z-index: z-index( '.customize-widgets__topbar' );
+	z-index: z-index(".customize-widgets__topbar");
 }
 
 .customize-widgets-header-toolbar {
@@ -28,7 +28,6 @@
 	border: none;
 	width: 100%;
 	align-items: center;
-	margin: -4px 0;
 
 	.customize-widgets-header-toolbar__inserter-toggle.components-button.has-icon {
 		border-radius: 2px;
@@ -47,15 +46,8 @@
 		}
 	}
 
-	.components-button.has-icon.customize-widgets-editor-history-button {
-		padding: 0;
-		width: 32px;
-		height: 32px;
-		min-width: 32px;
-
-		&::before {
-			left: 0;
-			right: 0;
-		}
+	// Move it more closely to he left visually.
+	.components-button.has-icon.customize-widgets-editor-history-button.redo-button {
+		margin-left: -12px;
 	}
 }

--- a/packages/customize-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcuts/index.js
@@ -1,0 +1,90 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import {
+	useShortcut,
+	store as keyboardShortcutsStore,
+} from '@wordpress/keyboard-shortcuts';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+function KeyboardShortcuts( { undo, redo, save } ) {
+	useShortcut(
+		'core/customize-widgets/undo',
+		( event ) => {
+			undo();
+			event.preventDefault();
+		},
+		{ bindGlobal: true }
+	);
+
+	useShortcut(
+		'core/customize-widgets/redo',
+		( event ) => {
+			redo();
+			event.preventDefault();
+		},
+		{ bindGlobal: true }
+	);
+
+	useShortcut(
+		'core/customize-widgets/save',
+		( event ) => {
+			event.preventDefault();
+			save();
+		},
+		{ bindGlobal: true }
+	);
+
+	return null;
+}
+
+function KeyboardShortcutsRegister() {
+	const { registerShortcut, unregisterShortcut } = useDispatch(
+		keyboardShortcutsStore
+	);
+
+	useEffect( () => {
+		registerShortcut( {
+			name: 'core/customize-widgets/undo',
+			category: 'global',
+			description: __( 'Undo your last changes.' ),
+			keyCombination: {
+				modifier: 'primary',
+				character: 'z',
+			},
+		} );
+
+		registerShortcut( {
+			name: 'core/customize-widgets/redo',
+			category: 'global',
+			description: __( 'Redo your last undo.' ),
+			keyCombination: {
+				modifier: 'primaryShift',
+				character: 'z',
+			},
+		} );
+
+		registerShortcut( {
+			name: 'core/customize-widgets/save',
+			category: 'global',
+			description: __( 'Save your changes.' ),
+			keyCombination: {
+				modifier: 'primary',
+				character: 's',
+			},
+		} );
+
+		return () => {
+			unregisterShortcut( 'core/customize-widgets/undo' );
+			unregisterShortcut( 'core/customize-widgets/redo' );
+			unregisterShortcut( 'core/customize-widgets/save' );
+		};
+	}, [ registerShortcut ] );
+
+	return null;
+}
+
+KeyboardShortcuts.Register = KeyboardShortcutsRegister;
+export default KeyboardShortcuts;

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -98,10 +98,11 @@ export default function SidebarBlockEditor( {
 				<BlockEditorKeyboardShortcuts />
 
 				<Header
-					isFixedToolbarActive={ isFixedToolbarActive }
+					sidebar={ sidebar }
 					inserter={ inserter }
 					isInserterOpened={ isInserterOpened }
 					setIsInserterOpened={ setIsInserterOpened }
+					isFixedToolbarActive={ isFixedToolbarActive }
 				/>
 
 				<BlockTools>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -30,6 +30,7 @@ import useInserter from '../inserter/use-inserter';
 import SidebarEditorProvider from './sidebar-editor-provider';
 import { store as customizeWidgetsStore } from '../../store';
 import WelcomeGuide from '../welcome-guide';
+import KeyboardShortcuts from '../keyboard-shortcuts';
 
 export default function SidebarBlockEditor( {
 	blockEditorSettings,
@@ -93,9 +94,15 @@ export default function SidebarBlockEditor( {
 	return (
 		<>
 			<BlockEditorKeyboardShortcuts.Register />
+			<KeyboardShortcuts.Register />
 
 			<SidebarEditorProvider sidebar={ sidebar } settings={ settings }>
 				<BlockEditorKeyboardShortcuts />
+				<KeyboardShortcuts
+					undo={ sidebar.undo }
+					redo={ sidebar.redo }
+					save={ sidebar.save }
+				/>
 
 				<Header
 					sidebar={ sidebar }

--- a/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-adapter.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-adapter.js
@@ -81,6 +81,7 @@ export default class SidebarAdapter {
 
 		this.undo = this.undo.bind( this );
 		this.redo = this.redo.bind( this );
+		this.save = this.save.bind( this );
 	}
 
 	subscribe( callback ) {
@@ -341,5 +342,9 @@ export default class SidebarAdapter {
 		return () => {
 			this.historySubscribers.delete( listener );
 		};
+	}
+
+	save() {
+		this.api.previewer.save();
 	}
 }

--- a/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
@@ -172,6 +172,11 @@ export default function useSidebarBlockEditor( sidebar ) {
 					return blockToWidget( nextBlock );
 				} );
 
+				// Bail out updates if the updated widgets are the same.
+				if ( isShallowEqual( sidebar.getWidgets(), nextWidgets ) ) {
+					return prevBlocks;
+				}
+
 				const addedWidgetIds = sidebar.setWidgets( nextWidgets );
 
 				return nextBlocks.reduce(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Close #30400. Probably need a rebase after #31589.

Implement a naive solution for undo redo in the Widgets Customizer. The changes are debounced for 1 second to micmic the same behavior in the block editor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually. e2e tests TBD.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/117643574-22749b00-b1bb-11eb-9b1b-ec309a3a710c.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
