### PR TITLE
Spacing Support: Hide UI for disabled properties

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -49,11 +49,10 @@ export function MarginEdit( props ) {
 		setAttributes,
 	} = props;
 
-	const isDisabled = useIsMarginDisabled( props );
 	const units = useCustomUnits();
 	const sides = useCustomSides( blockName, 'margin' );
 
-	if ( ! hasMarginSupport( blockName ) || isDisabled ) {
+	if ( useIsMarginDisabled( { name: blockName } ) ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -49,10 +49,11 @@ export function MarginEdit( props ) {
 		setAttributes,
 	} = props;
 
+	const isDisabled = useIsMarginDisabled( props );
 	const units = useCustomUnits();
 	const sides = useCustomSides( blockName, 'margin' );
 
-	if ( useIsMarginDisabled( { name: blockName } ) ) {
+	if ( ! hasMarginSupport( blockName ) || isDisabled ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -52,7 +52,7 @@ export function MarginEdit( props ) {
 	const units = useCustomUnits();
 	const sides = useCustomSides( blockName, 'margin' );
 
-	if ( ! hasMarginSupport( blockName ) ) {
+	if ( useIsMarginDisabled( { name: blockName } ) ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -52,7 +52,7 @@ export function MarginEdit( props ) {
 	const units = useCustomUnits();
 	const sides = useCustomSides( blockName, 'margin' );
 
-	if ( useIsMarginDisabled( { name: blockName } ) ) {
+	if ( useIsMarginDisabled( props ) ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -79,11 +79,10 @@ export function PaddingEdit( props ) {
 		setAttributes,
 	} = props;
 
-	const isDisabled = useIsPaddingDisabled( props );
 	const units = useCustomUnits( CSS_UNITS );
 	const sides = useCustomSides( blockName, 'padding' );
 
-	if ( ! hasPaddingSupport( blockName ) || isDisabled ) {
+	if ( useIsPaddingDisabled( { name: blockName } ) ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -79,10 +79,11 @@ export function PaddingEdit( props ) {
 		setAttributes,
 	} = props;
 
+	const isDisabled = useIsPaddingDisabled( props );
 	const units = useCustomUnits( CSS_UNITS );
 	const sides = useCustomSides( blockName, 'padding' );
 
-	if ( useIsPaddingDisabled( { name: blockName } ) ) {
+	if ( ! hasPaddingSupport( blockName ) || isDisabled ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -82,7 +82,7 @@ export function PaddingEdit( props ) {
 	const units = useCustomUnits( CSS_UNITS );
 	const sides = useCustomSides( blockName, 'padding' );
 
-	if ( useIsPaddingDisabled( { name: blockName } ) ) {
+	if ( useIsPaddingDisabled( props ) ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -82,7 +82,7 @@ export function PaddingEdit( props ) {
 	const units = useCustomUnits( CSS_UNITS );
 	const sides = useCustomSides( blockName, 'padding' );
 
-	if ( ! hasPaddingSupport( blockName ) ) {
+	if ( useIsPaddingDisabled( { name: blockName } ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes issue #31725
The Spacing block support has support for both padding and margin independently; it is possible for a theme to opt in to only one or the other. Currently the UI for both is displayed as long as the block supports that feature, and the theme supports _either_ feature. This PR updates the block support to only display the UI if it is supported by both the block and the theme.


## How has this been tested?
Manually

To test, you need a block that supports both padding and margin. I used Site Title and updated the block.json  to include:

```
"supports": {
    // ...other supports
    "spacing": {
        "padding": true,
        "margin:": true
    }
}
```

You also need to update your theme.json to enable customPadding, but disable customMargin:
```
"settings": {
   "spacing": {
        "customPadding": true,
        "customMargin": false
    }
}
```

1.  Open the site editor and select the Site Title block. View the Inspector Controls and verify that only the Padding controls display.
2. Update the theme.json to set both `customMargin` and `customPadding` to true. Verify that now both Margin & Padding controls display.
3. Update theme.json to only enable `customMargin`, and verify that now only Margin controls display.
4. -Update theme.json to disable both padding and margin, and verify that the Spacing panel is not rendered at all.

## Screenshots <!-- if applicable -->
The Spacing panel when both Padding & Margin are supported by both the block and the theme:
<img width="269" alt="Screen Shot 2021-05-11 at 1 42 56 PM" src="https://user-images.githubusercontent.com/63313398/117882094-d5e29b80-b25e-11eb-8b3f-a83c118f05cb.png">

The Spacing panel when the block supports both Padding & Margin, but the theme only supports Margin:
<img width="279" alt="Screen Shot 2021-05-11 at 12 53 50 PM" src="https://user-images.githubusercontent.com/63313398/117881906-a16edf80-b25e-11eb-9bd5-c0a4d5c5648a.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
