### PR TITLE
Fix template part variations registration subscription.

### DIFF
--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -15,10 +15,12 @@ import { layout } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
-import './variations';
+import variations from './variations';
 
 const { name } = metadata;
 export { metadata, name };
+
+variations();
 
 export const settings = {
 	icon: layout,

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -15,12 +15,12 @@ import { layout } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
-import variations from './variations';
+import setupVariations from './variations';
 
 const { name } = metadata;
 export { metadata, name };
 
-variations();
+setupVariations();
 
 export const settings = {
 	icon: layout,

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -6,7 +6,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as blocksStore } from '@wordpress/blocks';
 import { dispatch, select, subscribe } from '@wordpress/data';
 
-export default function subscribeToCreateVatiations() {
+export default function setupVatiations() {
 	// Subscribe to wait for the variation definitions to initialize in the editor store.
 	const unsubscribe = subscribe( () => {
 		const definedVariations = select(

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -7,6 +7,7 @@ import { store as blocksStore } from '@wordpress/blocks';
 import { dispatch, select, subscribe } from '@wordpress/data';
 
 export default function subscribeToCreateVatiations() {
+	// Subscribe to wait for the variation definitions to initialize in the editor store.
 	const unsubscribe = subscribe( () => {
 		const definedVariations = select(
 			editorStore

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -6,55 +6,57 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as blocksStore } from '@wordpress/blocks';
 import { dispatch, select, subscribe } from '@wordpress/data';
 
-const unsubscribe = subscribe( () => {
-	const definedVariations = select(
-		editorStore
-	).__experimentalGetDefaultTemplatePartAreas();
+export default function subscribeToCreateVatiations() {
+	const unsubscribe = subscribe( () => {
+		const definedVariations = select(
+			editorStore
+		).__experimentalGetDefaultTemplatePartAreas();
 
-	if ( ! definedVariations?.length ) {
-		return;
-	}
-	unsubscribe();
+		if ( ! definedVariations?.length ) {
+			return;
+		}
+		unsubscribe();
 
-	const variations = definedVariations
-		.filter( ( { area } ) => 'uncategorized' !== area )
-		.map( ( { area, label, description, icon } ) => {
-			return {
-				name: area,
-				title: label,
-				description,
-				icon,
-				attributes: { area },
-				scope: [ 'inserter' ],
+		const variations = definedVariations
+			.filter( ( { area } ) => 'uncategorized' !== area )
+			.map( ( { area, label, description, icon } ) => {
+				return {
+					name: area,
+					title: label,
+					description,
+					icon,
+					attributes: { area },
+					scope: [ 'inserter' ],
+				};
+			} );
+
+		/**
+		 * Add `isActive` function to all `Template Part` variations, if not defined.
+		 * `isActive` function is used to find a variation match from a created
+		 *  Block by providing its attributes.
+		 */
+		variations.forEach( ( variation ) => {
+			if ( variation.isActive ) return;
+			variation.isActive = ( blockAttributes, variationAttributes ) => {
+				const { area, theme, slug } = blockAttributes;
+				// We first check the `area` block attribute which is set during insertion.
+				// This property is removed on the creation of a template part.
+				if ( area ) return area === variationAttributes.area;
+				// Find a matching variation from the created template part
+				// by checking the entity's `area` property.
+				if ( ! slug ) return false;
+				const entity = select( coreDataStore ).getEntityRecord(
+					'postType',
+					'wp_template_part',
+					`${ theme }//${ slug }`
+				);
+				return entity?.area === variationAttributes.area;
 			};
 		} );
 
-	/**
-	 * Add `isActive` function to all `Template Part` variations, if not defined.
-	 * `isActive` function is used to find a variation match from a created
-	 *  Block by providing its attributes.
-	 */
-	variations.forEach( ( variation ) => {
-		if ( variation.isActive ) return;
-		variation.isActive = ( blockAttributes, variationAttributes ) => {
-			const { area, theme, slug } = blockAttributes;
-			// We first check the `area` block attribute which is set during insertion.
-			// This property is removed on the creation of a template part.
-			if ( area ) return area === variationAttributes.area;
-			// Find a matching variation from the created template part
-			// by checking the entity's `area` property.
-			if ( ! slug ) return false;
-			const entity = select( coreDataStore ).getEntityRecord(
-				'postType',
-				'wp_template_part',
-				`${ theme }//${ slug }`
-			);
-			return entity?.area === variationAttributes.area;
-		};
+		dispatch( blocksStore ).addBlockVariations(
+			'core/template-part',
+			variations
+		);
 	} );
-
-	dispatch( blocksStore ).addBlockVariations(
-		'core/template-part',
-		variations
-	);
-} );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes template part variations from not being present in non-dev builds.

`import './variations';` is ignored by the non-dev build process as it does not see any use from the import.  Instead we can import a function and call it from the code.

#31761 fixes this issue as well but also explores refactoring the registration to avoid the initial store subscription.  At this point Im not sure if the refactor makes more sense or not, but I explored this refactor before figuring out the root cause of the bug.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
run `npm run build` from this PR and verify variations ("Header", "Footer", in the block inserter) show up as expected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
