### PR TITLE
BoxControl: Filter out unit only values when checking values defined

### DIFF
--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -109,6 +109,13 @@ export function isValuesMixed( values = {} ) {
 export function isValuesDefined( values ) {
 	return (
 		values !== undefined &&
-		! isEmpty( Object.values( values ).filter( Boolean ) )
+		! isEmpty(
+			Object.values( values ).filter(
+				// Switching units when input is empty causes values only
+				// containing units. This gives false positive on mixed values
+				// unless filtered.
+				( value ) => !! value && /\d/.test( value )
+			)
+		)
 	);
 }


### PR DESCRIPTION
## Description
This fixes an issue when if a BoxControl's unit is changed while the field is empty the input gets the "mixed" placeholder text.

## How has this been tested?
Manually.

1. Create a post, add the group block (it already has padding support using the box control)
2. Select the group block and in the sidebar confirm you can change units on the padding control while it is empty without receiving the incorrect "mixed" placeholder.

## Screenshots <!-- if applicable -->
| Before | After |
|---|---|
| ![BoxControlMixed](https://user-images.githubusercontent.com/60436221/118071838-ebd19700-b3eb-11eb-815e-96aa1269b7f5.gif) | ![BoxControlMixed-Fixed](https://user-images.githubusercontent.com/60436221/118071842-eecc8780-b3eb-11eb-8248-3509afdb4cd5.gif) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
