### PR TITLE
Add additional text formatting options to the site title block

### DIFF
--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -31,7 +31,6 @@
 		"__experimentalFontFamily": true,
 		"__experimentalTextTransform": true,
 		"__experimentalFontStyle": true,
-		"__experimentalFontWeight": true,
-		"__experimentalTextDecoration": true
+		"__experimentalFontWeight": true
 	}
 }

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -29,6 +29,9 @@
 		"fontSize": true,
 		"lineHeight": true,
 		"__experimentalFontFamily": true,
-		"__experimentalTextTransform": true
+		"__experimentalTextTransform": true,
+		"__experimentalFontStyle": true,
+		"__experimentalFontWeight": true,
+		"__experimentalTextDecoration": true
 	}
 }

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -26,7 +26,7 @@ export default function SiteTitleEdit( {
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { level, textAlign, style: { typography } = {} } = attributes;
+	const { level, textAlign } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const blockProps = useBlockProps( {
@@ -34,13 +34,6 @@ export default function SiteTitleEdit( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
-
-	// Text decoration is not applied to a nested inline block so need to pass this down to
-	// richtext child element.
-	const textDecoration = typography?.textDecoration
-		? typography?.textDecoration
-		: undefined;
-
 	return (
 		<>
 			<BlockControls group="block">
@@ -60,10 +53,7 @@ export default function SiteTitleEdit( {
 			<TagName { ...blockProps }>
 				<RichText
 					tagName="a"
-					style={ {
-						display: 'inline-block',
-						textDecoration,
-					} }
+					style={ { display: 'inline-block' } }
 					aria-label={ __( 'Site title text' ) }
 					placeholder={ __( 'Write site title…' ) }
 					value={ title }

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -26,7 +26,7 @@ export default function SiteTitleEdit( {
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { level, textAlign } = attributes;
+	const { level, textAlign, style: { typography } = {} } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const blockProps = useBlockProps( {
@@ -34,6 +34,13 @@ export default function SiteTitleEdit( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
+
+	// Text decoration is not applied to a nested inline block so need to pass this down to
+	// richtext child element.
+	const textDecoration = typography?.textDecoration
+		? typography?.textDecoration
+		: undefined;
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -53,7 +60,10 @@ export default function SiteTitleEdit( {
 			<TagName { ...blockProps }>
 				<RichText
 					tagName="a"
-					style={ { display: 'inline-block' } }
+					style={ {
+						display: 'inline-block',
+						textDecoration,
+					} }
 					aria-label={ __( 'Site title text' ) }
 					placeholder={ __( 'Write site title…' ) }
 					value={ title }


### PR DESCRIPTION
## Description
Partly fixes #27830 There is currently no way to add inline html to the site title block due to the fact that the site title can only be saved as a plan string, and is used in multiple places, eg. browser tab titles.

Adding additional text formatting block supports at least gives additional control of the formatting of the complete string.

## To Test

- Check out this PR to local test env
- Add a `Site title` block
- Check that Typography Appearance option now appears in the right settings panel and the various style combinations can be applied
- Check that any styles applied also show in the frontend

## Screenshots 

Before:
<img width="895" alt="Screen Shot 2021-05-12 at 5 13 29 PM" src="https://user-images.githubusercontent.com/3629020/117921872-993d9f80-b345-11eb-9c82-7f4cd93231ce.png">

After:
<img width="833" alt="Screen Shot 2021-05-13 at 10 41 03 AM" src="https://user-images.githubusercontent.com/3629020/118052951-c20e7500-b3d7-11eb-835a-a5dc6ab3da9e.png">


