### PR TITLE
Fix Post Featured Image placeholder regression

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -119,10 +119,14 @@ function PostFeaturedImageDisplay( {
 
 const PostFeaturedImageWithNotices = withNotices( PostFeaturedImageDisplay );
 
-export default function PostFeaturedImageEdit( props ) {
+const OutofContextPlaceholder = () => {
 	const blockProps = useBlockProps();
+	return <div { ...blockProps }>{ placeholderChip }</div>;
+};
+
+export default function PostFeaturedImageEdit( props ) {
 	if ( ! props.context?.postId ) {
-		return <div { ...blockProps }>{ placeholderChip }</div>;
+		return <OutofContextPlaceholder />;
 	}
 	return <PostFeaturedImageWithNotices { ...props } />;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
I just [created a regression](https://github.com/WordPress/gutenberg/pull/31663) with the Post Featured Image placeholder when outside of `postId` context. This fixes it.

