### PR TITLE
Allow more complex contentWidth & wideWidth values

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -56,15 +56,19 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$all_max_width_value  = $content_size ? $content_size : $wide_size;
 	$wide_max_width_value = $wide_size ? $wide_size : $content_size;
 
+	// Make sure we only have a single CSS rule and strip all tags for security.
+	$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
+	$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
+
 	$style = '';
 	if ( $content_size || $wide_size ) {
 		$style  = ".wp-container-$id > * {";
-		$style .= 'max-width: ' . esc_html( wp_strip_all_tags( $all_max_width_value ) ) . ';';
+		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 		$style .= 'margin-left: auto !important;';
 		$style .= 'margin-right: auto !important;';
 		$style .= '}';
 
-		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( wp_strip_all_tags( $wide_max_width_value ) ) . ';}';
+		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
 
 		$style .= ".wp-container-$id .alignfull { max-width: none; }";
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -56,7 +56,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$all_max_width_value  = $content_size ? $content_size : $wide_size;
 	$wide_max_width_value = $wide_size ? $wide_size : $content_size;
 
-	// Make sure we only have a single CSS rule and strip all tags for security.
+	// Make sure there is a single CSS rule, and all tags are stripped for security.
+	// TODO: Use `safecss_filter_attr` instead - once https://core.trac.wordpress.org/ticket/46197 is patched.
 	$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
 	$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -59,12 +59,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$style = '';
 	if ( $content_size || $wide_size ) {
 		$style  = ".wp-container-$id > * {";
-		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
+		$style .= 'max-width: ' . esc_html( wp_strip_all_tags( $all_max_width_value ) ) . ';';
 		$style .= 'margin-left: auto !important;';
 		$style .= 'margin-right: auto !important;';
 		$style .= '}';
 
-		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
+		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( wp_strip_all_tags( $wide_max_width_value ) ) . ';}';
 
 		$style .= ".wp-container-$id .alignfull { max-width: none; }";
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -53,46 +53,24 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$content_size = isset( $used_layout['contentSize'] ) ? $used_layout['contentSize'] : null;
 	$wide_size    = isset( $used_layout['wideSize'] ) ? $used_layout['wideSize'] : null;
 
-	$all_max_width_value       = $content_size ? $content_size : $wide_size;
-	$all_max_width_declaration = "max-width: $all_max_width_value";
-
-	$wide_max_width_value       = $wide_size ? $wide_size : $content_size;
-	$wide_max_width_declaration = "max-width: $wide_max_width_value";
+	$all_max_width_value  = $content_size ? $content_size : $wide_size;
+	$wide_max_width_value = $wide_size ? $wide_size : $content_size;
 
 	$style = '';
 	if ( $content_size || $wide_size ) {
-		ob_start();
-		?>
-			<?php echo '.wp-container-' . $id; ?> > * {
-				<?php echo esc_html( safecss_filter_attr( $all_max_width_declaration ) ); ?>;
-				margin-left: auto !important;
-				margin-right: auto !important;
-			}
+		$style  = ".wp-container-$id > * {";
+		$style .= "max-width: $all_max_width_value;";
+		$style .= 'margin-left: auto !important;';
+		$style .= 'margin-right: auto !important;';
+		$style .= '}';
 
-			<?php echo '.wp-container-' . $id; ?> > .alignwide {
-				<?php echo esc_html( safecss_filter_attr( $wide_max_width_declaration ) ); ?>;
-			}
+		$style .= ".wp-container-$id > .alignwide { max-width: $wide_max_width_value; }";
 
-			<?php echo '.wp-container-' . $id; ?> .alignfull {
-				max-width: none;
-			}
-		<?php
-		$style = ob_get_clean();
+		$style .= ".wp-container-$id .alignfull { max-width: none; }";
 	}
 
-	ob_start();
-	?>
-		<?php echo '.wp-container-' . $id; ?> .alignleft {
-			float: left;
-			margin-right: 2em;
-		}
-
-		<?php echo '.wp-container-' . $id; ?> .alignright {
-			float: right;
-			margin-left: 2em;
-		}
-	<?php
-	$style .= ob_get_clean();
+	$style .= ".wp-container-$id .alignleft { float: left; margin-right: 2em; }";
+	$style .= ".wp-container-$id .alignright { float: right; margin-left: 2em; }";
 
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -59,12 +59,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$style = '';
 	if ( $content_size || $wide_size ) {
 		$style  = ".wp-container-$id > * {";
-		$style .= "max-width: $all_max_width_value;";
+		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 		$style .= 'margin-left: auto !important;';
 		$style .= 'margin-right: auto !important;';
 		$style .= '}';
 
-		$style .= ".wp-container-$id > .alignwide { max-width: $wide_max_width_value; }";
+		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
 
 		$style .= ".wp-container-$id .alignfull { max-width: none; }";
 	}


### PR DESCRIPTION
## Description

`contentWidth` and `wideWidth` will not always be as simple as `800px` or `70em`. In some cases, more complex values are used to accomplish different results. In the [Q theme](https://github.com/aristath/q) for example, I'm using adaptive/responsive typography and the content-width adapts to the values of that.
So in the `theme.json` file I have this:

```json
{
	"settings": {
		"layout": {
			"contentSize": "calc((var(--wp--custom--typo--root-size) * 1px + var(--wp--custom--typo--adaptive-ratio) * 1vw) * var(--wp--custom--typo--line-width) / 2)",
			"wideSize": "calc(1.5 * (var(--wp--custom--typo--root-size) * 1px + var(--wp--custom--typo--adaptive-ratio) * 1vw) * var(--wp--custom--typo--line-width) / 2)"
		},
		"custom": {
			"typo": {
				"rootSize": 16,
				"adaptiveRatio": 0.8,
				"scale": 1.333,
				"lineHeight": 1.55,
				"lineWidth": 74
			}
		}
	}
}
```

Now, if with these settings I add a group and set it to inherit the default layout, then this is the CSS that gets added on the frontend:
```css
.wp-container-609b87bce1965 > * {
	;
	margin-left: auto !important;
	margin-right: auto !important;
}
.wp-container-609b87bce1965 > .alignwide {
	;
}
...
```
so, the `max-width` definitions are missing.

This PR fixes the issue by removing the `safecss_filter_attr` call which can't handle values including complex `calc()`. 
In the process of doing that, the PR also simplifies the implementation a bit by setting the `$style` PHP var instead of using an output buffer.

## How has this been tested?

Tested with the TT1-blocks & Q themes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
