### PR TITLE
Allow pre-publish sidebar to be forcibly shown or hidden

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -28,6 +28,7 @@ import { createRegistrySelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { Platform } from '@wordpress/element';
 import { layout } from '@wordpress/icons';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -1200,10 +1201,23 @@ export function canUserUseUnfilteredHTML( state ) {
  * @return {boolean} Whether the pre-publish panel should be shown or not.
  */
 export function isPublishSidebarEnabled( state ) {
+	let enabled;
+
 	if ( state.preferences.hasOwnProperty( 'isPublishSidebarEnabled' ) ) {
-		return state.preferences.isPublishSidebarEnabled;
+		enabled = state.preferences.isPublishSidebarEnabled;
+	} else {
+		enabled = PREFERENCES_DEFAULTS.isPublishSidebarEnabled;
 	}
-	return PREFERENCES_DEFAULTS.isPublishSidebarEnabled;
+
+	/**
+	 * Filters the user setting to enable or disable the pre-publish panel.
+	 *
+	 * @param {boolean} enabled Pre-publish panel display setting.
+	 */
+	return applyFilters(
+		'editor.userPreferences.isPublishSidebarEnabled',
+		enabled
+	);
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The pre-publish sidebar provides a valuable, dedicated place to present
one-time information to users ahead of publishing an item, but its value is
limited if its use cannot be relied on. For example, if a pre-publish checklist
is implemented in the pre-publish sidebar, the sidebar should always be enabled
otherwise an author may miss important notifications.

Without this filter, the pre-publish sidebar can only be forcibly enabled using
a `subscribe` callback to override the user's selection, an approach that
raises performance concerns. In basic testing, the `subscribe` callback fired
approximately 80 times to ready the editor, compared with one or two times
for the filter callback.

## How has this been tested?
Testing was performed by adding the following snippet to a script enqueued for
the editor. I then attempted to change the display setting for the pre-publish
sidebar, both in the sidebar itself and through Gutenberg's Preferences modal,
and confirmed that the filter's value took precedence.

```js
import { addFilter } from '@wordpress/hooks';

addFilter(
	'editor.userPreferences.isPublishSidebarEnabled',
	'ethitter-force-enable-publish-sidebar',
	() => true
);
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Adds a filter to override a user setting without the use of a `subscribe` callback.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
