### PR TITLE
Scripts: Update PostCSS minimum version to ensure it is secure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14350,7 +14350,7 @@
 				"mini-css-extract-plugin": "^1.3.9",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^5.0.0",
-				"postcss": "^8.2.2",
+				"postcss": "^8.2.15",
 				"postcss-loader": "^4.2.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"puppeteer-core": "^9.0.0",
@@ -46159,26 +46159,26 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.2.tgz",
-			"integrity": "sha512-HM1NDNWLgglJPQQMNwvLxgH2KcrKZklKLi/xXYIOaqQB57p/pDWEJNS83PVICYsn1Dg/9C26TiejNr422/ePaQ==",
+			"version": "8.2.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+			"integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
 			"dev": true,
 			"requires": {
-				"colorette": "^1.2.1",
-				"nanoid": "^3.1.20",
+				"colorette": "^1.2.2",
+				"nanoid": "^3.1.23",
 				"source-map": "^0.6.1"
 			},
 			"dependencies": {
 				"colorette": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-					"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
 					"dev": true
 				},
 				"nanoid": {
-					"version": "3.1.20",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-					"integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+					"version": "3.1.23",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+					"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
 					"dev": true
 				},
 				"source-map": {

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
 		"nock": "12.0.3",
 		"node-watch": "0.7.0",
 		"patch-package": "6.2.2",
-		"postcss": "8.2.2",
+		"postcss": "8.2.15",
 		"postcss-loader": "4.2.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"progress": "2.0.3",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -14,6 +14,12 @@
 -   Have the `format` command ignore files listed in a `.prettierignore` file, add a fallback `.prettierignore` to the package ([30844](https://github.com/WordPress/gutenberg/pull/30844)).
 -   The e2e tests are now using [`jest-circus`](https://github.com/facebook/jest/tree/master/packages/jest-circus) as the test runner. This enable us to capture screenshots at the time the tests failed. The unit tests are also using the same test runner for consistency ([#28449](https://github.com/WordPress/gutenberg/pull/28449), [#31178](https://github.com/WordPress/gutenberg/pull/31178)).
 
+### Security Fix
+
+-   Update `postcss` dependency to the latest patch version. Versions before 8.2.10 are vulnerable to Regular Expression Denial of Service (ReDoS) during source map parsing ([#31685](https://github.com/WordPress/gutenberg/pull/31685)).
+
+## 15.0.1 (2021-04-30)
+
 ### Bug Fix
 
 -   Add `postcss` as a dependency to ensure that the correct version gets installed.

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -66,7 +66,7 @@
 		"mini-css-extract-plugin": "^1.3.9",
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^5.0.0",
-		"postcss": "^8.2.2",
+		"postcss": "^8.2.15",
 		"postcss-loader": "^4.2.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"puppeteer-core": "^9.0.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

> The package postcss from 7.0.0 and before 8.2.10 are vulnerable to Regular Expression Denial of Service (ReDoS) during source map parsing.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
