### PR TITLE
Generate an entry for the minified file and another for the unminifie…

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -127,7 +127,7 @@ function gutenberg_override_translation_file( $file, $handle ) {
 	}
 
 	// Ignore scripts that are not found in the expected `build/` location.
-	$script_path = gutenberg_dir_path() . 'build/' . substr( $handle, 3 ) . '/index.js';
+	$script_path = gutenberg_dir_path() . 'build/' . substr( $handle, 3 ) . '/index.min.js';
 	if ( ! file_exists( $script_path ) ) {
 		return $file;
 	}
@@ -237,7 +237,7 @@ function gutenberg_register_packages_scripts( $scripts ) {
 	// else (for development or test) default to use the current time.
 	$default_version = defined( 'GUTENBERG_VERSION' ) && ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? GUTENBERG_VERSION : time();
 
-	foreach ( glob( gutenberg_dir_path() . 'build/*/index.js' ) as $path ) {
+	foreach ( glob( gutenberg_dir_path() . 'build/*/index.min.js' ) as $path ) {
 		// Prefix `wp-` to package directory to get script handle.
 		// For example, `…/build/a11y/index.js` becomes `wp-a11y`.
 		$handle = 'wp-' . basename( dirname( $path ) );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,16 +146,17 @@ module.exports = {
 			const isMinified = name.indexOf( '.min' ) !== -1;
 
 			const dirName = isMinified ? name.split( '.' )[ 0 ] : name;
+			const ext = isMinified ? '.min.js' : '.js';
 
 			/*
 			 * If the file being built is a Core Block's frontend file,
 			 * we build it in the block's directory.
 			 */
 			if ( rawRequest && rawRequest.includes( '/frontend.js' ) ) {
-				return `./build/block-library/blocks/${ dirName }/${ name }.js`;
+				return `./build/block-library/blocks/${ dirName }/frontend${ ext }`;
 			}
 
-			return `./build/${ dirName }/${ name }.js`;
+			return `./build/${ dirName }/index${ ext }`;
 		},
 		path: __dirname,
 		library: [ 'wp', '[camelName]' ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,6 +92,7 @@ const createEntrypoints = () => {
 
 		return {
 			...entries,
+			[ blockName + '.min' ]: scriptPath,
 			[ blockName ]: scriptPath,
 		};
 	}, {} );
@@ -99,6 +100,7 @@ const createEntrypoints = () => {
 	const packageEntries = gutenbergPackages.reduce( ( memo, packageName ) => {
 		return {
 			...memo,
+			[ packageName + '.min' ]: `./packages/${ packageName }`,
 			[ packageName ]: `./packages/${ packageName }`,
 		};
 	}, {} );
@@ -113,6 +115,7 @@ module.exports = {
 			mode === 'production' && ! process.env.WP_BUNDLE_ANALYZER,
 		minimizer: [
 			new TerserPlugin( {
+				test: /\.min\.js$/,
 				cache: true,
 				parallel: true,
 				sourceMap: mode !== 'production',
@@ -139,16 +142,20 @@ module.exports = {
 			const { chunk } = data;
 			const { entryModule } = chunk;
 			const { rawRequest } = entryModule;
+			const { name } = chunk;
+			const isMinified = name.indexOf( '.min' ) !== -1;
+
+			const dirName = isMinified ? name.split( '.' )[ 0 ] : name;
 
 			/*
 			 * If the file being built is a Core Block's frontend file,
 			 * we build it in the block's directory.
 			 */
 			if ( rawRequest && rawRequest.includes( '/frontend.js' ) ) {
-				return `./build/block-library/blocks/[name]/frontend.js`;
+				return `./build/block-library/blocks/${ dirName }/${ name }.js`;
 			}
 
-			return './build/[name]/index.js';
+			return `./build/${ dirName }/${ name }.js`;
 		},
 		path: __dirname,
 		library: [ 'wp', '[camelName]' ],


### PR DESCRIPTION
## Description

Attempts to solve https://github.com/WordPress/gutenberg/issues/23960.

* Generate an entry for the minified file and another for the unminified version for each entry-point;
* Add heuristic in the filename block to generate the min.js file in the same directory as the unminified one;
* Configure the `TerserPlugin` to only apply to files that match `.min.js`.


## How has this been tested?

- [x] Run `npm run build` and verify that for each of the generated packages, there's a `<name>/index.js` that is NOT minified and `<name>/index.min.js` that is minified (if it's a block, check that the same applies for the `frontend.[min].js` script).
- [ ] Verify that the Gutenberg plugin is working correctly and that these changes do not break it in some unexpected way. The minified files should load by default.
- [ ] Look into adding support for WordPress' `SCRIPT_DEBUG` constant. When it's `true`, the unminified version of the script should be loaded, instead.

## Outstanding questions
- Due to the way it works by duplicating the entry-points, this will generate an assets PHP file for the minified file (i.e `index.min.asset.php`. I don't know yet if that's desirable/needed.

## Screenshots <!-- if applicable -->

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
