### PR TITLE
Fixes FSE Navigation sub-menu item styling regression

### DIFF
--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -224,4 +224,5 @@ export const ItemTitleUI = styled( Text )`
 	${ () => ( isRTL() ? 'margin-left: auto;' : 'margin-right: auto;' ) }
 	font-size: 14px;
 	line-height: 20px;
+	color: inherit;
 `;


### PR DESCRIPTION
Attempts to fix the regression of the FSE Navigation sub-menu item styling as reported in #31574. 

Closes #31574.

Screenshot:
![image](https://user-images.githubusercontent.com/772137/117973747-0d1f7e00-b32d-11eb-92b1-b556a70af158.png)

Right now, it uses `inherit` as color. Not sure about the text color before this issue, but it seems to be the right color now without adding more complexity, but that might not be the correct approach. 

_My [original suggestion](https://github.com/WordPress/gutenberg/issues/31574#issuecomment-834142422) was to move back to a `span` element, but I'm not sure on plans for that `Text` component, so this might be a better solution._