### PR TITLE
Rich text: extract splitValue to separate file

### DIFF
--- a/packages/block-editor/src/components/rich-text/split-value.js
+++ b/packages/block-editor/src/components/rich-text/split-value.js
@@ -4,10 +4,9 @@
 import { isEmpty, split, toHTMLString } from '@wordpress/rich-text';
 
 /*
- * Signals to the RichText owner that the block can be replaced with two
- * blocks as a result of splitting the block by pressing enter, or with
- * blocks as a result of splitting the block by pasting block content in the
- * instance.
+ * Signals to the RichText owner that the block can be replaced with two blocks
+ * as a result of splitting the block by pressing enter, or with blocks as a
+ * result of splitting the block by pasting block content in the instance.
  */
 export function splitValue( {
 	value,
@@ -26,14 +25,14 @@ export function splitValue( {
 	const hasPastedBlocks = pastedBlocks.length > 0;
 	let lastPastedBlockIndex = -1;
 
-	// Consider the after value to be the original it is not empty and
-	// the before value *is* empty.
+	// Consider the after value to be the original it is not empty and the
+	// before value *is* empty.
 	const isAfterOriginal = isEmpty( before ) && ! isEmpty( after );
 
 	// Create a block with the content before the caret if there's no pasted
-	// blocks, or if there are pasted blocks and the value is not empty.
-	// We do not want a leading empty block on paste, but we do if split
-	// with e.g. the enter key.
+	// blocks, or if there are pasted blocks and the value is not empty. We do
+	// not want a leading empty block on paste, but we do if split with e.g. the
+	// enter key.
 	if ( ! hasPastedBlocks || ! isEmpty( before ) ) {
 		blocks.push(
 			onSplit(
@@ -54,10 +53,10 @@ export function splitValue( {
 		blocks.push( onSplitMiddle() );
 	}
 
-	// If there's pasted blocks, append a block with non empty content
-	/// after the caret. Otherwise, do append an empty block if there
-	// is no `onSplitMiddle` prop, but if there is and the content is
-	// empty, the middle block is enough to set focus in.
+	// If there's pasted blocks, append a block with non empty content / after
+	// the caret. Otherwise, do append an empty block if there is no
+	// `onSplitMiddle` prop, but if there is and the content is empty, the
+	// middle block is enough to set focus in.
 	if (
 		hasPastedBlocks
 			? ! isEmpty( after )
@@ -74,12 +73,12 @@ export function splitValue( {
 		);
 	}
 
-	// If there are pasted blocks, set the selection to the last one.
-	// Otherwise, set the selection to the second block.
+	// If there are pasted blocks, set the selection to the last one. Otherwise,
+	// set the selection to the second block.
 	const indexToSelect = hasPastedBlocks ? lastPastedBlockIndex : 1;
 
-	// If there are pasted blocks, move the caret to the end of the selected block
-	// Otherwise, retain the default value.
+	// If there are pasted blocks, move the caret to the end of the selected
+	// block Otherwise, retain the default value.
 	const initialPosition = hasPastedBlocks ? -1 : 0;
 
 	onReplace( blocks, indexToSelect, initialPosition );

--- a/packages/block-editor/src/components/rich-text/split-value.js
+++ b/packages/block-editor/src/components/rich-text/split-value.js
@@ -10,7 +10,7 @@ import { isEmpty, split, toHTMLString } from '@wordpress/rich-text';
  * instance.
  */
 export function splitValue( {
-	record,
+	value,
 	pastedBlocks = [],
 	onReplace,
 	onSplit,
@@ -22,7 +22,7 @@ export function splitValue( {
 	}
 
 	const blocks = [];
-	const [ before, after ] = split( record );
+	const [ before, after ] = split( value );
 	const hasPastedBlocks = pastedBlocks.length > 0;
 	let lastPastedBlockIndex = -1;
 

--- a/packages/block-editor/src/components/rich-text/split-value.js
+++ b/packages/block-editor/src/components/rich-text/split-value.js
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import { isEmpty, split, toHTMLString } from '@wordpress/rich-text';
+
+/*
+ * Signals to the RichText owner that the block can be replaced with two
+ * blocks as a result of splitting the block by pressing enter, or with
+ * blocks as a result of splitting the block by pasting block content in the
+ * instance.
+ */
+export function splitValue( {
+	record,
+	pastedBlocks = [],
+	onReplace,
+	onSplit,
+	onSplitMiddle,
+	multilineTag,
+} ) {
+	if ( ! onReplace || ! onSplit ) {
+		return;
+	}
+
+	const blocks = [];
+	const [ before, after ] = split( record );
+	const hasPastedBlocks = pastedBlocks.length > 0;
+	let lastPastedBlockIndex = -1;
+
+	// Consider the after value to be the original it is not empty and
+	// the before value *is* empty.
+	const isAfterOriginal = isEmpty( before ) && ! isEmpty( after );
+
+	// Create a block with the content before the caret if there's no pasted
+	// blocks, or if there are pasted blocks and the value is not empty.
+	// We do not want a leading empty block on paste, but we do if split
+	// with e.g. the enter key.
+	if ( ! hasPastedBlocks || ! isEmpty( before ) ) {
+		blocks.push(
+			onSplit(
+				toHTMLString( {
+					value: before,
+					multilineTag,
+				} ),
+				! isAfterOriginal
+			)
+		);
+		lastPastedBlockIndex += 1;
+	}
+
+	if ( hasPastedBlocks ) {
+		blocks.push( ...pastedBlocks );
+		lastPastedBlockIndex += pastedBlocks.length;
+	} else if ( onSplitMiddle ) {
+		blocks.push( onSplitMiddle() );
+	}
+
+	// If there's pasted blocks, append a block with non empty content
+	/// after the caret. Otherwise, do append an empty block if there
+	// is no `onSplitMiddle` prop, but if there is and the content is
+	// empty, the middle block is enough to set focus in.
+	if (
+		hasPastedBlocks
+			? ! isEmpty( after )
+			: ! onSplitMiddle || ! isEmpty( after )
+	) {
+		blocks.push(
+			onSplit(
+				toHTMLString( {
+					value: after,
+					multilineTag,
+				} ),
+				isAfterOriginal
+			)
+		);
+	}
+
+	// If there are pasted blocks, set the selection to the last one.
+	// Otherwise, set the selection to the second block.
+	const indexToSelect = hasPastedBlocks ? lastPastedBlockIndex : 1;
+
+	// If there are pasted blocks, move the caret to the end of the selected block
+	// Otherwise, retain the default value.
+	const initialPosition = hasPastedBlocks ? -1 : 0;
+
+	onReplace( blocks, indexToSelect, initialPosition );
+}

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -78,7 +78,7 @@ export function useEnter( props ) {
 					}
 				} else if ( canSplit && isEmptyLine( _value ) ) {
 					splitValue( {
-						record: _value,
+						value: _value,
 						onReplace,
 						onSplit,
 						onSplitMiddle,
@@ -100,7 +100,7 @@ export function useEnter( props ) {
 					onSplitAtEnd();
 				} else if ( canSplit ) {
 					splitValue( {
-						record: _value,
+						value: _value,
 						onReplace,
 						onSplit,
 						onSplitMiddle,

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -19,6 +19,7 @@ import { useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { splitValue } from './split-value';
 
 export function useEnter( props ) {
 	const { __unstableMarkAutomaticChange } = useDispatch( blockEditorStore );
@@ -35,10 +36,10 @@ export function useEnter( props ) {
 				value,
 				onReplace,
 				onSplit,
-				multiline,
+				onSplitMiddle,
+				multilineTag,
 				onChange,
 				disableLineBreaks,
-				splitValue,
 				onSplitAtEnd,
 			} = propsRef.current;
 
@@ -70,13 +71,19 @@ export function useEnter( props ) {
 				}
 			}
 
-			if ( multiline ) {
+			if ( multilineTag ) {
 				if ( event.shiftKey ) {
 					if ( ! disableLineBreaks ) {
 						onChange( insert( _value, '\n' ) );
 					}
 				} else if ( canSplit && isEmptyLine( _value ) ) {
-					splitValue( _value );
+					splitValue( {
+						record: _value,
+						onReplace,
+						onSplit,
+						onSplitMiddle,
+						multilineTag,
+					} );
 				} else {
 					onChange( insertLineSeparator( _value ) );
 				}
@@ -92,7 +99,13 @@ export function useEnter( props ) {
 				} else if ( ! canSplit && canSplitAtEnd ) {
 					onSplitAtEnd();
 				} else if ( canSplit ) {
-					splitValue( _value );
+					splitValue( {
+						record: _value,
+						onReplace,
+						onSplit,
+						onSplitMiddle,
+						multilineTag,
+					} );
 				}
 			}
 		}

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -19,6 +19,7 @@ import { isURL } from '@wordpress/url';
  */
 import { filePasteHandler } from './file-paste-handler';
 import { addActiveFormats, isShortcode } from './utils';
+import { splitValue } from './split-value';
 
 export function usePasteHandler( props ) {
 	const propsRef = useRef( props );
@@ -34,7 +35,7 @@ export function usePasteHandler( props ) {
 				tagName,
 				onReplace,
 				onSplit,
-				splitValue,
+				onSplitMiddle,
 				__unstableEmbedURLOnPaste,
 				multilineTag,
 				preserveWhiteSpace,
@@ -140,7 +141,14 @@ export function usePasteHandler( props ) {
 				if ( onReplace && isEmpty( value ) ) {
 					onReplace( content );
 				} else {
-					splitValue( value, content );
+					splitValue( {
+						value,
+						pastedBlocks: content,
+						onReplace,
+						onSplit,
+						onSplitMiddle,
+						multilineTag,
+					} );
 				}
 
 				return;
@@ -196,7 +204,14 @@ export function usePasteHandler( props ) {
 				if ( onReplace && isEmpty( value ) ) {
 					onReplace( content, content.length - 1, -1 );
 				} else {
-					splitValue( value, content );
+					splitValue( {
+						value,
+						pastedBlocks: content,
+						onReplace,
+						onSplit,
+						onSplitMiddle,
+						multilineTag,
+					} );
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Just trying to reduce the size of the rich text files.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
