### PR TITLE
Site Logo block: Only request media entity when we have a site logo chosen

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -260,11 +260,13 @@ export default function LogoEdit( {
 			'root',
 			'site'
 		);
-		const mediaItem = select( coreStore ).getEntityRecord(
-			'root',
-			'media',
-			siteSettings.site_logo
-		);
+		const mediaItem = siteSettings.site_logo
+			? select( coreStore ).getEntityRecord(
+					'root',
+					'media',
+					siteSettings.site_logo
+			  )
+			: null;
 		return {
 			mediaItemData: mediaItem && {
 				url: mediaItem.source_url,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Site Logo fires a request that always result in a 404: `http://localhost:8888/index.php?rest_route=%2Fwp%2Fv2%2Fmedia%2Fnull&context=edit&_locale=user`

Notice the `null` in the URL.

This PR simply skips the `getEntityRecord` selector when the `sitelogo` is empty.

## How has this been tested?
1. Open block editor
2. Open browser inspector -> network tab, set filter for `rest_route=%2Fwp%2Fv2%2Fmedia`
3. Add site logo block
4. Make sure no network requests are fired (if you try this on `trunk` then you will see a request with a 404 response)

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
