### PR TITLE
REST API: Add locations to the menu response

### DIFF
--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -536,6 +536,8 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	/**
 	 * Returns names of the locations assigned to the menu.
 	 *
+	 * @since 5.8.0
+	 *
 	 * @param int $menu_id The menu id.
 	 *
 	 * @return string[] $menu_locations The locations assigned to the menu.

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -219,16 +219,14 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	protected function prepare_links( $term ) {
 		$links = parent::prepare_links( $term );
 
-		$locations = get_nav_menu_locations();
+		$locations = $this->get_menu_locations( $term->term_id );
 		$rest_base = 'menu-locations';
-		foreach ( $locations as $menu_name => $menu_id ) {
-			if ( $term->term_id === $menu_id ) {
-				$url                                        = rest_url( sprintf( '__experimental/%s/%s', $rest_base, $menu_name ) );
-				$links['https://api.w.org/menu-location'][] = array(
-					'href'       => $url,
-					'embeddable' => true,
-				);
-			}
+		foreach ( $locations as $location ) {
+			$url                                        = rest_url( sprintf( '__experimental/%s/%s', $rest_base, $location ) );
+			$links['https://api.w.org/menu-location'][] = array(
+				'href'       => $url,
+				'embeddable' => true,
+			);
 		}
 
 		return $links;

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -189,6 +189,10 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 		$fields = $this->get_fields_for_response( $request );
 		$data   = $response->get_data();
 
+		if ( in_array( 'locations', $fields, true ) ) {
+			$data['locations'] = $this->get_menu_locations( $nav_menu->term_id );
+		}
+
 		if ( in_array( 'auto_add', $fields, true ) ) {
 			$auto_add         = $this->get_menu_auto_add( $nav_menu->term_id );
 			$data['auto_add'] = $auto_add;
@@ -529,6 +533,26 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 		do_action( 'wp_update_nav_menu', $menu_id );
 
 		return $update;
+	}
+
+	/**
+	 * Returns names of the locations assigned to the menu.
+	 *
+	 * @param int $menu_id The menu id.
+	 *
+	 * @return string[] $menu_locations The locations assigned to the menu.
+	 */
+	protected function get_menu_locations( $menu_id ) {
+		$locations      = get_nav_menu_locations();
+		$menu_locations = array();
+
+		foreach ( $locations as $location => $assigned_menu_id ) {
+			if ( $menu_id === $assigned_menu_id ) {
+				$menu_locations[] = $location;
+			}
+		}
+
+		return $menu_locations;
 	}
 
 	/**

--- a/phpunit/class-rest-nav-menus-controller-test.php
+++ b/phpunit/class-rest-nav-menus-controller-test.php
@@ -193,6 +193,10 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'menu-name'   => 'test Name',
 			)
 		);
+
+		$this->register_nav_menu_locations( array( 'primary' ) );
+		set_theme_mod( 'nav_menu_locations', array( 'primary' => $nav_menu_id ) );
+
 		$request     = new WP_REST_Request( 'GET', '/__experimental/menus/' . $nav_menu_id );
 		$response    = rest_get_server()->dispatch( $request );
 		$this->check_get_taxonomy_term_response( $response, $nav_menu_id );
@@ -561,6 +565,18 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( $term->description, $data['description'] );
 		$this->assertFalse( isset( $data['parent'] ) );
 
+		$locations = get_nav_menu_locations();
+		if ( ! empty( $locations ) ) {
+			$menu_locations = array();
+			foreach ( $locations as $location => $menu_id ) {
+				if ( $menu_id === $term->term_id ) {
+					$menu_locations[] = $location;
+				}
+			}
+
+			$this->assertSame( $menu_locations, $data['locations'] );
+		}
+
 		$relations = array(
 			'self',
 			'collection',
@@ -572,9 +588,12 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			$relations[] = 'up';
 		}
 
+		if ( ! empty( $data['locations'] ) ) {
+			$relations[] = 'https://api.w.org/menu-location';
+		}
+
 		$this->assertEqualSets( $relations, array_keys( $links ) );
 		$this->assertContains( 'wp/v2/taxonomies/' . $term->taxonomy, $links['about'][0]['href'] );
 		$this->assertEquals( add_query_arg( 'menus', $term->term_id, rest_url( 'wp/v2/menu-items' ) ), $links['https://api.w.org/post_type'][0]['href'] );
 	}
-
 }


### PR DESCRIPTION
## Description
Fixes #31648.

## How has this been tested?
1. Send a request to get a menu item. GET `/wp-json/__experimental/menus/:id`
2. See that response has a `locations` property with assigned menu locations.

## Screenshots <!-- if applicable -->

## Types of changes
 Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
