### PR TITLE
Page List: Create a JS version for the editor

### DIFF
--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -7,39 +7,6 @@
 	"keywords": [ "menu", "navigation" ],
 	"textdomain": "default",
 	"attributes": {
-		"textColor": {
-			"type": "string"
-		},
-		"customTextColor": {
-			"type": "string"
-		},
-		"backgroundColor": {
-			"type": "string"
-		},
-		"customBackgroundColor": {
-			"type": "string"
-		},
-		"overlayBackgroundColor": {
-			"type": "string"
-		},
-		"customOverlayBackgroundColor": {
-			"type": "string"
-		},
-		"overlayTextColor": {
-			"type": "string"
-		},
-		"customOverlayTextColor": {
-			"type": "string"
-		},
-		"isNavigationChild": {
-			"type": "boolean"
-		},
-		"showSubmenuIcon": {
-			"type": "boolean"
-		},
-		"openSubmenusOnClick" : {
-			"type": "boolean"
-		}
 	},
 	"usesContext": [
 		"textColor",

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { sortBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -86,14 +87,20 @@ function usePagesByParentId() {
 
 	useEffect( () => {
 		async function performFetch() {
-			const pages = await apiFetch( {
+			let pages = await apiFetch( {
 				path: addQueryArgs( '/wp/v2/pages', {
 					orderby: 'menu_order',
 					order: 'asc',
-					_fields: [ 'id', 'link', 'parent', 'title' ],
+					_fields: [ 'id', 'link', 'parent', 'title', 'menu_order' ],
 					per_page: -1,
 				} ),
 			} );
+
+			// TODO: Once the REST API supports passing multiple values to
+			// 'orderby', this an be removed.
+			// https://core.trac.wordpress.org/ticket/39037
+			pages = sortBy( pages, [ 'menu_order', 'title.rendered' ] );
+
 			pagesByParentIdRef.current = pages.reduce(
 				( pagesByParentId, page ) => {
 					const { parent } = page;

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -86,16 +86,14 @@ function usePagesByParentId() {
 
 	useEffect( () => {
 		async function performFetch() {
-			const response = await apiFetch( {
+			const pages = await apiFetch( {
 				path: addQueryArgs( '/wp/v2/pages', {
 					orderby: 'menu_order',
 					order: 'asc',
 					_fields: [ 'id', 'link', 'parent', 'title' ],
+					per_page: -1,
 				} ),
-				parse: false,
 			} );
-
-			const pages = await response.json();
 			pagesByParentIdRef.current = pages.reduce(
 				( pagesByParentId, page ) => {
 					const { parent } = page;
@@ -108,8 +106,7 @@ function usePagesByParentId() {
 				},
 				new Map()
 			);
-
-			totalPagesRef.current = response.headers.get( 'X-WP-Total' );
+			totalPagesRef.current = pages.length;
 		}
 		performFetch();
 	}, [] );

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -144,17 +144,13 @@ function PageItems( { context, pagesByParentId, parentId = 0, depth = 0 } ) {
 				className={ classnames( 'wp-block-pages-list__item', {
 					'has-child': hasChildren,
 					'wp-block-navigation-item': isNavigationChild,
-					'open-on-click':
-						isNavigationChild && context.openSubmenusOnClick,
+					'open-on-click': context.openSubmenusOnClick,
 					'open-on-hover-click':
-						isNavigationChild &&
 						! context.openSubmenusOnClick &&
 						context.showSubmenuIcon,
 				} ) }
 			>
-				{ hasChildren &&
-				isNavigationChild &&
-				context.openSubmenusOnClick ? (
+				{ hasChildren && context.openSubmenusOnClick ? (
 					<ItemSubmenuToggle title={ page.title?.rendered } />
 				) : (
 					<a
@@ -171,8 +167,7 @@ function PageItems( { context, pagesByParentId, parentId = 0, depth = 0 } ) {
 				) }
 				{ hasChildren && (
 					<>
-						{ isNavigationChild &&
-							! context.openSubmenusOnClick &&
+						{ ! context.openSubmenusOnClick &&
 							context.showSubmenuIcon && <ItemSubmenuToggle /> }
 						<ul
 							className={ classnames( 'submenu-container', {

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -14,7 +14,7 @@ import {
 } from '@wordpress/block-editor';
 import { ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -88,8 +88,8 @@ export default function PageListEdit( { context, clientId } ) {
 }
 
 function usePagesByParentId() {
-	const pagesByParentIdRef = useRef( new Map() );
-	const totalPagesRef = useRef( 0 );
+	const [ pagesByParentId, setPagesByParentId ] = useState( new Map() );
+	const [ totalPages, setTotalPages ] = useState( 0 );
 
 	useEffect( () => {
 		async function performFetch() {
@@ -107,26 +107,25 @@ function usePagesByParentId() {
 			// https://core.trac.wordpress.org/ticket/39037
 			pages = sortBy( pages, [ 'menu_order', 'title.rendered' ] );
 
-			pagesByParentIdRef.current = pages.reduce(
-				( pagesByParentId, page ) => {
+			setPagesByParentId(
+				pages.reduce( ( accumulator, page ) => {
 					const { parent } = page;
-					if ( pagesByParentId.has( parent ) ) {
-						pagesByParentId.get( parent ).push( page );
+					if ( accumulator.has( parent ) ) {
+						accumulator.get( parent ).push( page );
 					} else {
-						pagesByParentId.set( parent, [ page ] );
+						accumulator.set( parent, [ page ] );
 					}
-					return pagesByParentId;
-				},
-				new Map()
+					return accumulator;
+				}, new Map() )
 			);
-			totalPagesRef.current = pages.length;
+			setTotalPages( pages.length );
 		}
 		performFetch();
 	}, [] );
 
 	return {
-		pagesByParentId: pagesByParentIdRef.current,
-		totalPages: totalPagesRef.current,
+		pagesByParentId,
+		totalPages,
 	};
 }
 

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -14,7 +14,7 @@ import {
 } from '@wordpress/block-editor';
 import { ToolbarButton, Placeholder, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, memo } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -139,7 +139,12 @@ function usePagesByParentId() {
 	};
 }
 
-function PageItems( { context, pagesByParentId, parentId = 0, depth = 0 } ) {
+const PageItems = memo( function PageItems( {
+	context,
+	pagesByParentId,
+	parentId = 0,
+	depth = 0,
+} ) {
 	const pages = pagesByParentId.get( parentId );
 
 	if ( ! pages?.length ) {
@@ -197,7 +202,7 @@ function PageItems( { context, pagesByParentId, parentId = 0, depth = 0 } ) {
 			</li>
 		);
 	} );
-}
+} );
 
 function ItemSubmenuToggle( { title } ) {
 	return (

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -40,7 +40,6 @@ export default function PageListEdit( { context, clientId } ) {
 	const closeModal = () => setOpen( false );
 
 	const blockProps = useBlockProps( {
-		// TODO: Test that this behaviour matches index.php.
 		className: classnames( 'wp-block-page-list', {
 			'has-text-color': !! context.textColor,
 			[ getColorClassName(
@@ -151,7 +150,6 @@ function PageItems( { context, pagesByParentId, parentId = 0, depth = 0 } ) {
 						isNavigationChild &&
 						! context.openSubmenusOnClick &&
 						context.showSubmenuIcon,
-					// TODO: Overlay classes and styles?
 				} ) }
 			>
 				{ hasChildren &&

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -12,7 +12,6 @@ import {
 	store as blockEditorStore,
 	getColorClassName,
 } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
 import { ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
@@ -24,10 +23,45 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import ConvertToLinksModal from './convert-to-links-modal';
+import { ItemSubmenuIcon } from '../navigation-link/icons';
 
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
 // Performance of Navigation Links is not good past this value.
 const MAX_PAGE_COUNT = 100;
+
+const Menu = ( { pagesByParentId, parentId, depth = 0 } ) => {
+	return pagesByParentId.get( parentId )?.map( ( page ) => {
+		const hasChildren = pagesByParentId.has( page.id );
+		const classes = classnames( 'wp-block-pages-list__item', {
+			'has-child': hasChildren,
+		} );
+
+		return (
+			<li key={ page.id } className={ classes }>
+				<a
+					href={ page.link }
+					className="wp-block-pages-list__item__link"
+				>
+					{ page.title?.rendered }
+				</a>
+				{ hasChildren && (
+					<>
+						<span className="wp-block-page-list__submenu-icon">
+							<ItemSubmenuIcon />
+						</span>
+						<ul className="submenu-container">
+							<Menu
+								pagesByParentId={ pagesByParentId }
+								parentId={ page.id }
+								depth={ depth + 1 }
+							/>
+						</ul>
+					</>
+				) }
+			</li>
+		);
+	} );
+};
 
 export default function PageListEdit( {
 	context,
@@ -72,6 +106,9 @@ export default function PageListEdit( {
 	const { textColor, backgroundColor, style } = context || {};
 
 	const [ allowConvertToLinks, setAllowConvertToLinks ] = useState( false );
+	const [ pagesByParentId, setPagesByParentId ] = useState(
+		new Map( [ [ 0, [] ] ] )
+	);
 
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -106,21 +143,28 @@ export default function PageListEdit( {
 	}, [ context.openSubmenusOnClick, context.showSubmenuIcon ] );
 
 	useEffect( () => {
-		if ( isParentNavigation ) {
-			apiFetch( {
-				path: addQueryArgs( '/wp/v2/pages', {
-					per_page: 1,
-					_fields: [ 'id' ],
-				} ),
-				parse: false,
-			} ).then( ( res ) => {
-				setAllowConvertToLinks(
+		apiFetch( {
+			path: addQueryArgs( '/wp/v2/pages', {
+				orderby: 'menu_order',
+				order: 'asc',
+				_fields: [ 'id', 'link', 'parent', 'title' ],
+			} ),
+		} ).then( ( res ) => {
+			const groupedPages = res.reduce( ( parentMap, page ) => {
+				const { parent } = page;
+				if ( parentMap.has( parent ) ) {
+					parentMap.get( parent ).push( page );
+				} else {
+					parentMap.set( parent, [ page ] );
+				}
+				return parentMap;
+			}, new Map() );
+			setPagesByParentId( groupedPages );
+			setAllowConvertToLinks(
+				isParentNavigation &&
 					res.headers.get( 'X-WP-Total' ) <= MAX_PAGE_COUNT
-				);
-			} );
-		} else {
-			setAllowConvertToLinks( false );
-		}
+			);
+		} );
 	}, [ isParentNavigation ] );
 
 	const [ isOpen, setOpen ] = useState( false );
@@ -151,13 +195,9 @@ export default function PageListEdit( {
 				/>
 			) }
 			<div { ...blockProps }>
-				<ServerSideRender
-					block="core/page-list"
-					attributes={ attributesWithParentStatus }
-					EmptyResponsePlaceholder={ () => (
-						<span>{ __( 'Page List: No pages to show.' ) }</span>
-					) }
-				/>
+				<ul className="wp-block-page-list">
+					<Menu pagesByParentId={ pagesByParentId } parentId={ 0 } />
+				</ul>
 			</div>
 		</>
 	);

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -63,46 +63,7 @@ const Menu = ( { pagesByParentId, parentId, depth = 0 } ) => {
 	} );
 };
 
-export default function PageListEdit( {
-	context,
-	clientId,
-	attributes,
-	setAttributes,
-} ) {
-	// Copy context to attributes to make it accessible in the editor's
-	// ServerSideRender
-	useEffect( () => {
-		const {
-			textColor,
-			customTextColor,
-			backgroundColor,
-			customBackgroundColor,
-			overlayTextColor,
-			customOverlayTextColor,
-			overlayBackgroundColor,
-			customOverlayBackgroundColor,
-		} = context;
-		setAttributes( {
-			textColor,
-			customTextColor,
-			backgroundColor,
-			customBackgroundColor,
-			overlayTextColor,
-			customOverlayTextColor,
-			overlayBackgroundColor,
-			customOverlayBackgroundColor,
-		} );
-	}, [
-		context.textColor,
-		context.customTextColor,
-		context.backgroundColor,
-		context.customBackgroundColor,
-		context.overlayTextColor,
-		context.customOverlayTextColor,
-		context.overlayBackgroundColor,
-		context.customOverlayBackgroundColor,
-	] );
-
+export default function PageListEdit( { context, clientId } ) {
 	const { textColor, backgroundColor, style } = context || {};
 
 	const [ allowConvertToLinks, setAllowConvertToLinks ] = useState( false );
@@ -135,14 +96,6 @@ export default function PageListEdit( {
 	);
 
 	useEffect( () => {
-		setAttributes( {
-			isNavigationChild: isParentNavigation,
-			openSubmenusOnClick: !! context.openSubmenusOnClick,
-			showSubmenuIcon: !! context.showSubmenuIcon,
-		} );
-	}, [ context.openSubmenusOnClick, context.showSubmenuIcon ] );
-
-	useEffect( () => {
 		apiFetch( {
 			path: addQueryArgs( '/wp/v2/pages', {
 				orderby: 'menu_order',
@@ -170,14 +123,6 @@ export default function PageListEdit( {
 	const [ isOpen, setOpen ] = useState( false );
 	const openModal = () => setOpen( true );
 	const closeModal = () => setOpen( false );
-
-	// Update parent status before component first renders.
-	const attributesWithParentStatus = {
-		...attributes,
-		isNavigationChild: isParentNavigation,
-		openSubmenusOnClick: !! context.openSubmenusOnClick,
-		showSubmenuIcon: !! context.showSubmenuIcon,
-	};
 
 	return (
 		<>

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -12,7 +12,7 @@ import {
 	useBlockProps,
 	getColorClassName,
 } from '@wordpress/block-editor';
-import { ToolbarButton } from '@wordpress/components';
+import { ToolbarButton, Placeholder, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -70,28 +70,39 @@ export default function PageListEdit( { context, clientId } ) {
 					clientId={ clientId }
 				/>
 			) }
-			{ totalPages > 0 ? (
+			{ totalPages === null && (
+				<div { ...blockProps }>
+					<Placeholder>
+						<Spinner />
+					</Placeholder>
+				</div>
+			) }
+			{ totalPages === 0 && (
+				<div { ...blockProps }>
+					<span>{ __( 'Page List: No pages to show.' ) }</span>
+				</div>
+			) }
+			{ totalPages > 0 && (
 				<ul { ...blockProps }>
 					<PageItems
 						context={ context }
 						pagesByParentId={ pagesByParentId }
 					/>
 				</ul>
-			) : (
-				<div { ...blockProps }>
-					<span>{ __( 'Page List: No pages to show.' ) }</span>
-				</div>
 			) }
 		</>
 	);
 }
 
 function usePagesByParentId() {
-	const [ pagesByParentId, setPagesByParentId ] = useState( new Map() );
-	const [ totalPages, setTotalPages ] = useState( 0 );
+	const [ pagesByParentId, setPagesByParentId ] = useState( null );
+	const [ totalPages, setTotalPages ] = useState( null );
 
 	useEffect( () => {
 		async function performFetch() {
+			setPagesByParentId( null );
+			setTotalPages( null );
+
 			let pages = await apiFetch( {
 				path: addQueryArgs( '/wp/v2/pages', {
 					orderby: 'menu_order',

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -71,12 +71,18 @@ export default function PageListEdit( { context, clientId } ) {
 					clientId={ clientId }
 				/>
 			) }
-			<ul { ...blockProps }>
-				<PageItems
-					context={ context }
-					pagesByParentId={ pagesByParentId }
-				/>
-			</ul>
+			{ totalPages > 0 ? (
+				<ul { ...blockProps }>
+					<PageItems
+						context={ context }
+						pagesByParentId={ pagesByParentId }
+					/>
+				</ul>
+			) : (
+				<div { ...blockProps }>
+					<span>{ __( 'Page List: No pages to show.' ) }</span>
+				</div>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -102,7 +102,7 @@ function usePagesByParentId() {
 			} );
 
 			// TODO: Once the REST API supports passing multiple values to
-			// 'orderby', this an be removed.
+			// 'orderby', this can be removed.
 			// https://core.trac.wordpress.org/ticket/39037
 			pages = sortBy( pages, [ 'menu_order', 'title.rendered' ] );
 

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -246,7 +246,6 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	);
 
 	// If thare are no pages, there is nothing to show.
-	// Return early and empty to trigger EmptyResponsePlaceholder.
 	if ( empty( $all_pages ) ) {
 		return;
 	}

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -238,14 +238,9 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	static $block_id = 0;
 	$block_id++;
 
-	// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby values is resolved,
-	// update 'sort_column' to 'menu_order, post_title'. Sorting by both menu_order and post_title ensures a stable sort.
-	// Otherwise with pages that have the same menu_order value, we can see different ordering depending on how DB
-	// queries are constructed internally. For example we might see a different order when a limit is set to <499
-	// versus >= 500.
 	$all_pages = get_pages(
 		array(
-			'sort_column' => 'menu_order',
+			'sort_column' => 'menu_order,post_title',
 			'order'       => 'asc',
 		)
 	);

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -22,8 +22,8 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
 	);
 
 	// Text color.
-	$has_named_text_color  = array_key_exists( 'textColor', $attributes );
-	$has_picked_text_color = array_key_exists( 'customTextColor', $attributes );
+	$has_named_text_color  = array_key_exists( 'textColor', $context );
+	$has_picked_text_color = array_key_exists( 'customTextColor', $context );
 	$has_custom_text_color = isset( $context['style']['color']['text'] );
 
 	// If has text color.
@@ -34,17 +34,17 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
 
 	if ( $has_named_text_color ) {
 		// Add the color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-color', gutenberg_experimental_to_kebab_case( $attributes['textColor'] ) );
+		$colors['css_classes'][] = sprintf( 'has-%s-color', gutenberg_experimental_to_kebab_case( $context['textColor'] ) );
 	} elseif ( $has_picked_text_color ) {
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $context['customTextColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
 		$colors['inline_styles'] .= sprintf( 'color: %s;', $context['style']['color']['text'] );
 	}
 
 	// Background color.
-	$has_named_background_color  = array_key_exists( 'backgroundColor', $attributes );
-	$has_picked_background_color = array_key_exists( 'customBackgroundColor', $attributes );
+	$has_named_background_color  = array_key_exists( 'backgroundColor', $context );
+	$has_picked_background_color = array_key_exists( 'customBackgroundColor', $context );
 	$has_custom_background_color = isset( $context['style']['color']['background'] );
 
 	// If has background color.
@@ -55,17 +55,17 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
 
 	if ( $has_named_background_color ) {
 		// Add the background-color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-background-color', gutenberg_experimental_to_kebab_case( $attributes['backgroundColor'] ) );
+		$colors['css_classes'][] = sprintf( 'has-%s-background-color', gutenberg_experimental_to_kebab_case( $context['backgroundColor'] ) );
 	} elseif ( $has_picked_background_color ) {
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $context['customBackgroundColor'] );
 	} elseif ( $has_custom_background_color ) {
 		// Add the custom background-color inline style.
 		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $context['style']['color']['background'] );
 	}
 
 	// Overlay text color.
-	$has_named_overlay_text_color  = array_key_exists( 'overlayTextColor', $attributes );
-	$has_picked_overlay_text_color = array_key_exists( 'customOverlayTextColor', $attributes );
+	$has_named_overlay_text_color  = array_key_exists( 'overlayTextColor', $context );
+	$has_picked_overlay_text_color = array_key_exists( 'customOverlayTextColor', $context );
 
 	// If it has a text color.
 	if ( $has_named_overlay_text_color || $has_picked_overlay_text_color ) {
@@ -74,14 +74,14 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
 
 	// Give overlay colors priority, fall back to Navigation block colors, then global styles.
 	if ( $has_named_overlay_text_color ) {
-		$colors['overlay_css_classes'][] = sprintf( 'has-%s-color', gutenberg_experimental_to_kebab_case( $attributes['overlayTextColor'] ) );
+		$colors['overlay_css_classes'][] = sprintf( 'has-%s-color', gutenberg_experimental_to_kebab_case( $context['overlayTextColor'] ) );
 	} elseif ( $has_picked_overlay_text_color ) {
-		$colors['overlay_inline_styles'] .= sprintf( 'color: %s;', $attributes['customOverlayTextColor'] );
+		$colors['overlay_inline_styles'] .= sprintf( 'color: %s;', $context['customOverlayTextColor'] );
 	}
 
 	// Overlay background colors.
-	$has_named_overlay_background_color  = array_key_exists( 'overlayBackgroundColor', $attributes );
-	$has_picked_overlay_background_color = array_key_exists( 'customOverlayBackgroundColor', $attributes );
+	$has_named_overlay_background_color  = array_key_exists( 'overlayBackgroundColor', $context );
+	$has_picked_overlay_background_color = array_key_exists( 'customOverlayBackgroundColor', $context );
 
 	// If has background color.
 	if ( $has_named_overlay_background_color || $has_picked_overlay_background_color ) {
@@ -89,9 +89,9 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
 	}
 
 	if ( $has_named_overlay_background_color ) {
-		$colors['overlay_css_classes'][] = sprintf( 'has-%s-background-color', gutenberg_experimental_to_kebab_case( $attributes['overlayBackgroundColor'] ) );
+		$colors['overlay_css_classes'][] = sprintf( 'has-%s-background-color', gutenberg_experimental_to_kebab_case( $context['overlayBackgroundColor'] ) );
 	} elseif ( $has_picked_overlay_background_color ) {
-		$colors['overlay_inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customOverlayBackgroundColor'] );
+		$colors['overlay_inline_styles'] .= sprintf( 'background-color: %s;', $context['customOverlayBackgroundColor'] );
 	}
 
 	return $colors;
@@ -292,11 +292,11 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
-	$is_navigation_child = array_key_exists( 'isNavigationChild', $attributes ) ? $attributes['isNavigationChild'] : ! empty( $block->context );
+	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );
 
-	$open_submenus_on_click = array_key_exists( 'openSubmenusOnClick', $attributes ) ? $attributes['openSubmenusOnClick'] : false;
+	$open_submenus_on_click = array_key_exists( 'openSubmenusOnClick', $block->context ) ? $block->context['openSubmenusOnClick'] : false;
 
-	$show_submenu_icons = array_key_exists( 'showSubmenuIcon', $attributes ) ? $attributes['showSubmenuIcon'] : false;
+	$show_submenu_icons = array_key_exists( 'showSubmenuIcon', $block->context ) ? $block->context['showSubmenuIcon'] : false;
 
 	$wrapper_markup = '<ul %1$s>%2$s</ul>';
 

--- a/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
@@ -40,7 +40,7 @@ exports[`Navigation Creating from existing Menus creates an empty navigation blo
 
 exports[`Navigation Creating from existing Pages allows a navigation block to be created using existing pages 1`] = `
 "<!-- wp:navigation -->
-<!-- wp:page-list {\\"isNavigationChild\\":true,\\"showSubmenuIcon\\":true,\\"openSubmenusOnClick\\":false} /-->
+<!-- wp:page-list /-->
 <!-- /wp:navigation -->"
 `;
 


### PR DESCRIPTION
## Description

Closes https://github.com/WordPress/gutenberg/issues/35632.

This replaces the `<ServerSideRender>` in Page List's edit method with a client-side version. The advantage of rendering locally is that there is no lag after changing a block attribute (e.g. on the Navigation block). 

https://user-images.githubusercontent.com/612155/138216445-c9343d69-3d04-47a0-a050-50afe6e15c56.mp4

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
