### PR TITLE
WIP: Move search block alignment from float to flex

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -335,6 +335,9 @@ export default function SearchEdit( {
 
 			{ showLabel && (
 				<RichText
+					style={ {
+						width: `${ width }${ widthUnit }`,
+					} }
 					className="wp-block-search__label"
 					aria-label={ __( 'Label text' ) }
 					placeholder={ __( 'Add label…' ) }

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -1,8 +1,36 @@
 .wp-block[data-align="center"] {
 	.wp-block-search {
+		float: unset;
+		display: flex;
+		align-items: center;
+		flex-direction: column;
+		margin-left: 0;
 		.wp-block-search__inside-wrapper {
 			margin: auto;
 		}
+	}
+}
+
+.wp-block[data-align="right"] {
+	.wp-block-search {
+		float: unset;
+		display: flex;
+		align-items: flex-end;
+		flex-direction: column;
+		margin-left: 0;
+	}
+	.wp-block-search__label {
+		min-width: 220px !important;
+	}
+}
+
+.wp-block[data-align="left"] {
+	.wp-block-search {
+		float: unset;
+		display: flex;
+		align-items: flex-start;
+		flex-direction: column;
+		margin-left: 0;
 	}
 }
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -41,14 +41,16 @@ function render_block_core_search( $attributes ) {
 	if ( $show_label ) {
 		if ( ! empty( $attributes['label'] ) ) {
 			$label_markup = sprintf(
-				'<label for="%s" class="wp-block-search__label">%s</label>',
+				'<label for="%s" class="wp-block-search__label" %s>%s</label>',
 				$input_id,
-				$attributes['label']
+				$inline_styles['wrapper'],
+				$attributes['label'],
 			);
 		} else {
 			$label_markup = sprintf(
-				'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
+				'<label for="%s" class="wp-block-search__label screen-reader-text" %s>%s</label>',
 				$input_id,
+				$inline_styles['wrapper'],
 				__( 'Search' )
 			);
 		}

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -18,6 +18,30 @@
 		}
 	}
 
+	&.alignright {
+		float: unset;
+		display: flex;
+		align-items: flex-end;
+		flex-direction: column;
+		margin-left: 0;
+	}
+
+	&.alignleft {
+		float: unset;
+		display: flex;
+		align-items: flex-start;
+		flex-direction: column;
+		margin-left: 0;
+	}
+
+	&.aligncenter {
+		float: unset;
+		display: flex;
+		align-items: center;
+		flex-direction: column;
+		margin-left: 0;
+	}
+
 	.wp-block-search__inside-wrapper {
 		display: flex;
 		flex: auto;


### PR DESCRIPTION
## Description
Currently right align doesn't play nice with the %width selections, and also doesn't float to the very edge of the page. This seems to be an issue with the way browsers deal with floated items with width applied. I couldn't find a fix for this other than moving to a flex layout, but not sure what the implications of moving from a float are in terms of backwards compat with themes, etc.

## To test

- Check out this PR
- Add a search block. If no alignment options then nest the block in a group and they should appear
- Set right alignment and a percentage width and check that it displays as expected. Also check on frontend
- Also check centre and left align

## Screenshots 

Before:
![search-before](https://user-images.githubusercontent.com/3629020/118209154-33bfef00-b4bc-11eb-8a5e-6a5a199772f4.gif)

After:
![search-after](https://user-images.githubusercontent.com/3629020/118209162-391d3980-b4bc-11eb-900e-759d6a01b239.gif)



