### PR TITLE
Make core colors classes and custom properties always available

### DIFF
--- a/lib/class-wp-theme-json-resolver.php
+++ b/lib/class-wp-theme-json-resolver.php
@@ -419,7 +419,7 @@ class WP_Theme_JSON_Resolver {
 		$result->merge( self::get_theme_data( $theme_support_data ) );
 
 		if ( 'user' === $origin ) {
-			$result->merge( self::get_user_data() );
+			$result->merge( self::get_user_data(), 'update' );
 		}
 
 		return $result;

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1114,7 +1114,7 @@ class WP_Theme_JSON {
 				$incoming_node = _wp_array_get( $incoming_data, $path, array() );
 				$existing_node = _wp_array_get( $existing_data, $path, array() );
 
-				if ( empty( $incoming_node ) && empty( $existing_data ) ) {
+				if ( empty( $incoming_node ) && empty( $existing_node ) ) {
 					continue;
 				}
 

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1076,7 +1076,7 @@ class WP_Theme_JSON {
 	 * Merge new incoming data.
 	 *
 	 * @param WP_Theme_JSON $incoming Data to merge.
-	 * @param string $update_or_remove Whether update or remove existing colors
+	 * @param string        $update_or_remove Whether update or remove existing colors
 	 *                                 for which the incoming data has a duplicated slug.
 	 */
 	public function merge( $incoming, $update_or_remove = 'remove' ) {
@@ -1129,15 +1129,15 @@ class WP_Theme_JSON {
 				$index_table    = array();
 				$existing_slugs = array();
 				$merged         = array();
-				foreach( $existing_node as $key => $value ) {
+				foreach ( $existing_node as $key => $value ) {
 					$index_table[ $value['slug'] ] = $key;
 					$existing_slugs[]              = $value['slug'];
 					$merged[ $key ]                = $value;
 				}
 
-				$to_remove = [];
-				foreach( $incoming_node as $value ) {
-					if ( ! in_array( $value['slug'], $existing_slugs ) ) {
+				$to_remove = array();
+				foreach ( $incoming_node as $value ) {
+					if ( ! in_array( $value['slug'], $existing_slugs, true ) ) {
 						$merged[] = $value;
 					} elseif ( 'update' === $update_or_remove ) {
 						$merged[ $index_table[ $value['slug'] ] ] = $value;
@@ -1148,7 +1148,7 @@ class WP_Theme_JSON {
 				}
 
 				// Remove the duplicated values and pack the sparsed array.
-				foreach( $to_remove as $index ) {
+				foreach ( $to_remove as $index ) {
 					unset( $merged[ $index ] );
 				}
 				$merged = array_values( $merged );

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1079,29 +1079,46 @@ class WP_Theme_JSON {
 	 */
 	public function merge( $incoming ) {
 		$incoming_data    = $incoming->get_raw_data();
-		$this->theme_json = array_replace_recursive( $this->theme_json, $incoming_data );
+		$existing_data    = $this->theme_json;
 
 		// The array_replace_recursive algorithm merges at the leaf level.
 		// For leaf values that are arrays it will use the numeric indexes for replacement.
-		// In those cases, what we want is to use the incoming value, if it exists.
-		//
-		// These are the cases that have array values at the leaf levels.
-		$properties   = array();
-		$properties[] = array( 'color', 'palette' );
-		$properties[] = array( 'color', 'gradients' );
-		$properties[] = array( 'custom' );
-		$properties[] = array( 'spacing', 'units' );
-		$properties[] = array( 'typography', 'fontSizes' );
-		$properties[] = array( 'typography', 'fontFamilies' );
+		$this->theme_json = array_replace_recursive( $this->theme_json, $incoming_data );
+
+		// There are a few cases in which we want to merge things differently
+		// from what array_replace_recursive does.
+
+		// Some incoming properties should replace the existing.
+		$to_replace   = array();
+		$to_replace[] = array( 'custom' );
+		$to_replace[] = array( 'spacing', 'units' );
+		$to_replace[] = array( 'typography', 'fontSizes' );
+		$to_replace[] = array( 'typography', 'fontFamilies' );
+
+		// Some others should be appended to the existing.
+		$to_append   = array();
+		$to_append[] = array( 'color', 'palette' );
+		$to_append[] = array( 'color', 'gradients' );
 
 		$nodes = self::get_setting_nodes( $this->theme_json );
 		foreach ( $nodes as $metadata ) {
-			foreach ( $properties as $property_path ) {
-				$path = array_merge( $metadata['path'], $property_path );
+			foreach ( $to_replace as $path_to_replace ) {
+				$path = array_merge( $metadata['path'], $path_to_replace );
 				$node = _wp_array_get( $incoming_data, $path, array() );
 				if ( ! empty( $node ) ) {
 					gutenberg_experimental_set( $this->theme_json, $path, $node );
 				}
+			}
+			foreach ( $to_append as $path_to_append ) {
+				$path          = array_merge( $metadata['path'], $path_to_append );
+				$incoming_node = _wp_array_get( $incoming_data, $path, array() );
+				$existing_node = _wp_array_get( $existing_data, $path, array() );
+
+				if ( empty( $incoming_node ) && empty( $existing_data ) ) {
+					continue;
+				}
+
+				gutenberg_experimental_set( $this->theme_json, $path, array_merge( $existing_node, $incoming_node ) );
 			}
 		}
 

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1095,7 +1095,8 @@ class WP_Theme_JSON {
 		$to_replace[] = array( 'typography', 'fontSizes' );
 		$to_replace[] = array( 'typography', 'fontFamilies' );
 
-		// Some others should be appended to the existing.
+		// Some others should be either appended to the existing
+		// or update the existing if the slug is the same.
 		$to_append   = array();
 		$to_append[] = array( 'color', 'palette' );
 		$to_append[] = array( 'color', 'gradients' );
@@ -1118,7 +1119,24 @@ class WP_Theme_JSON {
 					continue;
 				}
 
-				gutenberg_experimental_set( $this->theme_json, $path, array_merge( $existing_node, $incoming_node ) );
+				$index_table    = array();
+				$existing_slugs = array();
+				$merged         = array();
+				foreach( $existing_node as $key => $value ) {
+					$index_table[ $value['slug'] ] = $key;
+					$existing_slugs[]              = $value['slug'];
+					$merged[ $key ]                = $value;
+				}
+
+				foreach( $incoming_node as $value ) {
+					if ( in_array( $value['slug'], $existing_slugs ) ) {
+						$merged[ $index_table[ $value['slug'] ] ] = $value;
+					} else {
+						$merged[] = $value;
+					}
+				}
+
+				gutenberg_experimental_set( $this->theme_json, $path, $merged );
 			}
 		}
 

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1078,8 +1078,8 @@ class WP_Theme_JSON {
 	 * @param WP_Theme_JSON $incoming Data to merge.
 	 */
 	public function merge( $incoming ) {
-		$incoming_data    = $incoming->get_raw_data();
-		$existing_data    = $this->theme_json;
+		$incoming_data = $incoming->get_raw_data();
+		$existing_data = $this->theme_json;
 
 		// The array_replace_recursive algorithm merges at the leaf level.
 		// For leaf values that are arrays it will use the numeric indexes for replacement.

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -6,124 +6,148 @@
 				{
 					"name": "Black",
 					"slug": "black",
-					"color": "#000000"
+					"color": "#000000",
+					"origin": "core"
 				},
 				{
 					"name": "Cyan bluish gray",
 					"slug": "cyan-bluish-gray",
-					"color": "#abb8c3"
+					"color": "#abb8c3",
+					"origin": "core"
 				},
 				{
 					"name": "White",
 					"slug": "white",
-					"color": "#ffffff"
+					"color": "#ffffff",
+					"origin": "core"
 				},
 				{
 					"name": "Pale pink",
 					"slug": "pale-pink",
-					"color": "#f78da7"
+					"color": "#f78da7",
+					"origin": "core"
 				},
 				{
 					"name": "Vivid red",
 					"slug": "vivid-red",
-					"color": "#cf2e2e"
+					"color": "#cf2e2e",
+					"origin": "core"
 				},
 				{
 					"name": "Luminous vivid orange",
 					"slug": "luminous-vivid-orange",
-					"color": "#ff6900"
+					"color": "#ff6900",
+					"origin": "core"
 				},
 				{
 					"name": "Luminous vivid amber",
 					"slug": "luminous-vivid-amber",
-					"color": "#fcb900"
+					"color": "#fcb900",
+					"origin": "core"
 				},
 				{
 					"name": "Light green cyan",
 					"slug": "light-green-cyan",
-					"color": "#7bdcb5"
+					"color": "#7bdcb5",
+					"origin": "core"
 				},
 				{
 					"name": "Vivid green cyan",
 					"slug": "vivid-green-cyan",
-					"color": "#00d084"
+					"color": "#00d084",
+					"origin": "core"
 				},
 				{
 					"name": "Pale cyan blue",
 					"slug": "pale-cyan-blue",
-					"color": "#8ed1fc"
+					"color": "#8ed1fc",
+					"origin": "core"
 				},
 				{
 					"name": "Vivid cyan blue",
 					"slug": "vivid-cyan-blue",
-					"color": "#0693e3"
+					"color": "#0693e3",
+					"origin": "core"
 				},
 				{
 					"name": "Vivid purple",
 					"slug": "vivid-purple",
-					"color": "#9b51e0"
+					"color": "#9b51e0",
+					"origin": "core"
 				}
 			],
 			"gradients": [
 				{
 					"name": "Vivid cyan blue to vivid purple",
 					"gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
-					"slug": "vivid-cyan-blue-to-vivid-purple"
+					"slug": "vivid-cyan-blue-to-vivid-purple",
+					"origin": "core"
 				},
 				{
 					"name": "Light green cyan to vivid green cyan",
 					"gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
-					"slug": "light-green-cyan-to-vivid-green-cyan"
+					"slug": "light-green-cyan-to-vivid-green-cyan",
+					"origin": "core"
 				},
 				{
 					"name": "Luminous vivid amber to luminous vivid orange",
 					"gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
-					"slug": "luminous-vivid-amber-to-luminous-vivid-orange"
+					"slug": "luminous-vivid-amber-to-luminous-vivid-orange",
+					"origin": "core"
 				},
 				{
 					"name": "Luminous vivid orange to vivid red",
 					"gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
-					"slug": "luminous-vivid-orange-to-vivid-red"
+					"slug": "luminous-vivid-orange-to-vivid-red",
+					"origin": "core"
 				},
 				{
 					"name": "Very light gray to cyan bluish gray",
 					"gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
-					"slug": "very-light-gray-to-cyan-bluish-gray"
+					"slug": "very-light-gray-to-cyan-bluish-gray",
+					"origin": "core"
 				},
 				{
 					"name": "Cool to warm spectrum",
 					"gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
-					"slug": "cool-to-warm-spectrum"
+					"slug": "cool-to-warm-spectrum",
+					"origin": "core"
 				},
 				{
 					"name": "Blush light purple",
 					"gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
-					"slug": "blush-light-purple"
+					"slug": "blush-light-purple",
+					"origin": "core"
 				},
 				{
 					"name": "Blush bordeaux",
 					"gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
-					"slug": "blush-bordeaux"
+					"slug": "blush-bordeaux",
+					"origin": "core"
 				},
 				{
 					"name": "Luminous dusk",
 					"gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
-					"slug": "luminous-dusk"
+					"slug": "luminous-dusk",
+					"origin": "core"
 				},
 				{
 					"name": "Pale ocean",
 					"gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
-					"slug": "pale-ocean"
+					"slug": "pale-ocean",
+					"origin": "core"
 				},
 				{
 					"name": "Electric grass",
 					"gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
-					"slug": "electric-grass"
+					"slug": "electric-grass",
+					"origin": "core"
 				},
 				{
 					"name": "Midnight",
 					"gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
-					"slug": "midnight"
+					"slug": "midnight",
+					"origin": "core"
 				}
 			],
 			"duotone": [

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -49,16 +49,18 @@ const deprecatedFlags = {
 	'spacing.customPadding': ( settings ) => settings.enableCustomSpacing,
 };
 
-const filterColorsFromCoreOrigin = ( path, colors ) => {
+const filterColorsFromCoreOrigin = ( path, setting ) => {
 	if ( path !== 'color.palette' && path !== 'color.gradients' ) {
-		return colors;
+		return setting;
 	}
 
-	if ( ! Array.isArray( colors ) ) {
-		return colors;
+	if ( ! Array.isArray( setting ) ) {
+		return setting;
 	}
 
-	return colors.filter( ( color ) => color?.origin !== 'core' );
+	const colors = setting.filter( ( color ) => color?.origin !== 'core' );
+
+	return colors.length > 0 ? colors : setting;
 };
 
 /**

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -49,6 +49,18 @@ const deprecatedFlags = {
 	'spacing.customPadding': ( settings ) => settings.enableCustomSpacing,
 };
 
+const filterColorsFromCoreOrigin = ( path, colors ) => {
+	if ( path !== 'color.palette' && path !== 'color.gradients' ) {
+		return colors;
+	}
+
+	if ( ! Array.isArray( colors ) ) {
+		return colors;
+	}
+
+	return colors.filter( ( color ) => color?.origin !== 'core' );
+};
+
 /**
  * Hook that retrieves the editor setting.
  * It works with nested objects using by finding the value at path.
@@ -76,7 +88,10 @@ export default function useSetting( path ) {
 			const experimentalFeaturesResult =
 				get( settings, blockPath ) ?? get( settings, defaultsPath );
 			if ( experimentalFeaturesResult !== undefined ) {
-				return experimentalFeaturesResult;
+				return filterColorsFromCoreOrigin(
+					path,
+					experimentalFeaturesResult
+				);
 			}
 
 			// 2 - Use deprecated settings, otherwise.
@@ -84,7 +99,10 @@ export default function useSetting( path ) {
 				? deprecatedFlags[ path ]( settings )
 				: undefined;
 			if ( deprecatedSettingsValue !== undefined ) {
-				return deprecatedSettingsValue;
+				return filterColorsFromCoreOrigin(
+					path,
+					deprecatedSettingsValue
+				);
 			}
 
 			// 3 - Fall back for typography.dropCap:

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -47,7 +47,31 @@ const GlobalStylesContext = createContext( {
 	/* eslint-enable no-unused-vars */
 } );
 
-const mergeTreesCustomizer = ( objValue, srcValue ) => {
+const mergeTreesCustomizer = ( objValue, srcValue, key ) => {
+	// Users can add their own colors.
+	// We want to append them when they don't
+	// have the same slug as an existing color,
+	// otherwise we want to update the existing color instead.
+	if ( 'palette' === key ) {
+		const indexTable = {};
+		const existingSlugs = [];
+		const result = [ ...( objValue ?? [] ) ];
+		result.forEach( ( { slug }, index ) => {
+			indexTable[ slug ] = index;
+			existingSlugs.push( slug );
+		} );
+
+		( srcValue ?? [] ).forEach( ( element ) => {
+			if ( existingSlugs.includes( element?.slug ) ) {
+				result[ indexTable[ element?.slug ] ] = element;
+			} else {
+				result.push( element );
+			}
+		} );
+
+		return result;
+	}
+
 	// We only pass as arrays the presets,
 	// in which case we want the new array of values
 	// to override the old array (no merging).

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -90,16 +90,18 @@ function getPresetMetadataFromStyleProperty( styleProperty ) {
 	return getPresetMetadataFromStyleProperty.MAP[ styleProperty ];
 }
 
-const filterColorsFromCoreOrigin = ( path, colors ) => {
+const filterColorsFromCoreOrigin = ( path, setting ) => {
 	if ( path !== 'color.palette' && path !== 'color.gradients' ) {
-		return colors;
+		return setting;
 	}
 
-	if ( ! Array.isArray( colors ) ) {
-		return colors;
+	if ( ! Array.isArray( setting ) ) {
+		return setting;
 	}
 
-	return colors.filter( ( color ) => color?.origin !== 'core' );
+	const colors = setting.filter( ( color ) => color?.origin !== 'core' );
+
+	return colors.length > 0 ? colors : setting;
 };
 
 export function useSetting( path, blockName = '' ) {

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -90,13 +90,26 @@ function getPresetMetadataFromStyleProperty( styleProperty ) {
 	return getPresetMetadataFromStyleProperty.MAP[ styleProperty ];
 }
 
+const filterColorsFromCoreOrigin = ( path, colors ) => {
+	if ( path !== 'color.palette' && path !== 'color.gradients' ) {
+		return colors;
+	}
+
+	if ( ! Array.isArray( colors ) ) {
+		return colors;
+	}
+
+	return colors.filter( ( color ) => color?.origin !== 'core' );
+};
+
 export function useSetting( path, blockName = '' ) {
 	const settings = useSelect( ( select ) => {
 		return select( editSiteStore ).getSettings();
 	} );
 	const topLevelPath = `__experimentalFeatures.${ path }`;
 	const blockPath = `__experimentalFeatures.blocks.${ blockName }.${ path }`;
-	return get( settings, blockPath ) ?? get( settings, topLevelPath );
+	const setting = get( settings, blockPath ) ?? get( settings, topLevelPath );
+	return filterColorsFromCoreOrigin( path, setting );
 }
 
 export function getPresetVariable( styles, context, propertyName, value ) {

--- a/packages/edit-site/src/components/sidebar/color-palette-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-palette-panel.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { difference, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -58,7 +58,21 @@ export default function ColorPalettePanel( {
 			immutableColorSlugs={ immutableColorSlugs }
 			colors={ colors }
 			onChange={ ( newColors ) => {
-				setSetting( contextName, 'color.palette', newColors );
+				const existingUserColors = ( newColors ?? [] ).filter(
+					( color ) => color.origin === 'user'
+				);
+				const differentUserColors = difference( newColors, colors );
+				if ( differentUserColors.length === 1 ) {
+					differentUserColors[ 0 ] = {
+						...differentUserColors[ 0 ],
+						origin: 'user',
+					};
+				}
+
+				setSetting( contextName, 'color.palette', [
+					...existingUserColors,
+					...differentUserColors,
+				] );
 			} }
 			emptyUI={ __(
 				'Colors are empty! Add some colors to create your own color palette.'

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -411,6 +411,14 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					'customGradient' => true,
 					'palette'        => array(
 						array(
+							'slug'  => 'red',
+							'color' => 'red',
+						),
+						array(
+							'slug'  => 'green',
+							'color' => 'green',
+						),
+						array(
 							'slug'  => 'blue',
 							'color' => 'blue',
 						),


### PR DESCRIPTION
Implements first iteration of https://github.com/WordPress/gutenberg/issues/29568

This PR makes it so the CSS styles (classes and custom properties) related to the core palette and gradients are always enqueued.

At the UI level, it doesn't change anything, and only the theme colors are shown.

## Changes in this PR

- It updates the merge algorithm of theme.json so that the color palette and the gradients are not merged. Instead, colors are appended.
- It updates the `useSetting` hook to filter colors based on a key. If the color has the key `origin: "core"` it'll be filtered out, hence not used in the UI controls. Alternatives I've considered for this key are `__experimentalNotUI`. However, given that the final goal is to show them all at once, the `origin` key seems more future-proof.

## What happens if a theme uses the same slug as core

If a theme provides the same slug as a core color uses (for example, both core and theme declare `black`) the theme's color classes and CSS Custom Properties are enqueued after the core's, so the theme's styles will override core's.

At the UI level, there's no change: only the theme colors are shown.

## How to test

Front-end:

- Using the TT1-blocks theme, visit the front-end. Verify that the `#global-styles-inline-css` inline stylesheet has the corresponding CSS Custom Properties and classes for both core and theme colors.

Post editor:

- Using the TT1-blocks theme, visit the post editor.
- Add a block with support for colors. Verify the UI color control only contains the theme colors.
- Check that the CSS Custom Properties and classes for core and theme colors are present in the inline stylesheet. Tip: search for `--wp--preset--color--purple` and `.has-purple-color` to find the stylesheets.

Site editor:

- Using the TT1-blocks theme, visit the site editor.
- Add a block with support for colors. Verify the UI color control only contains the theme colors.
- Go to the global styles sidebar. Verify the UI color control only contains the theme colors.
- Check that the CSS Custom Properties and classes for core and theme colors are present in the inline stylesheet. Tip: search for `--wp--preset--color--purple` and `.has-purple-color` to find the stylesheets.
