### PR TITLE
Rich text: investigate intermittent e2e test failure

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -97,6 +97,24 @@ exports[`RichText should preserve internal formatting 1`] = `
 exports[`RichText should preserve internal formatting 2`] = `
 "<!-- wp:paragraph -->
 <p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should preserve internal formatting 3`] = `
+"<!-- wp:paragraph -->
+<p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should preserve internal formatting 4`] = `
+"<!-- wp:paragraph -->
+<p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should preserve internal formatting 5`] = `
+"<!-- wp:paragraph -->
+<p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -104,7 +122,7 @@ exports[`RichText should preserve internal formatting 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`RichText should preserve internal formatting 3`] = `
+exports[`RichText should preserve internal formatting 6`] = `
 "<!-- wp:paragraph -->
 <p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
 <!-- /wp:paragraph -->

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -100,6 +100,16 @@ exports[`RichText should preserve internal formatting 2`] = `
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should preserve internal formatting 3`] = `
+"<!-- wp:paragraph -->
+<p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
 <p><span class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</span></p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -413,6 +413,8 @@ describe( 'RichText', () => {
 		// Create a new paragraph.
 		await page.keyboard.press( 'Enter' );
 
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
 		// Paste the colored text.
 		await pressKeyWithModifier( 'primary', 'v' );
 

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -404,11 +404,17 @@ describe( 'RichText', () => {
 		await page.keyboard.press( 'Tab' );
 		await pressKeyWithModifier( 'primary', 'a' );
 
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
 		// Copy the colored text.
 		await pressKeyWithModifier( 'primary', 'c' );
 
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
 		// Collapsed the selection to the end.
 		await page.keyboard.press( 'ArrowRight' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Create a new paragraph.
 		await page.keyboard.press( 'Enter' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

First occurrence (I think) is #31643.
The last rich text change before the first time it fails is #31644.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
