### PR TITLE
Rich text: extract implementation specific undo handling of automatic changes

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -54,6 +54,7 @@ import { filePasteHandler } from './file-paste-handler';
 import FormatToolbarContainer from './format-toolbar-container';
 import { useNativeProps } from './use-native-props';
 import { store as blockEditorStore } from '../../store';
+import { useUndoAutomaticChange } from './use-undo-automatic-change';
 
 const wrapperClasses = 'block-editor-rich-text';
 const classes = 'block-editor-rich-text__editable';
@@ -241,6 +242,11 @@ function Element( {
 		}
 	}
 
+	const mergedRefs = useMergeRefs( [
+		useUndoAutomaticChange(),
+		richTextRef,
+	] );
+
 	return (
 		<TagName
 			// Overridable props.
@@ -248,7 +254,7 @@ function Element( {
 			aria-multiline={ true }
 			aria-label={ placeholder }
 			{ ...props }
-			ref={ richTextRef }
+			ref={ mergedRefs }
 			// Do not set the attribute if disabled.
 			contentEditable={ disabled ? undefined : true }
 			suppressContentEditableWarning={ ! disabled }
@@ -327,16 +333,12 @@ function RichTextWrapper(
 		const {
 			getSelectionStart,
 			getSelectionEnd,
-			getSettings,
-			didAutomaticChange,
 			__unstableGetBlockWithoutInnerBlocks,
 			isMultiSelecting,
 			hasMultiSelection,
 		} = select( blockEditorStore );
-
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
-		const { __experimentalUndo: undo } = getSettings();
 
 		let isSelected;
 
@@ -366,9 +368,7 @@ function RichTextWrapper(
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,
 			isSelected,
-			didAutomaticChange: didAutomaticChange(),
 			disabled: isMultiSelecting() || hasMultiSelection(),
-			undo,
 			...extraProps,
 		};
 	};
@@ -379,9 +379,7 @@ function RichTextWrapper(
 		selectionStart,
 		selectionEnd,
 		isSelected,
-		didAutomaticChange,
 		disabled,
-		undo,
 		shouldBlurOnUnmount,
 	} = useSelect( selector );
 	const {
@@ -679,8 +677,6 @@ function RichTextWrapper(
 			__unstableMultilineTag={ multilineTag }
 			__unstableOnCreateUndoLevel={ __unstableMarkLastChangeAsPersistent }
 			__unstableMarkAutomaticChange={ __unstableMarkAutomaticChange }
-			__unstableDidAutomaticChange={ didAutomaticChange }
-			__unstableUndo={ undo }
 			__unstableDisableFormats={ disableFormats }
 			preserveWhiteSpace={ preserveWhiteSpace }
 			unstableOnFocus={ unstableOnFocus }

--- a/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
+++ b/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
@@ -1,21 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 import { BACKSPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
 
-export function useUndoAutomaticChange( props ) {
-	const propsRef = useRef( props );
-	propsRef.current = props;
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export function useUndoAutomaticChange() {
+	const { didAutomaticChange, getSettings } = useSelect( blockEditorStore );
 	return useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
 			const { keyCode } = event;
-			const { didAutomaticChange, undo } = propsRef.current;
-
-			if ( ! didAutomaticChange || ! undo ) {
-				return;
-			}
 
 			if (
 				keyCode !== DELETE &&
@@ -25,8 +24,12 @@ export function useUndoAutomaticChange( props ) {
 				return;
 			}
 
+			if ( ! didAutomaticChange() ) {
+				return;
+			}
+
 			event.preventDefault();
-			undo();
+			getSettings().__experimentalUndo();
 		}
 
 		element.addEventListener( 'keydown', onKeyDown );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -24,7 +24,6 @@ import { useInlineWarning } from './use-inline-warning';
 import { useCopyHandler } from './use-copy-handler';
 import { useFormatBoundaries } from './use-format-boundaries';
 import { useSelectObject } from './use-select-object';
-import { useUndoAutomaticChange } from './use-undo-automatic-change';
 import { usePasteHandler } from './use-paste-handler';
 import { useIndentListItemOnSpace } from './use-indent-list-item-on-space';
 import { useInputAndSelection } from './use-input-and-selection';
@@ -60,11 +59,9 @@ function RichText(
 		__unstableMultilineTag: multilineTag,
 		__unstableMultilineRootTag: multilineRootTag,
 		__unstableDisableFormats: disableFormats,
-		__unstableDidAutomaticChange: didAutomaticChange,
 		__unstableInputRule: inputRule,
 		__unstableMarkAutomaticChange: markAutomaticChange,
 		__unstableAllowPrefixTransformations: allowPrefixTransformations,
-		__unstableUndo: undo,
 		__unstableOnCreateUndoLevel: onCreateUndoLevel,
 		__unstableIsSelected: isSelected,
 	},
@@ -323,7 +320,6 @@ function RichText(
 		useCopyHandler( { record, multilineTag, preserveWhiteSpace } ),
 		useSelectObject(),
 		useFormatBoundaries( { record, applyRecord, setActiveFormats } ),
-		useUndoAutomaticChange( { didAutomaticChange, undo } ),
 		useDelete( {
 			createRecord,
 			handleChange,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Extract undo handling of automatic changes from core rich text.

## How has this been tested?

Nothing should have changed. Undo of automatic changes such as backticks for code should work correctly.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
