### PR TITLE
[Block Library - Post Featured Image]: Fix non-interactive placeholder when outside of a post context

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -120,8 +120,9 @@ function PostFeaturedImageDisplay( {
 const PostFeaturedImageWithNotices = withNotices( PostFeaturedImageDisplay );
 
 export default function PostFeaturedImageEdit( props ) {
+	const blockProps = useBlockProps();
 	if ( ! props.context?.postId ) {
-		return placeholderChip;
+		return <div { ...blockProps }>{ placeholderChip }</div>;
 	}
 	return <PostFeaturedImageWithNotices { ...props } />;
 }


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes: https://github.com/WordPress/gutenberg/issues/31626

Currently if a `Post Featured Image` block is inserted in a context where a `postId` doesn't exist, like a Single Post or Page template, is not marked as a block and is not interactive to any action. This PR resolves this.