### PR TITLE
Template Loader: Make templates arg required

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -62,7 +62,7 @@ function get_template_hierarchy( $template_type ) {
  * @param array  $templates A list of template candidates, in descending order of priority.
  * @return string The path to the Full Site Editing template canvas file.
  */
-function gutenberg_override_query_template( $template, $type, array $templates = array() ) {
+function gutenberg_override_query_template( $template, $type, array $templates ) {
 	global $_wp_current_template_content;
 	$current_template = gutenberg_resolve_template( $type, $templates );
 
@@ -163,17 +163,13 @@ function gutenberg_override_query_template( $template, $type, array $templates =
  *  @type int[] A list of template parts IDs for the template.
  * }
  */
-function gutenberg_resolve_template( $template_type, $template_hierarchy = array() ) {
+function gutenberg_resolve_template( $template_type, $template_hierarchy ) {
 	if ( ! $template_type ) {
 		return null;
 	}
 
 	if ( empty( $template_hierarchy ) ) {
-		if ( 'index' === $template_type ) {
-			$template_hierarchy = get_template_hierarchy( 'index' );
-		} else {
-			$template_hierarchy = array_merge( get_template_hierarchy( $template_type ), get_template_hierarchy( 'index' ) );
-		}
+		$template_hierarchy = array( $template_type );
 	}
 
 	$slugs = array_map(

--- a/phpunit/class-template-loader-test.php
+++ b/phpunit/class-template-loader-test.php
@@ -191,6 +191,14 @@ class Template_Loader_Test extends WP_UnitTestCase {
 		$this->assertEquals( self::$post->post_content, $_wp_current_template_content );
 	}
 
+	/**
+	 * Regression: https://github.com/WordPress/gutenberg/issues/31652.
+	 */
+	function test_gutenberg_template_remains_unchanged_if_templates_array_is_empty() {
+		$resolved_template_path = gutenberg_override_query_template( '', 'search', array() );
+		$this->assertEquals( '', $resolved_template_path );
+	}
+
 	static function change_theme_directory( $theme_dir, $theme ) {
 		return __DIR__ . '/fixtures/themes/' . $theme;
 	}


### PR DESCRIPTION
## Description
Fixes #31652. Based on #31498 (which adds unit test coverage for `lib/full-site-editing/template-loader.php`).
**Don't merge this PR before #31498!**

In `gutenberg_override_query_template()`, we used to allow for a missing `$templates` argument (in which case it defaulted to an empty array), which was previously needed (when we were calling `gutenberg_override_query_template()` from another callsite that couldn't provide the template hierarchy as an argument). However, we don't need to allow for that case anymore, as `gutenberg_override_query_template()` is only ever called through the [`{type}_template` filter](https://developer.wordpress.org/reference/hooks/type_template/), which always includes a `$templates` argument.

## How has this been tested?
A unit test case that covers #31652 was added, and it passes. To verify locally:

```
npm run test-unit-php -- /var/www/html/wp-content/plugins/gutenberg/phpunit/class-template-loader-test.php
```