### PR TITLE
[RNMobile] Disable mentions when editing menu is disabled

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -969,9 +969,13 @@ export class RichText extends Component {
 					onFocus={ this.onFocus }
 					onBlur={ this.onBlur }
 					onKeyDown={ this.onKeyDown }
-					triggerKeyCodes={ this.suggestionOptions().map(
-						( op ) => op.triggerChar
-					) }
+					triggerKeyCodes={
+						disableEditingMenu
+							? []
+							: this.suggestionOptions().map(
+									( op ) => op.triggerChar
+							  )
+					}
 					onPaste={ this.onPaste }
 					activeFormats={ this.getActiveFormatNames( record ) }
 					onContentSizeChange={ this.onContentSizeChange }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is addressing https://github.com/wordpress-mobile/gutenberg-mobile/issues/3486, which notes that inserting mentions in the title of a post results in duplicate text. In fact, it should not even be possible to insert mentions in the title. This issue [was fixed earlier](https://github.com/WordPress/gutenberg/pull/22119/commits/8a825c311aff101796062487c4628a7727d07d7e), but someone (that would be me) did [a refactor](https://github.com/WordPress/gutenberg/pull/26211/commits/056125ff694b1a57586fbc7c8b04bb55987ba254) that unintentionally removed the fix. This PR adds the fix back in.

gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3492

## How has this been tested?

### Title component
1. Select the title component
2. Attempt to insert a mention with the `@` character after a space (or at the beginning of the block)
3. Observe a mention is NOT inserted
4. Attempt to insert a post with the `+` character after a space (or at the beginning of the block)
5. Observe a xpost is NOT inserted
6. Observe that there is no toolbar button for xpost or mentions

### Other RichText components
1. Select another RichText based component (i.e., paragraph, heading, caption, preformatted, etc.)
2. Attempt to insert a mention with the `@` character after a space (or at the beginning of the block)
3. Observe a mention IS inserted
4. Attempt to insert a post with the `+` character after a space (or at the beginning of the block)
5. Observe a xpost IS inserted
6. Observe that there is no toolbar button for xpost or mentions

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
