### PR TITLE
Move the Query and PostTitle e2e tests out of the experimental directory

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/post-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/post-title.test.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	activateTheme,
 	createNewPost,
 	insertBlock,
 	pressKeyWithModifier,
@@ -10,14 +9,6 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Post Title block', () => {
-	beforeAll( async () => {
-		await activateTheme( 'tt1-blocks' );
-	} );
-
-	afterAll( async () => {
-		await activateTheme( 'twentytwentyone' );
-	} );
-
 	beforeEach( async () => {
 		await createNewPost();
 	} );

--- a/packages/e2e-tests/specs/editor/blocks/query.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/query.test.js
@@ -4,7 +4,6 @@
 import {
 	activatePlugin,
 	deactivatePlugin,
-	activateTheme,
 	createNewPost,
 	insertBlock,
 	publishPost,
@@ -19,11 +18,9 @@ const createDemoPosts = async () => {
 describe( 'Query block', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-query-block' );
-		await activateTheme( 'tt1-blocks' );
 		await createDemoPosts();
 	} );
 	afterAll( async () => {
-		await activateTheme( 'twentytwentyone' );
 		await trashAllPosts();
 		await deactivatePlugin( 'gutenberg-test-query-block' );
 	} );


### PR DESCRIPTION
Since these blocks are now stable, their tests should be as well.