### PR TITLE
[RNMobile] Bottom-sheet: Limit layout animation to header changes

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -274,10 +274,14 @@ class BottomSheet extends Component {
 
 	onHeaderLayout( { nativeEvent } ) {
 		const { height } = nativeEvent.layout;
+		// The layout animation should only be triggered if the header
+		// height has changed after being mounted.
+		if ( this.headerHeight !== 0 && height !== this.headerHeight ) {
+			this.performRegularLayoutAnimation( {
+				useLastLayoutAnimation: true,
+			} );
+		}
 		this.headerHeight = height;
-		this.performRegularLayoutAnimation( {
-			useLastLayoutAnimation: true,
-		} );
 		this.onSetMaxHeight();
 	}
 


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3470

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Prevent dispatching a layout animation unless the layout of bottom-sheet's header has changed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Add an Image block
1. Select an image
1. Tap on the align button located in the toolbar
1. Tap "Full width" value
1. Observe that the transition of the block is animated

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/14905380/117647248-065a0500-b18d-11eb-83d9-eb1efb4ff41f.mp4



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
