### PR TITLE
[Inserter]: Hide patterns tab if no patterns are available

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -54,11 +54,9 @@ function InserterMenu( {
 			);
 
 			return {
-				showPatterns:
-					! destinationRootClientId ||
-					!! __experimentalGetAllowedPatterns(
-						destinationRootClientId
-					).length,
+				showPatterns: !! __experimentalGetAllowedPatterns(
+					destinationRootClientId
+				).length,
 				hasReusableBlocks: !! getSettings().__experimentalReusableBlocks
 					?.length,
 			};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Based on @vdwijngaert 's comment here: https://github.com/WordPress/gutenberg/pull/31546#pullrequestreview-655906619.

>One side-effect, however, is that when a theme does not add patterns of itself, the pattern tab in the inserter is empty. But that could be addressed in a follow-up issue.


![image](https://user-images.githubusercontent.com/772137/117701965-29ee7100-b1c8-11eb-9137-294b01e75bcf.png)

## Testing instructions
1. Enable a theme which doesn't provide patterns
2. Remove support for core patterns (see snippet below)
3. Observe that the `patterns` tab in the inserter is not shown

** remove core patterns support snippet
```
add_action( 'after_setup_theme', 'my_theme_setup' );
function my_theme_setup(){
	remove_theme_support( 'core-block-patterns' );
}
```
