### PR TITLE
DatePicker: Fix crash when navigating between months

### DIFF
--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -82,7 +82,7 @@ class DatePicker extends Component {
 	}
 
 	onMonthPreviewedHandler( newMonthDate ) {
-		this.props?.onMonthPreviewed( newMonthDate.toISOString() );
+		this.props.onMonthPreviewed?.( newMonthDate.toISOString() );
 		this.keepFocusInside();
 	}
 

--- a/packages/components/src/date-time/stories/date.js
+++ b/packages/components/src/date-time/stories/date.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import DatePicker from '../date';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+export default { title: 'Components/DatePicker', component: DatePicker };
+
+export const _default = () => {
+	const [ date, setDate ] = useState();
+
+	return <DatePicker currentDate={ date } onChange={ setDate } />;
+};


### PR DESCRIPTION
## Description

A bug was introduced in #29716 that causes a `onMonthPreviewed is not a function` crash when the prev/next month buttons are clicked in `DatePicker` (but not `DateTimePicker`).

This PR:

- Adds a `DatePicker` story in Storybook for testing.
- Fixes the component so it doesn't call the `onMonthPreviewed` prop function if it wasn't passed.

## How has this been tested?

Both the `DatePicker` and `DateTimePicker` components in Storybook work as expected.

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
