### PR TITLE
Editor: Debounce flat term search

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import {
+	debounce,
 	escape as escapeString,
 	find,
 	get,
 	invoke,
 	isEmpty,
-	throttle,
 	uniqBy,
 } from 'lodash';
 
@@ -60,7 +60,7 @@ class FlatTermSelector extends Component {
 	constructor() {
 		super( ...arguments );
 		this.onChange = this.onChange.bind( this );
-		this.searchTerms = throttle( this.searchTerms.bind( this ), 500 );
+		this.searchTerms = debounce( this.searchTerms.bind( this ), 500 );
 		this.findOrCreateTerm = this.findOrCreateTerm.bind( this );
 		this.appendTerm = this.appendTerm.bind( this );
 		this.state = {


### PR DESCRIPTION
## Description
Replaces `throttle` with `debounce` for flat term search since it's better suited for similar actions.

Fixes #28708.

## How has this been tested?
_The original issue is hard to reproduce locally, even when generating 1000 tags._

1. Go to the post editor screen.
2. In the "Tags" panel, search for tags.
3. See that results are correctly returned after few seconds when you stop typing.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
