### PR TITLE
Search Block: Add border color support

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -42,6 +42,7 @@
 	"supports": {
 		"align": [ "left", "center", "right" ],
 		"__experimentalBorder": {
+			"color": true,
 			"radius": true,
 			"__experimentalSkipSerialization": true
 		},

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -85,6 +85,9 @@ export default function SearchEdit( {
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 	const isButtonPositionInside = 'button-inside' === buttonPosition;
+	const isButtonPositionOutside = 'button-outside' === buttonPosition;
+	const hasNoButton = 'no-button' === buttonPosition;
+	const hasOnlyButton = 'button-only' === buttonPosition;
 
 	const units = useCustomUnits( {
 		availableUnits: [ '%', 'px' ],
@@ -98,19 +101,15 @@ export default function SearchEdit( {
 			isButtonPositionInside
 				? 'wp-block-search__button-inside'
 				: undefined,
-			'button-outside' === buttonPosition
+			isButtonPositionOutside
 				? 'wp-block-search__button-outside'
 				: undefined,
-			'no-button' === buttonPosition
-				? 'wp-block-search__no-button'
-				: undefined,
-			'button-only' === buttonPosition
-				? 'wp-block-search__button-only'
-				: undefined,
-			! buttonUseIcon && 'no-button' !== buttonPosition
+			hasNoButton ? 'wp-block-search__no-button' : undefined,
+			hasOnlyButton ? 'wp-block-search__button-only' : undefined,
+			! buttonUseIcon && ! hasNoButton
 				? 'wp-block-search__text-button'
 				: undefined,
-			buttonUseIcon && 'no-button' !== buttonPosition
+			buttonUseIcon && ! hasNoButton
 				? 'wp-block-search__icon-button'
 				: undefined
 		);
@@ -166,26 +165,26 @@ export default function SearchEdit( {
 	};
 
 	const getResizableSides = () => {
-		if ( 'button-only' === buttonPosition ) {
+		if ( hasOnlyButton ) {
 			return {};
 		}
 
 		return {
-			right: align === 'right' ? false : true,
-			left: align === 'right' ? true : false,
+			right: align !== 'right',
+			left: align === 'right',
 		};
 	};
 
 	const renderTextField = () => {
+		// If the input is inside the wrapper, the wrapper gets the border color styles/classes, not the input control.
 		const textFieldClasses = classnames(
 			'wp-block-search__input',
-			! isButtonPositionInside ? borderProps.className : undefined
+			isButtonPositionInside ? undefined : borderProps.className
 		);
-		// If the button is inside the wrapper, the wrapper gets the border styles, not the input control.
-		const textFieldStyles = {
-			borderRadius: ! isButtonPositionInside ? borderRadius : undefined,
-			borderColor: ! isButtonPositionInside ? borderColor : undefined,
-		};
+		const textFieldStyles = isButtonPositionInside
+			? { borderRadius }
+			: borderProps.style;
+
 		return (
 			<input
 				className={ textFieldClasses }
@@ -206,24 +205,29 @@ export default function SearchEdit( {
 	};
 
 	const renderButton = () => {
+		// If the button is inside the wrapper, the wrapper gets the border color styles/classes, not the button.
 		const buttonClasses = classnames(
 			'wp-block-search__button',
-			borderProps.className
+			isButtonPositionInside ? undefined : borderProps.className
 		);
+		const buttonStyles = isButtonPositionInside
+			? { borderRadius }
+			: borderProps.style;
+
 		return (
 			<>
 				{ buttonUseIcon && (
 					<Button
 						icon={ search }
 						className={ buttonClasses }
-						style={ { borderRadius, borderColor } }
+						style={ buttonStyles }
 					/>
 				) }
 
 				{ ! buttonUseIcon && (
 					<RichText
 						className={ buttonClasses }
-						style={ { borderRadius, borderColor } }
+						style={ buttonStyles }
 						aria-label={ __( 'Button text' ) }
 						placeholder={ __( 'Add button text…' ) }
 						withoutInteractiveFormatting
@@ -256,7 +260,7 @@ export default function SearchEdit( {
 						label={ __( 'Change button position' ) }
 						controls={ buttonPositionControls }
 					/>
-					{ 'no-button' !== buttonPosition && (
+					{ ! hasNoButton && (
 						<ToolbarButton
 							title={ __( 'Use button with icon' ) }
 							icon={ buttonWithIcon }
@@ -351,7 +355,7 @@ export default function SearchEdit( {
 
 		const isNonZeroBorderRadius = parseInt( borderRadius, 10 ) !== 0;
 
-		if ( 'button-inside' === buttonPosition && isNonZeroBorderRadius ) {
+		if ( isButtonPositionInside && isNonZeroBorderRadius ) {
 			// We have button inside wrapper and a border radius value to apply.
 			// Add default padding so we don't get "fat" corners.
 			//
@@ -434,16 +438,15 @@ export default function SearchEdit( {
 				} }
 				showHandle={ isSelected }
 			>
-				{ ( isButtonPositionInside ||
-					'button-outside' === buttonPosition ) && (
+				{ ( isButtonPositionInside || isButtonPositionOutside ) && (
 					<>
 						{ renderTextField() }
 						{ renderButton() }
 					</>
 				) }
 
-				{ 'button-only' === buttonPosition && renderButton() }
-				{ 'no-button' === buttonPosition && renderTextField() }
+				{ hasOnlyButton && renderButton() }
+				{ hasNoButton && renderTextField() }
 			</ResizableBox>
 		</div>
 	);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -87,7 +87,7 @@ function render_block_core_search( $attributes ) {
 		}
 
 		$button_markup = sprintf(
-	'<button type="submit" class="wp-block-search__button %s" %s>%s</button>',
+			'<button type="submit" class="wp-block-search__button %s" %s>%s</button>',
 			$button_classes,
 			$inline_styles['shared'],
 			$button_internal_markup

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -87,7 +87,8 @@ function render_block_core_search( $attributes ) {
 		}
 
 		$button_markup = sprintf(
-'			<button type="submit" class="wp-block-search__button %s" %s>%s</button>',			$button_classes,
+	'<button type="submit" class="wp-block-search__button %s" %s>%s</button>',
+			$button_classes,
 			$inline_styles['shared'],
 			$button_internal_markup
 		);
@@ -100,7 +101,7 @@ function render_block_core_search( $attributes ) {
 		$inline_styles['wrapper'],
 		$input_markup . $button_markup
 	);
-$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+	$wrapper_attributes   = get_block_wrapper_attributes( array( 'class' => $classnames ) );
 
 	return sprintf(
 		'<form role="search" method="get" action="%s" %s>%s</form>',


### PR DESCRIPTION
## Description

This PR add border color support to the search block pursuant to https://github.com/WordPress/gutenberg/issues/22071

We're skipping serialization since the targets for border classnames and custom styles change according to the search block style, that is, whether the button appear inside the border or not.

## How has this been tested?

Manually for now. 

To test, enable `customColor` in the `(experimental-)theme.json`:

```json
		"border": {
			"customColor": true,
			"customRadius": false,
			"customStyle": false,
			"customWidth": false
		},
```

Please check that the editor and frontend match for:

1. Button inside with border swatch color and custom color
2. Button outside with border swatch color and custom color
3. Icon as button
4. Enable `border.customRadius` in the `(experimental-)theme.json` and ensure there are no regressions.


## Screenshots 
**Button inside**
<img width="651" alt="Screen Shot 2021-05-19 at 10 01 56 am" src="https://user-images.githubusercontent.com/6458278/118738571-b7962480-b88a-11eb-9007-8a0e06a14972.png">

**Button outside**
<img width="644" alt="Screen Shot 2021-05-19 at 10 02 08 am" src="https://user-images.githubusercontent.com/6458278/118738576-b8c75180-b88a-11eb-81d1-5a1b17ba97d8.png">

**Button icon**
<img width="639" alt="Screen Shot 2021-05-19 at 10 12 52 am" src="https://user-images.githubusercontent.com/6458278/118738604-c977c780-b88a-11eb-9e13-72dd838148d2.png">



## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
