### PR TITLE
Widget Screen: Fix unsaved changes notification

### DIFF
--- a/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
+++ b/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
@@ -6,6 +6,11 @@ import { useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
+ * Internal dependencies
+ */
+import { store as editWidgetsStore } from '../../store';
+
+/**
  * Warns the user if there are unsaved changes before leaving the editor.
  *
  * This is a duplicate of the component implemented in the editor package.
@@ -14,12 +19,11 @@ import { useSelect } from '@wordpress/data';
  * @return {WPComponent} The component.
  */
 export default function UnsavedChangesWarning() {
-	const getIsDirty = useSelect( ( select ) => {
-		return () => {
-			const { __experimentalGetDirtyEntityRecords } = select( 'core' );
-			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-			return dirtyEntityRecords.length > 0;
-		};
+	const isDirty = useSelect( ( select ) => {
+		const { getEditedWidgetAreas } = select( editWidgetsStore );
+		const editedWidgetAreas = getEditedWidgetAreas();
+
+		return editedWidgetAreas?.length > 0;
 	}, [] );
 
 	useEffect( () => {
@@ -31,11 +35,7 @@ export default function UnsavedChangesWarning() {
 		 * @return {?string} Warning prompt message, if unsaved changes exist.
 		 */
 		const warnIfUnsavedChanges = ( event ) => {
-			// We need to call the selector directly in the listener to avoid race
-			// conditions with `BrowserURL` where `componentDidUpdate` gets the
-			// new value of `isEditedPostDirty` before this component does,
-			// causing this component to incorrectly think a trashed post is still dirty.
-			if ( getIsDirty() ) {
+			if ( isDirty ) {
 				event.returnValue = __(
 					'You have unsaved changes. If you proceed, they will be lost.'
 				);
@@ -48,7 +48,7 @@ export default function UnsavedChangesWarning() {
 		return () => {
 			window.removeEventListener( 'beforeunload', warnIfUnsavedChanges );
 		};
-	}, [ getIsDirty ] );
+	}, [ isDirty ] );
 
 	return null;
 }


### PR DESCRIPTION
## Description
Updates the `UnsavedChangesWarning` component to use the same selector that the `SaveButton` component uses for detecting unsaved changes.

Fixes #26468.

P.S. Also removes direct selector call, since `BrowserURL` component isn't used on this screen.

## How has this been tested?
1. Go to Appearance → Widgets.
2. Modify widgets
3. Save changes and make sure the "Update" button is disabled.
4. Reloading page shouldn't display unsaved changes warning.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
