### PR TITLE
Margin Support: Fix custom units

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -14,6 +14,35 @@ import { SPACING_SUPPORT_KEY, useCustomSides } from './spacing';
 import { cleanEmptyObject } from './utils';
 import { useCustomUnits } from '../components/unit-control';
 
+const isWeb = Platform.OS === 'web';
+const CSS_UNITS = [
+	{
+		value: '%',
+		label: isWeb ? '%' : __( 'Percentage (%)' ),
+		default: '',
+	},
+	{
+		value: 'px',
+		label: isWeb ? 'px' : __( 'Pixels (px)' ),
+		default: '',
+	},
+	{
+		value: 'em',
+		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
+		default: '',
+	},
+	{
+		value: 'rem',
+		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
+		default: '',
+	},
+	{
+		value: 'vw',
+		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
+		default: '',
+	},
+];
+
 /**
  * Determines if there is margin support.
  *
@@ -49,7 +78,7 @@ export function MarginEdit( props ) {
 		setAttributes,
 	} = props;
 
-	const units = useCustomUnits();
+	const units = useCustomUnits( CSS_UNITS );
 	const sides = useCustomSides( blockName, 'margin' );
 
 	if ( useIsMarginDisabled( props ) ) {


### PR DESCRIPTION
## Description
This introduces the same fix for custom units as for padding support. Prior to this change it was not possible to select non-pixel units in the margin block support box control.

## How has this been tested?
Manually.

1. Enable custom margins in theme.json and opt into margin support for a block
2. Create a post, add a block with margin support
3. Select block and under the spacing panel in the sidebar check that custom units can be selected for margin
4. Adjust value and save. Confirm custom unit on frontend

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![MarginSupportUnits](https://user-images.githubusercontent.com/60436221/118065456-58df2f80-b3e0-11eb-94bf-581644702d08.gif) | <img width="281" alt="Screen Shot 2021-05-13 at 10 49 37 am" src="https://user-images.githubusercontent.com/60436221/118061757-f0408480-b3d8-11eb-9569-cc6f7b8bf5f4.png"> |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
