### PR TITLE
BoxControl: Fix tooltip display for unlinked box control inputs

### DIFF
--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -94,7 +94,7 @@ export default function BoxInputControls( {
 						onFocus={ createHandleOnFocus( side ) }
 						onHoverOn={ createHandleOnHoverOn( side ) }
 						onHoverOff={ createHandleOnHoverOff( side ) }
-						label={ LABELS.top }
+						label={ LABELS[ side ] }
 						key={ `box-control-${ side }` }
 					/>
 				) ) }


### PR DESCRIPTION
## Description
Fixes incorrect tooltips for the unlinked inputs of the BoxControl.

## How has this been tested?
Manually.

1. Create a post, add a group block and select it
2. In the sidebar, find the Spacing panel and the padding's box control
3. Unlink it and hover over each field ensuring the correct tooltip.

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![BoxControlLabels](https://user-images.githubusercontent.com/60436221/117942417-5fbd6200-b34e-11eb-86f5-d528622a97ca.gif) | ![BoxControlLabels-Fixed](https://user-images.githubusercontent.com/60436221/117942433-651aac80-b34e-11eb-9fb5-6c6a471d2fe6.gif) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
