### PR TITLE
Block Controls: add None option for text decoration

### DIFF
--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -2,14 +2,18 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { formatStrikethrough, formatUnderline, none } from '@wordpress/icons';
+import {
+	formatStrikethrough,
+	formatUnderline,
+	smallDash,
+} from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 const TEXT_DECORATIONS = [
 	{
-		name: __( 'None' ),
-		value: 'none',
-		icon: none,
+		name: __( 'Default' ),
+		value: undefined,
+		icon: smallDash,
 	},
 	{
 		name: __( 'Underline' ),
@@ -46,7 +50,7 @@ export default function TextDecorationControl( { value, onChange } ) {
 							onClick={ () =>
 								onChange(
 									textDecoration.value === value
-										? undefined
+										? 'none'
 										: textDecoration.value
 								)
 							}

--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -2,10 +2,15 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { formatStrikethrough, formatUnderline } from '@wordpress/icons';
+import { formatStrikethrough, formatUnderline, none } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 const TEXT_DECORATIONS = [
+	{
+		name: __( 'None' ),
+		value: 'none',
+		icon: none,
+	},
 	{
 		name: __( 'Underline' ),
 		value: 'underline',
@@ -45,7 +50,8 @@ export default function TextDecorationControl( { value, onChange } ) {
 										: textDecoration.value
 								)
 							}
-							aria-label={ textDecoration.name }
+							label={ textDecoration.name }
+							showTooltip
 						/>
 					);
 				} ) }

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -123,7 +123,6 @@ export { default as moreHorizontalMobile } from './library/more-horizontal-mobil
 export { default as moreVertical } from './library/more-vertical';
 export { default as moveTo } from './library/move-to';
 export { default as navigation } from './library/navigation';
-export { default as none } from './library/none';
 export { default as overlayText } from './library/overlay-text';
 export { default as pageBreak } from './library/page-break';
 export { default as customLink } from './library/custom-link';
@@ -177,6 +176,7 @@ export { default as settings } from './library/settings';
 export { default as share } from './library/share';
 export { default as siteLogo } from './library/site-logo';
 export { default as shortcode } from './library/shortcode';
+export { default as smallDash } from './library/small-dash';
 export { default as stack } from './library/stack';
 export { default as starEmpty } from './library/star-empty';
 export { default as starFilled } from './library/star-filled';

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -123,6 +123,7 @@ export { default as moreHorizontalMobile } from './library/more-horizontal-mobil
 export { default as moreVertical } from './library/more-vertical';
 export { default as moveTo } from './library/move-to';
 export { default as navigation } from './library/navigation';
+export { default as none } from './library/none';
 export { default as overlayText } from './library/overlay-text';
 export { default as pageBreak } from './library/page-break';
 export { default as customLink } from './library/custom-link';

--- a/packages/icons/src/library/none.js
+++ b/packages/icons/src/library/none.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const none = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M16 12.75H8V11.25H16V12.75Z" />
+	</SVG>
+);
+
+export default none;

--- a/packages/icons/src/library/small-dash.js
+++ b/packages/icons/src/library/small-dash.js
@@ -3,10 +3,10 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const none = (
+const smallDash = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M16 12.75H8V11.25H16V12.75Z" />
 	</SVG>
 );
 
-export default none;
+export default smallDash;


### PR DESCRIPTION
## Description

- Adds a default option for text decoration, for when there's no block specific setting and text decoration is inherited by global styles
- Sets a block specific `text-decoration: none` when all toggles are turned off

This option is needed for overriding styles that a theme sets for a block.

Uses a new icon, as suggested [here](https://github.com/WordPress/gutenberg/pull/31623#issuecomment-838131737). [Figma link](https://www.figma.com/file/Ngtfpl2j52PJksXJzoO9EuPo/None-Icon-for-Gutenberg?node-id=0%3A1)

## How has this been tested?

- With a block based theme (e.g. TT1 Blocks) activated, visit the site editor
- Select the Navigation block (top level) and open the block settings in the sidebar
- See that you can set the text decoration options for the block

To test overriding a theme, insert block settings in the theme.json of your theme, which will default an underline style to the navigation:

```json
{
  "styles": {
    "blocks": {
      "core/navigation": {
        "typography": {
          "textDecoration": "underline"
        }
      }
    }
  }
}
```

## Screenshots <!-- if applicable -->

<img width="277" alt="image" src="https://user-images.githubusercontent.com/1699996/118371094-95419580-b570-11eb-9f3d-61a6da88a029.png">


## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
