### PR TITLE
Plugin: Tweaks to accommodate latest changes in core for styles loading

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -170,6 +170,7 @@ function gutenberg_register_core_block_styles( $block_name ) {
 	$editor_style_path = "build/block-library/blocks/$block_name/style-editor.css";
 
 	if ( file_exists( gutenberg_dir_path() . $style_path ) ) {
+		wp_deregister_style( "wp-block-{$block_name}" );
 		wp_register_style(
 			"wp-block-{$block_name}",
 			gutenberg_url( $style_path ),
@@ -183,6 +184,7 @@ function gutenberg_register_core_block_styles( $block_name ) {
 	}
 
 	if ( file_exists( gutenberg_dir_path() . $editor_style_path ) ) {
+		wp_deregister_style( "wp-block-{$block_name}-editor" );
 		wp_register_style(
 			"wp-block-{$block_name}-editor",
 			gutenberg_url( $editor_style_path ),
@@ -198,9 +200,16 @@ function gutenberg_register_core_block_styles( $block_name ) {
  *
  * Optimizes performance and sustainability of styles by inlining smaller stylesheets.
  *
+ * @todo Remove this function when the minimum supported version is WordPress 5.8.
+ *
  * @return void
  */
 function gutenberg_maybe_inline_styles() {
+
+	// Early exit if the "wp_maybe_inline_styles" function exists.
+	if ( function_exists( 'wp_maybe_inline_styles' ) ) {
+		return;
+	}
 
 	$total_inline_limit = 20000;
 	/**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -11,10 +11,22 @@
 /**
  * Determine if the current theme needs to load separate block styles or not.
  *
+ * @todo Remove this function when the minimum supported version is WordPress 5.8.
+ *
  * @return bool
  */
 function gutenberg_should_load_separate_block_assets() {
-	$load_separate_styles = gutenberg_is_fse_theme();
+	if ( function_exists( 'should_load_separate_core_block_assets' ) ) {
+		return should_load_separate_core_block_assets();
+	}
+
+	if ( is_admin() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+		return false;
+	}
+
+	// The `separate_core_block_assets` filter was added in WP 5.8.
+	$load_separate_styles = apply_filters( 'separate_core_block_assets', gutenberg_is_fse_theme() );
+
 	/**
 	 * Determine if separate styles will be loaded for blocks on-render or not.
 	 *
@@ -24,6 +36,21 @@ function gutenberg_should_load_separate_block_assets() {
 	 */
 	return apply_filters( 'load_separate_block_assets', $load_separate_styles );
 }
+
+/**
+ * Opt-in to separate styles loading for block themes in WordPress 5.8.
+ *
+ * @todo Remove this function when the minimum supported version is WordPress 5.8.
+ */
+add_filter(
+	'separate_core_block_assets',
+	function( $load_separate_styles ) {
+		if ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() ) {
+			return true;
+		}
+		return $load_separate_styles;
+	}
+);
 
 /**
  * Remove the `wp_enqueue_registered_block_scripts_and_styles` hook if needed.


### PR DESCRIPTION
## Description

A commit was backported from Gutenberg to core to allow loading separate stylesheets per-block on render - See https://core.trac.wordpress.org/changeset/50836
This PR tweaks Gutenberg to make sure nothing breaks when using WP5.8.

## How has this been tested?
Tested with WordPress trunk, using the default theme, with and without this line in the theme's `functions.php` file:
```php
add_filter( 'separate_core_block_assets', '__return_true' );
```
Also tested with a block theme with and without the filter.

Using the default theme, without the filter it loads the single `style.css` file for all blocks. With the filter, it loads separate styles.
Using a block theme the separate styles get loaded properly.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
