### PR TITLE
Rich text: remove tag name dependency

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -300,7 +300,6 @@ function RichTextWrapper(
 		disableLineBreaks,
 		unstableOnFocus,
 		__unstableAllowPrefixTransformations,
-		__unstableMultilineRootTag,
 		// Native props.
 		__unstableMobileNoFocusOnMount,
 		deleteEnter,
@@ -683,7 +682,6 @@ function RichTextWrapper(
 			__unstableAllowPrefixTransformations={
 				__unstableAllowPrefixTransformations
 			}
-			__unstableMultilineRootTag={ __unstableMultilineRootTag }
 			// Native props.
 			{ ...nativeProps }
 			blockIsSelected={

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -148,7 +148,6 @@ export default function ListEdit( {
 			<RichText
 				identifier="values"
 				multiline="li"
-				__unstableMultilineRootTag={ tagName }
 				tagName={ tagName }
 				onChange={ ( nextValues ) =>
 					setAttributes( { values: nextValues } )

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -7,7 +7,7 @@ import {
 	useState,
 	useLayoutEffect,
 } from '@wordpress/element';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -41,7 +41,6 @@ function createPrepareEditableTree( fns ) {
 
 function RichText(
 	{
-		tagName = 'div',
 		value = '',
 		selectionStart,
 		selectionEnd,
@@ -57,7 +56,6 @@ function RichText(
 		clientId,
 		identifier,
 		__unstableMultilineTag: multilineTag,
-		__unstableMultilineRootTag: multilineRootTag,
 		__unstableDisableFormats: disableFormats,
 		__unstableInputRule: inputRule,
 		__unstableMarkAutomaticChange: markAutomaticChange,
@@ -81,12 +79,6 @@ function RichText(
 		withoutInteractiveFormatting,
 		allowedFormats,
 	} );
-
-	// For backward compatibility, fall back to tagName if it's a string.
-	// tagName can now be a component for light blocks.
-	if ( ! multilineRootTag && typeof tagName === 'string' ) {
-		multilineRootTag = tagName;
-	}
 
 	/**
 	 * Converts the outside data structure to our internal representation.
@@ -269,17 +261,6 @@ function RichText(
 
 	// Value updates must happen synchonously to avoid overwriting newer values.
 	useLayoutEffect( () => {
-		if ( didMount.current ) {
-			applyFromProps();
-		} else {
-			applyFromProps( { domOnly: true } );
-		}
-
-		didMount.current = true;
-	}, [ tagName, placeholder, ...dependencies ] );
-
-	// Value updates must happen synchonously to avoid overwriting newer values.
-	useLayoutEffect( () => {
 		if ( didMount.current && value !== _value.current ) {
 			applyFromProps();
 		}
@@ -327,7 +308,6 @@ function RichText(
 		} ),
 		useIndentListItemOnSpace( {
 			multilineTag,
-			multilineRootTag,
 			createRecord,
 			handleChange,
 		} ),
@@ -356,6 +336,15 @@ function RichText(
 			onSelectionChange,
 			setActiveFormats,
 		} ),
+		useRefEffect( () => {
+			if ( didMount.current ) {
+				applyFromProps();
+			} else {
+				applyFromProps( { domOnly: true } );
+			}
+
+			didMount.current = true;
+		}, [ placeholder, ...dependencies ] ),
 	] );
 
 	return (

--- a/packages/rich-text/src/component/use-indent-list-item-on-space.js
+++ b/packages/rich-text/src/component/use-indent-list-item-on-space.js
@@ -20,7 +20,6 @@ export function useIndentListItemOnSpace( props ) {
 			const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
 			const {
 				multilineTag,
-				multilineRootTag,
 				createRecord,
 				handleChange,
 			} = propsRef.current;
@@ -52,7 +51,9 @@ export function useIndentListItemOnSpace( props ) {
 			}
 
 			handleChange(
-				indentListItems( currentValue, { type: multilineRootTag } )
+				indentListItems( currentValue, {
+					type: element.tagName.toLowerCase(),
+				} )
 			);
 			event.preventDefault();
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Rely on a ref callback instead to reapply content if the element changes.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
