### PR TITLE
Image: Add caption positioning

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -10,6 +10,9 @@
 		"align": {
 			"type": "string"
 		},
+		"alignCaption": {
+			"type": "string"
+		},
 		"url": {
 			"type": "string",
 			"source": "attribute",

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -86,6 +86,7 @@ export function ImageEdit( {
 		alt,
 		caption,
 		align,
+		alignCaption,
 		id,
 		width,
 		height,
@@ -279,6 +280,7 @@ export function ImageEdit( {
 		'is-transient': temporaryURL,
 		'is-resized': !! width || !! height,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
+		[ `align-caption-${ alignCaption }` ]: alignCaption,
 	} );
 
 	const blockProps = useBlockProps( {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -9,6 +9,7 @@ import { get, filter, map, last, pick, includes } from 'lodash';
 import { isBlobURL } from '@wordpress/blob';
 import {
 	ExternalLink,
+	Fill,
 	PanelBody,
 	ResizableBox,
 	Spinner,
@@ -19,6 +20,7 @@ import {
 import { useViewportMatch, usePrevious } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
+	AlignmentControl,
 	BlockControls,
 	InspectorControls,
 	InspectorAdvancedControls,
@@ -68,6 +70,7 @@ export default function Image( {
 		alt,
 		caption,
 		align,
+		alignCaption,
 		id,
 		href,
 		rel,
@@ -394,6 +397,17 @@ export default function Image( {
 		</>
 	);
 
+	const captionControls = (
+		<Fill name="RichText.ToolbarControls.text-color">
+			<AlignmentControl
+				value={ alignCaption }
+				onChange={ ( newAlignCaption ) =>
+					setAttributes( { alignCaption: newAlignCaption } )
+				}
+			/>
+		</Fill>
+	);
+
 	const filename = getFilename( url );
 	let defaultedAlt;
 
@@ -557,6 +571,7 @@ export default function Image( {
 				which causes duplicated image upload. */ }
 			{ ! temporaryURL && controls }
 			{ img }
+			{ isSelected && captionControls }
 			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 				<RichText
 					ref={ captionRef }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -15,6 +15,7 @@ export default function save( { attributes } ) {
 		alt,
 		caption,
 		align,
+		alignCaption,
 		href,
 		rel,
 		linkClass,
@@ -30,6 +31,7 @@ export default function save( { attributes } ) {
 
 	const classes = classnames( {
 		[ `align${ align }` ]: align,
+		[ `align-caption-${ alignCaption }` ]: alignCaption,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 		'is-resized': width || height,
 	} );

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -54,6 +54,18 @@
 		margin-right: auto;
 	}
 
+	&.align-caption-left > figcaption {
+		text-align: left;
+	}
+
+	&.align-caption-right > figcaption {
+		text-align: right;
+	}
+
+	&.align-caption-center > figcaption {
+		text-align: center;
+	}
+
 	// Supply caption styles to images, even if the theme hasn't opted in.
 	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
 	// so we supply the styles so as to not appear broken or unstyled in those themes.


### PR DESCRIPTION
## Description
Adds text alignment control to image caption's inline toolbar.

I'm not 100% sure if this is the best way to add this feature, but I couldn't think of anything else without modifying RichText and having access to block attributes.

I would appreciate the sanity check of new caption positioning styles.

Fixes #12997.

## How has this been tested?
1. Add image block.
2. Add a caption.
3. New text alignment controls should appear for the caption.
4. Changing alignment should change text position.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/240569/118227604-de72e600-b499-11eb-9268-ce596aa2c53c.mp4

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
