### PR TITLE
[Automated Testing]: Increase test coverage for pattern transforms

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1884,7 +1884,6 @@ export const __experimentalGetPatternsByBlockTypes = createSelector(
  *
  * @return {WPBlockPattern[]} Items that are eligible for a pattern transformation.
  */
-// TODO tests
 export const __experimentalGetPatternTransformItems = createSelector(
 	( state, blocks, rootClientId = null ) => {
 		if ( ! blocks ) return EMPTY_ARRAY;

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -75,6 +75,7 @@ const {
 	__experimentalGetPatternsByBlockTypes,
 	__unstableGetClientIdWithClientIdsTree,
 	__unstableGetClientIdsTree,
+	__experimentalGetPatternTransformItems,
 	wasBlockJustInserted,
 } = selectors;
 
@@ -3483,6 +3484,154 @@ describe( 'selectors', () => {
 			expect( patterns[ 0 ] ).toEqual(
 				expect.objectContaining( { title: 'pattern c' } )
 			);
+		} );
+	} );
+	describe( '__experimentalGetPatternTransformItems', () => {
+		const state = {
+			blocks: {
+				byClientId: {
+					block1: { name: 'core/test-block-a' },
+					block2: { name: 'core/test-block-b' },
+				},
+				controlledInnerBlocks: { 'block2-clientId': true },
+			},
+			blockListSettings: {
+				block1: {
+					allowedBlocks: [ 'core/test-block-b' ],
+				},
+			},
+			settings: {
+				__experimentalBlockPatterns: [
+					{
+						name: 'pattern-a',
+						blockTypes: [ 'test/block-a' ],
+						title: 'pattern a',
+						content:
+							'<!-- wp:test-block-a --><!-- /wp:test-block-a -->',
+					},
+					{
+						name: 'pattern-b',
+						blockTypes: [ 'test/block-b' ],
+						title: 'pattern b',
+						content:
+							'<!-- wp:test-block-b --><!-- /wp:test-block-b -->',
+					},
+					{
+						name: 'pattern-c',
+						title: 'pattern c',
+						blockTypes: [ 'test/block-a' ],
+						content:
+							'<!-- wp:test-block-b --><!-- /wp:test-block-b -->',
+					},
+					{
+						name: 'pattern-mix',
+						title: 'pattern mix',
+						blockTypes: [
+							'core/test-block-a',
+							'core/test-block-b',
+						],
+						content:
+							'<!-- wp:test-block-b --><!-- /wp:test-block-b -->',
+					},
+				],
+			},
+		};
+		describe( 'should return empty array', () => {
+			it( 'when no blocks are selected', () => {
+				expect(
+					__experimentalGetPatternTransformItems( state )
+				).toEqual( [] );
+			} );
+			it( 'when a selected block has inner blocks', () => {
+				const blocks = [
+					{ name: 'core/test-block-a', innerBlocks: [] },
+					{
+						name: 'core/test-block-b',
+						innerBlocks: [ { name: 'some inner block' } ],
+					},
+				];
+				expect(
+					__experimentalGetPatternTransformItems( state, blocks )
+				).toEqual( [] );
+			} );
+			it( 'when is inner block controller', () => {
+				const blocks = [
+					{ name: 'core/test-block-a', innerBlocks: [] },
+					{
+						name: 'core/test-block-b',
+						clientId: 'block2-clientId',
+						innerBlocks: [],
+					},
+				];
+				expect(
+					__experimentalGetPatternTransformItems( state, blocks )
+				).toEqual( [] );
+			} );
+			it( 'when no patterns are available based on the selected blocks', () => {
+				const blocks = [
+					{ name: 'block-with-no-patterns', innerBlocks: [] },
+				];
+				expect(
+					__experimentalGetPatternTransformItems( state, blocks )
+				).toEqual( [] );
+			} );
+		} );
+		describe( 'should return proper results', () => {
+			it( 'when a single block is selected', () => {
+				const blocks = [
+					{ name: 'core/test-block-b', innerBlocks: [] },
+				];
+				const patterns = __experimentalGetPatternTransformItems(
+					state,
+					blocks
+				);
+				expect( patterns ).toHaveLength( 1 );
+				expect( patterns[ 0 ] ).toEqual(
+					expect.objectContaining( {
+						name: 'pattern-mix',
+					} )
+				);
+			} );
+			it( 'when different multiple blocks are selected', () => {
+				const blocks = [
+					{ name: 'core/test-block-b', innerBlocks: [] },
+					{ name: 'test/block-b', innerBlocks: [] },
+					{ name: 'some other block', innerBlocks: [] },
+				];
+				const patterns = __experimentalGetPatternTransformItems(
+					state,
+					blocks
+				);
+				expect( patterns ).toHaveLength( 2 );
+				expect( patterns ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							name: 'pattern-mix',
+						} ),
+						expect.objectContaining( {
+							name: 'pattern-b',
+						} ),
+					] )
+				);
+			} );
+			it( 'when multiple blocks are selected containing multiple times the same block', () => {
+				const blocks = [
+					{ name: 'core/test-block-b', innerBlocks: [] },
+					{ name: 'some other block', innerBlocks: [] },
+					{ name: 'core/test-block-a', innerBlocks: [] },
+					{ name: 'core/test-block-b', innerBlocks: [] },
+				];
+				const patterns = __experimentalGetPatternTransformItems(
+					state,
+					blocks
+				);
+				expect( patterns ).toHaveLength( 1 );
+				expect( patterns[ 0 ] ).toEqual(
+					expect.objectContaining( {
+						name: 'pattern-mix',
+					} )
+				);
+			} );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3554,7 +3554,7 @@ describe( 'selectors', () => {
 					__experimentalGetPatternTransformItems( state, blocks )
 				).toEqual( [] );
 			} );
-			it( 'when is inner block controller', () => {
+			it( 'when a selected block has controlled inner blocks', () => {
 				const blocks = [
 					{ name: 'core/test-block-a', innerBlocks: [] },
 					{


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR just increases the test coverage for the pattern transformations feature introduced here: https://github.com/WordPress/gutenberg/pull/30469

