### PR TITLE
Image/Gallery block: remove use of unstableOnFocus

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -34,7 +34,9 @@ export function useFocusHandler( clientId ) {
 				// getting data through `useSelect` asynchronously.
 				if ( isBlockSelected( clientId ) ) {
 					// Potentially change selection away from rich text.
-					selectionChange( clientId );
+					if ( ! event.target.isContentEditable ) {
+						selectionChange( clientId );
+					}
 					return;
 				}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -17,7 +17,7 @@ import { store as blockEditorStore } from '../../../store';
  */
 export function useFocusHandler( clientId ) {
 	const { isBlockSelected } = useSelect( blockEditorStore );
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
 
 	return useRefEffect(
 		( node ) => {
@@ -33,6 +33,8 @@ export function useFocusHandler( clientId ) {
 				// Check synchronously because a non-selected block might be
 				// getting data through `useSelect` asynchronously.
 				if ( isBlockSelected( clientId ) ) {
+					// Potentially change selection away from rich text.
+					selectionChange( clientId );
 					return;
 				}
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -295,10 +295,6 @@ function GalleryEdit( props ) {
 			: __( 'Thumbnails are not cropped.' );
 	}
 
-	function onFocusGalleryCaption() {
-		setSelectedImage();
-	}
-
 	function setImageAttributes( index, newAttributes ) {
 		if ( ! images[ index ] ) {
 			return;
@@ -466,7 +462,6 @@ function GalleryEdit( props ) {
 				onSelectImage={ onSelectImage }
 				onDeselectImage={ onDeselectImage }
 				onSetImageAttributes={ setImageAttributes }
-				onFocusGalleryCaption={ onFocusGalleryCaption }
 				blockProps={ blockProps }
 			/>
 		</>

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -44,7 +44,6 @@ class GalleryImage extends Component {
 		super( ...arguments );
 
 		this.onSelectImage = this.onSelectImage.bind( this );
-		this.onSelectCaption = this.onSelectCaption.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
 		this.onEdit = this.onEdit.bind( this );
@@ -53,7 +52,6 @@ class GalleryImage extends Component {
 		);
 		this.onSelectCustomURL = this.onSelectCustomURL.bind( this );
 		this.state = {
-			captionSelected: false,
 			isEditing: false,
 		};
 	}
@@ -62,27 +60,9 @@ class GalleryImage extends Component {
 		this.container = ref;
 	}
 
-	onSelectCaption() {
-		if ( ! this.state.captionSelected ) {
-			this.setState( {
-				captionSelected: true,
-			} );
-		}
-
-		if ( ! this.props.isSelected ) {
-			this.props.onSelect();
-		}
-	}
-
 	onSelectImage() {
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
-		}
-
-		if ( this.state.captionSelected ) {
-			this.setState( {
-				captionSelected: false,
-			} );
 		}
 	}
 
@@ -104,9 +84,8 @@ class GalleryImage extends Component {
 		} );
 	}
 
-	componentDidUpdate( prevProps ) {
+	componentDidUpdate() {
 		const {
-			isSelected,
 			image,
 			url,
 			__unstableMarkNextChangeAsNotPersistent,
@@ -116,18 +95,6 @@ class GalleryImage extends Component {
 			this.props.setAttributes( {
 				url: image.source_url,
 				alt: image.alt_text,
-			} );
-		}
-
-		// unselect the caption so when the user selects other image and comeback
-		// the caption is not immediately selected
-		if (
-			this.state.captionSelected &&
-			! isSelected &&
-			prevProps.isSelected
-		) {
-			this.setState( {
-				captionSelected: false,
 			} );
 		}
 	}
@@ -283,11 +250,9 @@ class GalleryImage extends Component {
 						aria-label={ __( 'Image caption text' ) }
 						placeholder={ isSelected ? __( 'Add caption' ) : null }
 						value={ caption }
-						isSelected={ this.state.captionSelected }
 						onChange={ ( newCaption ) =>
 							setAttributes( { caption: newCaption } )
 						}
-						unstableOnFocus={ this.onSelectCaption }
 						inlineToolbar
 					/>
 				) }

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -183,8 +183,6 @@ class GalleryImage extends Component {
 					src={ url }
 					alt={ alt }
 					data-id={ id }
-					onClick={ this.onSelectImage }
-					onFocus={ this.onSelectImage }
 					onKeyDown={ this.onRemoveImage }
 					tabIndex="0"
 					aria-label={ ariaLabel }
@@ -201,7 +199,12 @@ class GalleryImage extends Component {
 		} );
 
 		return (
-			<figure className={ className }>
+			// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+			<figure
+				className={ className }
+				onClick={ this.onSelectImage }
+				onFocus={ this.onSelectImage }
+			>
 				{ ! isEditing && ( href ? <a href={ href }>{ img }</a> : img ) }
 				{ isEditing && (
 					<MediaPlaceholder

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -30,7 +30,6 @@ export const Gallery = ( props ) => {
 		onSelectImage,
 		onDeselectImage,
 		onSetImageAttributes,
-		onFocusGalleryCaption,
 		insertBlocksAfter,
 		blockProps,
 	} = props;
@@ -99,7 +98,6 @@ export const Gallery = ( props ) => {
 				aria-label={ __( 'Gallery caption text' ) }
 				placeholder={ __( 'Write gallery caption…' ) }
 				value={ caption }
-				unstableOnFocus={ onFocusGalleryCaption }
 				onChange={ ( value ) => setAttributes( { caption: value } ) }
 				inlineToolbar
 				__unstableOnSplitAtEnd={ () =>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -80,6 +80,7 @@ export function ImageEdit( {
 	insertBlocksAfter,
 	noticeOperations,
 	onReplace,
+	clientId,
 } ) {
 	const {
 		url = '',
@@ -300,6 +301,7 @@ export function ImageEdit( {
 					onSelectURL={ onSelectURL }
 					onUploadError={ onUploadError }
 					containerRef={ ref }
+					clientId={ clientId }
 				/>
 			) }
 			{ ! url && (

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -80,7 +80,6 @@ export function ImageEdit( {
 	insertBlocksAfter,
 	noticeOperations,
 	onReplace,
-	clientId,
 } ) {
 	const {
 		url = '',
@@ -301,7 +300,6 @@ export function ImageEdit( {
 					onSelectURL={ onSelectURL }
 					onUploadError={ onUploadError }
 					containerRef={ ref }
-					clientId={ clientId }
 				/>
 			) }
 			{ ! url && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -87,7 +87,6 @@ export default function Image( {
 	onSelectURL,
 	onUploadError,
 	containerRef,
-	clientId,
 } ) {
 	const captionRef = useRef();
 	const prevUrl = usePrevious( url );
@@ -108,8 +107,8 @@ export default function Image( {
 				multiImageSelection:
 					multiSelectedClientIds.length &&
 					multiSelectedClientIds.every(
-						( _clientId ) =>
-							getBlockName( _clientId ) === 'core/image'
+						( clientId ) =>
+							getBlockName( clientId ) === 'core/image'
 					),
 			};
 		},
@@ -126,9 +125,7 @@ export default function Image( {
 			] );
 		}
 	);
-	const { replaceBlocks, toggleSelection, selectionChange } = useDispatch(
-		blockEditorStore
-	);
+	const { replaceBlocks, toggleSelection } = useDispatch( blockEditorStore );
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
 		noticesStore
 	);
@@ -401,7 +398,6 @@ export default function Image( {
 			<img
 				src={ temporaryURL || url }
 				alt={ defaultedAlt }
-				onClick={ () => selectionChange( clientId ) }
 				onError={ () => onImageError() }
 				onLoad={ ( event ) => {
 					setNaturalSize(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Builds in selection changing when an element outside of rich text receives focus. This reduces complexity for the block author as they no longer need to manage selection state of rich text fields for more complex blocks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
