### PR TITLE
Rich text: fix showing toolbar when caret enters formatting (and extract as implementation detail for the block editor)

### DIFF
--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -427,4 +427,26 @@ describe( 'RichText', () => {
 		// Expect '1🍓'.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should show/hide toolbar when entering/exiting format', async () => {
+		const blockToolbarSelector = '.block-editor-block-toolbar';
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		expect( await page.$( blockToolbarSelector ) ).toBe( null );
+		await pressKeyWithModifier( 'primary', 'b' );
+		expect( await page.$( blockToolbarSelector ) ).not.toBe( null );
+		await page.keyboard.type( '2' );
+		expect( await page.$( blockToolbarSelector ) ).not.toBe( null );
+		await pressKeyWithModifier( 'primary', 'b' );
+		expect( await page.$( blockToolbarSelector ) ).toBe( null );
+		await page.keyboard.type( '3' );
+		await page.keyboard.press( 'ArrowLeft' );
+		expect( await page.$( blockToolbarSelector ) ).toBe( null );
+		await page.keyboard.press( 'ArrowLeft' );
+		expect( await page.$( blockToolbarSelector ) ).not.toBe( null );
+		await page.keyboard.press( 'ArrowLeft' );
+		expect( await page.$( blockToolbarSelector ) ).not.toBe( null );
+		await page.keyboard.press( 'ArrowLeft' );
+		expect( await page.$( blockToolbarSelector ) ).toBe( null );
+	} );
 } );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -67,9 +67,6 @@ function RichText(
 		__unstableMarkAutomaticChange: markAutomaticChange,
 		__unstableAllowPrefixTransformations: allowPrefixTransformations,
 		__unstableUndo: undo,
-		__unstableIsCaretWithinFormattedText: isCaretWithinFormattedText,
-		__unstableOnEnterFormattedText: onEnterFormattedText,
-		__unstableOnExitFormattedText: onExitFormattedText,
 		__unstableOnCreateUndoLevel: onCreateUndoLevel,
 		__unstableIsSelected: isSelected,
 	},
@@ -368,9 +365,6 @@ function RichText(
 				markAutomaticChange,
 				isSelected,
 				disabled,
-				isCaretWithinFormattedText,
-				onEnterFormattedText,
-				onExitFormattedText,
 				onSelectionChange,
 				setActiveFormats,
 			} ),
@@ -401,7 +395,7 @@ function RichText(
 					onFocus: focus,
 					editableProps,
 					editableTagName: TagName,
-					activeFormats,
+					hasActiveFormats: activeFormats.length,
 					removeEditorOnlyFormats,
 				} ) }
 			{ ! children && <TagName { ...editableProps } /> }

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -291,15 +291,6 @@ export function useInputAndSelection( props ) {
 				setActiveFormats( EMPTY_ACTIVE_FORMATS );
 			} else {
 				onSelectionChange( record.current.start, record.current.end );
-				setActiveFormats(
-					getActiveFormats(
-						{
-							...record.current,
-							activeFormats: undefined,
-						},
-						EMPTY_ACTIVE_FORMATS
-					)
-				);
 			}
 
 			// Update selection as soon as possible, which is at the next animation

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -178,9 +178,6 @@ export function useInputAndSelection( props ) {
 				createRecord,
 				isSelected,
 				disabled,
-				isCaretWithinFormattedText,
-				onEnterFormattedText,
-				onExitFormattedText,
 				onSelectionChange,
 				setActiveFormats,
 			} = propsRef.current;
@@ -238,15 +235,6 @@ export function useInputAndSelection( props ) {
 
 			// Update the value with the new active formats.
 			newValue.activeFormats = newActiveFormats;
-
-			if ( ! isCaretWithinFormattedText && newActiveFormats.length ) {
-				onEnterFormattedText();
-			} else if (
-				isCaretWithinFormattedText &&
-				! newActiveFormats.length
-			) {
-				onExitFormattedText();
-			}
 
 			// It is important that the internal value is updated first,
 			// otherwise the value will be wrong on render!


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes this long standing issue.

|Before|After|
|-|-|
|![caret-before](https://user-images.githubusercontent.com/4710635/117701665-2eb72300-b1d0-11eb-98e6-85e852ba9bc3.gif)|![caret-after](https://user-images.githubusercontent.com/4710635/117701675-337bd700-b1d0-11eb-922f-e5ba14fed4f7.gif)|

Related: #31644.

This PR also extracts implementation specific behaviour (communicating entering and exiting formatting) from rich text's core to the implementation for blocks.

The actions can be called on an async effect so toolbar rendering doesn't block selection change.
 
## How has this been tested?

See e2e test.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
