### PR TITLE
Spacing support: Fix box control label text where each side is labelled as 'Top'

### DIFF
--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -94,7 +94,7 @@ export default function BoxInputControls( {
 						onFocus={ createHandleOnFocus( side ) }
 						onHoverOn={ createHandleOnHoverOn( side ) }
 						onHoverOff={ createHandleOnHoverOff( side ) }
-						label={ LABELS.top }
+						label={ LABELS[ side ] || '' }
 						key={ `box-control-${ side }` }
 					/>
 				) ) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
In the Box Control used by the Spacing support, if you unlink sides in the inspector controls, you can control the values for each side individually. Currently the label text for each of these input fields when you hover over them reads "Top". This change grabs the correct label text to match the side and falls back to an empty string if one can't be found.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually. Insert a Group block, and with the block selected, open up the inspector controls. Under Spacing, click to unlink the sides for padding, and then hover over each of the input fields for controlling the padding.

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/118084032-50e4b700-b403-11eb-8b8d-58825a978ad4.png) | ![box-control-label-text](https://user-images.githubusercontent.com/14988353/118083965-34e11580-b403-11eb-9cb5-b62f90dae22a.gif) |

CC: @apeatling @glendaviesnz @aaronrobertshaw

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] ~My code is tested.~ (manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
