### PR TITLE
Rich text core: remove duplicate active formats state

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -303,10 +303,8 @@ function RichTextWrapper(
 		onChange,
 	} );
 
-	const hasActiveFormats =
-		value.activeFormats && !! value.activeFormats.length;
-	useCaretInFormat( hasActiveFormats );
-	useMarkPersistent( { hasActiveFormats, html: adjustedValue, value } );
+	useCaretInFormat( { value } );
+	useMarkPersistent( { html: adjustedValue, value } );
 
 	function onKeyDown( event ) {
 		const { keyCode } = event;
@@ -368,6 +366,8 @@ function RichTextWrapper(
 		} else if ( keyCode === DELETE || keyCode === BACKSPACE ) {
 			const { start, end, text } = value;
 			const isReverse = keyCode === BACKSPACE;
+			const hasActiveFormats =
+				value.activeFormats && !! value.activeFormats.length;
 
 			// Only process delete if the key press occurs at an uncollapsed edge.
 			if (

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -275,13 +275,7 @@ function RichTextWrapper(
 		);
 	}
 
-	const {
-		value,
-		onChange,
-		onFocus,
-		ref: richTextRef,
-		hasActiveFormats,
-	} = useRichText( {
+	const { value, onChange, onFocus, ref: richTextRef } = useRichText( {
 		value: adjustedValue,
 		onChange( html, { __unstableFormats, __unstableText } ) {
 			adjustedOnChange( html );
@@ -309,6 +303,8 @@ function RichTextWrapper(
 		onChange,
 	} );
 
+	const hasActiveFormats =
+		value.activeFormats && !! value.activeFormats.length;
 	useCaretInFormat( hasActiveFormats );
 	useMarkPersistent( { hasActiveFormats, html: adjustedValue, value } );
 

--- a/packages/block-editor/src/components/rich-text/use-caret-in-format.js
+++ b/packages/block-editor/src/components/rich-text/use-caret-in-format.js
@@ -9,7 +9,9 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
-export function useCaretInFormat( hasActiveFormats ) {
+export function useCaretInFormat( { value } ) {
+	const hasActiveFormats =
+		value.activeFormats && !! value.activeFormats.length;
 	const { isCaretWithinFormattedText } = useSelect( blockEditorStore );
 	const { enterFormattedText, exitFormattedText } = useDispatch(
 		blockEditorStore

--- a/packages/block-editor/src/components/rich-text/use-mark-persistent.js
+++ b/packages/block-editor/src/components/rich-text/use-mark-persistent.js
@@ -9,8 +9,10 @@ import { useDispatch } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
-export function useMarkPersistent( { hasActiveFormats, html, value } ) {
+export function useMarkPersistent( { html, value } ) {
 	const previousText = useRef();
+	const hasActiveFormats =
+		value.activeFormats && !! value.activeFormats.length;
 	const { __unstableMarkLastChangeAsPersistent } = useDispatch(
 		blockEditorStore
 	);

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -222,7 +222,6 @@ export function useRichText( {
 		onChange: handleChange,
 		onFocus: focus,
 		ref: mergedRefs,
-		hasActiveFormats: activeFormats.length,
 	};
 }
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useLayoutEffect } from '@wordpress/element';
+import { useRef, useLayoutEffect, useReducer } from '@wordpress/element';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 
 /**
@@ -36,6 +36,7 @@ export function useRichText( {
 	__unstableBeforeSerialize,
 	__unstableAddInvisibleFormats,
 } ) {
+	const [ , forceRender ] = useReducer( () => ( {} ) );
 	const ref = useRef();
 
 	function createRecord() {
@@ -129,6 +130,7 @@ export function useRichText( {
 			__unstableFormats: formats,
 			__unstableText: text,
 		} );
+		forceRender();
 	}
 
 	function applyFromProps( { domOnly } = {} ) {

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useState, useLayoutEffect } from '@wordpress/element';
+import { useRef, useLayoutEffect } from '@wordpress/element';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 
 /**
@@ -37,7 +37,6 @@ export function useRichText( {
 	__unstableAddInvisibleFormats,
 } ) {
 	const ref = useRef();
-	const [ activeFormats = [], setActiveFormats ] = useState();
 
 	function createRecord() {
 		const {
@@ -121,13 +120,7 @@ export function useRichText( {
 
 		record.current = newRecord;
 
-		const {
-			start,
-			end,
-			formats,
-			text,
-			activeFormats: newActiveFormats = [],
-		} = newRecord;
+		const { start, end, formats, text } = newRecord;
 
 		// Selection must be updated first, so it is recorded in history when
 		// the content change happens.
@@ -136,7 +129,6 @@ export function useRichText( {
 			__unstableFormats: formats,
 			__unstableText: text,
 		} );
-		setActiveFormats( newActiveFormats );
 	}
 
 	function applyFromProps( { domOnly } = {} ) {
@@ -182,11 +174,11 @@ export function useRichText( {
 	const mergedRefs = useMergeRefs( [
 		ref,
 		useDefaultStyle(),
-		useBoundaryStyle( { activeFormats } ),
+		useBoundaryStyle( { record } ),
 		useInlineWarning(),
 		useCopyHandler( { record, multilineTag, preserveWhiteSpace } ),
 		useSelectObject(),
-		useFormatBoundaries( { record, applyRecord, setActiveFormats } ),
+		useFormatBoundaries( { record, applyRecord } ),
 		useDelete( {
 			createRecord,
 			handleChange,
@@ -204,7 +196,6 @@ export function useRichText( {
 			handleChange,
 			isSelected,
 			onSelectionChange,
-			setActiveFormats,
 		} ),
 		useRefEffect( () => {
 			if ( didMount.current ) {

--- a/packages/rich-text/src/component/use-boundary-style.js
+++ b/packages/rich-text/src/component/use-boundary-style.js
@@ -7,8 +7,9 @@ import { useEffect, useRef } from '@wordpress/element';
  * Calculates and renders the format boundary style when the active formats
  * change.
  */
-export function useBoundaryStyle( { activeFormats } ) {
+export function useBoundaryStyle( { record } ) {
 	const ref = useRef();
+	const { activeFormats = [] } = record.current;
 	useEffect( () => {
 		// There's no need to recalculate the boundary styles if no formats are
 		// active, because no boundary styles will be visible.

--- a/packages/rich-text/src/component/use-format-boundaries.js
+++ b/packages/rich-text/src/component/use-format-boundaries.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useRef, useReducer } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
 
@@ -13,6 +13,7 @@ import { isCollapsed } from '../is-collapsed';
 const EMPTY_ACTIVE_FORMATS = [];
 
 export function useFormatBoundaries( props ) {
+	const [ , forceRender ] = useReducer( () => ( {} ) );
 	const propsRef = useRef( props );
 	propsRef.current = props;
 	return useRefEffect( ( element ) => {
@@ -30,7 +31,7 @@ export function useFormatBoundaries( props ) {
 				return;
 			}
 
-			const { record, applyRecord, setActiveFormats } = propsRef.current;
+			const { record, applyRecord } = propsRef.current;
 			const {
 				text,
 				formats,
@@ -125,7 +126,7 @@ export function useFormatBoundaries( props ) {
 			};
 			record.current = newValue;
 			applyRecord( newValue );
-			setActiveFormats( newActiveFormats );
+			forceRender();
 		}
 
 		element.addEventListener( 'keydown', onKeyDown );

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -80,10 +80,6 @@ export function useInputAndSelection( props ) {
 				inputType = event.inputType;
 			}
 
-			if ( ! inputType && event && event.nativeEvent ) {
-				inputType = event.nativeEvent.inputType;
-			}
-
 			const {
 				record,
 				applyRecord,
@@ -228,12 +224,7 @@ export function useInputAndSelection( props ) {
 		}
 
 		function onFocus() {
-			const {
-				record,
-				isSelected,
-				onSelectionChange,
-				setActiveFormats,
-			} = propsRef.current;
+			const { record, isSelected, onSelectionChange } = propsRef.current;
 
 			if ( ! isSelected ) {
 				// We know for certain that on focus, the old selection is invalid.
@@ -248,7 +239,6 @@ export function useInputAndSelection( props ) {
 					activeFormats: EMPTY_ACTIVE_FORMATS,
 				};
 				onSelectionChange( index, index );
-				setActiveFormats( EMPTY_ACTIVE_FORMATS );
 			} else {
 				onSelectionChange( record.current.start, record.current.end );
 			}

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -138,7 +138,6 @@ export function useInputAndSelection( props ) {
 				createRecord,
 				isSelected,
 				onSelectionChange,
-				setActiveFormats,
 			} = propsRef.current;
 
 			if ( event.type !== 'selectionchange' && ! isSelected ) {
@@ -203,7 +202,6 @@ export function useInputAndSelection( props ) {
 			record.current = newValue;
 			applyRecord( newValue, { domOnly: true } );
 			onSelectionChange( start, end );
-			setActiveFormats( newActiveFormats );
 		}
 
 		function onCompositionStart() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
