### PR TITLE
Improve parsing and retrieve additional data in REST url-details endpoint

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -116,14 +116,15 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			$this->set_cache( $cache_key, $remote_url_response );
 		}
 
-		$html_head = $this->get_document_head( $remote_url_response );
+		$html_head     = $this->get_document_head( $remote_url_response );
+		$meta_elements = $this->get_meta_with_content_elements( $html_head );
 
 		$data = $this->add_additional_fields_to_object(
 			array(
 				'title'       => $this->get_title( $html_head ),
 				'icon'        => $this->get_icon( $html_head, $url ),
-				'description' => $this->get_description( $html_head ),
-				'image'       => $this->get_image( $html_head, $url ),
+				'description' => $this->get_description( $meta_elements ),
+				'image'       => $this->get_image( $meta_elements, $url ),
 			),
 			$request
 		);
@@ -260,34 +261,31 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Parses the meta description from the provided HTML.
 	 *
-	 * @param string $html the HTML from the remote website at URL.
-	 * @return string the meta description contents (maybe empty).
+	 * @param array $meta_elements {
+	 *     A multi-dimensional indexed array on success, or empty array.
+	 *
+	 *     @type string[] 0 Meta elements with a content attribute.
+	 *     @type string[] 1 Content attribute's opening quotation mark.
+	 *     @type string[] 2 Content attribute's value for each meta element.
+	 * }
+	 * @return string The meta description contents on success, else empty string.
 	 */
-	private function get_description( $html ) {
-		$description = '';
-
-		$temp = tmpfile();
-
-		if ( ! $temp ) {
-			fclose( $temp ); // clean up tmp file.
-			return $description;
+	private function get_description( $meta_elements ) {
+		// Bail out if there are no meta elements.
+		if ( empty( $meta_elements[0] ) ) {
+			return '';
 		}
 
-		$path = stream_get_meta_data( $temp )['uri'];
+		$description = $this->get_metadata_from_meta_element( $meta_elements, 'name', '\bdescription\b' );
 
-		// Write HTML.
-		fwrite( $temp, $html );
-
-		$meta = get_meta_tags( $path );
-
-		if ( empty( $meta ) ) {
-			fclose( $temp ); // clean up tmp file.
-			return $description;
+		// Bail out if description not found.
+		if ( '' === $description ) {
+			return '';
 		}
 
-		$description = ! empty( $meta['description'] ) ? $meta['description'] : '';
+		// Convert any entities to HTML for use downstream.
+		$description = html_entity_decode( $description, ENT_QUOTES, get_bloginfo( 'charset' ) );
 
-		fclose( $temp ); // clean up tmp file.
 		return $description;
 	}
 
@@ -296,21 +294,28 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 *
 	 * See: https://ogp.me/.
 	 *
-	 * @param string $html the HTML from the remote website at URL.
-	 * @param string $url the target website URL.
-	 * @return string the OG image (maybe empty).
+	 * @param array  $meta_elements {
+	 *     A multi-dimensional indexed array on success, or empty array.
+	 *
+	 *     @type string[] 0 Meta elements with a content attribute.
+	 *     @type string[] 1 Content attribute's opening quotation mark.
+	 *     @type string[] 2 Content attribute's value for each meta element.
+	 * }
+	 * @param string $url The target website URL.
+	 * @return string The OG image on success, or empty string.
 	 */
-	private function get_image( $html, $url ) {
-		preg_match( '|<meta.*?property="og:image[:url]*?".*?content="(.*?)".*?\/?>|is', $html, $matches );
+	private function get_image( $meta_elements, $url ) {
+		$image = $this->get_metadata_from_meta_element( $meta_elements, 'property', '(?:og:image|og:image:url)' );
 
-		$image = isset( $matches[1] ) && is_string( $matches[1] ) ? trim( $matches[1] ) : '';
+		// Bail out if image not found.
+		if ( '' === $image ) {
+			return '';
+		}
 
 		// Attempt to convert relative URLs to absolute.
-		if ( ! empty( $image ) ) {
-			$parsed_url = parse_url( $url );
-			$root_url   = $parsed_url['scheme'] . '://' . $parsed_url['host'] . '/';
-			$image      = \WP_Http::make_absolute_url( $image, $root_url );
-		}
+		$parsed_url = parse_url( $url );
+		$root_url   = $parsed_url['scheme'] . '://' . $parsed_url['host'] . '/';
+		$image      = WP_Http::make_absolute_url( $image, $root_url );
 
 		return $image;
 	}
@@ -385,22 +390,182 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Retrieves the <head> section (including opening <body> tag from an HTML string if present.
+	 * Retrieves the `<head>` section.
 	 *
-	 * @param string $html the string of HTML to return the <head> section.
-	 * @return string the <head> section (may be empty).
+	 * @param string $html The string of HTML to parse.
+	 * @return string The `<head>..</head>` section on succes, or original HTML.
 	 */
 	private function get_document_head( $html ) {
-		preg_match( '|([\s\S]*)</head>|is', $html, $head_matches );
+		$head_html = $html;
 
-		$doc_head = isset( $head_matches[1] ) && is_string( $head_matches[1] ) ? trim( $head_matches[1] ) : '';
-
-		// If missing `</head>` then look for opening <body>.
-		if ( empty( $doc_head ) ) {
-			preg_match( '|([\s\S]*)<body>|is', $html, $body_matches );
-			$head = isset( $body_matches[1] ) && is_string( $body_matches[1] ) ? trim( $body_matches[1] ) : '';
+		// Find the opening `<head>` tag.
+		$head_start = strpos( $html, '<head' );
+		if ( false === $head_start ) {
+			// Didn't find it. Return the original HTML.
+			return $html;
 		}
 
-		return $doc_head;
+		// Find the closing `</head>` tag.
+		$head_end = strpos( $head_html, '</head>' );
+		if ( false === $head_end ) {
+			// Didn't find it. Find the opening `<body>` tag.
+			$head_end = strpos( $head_html, '<body' );
+
+			// Didn't find it. Return the original HTML.
+			if ( false === $head_end ) {
+				return $html;
+			}
+		}
+
+		// Extract the HTML from opening tag to the closing tag. Then add the closing tag.
+		$head_html  = substr( $head_html, $head_start, $head_end );
+		$head_html .= '</head>';
+
+		return $head_html;
+	}
+
+	/**
+	 * Gets all the <meta> elements that have a `content` attribute.
+	 *
+	 * @param string $html The string of HTML to be parsed.
+	 * @return array {
+	 *     A multi-dimensional indexed array on success, or empty array.
+	 *
+	 *     @type string[] 0 Meta elements with a content attribute.
+	 *     @type string[] 1 Content attribute's opening quotation mark.
+	 *     @type string[] 2 Content attribute's value for each meta element.
+	 * }
+	 */
+	private function get_meta_with_content_elements( $html ) {
+		/*
+		 * Parse all meta elements with a content attribute.
+		 *
+		 * Why first search for the content attribute rather than directly searching for name=description element?
+		 * tl;dr The content attribute's value will be truncated when it contains a > symbol.
+		 *
+		 * The content attribute's value (i.e. the description to get) can have HTML in it and be well-formed as
+		 * it's a string to the browser. Imagine what happens when attempting to match for the name=description
+		 * first. Hmm, if a > or /> symbol is in the content attribute's value, then it terminates the match
+		 * as the element's closing symbol. But wait, it's in the content attribute and is not the end of the
+		 * element. This is a limitation of using regex. It can't determine "wait a minute this is inside of quotation".
+		 * If this happens, what gets matched is not the entire element or all of the content.
+		 *
+		 * Why not search for the name=description and then content="(.*)"?
+		 * The attribute order could be opposite. Plus, additional attributes may exist including being between
+		 * the name and content attributes.
+		 *
+		 * Why not lookahead?
+		 * Lookahead is not constrained to stay within the element. The first <meta it finds may not include
+		 * the name or content, but rather could be from a different element downstream.
+		 */
+		$pattern = '#<meta\s' .
+
+			/*
+			 * Alows for additional attributes before the content attribute.
+			 * Searches for anything other than > symbol.
+			 */
+			'[^>]*' .
+
+			/*
+			 * Find the content attribute. When found, capture its value (.*).
+			 *
+			 * Allows for (a) single or double quotes and (b) whitespace in the value.
+			 *
+			 * Why capture the opening quotation mark, i.e. (["\']), and then backreference,
+			 * i.e \1, for the closing quotation mark?
+			 * To ensure the closing quotation mark matches the opening one. Why? Attribute values
+			 * can contain quotation marks, such as an apostrophe in the content.
+			 */
+			'content=(["\']??)(.*)\1' .
+
+			/*
+			 * Alows for additional attributes after the content attribute.
+			 * Searches for anything other than > symbol.
+			 */
+			'[^>]*' .
+
+			/*
+			 * \/?> searches for the closing > symbol, which can be in either /> or > format.
+			 * # ends the pattern.
+			 */
+			'\/?>#' .
+
+			/*
+			 * These are the options:
+			 * - i : case insensitive
+			 * - s : allows newline characters for the . match (needed for multiline elements)
+			 * - U means non-greedy matching
+			 */
+			'isU';
+
+		preg_match_all( $pattern, $html, $elements );
+
+		return $elements;
+	}
+
+	/**
+	 * Gets the metadata from a target meta element.
+	 *
+	 * @param array  $meta_elements {
+	 *     A multi-dimensional indexed array on success, or empty array.
+	 *
+	 *     @type string[] 0 Meta elements with a content attribute.
+	 *     @type string[] 1 Content attribute's opening quotation mark.
+	 *     @type string[] 2 Content attribute's value for each meta element.
+	 * }
+	 * @param string $attr Attribute that identifies the element with the target metadata.
+	 * @param string $attr_value The attribute's value that identifies the element with the target metadata.
+	 * @return string The metadata on success, or an empty string.
+	 */
+	private function get_metadata_from_meta_element( $meta_elements, $attr, $attr_value ) {
+		// Bail out if there are no meta elements.
+		if ( empty( $meta_elements[0] ) ) {
+			return '';
+		}
+
+		$metadata = '';
+		$pattern  = '#' .
+
+			/*
+			 * Target this attribute and value to find the metadata element.
+			 *
+			 * Allows for (a) no, single, double quotes and (b) whitespace in the value.
+			 *
+			 * Why capture the opening quotation mark, i.e. (["\']), and then backreference,
+			 * i.e \1, for the closing quotation mark?
+			 * To ensure the closing quotation mark matches the opening one. Why? Attribute values
+			 * can contain quotation marks, such as an apostrophe in the content.
+			 */
+			$attr . '=([\"\']??)\s*' . $attr_value . '\s*\1' .
+
+			/*
+			 * These are the options:
+			 * - i : case insensitive
+			 * - s : allows newline characters for the . match (needed for multiline elements)
+			 * - U means non-greedy matching
+			 */
+			'#isU';
+
+		// Find the metdata element.
+		foreach ( $meta_elements[0] as $index => $element ) {
+			preg_match( $pattern, $element, $match );
+
+			// This is not the metadata element. Skip it.
+			if ( empty( $match ) ) {
+				continue;
+			}
+
+			/*
+			 * Found the metadata element.
+			 * Get the metadata from its matching content array.
+			 */
+			if ( isset( $meta_elements[2][ $index ] ) && is_string( $meta_elements[2][ $index ] ) ) {
+				$metadata = trim( $meta_elements[2][ $index ] );
+			}
+
+			break;
+		}
+
+		return $metadata;
 	}
 }

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -163,6 +163,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		);
 	}
 
+
+
 	/**
 	 * Retrieves the document title from a remote URL.
 	 *
@@ -173,6 +175,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		$args = array(
 			'limit_response_size' => 150 * KB_IN_BYTES,
+			'user-agent'          => $this->get_random_user_agent(),
 		);
 
 		/**
@@ -343,5 +346,27 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$cache_expiration = apply_filters( 'rest_url_details_cache_expiration', $ttl );
 
 		return set_transient( $key, $data, $cache_expiration );
+	}
+
+	/**
+	 * Picks a random user agent string from a list of common defaults.
+	 * By default WordPress HTTP functions uses a semi-static string and
+	 * this maybe rejected by many websites.
+	 *
+	 * See: https://core.trac.wordpress.org/browser/tags/5.7.1/src/wp-includes/class-http.php#L191.
+	 *
+	 * @return string the user agent string.
+	 */
+	private function get_random_user_agent() {
+
+		$agents = array(
+			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246', // Windows 10-based PC using Edge browser.
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9', // Mac OS X-based computer using a Safari browser.
+			'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1', // Linux-based PC using a Firefox browser.
+		);
+
+		$chose = rand( 0, count( $agents ) - 1 );
+
+		return $agents[ $chose ];
 	}
 }

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -74,7 +74,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				),
 				'icon'        => array(
 					'description' => __( 'The favicon image link of the <link rel="icon"> element from the URL.', 'gutenberg' ),
-					'type'        => 'uri',
+					'type'        => 'string',
+					'format'      => 'uri',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
@@ -86,7 +87,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				),
 				'image'       => array(
 					'description' => __( 'The OG image link of the <meta property="og:image"> or <meta property="og:image:url"> element from the URL.', 'gutenberg' ),
-					'type'        => 'uri',
+					'type'        => 'string',
+					'format'      => 'uri',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -235,10 +235,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		// Attempt to convert relative URLs to absolute.
 		if ( ! empty( $icon ) ) {
-			$parsed = parse_url( $icon );
-			if ( empty( $parsed['host'] ) ) {
-				$icon = $url . $icon;
-			}
+			$icon = \WP_Http::make_absolute_url( $icon, $url );
 		}
 
 		return $icon;

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -168,7 +168,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * Retrieves the document title from a remote URL.
 	 *
 	 * @param string $url The website url whose HTML we want to access.
-	 * @return array|WP_Error the HTTP response from the remote URL, or an error.
+	 * @return string|WP_Error The HTTP response from the remote URL, or an error.
 	 */
 	private function get_remote_url( $url ) {
 		$args = array(

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -121,6 +121,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				'title'       => $this->get_title( $remote_url_response ),
 				'icon'        => $this->get_icon( $remote_url_response ),
 				'description' => $this->get_description( $remote_url_response ),
+				'image'       => $this->get_image( $remote_url_response ),
 			),
 			$request
 		);
@@ -212,30 +213,30 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	private function get_title( $html ) {
 		preg_match( '|<\s*title[^>]*>(.*?)<\s*/\s*title>|is', $html, $match_title );
 
-		$title = isset( $match_title[1] ) ? trim( $match_title[1] ) : '';
+		$title = isset( $match_title[1] ) && is_string( $match_title[1] ) ? trim( $match_title[1] ) : '';
 
 		return $title;
 	}
 
 	/**
-	 * Parses the <title> contents from the provided HTML
+	 * Parses the site icon from the provided HTML
 	 *
 	 * @param string $html the HTML from the remote website at URL.
-	 * @return string the title tag contents (maybe empty).
+	 * @return string the icon URI (maybe empty).
 	 */
 	private function get_icon( $html ) {
 		preg_match( '/<link.*href="(.*\.ico).*".*\/>/i', $html, $matches );
 
-		$icon = isset( $matches[1] ) ? trim( $matches[1] ) : '';
+		$icon = isset( $matches[1] ) && is_string( $matches[1] ) ? trim( $matches[1] ) : '';
 
 		return $icon;
 	}
 
 	/**
-	 * Parses the meta description from the provide HTML.
+	 * Parses the meta description from the provided HTML.
 	 *
 	 * @param string $html the HTML from the remote website at URL.
-	 * @return string the title tag contents (maybe empty).
+	 * @return string the meta description contents (maybe empty).
 	 */
 	private function get_description( $html ) {
 		$description = '';
@@ -263,6 +264,20 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		fclose( $temp ); // clean up tmp file
 		return $description;
+	}
+
+	/**
+	 * Parses the Open Graph Image from the provided HTML.
+	 *
+	 * @param string $html the HTML from the remote website at URL.
+	 * @return string the OG image (maybe empty).
+	 */
+	private function get_image( $html ) {
+		preg_match( '|<meta.*?property="og:image.*?".*?content="(.*?)".*?\/?>|is', $html, $matches );
+
+		$image = isset( $matches[1] ) && is_string( $matches[1] ) ? trim( $matches[1] ) : '';
+
+		return $image;
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -118,8 +118,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		$data = $this->add_additional_fields_to_object(
 			array(
-				'title' => $this->get_title( $remote_url_response ),
-				'icon'  => $this->get_icon( $remote_url_response ),
+				'title'       => $this->get_title( $remote_url_response ),
+				'icon'        => $this->get_icon( $remote_url_response ),
+				'description' => $this->get_description( $remote_url_response ),
 			),
 			$request
 		);
@@ -228,6 +229,39 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$icon = isset( $matches[1] ) ? trim( $matches[1] ) : '';
 
 		return $icon;
+	}
+
+	/**
+	 * Parses the meta description from the provide HTML.
+	 *
+	 * @param string $html the HTML from the remote website at URL.
+	 * @return string the title tag contents (maybe empty).
+	 */
+	private function get_description( $html ) {
+		$description = '';
+
+		$temp = tmpfile();
+
+		if ( ! $temp ) {
+			return $description;
+		}
+
+		$path = stream_get_meta_data( $temp )['uri'];
+
+		// Write HTML
+		fwrite( $temp, $html );
+
+		$meta = get_meta_tags( $path );
+
+		if ( empty( $meta ) ) {
+			return $description;
+		}
+
+		fclose( $temp ); // clean up tmp file
+
+		$description = ! empty( $meta['description'] ) ? $meta['description'] : '';
+
+		return $description;
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -225,7 +225,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return string the icon URI (maybe empty).
 	 */
 	private function get_icon( $html ) {
-		preg_match( '/<link.*href="(.*\.ico).*".*\/>/i', $html, $matches );
+		preg_match( '|<link.*?rel="\s*[shortcut]+(?:\s+[icon]+)*\s*".*?href="(.*?)".*?\/?>|is', $html, $matches );
 
 		$icon = isset( $matches[1] ) && is_string( $matches[1] ) ? trim( $matches[1] ) : '';
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -239,7 +239,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		// Attempt to convert relative URLs to absolute.
 		if ( ! empty( $icon ) ) {
-			$icon = \WP_Http::make_absolute_url( $icon, $url );
+			$parsed_url = parse_url( $url );
+			$root_url   = $parsed_url['scheme'] . '://' . $parsed_url['host'] . '/';
+			$icon = \WP_Http::make_absolute_url( $icon, $root_url );
 		}
 
 		return $icon;
@@ -295,7 +297,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		// Attempt to convert relative URLs to absolute.
 		if ( ! empty( $image ) ) {
-			$image = \WP_Http::make_absolute_url( $image, $url );
+			$parsed_url = parse_url( $url );
+			$root_url   = $parsed_url['scheme'] . '://' . $parsed_url['host'] . '/';
+			$image      = \WP_Http::make_absolute_url( $image, $root_url );
 		}
 
 		return $image;

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -244,25 +244,25 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$temp = tmpfile();
 
 		if ( ! $temp ) {
-			fclose( $temp ); // clean up tmp file.
+			fclose( $temp ); // clean up tmp file
 			return $description;
 		}
 
 		$path = stream_get_meta_data( $temp )['uri'];
 
-		// Write HTML.
+		// Write HTML
 		fwrite( $temp, $html );
 
 		$meta = get_meta_tags( $path );
 
 		if ( empty( $meta ) ) {
-			fclose( $temp ); // clean up tmp file.
+			fclose( $temp ); // clean up tmp file
 			return $description;
 		}
 
 		$description = ! empty( $meta['description'] ) ? $meta['description'] : '';
 
-		fclose( $temp ); // clean up tmp file.
+		fclose( $temp ); // clean up tmp file
 		return $description;
 	}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -118,9 +118,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		$data = $this->add_additional_fields_to_object(
 			array(
-				'title'       => $this->get_title( $remote_url_response, $url ),
+				'title'       => $this->get_title( $remote_url_response ),
 				'icon'        => $this->get_icon( $remote_url_response, $url ),
-				'description' => $this->get_description( $remote_url_response, $url ),
+				'description' => $this->get_description( $remote_url_response ),
 				'image'       => $this->get_image( $remote_url_response, $url ),
 			),
 			$request

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -374,27 +374,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Picks a random user agent string from a list of common defaults.
-	 * By default WordPress HTTP functions uses a semi-static string and
-	 * this maybe rejected by many websites.
-	 *
-	 * See: https://core.trac.wordpress.org/browser/tags/5.7.1/src/wp-includes/class-http.php#L191.
-	 *
-	 * @return string the user agent string.
-	 */
-	private function get_random_user_agent() {
-		$agents = array(
-			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246', // Windows 10-based PC using Edge browser.
-			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9', // Mac OS X-based computer using a Safari browser.
-			'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1', // Linux-based PC using a Firefox browser.
-		);
-
-		$chose = rand( 0, count( $agents ) - 1 );
-
-		return $agents[ $chose ];
-	}
-
-	/**
 	 * Retrieves the `<head>` section.
 	 *
 	 * @param string $html The string of HTML to parse.

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -173,7 +173,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	private function get_remote_url( $url ) {
 		$args = array(
 			'limit_response_size' => 150 * KB_IN_BYTES,
-			'user-agent'          => $this->get_random_user_agent(),
 		);
 
 		/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -119,6 +119,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$data = $this->add_additional_fields_to_object(
 			array(
 				'title' => $this->get_title( $remote_url_response ),
+				'icon'  => $this->get_icon( $remote_url_response ),
 			),
 			$request
 		);
@@ -213,6 +214,20 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$title = isset( $match_title[1] ) ? trim( $match_title[1] ) : '';
 
 		return $title;
+	}
+
+	/**
+	 * Parses the <title> contents from the provided HTML
+	 *
+	 * @param string $html the HTML from the remote website at URL.
+	 * @return string the title tag contents (maybe empty).
+	 */
+	private function get_icon( $html ) {
+		preg_match( '/<link.*href="(.*\.ico).*".*\/>/i', $html, $matches );
+
+		$icon = isset( $matches[1] ) ? trim( $matches[1] ) : '';
+
+		return $icon;
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -243,6 +243,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$temp = tmpfile();
 
 		if ( ! $temp ) {
+			fclose( $temp ); // clean up tmp file
 			return $description;
 		}
 
@@ -254,13 +255,13 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$meta = get_meta_tags( $path );
 
 		if ( empty( $meta ) ) {
+			fclose( $temp ); // clean up tmp file
 			return $description;
 		}
 
-		fclose( $temp ); // clean up tmp file
-
 		$description = ! empty( $meta['description'] ) ? $meta['description'] : '';
 
+		fclose( $temp ); // clean up tmp file
 		return $description;
 	}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -116,12 +116,14 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			$this->set_cache( $cache_key, $remote_url_response );
 		}
 
+		$html_head = $this->get_document_head( $remote_url_response );
+
 		$data = $this->add_additional_fields_to_object(
 			array(
-				'title'       => $this->get_title( $remote_url_response ),
-				'icon'        => $this->get_icon( $remote_url_response, $url ),
-				'description' => $this->get_description( $remote_url_response ),
-				'image'       => $this->get_image( $remote_url_response, $url ),
+				'title'       => $this->get_title( $html_head ),
+				'icon'        => $this->get_icon( $html_head, $url ),
+				'description' => $this->get_description( $html_head ),
+				'image'       => $this->get_image( $html_head, $url ),
 			),
 			$request
 		);
@@ -139,6 +141,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		 */
 		return apply_filters( 'rest_prepare_url_details', $response, $url, $request, $remote_url_response );
 	}
+
+
 
 	/**
 	 * Checks whether a given request has permission to read remote urls.
@@ -364,5 +368,17 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$chose = rand( 0, count( $agents ) - 1 );
 
 		return $agents[ $chose ];
+	}
+
+	/**
+	 * Retrieves the <head> section (including opening <body> tag from an HTML string if present.
+	 *
+	 * @param string $html the string of HTML to return the <head> section.
+	 * @return string the <head> section (may be empty).
+	 */
+	private function get_document_head( $html ) {
+		preg_match( '|([\s\S]*)<body>|is', $html, $matches );
+		$head = isset( $matches[1] ) && is_string( $matches[1] ) ? trim( $matches[1] ) : '';
+		return $head;
 	}
 }

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -391,8 +391,16 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return string the <head> section (may be empty).
 	 */
 	private function get_document_head( $html ) {
-		preg_match( '|([\s\S]*)<body>|is', $html, $matches );
-		$head = isset( $matches[1] ) && is_string( $matches[1] ) ? trim( $matches[1] ) : '';
-		return $head;
+		preg_match( '|([\s\S]*)</head>|is', $html, $head_matches );
+
+		$doc_head = isset( $head_matches[1] ) && is_string( $head_matches[1] ) ? trim( $head_matches[1] ) : '';
+
+		// If missing `</head>` then look for opening <body>.
+		if ( empty( $doc_head ) ) {
+			preg_match( '|([\s\S]*)<body>|is', $html, $body_matches );
+			$head = isset( $body_matches[1] ) && is_string( $body_matches[1] ) ? trim( $body_matches[1] ) : '';
+		}
+
+		return $doc_head;
 	}
 }

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -281,21 +281,20 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Parses the Open Graph Image from the provided HTML.
 	 *
+	 * See: https://ogp.me/.
+	 *
 	 * @param string $html the HTML from the remote website at URL.
 	 * @param string $url the target website URL.
 	 * @return string the OG image (maybe empty).
 	 */
 	private function get_image( $html, $url ) {
-		preg_match( '|<meta.*?property="og:image.*?".*?content="(.*?)".*?\/?>|is', $html, $matches );
+		preg_match( '|<meta.*?property="og:image[:url]*?".*?content="(.*?)".*?\/?>|is', $html, $matches );
 
 		$image = isset( $matches[1] ) && is_string( $matches[1] ) ? trim( $matches[1] ) : '';
 
 		// Attempt to convert relative URLs to absolute.
 		if ( ! empty( $image ) ) {
-			$parsed = parse_url( $image );
-			if ( empty( $parsed['host'] ) ) {
-				$image = $url . $image;
-			}
+			$image = \WP_Http::make_absolute_url( $image, $url );
 		}
 
 		return $image;

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -66,8 +66,26 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			'title'      => 'url-details',
 			'type'       => 'object',
 			'properties' => array(
-				'title' => array(
-					'description' => __( 'The contents of the <title> tag from the URL.', 'gutenberg' ),
+				'title'       => array(
+					'description' => __( 'The contents of the <title> element from the URL.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'icon'        => array(
+					'description' => __( 'The favicon image link of the <link rel="icon"> element from the URL.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'description' => array(
+					'description' => __( 'The content of the <meta name="description"> element from the URL.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'image'       => array(
+					'description' => __( 'The OG image link of the <meta property="og:image"> or <meta property="og:image:url"> element from the URL.', 'gutenberg' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -247,6 +247,12 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			return '';
 		}
 
+		// If the icon is a data URL, return it.
+		$parsed_icon = parse_url( $icon );
+		if ( 'data' === $parsed_icon['scheme'] ) {
+			return $icon;
+		}
+
 		// Attempt to convert relative URLs to absolute.
 		$parsed_url = parse_url( $url );
 		$root_url   = $parsed_url['scheme'] . '://' . $parsed_url['host'] . '/';

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -210,7 +210,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return string the title tag contents (maybe empty).
 	 */
 	private function get_title( $html ) {
-		preg_match( '|<title>([^<]*?)</title>|is', $html, $match_title );
+		preg_match( '|<\s*title[^>]*>(.*?)<\s*/\s*title>|is', $html, $match_title );
 
 		$title = isset( $match_title[1] ) ? trim( $match_title[1] ) : '';
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -74,7 +74,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				),
 				'icon'        => array(
 					'description' => __( 'The favicon image link of the <link rel="icon"> element from the URL.', 'gutenberg' ),
-					'type'        => 'string',
+					'type'        => 'uri',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
@@ -86,7 +86,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				),
 				'image'       => array(
 					'description' => __( 'The OG image link of the <meta property="og:image"> or <meta property="og:image:url"> element from the URL.', 'gutenberg' ),
-					'type'        => 'string',
+					'type'        => 'uri',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -244,25 +244,25 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$temp = tmpfile();
 
 		if ( ! $temp ) {
-			fclose( $temp ); // clean up tmp file
+			fclose( $temp ); // clean up tmp file.
 			return $description;
 		}
 
 		$path = stream_get_meta_data( $temp )['uri'];
 
-		// Write HTML
+		// Write HTML.
 		fwrite( $temp, $html );
 
 		$meta = get_meta_tags( $path );
 
 		if ( empty( $meta ) ) {
-			fclose( $temp ); // clean up tmp file
+			fclose( $temp ); // clean up tmp file.
 			return $description;
 		}
 
 		$description = ! empty( $meta['description'] ) ? $meta['description'] : '';
 
-		fclose( $temp ); // clean up tmp file
+		fclose( $temp ); // clean up tmp file.
 		return $description;
 	}
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -126,7 +126,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 		// Note the <title> comes from the fixture HTML returned by
 		// the filter `pre_http_request`.
-		$this->assertEquals(
+		$this->assertArraySubset(
 			array(
 				'title' => 'Example Website &mdash; - with encoded content.',
 			),
@@ -385,7 +385,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 		// Instead of the default data retrieved we expect to see the modified
 		// data we provided via the filter.
-		$this->assertEquals(
+		$this->assertArraySubset(
 			array(
 				'title'    => 'Example Website &mdash; - with encoded content.',
 				'og_title' => 'This was manually added to the data via filter',

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -567,6 +567,57 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
+	/**
+	 * @dataProvider provide_get_image_data
+	 */
+	public function test_get_image( $html, $expected_image ) {
+		$target_url = 'https://wordpress.org';
+		$controller = new WP_REST_URL_Details_Controller();
+		$method     = $this->get_reflective_method( 'get_image' );
+		$result     = $method->invoke(
+			$controller,
+			$this->wrap_html_in_doc( $html ),
+			$target_url
+		);
+		$this->assertEquals( $expected_image, $result );
+	}
+
+	public function provide_get_image_data() {
+		return array(
+			'default'                       => array(
+				'<meta property="og:image" content="https://wordpress.org/images/myimage.jpg" />',
+				'https://wordpress.org/images/myimage.jpg',
+			),
+			'no_closing_tag'                => array(
+				'<meta property="og:image" content="https://wordpress.org/images/myimage.jpg">',
+				'https://wordpress.org/images/myimage.jpg',
+			),
+			'using_url_modifier'            => array(
+				'<meta property="og:image:url" content="https://wordpress.org/images/myimage.jpg" />
+				<meta property="og:image:alt" content="Ignore this please" />',
+				'https://wordpress.org/images/myimage.jpg',
+			),
+			'should_ignore_other_modifiers' => array(
+				'<meta property="og:image:height" content="720" />
+				<meta property="og:image" content="https://wordpress.org/images/myimage.jpg" />
+				<meta property="og:image:alt" content="Ignore this please" />',
+				'https://wordpress.org/images/myimage.jpg',
+			),
+			'with_query_string'             => array(
+				'<meta property="og:image" content="https://wordpress.org/images/myimage.jpg?foo=bar&bar=foo" />',
+				'https://wordpress.org/images/myimage.jpg?foo=bar&bar=foo',
+			),
+			'relative_url'                  => array(
+				'<meta property="og:image" content="/images/myimage.jpg" />',
+				'https://wordpress.org/images/myimage.jpg',
+			),
+			'relative_url_no_slash'         => array(
+				'<meta property="og:image" content="images/myimage.jpg" />',
+				'https://wordpress.org/images/myimage.jpg',
+			),
+		);
+	}
+
 
 
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -606,7 +606,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			),
 			'with data URL x-icon type'             => array(
 				'<link rel="icon" href="data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII=" type="image/x-icon" />',
-				'data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII="',
+				'data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII=',
 			),
 			'with data URL png type'                => array(
 				'<link href="data:image/png;base64,iVBORw0KGgo=" rel="icon" type="image/png" />',

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -495,11 +495,12 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	 * @dataProvider provide_get_title_data
 	 */
 	public function test_get_title( $html, $expected_title ) {
+
 		$controller = new WP_REST_URL_Details_Controller();
 		$method     = $this->get_reflective_method( 'get_title' );
 		$result     = $method->invoke(
 			$controller,
-			$html
+			$html,
 		);
 		$this->assertEquals( $expected_title, $result );
 	}
@@ -507,13 +508,62 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 	public function provide_get_title_data() {
 		return array(
-			'no_attributes' => array(
+			'no_attributes'   => array(
 				'<title>Testing the title</title>',
 				'Testing the title',
 			),
 			'with_attributes' => array(
 				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing the title</title>',
 				'Testing the title',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider provide_get_icon_data
+	 */
+	public function test_get_icon( $html, $expected_icon ) {
+		$target_url = 'https://wordpress.org';
+		$controller = new WP_REST_URL_Details_Controller();
+		$method     = $this->get_reflective_method( 'get_icon' );
+		$result     = $method->invoke(
+			$controller,
+			$html,
+			$target_url
+		);
+		$this->assertEquals( $expected_icon, $result );
+	}
+
+
+	public function provide_get_icon_data() {
+		return array(
+			'default' => array(
+				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" />',
+				'https://wordpress.org/favicon.ico',
+			),
+			'with_query_string' => array(
+				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico?somequerystring=foo&another=bar" />',
+				'https://wordpress.org/favicon.ico?somequerystring=foo&another=bar',
+			),
+			'relative_url' => array(
+				'<link rel="shortcut icon" href="/favicon.ico" />',
+				'https://wordpress.org/favicon.ico',
+			),
+			'relative_url_no_slash' => array(
+				'<link rel="shortcut icon" href="favicon.ico" />',
+				'https://wordpress.org/favicon.ico',
+			),
+			'rel_reverse_order' => array(
+				'<link rel="icon shortcut" href="https://wordpress.org/favicon.ico" />',
+				'https://wordpress.org/favicon.ico',
+			),
+			'rel_icon_only' => array(
+				'<link rel="icon" href="https://wordpress.org/favicon.ico" />',
+				'https://wordpress.org/favicon.ico',
+			),
+			'rel_shortcut_only' => array(
+				'<link rel="icon" href="https://wordpress.org/favicon.ico" />',
+				'https://wordpress.org/favicon.ico',
 			),
 		);
 	}

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -491,6 +491,37 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
+	/**
+	 * @dataProvider provide_get_title_data
+	 */
+	public function test_get_title( $html, $expected_title ) {
+		$controller = new WP_REST_URL_Details_Controller();
+		$method     = $this->get_reflective_method( 'get_title' );
+		$result     = $method->invoke(
+			$controller,
+			$html
+		);
+		$this->assertEquals( $expected_title, $result );
+	}
+
+
+	public function provide_get_title_data() {
+		return array(
+			'no_attributes' => array(
+				'<title>Testing the title</title>',
+				'Testing the title',
+			),
+			'with_attributes' => array(
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing the title</title>',
+				'Testing the title',
+			),
+		);
+	}
+
+
+
+
+
 	public function provide_invalid_url_data() {
 		return array(
 			'empty_url'          => array(
@@ -568,5 +599,21 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			'success'     => $should_200 ? 1 : 0,
 			'body'        => 'success' === $result_type ? file_get_contents( __DIR__ . '/fixtures/example-website.html' ) : '',
 		);
+	}
+
+	/**
+	 * Get reflective access to a private/protected method on
+	 * the WP_REST_URL_Details_Controller class.
+	 *
+	 * @param string $method_name Method name for which to gain access.
+	 *
+	 * @return ReflectionMethod
+	 * @throws ReflectionException Throws an exception if method does not exist.
+	 */
+	protected function get_reflective_method( $method_name ) {
+		$class  = new ReflectionClass( WP_REST_URL_Details_Controller::class );
+		$method = $class->getMethod( $method_name );
+		$method->setAccessible( true );
+		return $method;
 	}
 }

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -494,80 +494,191 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	/**
 	 * @dataProvider provide_get_title_data
 	 */
-	public function test_get_title( $html, $expected_title ) {
-
+	public function test_get_title( $html, $expected ) {
 		$controller = new WP_REST_URL_Details_Controller();
 		$method     = $this->get_reflective_method( 'get_title' );
-		$result     = $method->invoke(
+
+		$actual = $method->invoke(
 			$controller,
-			$this->wrap_html_in_doc( $html ),
+			$this->wrap_html_in_doc( $html )
 		);
-		$this->assertEquals( $expected_title, $result );
+		$this->assertSame( $expected, $actual );
 	}
 
 
 	public function provide_get_title_data() {
 		return array(
-			'no_attributes'   => array(
-				'<title>Testing the title</title>',
-				'Testing the title',
+			'no attributes'                  => array(
+				'<title>Testing &lt;title&gt;:</title>',
+				'Testing &lt;title&gt;:',
 			),
-			'with_attributes' => array(
-				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing the title</title>',
-				'Testing the title',
+			'with attributes'                => array(
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing &lt;title&gt;:</title>',
+				'Testing &lt;title&gt;:',
+			),
+			'with text whitespace'           => array(
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">   Testing &lt;title&gt;:	</title>',
+				'Testing &lt;title&gt;:',
+			),
+			'when opening tag is malformed'  => array(
+				'< title>Testing &lt;title&gt;: when opening tag is invalid</title>',
+				'',
+			),
+			'with whitespace in opening tag' => array(
+				'<title >Testing &lt;title&gt;: with whitespace in opening tag</title>',
+				'Testing &lt;title&gt;: with whitespace in opening tag',
+			),
+			'when whitepace in closing tag'  => array(
+				'<title>Testing &lt;title&gt;: with whitespace in closing tag</ title>',
+				'Testing &lt;title&gt;: with whitespace in closing tag',
 			),
 		);
 	}
 
 	/**
-	 * @dataProvider provide_get_icon_data
+	 * @dataProvider data_get_icon
 	 */
-	public function test_get_icon( $html, $expected_icon, $target_url = 'https://wordpress.org' ) {
-
+	public function test_get_icon( $html, $expected, $target_url = 'https://wordpress.org' ) {
 		$controller = new WP_REST_URL_Details_Controller();
 		$method     = $this->get_reflective_method( 'get_icon' );
-		$result     = $method->invoke(
+
+		$actual = $method->invoke(
 			$controller,
 			$this->wrap_html_in_doc( $html ),
 			$target_url
 		);
-		$this->assertEquals( $expected_icon, $result );
+		$this->assertSame( $expected, $actual );
 	}
 
-	public function provide_get_icon_data() {
+	public function data_get_icon() {
 		return array(
-			'default'                => array(
+
+			// Happy path for default.
+			'default'                               => array(
 				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'with_query_string'      => array(
+			'default with no closing whitespace'    => array(
+				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico"/>',
+				'https://wordpress.org/favicon.ico',
+			),
+			'default without self-closing'          => array(
+				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico">',
+				'https://wordpress.org/favicon.ico',
+			),
+			'default with href first'               => array(
+				'<link href="https://wordpress.org/favicon.ico" rel="shortcut icon" />',
+				'https://wordpress.org/favicon.ico',
+			),
+			'default with type last'                => array(
+				'<link href="https://wordpress.org/favicon.png" rel="icon" type="image/png" />',
+				'https://wordpress.org/favicon.png',
+			),
+			'default with type first'               => array(
+				'<link type="image/png" href="https://wordpress.org/favicon.png" rel="icon" />',
+				'https://wordpress.org/favicon.png',
+			),
+			'default with single quotes'            => array(
+				'<link type="image/png" href=\'https://wordpress.org/favicon.png\' rel=\'icon\' />',
+				'https://wordpress.org/favicon.png',
+			),
+
+			// Happy paths.
+			'with query string'                     => array(
 				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico?somequerystring=foo&another=bar" />',
 				'https://wordpress.org/favicon.ico?somequerystring=foo&another=bar',
 			),
-			'relative_url'           => array(
+			'with another link'                     => array(
+				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" /><link rel="canonical" href="https://example.com">',
+				'https://wordpress.org/favicon.ico',
+			),
+			'relative url'                          => array(
 				'<link rel="shortcut icon" href="/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'relative_url_no_slash'  => array(
+			'relative url no slash'                 => array(
 				'<link rel="shortcut icon" href="favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'relative_url_with_path' => array(
+			'relative url with path'                => array(
 				'<link rel="shortcut icon" href="favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 				'https://wordpress.org/my/path/here/',
 			),
-			'rel_reverse_order'      => array(
+			'rel reverse order'                     => array(
 				'<link rel="icon shortcut" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'rel_icon_only'          => array(
+			'rel icon only'                         => array(
 				'<link rel="icon" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'rel_shortcut_only'      => array(
-				'<link rel="icon" href="https://wordpress.org/favicon.ico" />',
+			'rel icon only with whitespace'         => array(
+				'<link rel=" icon " href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
+			),
+			'multiline attributes'                  => array(
+				'<link
+					rel="icon"
+					href="https://wordpress.org/favicon.ico" 
+				/>',
+				'https://wordpress.org/favicon.ico',
+			),
+			'multiline attributes in reverse order' => array(
+				'<link
+					rel="icon"
+					href="https://wordpress.org/favicon.ico" 
+				/>',
+				'https://wordpress.org/favicon.ico',
+			),
+			'multiline attributes with type'        => array(
+				'<link
+					rel="icon"
+					href="https://wordpress.org/favicon.ico"
+					type="image/x-icon"
+				/>',
+				'https://wordpress.org/favicon.ico',
+			),
+			'multiline with type first'             => array(
+				'<link
+					type="image/x-icon"
+					rel="icon"
+					href="https://wordpress.org/favicon.ico"
+				/>',
+				'https://wordpress.org/favicon.ico',
+			),
+
+			// Unhappy paths.
+			'empty rel'                             => array(
+				'<link rel="" href="https://wordpress.org/favicon.ico" />',
+				'',
+			),
+			'empty href'                            => array(
+				'<link rel="icon" href="" />',
+				'',
+			),
+			'no rel'                                => array(
+				'<link href="https://wordpress.org/favicon.ico" />',
+				'',
+			),
+			'link to external stylesheet'           => array(
+				'<link rel="stylesheet" href="https://example.com/assets/style.css" />',
+				'',
+				'https://example.com',
+			),
+			'multiline with no href'                => array(
+				'<link
+					rel="icon"
+					href="" 
+				/>',
+				'',
+			),
+			'multiline with no rel'                 => array(
+				'<link
+					rel=""
+					href="https://wordpress.org/favicon.ico"
+				/>',
+				'',
 			),
 		);
 	}
@@ -711,18 +822,22 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
-	private function wrap_html_in_doc( $html ) {
+	private function wrap_html_in_doc( $html, $with_body = false ) {
 		$doc = '<!DOCTYPE html>
 				<html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
 				<head>
-					%%HEAD_CONTENT%%
-				</head>
+				<meta charset="utf-8" />' . $html . "\n" . '</head>';
+
+		if ( $with_body ) {
+			$doc .= '
 				<body>
 					<h1>Example Website</h1>
 					<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 				</body>
-				</html>';
-		return str_replace( '%%HEAD_CONTENT%%', $html, $doc );
+			</html>';
+		}
+
+		return $doc;
 	}
 
 	/**

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -129,9 +129,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertArraySubset(
 			array(
 				'title'       => 'Example Website &mdash; - with encoded content.',
-				'icon'        => '//s.w.org/favicon.ico?querystringaddedfortesting',
+				'icon'        => 'https://placeholder-site.com/favicon.ico?querystringaddedfortesting',
 				'description' => 'Example description text here. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.',
-				'image'       => 'https://s.w.org/images/home/screen-themes.png?3',
+				'image'       => 'https://placeholder-site.com/images/home/screen-themes.png?3',
 			),
 			$data
 		);

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -18,40 +18,13 @@
  */
 class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
-	/**
-	 * Admin user ID.
-	 *
-	 * @since x.x.0
-	 *
-	 * @var int $subscriber_id
-	 */
 	protected static $admin_id;
-
-	/**
-	 * Subscriber user ID.
-	 *
-	 * @since x.x.0
-	 *
-	 * @var int $subscriber_id
-	 */
 	protected static $subscriber_id;
-
-
-	protected static $route = '/__experimental/url-details';
-
-
+	protected static $route           = '/__experimental/url-details';
 	protected static $url_placeholder = 'https://placeholder-site.com';
+	protected static $request_args    = array();
 
-	protected static $request_args = array();
-
-	/**
-	 * Create fake data before our tests run.
-	 *
-	 * @since x.x.0
-	 *
-	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
-	 */
-	public static function wpSetUpBeforeClass( $factory ) {
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$admin_id      = $factory->user->create(
 			array(
 				'role' => 'administrator',
@@ -69,11 +42,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		self::delete_user( self::$subscriber_id );
 	}
 
-
-
-	/**
-	 * Setup.
-	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -81,28 +49,17 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 		// Disables usage of cache during major of tests.
 		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
-		add_filter(
-			"pre_transient_$transient_name",
-			'__return_null'
-		);
+		add_filter( "pre_transient_{$transient_name}", '__return_null' );
 	}
 
-	/**
-	 * Tear down.
-	 */
 	public function tearDown() {
 		remove_filter( 'pre_http_request', array( $this, 'mock_success_request_to_remote_url' ), 10 );
 		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
 
-		remove_filter(
-			"pre_transient_$transient_name",
-			'__return_null'
-		);
+		remove_filter( "pre_transient_{$transient_name}", '__return_null' );
 		static::$request_args = array();
 		parent::tearDown();
 	}
-
-
 
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
@@ -124,11 +81,13 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Note the data in the subset comes from the fixture HTML returned by
-		// the filter `pre_http_request` (see this class's `setUp` method).
-		$this->assertArraySubset(
+		/*
+		 * Note the data in the subset comes from the fixture HTML returned by
+		 * the filter `pre_http_request` (see this class's `setUp` method).
+		 */
+		$this->assertSame(
 			array(
-				'title'       => 'Example Website &mdash; - with encoded content.',
+				'title'       => 'Example Website — - with encoded content.',
 				'icon'        => 'https://placeholder-site.com/favicon.ico?querystringaddedfortesting',
 				'description' => 'Example description text here. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.',
 				'image'       => 'https://placeholder-site.com/images/home/screen-themes.png?3',
@@ -136,7 +95,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			$data
 		);
 	}
-
 
 	public function test_get_items_fails_for_unauthenticated_user() {
 		wp_set_current_user( 0 );
@@ -150,12 +108,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( WP_Http::UNAUTHORIZED, $response->get_status() );
+		$this->assertSame( WP_Http::UNAUTHORIZED, $response->get_status() );
 
-		$this->assertEquals(
-			'rest_cannot_view_url_details',
-			$data['code']
-		);
+		$this->assertSame( 'rest_cannot_view_url_details', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'you are not allowed to process remote urls' ),
@@ -175,12 +130,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( WP_Http::FORBIDDEN, $response->get_status() );
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_status() );
 
-		$this->assertEquals(
-			'rest_cannot_view_url_details',
-			$data['code']
-		);
+		$this->assertSame( 'rest_cannot_view_url_details', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'you are not allowed to process remote urls' ),
@@ -189,10 +141,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @dataProvider provide_invalid_url_data
+	 * @dataProvider data_invalid_url
 	 */
 	public function test_get_items_fails_for_invalid_url( $expected, $invalid_url ) {
-
 		wp_set_current_user( self::$admin_id );
 
 		$request = new WP_REST_Request( 'GET', static::$route );
@@ -204,16 +155,30 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( WP_Http::BAD_REQUEST, $response->get_status() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $response->get_status() );
 
-		$this->assertEquals(
-			'rest_invalid_param',
-			$data['code']
-		);
+		$this->assertSame( 'rest_invalid_param', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'Invalid parameter(s): url' ),
 			strtolower( $data['message'] )
+		);
+	}
+
+	public function data_invalid_url() {
+		return array(
+			'empty_url'          => array(
+				null,
+				'',
+			), // empty!
+			'not_a_string'       => array(
+				null,
+				1234456,
+			),
+			'string_but_invalid' => array(
+				null,
+				'invalid.proto://wordpress.org',
+			),
 		);
 	}
 
@@ -233,12 +198,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 404, $response->get_status() );
 
-		$this->assertEquals(
-			'no_response',
-			$data['code']
-		);
+		$this->assertSame( 'no_response', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'Not found' ),
@@ -262,12 +224,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 404, $response->get_status() );
 
-		$this->assertEquals(
-			'no_content',
-			$data['code']
-		);
+		$this->assertSame( 'no_content', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'Unable to retrieve body from response at this URL' ),
@@ -303,7 +262,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		rest_get_server()->dispatch( $request );
 
 		// Check the args were filtered as expected.
-		$this->assertArraySubset(
+		$this->assertContains(
 			array(
 				'timeout'             => 27,
 				'limit_response_size' => 153600,
@@ -318,14 +277,11 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_will_return_from_cache_if_populated() {
 		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
 
-		remove_filter(
-			"pre_transient_$transient_name",
-			'__return_null'
-		);
+		remove_filter( "pre_transient_{$transient_name}", '__return_null' );
 
 		// Force cache to return a known value as the remote URL http response body.
 		add_filter(
-			"pre_transient_$transient_name",
+			"pre_transient_{$transient_name}",
 			function() {
 				return '<html><head><title>This value from cache.</title></head><body></body></html>';
 			}
@@ -343,18 +299,12 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$data     = $response->get_data();
 
 		// Data should be that from cache not from mocked network response.
-		$this->assertContains(
-			'This value from cache',
-			$data['title']
-		);
+		$this->assertContains( 'This value from cache', $data['title'] );
 
-		remove_all_filters(
-			"pre_transient_$transient_name"
-		);
+		remove_all_filters( "pre_transient_{$transient_name}" );
 	}
 
 	public function test_allows_filtering_data_retrieved_for_a_given_url() {
-
 		add_filter(
 			'rest_prepare_url_details',
 			function( $response ) {
@@ -386,28 +336,21 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Instead of the default data retrieved we expect to see the modified
-		// data we provided via the filter.
-		$this->assertArraySubset(
-			array(
-				'title'    => 'Example Website &mdash; - with encoded content.',
-				'og_title' => 'This was manually added to the data via filter',
-			),
-			$data
-		);
+		/*
+		 * Instead of the default data retrieved we expect to see the modified
+		 * data we provided via the filter.
+		 */
+		$this->assertSame( 'Example Website — - with encoded content.', $data['title'] );
+		$this->assertSame( 'This was manually added to the data via filter', $data['og_title'] );
 
-		remove_all_filters(
-			'rest_prepare_url_details'
-		);
+		remove_all_filters( 'rest_prepare_url_details' );
 	}
 
-
-
-
 	public function test_allows_filtering_response() {
-
-		// Filter the response to known set of values changing only
-		// based on whether the response came from the cache or not.
+		/*
+		 * Filter the response to known set of values changing only
+		 * based on whether the response came from the cache or not.
+		 */
 		add_filter(
 			'rest_prepare_url_details',
 			function( $response, $url ) {
@@ -435,22 +378,15 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 		$data = $response->get_data();
 
-		$this->assertEquals(
-			'418',
-			$data['status']
-		);
+		$this->assertSame( 418, $data['status'] );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Response for URL https://placeholder-site.com altered via rest_prepare_url_details filter',
 			$data['response']
 		);
 
-		remove_all_filters(
-			'rest_prepare_url_details'
-		);
+		remove_all_filters( 'rest_prepare_url_details' );
 	}
-
-
 
 	public function test_get_item() {
 	}
@@ -481,7 +417,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$endpoint = $data['endpoints'][0];
 
 		$this->assertArrayHasKey( 'url', $endpoint['args'] );
-		$this->assertArraySubset(
+		$this->assertContains(
 			array(
 				'type'     => 'string',
 				'required' => true,
@@ -492,7 +428,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @dataProvider provide_get_title_data
+	 * @dataProvider data_get_title
 	 */
 	public function test_get_title( $html, $expected ) {
 		$controller = new WP_REST_URL_Details_Controller();
@@ -505,32 +441,47 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertSame( $expected, $actual );
 	}
 
-
-	public function provide_get_title_data() {
+	public function data_get_title() {
 		return array(
-			'no attributes'                  => array(
-				'<title>Testing &lt;title&gt;:</title>',
-				'Testing &lt;title&gt;:',
+
+			// Happy path for default.
+			'default'                        => array(
+				'<title>Testing &lt;title&gt;</title>',
+				'Testing',
 			),
 			'with attributes'                => array(
-				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing &lt;title&gt;:</title>',
-				'Testing &lt;title&gt;:',
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing &lt;title&gt;</title>',
+				'Testing',
 			),
 			'with text whitespace'           => array(
-				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">   Testing &lt;title&gt;:	</title>',
-				'Testing &lt;title&gt;:',
-			),
-			'when opening tag is malformed'  => array(
-				'< title>Testing &lt;title&gt;: when opening tag is invalid</title>',
-				'',
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">   Testing &lt;title&gt;	</title>',
+				'Testing',
 			),
 			'with whitespace in opening tag' => array(
 				'<title >Testing &lt;title&gt;: with whitespace in opening tag</title>',
-				'Testing &lt;title&gt;: with whitespace in opening tag',
+				'Testing : with whitespace in opening tag',
 			),
 			'when whitepace in closing tag'  => array(
 				'<title>Testing &lt;title&gt;: with whitespace in closing tag</ title>',
-				'Testing &lt;title&gt;: with whitespace in closing tag',
+				'Testing : with whitespace in closing tag',
+			),
+			'with other elements'            => array(
+				'<meta name="viewport" content="width=device-width">
+				<title>Testing &lt;title&gt;</title>
+				<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" />',
+				'Testing',
+			),
+			'multiline'                      => array(
+				'<title>
+					Testing &lt;title&gt;
+				</title>',
+				'Testing',
+			),
+
+			// Unhappy paths.
+			'when opening tag is malformed'  => array(
+				'< title>Testing &lt;title&gt;: when opening tag is invalid</title>',
+				'',
 			),
 		);
 	}
@@ -788,19 +739,19 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			// Happy paths with HTML tags or entities in the description.
 			'with HTML tags'                             => array(
 				'<meta name="description" content="<strong>Description</strong>: has <em>HTML</em> tags">',
-				'<strong>Description</strong>: has <em>HTML</em> tags',
+				'Description: has HTML tags',
 			),
 			'with content first and HTML tags'           => array(
 				'<meta content="<strong>Description</strong>: has <em>HTML</em> tags" name="description">',
-				'<strong>Description</strong>: has <em>HTML</em> tags',
+				'Description: has HTML tags',
 			),
 			'with HTML tags and other attributes'        => array(
 				'<meta first="first" name="description" third="third" content="<strong>Description</strong>: has <em>HTML</em> tags" fifth="fifth>',
-				'<strong>Description</strong>: has <em>HTML</em> tags',
+				'Description: has HTML tags',
 			),
 			'with HTML entities'                         => array(
 				'<meta name="description" content="The &lt;strong&gt;description&lt;/strong&gt; meta &amp; its attribute value"',
-				'The <strong>description</strong> meta & its attribute value',
+				'The description meta & its attribute value',
 			),
 
 			// Unhappy paths.
@@ -978,42 +929,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
-
-
-
-
-	public function provide_invalid_url_data() {
-		return array(
-			'empty_url'          => array(
-				null,
-				'',
-			), // empty!
-			'not_a_string'       => array(
-				null,
-				1234456,
-			),
-			'string_but_invalid' => array(
-				null,
-				'invalid.proto://wordpress.org',
-			),
-		);
-	}
-
-	public function provide_response_is_from_cache() {
-		return array(
-			'uncached_response' => array(
-				null,
-				false,
-			), // empty!
-			'cached_response'   => array(
-				null,
-				true,
-			),
-		);
-	}
-
-
-
 	/**
 	 * Mocks the HTTP response for the the `wp_safe_remote_get()` which
 	 * would otherwise make a call to a real website.
@@ -1033,7 +948,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	private function mock_request_to_remote_url( $result_type = 'success', $args ) {
-
 		static::$request_args = $args;
 
 		$types = array(

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -522,8 +522,8 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	/**
 	 * @dataProvider provide_get_icon_data
 	 */
-	public function test_get_icon( $html, $expected_icon ) {
-		$target_url = 'https://wordpress.org';
+	public function test_get_icon( $html, $expected_icon, $target_url = 'https://wordpress.org' ) {
+
 		$controller = new WP_REST_URL_Details_Controller();
 		$method     = $this->get_reflective_method( 'get_icon' );
 		$result     = $method->invoke(
@@ -536,31 +536,36 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 	public function provide_get_icon_data() {
 		return array(
-			'default'               => array(
+			'default'                => array(
 				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'with_query_string'     => array(
+			'with_query_string'      => array(
 				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico?somequerystring=foo&another=bar" />',
 				'https://wordpress.org/favicon.ico?somequerystring=foo&another=bar',
 			),
-			'relative_url'          => array(
+			'relative_url'           => array(
 				'<link rel="shortcut icon" href="/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'relative_url_no_slash' => array(
+			'relative_url_no_slash'  => array(
 				'<link rel="shortcut icon" href="favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'rel_reverse_order'     => array(
+			'relative_url_with_path' => array(
+				'<link rel="shortcut icon" href="favicon.ico" />',
+				'https://wordpress.org/favicon.ico',
+				'https://wordpress.org/my/path/here/',
+			),
+			'rel_reverse_order'      => array(
 				'<link rel="icon shortcut" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'rel_icon_only'         => array(
+			'rel_icon_only'          => array(
 				'<link rel="icon" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'rel_shortcut_only'     => array(
+			'rel_shortcut_only'      => array(
 				'<link rel="icon" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
@@ -570,8 +575,8 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	/**
 	 * @dataProvider provide_get_image_data
 	 */
-	public function test_get_image( $html, $expected_image ) {
-		$target_url = 'https://wordpress.org';
+	public function test_get_image( $html, $expected_image, $target_url = 'https://wordpress.org' ) {
+
 		$controller = new WP_REST_URL_Details_Controller();
 		$method     = $this->get_reflective_method( 'get_image' );
 		$result     = $method->invoke(
@@ -614,6 +619,11 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			'relative_url_no_slash'         => array(
 				'<meta property="og:image" content="images/myimage.jpg" />',
 				'https://wordpress.org/images/myimage.jpg',
+			),
+			'relative_url_with_path'        => array(
+				'<meta property="og:image" content="images/myimage.jpg" />',
+				'https://wordpress.org/images/myimage.jpg',
+				'https://wordpress.org/my/path/here/',
 			),
 		);
 	}

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -124,11 +124,14 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Note the <title> comes from the fixture HTML returned by
-		// the filter `pre_http_request`.
+		// Note the data in the subset comes from the fixture HTML returned by
+		// the filter `pre_http_request` (see this class's `setUp` method).
 		$this->assertArraySubset(
 			array(
-				'title' => 'Example Website &mdash; - with encoded content.',
+				'title'       => 'Example Website &mdash; - with encoded content.',
+				'icon'        => '//s.w.org/favicon.ico',
+				'description' => 'Example description text here. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.',
+				'image'       => 'https://s.w.org/images/home/screen-themes.png?3',
 			),
 			$data
 		);

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -604,6 +604,14 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				/>',
 				'https://wordpress.org/favicon.ico',
 			),
+			'with data URL x-icon type'             => array(
+				'<link rel="icon" href="data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII=" type="image/x-icon" />',
+				'data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII="',
+			),
+			'with data URL png type'                => array(
+				'<link href="data:image/png;base64,iVBORw0KGgo=" rel="icon" type="image/png" />',
+				'data:image/png;base64,iVBORw0KGgo=',
+			),
 
 			// Unhappy paths.
 			'empty rel'                             => array(

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -500,7 +500,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$method     = $this->get_reflective_method( 'get_title' );
 		$result     = $method->invoke(
 			$controller,
-			$html,
+			$this->wrap_html_in_doc( $html ),
 		);
 		$this->assertEquals( $expected_title, $result );
 	}
@@ -528,24 +528,26 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$method     = $this->get_reflective_method( 'get_icon' );
 		$result     = $method->invoke(
 			$controller,
-			$html,
+			$this->wrap_html_in_doc( $html ),
 			$target_url
 		);
 		$this->assertEquals( $expected_icon, $result );
 	}
 
 
+
+
 	public function provide_get_icon_data() {
 		return array(
-			'default' => array(
+			'default'               => array(
 				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'with_query_string' => array(
+			'with_query_string'     => array(
 				'<link rel="shortcut icon" href="https://wordpress.org/favicon.ico?somequerystring=foo&another=bar" />',
 				'https://wordpress.org/favicon.ico?somequerystring=foo&another=bar',
 			),
-			'relative_url' => array(
+			'relative_url'          => array(
 				'<link rel="shortcut icon" href="/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
@@ -553,15 +555,15 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				'<link rel="shortcut icon" href="favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'rel_reverse_order' => array(
+			'rel_reverse_order'     => array(
 				'<link rel="icon shortcut" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'rel_icon_only' => array(
+			'rel_icon_only'         => array(
 				'<link rel="icon" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
-			'rel_shortcut_only' => array(
+			'rel_shortcut_only'     => array(
 				'<link rel="icon" href="https://wordpress.org/favicon.ico" />',
 				'https://wordpress.org/favicon.ico',
 			),
@@ -649,6 +651,19 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			'success'     => $should_200 ? 1 : 0,
 			'body'        => 'success' === $result_type ? file_get_contents( __DIR__ . '/fixtures/example-website.html' ) : '',
 		);
+	}
+
+	private function wrap_html_in_doc( $html ) {
+		$start = '<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
+<head>';
+		$end   = '</head>
+<body>
+	<h1>Example Website</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</body>
+</html>';
+		return $start . $html . $end;
 	}
 
 	/**

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -129,7 +129,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertArraySubset(
 			array(
 				'title'       => 'Example Website &mdash; - with encoded content.',
-				'icon'        => '//s.w.org/favicon.ico',
+				'icon'        => '//s.w.org/favicon.ico?querystringaddedfortesting',
 				'description' => 'Example description text here. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.',
 				'image'       => 'https://s.w.org/images/home/screen-themes.png?3',
 			),

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -327,7 +327,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		add_filter(
 			"pre_transient_$transient_name",
 			function() {
-				return '<html><head><title>This value from cache.</title></head></html>';
+				return '<html><head><title>This value from cache.</title></head><body></body></html>';
 			}
 		);
 
@@ -533,9 +533,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 		$this->assertEquals( $expected_icon, $result );
 	}
-
-
-
 
 	public function provide_get_icon_data() {
 		return array(

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -651,16 +651,17 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	private function wrap_html_in_doc( $html ) {
-		$start = '<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
-<head>';
-		$end   = '</head>
-<body>
-	<h1>Example Website</h1>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-</body>
-</html>';
-		return $start . $html . $end;
+		$doc = '<!DOCTYPE html>
+				<html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
+				<head>
+					%%HEAD_CONTENT%%
+				</head>
+				<body>
+					<h1>Example Website</h1>
+					<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+				</body>
+				</html>';
+		return str_replace( '%%HEAD_CONTENT%%', $html, $doc );
 	}
 
 	/**

--- a/phpunit/fixtures/example-website.html
+++ b/phpunit/fixtures/example-website.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
 <head>
 <meta charset="utf-8" />
-<title>Example Website &mdash; - with encoded content.</title>
+<title data-test-title-attr="test">Example Website &mdash; - with encoded content.</title>
 
 <link rel="shortcut icon" href="//s.w.org/favicon.ico?2" type="image/x-icon" />
 
@@ -14,10 +14,11 @@
 <meta property="og:title" content="Example Website" />
 <meta property="og:url" content="https://example.com" />
 <meta property="og:site_name" content="Example Website" />
+<meta property="og:image" content="https://s.w.org/images/home/screen-themes.png?3" />
 
 </head>
 <body>
 	<h1>Example Website</h1>
-    <p>loreLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 </body>
 </html>

--- a/phpunit/fixtures/example-website.html
+++ b/phpunit/fixtures/example-website.html
@@ -4,10 +4,11 @@
 <meta charset="utf-8" />
 <title data-test-title-attr="test">Example Website &mdash; - with encoded content.</title>
 
-<link rel="shortcut icon" href="//s.w.org/favicon.ico?2" type="image/x-icon" />
+<link rel="shortcut icon" href="//s.w.org/favicon.ico?querystringaddedfortesting" type="image/x-icon" />
 
 <link rel="canonical" href="https://example.com">
 
+<meta name="description" content="Example description text here. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore." />
 
 <!-- Open Graph Tags -->
 <meta property="og:type" content="website" />

--- a/phpunit/fixtures/example-website.html
+++ b/phpunit/fixtures/example-website.html
@@ -15,6 +15,7 @@
 <meta property="og:title" content="Example Website" />
 <meta property="og:url" content="https://example.com" />
 <meta property="og:site_name" content="Example Website" />
+<meta property="og:image:alt" content="Attempt to break image parsing" />
 <meta property="og:image" content="/images/home/screen-themes.png?3" />
 
 </head>

--- a/phpunit/fixtures/example-website.html
+++ b/phpunit/fixtures/example-website.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <title data-test-title-attr="test">Example Website &mdash; - with encoded content.</title>
 
-<link rel="shortcut icon" href="//s.w.org/favicon.ico?querystringaddedfortesting" type="image/x-icon" />
+<link rel="shortcut icon" href="/favicon.ico?querystringaddedfortesting" type="image/x-icon" />
 
 <link rel="canonical" href="https://example.com">
 
@@ -15,7 +15,7 @@
 <meta property="og:title" content="Example Website" />
 <meta property="og:url" content="https://example.com" />
 <meta property="og:site_name" content="Example Website" />
-<meta property="og:image" content="https://s.w.org/images/home/screen-themes.png?3" />
+<meta property="og:image" content="/images/home/screen-themes.png?3" />
 
 </head>
 <body>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

This PR is part of the effort to achieve the vision outlined in https://github.com/WordPress/gutenberg/issues/31466. Namely the ability to show meta data about a remote URL when inserting a hyperlink using the block editor.

Following input from @hellofromtonya in https://github.com/WordPress/gutenberg/pull/28791#issuecomment-825819648 this PR takes a regex based route to building on the original implementation from https://github.com/WordPress/gutenberg/pull/18042 to add a better mechanism for parsing the information from the remote URL's response body HTML.

This helps to address feedback such as https://github.com/WordPress/gutenberg/issues/27762 and also sets things up nicely for parsing additional detail from the remote URL (eg: favicon, Open Graph meta...etc).

This PR aims to:

- [x] Parse the site **icon** from the HTML in order to retrieve a usable site icon.
- [x] Parse a representative **image** from the HTML to use as a preview.
- [x] Parse a **description** from the HTML to serve as a longer description.

It should also:

- [x] Improve the means by which we parse regex - for example look only in the `<head>` tag.
- [x] Improve parsing of a **title** to account for edge cases where an attribute is added to the `<title>` tag (eg: `<title data-rh="true">BBC - Home</title>`).

Note [the Open Graph spec](https://ogp.me/).

Closes https://github.com/WordPress/gutenberg/issues/27762

## Automated Testing Instructions

Run the test suite with 

```
wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose --filter WP_REST_URL_Details_Controller_Test'
```

The tests themselves reside in `phpunit/class-wp-rest-url-details-controller-test.php`.

## Manual Testing Instructions

* Check out this PR.
* Run `npm run wp-env start` to boot the local testing env.
* Open the Gutenberg local testing env at `http://localhost:8889/wp-admin/` and login.
* Create a new Post.
* Choose one of the following options:

### Option 1

* Open devtools and in the `console` enter:

```
wp.apiFetch( { path: '/__experimental/url-details/?url=https://wordpress.org' } ).then( data => {
    console.log( data );
} );
```

...also try some non-English websites:

```
wp.apiFetch( { path: '/__experimental/url-details/?url=http://www.baidu.com' } ).then( data => {
    console.log( data );
} );
```


You should see a valid REST API response containing 
  - the contents of the title tag from `wordpress.org` (ie: `"Blog Tool, Publishing Platform, and CMS \u2014 WordPress.org"`).
  - the favicon URL from WordPress.org

### Option 2
* Open devtools and in the `console` enter `wpApiSettings.nonce`. You should see a valid nonce returned as a string.
* Copy the nonce.
* In your browser goto: `http://localhost:8889/wp-json/__experimental/url-details/?url=https://wordpress.org&_wpnonce=%YOUR_NONCE_HERE%` - be sure to replace the nonce value with that copied from the previous step.
* You should see a valid REST API response containing 
  - the contents of the title tag from `wordpress.org` (ie: `"Blog Tool, Publishing Platform, and CMS \u2014 WordPress.org"`).
  - the favicon URL from WordPress.org
