### PR TITLE
Navigation Editor: Clear 'stub' navigation post edits on save

### DIFF
--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -20,6 +20,7 @@ import {
 	select,
 	apiFetch,
 } from './controls';
+import { NAVIGATION_POST_KIND, NAVIGATION_POST_POST_TYPE } from '../constants';
 import {
 	menuItemsQuery,
 	serializeProcessing,
@@ -135,6 +136,16 @@ export const saveNavigationPost = serializeProcessing( function* ( post ) {
 		if ( ! batchSaveResponse.success ) {
 			throw new Error( batchSaveResponse.data.message );
 		}
+
+		// Clear "stub" navigation post edits to avoid a false "dirty" state.
+		yield dispatch(
+			'core',
+			'receiveEntityRecords',
+			NAVIGATION_POST_KIND,
+			NAVIGATION_POST_POST_TYPE,
+			[ post ],
+			undefined
+		);
 
 		yield dispatch(
 			noticesStore,

--- a/packages/edit-navigation/src/store/test/actions.js
+++ b/packages/edit-navigation/src/store/test/actions.js
@@ -20,6 +20,10 @@ import {
 	apiFetch,
 } from '../controls';
 import { menuItemsQuery, computeCustomizedAttribute } from '../utils';
+import {
+	NAVIGATION_POST_KIND,
+	NAVIGATION_POST_POST_TYPE,
+} from '../../constants';
 
 jest.mock( '../utils', () => {
 	const utils = jest.requireActual( '../utils' );
@@ -358,6 +362,17 @@ describe( 'saveNavigationPost', () => {
 		);
 
 		expect( action.next( { success: true } ).value ).toEqual(
+			dispatch(
+				'core',
+				'receiveEntityRecords',
+				NAVIGATION_POST_KIND,
+				NAVIGATION_POST_POST_TYPE,
+				[ post ],
+				undefined
+			)
+		);
+
+		expect( action.next().value ).toEqual(
 			dispatch(
 				noticesStore,
 				'createSuccessNotice',


### PR DESCRIPTION
## Description
The Navigation Editor uses the 'stub' post entity on runtime to provide a convenient way of editing navigation items using a regular post editor.

While this works as expected. We can't save this runtime entity using the regular `saveEntityRecord` action when saving the menu, and the state stays "dirty." Latter causes an issue when we want to warn users about unsaved changes (#31197).

This PR tries to solve the issue by clearing navigation post edits when a menu is successfully saved.

## How has this been tested?
1. Got to the experimental navigation screen.
2. Edit or add menu items.
3. This should enable the "Save" button.
4. Saving changes should disable the "Save" button again.

Make sure store unit tests are passing:
```
npm run test-unit -- packages/edit-navigation/src/store/test
```

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/240569/117926994-a5583b80-b30a-11eb-9f7b-6e70548a18db.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
