### PR TITLE
Add: Delete template action.

### DIFF
--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -43,6 +43,7 @@ export default function DeleteTemplate() {
 				isDestructive
 				isTertiary
 				isLink
+				aria-label = { __( 'Delete template' ) }
 				onClick={ () => {
 					if (
 						// eslint-disable-next-line no-alert

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -38,8 +38,8 @@ export default function DeleteTemplate() {
 		return null;
 	}
 	let templateTitle = template.slug;
-	if ( template?.title?.raw ) {
-		templateTitle = template.title.raw;
+	if ( template?.title ) {
+		templateTitle = template.title;
 	}
 
 	return (
@@ -48,7 +48,7 @@ export default function DeleteTemplate() {
 				isDestructive
 				isTertiary
 				isLink
-				aria-label = { __( 'Delete template' ) }
+				aria-label={ __( 'Delete template' ) }
 				onClick={ () => {
 					if (
 						// eslint-disable-next-line no-alert

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -6,7 +6,7 @@ import { pickBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -37,6 +37,11 @@ export default function DeleteTemplate() {
 	if ( ! template || ! template.wp_id ) {
 		return null;
 	}
+	let templateTitle = template.slug;
+	if ( template?.title?.raw ) {
+		templateTitle = template.title.raw;
+	}
+
 	return (
 		<MenuGroup className="edit-post-template-top-area__second-menu-group">
 			<MenuItem

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { pickBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuGroup, MenuItem } from '@wordpress/components';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../../store';
+
+export default function DeleteTemplate() {
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
+	const { setIsEditingTemplate } = useDispatch( editPostStore );
+	const { getEditorSettings } = useSelect( editorStore );
+	const { updateEditorSettings, editPost } = useDispatch( editorStore );
+	const { deleteEntityRecord } = useDispatch( coreStore );
+	const { template } = useSelect( ( select ) => {
+		const { isEditingTemplate, getEditedPostTemplate } = select(
+			editPostStore
+		);
+		const _isEditing = isEditingTemplate();
+		return {
+			template: _isEditing ? getEditedPostTemplate() : null,
+		};
+	}, [] );
+
+	if ( ! template || ! template.wp_id ) {
+		return null;
+	}
+	return (
+		<MenuGroup className="edit-post-template-top-area__second-menu-group">
+			<MenuItem
+				isDestructive
+				isTertiary
+				isLink
+				onClick={ () => {
+					if (
+						// eslint-disable-next-line no-alert
+						window.confirm(
+							__(
+								'Are you sure you want to delete this template? It may be currently in use by other pages or posts.'
+							)
+						)
+					) {
+						clearSelectedBlock();
+						setIsEditingTemplate( false );
+
+						editPost( {
+							template: '',
+						} );
+						const settings = getEditorSettings();
+						const newAvailableTemplates = pickBy(
+							settings.availableTemplates,
+							( _title, id ) => {
+								return id !== template.slug;
+							}
+						);
+						updateEditorSettings( {
+							...settings,
+							availableTemplates: newAvailableTemplates,
+						} );
+						deleteEntityRecord(
+							'postType',
+							'wp_template',
+							template.id
+						);
+					}
+				} }
+			>
+				{ __( 'Delete' ) }
+			</MenuItem>
+		</MenuGroup>
+	);
+}

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -85,7 +85,7 @@ export default function DeleteTemplate() {
 					}
 				} }
 			>
-				{ __( 'Delete' ) }
+				{ __( 'Delete template' ) }
 			</MenuItem>
 		</MenuGroup>
 	);

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -53,8 +53,10 @@ export default function DeleteTemplate() {
 					if (
 						// eslint-disable-next-line no-alert
 						window.confirm(
-							__(
-								'Are you sure you want to delete this template? It may be currently in use by other pages or posts.'
+							/* translators: %1$s: template name */
+							sprintf(
+								'Are you sure you want to delete the %s template? It may be used by other pages or posts.',
+								templateTitle
 							)
 						)
 					) {

--- a/packages/edit-post/src/components/header/template-title/edit-template-title.js
+++ b/packages/edit-post/src/components/header/template-title/edit-template-title.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { mapValues } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../../store';
+
+export default function EditTemplateTitle() {
+	const { template } = useSelect( ( select ) => {
+		const { getEditedPostTemplate } = select( editPostStore );
+		return {
+			template: getEditedPostTemplate(),
+		};
+	}, [] );
+
+	const { editEntityRecord } = useDispatch( coreStore );
+	const { getEditorSettings } = useSelect( editorStore );
+	const { updateEditorSettings } = useDispatch( editorStore );
+
+	let templateTitle = __( 'Default' );
+	if ( template?.title ) {
+		templateTitle = template.title;
+	} else if ( !! template ) {
+		templateTitle = template.slug;
+	}
+
+	return (
+		<TextControl
+			label={ __( 'Title' ) }
+			value={ templateTitle }
+			onChange={ ( newTitle ) => {
+				const settings = getEditorSettings();
+				const newAvailableTemplates = mapValues(
+					settings.availableTemplates,
+					( existingTitle, id ) => {
+						if ( id !== template.slug ) {
+							return existingTitle;
+						}
+						return newTitle;
+					}
+				);
+				updateEditorSettings( {
+					...settings,
+					availableTemplates: newAvailableTemplates,
+				} );
+				editEntityRecord( 'postType', 'wp_template', template.id, {
+					title: newTitle,
+				} );
+			} }
+		/>
+	);
+}

--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -1,13 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import {
+	Button,
+	NavigableMenu,
+	Dropdown,
+	MenuGroup,
+	MenuItem,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { store as editPostStore } from '../../../store';
+import DeleteTemplate from './delete-template';
 
 function TemplateTitle() {
 	const { template, isEditing } = useSelect( ( select ) => {
@@ -33,12 +41,33 @@ function TemplateTitle() {
 	}
 
 	return (
-		<span className="edit-post-template-title">
-			{
-				/* translators: 1: Template name. */
-				sprintf( __( 'Editing template: %s' ), templateTitle )
-			}
-		</span>
+		<Dropdown
+			position="bottom center"
+			className="edit-post-template-top-area"
+			contentClassName="edit-post-template-top-area__popover"
+			renderToggle={ ( { onToggle } ) => (
+				<>
+					<div className="edit-post-template-title">
+						{ __( 'About' ) }
+					</div>
+					<Button isSmall isTertiary onClick={ onToggle }>
+						{ templateTitle }
+					</Button>
+				</>
+			) }
+			renderContent={ () => (
+				<NavigableMenu>
+					<MenuGroup
+						className="edit-post-template-top-area__first-menu-group"
+						label={ __( 'Title' ) }
+						disabled
+					>
+						<MenuItem>{ templateTitle }</MenuItem>
+					</MenuGroup>
+					<DeleteTemplate />
+				</NavigableMenu>
+			) }
+		/>
 	);
 }
 

--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -3,19 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import {
-	Button,
-	NavigableMenu,
-	Dropdown,
-	MenuGroup,
-	MenuItem,
-} from '@wordpress/components';
+import { Button, Dropdown } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { store as editPostStore } from '../../../store';
 import DeleteTemplate from './delete-template';
+import EditTemplateTitle from './edit-template-title';
 
 function TemplateTitle() {
 	const { template, isEditing } = useSelect( ( select ) => {
@@ -34,8 +29,8 @@ function TemplateTitle() {
 	}
 
 	let templateTitle = __( 'Default' );
-	if ( template?.title?.raw ) {
-		templateTitle = template.title.raw;
+	if ( template?.title ) {
+		templateTitle = template.title;
 	} else if ( !! template ) {
 		templateTitle = template.slug;
 	}
@@ -50,22 +45,21 @@ function TemplateTitle() {
 					<div className="edit-post-template-title">
 						{ __( 'About' ) }
 					</div>
-					<Button isSmall isTertiary onClick={ onToggle } aria-label={ __( 'Template Options' ) }>
+					<Button
+						isSmall
+						isTertiary
+						onClick={ onToggle }
+						aria-label={ __( 'Template Options' ) }
+					>
 						{ templateTitle }
 					</Button>
 				</>
 			) }
 			renderContent={ () => (
-				<NavigableMenu>
-					<MenuGroup
-						className="edit-post-template-top-area__first-menu-group"
-						label={ __( 'Title' ) }
-						disabled
-					>
-						<MenuItem>{ templateTitle }</MenuItem>
-					</MenuGroup>
+				<>
+					<EditTemplateTitle />
 					<DeleteTemplate />
-				</NavigableMenu>
+				</>
 			) }
 		/>
 	);

--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -50,7 +50,7 @@ function TemplateTitle() {
 					<div className="edit-post-template-title">
 						{ __( 'About' ) }
 					</div>
-					<Button isSmall isTertiary onClick={ onToggle }>
+					<Button isSmall isTertiary onClick={ onToggle } aria-label={ __( 'Template Options' ) }>
 						{ templateTitle }
 					</Button>
 				</>

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -3,3 +3,27 @@
 	flex-grow: 1;
 	justify-content: center;
 }
+
+.edit-post-template-top-area {
+	display: flex;
+	flex-direction: column;
+	align-content: space-between;
+	width: 100%;
+	align-items: center;
+}
+
+.edit-post-template-top-area__popover .components-popover__content {
+	min-width: 360px;
+}
+
+.edit-post-template-top-area__popover.components-dropdown__content .components-popover__content > div {
+	padding: 0;
+}
+
+.edit-post-template-top-area__first-menu-group {
+	padding: $grid-unit-15 $grid-unit-15 0 $grid-unit-15;
+}
+
+.edit-post-template-top-area__second-menu-group {
+	padding: $grid-unit-15;
+}

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -15,15 +15,3 @@
 .edit-post-template-top-area__popover .components-popover__content {
 	min-width: 360px;
 }
-
-.edit-post-template-top-area__popover.components-dropdown__content .components-popover__content > div {
-	padding: 0;
-}
-
-.edit-post-template-top-area__first-menu-group {
-	padding: $grid-unit-15 $grid-unit-15 0 $grid-unit-15;
-}
-
-.edit-post-template-top-area__second-menu-group {
-	padding: $grid-unit-15;
-}

--- a/packages/edit-post/src/components/sidebar/template-summary/index.js
+++ b/packages/edit-post/src/components/sidebar/template-summary/index.js
@@ -29,7 +29,7 @@ function TemplateSummary() {
 
 				<FlexBlock>
 					<h2 className="edit-post-template-summary__title">
-						{ template?.title?.raw || template?.slug }
+						{ template?.title || template?.slug }
 					</h2>
 					<p>{ template?.description }</p>
 				</FlexBlock>

--- a/packages/edit-post/src/components/sidebar/template/index.js
+++ b/packages/edit-post/src/components/sidebar/template/index.js
@@ -79,7 +79,7 @@ export function TemplatePanel() {
 		panelTitle = sprintf(
 			/* translators: %s: template title */
 			__( 'Template: %s' ),
-			template?.title?.raw ?? template.slug
+			template?.title ?? template.slug
 		);
 	}
 

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -361,9 +361,17 @@ export const getEditedPostTemplate = createRegistrySelector(
 			'template'
 		);
 		if ( currentTemplate ) {
-			return select( coreStore )
+			const templateWithSameSlug = select( coreStore )
 				.getEntityRecords( 'postType', 'wp_template' )
 				?.find( ( template ) => template.slug === currentTemplate );
+			if ( ! templateWithSameSlug ) {
+				return templateWithSameSlug;
+			}
+			return select( coreStore ).getEditedEntityRecord(
+				'postType',
+				'wp_template',
+				templateWithSameSlug.id
+			);
 		}
 
 		const post = select( editorStore ).getCurrentPost();


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/31076.

This PR implements a delete action for page templates.

For now, the UI is a simple action link like the other actions (edit and new), in the future we may iterate on the design.


## How has this been tested?
I verified I could delete user-created templates.
