### PR TITLE
Rich text: simplify with hooks

### DIFF
--- a/packages/block-editor/src/components/autocomplete/index.js
+++ b/packages/block-editor/src/components/autocomplete/index.js
@@ -7,7 +7,10 @@ import { clone } from 'lodash';
  * WordPress dependencies
  */
 import { applyFilters, hasFilter } from '@wordpress/hooks';
-import { Autocomplete } from '@wordpress/components';
+import {
+	Autocomplete,
+	__unstableUseAutocompleteProps as useAutocompleteProps,
+} from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { getDefaultBlockName } from '@wordpress/blocks';
 
@@ -25,18 +28,9 @@ import blockAutocompleter from '../../autocompleters/block';
  */
 const EMPTY_ARRAY = [];
 
-/**
- * Wrap the default Autocomplete component with one that supports a filter hook
- * for customizing its list of autocompleters.
- *
- * @type {import('react').FC}
- */
-function BlockEditorAutocomplete( props ) {
+function useCompleters( { completers = EMPTY_ARRAY } ) {
 	const { name } = useBlockEditContext();
-
-	let { completers = EMPTY_ARRAY } = props;
-
-	completers = useMemo( () => {
+	return useMemo( () => {
 		let filteredCompleters = completers;
 
 		if ( name === getDefaultBlockName() ) {
@@ -60,8 +54,23 @@ function BlockEditorAutocomplete( props ) {
 
 		return filteredCompleters;
 	}, [ completers, name ] );
+}
 
-	return <Autocomplete { ...props } completers={ completers } />;
+export function useBlockEditorAutocompleteProps( props ) {
+	return useAutocompleteProps( {
+		...props,
+		completers: useCompleters( props ),
+	} );
+}
+
+/**
+ * Wrap the default Autocomplete component with one that supports a filter hook
+ * for customizing its list of autocompleters.
+ *
+ * @type {import('react').FC}
+ */
+function BlockEditorAutocomplete( props ) {
+	return <Autocomplete { ...props } completers={ useCompleters( props ) } />;
 }
 
 /**

--- a/packages/block-editor/src/components/rich-text/use-caret-in-format.js
+++ b/packages/block-editor/src/components/rich-text/use-caret-in-format.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export function useCaretInFormat( hasActiveFormats ) {
+	const { isCaretWithinFormattedText } = useSelect( blockEditorStore );
+	const { enterFormattedText, exitFormattedText } = useDispatch(
+		blockEditorStore
+	);
+	useEffect( () => {
+		if ( hasActiveFormats ) {
+			if ( ! isCaretWithinFormattedText() ) {
+				enterFormattedText();
+			}
+		} else if ( isCaretWithinFormattedText() ) {
+			exitFormattedText();
+		}
+	}, [ hasActiveFormats ] );
+}

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -12,6 +12,7 @@ import {
 	useEffect,
 	useLayoutEffect,
 	useState,
+	useRef,
 } from '@wordpress/element';
 import {
 	ENTER,
@@ -23,7 +24,7 @@ import {
 	BACKSPACE,
 } from '@wordpress/keycodes';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, useDebounce } from '@wordpress/compose';
 import {
 	create,
 	slice,
@@ -32,13 +33,13 @@ import {
 	getTextContent,
 	useAnchorRef,
 } from '@wordpress/rich-text';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import Button from '../button';
 import Popover from '../popover';
-import withSpokenMessages from '../higher-order/with-spoken-messages';
 
 /**
  * A raw completer option.
@@ -285,17 +286,15 @@ const getAutoCompleterUI = ( autocompleter ) => {
 	return AutocompleterUI;
 };
 
-function Autocomplete( {
-	children,
-	isSelected,
+function useAutocomplete( {
 	record,
 	onChange,
 	onReplace,
 	completers,
-	debouncedSpeak,
 	contentRef,
 } ) {
-	const instanceId = useInstanceId( Autocomplete );
+	const debouncedSpeak = useDebounce( speak, 500 );
+	const instanceId = useInstanceId( useAutocomplete );
 	const [ selectedIndex, setSelectedIndex ] = useState( 0 );
 	const [ filteredOptions, setFilteredOptions ] = useState( [] );
 	const [ filterValue, setFilterValue ] = useState( '' );
@@ -544,29 +543,49 @@ function Autocomplete( {
 		? `components-autocomplete-item-${ instanceId }-${ selectedKey }`
 		: null;
 
+	return {
+		listBoxId,
+		activeId,
+		onKeyDown: handleKeyDown,
+		popover: AutocompleterUI && (
+			<AutocompleterUI
+				className={ className }
+				filterValue={ filterValue }
+				instanceId={ instanceId }
+				listBoxId={ listBoxId }
+				selectedIndex={ selectedIndex }
+				onChangeOptions={ onChangeOptions }
+				onSelect={ select }
+				value={ record }
+				contentRef={ contentRef }
+			/>
+		),
+	};
+}
+
+export function useAutocompleteProps( options ) {
+	const ref = useRef();
+	const { popover, listBoxId, activeId, onKeyDown } = useAutocomplete( {
+		...options,
+		contentRef: ref,
+	} );
+
+	return {
+		ref,
+		children: popover,
+		onKeyDown,
+		'aria-autocomplete': listBoxId ? 'list' : undefined,
+		'aria-owns': listBoxId,
+		'aria-activedescendant': activeId,
+	};
+}
+
+export default function Autocomplete( { children, isSelected, ...options } ) {
+	const { popover, ...props } = useAutocomplete( options );
 	return (
 		<>
-			{ children( {
-				isExpanded,
-				listBoxId,
-				activeId,
-				onKeyDown: handleKeyDown,
-			} ) }
-			{ isSelected && AutocompleterUI && (
-				<AutocompleterUI
-					className={ className }
-					filterValue={ filterValue }
-					instanceId={ instanceId }
-					listBoxId={ listBoxId }
-					selectedIndex={ selectedIndex }
-					onChangeOptions={ onChangeOptions }
-					onSelect={ select }
-					value={ record }
-					contentRef={ contentRef }
-				/>
-			) }
+			{ children( props ) }
+			{ isSelected && popover }
 		</>
 	);
 }
-
-export default withSpokenMessages( Autocomplete );

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -17,7 +17,10 @@ export {
 	getAnimateClassName as __unstableGetAnimateClassName,
 } from './animate';
 export { default as AnglePickerControl } from './angle-picker-control';
-export { default as Autocomplete } from './autocomplete';
+export {
+	default as Autocomplete,
+	useAutocompleteProps as __unstableUseAutocompleteProps,
+} from './autocomplete';
 export { default as BaseControl } from './base-control';
 export { default as __experimentalBoxControl } from './box-control';
 export { default as Button } from './button';

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	forwardRef,
-	useRef,
-	useState,
-	useLayoutEffect,
-} from '@wordpress/element';
+import { useRef, useState, useLayoutEffect } from '@wordpress/element';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 
 /**
@@ -39,32 +34,28 @@ function createPrepareEditableTree( fns ) {
 		);
 }
 
-function RichText(
-	{
-		value = '',
-		selectionStart,
-		selectionEnd,
-		children,
-		allowedFormats,
-		withoutInteractiveFormatting,
-		placeholder,
-		preserveWhiteSpace,
-		onPaste,
-		format = 'string',
-		onSelectionChange,
-		onChange,
-		clientId,
-		identifier,
-		__unstableMultilineTag: multilineTag,
-		__unstableDisableFormats: disableFormats,
-		__unstableInputRule: inputRule,
-		__unstableMarkAutomaticChange: markAutomaticChange,
-		__unstableAllowPrefixTransformations: allowPrefixTransformations,
-		__unstableOnCreateUndoLevel: onCreateUndoLevel,
-		__unstableIsSelected: isSelected,
-	},
-	forwardedRef
-) {
+export function useRichText( {
+	value = '',
+	selectionStart,
+	selectionEnd,
+	allowedFormats,
+	withoutInteractiveFormatting,
+	placeholder,
+	preserveWhiteSpace,
+	onPaste,
+	format = 'string',
+	onSelectionChange,
+	onChange,
+	clientId,
+	identifier,
+	__unstableMultilineTag: multilineTag,
+	__unstableDisableFormats: disableFormats,
+	__unstableInputRule: inputRule,
+	__unstableMarkAutomaticChange: markAutomaticChange,
+	__unstableAllowPrefixTransformations: allowPrefixTransformations,
+	__unstableOnCreateUndoLevel: onCreateUndoLevel,
+	__unstableIsSelected: isSelected,
+} ) {
 	const ref = useRef();
 	const [ activeFormats = [], setActiveFormats ] = useState();
 	const {
@@ -293,7 +284,6 @@ function RichText(
 	}
 
 	const mergedRefs = useMergeRefs( [
-		forwardedRef,
 		ref,
 		useDefaultStyle(),
 		useBoundaryStyle( { activeFormats } ),
@@ -347,32 +337,24 @@ function RichText(
 		}, [ placeholder, ...dependencies ] ),
 	] );
 
-	return (
-		<>
-			{ isSelected && (
-				<FormatEdit
-					value={ record.current }
-					onChange={ handleChange }
-					onFocus={ focus }
-					formatTypes={ formatTypes }
-					forwardedRef={ ref }
-				/>
-			) }
-			{ children( {
-				isSelected,
-				value: record.current,
-				onChange: handleChange,
-				onFocus: focus,
-				ref: mergedRefs,
-				hasActiveFormats: activeFormats.length,
-				removeEditorOnlyFormats,
-			} ) }
-		</>
-	);
+	return {
+		isSelected,
+		value: record.current,
+		onChange: handleChange,
+		onFocus: focus,
+		ref: mergedRefs,
+		hasActiveFormats: activeFormats.length,
+		removeEditorOnlyFormats,
+		children: isSelected && (
+			<FormatEdit
+				value={ record.current }
+				onChange={ handleChange }
+				onFocus={ focus }
+				formatTypes={ formatTypes }
+				forwardedRef={ ref }
+			/>
+		),
+	};
 }
 
-/**
- * Renders a rich content input, providing users with the option to format the
- * content.
- */
-export default forwardRef( RichText );
+export default function __experimentalRichText() {}

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -34,5 +34,8 @@ export { createElement as __unstableCreateElement } from './create-element';
 
 export { useAnchorRef } from './component/use-anchor-ref';
 
-export { default as __experimentalRichText } from './component';
+export {
+	default as __experimentalRichText,
+	useRichText as __unstableUseRichText,
+} from './component';
 export { default as __unstableFormatEdit } from './component/format-edit';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR simplifies the rich text implementation for blocks by using core rich text and autocomplete as hooks. Extending rich text by child functions becomes overly complex, especially when there's dependencies between them and when using hooks for nested components.

This PR also gets us one step closer to have a simple rich text hook returning a ref callback to add rich text behaviours. See #31693. What remains to be done is moving the rest of the implementation specific code like the client ID, format types, history etc.

Additionally, this is one step closer to #30587, which needs the toolbars to move into the tag element and native events to be used for enter/delete.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
