### PR TITLE
[WIP] Table: Add header, footer and striped style colors

### DIFF
--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -16,6 +16,42 @@
 			"selector": "figcaption",
 			"default": ""
 		},
+		"secondaryBackgroundColor": {
+			"type": "string"
+		},
+		"customSecondaryBackgroundColor": {
+			"type": "string"
+		},
+		"secondaryTextColor": {
+			"type": "string"
+		},
+		"customSecondaryTextColor": {
+			"type": "string"
+		},
+		"headerBackgroundColor": {
+			"type": "string"
+		},
+		"customHeaderBackgroundColor": {
+			"type": "string"
+		},
+		"headerTextColor": {
+			"type": "string"
+		},
+		"customHeaderTextColor": {
+			"type": "string"
+		},
+		"footerBackgroundColor": {
+			"type": "string"
+		},
+		"customFooterBackgroundColor": {
+			"type": "string"
+		},
+		"footerTextColor": {
+			"type": "string"
+		},
+		"customFooterTextColor": {
+			"type": "string"
+		},
 		"head": {
 			"type": "array",
 			"default": [],

--- a/packages/block-library/src/table/secondary-color-controls.js
+++ b/packages/block-library/src/table/secondary-color-controls.js
@@ -1,0 +1,116 @@
+/**
+ * WordPress dependencies
+ */
+import { ContrastChecker, PanelColorSettings } from '@wordpress/block-editor';
+import { Platform } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const SecondaryColorControls = ( {
+	sections,
+	isStripedStyle,
+	tableProps: {
+		secondaryBackgroundColor,
+		setSecondaryBackgroundColor,
+		secondaryTextColor,
+		setSecondaryTextColor,
+		headerBackgroundColor,
+		setHeaderBackgroundColor,
+		headerTextColor,
+		setHeaderTextColor,
+		footerBackgroundColor,
+		setFooterBackgroundColor,
+		footerTextColor,
+		setFooterTextColor,
+	},
+} ) => {
+	const activeColors = [];
+	const contrastCheckerConfigs = [];
+
+	// Color options are only included as required to reduce clutter in the
+	// inspector controls sidebar. Contrast checkers are setup for each
+	// background and text color pairing.
+
+	if ( sections.includes( 'head' ) ) {
+		activeColors.push(
+			{
+				value: headerTextColor.color,
+				onChange: setHeaderTextColor,
+				label: __( 'Header text color' ),
+			},
+			{
+				value: headerBackgroundColor.color,
+				onChange: setHeaderBackgroundColor,
+				label: __( 'Header background color' ),
+			}
+		);
+		contrastCheckerConfigs.push( {
+			textColor: headerTextColor?.color,
+			backgroundColor: headerBackgroundColor?.color,
+			isLargeText: false,
+			id: 'header-contrast-checker',
+		} );
+	}
+
+	if ( isStripedStyle ) {
+		activeColors.push(
+			{
+				value: secondaryTextColor.color,
+				onChange: setSecondaryTextColor,
+				label: __( 'Striped text color' ),
+			},
+			{
+				value: secondaryBackgroundColor.color,
+				onChange: setSecondaryBackgroundColor,
+				label: __( 'Striped background color' ),
+			}
+		);
+		contrastCheckerConfigs.push( {
+			textColor: secondaryTextColor?.color,
+			backgroundColor: secondaryBackgroundColor?.color,
+			isLargeText: false,
+			id: 'striped-contrast-checker',
+		} );
+	}
+
+	if ( sections.includes( 'foot' ) ) {
+		activeColors.push(
+			{
+				value: footerTextColor.color,
+				onChange: setFooterTextColor,
+				label: __( 'Footer text color' ),
+			},
+			{
+				value: footerBackgroundColor.color,
+				onChange: setFooterBackgroundColor,
+				label: __( 'Footer background color' ),
+			}
+		);
+		contrastCheckerConfigs.push( {
+			textColor: footerTextColor?.color,
+			backgroundColor: footerBackgroundColor?.color,
+			isLargeText: false,
+			id: 'footer-contrast-checker',
+		} );
+	}
+
+	// Don't display color controls for Native or if there aren't any needed.
+	if ( Platform.OS !== 'web' && ! activeColors.length ) {
+		return null;
+	}
+
+	const contrastCheckers = contrastCheckerConfigs.map( ( config ) => (
+		<ContrastChecker key={ config.id } { ...config } />
+	) );
+
+	return (
+		<PanelColorSettings
+			title={ __( 'Secondary Colors' ) }
+			colorSettings={ activeColors }
+			initialOpen={ false }
+		>
+			{ contrastCheckers }
+		</PanelColorSettings>
+	);
+};
+
+export default SecondaryColorControls;

--- a/packages/block-library/src/table/secondary-color-controls.js
+++ b/packages/block-library/src/table/secondary-color-controls.js
@@ -94,7 +94,7 @@ const SecondaryColorControls = ( {
 	}
 
 	// Don't display color controls for Native or if there aren't any needed.
-	if ( Platform.OS !== 'web' && ! activeColors.length ) {
+	if ( Platform.OS !== 'web' || ! activeColors.length ) {
 		return null;
 	}
 

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -61,6 +61,7 @@
 		border-spacing: 0;
 		border-collapse: inherit;
 		background-color: transparent;
+		border-bottom: 1px solid $gray-100;
 
 		tbody tr:nth-child(odd) {
 			background-color: $gray-100;
@@ -95,7 +96,16 @@
 			border-color: transparent;
 		}
 
-		border-bottom: 1px solid $gray-100;
+		// Force user selected colors while stripe style is active.
+		table.has-text-color {
+			thead,
+			tfoot,
+			tbody {
+				tr:not(.has-text-color) {
+					color: currentColor;
+				}
+			}
+		}
 	}
 
 	// Border Styles

--- a/packages/block-library/src/table/utils.js
+++ b/packages/block-library/src/table/utils.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { capitalize } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { getColorClassName } from '@wordpress/block-editor';
+
+/**
+ * Determines CSS classnames and styles for supplied background and text color
+ * pairing. This is intended for use with the Table block's secondary, header
+ * and footer color pairs.
+ *
+ * @param  {string} name  Base name for the table color set.
+ * @param  {Object} props Table block props.
+ *
+ * @return {Object} CSS class and style props for specified table color set.
+ */
+export function getColorPropsFromObjects( name, props ) {
+	const backgroundColor = props[ `${ name }BackgroundColor` ];
+	const textColor = props[ `${ name }TextColor` ];
+
+	return {
+		className: classnames( backgroundColor?.class, textColor?.class, {
+			'has-background': !! backgroundColor?.color,
+			'has-text-color': !! textColor?.color,
+		} ),
+		style: {
+			backgroundColor: ! backgroundColor?.class && backgroundColor?.color,
+			color: ! textColor?.class && textColor?.color,
+		},
+	};
+}
+
+/**
+ * Builds object containing classname and style prop values for a specified
+ * table color set (secondary, header and footer). It is intended to be used
+ * within the table block's save function.
+ *
+ * @param  {string} name       Base name for table color set.
+ * @param  {Object} attributes Table block attributes.
+ *
+ * @return {Object} CSS class and style props for supplied colors.
+ */
+export function getColorProps( name, attributes ) {
+	const capitalizedName = capitalize( name );
+
+	// Background class and color.
+	const backgroundClass = getColorClassName(
+		'background-color',
+		attributes[ `${ name }BackgroundColor` ]
+	);
+	const customBackgroundColor =
+		attributes[ `custom${ capitalizedName }BackgroundColor` ];
+
+	// Text class and color.
+	const textClass = getColorClassName(
+		'color',
+		attributes[ `${ name }TextColor` ]
+	);
+	const customTextColor = attributes[ `custom${ capitalizedName }TextColor` ];
+
+	return {
+		className: classnames( {
+			'has-background': backgroundClass || customBackgroundColor,
+			'has-text-color': textClass || customTextColor,
+			[ backgroundClass ]: backgroundClass,
+			[ textClass ]: textClass,
+		} ),
+		style: {
+			backgroundColor: backgroundClass
+				? undefined
+				: customBackgroundColor,
+			color: textClass ? undefined : customTextColor,
+		},
+	};
+}


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/31261

## Description
Adds control for setting background and font colors for the table block's header and footer as well as the striped block style's alternating rows.

## How has this been tested?
Manually.

1. Check out this PR, create a new post, add a table block and select it
2. In its default state the secondary color controls should not be visible in the sidebar
3. Under the "Table settings" panel, toggle on the header section, secondary colors panel should now show
4. Add text to the header row, then confirm header color options are present under the secondary colors panel
5. Toggle on the footer section via the "Table settings" panel and check the controls are present under secondary colors
6. Add text to the table's footer and adjust the footer colors via the secondary colors
7. Select the "Stripes" block style and confirm new color options under the secondary colors panel
8. Add a few extra rows to the body of the table along with some text
9. Adjust the table's secondary colors 

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/60436221/117804988-c9c8ff00-b29b-11eb-875c-0eb48c9094ff.gif" width="500"/>

## Types of changes
New feature.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
