### PR TITLE
Improve display for multiple action buttons in notices

### DIFF
--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -88,36 +88,38 @@ function Notice( {
 		<div className={ classes }>
 			<div className="components-notice__content">
 				{ children }
-				{ actions.map(
-					(
-						{
-							className: buttonCustomClasses,
-							label,
-							isPrimary,
-							noDefaultClasses = false,
-							onClick,
-							url,
-						},
-						index
-					) => {
-						return (
-							<Button
-								key={ index }
-								href={ url }
-								isPrimary={ isPrimary }
-								isSecondary={ ! noDefaultClasses && ! url }
-								isLink={ ! noDefaultClasses && !! url }
-								onClick={ url ? undefined : onClick }
-								className={ classnames(
-									'components-notice__action',
-									buttonCustomClasses
-								) }
-							>
-								{ label }
-							</Button>
-						);
-					}
-				) }
+				<div className="components-notice__actions">
+					{ actions.map(
+						(
+							{
+								className: buttonCustomClasses,
+								label,
+								isPrimary,
+								noDefaultClasses = false,
+								onClick,
+								url,
+							},
+							index
+						) => {
+							return (
+								<Button
+									key={ index }
+									href={ url }
+									isPrimary={ isPrimary }
+									isSecondary={ ! noDefaultClasses && ! url }
+									isLink={ ! noDefaultClasses && !! url }
+									onClick={ url ? undefined : onClick }
+									className={ classnames(
+										'components-notice__action',
+										buttonCustomClasses
+									) }
+								>
+									{ label }
+								</Button>
+							);
+						}
+					) }
+				</div>
 			</div>
 			{ isDismissible && (
 				<Button

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -88,6 +88,5 @@
 		display: block;
 		margin-left: 0;
 		margin-top: $grid-unit-10;
-		margin-right: $grid-unit-10;
 	}
 }

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -81,3 +81,17 @@
 		margin-top: $grid-unit-10;
 	}
 }
+
+.components-notice__actions {
+	display: flex;
+	flex-wrap: wrap;
+
+	// Fallback until there is better support on
+	// Safari on iOS and Samsung Internet
+	margin-right: $grid-unit-15;
+
+	@supports ( gap: 10px ) {
+		margin-right: 0;
+		gap: $grid-unit-15;
+	}
+}

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -34,6 +34,11 @@
 	margin: $grid-unit-05 #{ $button-size-small + $border-width } $grid-unit-05 0;
 }
 
+.components-notice__actions {
+	display: flex;
+	flex-wrap: wrap;
+}
+
 .components-notice__action.components-button {
 	&,
 	&.is-link {
@@ -42,6 +47,9 @@
 	&.is-secondary {
 		vertical-align: initial;
 	}
+
+	// These are flex items and aligned
+	margin-right: $grid-unit-10;
 }
 
 .components-notice__dismiss {
@@ -79,19 +87,6 @@
 		display: block;
 		margin-left: 0;
 		margin-top: $grid-unit-10;
-	}
-}
-
-.components-notice__actions {
-	display: flex;
-	flex-wrap: wrap;
-
-	// Fallback until there is better support on
-	// Safari on iOS and Samsung Internet
-	margin-right: $grid-unit-15;
-
-	@supports ( gap: 10px ) {
-		margin-right: 0;
-		gap: $grid-unit-15;
+		margin-right: $grid-unit-10;
 	}
 }

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -48,7 +48,8 @@
 		vertical-align: initial;
 	}
 
-	// These are flex items and aligned
+	// When it has better support, this can be replaces with column-gap
+	// since these are flex items.
 	margin-right: $grid-unit-10;
 }
 

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -48,8 +48,8 @@
 		vertical-align: initial;
 	}
 
-	// When it has better support, this can be replaces with column-gap
-	// since these are flex items.
+	// When it has better support, this can be replaced
+	// with column-gap since these are flex items.
 	margin-right: $grid-unit-10;
 }
 

--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -8,31 +8,35 @@ exports[`Notice should match snapshot 1`] = `
     className="components-notice__content"
   >
     Example
-    <ForwardRef(Button)
-      className="components-notice__action"
-      href="https://example.com"
-      isLink={true}
-      isSecondary={false}
+    <div
+      className="components-notice__actions"
     >
-      More information
-    </ForwardRef(Button)>
-    <ForwardRef(Button)
-      className="components-notice__action"
-      isLink={false}
-      isSecondary={true}
-      onClick={[Function]}
-    >
-      Cancel
-    </ForwardRef(Button)>
-    <ForwardRef(Button)
-      className="components-notice__action"
-      isLink={false}
-      isPrimary={true}
-      isSecondary={true}
-      onClick={[Function]}
-    >
-      Submit
-    </ForwardRef(Button)>
+      <ForwardRef(Button)
+        className="components-notice__action"
+        href="https://example.com"
+        isLink={true}
+        isSecondary={false}
+      >
+        More information
+      </ForwardRef(Button)>
+      <ForwardRef(Button)
+        className="components-notice__action"
+        isLink={false}
+        isSecondary={true}
+        onClick={[Function]}
+      >
+        Cancel
+      </ForwardRef(Button)>
+      <ForwardRef(Button)
+        className="components-notice__action"
+        isLink={false}
+        isPrimary={true}
+        isSecondary={true}
+        onClick={[Function]}
+      >
+        Submit
+      </ForwardRef(Button)>
+    </div>
   </div>
   <ForwardRef(Button)
     className="components-notice__dismiss"


### PR DESCRIPTION
## Description
When adding multiple buttons via actions in the `Notice` component, the buttons are each added on a new line. When there are multiple notices and multiple buttons, this becomes quite intrusive and overtakes a significant portion of the browser window.

This PR adds a structural div around the actions in the `Notice` component, and some styling to align buttons on the same line so that the display is less intrusive when there are multiple notices and multiple actions.

## How has this been tested?

Tested in: 
* Safari 14.0.3
* Firefox Developer 89.0b10 (64-bit) and mobile device simulator
* Chrome 90.0.4430.212 and mobile device simulator

## Screenshots <!-- if applicable -->

Without wrapping (current):
![Desktop Screenshot without Wrapping Buttons](https://user-images.githubusercontent.com/445861/118156205-166d2100-b3e7-11eb-9919-f0882f4b7102.png)
![Mobile Screenshot without Wrapping Buttons](https://user-images.githubusercontent.com/445861/118156226-1d942f00-b3e7-11eb-92c9-a9175361b345.png)

With wrapping (this PR):
![Desktop Screenshot with Wrapping Buttons](https://user-images.githubusercontent.com/445861/118156345-3ef51b00-b3e7-11eb-919a-ab9c878621b2.png)
![Mobile Screenshot with Wrapping Buttons](https://user-images.githubusercontent.com/445861/118159723-6221c980-b3eb-11eb-9b35-a319a88672b7.png)
<img width="491" alt="Example of wrapping buttons" src="https://user-images.githubusercontent.com/445861/118193604-fdc82f80-b415-11eb-9a6b-3771040af45e.png">

## Types of changes
This is a bugfix / styling improvement and does not affect any areas of the code-base outside of the `Notice` component. 

Note: The `column-gap` property would be perfect for this, but due to partial implementation / conflicting naming with the `column-gap` property used for Grid, it is not possible to detect support via `@supports` for this property in the Flex context ([more info](https://github.com/w3c/csswg-drafts/issues/3559)). This is an issue in Safari 14, which is within the two latest versions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
